### PR TITLE
fix(benchmark-memory): Remove dereferencing measured objects in afterIteration

### DIFF
--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -70,7 +70,6 @@ function runBenchmark({
 				afterOperation?.(this.matrix, this.undoRedoStack);
 
 				this.cleanUp();
-				this.matrix = undefined;
 				this.undoRedoStack = undefined;
 				this.cleanUp = undefined;
 			}

--- a/packages/dds/tree/src/test/memory/tableTree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tableTree.spec.ts
@@ -120,7 +120,6 @@ function createBenchmark({
 			assert(this.cleanUp !== undefined, "cleanUp is not initialized");
 
 			this.cleanUp();
-			this.table = undefined;
 			this.cleanUp = undefined;
 		}
 	})();
@@ -180,7 +179,6 @@ function createUndoRedoBenchmark({
 			assert(this.cleanUp !== undefined, "cleanUp is not initialized");
 
 			this.cleanUp();
-			this.table = undefined;
 			this.undoRedoStack = undefined;
 			this.cleanUp = undefined;
 		}


### PR DESCRIPTION
## Description
Current memory benchmarks follow the sequence:
GC → measure before → run operation → afterIteration → GC → measure after
This design can produce misleading results when afterIteration dereferences key objects (e.g., matrices or trees), causing GC to clear memory before the "after" measurement.To address this, audit existing memory tests (e.g., Matrix, Tree) and remove lines like matrix = null from afterIteration