### PR TITLE
refactor(packages/drivers): Update client packages to use `@legacy @beta` instead of `@legacy @alpha`

### DIFF
--- a/packages/drivers/driver-web-cache/api-report/driver-web-cache.legacy.alpha.api.md
+++ b/packages/drivers/driver-web-cache/api-report/driver-web-cache.legacy.alpha.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export function deleteFluidCacheIndexDbInstance(deleteDBCallbacks?: DeleteDBCallbacks): Promise<void>;
 
-// @alpha @legacy
+// @beta @legacy
 export class FluidCache implements IPersistedCache {
     constructor(config: FluidCacheConfig);
     // (undocumented)
@@ -18,7 +18,7 @@ export class FluidCache implements IPersistedCache {
     removeEntries(file: IFileEntry): Promise<void>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface FluidCacheConfig {
     closeDbAfterMs?: number;
     logger?: ITelemetryBaseLogger;

--- a/packages/drivers/driver-web-cache/src/FluidCache.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCache.ts
@@ -39,8 +39,7 @@ interface StorageQuotaUsageDetails {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface FluidCacheConfig {
 	/**
@@ -73,8 +72,7 @@ export interface FluidCacheConfig {
 
 /**
  * A cache that can be used by the Fluid ODSP driver to cache data for faster performance.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class FluidCache implements IPersistedCache {
 	private readonly logger: ITelemetryLoggerExt;

--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -76,8 +76,7 @@ export function getFluidCacheIndexedDbInstance(
  * Deletes the indexed DB instance.
  *
  * @remarks Warning this can throw an error in Firefox incognito, where accessing storage is prohibited.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function deleteFluidCacheIndexDbInstance(
 	deleteDBCallbacks?: DeleteDBCallbacks,

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.alpha.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export function createLocalResolverCreateNewRequest(documentId: string): IRequest;
 
 // @alpha @legacy
@@ -18,7 +18,7 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
     nackClient(clientId: string, code?: number, type?: NackErrorType, message?: any): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class LocalResolver implements IUrlResolver {
     constructor();
     // (undocumented)

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -22,8 +22,7 @@ import { localDriverCompatDetailsForLoader } from "./localLayerCompatState.js";
 
 /**
  * Implementation of document service factory for local use.
- * @legacy
- * @alpha
+ * @legacy @alpha
  */
 export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
 	// A map of clientId to LocalDocumentService.

--- a/packages/drivers/local-driver/src/localResolver.ts
+++ b/packages/drivers/local-driver/src/localResolver.ts
@@ -15,8 +15,7 @@ import {
 import { generateToken } from "./auth.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function createLocalResolverCreateNewRequest(documentId: string): IRequest {
 	const createNewRequest: IRequest = {
@@ -31,8 +30,7 @@ export function createLocalResolverCreateNewRequest(documentId: string): IReques
 /**
  * Resolves URLs by providing fake URLs which succeed with the other
  * related local classes.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class LocalResolver implements IUrlResolver {
 	private readonly tenantId = "tenantId";

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type CacheContentType = "snapshot" | "ops" | "snapshotWithLoadingGroupId";
 
 // @alpha @legacy (undocumented)
@@ -30,7 +30,7 @@ export interface HostStoragePolicy {
     snapshotOptions?: ISnapshotOptions;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ICacheEntry extends IEntry {
     file: IFileEntry;
 }
@@ -47,13 +47,13 @@ export interface ICollabSessionOptions {
 // @alpha @legacy
 export type IdentityType = "Consumer" | "Enterprise";
 
-// @alpha @legacy
+// @beta @legacy
 export interface IEntry {
     key: string;
     type: CacheContentType;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IFileEntry {
     docId: string;
     resolvedUrl: IResolvedUrl;
@@ -131,26 +131,26 @@ export interface IOpsCachingPolicy {
     totalOpsToCache?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IPersistedCache {
     get(entry: ICacheEntry): Promise<any>;
     put(entry: ICacheEntry, value: any): Promise<void>;
     removeEntries(file: IFileEntry): Promise<void>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IProvideSessionAwareDriverFactory {
     // (undocumented)
     readonly IRelaySessionAwareDriverFactory: IRelaySessionAwareDriverFactory;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRelaySessionAwareDriverFactory extends IProvideSessionAwareDriverFactory {
     // (undocumented)
     getRelayServiceSessionInfo(resolvedUrl: IResolvedUrl): Promise<ISocketStorageDiscovery | undefined>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISensitivityLabel {
     appliedByUserEmail: string;
     assignmentMethod: string;
@@ -158,7 +158,7 @@ export interface ISensitivityLabel {
     tenantId: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISensitivityLabelsInfo {
     labels: ISensitivityLabel[];
     timestamp: string;
@@ -191,7 +191,7 @@ export interface ISnapshotOptions {
     timeout?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISocketStorageDiscovery {
     // (undocumented)
     deltaStorageUrl: string;

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -29,7 +29,7 @@ export const snapshotWithLoadingGroupIdKey = "snapshotWithLoadingGroupId";
 
 /**
  * @legacy
- * @alpha
+ * @beta
  */
 export type CacheContentType = "snapshot" | "ops" | "snapshotWithLoadingGroupId";
 
@@ -40,7 +40,7 @@ export type CacheContentType = "snapshot" | "ops" | "snapshotWithLoadingGroupId"
  */
 /**
  * @legacy
- * @alpha
+ * @beta
  */
 export interface IFileEntry {
 	/**
@@ -60,7 +60,7 @@ export interface IFileEntry {
 /**
  * Cache entry. Identifies file that this entry belongs to, and type of content stored in it.
  * @legacy
- * @alpha
+ * @beta
  */
 export interface IEntry {
 	/**
@@ -84,7 +84,7 @@ export interface IEntry {
 /**
  * Cache entry. Identifies file that this entry belongs to, and type of content stored in it.
  * @legacy
- * @alpha
+ * @beta
  */
 export interface ICacheEntry extends IEntry {
 	/**
@@ -100,7 +100,7 @@ export interface ICacheEntry extends IEntry {
  * IPersistedCache will be considered stale and removed after 2 days. Read the README for more
  * information.
  * @legacy
- * @alpha
+ * @beta
  */
 export interface IPersistedCache {
 	/**

--- a/packages/drivers/odsp-driver-definitions/src/sessionProvider.ts
+++ b/packages/drivers/odsp-driver-definitions/src/sessionProvider.ts
@@ -7,8 +7,7 @@ import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 
 /**
  * Socket storage discovery api response
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISocketStorageDiscovery {
 	// The id of the web socket
@@ -50,8 +49,7 @@ export interface ISocketStorageDiscovery {
 
 /**
  * Sensitivity labels information for a file, part of the socket storage discovery response.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISensitivityLabelsInfo {
 	/** ISO format timestamp when the label info snapshot was generated. */
@@ -62,8 +60,7 @@ export interface ISensitivityLabelsInfo {
 
 /**
  * A single sensitivity label applied to a document, part of the socket storage discovery response.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISensitivityLabel {
 	/** Unique identifier of the sensitivity label. */
@@ -80,7 +77,7 @@ export interface ISensitivityLabel {
  * An interface that allows a concrete instance of a driver factory to interrogate itself
  * to find out if it is session aware.
  * @legacy
- * @alpha
+ * @beta
  */
 export interface IProvideSessionAwareDriverFactory {
 	readonly IRelaySessionAwareDriverFactory: IRelaySessionAwareDriverFactory;
@@ -90,7 +87,7 @@ export interface IProvideSessionAwareDriverFactory {
  * An interface that allows a concrete instance of a driver factory to call the `getRelayServiceSessionInfo`
  * function if it session aware.
  * @legacy
- * @alpha
+ * @beta
  */
 export interface IRelaySessionAwareDriverFactory extends IProvideSessionAwareDriverFactory {
 	getRelayServiceSessionInfo(

--- a/packages/drivers/routerlicious-driver/api-report/routerlicious-driver.legacy.alpha.api.md
+++ b/packages/drivers/routerlicious-driver/api-report/routerlicious-driver.legacy.alpha.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export function createRouterliciousDocumentServiceFactory(tokenProvider: ITokenProvider): IDocumentServiceFactory;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRouterliciousResolvedUrl extends IResolvedUrl {
     createAsEphemeral?: boolean;
     routerliciousResolvedUrl: true;

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -408,8 +408,7 @@ export class DocumentPostCreateError extends Error {
 /**
  * Creates factory for creating the routerlicious document service.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function createRouterliciousDocumentServiceFactory(
 	tokenProvider: ITokenProvider,

--- a/packages/drivers/routerlicious-driver/src/routerliciousResolvedUrl.ts
+++ b/packages/drivers/routerlicious-driver/src/routerliciousResolvedUrl.ts
@@ -12,8 +12,7 @@ import type { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
  * {@link isRouterliciousResolvedUrl} can be used to detect whether an {@link @fluidframework/driver-definitions#IResolvedUrl}
  * is an IRouterliciousResolvedUrl.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRouterliciousResolvedUrl extends IResolvedUrl {
 	/**


### PR DESCRIPTION
## Description
@legacy @alpha annotations in the drivers packages that should be updated to @legacy @beta:

Updated Packages:

driver-web-cache - FluidCacheConfig, FluidCache, deleteFluidCacheIndexDbInstance
local-driver - LocalDocumentServiceFactory, createLocalResolverCreateNewRequest, LocalResolver
routerlicious-driver - IRouterliciousResolvedUrl, createRouterliciousDocumentServiceFactory
odsp-driver-definitions - ISocketStorageDiscovery, ISensitivityLabelsInfo, ISensitivityLabel, IProvideSessionAwareDriverFactory, IRelaySessionAwareDriverFactory

**Except:**
localDocumentServiceFactory.ts remains @legacy @alpha
This was necessary because the class constructor uses [ILocalDeltaConnectionServer](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which is marked as @alpha

And according to
The API Extractor 7.52.8 enforces strict release tag compatibility rules:

1. @beta symbols cannot reference @alpha symbols
2. All symbols in the dependency chain must be at the same or higher release level