### PR TITLE
Switch to handling uncaughtException so we don't lose telemetry

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -108,9 +108,27 @@ async function main() {
 	// https://v8.dev/docs/stack-trace-api
 	Error.stackTraceLimit = Infinity;
 
-	process.on("uncaughtExceptionMonitor", (error, origin) => {
+	// We need to install an uncaughtException monitor to prevent Node from killing our process
+	// for not handling exceptions, otherwise we don't get a chance to flush the logger and will
+	// simply lose the telemetry that led up to the uncaught exception.
+	process.on("uncaughtException", (error, origin) => {
 		try {
-			logger.sendErrorEvent({ eventName: "uncaughtExceptionMonitor", origin }, error);
+			logger.sendErrorEvent({ eventName: "uncaughtException", origin }, error);
+			// Since flush is async, it's possible that more telemetry may be added and sent after the
+			// uncaught exception occurs. It's probably best to ignore telemetry after the above
+			// "uncaughtException" event, since we are now in an undefined state and the process
+			// is about to die.
+			flush()
+				.then(() => {
+					// Using exit code 2 to denote this "handled" unhandled exception exit, which
+					// can later be detected via "Runner Exited" telemetry in stressTest.ts.
+					// This sets it apart from a truly unhandled exception, which exits with code 1.
+					process.exit(2);
+				})
+				.catch(() => {
+					// If flush errors, exit with code 3.
+					process.exit(3);
+				});
 		} catch (e) {
 			console.error("Error during logging unhandled exception: ", e);
 		}

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -120,14 +120,14 @@ async function main() {
 			// is about to die.
 			flush()
 				.then(() => {
-					// Using exit code 2 to denote this "handled" unhandled exception exit, which
+					// Using exit code -2 to denote this "handled" unhandled exception exit, which
 					// can later be detected via "Runner Exited" telemetry in stressTest.ts.
 					// This sets it apart from a truly unhandled exception, which exits with code 1.
-					process.exit(2);
+					process.exit(-2);
 				})
 				.catch(() => {
-					// If flush errors, exit with code 3.
-					process.exit(3);
+					// If flush errors, exit with code -3.
+					process.exit(-3);
 				});
 		} catch (e) {
 			console.error("Error during logging unhandled exception: ", e);


### PR DESCRIPTION
[AB#46832](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/46832)

In #13834 the `unhandledPromise` listener was switched to an `uncaughtExceptionMonitor` to also cover uncaught exceptions.  However, this had an additional probably-unintended consequence, as `unhandledPromise` (and `uncaughtException`) event handlers impose a side-effect that `uncaughtExceptionMonitor` does not - they prevent the process from being killed.  Another case study on why event registration should never cause behavioral side-effects :(

As a result, the runner process currently gets killed immediately for uncaught exceptions or unhandled rejections, before we're able to call `flush()`.  This results in the process exiting with code 1, which we can see happening quite frequently in telemetry - and in my experience running the tests locally, I typically see 1-3 runner processes exit with code 1 per run of `start:odsp`.  And note that we get no telemetry hits of `uncaughtExceptionMonitor`, because this path will always kill the process before that telemetry can be flushed.

Solution is to switch to `uncaughtException`.  This covers both normal exceptions and unhandled promises, because unhandled promises are converted to exceptions (and then that exception is what actually kills the process).  `uncaughtException` also supports an `origin` parameter so we can still find out whether the failure came from a normal exception or an unhandled promise.

This sort of global handler is basically required for unhandled promises in particular, since there are many places in Fluid where we either float promises or reject them prior to a rejection handler being attached (in particular, I see some failures because the construction of `Deferred` makes it impossible by default for the holder of the deferred to know if any consumer is watching for the `deferred.promise` to reject before they call `deferred.reject()`).  These can't be caught directly up at the runner level, so we need the global catchall to snag them.

