### PR TITLE
refactor(packages/dds): Update client packages to use `@legacy @beta` instead of `@legacy @alpha`

### DIFF
--- a/packages/dds/counter/api-report/counter.legacy.alpha.api.md
+++ b/packages/dds/counter/api-report/counter.legacy.alpha.api.md
@@ -4,22 +4,22 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedCounter extends ISharedObject<ISharedCounterEvents> {
     increment(incrementAmount: number): void;
     value: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedCounterEvents extends ISharedObjectEvents {
     // @eventProperty
     (event: "incremented", listener: (incrementAmount: number, newValue: number) => void): any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedCounter: ISharedObjectKind<ISharedCounter> & SharedObjectKind<ISharedCounter>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedCounter = ISharedCounter;
 
 ```

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -45,8 +45,7 @@ const snapshotFileName = "header";
 
 /**
  * {@inheritDoc ISharedCounter}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class SharedCounter
 	extends SharedObject<ISharedCounterEvents>

--- a/packages/dds/counter/src/counterFactory.ts
+++ b/packages/dds/counter/src/counterFactory.ts
@@ -75,14 +75,12 @@ export class CounterFactory implements IChannelFactory<ISharedCounter> {
 
 /**
  * Entrypoint for {@link ISharedCounter} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedCounter = createSharedObjectKind<ISharedCounter>(CounterFactory);
 
 /**
  * Alias for {@link ISharedCounter} for compatibility.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SharedCounter = ISharedCounter;

--- a/packages/dds/counter/src/interfaces.ts
+++ b/packages/dds/counter/src/interfaces.ts
@@ -10,8 +10,7 @@ import type {
 
 /**
  * Events sent by {@link ISharedCounter}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedCounterEvents extends ISharedObjectEvents {
 	/**
@@ -62,8 +61,7 @@ export interface ISharedCounterEvents extends ISharedObjectEvents {
  *     console.log(`The counter incremented by ${incrementAmount} and now has a value of ${newValue}`);
  * });
  * ```
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedCounter extends ISharedObject<ISharedCounterEvents> {
 	/**

--- a/packages/dds/legacy-dds/api-report/legacy-dds.legacy.alpha.api.md
+++ b/packages/dds/legacy-dds/api-report/legacy-dds.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDeleteOperation {
     // (undocumented)
     entryId: string;
@@ -12,7 +12,7 @@ export interface IDeleteOperation {
     type: typeof OperationType.deleteEntry;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IInsertOperation<T = unknown> {
     // (undocumented)
     entryId: string;
@@ -24,7 +24,7 @@ export interface IInsertOperation<T = unknown> {
     value: T;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMoveOperation {
     // (undocumented)
     changedToEntryId: string;
@@ -36,7 +36,7 @@ export interface IMoveOperation {
     type: typeof OperationType.moveEntry;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IRevertible {
     // (undocumented)
     dispose(): void;
@@ -44,7 +44,7 @@ export interface IRevertible {
     revert(): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedArray<T extends SerializableTypeForSharedArray> extends ISharedObject<ISharedArrayEvents> {
     // (undocumented)
     delete(index: number): void;
@@ -62,7 +62,7 @@ export interface ISharedArray<T extends SerializableTypeForSharedArray> extends 
     toggleMove(oldEntryId: string, newEntryId: string): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedArrayEvents extends ISharedObjectEvents {
     // @eventProperty (undocumented)
     (event: "valueChanged", listener: (op: ISharedArrayOperation, isLocal: boolean, target: IEventThisPlaceHolder) => void): void;
@@ -70,25 +70,25 @@ export interface ISharedArrayEvents extends ISharedObjectEvents {
     (event: "revertible", listener: (revertible: IRevertible) => void): void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type ISharedArrayOperation<T = unknown> = IInsertOperation<T> | IDeleteOperation | IMoveOperation | ISharedArrayRevertibleOperation;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type ISharedArrayRevertibleOperation = IToggleOperation | IToggleMoveOperation;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISharedSignal<T extends SerializableTypeForSharedSignal = any> extends ISharedObject<ISharedSignalEvents<T>> {
     // (undocumented)
     notify(metadata?: T): void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISharedSignalEvents<T extends SerializableTypeForSharedSignal> extends ISharedObjectEvents {
     // (undocumented)
     (event: "notify", listener: (value: T, isLocal: boolean) => void): any;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IToggleMoveOperation {
     // (undocumented)
     changedToEntryId: string;
@@ -98,7 +98,7 @@ export interface IToggleMoveOperation {
     type: typeof OperationType.toggleMove;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IToggleOperation {
     // (undocumented)
     entryId: string;
@@ -108,7 +108,7 @@ export interface IToggleOperation {
     type: typeof OperationType.toggle;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const OperationType: {
     readonly insertEntry: 0;
     readonly deleteEntry: 1;
@@ -117,22 +117,22 @@ export const OperationType: {
     readonly toggleMove: 4;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type OperationType = (typeof OperationType)[keyof typeof OperationType];
 
-// @alpha @legacy
+// @beta @legacy
 export type SerializableTypeForSharedArray = boolean | number | string | object | IFluidHandle;
 
-// @alpha @legacy
+// @beta @legacy
 export type SerializableTypeForSharedSignal = boolean | number | string | IFluidHandle | object;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedArray: ISharedObjectKind<ISharedArray<SerializableTypeForSharedArray>> & SharedObjectKind<ISharedArray<SerializableTypeForSharedArray>>;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedArrayBuilder: <T extends SerializableTypeForSharedArray>() => ISharedObjectKind<ISharedArray<T>> & SharedObjectKind<ISharedArray<T>>;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedSignal: ISharedObjectKind<ISharedSignal<any>> & SharedObjectKind<ISharedSignal<any>>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/dds/legacy-dds/src/array/interfaces.ts
+++ b/packages/dds/legacy-dds/src/array/interfaces.ts
@@ -16,8 +16,7 @@ import type { ISharedArrayOperation } from "./sharedArrayOperations.js";
  * It can be used as a generic constraint (`extends SerializableTypeForSharedArray`) but is
  * *never* meant to be a concrete/real type on its own.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SerializableTypeForSharedArray = boolean | number | string | object | IFluidHandle;
 
@@ -25,8 +24,7 @@ export type SerializableTypeForSharedArray = boolean | number | string | object 
  * Interface defining the events that can be emitted by the SharedArray DDS
  * and the events that can be listened to by the SharedArray DDS
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedArrayEvents extends ISharedObjectEvents {
 	/**
@@ -62,8 +60,7 @@ export interface ISharedArrayEvents extends ISharedObjectEvents {
  *
  * @typeParam T - The type of the SharedArray
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedArray<T extends SerializableTypeForSharedArray>
 	extends ISharedObject<ISharedArrayEvents> {
@@ -160,8 +157,7 @@ export interface SnapshotFormat<T> {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRevertible {
 	revert(): void;

--- a/packages/dds/legacy-dds/src/array/sharedArrayFactory.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArrayFactory.ts
@@ -68,8 +68,7 @@ export class SharedArrayFactory<T extends SerializableTypeForSharedArray>
 
 /**
  * Entrypoint for {@link ISharedArray} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedArray: ISharedObjectKind<ISharedArray<SerializableTypeForSharedArray>> &
 	SharedObjectKind<ISharedArray<SerializableTypeForSharedArray>> =
@@ -77,8 +76,7 @@ export const SharedArray: ISharedObjectKind<ISharedArray<SerializableTypeForShar
 
 /**
  * Entrypoint for {@link ISharedArray} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedArrayBuilder = <
 	T extends SerializableTypeForSharedArray,

--- a/packages/dds/legacy-dds/src/array/sharedArrayOperations.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArrayOperations.ts
@@ -4,8 +4,7 @@
  */
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const OperationType = {
 	insertEntry: 0,
@@ -16,14 +15,12 @@ export const OperationType = {
 } as const;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type OperationType = (typeof OperationType)[keyof typeof OperationType];
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IInsertOperation<T = unknown> {
 	type: typeof OperationType.insertEntry;
@@ -33,8 +30,7 @@ export interface IInsertOperation<T = unknown> {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeleteOperation {
 	type: typeof OperationType.deleteEntry;
@@ -42,8 +38,7 @@ export interface IDeleteOperation {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMoveOperation {
 	type: typeof OperationType.moveEntry;
@@ -53,8 +48,7 @@ export interface IMoveOperation {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IToggleOperation {
 	type: typeof OperationType.toggle;
@@ -63,8 +57,7 @@ export interface IToggleOperation {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IToggleMoveOperation {
 	type: typeof OperationType.toggleMove;
@@ -73,14 +66,12 @@ export interface IToggleMoveOperation {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ISharedArrayRevertibleOperation = IToggleOperation | IToggleMoveOperation;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ISharedArrayOperation<T = unknown> =
 	| IInsertOperation<T>

--- a/packages/dds/legacy-dds/src/signal/interfaces.ts
+++ b/packages/dds/legacy-dds/src/signal/interfaces.ts
@@ -13,8 +13,7 @@ import type {
  * Basic types for the SharedSignal DDS
  * It can be used as a generic constraint (`extends SerializableTypeForSharedSignal`) but is
  * *never* meant to be a concrete/real type on its own.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SerializableTypeForSharedSignal =
 	| boolean
@@ -24,8 +23,7 @@ export type SerializableTypeForSharedSignal =
 	| object;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedSignalEvents<T extends SerializableTypeForSharedSignal>
 	extends ISharedObjectEvents {
@@ -35,8 +33,7 @@ export interface ISharedSignalEvents<T extends SerializableTypeForSharedSignal>
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ISharedSignal<T extends SerializableTypeForSharedSignal = any>

--- a/packages/dds/legacy-dds/src/signal/sharedSignalFactory.ts
+++ b/packages/dds/legacy-dds/src/signal/sharedSignalFactory.ts
@@ -56,7 +56,6 @@ export class SharedSignalFactory implements IChannelFactory<ISharedSignal> {
 
 /**
  * Entrypoint for {@link ISharedSignal} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedSignal = createSharedObjectKind<ISharedSignal>(SharedSignalFactory);

--- a/packages/dds/map/api-report/map.legacy.alpha.api.md
+++ b/packages/dds/map/api-report/map.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
     static readonly Attributes: IChannelAttributes;
     get attributes(): IChannelAttributes;
@@ -14,7 +14,7 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
     get type(): string;
 }
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export interface ICreateInfo {
     ccIds: string[];
     csn: number;
@@ -34,7 +34,7 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     subdirectories(): IterableIterator<[string, IDirectory]>;
 }
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export interface IDirectoryDataObject {
     ci?: ICreateInfo;
     storage?: Record<string, ISerializableValue>;
@@ -50,7 +50,7 @@ export interface IDirectoryEvents extends IEvent {
     (event: "undisposed", listener: (target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export interface IDirectoryNewStorageFormat {
     blobs: string[];
     content: IDirectoryDataObject;
@@ -61,13 +61,13 @@ export interface IDirectoryValueChanged extends IValueChanged {
     path: string;
 }
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export interface ISerializableValue {
     type: string;
     value: any;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>, Omit<IDirectory, "on" | "once" | "off"> {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<[string, any]>;
@@ -75,7 +75,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
     readonly [Symbol.toStringTag]: string;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -83,13 +83,13 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
     get<T = any>(key: string): T | undefined;
     set<T = unknown>(key: string, value: T): this;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -101,7 +101,7 @@ export interface IValueChanged {
     readonly previousValue: any;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export class MapFactory implements IChannelFactory<ISharedMap> {
     static readonly Attributes: IChannelAttributes;
     get attributes(): IChannelAttributes;
@@ -111,16 +111,16 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
     get type(): string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory> & SharedObjectKind<ISharedDirectory>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedDirectory = ISharedDirectory;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedMap: ISharedObjectKind<ISharedMap> & SharedObjectKind<ISharedMap>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedMap = ISharedMap;
 
 ```

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -250,8 +250,7 @@ type PendingStorageEntry = PendingKeyLifetime | PendingKeyDelete | PendingClear;
  *
  * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICreateInfo {
 	/**
@@ -275,8 +274,7 @@ export interface ICreateInfo {
  *
  * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDirectoryDataObject {
 	/**
@@ -305,8 +303,7 @@ export interface IDirectoryDataObject {
  *
  * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDirectoryNewStorageFormat {
 	/**

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -20,8 +20,7 @@ import { pkgVersion } from "./packageVersion.js";
  * @privateRemarks
  * TODO: AB#35245: Deprecate and stop exporting this class.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 	/**
@@ -80,15 +79,13 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 
 /**
  * Entrypoint for {@link ISharedDirectory} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedDirectory = createSharedObjectKind<ISharedDirectory>(DirectoryFactory);
 
 /**
  * Entrypoint for {@link ISharedDirectory} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @privateRemarks
  * This alias is for legacy compat from when the SharedDirectory class was exported as public.
  */

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -125,8 +125,7 @@ export interface IDirectory
  * @remarks
  * These events only emit on the {@link ISharedDirectory} itself, and not on subdirectories.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 	/**
@@ -283,8 +282,7 @@ export interface IDirectoryEvents extends IEvent {
  * The values stored within can be accessed like a map, and the hierarchy can be navigated using path syntax.
  * SubDirectories can be retrieved for use as working directories.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedDirectory
 	extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>,
@@ -316,8 +314,7 @@ export interface IDirectoryValueChanged extends IValueChanged {
 /**
  * Events emitted in response to changes to the {@link ISharedMap | map} data.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedMapEvents extends ISharedObjectEvents {
 	/**
@@ -361,8 +358,7 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
  *
  * For more information, including example usages, see {@link https://fluidframework.com/docs/data-structures/map/}.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // TODO: Use `unknown` instead (breaking change).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dds/map/src/internalInterfaces.ts
+++ b/packages/dds/map/src/internalInterfaces.ts
@@ -70,8 +70,7 @@ export interface IMapDeleteOperation {
  * channel ID.
  *
  * @deprecated This type is legacy and deprecated(AB#8004).
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISerializableValue {
 	/**

--- a/packages/dds/map/src/mapFactory.ts
+++ b/packages/dds/map/src/mapFactory.ts
@@ -20,8 +20,7 @@ import { pkgVersion } from "./packageVersion.js";
  * @privateRemarks
  * TODO: AB#35245: Deprecate and stop exporting this class.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class MapFactory implements IChannelFactory<ISharedMap> {
 	/**
@@ -80,15 +79,13 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
 
 /**
  * Entrypoint for {@link ISharedMap} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedMap = createSharedObjectKind<ISharedMap>(MapFactory);
 
 /**
  * Entrypoint for {@link ISharedMap} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @privateRemarks
  * This alias is for legacy compat from when the SharedMap class was exported as public.
  */

--- a/packages/dds/matrix/api-report/matrix.legacy.alpha.api.md
+++ b/packages/dds/matrix/api-report/matrix.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IRevertible {
     // (undocumented)
     discard(): void;
@@ -12,7 +12,7 @@ export interface IRevertible {
     revert(): void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISharedMatrix<T = any> extends IEventProvider<ISharedMatrixEvents<T>>, IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>>, IChannel {
     insertCols(colStart: number, count: number): void;
     insertRows(rowStart: number, count: number): void;
@@ -24,27 +24,27 @@ export interface ISharedMatrix<T = any> extends IEventProvider<ISharedMatrixEven
     switchSetCellPolicy(): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedMatrixEvents<T> extends IEvent {
     (event: "conflict", listener: (row: number, col: number, currentValue: MatrixItem<T>, conflictingValue: MatrixItem<T>, target: IEventThisPlaceHolder) => void): void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IUndoConsumer {
     // (undocumented)
     pushToCurrentOperation(revertible: IRevertible): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedMatrix: ISharedObjectKind<ISharedMatrix<any>> & SharedObjectKind<ISharedMatrix<any>>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedMatrix<T = any> = ISharedMatrix<T>;
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -73,8 +73,7 @@ interface ISetOpMetadata {
 
 /**
  * Events emitted by Shared Matrix.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedMatrixEvents<T> extends IEvent {
 	/**
@@ -117,8 +116,7 @@ interface CellLastWriteTrackerItem {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // Changing this to `unknown` would be a breaking change.
 // TODO: if possible, transition ISharedMatrix to not use `any`.
@@ -240,8 +238,7 @@ interface PendingCellChanges<T> {
  * matrix data and physically stores data in Z-order to leverage CPU caches and
  * prefetching when reading in either row or column major order.  (See README.md
  * for more details.)
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // Changing this to `unknown` would be a breaking change.
 // TODO: if possible, transition SharedMatrix to not use `any`.

--- a/packages/dds/matrix/src/ops.ts
+++ b/packages/dds/matrix/src/ops.ts
@@ -26,8 +26,7 @@ export enum SnapshotPath {
 /**
  * A matrix cell value may be undefined (indicating an empty cell) or any serializable type,
  * excluding null.  (However, nulls may be embedded inside objects and arrays.)
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @rushstack/no-new-null -- Using 'null' to disallow 'null'.
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -17,8 +17,7 @@ import { pkgVersion } from "./packageVersion.js";
 
 /**
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link ISharedMatrix}.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @deprecated - Use `SharedMatrix.getFactory` instead.
  */
 export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
@@ -61,16 +60,14 @@ export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
 
 /**
  * Entrypoint for {@link ISharedMatrix} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedMatrix = createSharedObjectKind<ISharedMatrix>(SharedMatrixFactory);
 
 /**
  * Convenience alias for {@link ISharedMatrix}. Prefer to use {@link ISharedMatrix} when referring to
  * SharedMatrix as a type.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @privateRemarks
  * This alias is for legacy compat from when the SharedMatrix class was exported as public.
  */

--- a/packages/dds/matrix/src/types.ts
+++ b/packages/dds/matrix/src/types.ts
@@ -7,8 +7,7 @@
 //       of SharedMatrix undo while we decide on the correct layering for undo.
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRevertible {
 	revert(): void;
@@ -16,8 +15,7 @@ export interface IRevertible {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IUndoConsumer {
 	pushToCurrentOperation(revertible: IRevertible): void;

--- a/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
@@ -4,17 +4,17 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export interface AdjustParams {
     delta: number;
     max?: number | undefined;
     min?: number | undefined;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function appendToMergeTreeDeltaRevertibles(deltaArgs: IMergeTreeDeltaCallbackArgs, revertibles: MergeTreeDeltaRevertible[]): void;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export abstract class BaseSegment implements ISegment {
     constructor(properties?: PropertySet);
     // (undocumented)
@@ -49,10 +49,10 @@ export abstract class BaseSegment implements ISegment {
     abstract readonly type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function discardMergeTreeDeltaRevertible(revertibles: MergeTreeDeltaRevertible[]): void;
 
-// @alpha @legacy
+// @beta @legacy
 export function endpointPosAndSide(start: SequencePlace | undefined, end: SequencePlace | undefined): {
     startSide: Side | undefined;
     endSide: Side | undefined;
@@ -60,7 +60,7 @@ export function endpointPosAndSide(start: SequencePlace | undefined, end: Sequen
     endPos: number | "start" | "end" | undefined;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IAttributionCollection<T> {
     // (undocumented)
     append(other: IAttributionCollection<T>): void;
@@ -80,7 +80,7 @@ export interface IAttributionCollection<T> {
     update(name: string | undefined, channel: IAttributionCollection<T>): void;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export interface IAttributionCollectionSerializer {
     populateAttributionCollections(segments: Iterable<ISegment>, summary: SerializedAttributionCollection): void;
     // (undocumented)
@@ -90,7 +90,7 @@ export interface IAttributionCollectionSerializer {
     }>): SerializedAttributionCollection;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IAttributionCollectionSpec<T> {
     // (undocumented)
     channels?: {
@@ -108,31 +108,31 @@ export interface IAttributionCollectionSpec<T> {
     }>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IJSONMarkerSegment extends IJSONSegment {
     // (undocumented)
     marker: IMarkerDef;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IJSONSegment {
     // (undocumented)
     props?: Record<string, any>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IJSONTextSegment extends IJSONSegment {
     // (undocumented)
     text: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMarkerDef {
     // (undocumented)
     refType?: ReferenceType;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeAnnotateAdjustMsg extends IMergeTreeDelta {
     // (undocumented)
     adjust: Record<string, AdjustParams>;
@@ -150,7 +150,7 @@ export interface IMergeTreeAnnotateAdjustMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.ANNOTATE;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
     // (undocumented)
     adjust?: never;
@@ -168,21 +168,21 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.ANNOTATE;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeDelta {
     type: MergeTreeDeltaType;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeDeltaCallbackArgs<TOperationType extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType> {
     readonly deltaSegments: IMergeTreeSegmentDelta[];
     readonly operation: TOperationType;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type IMergeTreeDeltaOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg | IMergeTreeAnnotateAdjustMsg | IMergeTreeObliterateMsg | IMergeTreeObliterateSidedMsg;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeDeltaOpArgs {
     readonly groupOp?: IMergeTreeGroupMsg;
     readonly op: IMergeTreeOp;
@@ -190,7 +190,7 @@ export interface IMergeTreeDeltaOpArgs {
     readonly sequencedMessage?: ISequencedDocumentMessage;
 }
 
-// @alpha @deprecated @legacy (undocumented)
+// @beta @deprecated @legacy (undocumented)
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     // (undocumented)
     ops: IMergeTreeDeltaOp[];
@@ -198,7 +198,7 @@ export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.GROUP;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     // (undocumented)
     pos1?: number;
@@ -214,11 +214,11 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.INSERT;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeMaintenanceCallbackArgs extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> {
 }
 
-// @alpha @deprecated @legacy (undocumented)
+// @beta @deprecated @legacy (undocumented)
 export interface IMergeTreeObliterateMsg extends IMergeTreeDelta {
     // (undocumented)
     pos1?: number;
@@ -230,7 +230,7 @@ export interface IMergeTreeObliterateMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.OBLITERATE;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeObliterateSidedMsg extends IMergeTreeDelta {
     // (undocumented)
     pos1: {
@@ -248,10 +248,10 @@ export interface IMergeTreeObliterateSidedMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.OBLITERATE_SIDED;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type IMergeTreeOp = IMergeTreeDeltaOp | IMergeTreeGroupMsg;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeOptions {
     // (undocumented)
     catchUpBlobName?: string;
@@ -265,7 +265,7 @@ export interface IMergeTreeOptions {
     newMergeTreeSnapshotFormat?: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     // (undocumented)
     pos1?: number;
@@ -279,13 +279,13 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.REMOVE;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IMergeTreeSegmentDelta {
     propertyDeltas?: PropertySet;
     segment: ISegment;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface InteriorSequencePlace {
     // (undocumented)
     pos: number;
@@ -293,14 +293,14 @@ export interface InteriorSequencePlace {
     side: Side;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRelativePosition {
     before?: boolean;
     id?: string;
     offset?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISegment {
     // (undocumented)
     append(segment: ISegment): void;
@@ -323,13 +323,13 @@ export interface ISegment {
     readonly type: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISegmentAction<TClientData> {
     // (undocumented)
     (segment: ISegment, pos: number, refSeq: number, clientId: number, start: number, end: number, accum: TClientData): boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ITrackingGroup {
     // (undocumented)
     has(trackable: Trackable): boolean;
@@ -343,7 +343,7 @@ export interface ITrackingGroup {
     unlink(trackable: Trackable): boolean;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export interface LocalReferencePosition extends ReferencePosition {
     // (undocumented)
     addProperties(newProps: PropertySet): void;
@@ -354,13 +354,13 @@ export interface LocalReferencePosition extends ReferencePosition {
     readonly trackingCollection: TrackingGroupCollection;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface MapLike<T> {
     // (undocumented)
     [index: string]: T;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class Marker extends BaseSegment implements ReferencePosition, ISegment {
     constructor(refType: ReferenceType, props?: PropertySet);
     // (undocumented)
@@ -397,13 +397,13 @@ export class Marker extends BaseSegment implements ReferencePosition, ISegment {
     readonly type = "Marker";
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type MergeTreeDeltaOperationType = typeof MergeTreeDeltaType.ANNOTATE | typeof MergeTreeDeltaType.INSERT | typeof MergeTreeDeltaType.REMOVE | typeof MergeTreeDeltaType.OBLITERATE;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type MergeTreeDeltaRevertible = {
     operation: typeof MergeTreeDeltaType.INSERT;
     trackingGroup: ITrackingGroup;
@@ -416,7 +416,7 @@ export type MergeTreeDeltaRevertible = {
     propertyDeltas: PropertySet;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const MergeTreeDeltaType: {
     readonly INSERT: 0;
     readonly REMOVE: 1;
@@ -426,10 +426,10 @@ export const MergeTreeDeltaType: {
     readonly OBLITERATE_SIDED: 5;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type MergeTreeDeltaType = (typeof MergeTreeDeltaType)[keyof typeof MergeTreeDeltaType];
 
-// @alpha @legacy
+// @beta @legacy
 export const MergeTreeMaintenanceType: {
     readonly APPEND: -1;
     readonly SPLIT: -2;
@@ -437,10 +437,10 @@ export const MergeTreeMaintenanceType: {
     readonly ACKNOWLEDGED: -4;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type MergeTreeMaintenanceType = (typeof MergeTreeMaintenanceType)[keyof typeof MergeTreeMaintenanceType];
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface MergeTreeRevertibleDriver {
     // (undocumented)
     annotateRange(start: number, end: number, props: PropertySet): void;
@@ -450,10 +450,10 @@ export interface MergeTreeRevertibleDriver {
     removeRange(start: number, end: number): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type PropertySet = MapLike<any>;
 
-// @alpha @legacy
+// @beta @legacy
 export interface ReferencePosition {
     getOffset(): number;
     getSegment(): ISegment | undefined;
@@ -465,7 +465,7 @@ export interface ReferencePosition {
     slidingPreference?: SlidingPreference;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export enum ReferenceType {
     RangeBegin = 16,
     RangeEnd = 32,
@@ -477,32 +477,32 @@ export enum ReferenceType {
     Transient = 256
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const refGetTileLabels: (refPos: ReferencePosition) => string[] | undefined;
 
-// @alpha @legacy
+// @beta @legacy
 export function refHasTileLabel(refPos: ReferencePosition, label: string): boolean;
 
-// @alpha @legacy
+// @beta @legacy
 export const reservedMarkerIdKey = "markerId";
 
-// @alpha @legacy
+// @beta @legacy
 export function revertMergeTreeDeltaRevertibles(driver: MergeTreeRevertibleDriver, revertibles: MergeTreeDeltaRevertible[]): void;
 
-// @alpha @legacy
+// @beta @legacy
 export function segmentIsRemoved(segment: ISegment): boolean;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface SequenceOffsets {
     // (undocumented)
     posBreakpoints: number[];
     seqs: (number | AttributionKey | null)[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface SerializedAttributionCollection extends SequenceOffsets {
     // (undocumented)
     channels?: {
@@ -512,7 +512,7 @@ export interface SerializedAttributionCollection extends SequenceOffsets {
     length: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export enum Side {
     // (undocumented)
     After = 1,
@@ -520,16 +520,16 @@ export enum Side {
     Before = 0
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const SlidingPreference: {
     readonly BACKWARD: 0;
     readonly FORWARD: 1;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export type SlidingPreference = (typeof SlidingPreference)[keyof typeof SlidingPreference];
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export class TextSegment extends BaseSegment {
     constructor(text: string, props?: PropertySet);
     // (undocumented)
@@ -558,10 +558,10 @@ export class TextSegment extends BaseSegment {
     readonly type = "TextSegment";
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type Trackable = ISegment | LocalReferencePosition;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export class TrackingGroup implements ITrackingGroup {
     constructor();
     // (undocumented)
@@ -576,7 +576,7 @@ export class TrackingGroup implements ITrackingGroup {
     unlink(trackable: Trackable): boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class TrackingGroupCollection {
     constructor(trackable: Trackable);
     // (undocumented)

--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -14,8 +14,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { ISegment } from "./mergeTreeNodes.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface SequenceOffsets {
 	/**
@@ -36,8 +35,7 @@ export interface SequenceOffsets {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface SerializedAttributionCollection extends SequenceOffsets {
 	channels?: { [name: string]: SequenceOffsets };
@@ -46,8 +44,7 @@ export interface SerializedAttributionCollection extends SequenceOffsets {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IAttributionCollectionSpec<T> {
 	// eslint-disable-next-line @rushstack/no-new-null
@@ -58,8 +55,7 @@ export interface IAttributionCollectionSpec<T> {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface IAttributionCollectionSerializer {
@@ -81,8 +77,7 @@ export interface IAttributionCollectionSerializer {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IAttributionCollection<T> {
 	/**

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -20,8 +20,7 @@ import { ReferencePosition, refTypeIncludesFlag } from "./referencePositions.js"
 /**
  * Dictates the preferential direction for a {@link ReferencePosition} to slide
  * in a merge-tree
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SlidingPreference = {
 	/**
@@ -37,8 +36,7 @@ export const SlidingPreference = {
 /**
  * Dictates the preferential direction for a {@link ReferencePosition} to slide
  * in a merge-tree
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SlidingPreference = (typeof SlidingPreference)[keyof typeof SlidingPreference];
 
@@ -61,8 +59,7 @@ function _validateReferenceType(refType: ReferenceType): void {
 }
 /**
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface LocalReferencePosition extends ReferencePosition {
 	callbacks?: Partial<

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -215,8 +215,7 @@ function ackSegment(
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeOptions {
 	catchUpBlobName?: string;

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -11,8 +11,7 @@ import { IMergeTreeGroupMsg, IMergeTreeOp, MergeTreeDeltaType } from "./ops.js";
 import { PropertySet } from "./properties.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type MergeTreeDeltaOperationType =
 	| typeof MergeTreeDeltaType.ANNOTATE
@@ -25,8 +24,7 @@ export type MergeTreeDeltaOperationType =
  * Maintenance events correspond to structural segment changes or acks of pending segments.
  *
  * Note: these values are assigned negative integers to avoid clashing with `MergeTreeDeltaType`.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const MergeTreeMaintenanceType = {
 	/**
@@ -56,23 +54,20 @@ export const MergeTreeMaintenanceType = {
 	ACKNOWLEDGED: -4,
 } as const;
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type MergeTreeMaintenanceType =
 	(typeof MergeTreeMaintenanceType)[keyof typeof MergeTreeMaintenanceType];
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type MergeTreeDeltaOperationTypes =
 	| MergeTreeDeltaOperationType
 	| MergeTreeMaintenanceType;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeDeltaCallbackArgs<
 	TOperationType extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType,
@@ -94,8 +89,7 @@ export interface IMergeTreeDeltaCallbackArgs<
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeSegmentDelta {
 	/**
@@ -116,8 +110,7 @@ export interface IMergeTreeSegmentDelta {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeDeltaOpArgs {
 	/**
@@ -156,8 +149,7 @@ export type MergeTreeDeltaCallback = (
 ) => void;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IMergeTreeMaintenanceCallbackArgs

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -132,8 +132,7 @@ export type IMergeNode = MergeBlock | ISegmentLeaf;
 /**
  * A segment representing a portion of the merge tree.
  * Segments are leaf nodes of the merge tree and contain data.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISegment {
 	readonly type: string;
@@ -178,16 +177,14 @@ export interface ISegment {
 
 /**
  * Determine if a segment has been removed.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function segmentIsRemoved(segment: ISegment): boolean {
 	return isRemoved(segment);
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISegmentAction<TClientData> {
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
@@ -330,8 +327,7 @@ export function seqLTE(seq: number, minOrRefSeq: number): boolean {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export abstract class BaseSegment implements ISegment {
 	public cachedLength: number = 0;
@@ -469,8 +465,7 @@ export abstract class BaseSegment implements ISegment {
  *
  * @remarks In general, marker ids should be accessed using the inherent method
  * {@link Marker.getId}. Marker ids should not be updated after creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const reservedMarkerIdKey = "markerId";
 
@@ -480,8 +475,7 @@ export const reservedMarkerIdKey = "markerId";
 export const reservedMarkerSimpleTypeKey = "markerSimpleType";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IJSONMarkerSegment extends IJSONSegment {
 	marker: IMarkerDef;
@@ -496,8 +490,7 @@ export interface IJSONMarkerSegment extends IJSONSegment {
  * start of a paragraph to the end, assuming a paragraph is bound by markers at
  * the start and end.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class Marker extends BaseSegment implements ReferencePosition, ISegment {
 	public static readonly type = "Marker";

--- a/packages/dds/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/dds/merge-tree/src/mergeTreeTracking.ts
@@ -8,14 +8,12 @@ import { ISegment } from "./mergeTreeNodes.js";
 import { SortedSegmentSet } from "./sortedSegmentSet.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type Trackable = ISegment | LocalReferencePosition;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITrackingGroup {
 	tracked: readonly Trackable[];
@@ -26,8 +24,7 @@ export interface ITrackingGroup {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class TrackingGroup implements ITrackingGroup {
 	private readonly trackedSet: SortedSegmentSet<Trackable>;
@@ -104,8 +101,7 @@ export class UnorderedTrackingGroup implements ITrackingGroup {
 
 /**
  * A collection of {@link ITrackingGroup}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class TrackingGroupCollection {
 	private readonly _trackingGroups: Set<ITrackingGroup>;

--- a/packages/dds/merge-tree/src/ops.ts
+++ b/packages/dds/merge-tree/src/ops.ts
@@ -5,8 +5,7 @@
 
 /**
  * Flags enum that dictates behavior of a {@link ReferencePosition}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum ReferenceType {
 	Simple = 0x0,
@@ -49,8 +48,7 @@ export enum ReferenceType {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMarkerDef {
 	refType?: ReferenceType;
@@ -58,8 +56,7 @@ export interface IMarkerDef {
 
 // Note: Assigned positive integers to avoid clashing with MergeTreeMaintenanceType
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const MergeTreeDeltaType = {
 	INSERT: 0,
@@ -74,14 +71,12 @@ export const MergeTreeDeltaType = {
 } as const;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type MergeTreeDeltaType = (typeof MergeTreeDeltaType)[keyof typeof MergeTreeDeltaType];
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeDelta {
 	/**
@@ -92,8 +87,7 @@ export interface IMergeTreeDelta {
 
 /**
  * A position specified relative to a segment.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRelativePosition {
 	/**
@@ -113,8 +107,7 @@ export interface IRelativePosition {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.INSERT;
@@ -129,8 +122,7 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.REMOVE;
@@ -144,8 +136,7 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
  * @deprecated We no longer intend to support this functionality and it will
  * be removed in a future release. There is no replacement for this
  * functionality.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeObliterateMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.OBLITERATE;
@@ -164,8 +155,7 @@ export interface IMergeTreeObliterateMsg extends IMergeTreeDelta {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeObliterateSidedMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.OBLITERATE_SIDED;
@@ -184,8 +174,7 @@ export interface IMergeTreeObliterateSidedMsg extends IMergeTreeDelta {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.ANNOTATE;
@@ -200,8 +189,7 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 
 /**
  * Used to define per key adjustments in an {@link IMergeTreeAnnotateAdjustMsg}
- * @alpha
- * @legacy
+ * @legacy @beta
  */
 export interface AdjustParams {
 	/**
@@ -222,8 +210,7 @@ export interface AdjustParams {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeAnnotateAdjustMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.ANNOTATE;
@@ -240,8 +227,7 @@ export interface IMergeTreeAnnotateAdjustMsg extends IMergeTreeDelta {
  * release, as group ops are redundant with the native batching capabilities
  * of the runtime
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.GROUP;
@@ -249,8 +235,7 @@ export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IJSONSegment {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -258,8 +243,7 @@ export interface IJSONSegment {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IMergeTreeDeltaOp =
 	| IMergeTreeInsertMsg
@@ -270,7 +254,6 @@ export type IMergeTreeDeltaOp =
 	| IMergeTreeObliterateSidedMsg;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IMergeTreeOp = IMergeTreeDeltaOp | IMergeTreeGroupMsg;

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -5,8 +5,7 @@
 
 /**
  * Any mapping from a string to values of type `T`
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface MapLike<T> {
 	[index: string]: T;
@@ -20,8 +19,7 @@ export interface MapLike<T> {
  * @privateRemarks PropertySet is typed using `any` because when you include
  * custom methods such as toJSON(), JSON.stringify accepts most types other than
  * functions
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PropertySet = MapLike<any>;

--- a/packages/dds/merge-tree/src/referencePositions.ts
+++ b/packages/dds/merge-tree/src/referencePositions.ts
@@ -33,8 +33,7 @@ export function refTypeIncludesFlag(
 
 /**
  * Gets the tile labels stored in the given reference position.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const refGetTileLabels = (refPos: ReferencePosition): string[] | undefined =>
 	refTypeIncludesFlag(refPos, ReferenceType.Tile) && refPos.properties
@@ -43,8 +42,7 @@ export const refGetTileLabels = (refPos: ReferencePosition): string[] | undefine
 
 /**
  * Determines if a reference position has the given tile label.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function refHasTileLabel(refPos: ReferencePosition, label: string): boolean {
 	const tileLabels = refGetTileLabels(refPos);
@@ -63,8 +61,7 @@ export function refHasTileLabels(refPos: ReferencePosition): boolean {
  * Represents a reference to a place within a merge tree. This place conceptually remains stable over time
  * by referring to a particular segment and offset within that segment.
  * Thus, this reference's character position changes as the tree is edited.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ReferencePosition {
 	/**

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -29,8 +29,7 @@ import { DetachedReferencePosition } from "./referencePositions.js";
 import { toRemovalInfo } from "./segmentInfos.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type MergeTreeDeltaRevertible =
 	| {
@@ -72,8 +71,7 @@ interface RemoveSegmentRefProperties {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface MergeTreeRevertibleDriver {
 	insertFromSpec(pos: number, spec: IJSONSegment): void;
@@ -203,8 +201,7 @@ function appendLocalAnnotateToRevertibles(
 /**
  * Appends a merge tree delta to the list of revertibles.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function appendToMergeTreeDeltaRevertibles(
 	deltaArgs: IMergeTreeDeltaCallbackArgs,
@@ -240,8 +237,7 @@ export function appendToMergeTreeDeltaRevertibles(
 /**
  * Removes all revertibles from the list of revertibles.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function discardMergeTreeDeltaRevertible(
 	revertibles: MergeTreeDeltaRevertible[],
@@ -403,8 +399,7 @@ function getPosition(mergeTreeWithRevert: MergeTreeWithRevert, segment: ISegment
 /**
  * Reverts all operations in the list of revertibles.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function revertMergeTreeDeltaRevertibles(
 	driver: MergeTreeRevertibleDriver,

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -26,8 +26,7 @@
  * If a SequencePlace is the endpoint of a range (e.g. start/end of an interval or search range),
  * the Side value means it is exclusive if it is nearer to the other position and inclusive if it is farther.
  * E.g. the start of a range with Side.After is exclusive of the character at the position.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
@@ -35,8 +34,7 @@ export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
  * A sequence place that does not refer to the special endpoint segments.
  *
  * See {@link SequencePlace} for additional context.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface InteriorSequencePlace {
 	pos: number;
@@ -47,8 +45,7 @@ export interface InteriorSequencePlace {
  * Defines a side relative to a character in a sequence.
  *
  * @remarks See {@link SequencePlace} for additional context on usage.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum Side {
 	Before = 0,
@@ -58,8 +55,7 @@ export enum Side {
 /**
  * Returns the position and side of the start and end of a sequence.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function endpointPosAndSide(
 	start: SequencePlace | undefined,

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -21,16 +21,14 @@ import type { PropertySet } from "./properties.js";
 export const TextSegmentGranularity = 256;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IJSONTextSegment extends IJSONSegment {
 	text: string;
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class TextSegment extends BaseSegment {
 	public static readonly type = "TextSegment";

--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.alpha.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.alpha.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export type ConsensusCallback<T> = (value: T) => Promise<ConsensusResult>;
 
-// @alpha @legacy
+// @beta @legacy
 export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensusOrderedCollectionEvents<T>> implements IConsensusOrderedCollection<T> {
     protected constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, data: IOrderedCollection<T>);
     acquire(callback: ConsensusCallback<T>): Promise<boolean>;
@@ -34,18 +34,18 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensus
     waitAndAcquire(callback: ConsensusCallback<T>): Promise<void>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const ConsensusQueue: ISharedObjectKind<IConsensusOrderedCollection<any>> & SharedObjectKind<IConsensusOrderedCollection<any>>;
 
-// @alpha @legacy
+// @beta @legacy
 export type ConsensusQueue<T = any> = ConsensusQueueClass<T>;
 
-// @alpha @legacy
+// @beta @legacy
 export class ConsensusQueueClass<T = any> extends ConsensusOrderedCollection<T> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum ConsensusResult {
     // (undocumented)
     Complete = 1,
@@ -53,14 +53,14 @@ export enum ConsensusResult {
     Release = 0
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConsensusOrderedCollection<T = any> extends ISharedObject<IConsensusOrderedCollectionEvents<T>> {
     acquire(callback: ConsensusCallback<T>): Promise<boolean>;
     add(value: T): Promise<void>;
     waitAndAcquire(callback: ConsensusCallback<T>): Promise<void>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConsensusOrderedCollectionEvents<T> extends ISharedObjectEvents {
     (event: "add", listener: (value: T, newlyAdded: boolean) => void): this;
     (event: "acquire", listener: (value: T, clientId?: string) => void): this;
@@ -68,14 +68,14 @@ export interface IConsensusOrderedCollectionEvents<T> extends ISharedObjectEvent
     (event: "localRelease", listener: (value: T, intentional: boolean) => void): this;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IOrderedCollection<T = any> extends ISnapshotable<T> {
     add(value: T): any;
     remove(): T;
     size(): number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISnapshotable<T> {
     // (undocumented)
     asArray(): T[];

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -97,8 +97,7 @@ const idForLocalUnattachedClient = undefined;
  *
  * Generally not used directly. A derived type will pass in a backing data type
  * IOrderedCollection that will define the deterministic add/acquire order and snapshot ability.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 
 // TODO: #22835 Use undefined instead of any (breaking change)

--- a/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -62,15 +62,13 @@ export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory
 
 /**
  * {@inheritDoc ConsensusQueueClass}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const ConsensusQueue = createSharedObjectKind(ConsensusQueueFactory);
 
 /**
  * {@inheritDoc ConsensusQueueClass}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dds/ordered-collection/src/consensusQueue.ts
+++ b/packages/dds/ordered-collection/src/consensusQueue.ts
@@ -32,8 +32,7 @@ class SnapshotableQueue<T> extends SnapshotableArray<T> implements IOrderedColle
  * Implementation of a consensus stack
  *
  * An derived type of ConsensusOrderedCollection with a queue as the backing data and order.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dds/ordered-collection/src/interfaces.ts
+++ b/packages/dds/ordered-collection/src/interfaces.ts
@@ -15,8 +15,7 @@ import {
 } from "@fluidframework/shared-object-base/internal";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum ConsensusResult {
 	Release,
@@ -26,8 +25,7 @@ export enum ConsensusResult {
 /**
  * Callback provided to acquire() and waitAndAcquire() methods.
  * @returns ConsensusResult indicating whether item was completed, or releases back to the queue.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ConsensusCallback<T> = (value: T) => Promise<ConsensusResult>;
 
@@ -51,8 +49,7 @@ export interface IConsensusOrderedCollectionFactory extends IChannelFactory {
 
 /**
  * Events notifying about addition, acquisition, release and completion of items
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IConsensusOrderedCollectionEvents<T> extends ISharedObjectEvents {
 	/**
@@ -105,8 +102,7 @@ export interface IConsensusOrderedCollectionEvents<T> extends ISharedObjectEvent
  * All objects added to the collection will be cloned (via JSON).
  * They will not be references to the original input object.  Thus changed to
  * the input object will not reflect the object in the collection.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,8 +132,7 @@ export interface IConsensusOrderedCollection<T = any>
  *
  * TODO: move this to be use in other place
  * TODO: currently input and output is not symmetrical, can they become symmetrical?
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISnapshotable<T> {
 	asArray(): T[];
@@ -151,8 +146,7 @@ export interface ISnapshotable<T> {
  * Collection of objects that has deterministic add and remove ordering.
  * Object implementing this interface can be used as the data backing
  * for the ConsensusOrderedCollection
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dds/register-collection/api-report/register-collection.legacy.alpha.api.md
+++ b/packages/dds/register-collection/api-report/register-collection.legacy.alpha.api.md
@@ -4,13 +4,13 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export const ConsensusRegisterCollection: ISharedObjectKind<IConsensusRegisterCollection<any>> & SharedObjectKind<IConsensusRegisterCollection<any>>;
 
-// @alpha @legacy
+// @beta @legacy
 export type ConsensusRegisterCollection<T> = IConsensusRegisterCollection<T>;
 
-// @alpha @legacy
+// @beta @legacy
 export class ConsensusRegisterCollectionClass<T> extends SharedObject<IConsensusRegisterCollectionEvents> implements IConsensusRegisterCollection<T> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // (undocumented)
@@ -32,7 +32,7 @@ export class ConsensusRegisterCollectionClass<T> extends SharedObject<IConsensus
     write(key: string, value: T): Promise<boolean>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class ConsensusRegisterCollectionFactory implements IChannelFactory<IConsensusRegisterCollection> {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -47,7 +47,7 @@ export class ConsensusRegisterCollectionFactory implements IChannelFactory<ICons
     get type(): string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConsensusRegisterCollection<T = any> extends ISharedObject<IConsensusRegisterCollectionEvents> {
     keys(): string[];
     read(key: string, policy?: ReadPolicy): T | undefined;
@@ -55,16 +55,16 @@ export interface IConsensusRegisterCollection<T = any> extends ISharedObject<ICo
     write(key: string, value: T): Promise<boolean>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConsensusRegisterCollectionEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: "atomicChanged" | "versionChanged", listener: (key: string, value: any, local: boolean) => void): any;
 }
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export type IConsensusRegisterCollectionFactory = IChannelFactory<IConsensusRegisterCollection>;
 
-// @alpha @legacy
+// @beta @legacy
 export enum ReadPolicy {
     // (undocumented)
     Atomic = 0,

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -120,8 +120,7 @@ interface IConsensusRegisterCollectionInternalEvents {
 
 /**
  * {@inheritDoc IConsensusRegisterCollection}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class ConsensusRegisterCollection<T>
 	extends SharedObject<IConsensusRegisterCollectionEvents>

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -17,8 +17,7 @@ import { pkgVersion } from "./packageVersion.js";
 
 /**
  * The factory that defines the consensus queue.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class ConsensusRegisterCollectionFactory
 	implements IChannelFactory<IConsensusRegisterCollection>
@@ -66,15 +65,13 @@ export class ConsensusRegisterCollectionFactory
 
 /**
  * {@inheritDoc IConsensusRegisterCollection}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const ConsensusRegisterCollection = createSharedObjectKind(
 	ConsensusRegisterCollectionFactory,
 );
 /**
  * Compatibility alias for {@link IConsensusRegisterCollection}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ConsensusRegisterCollection<T> = IConsensusRegisterCollection<T>;

--- a/packages/dds/register-collection/src/interfaces.ts
+++ b/packages/dds/register-collection/src/interfaces.ts
@@ -14,8 +14,7 @@ import {
  *
  * Extends the base IChannelFactory to return a more definite type of IConsensusRegisterCollection
  * Use for the runtime to create and load distributed data structure by type name of each channel.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @deprecated Use `IChannelFactory<IConsensusRegisterCollection>`.
  */
 export type IConsensusRegisterCollectionFactory =
@@ -23,8 +22,7 @@ export type IConsensusRegisterCollectionFactory =
 
 /**
  * Events emitted by {@link IConsensusRegisterCollection}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IConsensusRegisterCollectionEvents extends ISharedObjectEvents {
 	(
@@ -49,8 +47,7 @@ export interface IConsensusRegisterCollectionEvents extends ISharedObjectEvents 
  * the value. So we can safely return the first value.
  *
  * LWW: The last write to a key always wins.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IConsensusRegisterCollection<T = any>
 	extends ISharedObject<IConsensusRegisterCollectionEvents> {
@@ -80,8 +77,7 @@ export interface IConsensusRegisterCollection<T = any>
 
 /**
  * Read policies used when reading the map value.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum ReadPolicy {
 	// On a concurrent update, returns the first agreed upon value amongst all clients.

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -4,33 +4,33 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export function appendAddIntervalToRevertibles(interval: SequenceInterval, revertibles: SharedStringRevertible[]): SharedStringRevertible[];
 
-// @alpha @legacy
+// @beta @legacy
 export function appendChangeIntervalToRevertibles(string: ISharedString, newInterval: SequenceInterval, previousInterval: SequenceInterval, revertibles: SharedStringRevertible[]): SharedStringRevertible[];
 
-// @alpha @legacy
+// @beta @legacy
 export function appendDeleteIntervalToRevertibles(string: ISharedString, interval: SequenceInterval, revertibles: SharedStringRevertible[]): SharedStringRevertible[];
 
-// @alpha @legacy
+// @beta @legacy
 export function appendIntervalPropertyChangedToRevertibles(interval: SequenceInterval, deltas: PropertySet, revertibles: SharedStringRevertible[]): SharedStringRevertible[];
 
-// @alpha @legacy
+// @beta @legacy
 export function appendSharedStringDeltaToRevertibles(string: ISharedString, delta: SequenceDeltaEvent, revertibles: SharedStringRevertible[]): void;
 
 export { BaseSegment }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export function createOverlappingIntervalsIndex(sharedString: ISharedString): ISequenceOverlappingIntervalsIndex;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type DeserializeCallback = (properties: PropertySet) => void;
 
-// @alpha @legacy
+// @beta @legacy
 export function discardSharedStringRevertibles(sharedString: ISharedString, revertibles: SharedStringRevertible[]): void;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IInterval {
     compare(b: IInterval): number;
     compareEnd(b: IInterval): number;
@@ -41,7 +41,7 @@ export interface IInterval {
 
 export { InteriorSequencePlace }
 
-// @alpha @legacy
+// @beta @legacy
 export const IntervalOpType: {
     readonly PROPERTY_CHANGED: "propertyChanged";
     readonly POSITION_REMOVE: "positionRemove";
@@ -50,10 +50,10 @@ export const IntervalOpType: {
     readonly CHANGE: "change";
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
 
-// @alpha @legacy
+// @beta @legacy
 export type IntervalRevertible = {
     event: typeof IntervalOpType.CHANGE;
     interval: SequenceInterval;
@@ -87,7 +87,7 @@ export type IntervalRevertible = {
     mergeTreeRevertible: MergeTreeDeltaRevertible;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export const IntervalStickiness: {
     readonly NONE: 0;
     readonly START: 1;
@@ -95,10 +95,10 @@ export const IntervalStickiness: {
     readonly FULL: 3;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export type IntervalStickiness = (typeof IntervalStickiness)[keyof typeof IntervalStickiness];
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum IntervalType {
     // (undocumented)
     Simple = 0,
@@ -107,7 +107,7 @@ export enum IntervalType {
 
 export { ISegment }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     operation: TOperation;
     position: number;
@@ -115,7 +115,7 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
     segment: ISegment;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequenceIntervalCollection extends TypedEventEmitter<ISequenceIntervalCollectionEvents> {
     // (undocumented)
     [Symbol.iterator](): Iterator<SequenceInterval>;
@@ -156,7 +156,7 @@ export interface ISequenceIntervalCollection extends TypedEventEmitter<ISequence
     removeIntervalById(id: string): SequenceInterval | undefined;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequenceIntervalCollectionEvents extends IEvent {
     (event: "changeInterval", listener: (interval: SequenceInterval, previousInterval: SequenceInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: SequenceInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
@@ -164,14 +164,14 @@ export interface ISequenceIntervalCollectionEvents extends IEvent {
     (event: "changed", listener: (interval: SequenceInterval, propertyDeltas: PropertySet, previousInterval: SequenceInterval | undefined, local: boolean, slide: boolean) => void): void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISequenceOverlappingIntervalsIndex extends SequenceIntervalIndex {
     // (undocumented)
     findOverlappingIntervals(start: SequencePlace, end: SequencePlace): SequenceInterval[];
     gatherIterationResults(results: SequenceInterval[], iteratesForward: boolean, start?: SequencePlace, end?: SequencePlace): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISerializedInterval {
     end: number | "start" | "end";
     // (undocumented)
@@ -185,7 +185,7 @@ export interface ISerializedInterval {
     stickiness?: IntervalStickiness;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISharedSegmentSequence<T extends ISegment> extends ISharedObject<ISharedSegmentSequenceEvents>, MergeTreeRevertibleDriver {
     annotateAdjustRange(start: number, end: number, adjust: MapLike<AdjustParams>): void;
     annotateRange(start: number, end: number, props: PropertySet): void;
@@ -223,7 +223,7 @@ export interface ISharedSegmentSequence<T extends ISegment> extends ISharedObjec
     walkSegments<TClientData>(handler: ISegmentAction<TClientData>, start?: number, end?: number, accum?: TClientData, splitRange?: boolean): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: "createIntervalCollection", listener: (label: string, local: boolean, target: IEventThisPlaceHolder) => void): void;
@@ -233,7 +233,7 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     (event: "maintenance", listener: (event: SequenceMaintenanceEvent, target: IEventThisPlaceHolder) => void): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedString extends ISharedSegmentSequence<SharedStringSegment> {
     annotateMarker(marker: Marker, props: PropertySet): void;
     getMarkerFromId(id: string): ISegment | undefined;
@@ -266,17 +266,17 @@ export { ReferenceType }
 
 export { reservedMarkerIdKey }
 
-// @alpha @legacy
+// @beta @legacy
 export function revertSharedStringRevertibles(sharedString: ISharedString, revertibles: SharedStringRevertible[]): void;
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
     readonly isLocal: boolean;
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     readonly clientId: string | undefined;
     // (undocumented)
@@ -288,7 +288,7 @@ export interface SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes =
     readonly ranges: readonly Readonly<ISequenceDeltaRange<TOperation>>[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceInterval extends IInterval {
     compare(b: SequenceInterval): number;
     compareEnd(b: SequenceInterval): number;
@@ -312,13 +312,13 @@ export interface SequenceInterval extends IInterval {
     readonly stickiness: IntervalStickiness;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceIntervalIndex {
     add(interval: SequenceInterval): void;
     remove(interval: SequenceInterval): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
@@ -326,16 +326,16 @@ export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMainten
 
 export { SequencePlace }
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedString: ISharedObjectKind<ISharedString> & SharedObjectKind<ISharedString>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedString = ISharedString;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertible;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type SharedStringSegment = TextSegment | Marker;
 
 export { Side }

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -334,8 +334,7 @@ export class LocalIntervalCollection {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type DeserializeCallback = (properties: PropertySet) => void;
 
@@ -372,8 +371,7 @@ class IntervalCollectionIterator implements Iterator<SequenceIntervalClass> {
 
 /**
  * Change events emitted by `IntervalCollection`s
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISequenceIntervalCollectionEvents extends IEvent {
 	/**
@@ -457,8 +455,7 @@ export interface ISequenceIntervalCollectionEvents extends IEvent {
 /**
  * Collection of intervals that supports addition, modification, removal, and efficient spatial querying.
  * Changes to this collection will be incur updates on collaborating clients (i.e. they are not local-only).
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISequenceIntervalCollection
 	extends TypedEventEmitter<ISequenceIntervalCollectionEvents> {

--- a/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
@@ -13,8 +13,7 @@ import { type SequenceInterval } from "../intervals/index.js";
  * - "find all intervals with start endpoint between these two points"
  * - "find all intervals which overlap this range"
  * etc.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface SequenceIntervalIndex {
 	/**

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -20,8 +20,7 @@ import { ISharedString } from "../sharedString.js";
 import { type SequenceIntervalIndex } from "./intervalIndex.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISequenceOverlappingIntervalsIndex extends SequenceIntervalIndex {
 	/**
@@ -169,8 +168,7 @@ export class OverlappingIntervalsIndex implements ISequenceOverlappingIntervalsI
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function createOverlappingIntervalsIndex(
 	sharedString: ISharedString,

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -9,8 +9,7 @@ import { PropertySet, SlidingPreference, Side } from "@fluidframework/merge-tree
 
 /**
  * Basic interval abstraction
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IInterval {
 	/**
@@ -55,8 +54,7 @@ export type IntervalDeltaOpType =
 
 /**
  * Values are used in revertibles.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IntervalOpType = {
 	...IntervalDeltaOpType,
@@ -64,14 +62,12 @@ export const IntervalOpType = {
 	POSITION_REMOVE: "positionRemove",
 } as const;
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum IntervalType {
 	Simple = 0x0,
@@ -94,8 +90,7 @@ export enum IntervalType {
 /**
  * Serialized object representation of an interval.
  * This representation is used for ops that create or change intervals.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISerializedInterval {
 	/**
@@ -192,8 +187,7 @@ export type CompressedSerializedInterval =
  * Note that interval stickiness is currently an experimental feature and must
  * be explicitly enabled with the `intervalStickinessEnabled` flag
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IntervalStickiness = {
 	/**
@@ -225,8 +219,7 @@ export const IntervalStickiness = {
  *
  * Note that interval stickiness is currently an experimental feature and must
  * be explicitly enabled with the `intervalStickinessEnabled` flag
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IntervalStickiness = (typeof IntervalStickiness)[keyof typeof IntervalStickiness];
 

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -125,8 +125,7 @@ export function getSerializedProperties(
  * `mergeTreeReferencesCanSlideToEndpoint` feature flag set to true, the endpoints
  * of the interval that are exclusive will have the ability to slide to these
  * special endpoint segments.
- * @alpha
- * @legacy
+ * @legacy @beta
  */
 export interface SequenceInterval extends IInterval {
 	readonly start: LocalReferencePosition;

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -34,8 +34,7 @@ import { ISharedString, SharedStringSegment } from "./sharedString.js";
 
 /**
  * Data for undoing edits on SharedStrings and Intervals.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertible;
 
@@ -43,8 +42,7 @@ const idMap = new Map<string, string>();
 
 /**
  * Data for undoing edits affecting Intervals.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IntervalRevertible =
 	| {
@@ -100,8 +98,7 @@ function getUpdatedId(intervalId: string): string {
 
 /**
  * Create revertibles for adding an interval
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function appendAddIntervalToRevertibles(
 	interval: SequenceInterval,
@@ -117,8 +114,7 @@ export function appendAddIntervalToRevertibles(
 
 /**
  * Create revertibles for deleting an interval
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function appendDeleteIntervalToRevertibles(
 	string: ISharedString,
@@ -168,8 +164,7 @@ export function appendDeleteIntervalToRevertibles(
 
 /**
  * Create revertibles for moving endpoints of an interval
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function appendChangeIntervalToRevertibles(
 	string: ISharedString,
@@ -217,8 +212,7 @@ export function appendChangeIntervalToRevertibles(
 
 /**
  * Create revertibles for changing properties of an interval
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function appendIntervalPropertyChangedToRevertibles(
 	interval: SequenceInterval,
@@ -278,8 +272,7 @@ function addIfRevertibleRef(
 /**
  * Create revertibles for SharedStringDeltas, handling indirectly modified intervals
  * (e.g. reverting remove of a range that contains an interval will move the interval back)
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function appendSharedStringDeltaToRevertibles(
 	string: ISharedString,
@@ -376,8 +369,7 @@ export function appendSharedStringDeltaToRevertibles(
 
 /**
  * Clean up resources held by revertibles that are no longer needed.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function discardSharedStringRevertibles(
 	sharedString: ISharedString,
@@ -673,8 +665,7 @@ function revertLocalSequenceRemove(
 
 /**
  * Invoke revertibles to reverse prior edits
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function revertSharedStringRevertibles(
 	sharedString: ISharedString,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -113,8 +113,7 @@ const contentPath = "content";
  * - `event` - Various information on the segments that were modified.
  *
  * - `target` - The sequence itself.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 	(
@@ -132,8 +131,7 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedSegmentSequence<T extends ISegment>
 	extends ISharedObject<ISharedSegmentSequenceEvents>,

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -24,8 +24,7 @@ import {
  * The properties of this object and its sub-objects represent the state of the sequence at the
  * point in time at which the operation was applied.
  * They will not take into any future modifications performed to the underlying sequence and merge tree.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface SequenceEvent<
 	TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes,
@@ -153,8 +152,7 @@ export abstract class SequenceEventClass<
  * For group ops, each op will get its own event, and the group op property will be set on the op args.
  *
  * Ops may get multiple events. For instance, an insert-replace will get a remove then an insert event.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
 	readonly opArgs: IMergeTreeDeltaOpArgs;
@@ -183,8 +181,7 @@ export class SequenceDeltaEventClass
  * The properties of this object and its sub-objects represent the state of the sequence at the
  * point in time at which the operation was applied.
  * They will not take into consideration any future modifications performed to the underlying sequence and merge tree.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
 	readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
@@ -209,8 +206,7 @@ export class SequenceMaintenanceEventClass
 
 /**
  * A range that has changed corresponding to a segment modification.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISequenceDeltaRange<
 	TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes,

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -74,14 +74,12 @@ export class SharedStringFactory implements IChannelFactory<ISharedString> {
 
 /**
  * Entrypoint for {@link ISharedString} creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedString = createSharedObjectKind<ISharedString>(SharedStringFactory);
 
 /**
  * Alias for {@link ISharedString} for compatibility.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SharedString = ISharedString;

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -24,8 +24,7 @@ import { SharedStringFactory } from "./sequenceFactory.js";
 
 /**
  * Fluid object interface describing access methods on a SharedString
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedString extends ISharedSegmentSequence<SharedStringSegment> {
 	/**
@@ -125,8 +124,7 @@ export interface ISharedString extends ISharedSegmentSequence<SharedStringSegmen
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SharedStringSegment = TextSegment | Marker;
 

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IFluidSerializer {
     decode(input: unknown): unknown;
     encode(value: unknown, bind: IFluidHandle): unknown;
@@ -12,12 +12,12 @@ export interface IFluidSerializer {
     stringify(value: unknown, bind: IFluidHandle): string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends IChannel, IEventProvider<TEvent> {
     bindToContext(): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedObjectEvents extends IErrorEvent {
     // @eventProperty
     (event: "pre-op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -25,19 +25,19 @@ export interface ISharedObjectEvents extends IErrorEvent {
     (event: "op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedObjectKind<TSharedObject> {
     create(runtime: IFluidDataStoreRuntime, id?: string): TSharedObject;
     getFactory(): IChannelFactory<TSharedObject>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function makeHandlesSerializable(value: unknown, serializer: IFluidSerializer, bind: IFluidHandle): unknown;
 
-// @alpha @legacy
+// @beta @legacy
 export function parseHandles(value: unknown, serializer: IFluidSerializer): unknown;
 
-// @alpha @legacy
+// @beta @legacy
 export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends SharedObjectCore<TEvent> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes,
     telemetryContextPrefix: string);
@@ -50,7 +50,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext, fullTree?: boolean): ISummaryTreeWithStats;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends EventEmitterWithErrorHandling<TEvent> implements ISharedObject<TEvent> {
     constructor(
     id: string,

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -22,8 +22,7 @@ import {
 import { isISharedObjectHandle, type ISharedObjectHandle } from "./handle.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidSerializer {
 	/**

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -83,8 +83,7 @@ interface ProcessTelemetryProperties {
  *
  * TODO:
  * This class should eventually be made internal, as custom subclasses of it outside this repository are intended to be made unsupported in the future.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export abstract class SharedObjectCore<
 		TEvent extends ISharedObjectEvents = ISharedObjectEvents,
@@ -789,8 +788,7 @@ export abstract class SharedObjectCore<
  * This class is badly named.
  * Once it becomes `@internal` "SharedObjectCore" should probably become "SharedObject"
  * and this class should be renamed to something like "SharedObjectSynchronous".
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export abstract class SharedObject<
 	TEvent extends ISharedObjectEvents = ISharedObjectEvents,
@@ -979,8 +977,7 @@ export abstract class SharedObject<
  * This does not extend {@link SharedObjectKind} since doing so would prevent implementing this interface in type safe code.
  * Any implementation of this can safely be used as a {@link SharedObjectKind} with an explicit type conversion,
  * but doing so is typically not needed as {@link createSharedObjectKind} is used to produce values that are both types simultaneously.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedObjectKind<TSharedObject> {
 	/**

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -13,8 +13,7 @@ import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitio
 
 /**
  * Events emitted by {@link ISharedObject}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedObjectEvents extends IErrorEvent {
 	/**
@@ -66,8 +65,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
  * Additionally the docs here need to define what a shared object is, not just claim this interface is for them.
  * If the intention is that the "shared object" concept `IFluidLoadable` mentions is only ever implemented by this interface then even more concept unification should be done.
  * If not then more clarity is needed on what this interface specifically is, what the other "shared object" concept means and how they relate.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents>
 	extends IChannel,

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -39,8 +39,7 @@ export function serializeHandles(
  * @param context - The handle context for the container
  * @param bind - Bind any other handles we find in the object against this given handle.
  * @returns The fully-plain object
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function makeHandlesSerializable(
 	value: unknown,
@@ -58,8 +57,7 @@ export function makeHandlesSerializable(
  * @param serializer - The serializer that knows how to convert serializable-form handles into handle objects
  * @param context - The handle context for the container
  * @returns The mostly-plain object with handle objects within
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function parseHandles(value: unknown, serializer: IFluidSerializer): unknown {
 	return serializer.decode(value);

--- a/packages/dds/shared-summary-block/api-report/shared-summary-block.legacy.alpha.api.md
+++ b/packages/dds/shared-summary-block/api-report/shared-summary-block.legacy.alpha.api.md
@@ -4,16 +4,16 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedSummaryBlock extends ISharedObject {
     get<T>(key: string): Jsonable<T>;
     set<T>(key: string, value: Jsonable<T>): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedSummaryBlock: ISharedObjectKind<ISharedSummaryBlock> & SharedObjectKind<ISharedSummaryBlock>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedSummaryBlock = ISharedSummaryBlock;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -11,8 +11,7 @@ import type { ISharedObject } from "@fluidframework/shared-object-base/internal"
  * The set on this interface must only be called in response to a remote op. Basically, if we replay same ops,
  * the set of calls on this interface to set data should be the same. This is critical because the object does not
  * generate ops of its own, but relies on the above principle to maintain eventual consistency and to summarize.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedSummaryBlock extends ISharedObject {
 	/**

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -33,8 +33,7 @@ interface ISharedSummaryBlockDataSerializable {
 /**
  * Implementation of a shared summary block. It does not generate any ops. It is only part of the summary.
  * Data should be set in this object in response to a remote op.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class SharedSummaryBlockClass extends SharedObject implements ISharedSummaryBlock {
 	/**

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
@@ -79,14 +79,12 @@ export class SharedSummaryBlockFactory implements IChannelFactory<ISharedSummary
 
 /**
  * {@inheritDoc ISharedSummaryBlock}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedSummaryBlock = createSharedObjectKind(SharedSummaryBlockFactory);
 
 /**
  * {@inheritDoc ISharedSummaryBlock}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SharedSummaryBlock = ISharedSummaryBlock;

--- a/packages/dds/task-manager/api-report/task-manager.legacy.alpha.api.md
+++ b/packages/dds/task-manager/api-report/task-manager.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     abandon(taskId: string): void;
     assigned(taskId: string): boolean;
@@ -16,7 +16,7 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     volunteerForTask(taskId: string): Promise<boolean>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITaskManagerEvents extends ISharedObjectEvents {
     // @eventProperty
     (event: "assigned", listener: TaskEventListener): any;
@@ -26,13 +26,13 @@ export interface ITaskManagerEvents extends ISharedObjectEvents {
     (event: "lost", listener: TaskEventListener): any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type TaskEventListener = (taskId: string) => void;
 
-// @alpha @legacy
+// @beta @legacy
 export const TaskManager: ISharedObjectKind<ITaskManager> & SharedObjectKind<ITaskManager>;
 
-// @alpha @legacy
+// @beta @legacy
 export type TaskManager = ITaskManager;
 
 ```

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -12,15 +12,13 @@ import type {
  * Describes the event listener format for {@link ITaskManagerEvents} events.
  *
  * @param taskId - The unique identifier of the related task.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type TaskEventListener = (taskId: string) => void;
 
 /**
  * Events emitted by {@link ITaskManager}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITaskManagerEvents extends ISharedObjectEvents {
 	/**
@@ -138,8 +136,7 @@ export interface ITaskManagerEvents extends ISharedObjectEvents {
  * when using {@link ITaskManager.subscribeToTask}.
  *
  * See {@link ITaskManagerEvents} for more details.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
 	/**

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -62,8 +62,7 @@ const placeholderClientId = "placeholder";
  * {@inheritDoc ITaskManager}
  *
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class TaskManagerClass
 	extends SharedObject<ITaskManagerEvents>

--- a/packages/dds/task-manager/src/taskManagerFactory.ts
+++ b/packages/dds/task-manager/src/taskManagerFactory.ts
@@ -58,14 +58,12 @@ export class TaskManagerFactory implements IChannelFactory<ITaskManager> {
 
 /**
  * {@inheritDoc ITaskManager}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const TaskManager = createSharedObjectKind(TaskManagerFactory);
 
 /**
  * {@inheritDoc ITaskManager}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type TaskManager = ITaskManager;

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -368,7 +368,7 @@ export interface SchemaStatics {
 // @public @system
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedTree: ISharedObjectKind<ITree> & SharedObjectKind<ITree>;
 
 // @alpha @legacy

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -84,8 +84,7 @@ function treeKernelFactory(
 /**
  * SharedTree is a hierarchical data structure for collaboratively editing strongly typed JSON-like trees
  * of objects, arrays, and other data types.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const SharedTree = configuredSharedTree({});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -75,7 +75,7 @@ export interface ContainerSchema {
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type DeserializeCallback = (properties: PropertySet) => void;
 
 // @public @sealed
@@ -427,7 +427,7 @@ export interface IFluidLoadable extends IProvideFluidLoadable {
     readonly handle: IFluidHandle;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IInterval {
     compare(b: IInterval): number;
     compareEnd(b: IInterval): number;
@@ -509,7 +509,7 @@ declare namespace InternalTypes {
 }
 export { InternalTypes }
 
-// @alpha @legacy
+// @beta @legacy
 export const IntervalStickiness: {
     readonly NONE: 0;
     readonly START: 1;
@@ -517,10 +517,10 @@ export const IntervalStickiness: {
     readonly FULL: 3;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export type IntervalStickiness = (typeof IntervalStickiness)[keyof typeof IntervalStickiness];
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum IntervalType {
     // (undocumented)
     Simple = 0,
@@ -554,7 +554,7 @@ export interface ISequencedDocumentMessage {
     type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     operation: TOperation;
     position: number;
@@ -562,7 +562,7 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
     segment: ISegment;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequenceIntervalCollection extends TypedEventEmitter<ISequenceIntervalCollectionEvents> {
     // (undocumented)
     [Symbol.iterator](): Iterator<SequenceInterval>;
@@ -603,7 +603,7 @@ export interface ISequenceIntervalCollection extends TypedEventEmitter<ISequence
     removeIntervalById(id: string): SequenceInterval | undefined;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequenceIntervalCollectionEvents extends IEvent {
     (event: "changeInterval", listener: (interval: SequenceInterval, previousInterval: SequenceInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: SequenceInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
@@ -611,7 +611,7 @@ export interface ISequenceIntervalCollectionEvents extends IEvent {
     (event: "changed", listener: (interval: SequenceInterval, propertyDeltas: PropertySet, previousInterval: SequenceInterval | undefined, local: boolean, slide: boolean) => void): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISerializedInterval {
     end: number | "start" | "end";
     // (undocumented)
@@ -644,7 +644,7 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 // @public
 export function isFluidHandle(value: unknown): value is IFluidHandle;
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>, Omit<IDirectory, "on" | "once" | "off"> {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<[string, any]>;
@@ -652,7 +652,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
     readonly [Symbol.toStringTag]: string;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -660,24 +660,24 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
     get<T = any>(key: string): T | undefined;
     set<T = unknown>(key: string, value: T): this;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends IChannel, IEventProvider<TEvent> {
     bindToContext(): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedObjectEvents extends IErrorEvent {
     // @eventProperty
     (event: "pre-op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -685,7 +685,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
     (event: "op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISharedSegmentSequence<T extends ISegment> extends ISharedObject<ISharedSegmentSequenceEvents>, MergeTreeRevertibleDriver {
     annotateAdjustRange(start: number, end: number, adjust: MapLike<AdjustParams>): void;
     annotateRange(start: number, end: number, props: PropertySet): void;
@@ -723,7 +723,7 @@ export interface ISharedSegmentSequence<T extends ISegment> extends ISharedObjec
     walkSegments<TClientData>(handler: ISegmentAction<TClientData>, start?: number, end?: number, accum?: TClientData, splitRange?: boolean): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: "createIntervalCollection", listener: (label: string, local: boolean, target: IEventThisPlaceHolder) => void): void;
@@ -733,7 +733,7 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     (event: "maintenance", listener: (event: SequenceMaintenanceEvent, target: IEventThisPlaceHolder) => void): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISharedString extends ISharedSegmentSequence<SharedStringSegment> {
     annotateMarker(marker: Marker, props: PropertySet): void;
     getMarkerFromId(id: string): ISegment | undefined;
@@ -1004,14 +1004,14 @@ export interface SchemaStatics {
 // @public @system
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
     readonly isLocal: boolean;
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     readonly clientId: string | undefined;
     // (undocumented)
@@ -1023,7 +1023,7 @@ export interface SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes =
     readonly ranges: readonly Readonly<ISequenceDeltaRange<TOperation>>[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceInterval extends IInterval {
     compare(b: SequenceInterval): number;
     compareEnd(b: SequenceInterval): number;
@@ -1047,13 +1047,13 @@ export interface SequenceInterval extends IInterval {
     readonly stickiness: IntervalStickiness;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceIntervalIndex {
     add(interval: SequenceInterval): void;
     remove(interval: SequenceInterval): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
@@ -1061,16 +1061,16 @@ export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMainten
 
 export { SequencePlace }
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory> & SharedObjectKind_2<ISharedDirectory>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedDirectory = ISharedDirectory;
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedMap: ISharedObjectKind<ISharedMap> & SharedObjectKind_2<ISharedMap>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedMap = ISharedMap;
 
 // @public @sealed
@@ -1078,13 +1078,13 @@ export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedTyp
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const SharedString: ISharedObjectKind<ISharedString> & SharedObjectKind_2<ISharedString>;
 
-// @alpha @legacy
+// @beta @legacy
 export type SharedString = ISharedString;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type SharedStringSegment = TextSegment | Marker;
 
 // @public

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export interface IChannel extends IFluidLoadable {
     // (undocumented)
     readonly attributes: IChannelAttributes;
@@ -16,14 +16,14 @@ export interface IChannel extends IFluidLoadable {
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IChannelAttributes {
     readonly packageVersion?: string;
     readonly snapshotFormatVersion: string;
     readonly type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IChannelFactory<out TChannel = unknown> {
     readonly attributes: IChannelAttributes;
     create(runtime: IFluidDataStoreRuntime, id: string): TChannel & IChannel;
@@ -31,7 +31,7 @@ export interface IChannelFactory<out TChannel = unknown> {
     readonly type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IChannelServices {
     // (undocumented)
     deltaConnection: IDeltaConnection;
@@ -39,7 +39,7 @@ export interface IChannelServices {
     objectStorage: IChannelStorageService;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IChannelStorageService {
     contains(path: string): Promise<boolean>;
     getSnapshotTree?(): ISnapshotTree | undefined;
@@ -47,7 +47,7 @@ export interface IChannelStorageService {
     readBlob(path: string): Promise<ArrayBufferLike>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDeltaConnection {
     attach(handler: IDeltaHandler): void;
     // (undocumented)
@@ -56,7 +56,7 @@ export interface IDeltaConnection {
     submit(messageContent: any, localOpMetadata: unknown): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDeltaHandler {
     applyStashedOp(message: any): void;
     processMessages: (messageCollection: IRuntimeMessageCollection) => void;
@@ -65,10 +65,10 @@ export interface IDeltaHandler {
     setConnectionState(connected: boolean): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type IDeltaManagerErased = ErasedType<"@fluidframework/container-definitions.IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>">;
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRuntimeEvents>, IDisposable {
     addChannel(channel: IChannel): void;
     readonly attachState: AttachState;
@@ -105,7 +105,7 @@ export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRu
     waitAttached(): Promise<void>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDataStoreRuntimeEvents extends IEvent {
     // (undocumented)
     (event: "disconnected", listener: () => void): any;
@@ -133,21 +133,21 @@ export interface IFluidDataStoreRuntimeExperimental extends IFluidDataStoreRunti
     readonly isDirty?: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface Internal_InterfaceOfJsonableTypesWith<T> {
     // (undocumented)
     [index: string | number]: JsonableTypeWith<T>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? T extends object ? T extends (infer U)[] ? Jsonable<U, TReplaced>[] : {
     [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
 } : never : never;
 
-// @alpha @legacy
+// @beta @legacy
 export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
 
-// @alpha @legacy
+// @beta @legacy
 export type Serializable<T> = Jsonable<T, IFluidHandle>;
 
 ```

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -32,8 +32,7 @@ import type { IChannelAttributes } from "./storage.js";
  * TODO:
  * Either Channels should become a useful well documented abstraction of which there could be another implementation, or it should be better integrated with SharedObject to reduce concept count.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IChannel extends IFluidLoadable {
 	/**
@@ -136,8 +135,7 @@ export interface IChannel extends IFluidLoadable {
 
 /**
  * Handler provided by shared data structure to process requests from the runtime.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaHandler {
 	/**
@@ -200,8 +198,7 @@ export interface IDeltaHandler {
 
 /**
  * Interface to represent a connection to a delta notification stream.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaConnection {
 	connected: boolean;
@@ -231,8 +228,7 @@ export interface IDeltaConnection {
 
 /**
  * Storage services to read the objects at a given path.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IChannelStorageService {
 	/**
@@ -259,8 +255,7 @@ export interface IChannelStorageService {
 
 /**
  * Storage services to read the objects at a given path using the given delta connection.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IChannelServices {
 	deltaConnection: IDeltaConnection;
@@ -294,8 +289,7 @@ export interface IChannelServices {
  * This approach (not requiring TChannel to extend IChannel) also makes it possible for SharedObject's public interfaces to not include IChannel if desired
  * (while still requiring the implementation to implement it).
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IChannelFactory<out TChannel = unknown> {
 	/**

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -23,8 +23,7 @@ import type { IChannel } from "./channel.js";
 
 /**
  * Events emitted by {@link IFluidDataStoreRuntime}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreRuntimeEvents extends IEvent {
 	(event: "disconnected", listener: () => void);
@@ -43,8 +42,7 @@ export interface IFluidDataStoreRuntimeEvents extends IEvent {
 
 /**
  * Manages the transmission of ops between the runtime and storage.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IDeltaManagerErased =
 	ErasedType<"@fluidframework/container-definitions.IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>">;
@@ -52,8 +50,7 @@ export type IDeltaManagerErased =
 /**
  * Represents the runtime for the data store. Contains helper functions/state of the data store.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreRuntime
 	extends IEventProvider<IFluidDataStoreRuntimeEvents>,

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -16,8 +16,7 @@
  *
  * @privateRemarks
  * Prefer using `Jsonable<unknown>` over this type that is an implementation detail.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type JsonableTypeWith<T> =
 	| undefined
@@ -38,8 +37,7 @@ export type JsonableTypeWith<T> =
  * This interface along with ArrayLike above avoids pure type recursion issues, but introduces a limitation on
  * the ability of {@link Jsonable} to detect array-like types that are not handled naively ({@link JSON.stringify}).
  * The TypeOnly filter is not useful for {@link JsonableTypeWith}; so, if type testing improves, this can be removed.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Use of mapped type required to prevent circular reference issue
 export interface Internal_InterfaceOfJsonableTypesWith<T> {
@@ -84,8 +82,7 @@ export interface Internal_InterfaceOfJsonableTypesWith<T> {
  * ```typescript
  * function foo<T>(value: Jsonable<T>) { ... }
  * ```
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extends (
 	T extends never

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -23,7 +23,6 @@ import type { Jsonable } from "./jsonable.js";
  * ```typescript
  * function serialize<T>(value: Serializable<T>) { ... }
  * ```
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type Serializable<T> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/datastore-definitions/src/storage.ts
+++ b/packages/runtime/datastore-definitions/src/storage.ts
@@ -5,8 +5,7 @@
 
 /**
  * Represents the attributes of a channel/DDS.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IChannelAttributes {
 	/**

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -7,13 +7,13 @@
 // @alpha @legacy
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
-// @alpha @legacy
+// @beta @legacy
 export interface AttributionInfo {
     timestamp: number;
     user: IUser;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAttributionKey;
 
 // @alpha @sealed @deprecated @legacy (undocumented)
@@ -46,7 +46,7 @@ export enum CreateSummarizerNodeSource {
     Local = 2
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface DetachedAttributionKey {
     id: 0;
     // (undocumented)
@@ -126,7 +126,7 @@ export interface IEnvelope {
     contents: any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IExperimentalIncrementalSummaryContext {
     readonly latestSummarySequenceNumber: number;
     readonly summaryPath: string;
@@ -249,7 +249,7 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandleInternal<ArrayBufferLike>>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IGarbageCollectionData {
     gcNodes: {
         [id: string]: string[];
@@ -262,7 +262,7 @@ export interface IGarbageCollectionDetailsBase {
     usedRoutes?: string[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IInboundSignalMessage<TMessage extends TypedMessage = TypedMessage> extends ISignalMessage<TMessage> {
     // (undocumented)
     readonly type: TMessage["type"];
@@ -285,14 +285,14 @@ export interface IProvideFluidDataStoreRegistry {
     readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IRuntimeMessageCollection {
     readonly envelope: ISequencedMessageEnvelope;
     readonly local: boolean;
     readonly messagesContent: readonly IRuntimeMessagesContent[];
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IRuntimeMessagesContent {
     readonly clientSequenceNumber: number;
     readonly contents: unknown;
@@ -322,7 +322,7 @@ export interface IRuntimeStorageService {
     uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type ISequencedMessageEnvelope = Omit<ISequencedDocumentMessage, "contents" | "clientSequenceNumber">;
 
 // @alpha @legacy
@@ -386,7 +386,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     updateUsedRoutes(usedRoutes: string[]): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummaryStats {
     // (undocumented)
     blobNodeCount: number;
@@ -400,19 +400,19 @@ export interface ISummaryStats {
     unreferencedBlobSize: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummaryTreeWithStats {
     stats: ISummaryStats;
     summary: ISummaryTree;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITelemetryContext {
     set(prefix: string, property: string, value: TelemetryBaseEventPropertyType): void;
     setMultiple(prefix: string, property: string, values: Record<string, TelemetryBaseEventPropertyType>): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface LocalAttributionKey {
     // (undocumented)
     type: "local";
@@ -433,7 +433,7 @@ string,
 Promise<FluidDataStoreRegistryEntry> | FluidDataStoreRegistryEntry
 ];
 
-// @alpha @legacy
+// @beta @legacy
 export interface OpAttributionKey {
     seq: number;
     type: "op";

--- a/packages/runtime/runtime-definitions/src/attribution.ts
+++ b/packages/runtime/runtime-definitions/src/attribution.ts
@@ -8,8 +8,7 @@ import type { IUser } from "@fluidframework/driver-definitions";
 /**
  * AttributionKey representing a reference to some op in the op stream.
  * Content associated with this key aligns with content modified by that op.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface OpAttributionKey {
 	/**
@@ -33,8 +32,7 @@ export interface OpAttributionKey {
  * is currently unsupported, as applications can effectively modify content anonymously while detached.
  * The runtime has no mechanism for reliably obtaining the user. It would be reasonable to start supporting
  * this functionality if the host provided additional context to their attributor or attach calls.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface DetachedAttributionKey {
 	type: "detached";
@@ -52,8 +50,7 @@ export interface DetachedAttributionKey {
 
 /**
  * AttributionKey associated with content that has been made locally but not yet acked by the server.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface LocalAttributionKey {
 	type: "local";
@@ -61,15 +58,13 @@ export interface LocalAttributionKey {
 
 /**
  * Can be indexed into the ContainerRuntime in order to retrieve {@link AttributionInfo}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAttributionKey;
 
 /**
  * Attribution information associated with a change.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface AttributionInfo {
 	/**

--- a/packages/runtime/runtime-definitions/src/garbageCollectionDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollectionDefinitions.ts
@@ -37,8 +37,7 @@ export const gcDataBlobKey = ".gcdata";
 /**
  * Garbage collection data returned by nodes in a Container.
  * Used for running GC in the Container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IGarbageCollectionData {
 	/**

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -40,8 +40,7 @@ export interface IEnvelope {
 
 /**
  * Represents ISignalMessage with its type.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IInboundSignalMessage<TMessage extends TypedMessage = TypedMessage>
 	extends ISignalMessage<TMessage> {
@@ -89,8 +88,7 @@ export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
  * It is the same as ISequencedDocumentMessage, but without the contents and clientSequenceNumbers
  * which are sent separately. The contents are modified at multiple layers in the stack so having it
  * separate doesn't require packing and unpacking the entire message.
- * @alpha
- * @legacy
+ * @legacy @beta
  */
 export type ISequencedMessageEnvelope = Omit<
 	ISequencedDocumentMessage,
@@ -99,8 +97,7 @@ export type ISequencedMessageEnvelope = Omit<
 
 /**
  * These are the contents of a runtime message as it is processed throughout the stack.
- * @alpha
- * @legacy
+ * @legacy @beta
  * @sealed
  */
 export interface IRuntimeMessagesContent {
@@ -120,8 +117,7 @@ export interface IRuntimeMessagesContent {
 
 /**
  * A collection of messages that are processed by the runtime.
- * @alpha
- * @legacy
+ * @legacy @beta
  * @sealed
  */
 export interface IRuntimeMessageCollection {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -20,8 +20,7 @@ import type {
 
 /**
  * Contains the aggregation data from a Tree/Subtree.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryStats {
 	treeNodeCount: number;
@@ -37,8 +36,7 @@ export interface ISummaryStats {
  * each of its DDS.
  * Any component that implements IChannelContext, IFluidDataStoreChannel or extends SharedObject
  * will be taking part of the summarization process.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryTreeWithStats {
 	/**
@@ -90,8 +88,7 @@ export interface ISummarizeInternalResult extends ISummarizeResult {
 /**
  * @experimental - Can be deleted/changed at any time
  * Contains the necessary information to allow DDSes to do incremental summaries
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IExperimentalIncrementalSummaryContext {
 	/**
@@ -366,8 +363,7 @@ export interface ITelemetryContextExt {
 /**
  * Contains telemetry data relevant to summarization workflows.
  * This object is expected to be modified directly by various summarize methods.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITelemetryContext {
 	/**

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.legacy.alpha.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.legacy.alpha.api.md
@@ -11,25 +11,25 @@ export function createChildLogger(props?: {
     properties?: ITelemetryLoggerPropertyBags;
 }): ITelemetryLoggerExt;
 
-// @alpha @legacy
+// @beta @legacy
 export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> extends TypedEventEmitter<TEvent> {
     constructor(errorHandler: (eventName: EventEmitterEventType, error: any) => void);
     // (undocumented)
     emit(event: EventEmitterEventType, ...args: unknown[]): boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITelemetryErrorEventExt extends ITelemetryPropertiesExt {
     eventName: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     category?: TelemetryEventCategory;
     eventName: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
     sendErrorEvent(event: ITelemetryErrorEventExt, error?: unknown): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEventExt, error?: unknown, logLevel?: typeof LogLevel.verbose | typeof LogLevel.default): void;
@@ -47,18 +47,18 @@ export interface ITelemetryLoggerPropertyBags {
     error?: ITelemetryLoggerPropertyBag;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt {
     duration?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type ITelemetryPropertiesExt = Record<string, TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>>;
 
-// @alpha @legacy
+// @beta @legacy
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
-// @alpha @legacy
+// @beta @legacy
 export type TelemetryEventPropertyTypeExt = string | number | boolean | undefined | (string | number | boolean)[] | Record<string, string | number | boolean | undefined | (string | number | boolean)[]>;
 
 // @alpha @legacy (undocumented)

--- a/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
+++ b/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
@@ -15,8 +15,7 @@ import type { IEvent } from "@fluidframework/core-interfaces";
  * @privateRemarks
  * This probably doesn't belong in this package, as it is not telemetry-specific, and is really only intended for internal fluid-framework use.
  * We should consider moving it to the `core-utils` package.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class EventEmitterWithErrorHandling<
 	TEvent extends IEvent = IEvent,

--- a/packages/utils/telemetry-utils/src/telemetryTypes.ts
+++ b/packages/utils/telemetry-utils/src/telemetryTypes.ts
@@ -13,8 +13,7 @@ import type { ITelemetryBaseLogger, LogLevel, Tagged } from "@fluidframework/cor
  * error - Error log event, ideally 0 of these are logged during a session
  *
  * performance - Includes duration, and often has _start, _end, or _cancel suffixes for activity tracking
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
@@ -24,8 +23,7 @@ export type TelemetryEventCategory = "generic" | "error" | "performance";
  * @remarks
  * Includes extra types beyond {@link @fluidframework/core-interfaces#TelemetryBaseEventPropertyType}, which must be
  * converted before sending to a base logger.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type TelemetryEventPropertyTypeExt =
 	| string
@@ -37,8 +35,7 @@ export type TelemetryEventPropertyTypeExt =
 
 /**
  * JSON-serializable properties, which will be logged with telemetry.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ITelemetryPropertiesExt = Record<
 	string,
@@ -68,8 +65,7 @@ export interface ITelemetryEventExt extends ITelemetryPropertiesExt {
 /**
  * Informational (non-error) telemetry event
  * @remarks Maps to category = "generic"
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
 	/**
@@ -87,8 +83,7 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
 /**
  * Error telemetry event.
  * @remarks Maps to category = "error"
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITelemetryErrorEventExt extends ITelemetryPropertiesExt {
 	/**
@@ -100,8 +95,7 @@ export interface ITelemetryErrorEventExt extends ITelemetryPropertiesExt {
 /**
  * Performance telemetry event.
  * @remarks Maps to category = "performance"
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt {
 	/**
@@ -116,8 +110,7 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
  * @remarks
  * This interface is meant to be used internally within the Fluid Framework,
  * and `ITelemetryBaseLogger` should be used when loggers are passed between layers.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
 	/**


### PR DESCRIPTION
## Description
All of the APIs in our client packages (packages under the following directories: "packages", "examples", "experimental", "common/lib") should be updated to convert any APIs tagged as @legacy and @alpha to be @legacy and @beta.

✅Fixed API extractor compatibility: Both interfaces now use compatible @legacy @beta tags
✅Verified DDS package builds: Counter, map, and tree packages all build successfully with the legacy-beta system

Also need to mark its reference type as @legacy @beta 
packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts:

EventEmitterWithErrorHandling class: @legacy @alpha → @legacy @beta
packages/utils/telemetry-utils/src/telemetryTypes.ts:

[ITelemetryLoggerExt](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[ITelemetryGenericEventExt](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[ITelemetryErrorEventExt](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[ITelemetryPerformanceEventExt](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[ITelemetryPropertiesExt](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type: @legacy @alpha → @legacy @beta
[TelemetryEventCategory](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type: @legacy @alpha → @legacy @beta
packages/runtime/datastore-definitions/src/dataStoreRuntime.ts:

[IFluidDataStoreRuntime](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IFluidDataStoreRuntimeEvents](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IDeltaManagerErased](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type: @legacy @alpha → @legacy @beta
packages/runtime/datastore-definitions/src/storage.ts:

[IChannelAttributes](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
packages/runtime/datastore-definitions/src/channel.ts:

[IChannelServices](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IChannelStorageService](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IChannel](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IChannelFactory](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IDeltaConnection](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IDeltaHandler](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
packages/runtime/runtime-definitions/src/summary.ts:

[ITelemetryContext](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[ISummaryTreeWithStats](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IGarbageCollectionData](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[IExperimentalIncrementalSummaryContext](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
[ISummaryStats](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
packages/runtime/runtime-definitions/src/protocol.ts:

[IRuntimeMessageCollection](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @alpha @legacy → @legacy @beta
[ISequencedMessageEnvelope](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type: @legacy @alpha → @legacy @beta
[IRuntimeMessagesContent](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface: @legacy @alpha → @legacy @beta
