### PR TITLE
Add KeyEncodingOptions

### DIFF
--- a/.changeset/floppy-bats-hide.md
+++ b/.changeset/floppy-bats-hide.md
@@ -8,4 +8,4 @@ Replace "TreeEncodingOptions.useStoredKeys" with "keys" and "KeyEncodingOptions"
 The alpha API `TreeEncodingOptions` has had its `useStoredKeys` `boolean` replaced with `keys` that takes a `KeyEncodingOptions` allowing for three options instead of the previous two.
 With the new API, it is now possible to control, for APIs which support it (like [`TreeAlpha.exportVerbose`](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#exportverbose-methodsignature)), if unknown optional fields will be included when exporting data using stored keys.
 
-Additionally the relevant options interfaces have been marked as `@input`, indicating that in the future more options may be added as optional parameters, and that should be considered non-breaking.
+Additionally, the relevant options interfaces have been marked as `@input`, indicating that more options may be added as optional parameters in the future, and that should be considered non-breaking.

--- a/.changeset/floppy-bats-hide.md
+++ b/.changeset/floppy-bats-hide.md
@@ -5,7 +5,7 @@
 ---
 Replace "TreeEncodingOptions.useStoredKeys" with "keys" and "KeyEncodingOptions"
 
-The alpha API `TreeEncodingOptions` has had its `useStoredKeys` boolean replaced with `keys` that takes a `KeyEncodingOptions` allowing for three options instead of the previous two.
+The alpha API `TreeEncodingOptions` has had its `useStoredKeys` `boolean` replaced with `keys` that takes a `KeyEncodingOptions` allowing for three options instead of the previous two.
 With the new API, it is now possible to control, for APIs which support it (like [`TreeAlpha.exportVerbose`](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#exportverbose-methodsignature)), if unknown optional fields will be included when exporting data using stored keys.
 
 Additionally the relevant options interfaces have been marked as `@input`, indicating that in the future more options may be added as optional parameters, and that should be considered non-breaking.

--- a/.changeset/floppy-bats-hide.md
+++ b/.changeset/floppy-bats-hide.md
@@ -1,0 +1,11 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+Replace "TreeEncodingOptions.useStoredKeys" with "keys" and "KeyEncodingOptions"
+
+The alpha API `TreeEncodingOptions` has had its `useStoredKeys` boolean replaced with `keys` that takes a `KeyEncodingOptions` allowing for three options instead of the previous two.
+With the new API, it is now possible to control, for APIs which support it (like [`TreeAlpha.exportVerbose`](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#exportverbose-methodsignature)), if unknown optional fields will be included when exporting data using stored keys.
+
+Additionally the relevant options interfaces have been marked as `@input`, indicating that in the future more options may be added as optional parameters, and that should be considered non-breaking.

--- a/examples/apps/tree-cli-app/src/utils.ts
+++ b/examples/apps/tree-cli-app/src/utils.ts
@@ -29,6 +29,7 @@ import {
 	type ViewContent,
 	type ConciseTree,
 	TreeAlpha,
+	KeyEncodingOptions,
 } from "@fluidframework/tree/alpha";
 import { type Static, Type } from "@sinclair/typebox";
 
@@ -67,7 +68,7 @@ export function loadDocument(source: string | undefined): List {
 		}
 		case "verbose-stored": {
 			return TreeAlpha.importVerbose(List, fileData as VerboseTree, {
-				useStoredKeys: true,
+				keys: KeyEncodingOptions.knownStoredKeys,
 			});
 		}
 		case "compressed": {
@@ -143,10 +144,14 @@ export function exportContent(destination: string, tree: List): JsonCompatible {
 			return TreeAlpha.exportVerbose(tree) as JsonCompatible;
 		}
 		case "concise-stored": {
-			return TreeAlpha.exportConcise(tree, { useStoredKeys: true }) as JsonCompatible;
+			return TreeAlpha.exportConcise(tree, {
+				keys: KeyEncodingOptions.knownStoredKeys,
+			}) as JsonCompatible;
 		}
 		case "verbose-stored": {
-			return TreeAlpha.exportVerbose(tree, { useStoredKeys: true }) as JsonCompatible;
+			return TreeAlpha.exportVerbose(tree, {
+				keys: KeyEncodingOptions.knownStoredKeys,
+			}) as JsonCompatible;
 		}
 		case "compressed": {
 			return TreeAlpha.exportCompressed(tree, {

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -529,6 +529,13 @@ export interface JsonValidator {
     compile<Schema extends TSchema>(schema: Schema): SchemaValidationFunction<Schema>;
 }
 
+// @alpha @input
+export enum KeyEncodingOptions {
+    allStoredKeys = "allStoredKeys",
+    knownStoredKeys = "knownStoredKeys",
+    usePropertyKeys = "usePropertyKeys"
+}
+
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
@@ -1271,7 +1278,7 @@ export interface TreeAlpha {
         idCompressor?: IIdCompressor;
     } & ICodecOptions): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
     importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
+    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: TreeParsingOptions): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
     key2(node: TreeNode): string | number | undefined;
 }
 
@@ -1352,9 +1359,9 @@ export enum TreeCompressionStrategy {
     Uncompressed = 1
 }
 
-// @alpha
-export interface TreeEncodingOptions {
-    readonly useStoredKeys?: boolean;
+// @alpha @input
+export interface TreeEncodingOptions<TKeyOptions = KeyEncodingOptions> {
+    readonly keys?: TKeyOptions;
 }
 
 // @public
@@ -1448,6 +1455,9 @@ export type TreeNodeSchemaNonClass<Name extends string = string, Kind extends No
 // @public
 export type TreeObjectNode<T extends RestrictiveStringRecord<ImplicitFieldSchema>, TypeName extends string = string> = TreeNode & ObjectFromSchemaRecord<T> & WithType<TypeName, NodeKind.Object, T>;
 
+// @alpha @input
+export type TreeParsingOptions = TreeEncodingOptions<KeyEncodingOptions.usePropertyKeys | KeyEncodingOptions.knownStoredKeys>;
+
 // @alpha
 export interface TreeRecordNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeNode, Record<string, TreeNodeFromImplicitAllowedTypes<TAllowedTypes>> {
     [Symbol.iterator](): IterableIterator<[
@@ -1471,8 +1481,8 @@ export interface TreeSchema extends SimpleTreeSchema {
     readonly root: FieldSchemaAlpha;
 }
 
-// @alpha
-export interface TreeSchemaEncodingOptions extends TreeEncodingOptions {
+// @alpha @input
+export interface TreeSchemaEncodingOptions extends TreeParsingOptions {
     readonly requireFieldsWithDefaults?: boolean;
 }
 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -264,6 +264,8 @@ export {
 	type RecordNodeInsertableData,
 	type RecordNodePojoEmulationSchema,
 	type TreeRecordNode,
+	KeyEncodingOptions,
+	type TreeParsingOptions,
 } from "./simple-tree/index.js";
 export {
 	SharedTree,

--- a/packages/dds/tree/src/simple-tree/api/conciseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/conciseTree.ts
@@ -13,6 +13,7 @@ import {
 	replaceHandles,
 	type TreeEncodingOptions,
 	type HandleConverter,
+	KeyEncodingOptions,
 } from "./customTree.js";
 
 /**
@@ -46,7 +47,7 @@ export function conciseFromCursor(
 	options: TreeEncodingOptions,
 ): ConciseTree {
 	const config: Required<TreeEncodingOptions> = {
-		useStoredKeys: false,
+		keys: KeyEncodingOptions.usePropertyKeys,
 		...options,
 	};
 

--- a/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
@@ -6,14 +6,18 @@
 import type { JsonTreeSchema } from "./jsonSchema.js";
 import type { ImplicitAllowedTypes } from "../core/index.js";
 import { toJsonSchema } from "./simpleSchemaToJsonSchema.js";
-import type { TreeEncodingOptions } from "./customTree.js";
+import type { TreeParsingOptions } from "./customTree.js";
 import { TreeViewConfigurationAlpha } from "./configuration.js";
 
 /**
  * Options for how to interpret or encode a tree when schema information is available.
+ * @remarks
+ * This currently extends {@link TreeParsingOptions},
+ * removing the option to declare {@link KeyEncodingOptions.allStoredKeys} since this option is currently not supported.
+ * @input
  * @alpha
  */
-export interface TreeSchemaEncodingOptions extends TreeEncodingOptions {
+export interface TreeSchemaEncodingOptions extends TreeParsingOptions {
 	/**
 	 * If true, fields with default providers (like {@link SchemaFactory.identifier}) will be required.
 	 * If false, they will be optional.
@@ -75,6 +79,7 @@ export interface TreeSchemaEncodingOptions extends TreeEncodingOptions {
  * 1. VerboseTree and (Done) ConciseTree
  * 2. (Done) With and without requiring values with defaults (for insertion vs reading)
  * 3. (Done) Using stored keys and property keys.
+ * 4. Control over unknown optional fields and staged allowed types (able to manually control them and/or get them from some context).
  *
  * This takes in `ImplicitAllowedTypes` since underlying `toJsonSchema` can't handle optional roots.
  *

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -101,6 +101,8 @@ export {
 	tryStoredSchemaAsArray,
 	replaceHandles,
 	type HandleConverter,
+	KeyEncodingOptions,
+	type TreeParsingOptions,
 } from "./customTree.js";
 
 export {

--- a/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
@@ -37,6 +37,7 @@ import {
 	ObjectNodeSchema,
 } from "../node-kinds/index.js";
 import { LeafNodeSchema } from "../leafNodeSchema.js";
+import { KeyEncodingOptions } from "./customTree.js";
 
 /**
  * Generates a JSON Schema representation from a simple tree schema.
@@ -45,8 +46,6 @@ import { LeafNodeSchema } from "../leafNodeSchema.js";
  *
  * This cannot handle the case where the root is undefined since undefined is not a concept in JSON.
  * This also cannot handle {@link SchemaStatics.handle} since they also are not supported in JSON.
- *
- * @internal
  */
 export function toJsonSchema(
 	schema: TreeSchema,
@@ -62,6 +61,7 @@ export function toJsonSchema(
 	// TODO: deduplicate field handling logic from convertObjectNodeSchema: at least include metadata's description.
 	// TODO: maybe account for consider schema.kind, or just take in ImplicitAllowedTypes
 	// TODO: handle case where allowedTypes is empty.
+	// TODO: handle staged types in a controllable way.
 	return hasSingle(allowedTypes)
 		? {
 				...allowedTypes[0],
@@ -160,7 +160,10 @@ export function convertObjectNodeSchema(
 	const properties: Record<string, JsonFieldSchema> = {};
 	const required: string[] = [];
 	for (const [propertyKey, fieldSchema] of schema.fields) {
-		const key = options.useStoredKeys ? fieldSchema.storedKey : propertyKey;
+		const key =
+			options.keys === KeyEncodingOptions.usePropertyKeys
+				? propertyKey
+				: fieldSchema.storedKey;
 		const allowedTypes: JsonSchemaRef[] = [];
 		for (const allowedType of fieldSchema.allowedTypesIdentifiers) {
 			allowedTypes.push(createSchemaRef(allowedType));
@@ -190,6 +193,7 @@ export function convertObjectNodeSchema(
 		_treeNodeSchemaKind: NodeKind.Object,
 		properties,
 		required,
+		// TODO: support unknown optional fields (only when using "allStoredKeys", and constrain the content to be in schema somehow)
 		additionalProperties: false,
 	};
 

--- a/packages/dds/tree/src/simple-tree/api/verboseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/verboseTree.ts
@@ -37,6 +37,7 @@ import {
 import { isObjectNodeSchema } from "../node-kinds/index.js";
 import {
 	customFromCursor,
+	KeyEncodingOptions,
 	replaceHandles,
 	unknownTypeError,
 	type CustomTreeNode,
@@ -118,53 +119,55 @@ export function applySchemaToParserOptions(
 	options: TreeEncodingOptions,
 ): SchemalessParseOptions {
 	const config: Required<TreeEncodingOptions> = {
-		useStoredKeys: false,
+		keys: KeyEncodingOptions.usePropertyKeys,
 		...options,
 	};
 
 	const context = getUnhydratedContext(schema);
 
 	return {
-		keyConverter: config.useStoredKeys
-			? undefined
-			: {
-					encode: (type, key: FieldKey): string => {
-						// translate stored key into property key.
-						const simpleNodeSchema =
-							context.schema.get(brand(type)) ?? fail(0xb39 /* missing schema */);
-						if (isObjectNodeSchema(simpleNodeSchema)) {
-							const propertyKey = simpleNodeSchema.storedKeyToPropertyKey.get(key);
-							if (propertyKey !== undefined) {
-								return propertyKey;
-							}
-							// Looking up an out of schema key.
-							// This must point to a non-existent field.
-							// It's possible that the key, if we returned it unmodified, could point to some data
-							// (for example if looking up a key which is a stored key already when using property keys).
-							// Thus return an arbitrary key that was selected randomly, so should not exist on non-adversarial data:
-							const arbitrary = "arbitrary unused key: fe71614a-bf3e-43b3-b7b0-4cef39538e90";
-							assert(
-								!simpleNodeSchema.storedKeyToPropertyKey.has(brand(arbitrary)),
-								0xa13 /* arbitrarily selected unused key was actually used */,
-							);
-							return arbitrary;
-						}
-						return key;
-					},
-					parse: (type, inputKey): FieldKey => {
-						const simpleNodeSchema = context.schema.get(brand(type)) ?? unknownTypeError(type);
-						if (isObjectNodeSchema(simpleNodeSchema)) {
-							const info = simpleNodeSchema.flexKeyMap.get(inputKey);
-							if (info === undefined) {
-								throw new UsageError(
-									`Failed to parse VerboseTree due to unexpected key ${JSON.stringify(inputKey)} on type ${JSON.stringify(type)}.`,
+		keyConverter:
+			config.keys !== KeyEncodingOptions.usePropertyKeys
+				? undefined
+				: {
+						encode: (type, key: FieldKey): string => {
+							// translate stored key into property key.
+							const simpleNodeSchema =
+								context.schema.get(brand(type)) ?? fail(0xb39 /* missing schema */);
+							if (isObjectNodeSchema(simpleNodeSchema)) {
+								const propertyKey = simpleNodeSchema.storedKeyToPropertyKey.get(key);
+								if (propertyKey !== undefined) {
+									return propertyKey;
+								}
+								// Looking up an out of schema key.
+								// This must point to a non-existent field.
+								// It's possible that the key, if we returned it unmodified, could point to some data
+								// (for example if looking up a key which is a stored key already when using property keys).
+								// Thus return an arbitrary key that was selected randomly, so should not exist on non-adversarial data:
+								const arbitrary = "arbitrary unused key: fe71614a-bf3e-43b3-b7b0-4cef39538e90";
+								assert(
+									!simpleNodeSchema.storedKeyToPropertyKey.has(brand(arbitrary)),
+									0xa13 /* arbitrarily selected unused key was actually used */,
 								);
+								return arbitrary;
 							}
-							return info.storedKey;
-						}
-						return brand(inputKey);
+							return key;
+						},
+						parse: (type, inputKey): FieldKey => {
+							const simpleNodeSchema =
+								context.schema.get(brand(type)) ?? unknownTypeError(type);
+							if (isObjectNodeSchema(simpleNodeSchema)) {
+								const info = simpleNodeSchema.flexKeyMap.get(inputKey);
+								if (info === undefined) {
+									throw new UsageError(
+										`Failed to parse VerboseTree due to unexpected key ${JSON.stringify(inputKey)} on type ${JSON.stringify(type)}.`,
+									);
+								}
+								return info.storedKey;
+							}
+							return brand(inputKey);
+						},
 					},
-				},
 	};
 }
 
@@ -284,7 +287,7 @@ export function verboseFromCursor(
 	options: TreeEncodingOptions,
 ): VerboseTree {
 	const config: Required<TreeEncodingOptions> = {
-		useStoredKeys: false,
+		keys: KeyEncodingOptions.usePropertyKeys,
 		...options,
 	};
 

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -161,6 +161,8 @@ export {
 	type NodeSchemaOptions,
 	type NodeSchemaOptionsAlpha,
 	type SchemaStaticsAlpha,
+	KeyEncodingOptions,
+	type TreeParsingOptions,
 } from "./api/index.js";
 export type {
 	SimpleTreeSchema,

--- a/packages/dds/tree/src/test/simple-tree/api/getJsonSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/getJsonSchema.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "node:assert";
 import {
 	getJsonSchema,
+	KeyEncodingOptions,
 	NodeKind,
 	SchemaFactory,
 	SchemaFactoryAlpha,
@@ -15,8 +16,9 @@ import {
 import { hydrate } from "../utils.js";
 import { getJsonValidator } from "./jsonSchemaUtilities.js";
 
-// TODO: consolidate these tests with those in getJsonSchema.spec.ts
+// TODO: consolidate these tests with those in src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
 // TODO: Add testing for requireFieldWithDefaults = false.
+// TODO: Add testing for KeyEncodingOptions.knownStoredKeys
 
 describe("getJsonSchema", () => {
 	it("Leaf node", () => {
@@ -24,7 +26,7 @@ describe("getJsonSchema", () => {
 		const Schema = schemaFactory.string;
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 
@@ -55,7 +57,7 @@ describe("getJsonSchema", () => {
 		const Schema = [schemaFactory.number, schemaFactory.string] as const;
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 
@@ -102,7 +104,7 @@ describe("getJsonSchema", () => {
 
 		assert.throws(() =>
 			getJsonSchema(Schema, {
-				useStoredKeys: false,
+				keys: KeyEncodingOptions.usePropertyKeys,
 				requireFieldsWithDefaults: true,
 			}),
 		);
@@ -117,7 +119,7 @@ describe("getJsonSchema", () => {
 		});
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 
@@ -163,7 +165,7 @@ describe("getJsonSchema", () => {
 		});
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 		const expected: JsonTreeSchema = {
@@ -228,7 +230,7 @@ describe("getJsonSchema", () => {
 		});
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 		const expected: JsonTreeSchema = {
@@ -291,7 +293,7 @@ describe("getJsonSchema", () => {
 		);
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 
@@ -379,7 +381,7 @@ describe("getJsonSchema", () => {
 		});
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 
@@ -413,7 +415,7 @@ describe("getJsonSchema", () => {
 		});
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 
@@ -454,7 +456,7 @@ describe("getJsonSchema", () => {
 		}) {}
 
 		const actual = getJsonSchema(Schema, {
-			useStoredKeys: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
 			requireFieldsWithDefaults: true,
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
@@ -8,6 +8,7 @@ import {
 	FieldKind,
 	generateSchemaFromSimpleSchema,
 	getJsonSchema,
+	KeyEncodingOptions,
 	NodeKind,
 	normalizeFieldSchema,
 	numberSchema,
@@ -37,7 +38,7 @@ function simpleToJsonSchema(simpleSchema: SimpleTreeSchema): JsonTreeSchema {
 	const schema = generateSchemaFromSimpleSchema(simpleSchema);
 	return toJsonSchema(schema, {
 		requireFieldsWithDefaults: false,
-		useStoredKeys: false,
+		keys: KeyEncodingOptions.usePropertyKeys,
 	});
 }
 
@@ -290,7 +291,7 @@ describe("simpleSchemaToJsonSchema", () => {
 			const empty = schemaFactory.objectAlpha("empty", {});
 			const emptyJson = convertObjectNodeSchema(empty, {
 				requireFieldsWithDefaults: false,
-				useStoredKeys: false,
+				keys: KeyEncodingOptions.usePropertyKeys,
 			});
 			const expectedEmpty: JsonObjectNodeSchema = {
 				type: "object",
@@ -312,7 +313,7 @@ describe("simpleSchemaToJsonSchema", () => {
 			}) {}
 			const withFieldJson = convertObjectNodeSchema(WithField, {
 				requireFieldsWithDefaults: false,
-				useStoredKeys: false,
+				keys: KeyEncodingOptions.usePropertyKeys,
 			});
 			const expectedWithField: JsonObjectNodeSchema = {
 				type: "object",
@@ -682,40 +683,48 @@ describe("simpleSchemaToJsonSchema", () => {
 				const testSchema = normalizeFieldSchema(testTree.schema).allowedTypes;
 
 				{
-					const withPropertyKeys = TreeAlpha.exportConcise(tree, { useStoredKeys: false });
+					const withPropertyKeys = TreeAlpha.exportConcise(tree, {
+						keys: KeyEncodingOptions.usePropertyKeys,
+					});
 					const jsonSchema = getJsonSchema(testSchema, {
 						requireFieldsWithDefaults: true,
-						useStoredKeys: false,
+						keys: KeyEncodingOptions.usePropertyKeys,
 					});
 					const validator = getJsonValidator(jsonSchema);
 					validator(withPropertyKeys, true);
 				}
 
 				{
-					const withStoredKeys = TreeAlpha.exportConcise(tree, { useStoredKeys: true });
+					const withStoredKeys = TreeAlpha.exportConcise(tree, {
+						keys: KeyEncodingOptions.knownStoredKeys,
+					});
 					const jsonSchema = getJsonSchema(testSchema, {
 						requireFieldsWithDefaults: true,
-						useStoredKeys: true,
+						keys: KeyEncodingOptions.knownStoredKeys,
 					});
 					const validator = getJsonValidator(jsonSchema);
 					validator(withStoredKeys, true);
 				}
 
 				{
-					const withPropertyKeys = TreeAlpha.exportConcise(tree, { useStoredKeys: false });
+					const withPropertyKeys = TreeAlpha.exportConcise(tree, {
+						keys: KeyEncodingOptions.usePropertyKeys,
+					});
 					const jsonSchema = getJsonSchema(testSchema, {
 						requireFieldsWithDefaults: false,
-						useStoredKeys: false,
+						keys: KeyEncodingOptions.usePropertyKeys,
 					});
 					const validator = getJsonValidator(jsonSchema);
 					validator(withPropertyKeys, true);
 				}
 
 				{
-					const withStoredKeys = TreeAlpha.exportConcise(tree, { useStoredKeys: true });
+					const withStoredKeys = TreeAlpha.exportConcise(tree, {
+						keys: KeyEncodingOptions.knownStoredKeys,
+					});
 					const jsonSchema = getJsonSchema(testSchema, {
 						requireFieldsWithDefaults: false,
-						useStoredKeys: true,
+						keys: KeyEncodingOptions.knownStoredKeys,
 					});
 					const validator = getJsonValidator(jsonSchema);
 					validator(withStoredKeys, true);

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -21,6 +21,7 @@ import {
 	type InsertableField,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	isTreeNode,
+	KeyEncodingOptions,
 	type NodeFromSchema,
 	permissiveStoredSchemaGenerationOptions,
 	SchemaFactory,
@@ -2824,15 +2825,34 @@ describe("treeNodeApi", () => {
 			for (const testCase of testDocuments) {
 				it(testCase.name, () => {
 					const view = testDocumentIndependentView(testCase);
-					const exported = TreeAlpha.exportConcise(view.root, { useStoredKeys: true });
+					const exported = TreeAlpha.exportConcise(view.root, {
+						keys: KeyEncodingOptions.allStoredKeys,
+					});
 					// We have nothing that imports concise trees with stored keys, so no validation here.
 
 					// Test exporting unhydrated nodes.
 					// For nodes with unknown optional fields and thus are picky about the context, this can catch issues with the context.
 					const clone = TreeBeta.clone(view.root);
-					const exported2 = TreeAlpha.exportConcise(clone, { useStoredKeys: true });
+					const exportedClone = TreeAlpha.exportConcise(clone, {
+						keys: KeyEncodingOptions.allStoredKeys,
+					});
 
-					assert.deepEqual(exported, exported2);
+					assert.deepEqual(exported, exportedClone);
+
+					const exportedKnown = TreeAlpha.exportConcise(view.root, {
+						keys: KeyEncodingOptions.knownStoredKeys,
+					});
+					const exportedCloneKnown = TreeAlpha.exportConcise(clone, {
+						keys: KeyEncodingOptions.knownStoredKeys,
+					});
+
+					assert.deepEqual(exportedKnown, exportedCloneKnown);
+
+					if (testCase.hasUnknownOptionalFields) {
+						assert.notDeepEqual(exported, exportedKnown);
+					} else {
+						assert.deepEqual(exported, exportedKnown);
+					}
 				});
 			}
 		});
@@ -2923,7 +2943,10 @@ describe("treeNodeApi", () => {
 				};
 
 				assert.throws(
-					() => TreeAlpha.importVerbose(Point, exported, { useStoredKeys: true }),
+					() =>
+						TreeAlpha.importVerbose(Point, exported, {
+							keys: KeyEncodingOptions.knownStoredKeys,
+						}),
 					validateUsageError('Field "x" is not defined in the schema "com.example.Point".'),
 				);
 				assert.throws(
@@ -2964,17 +2987,29 @@ describe("treeNodeApi", () => {
 				);
 				const node = createTreeNodeFromInner(flex);
 
-				assert.deepEqual(TreeAlpha.exportVerbose(node, { useStoredKeys: true }), {
-					type: PointUnknown.identifier,
-					fields: { x: 1 },
-				});
+				assert.deepEqual(
+					TreeAlpha.exportVerbose(node, { keys: KeyEncodingOptions.allStoredKeys }),
+					{
+						type: PointUnknown.identifier,
+						fields: { x: 1 },
+					},
+				);
 
-				// TODO AB#43548: provide and test a way to export with stored keys without unknown optional fields.
+				assert.deepEqual(
+					TreeAlpha.exportVerbose(node, { keys: KeyEncodingOptions.knownStoredKeys }),
+					{
+						type: PointUnknown.identifier,
+						fields: {},
+					},
+				);
 
-				assert.deepEqual(TreeAlpha.exportVerbose(node, { useStoredKeys: false }), {
-					type: PointUnknown.identifier,
-					fields: {},
-				});
+				assert.deepEqual(
+					TreeAlpha.exportVerbose(node, { keys: KeyEncodingOptions.usePropertyKeys }),
+					{
+						type: PointUnknown.identifier,
+						fields: {},
+					},
+				);
 			});
 
 			describe("test-documents", () => {
@@ -2984,7 +3019,9 @@ describe("treeNodeApi", () => {
 						const exported =
 							view.root === undefined
 								? undefined
-								: TreeAlpha.exportVerbose(view.root, { useStoredKeys: true });
+								: TreeAlpha.exportVerbose(view.root, {
+										keys: KeyEncodingOptions.allStoredKeys,
+									});
 						const fromView = view.checkout.exportVerbose();
 
 						assert.deepEqual(exported, fromView);
@@ -3016,9 +3053,11 @@ describe("treeNodeApi", () => {
 							const imported = TreeAlpha.importVerbose(testCase.schema, exported);
 							expectTreesEqual(tree, imported);
 
-							const exportedStored = TreeAlpha.exportVerbose(tree, { useStoredKeys: true });
+							const exportedStored = TreeAlpha.exportVerbose(tree, {
+								keys: KeyEncodingOptions.knownStoredKeys,
+							});
 							const importedStored = TreeAlpha.importVerbose(testCase.schema, exportedStored, {
-								useStoredKeys: true,
+								keys: KeyEncodingOptions.knownStoredKeys,
 							});
 							expectTreesEqual(tree, importedStored);
 							expectTreesEqual(imported, importedStored);
@@ -3039,22 +3078,32 @@ describe("treeNodeApi", () => {
 									// Stored keys
 									{
 										const exported = TreeAlpha.exportVerbose(root, {
-											useStoredKeys: true,
+											keys: KeyEncodingOptions.allStoredKeys,
 										});
 										if (testCase.hasUnknownOptionalFields) {
 											// is not defined in the schema
 											assert.throws(
 												() =>
 													TreeAlpha.importVerbose(view.schema, exported, {
-														useStoredKeys: true,
+														keys: KeyEncodingOptions.knownStoredKeys,
 													}),
 												validateUsageError(/is not defined in the schema/),
 											);
 										} else {
 											const imported = TreeAlpha.importVerbose(view.schema, exported, {
-												useStoredKeys: true,
+												keys: KeyEncodingOptions.knownStoredKeys,
 											});
 											expectTreesEqual(root, imported);
+										}
+
+										const exportedKnown = TreeAlpha.exportVerbose(root, {
+											keys: KeyEncodingOptions.knownStoredKeys,
+										});
+										const importedKnown = TreeAlpha.importVerbose(view.schema, exportedKnown, {
+											keys: KeyEncodingOptions.knownStoredKeys,
+										});
+										if (!testCase.hasUnknownOptionalFields) {
+											expectTreesEqual(root, importedKnown);
 										}
 									}
 
@@ -3165,8 +3214,12 @@ function expectTreesEqual(
 	// This should catch all cases, assuming exportVerbose works correctly.
 	// Use stored keys so unknown optional fields can be included.
 	assert.deepEqual(
-		TreeAlpha.exportVerbose(a, { useStoredKeys: true }),
-		TreeAlpha.exportVerbose(b, { useStoredKeys: true }),
+		TreeAlpha.exportVerbose(a, {
+			keys: KeyEncodingOptions.allStoredKeys,
+		}),
+		TreeAlpha.exportVerbose(b, {
+			keys: KeyEncodingOptions.allStoredKeys,
+		}),
 	);
 
 	// Since this uses some of the tools to compare trees that this is testing for, perform the comparison in a few ways to reduce risk of a bug making this pass when it shouldn't:

--- a/packages/dds/tree/src/test/simple-tree/api/verboseTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/verboseTree.spec.ts
@@ -9,7 +9,11 @@ import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
 import { testSpecializedCursor, type TestTree } from "../../cursorTestSuite.js";
 
-import { SchemaFactory, type TreeEncodingOptions } from "../../../simple-tree/index.js";
+import {
+	KeyEncodingOptions,
+	SchemaFactory,
+	type TreeEncodingOptions,
+} from "../../../simple-tree/index.js";
 
 import {
 	applySchemaToParserOptions,
@@ -39,7 +43,7 @@ describe("simple-tree verboseTree", () => {
 			}) {}
 			{
 				const options = applySchemaToParserOptions([A, B], {
-					useStoredKeys: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
 				});
 				assert(options.keyConverter !== undefined);
 				assert.equal(options.keyConverter.parse(A.identifier, "a"), "a");
@@ -51,7 +55,7 @@ describe("simple-tree verboseTree", () => {
 			}
 			{
 				const options = applySchemaToParserOptions([A, B], {
-					useStoredKeys: true,
+					keys: KeyEncodingOptions.allStoredKeys,
 				});
 				assert(options.keyConverter === undefined);
 			}
@@ -120,11 +124,17 @@ describe("simple-tree verboseTree", () => {
 
 		const RootSchema = [TestMap, TestObject, schema.string, schema.null] as const;
 
-		for (const useStoredKeys of [false, true]) {
-			describe(useStoredKeys ? "stored keys" : "property keys", () => {
+		for (const keysSetting of [
+			KeyEncodingOptions.usePropertyKeys,
+			KeyEncodingOptions.allStoredKeys,
+			KeyEncodingOptions.knownStoredKeys,
+		]) {
+			describe(keysSetting, () => {
 				const testTrees: TestTree<VerboseTree>[] = [];
 
-				for (const testCase of useStoredKeys ? storedKeyCases : propertyKeyCases) {
+				for (const testCase of keysSetting === KeyEncodingOptions.usePropertyKeys
+					? propertyKeyCases
+					: storedKeyCases) {
 					testTrees.push({
 						name: JSON.stringify(testCase),
 						dataFactory: () => testCase,
@@ -132,10 +142,10 @@ describe("simple-tree verboseTree", () => {
 				}
 
 				const options: TreeEncodingOptions = {
-					useStoredKeys,
+					keys: keysSetting,
 				};
 				const encodeOptions: TreeEncodingOptions = {
-					useStoredKeys,
+					keys: keysSetting,
 				};
 
 				const finalOptions = applySchemaToParserOptions(RootSchema, options);

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -11,6 +11,7 @@ import { independentView, Tree, TreeAlpha } from "../shared-tree/index.js";
 import {
 	allowUnused,
 	getJsonSchema,
+	KeyEncodingOptions,
 	SchemaFactoryAlpha,
 	TreeViewConfiguration,
 	type ConciseTree,
@@ -1469,7 +1470,7 @@ describe("TableFactory unit tests", () => {
 			takeJsonSnapshot(
 				getJsonSchema(Table, {
 					requireFieldsWithDefaults: false,
-					useStoredKeys: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
 				}) as unknown as JsonCompatibleReadOnly,
 			);
 		});

--- a/packages/framework/ai-collab/src/explicit-strategy/promptGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/promptGeneration.ts
@@ -16,6 +16,7 @@ import {
 	getSimpleSchema,
 	Tree,
 	type TreeNode,
+	KeyEncodingOptions,
 } from "@fluidframework/tree/internal";
 // eslint-disable-next-line import/no-internal-modules
 import { createZodJsonValidator } from "typechat/zod";
@@ -75,7 +76,10 @@ export function getPlanningSystemPrompt(
 	const schema = Tree.schema(treeNode);
 
 	const promptFriendlySchema = getPromptFriendlyTreeSchema(
-		getJsonSchema(schema, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+		getJsonSchema(schema, {
+			requireFieldsWithDefaults: false,
+			keys: KeyEncodingOptions.usePropertyKeys,
+		}),
 	);
 	const role = `I'm an agent who makes plans for another agent to achieve a user-specified goal to update the state of an application.${
 		systemRoleContext === undefined
@@ -129,7 +133,10 @@ export function getEditingSystemPrompt(
 ): string {
 	const schema = Tree.schema(treeNode);
 	const promptFriendlySchema = getPromptFriendlyTreeSchema(
-		getJsonSchema(schema, { useStoredKeys: false, requireFieldsWithDefaults: false }),
+		getJsonSchema(schema, {
+			keys: KeyEncodingOptions.usePropertyKeys,
+			requireFieldsWithDefaults: false,
+		}),
 	);
 	const decoratedTreeJson = toDecoratedJson(idGenerator, treeNode);
 
@@ -181,7 +188,10 @@ export function getReviewSystemPrompt(
 ): string {
 	const schema = Tree.schema(treeNode);
 	const promptFriendlySchema = getPromptFriendlyTreeSchema(
-		getJsonSchema(schema, { useStoredKeys: false, requireFieldsWithDefaults: false }),
+		getJsonSchema(schema, {
+			keys: KeyEncodingOptions.usePropertyKeys,
+			requireFieldsWithDefaults: false,
+		}),
 	);
 	const decoratedTreeJson = toDecoratedJson(idGenerator, treeNode);
 

--- a/packages/framework/ai-collab/src/test/explicit-strategy/agentEditing.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/agentEditing.spec.ts
@@ -14,6 +14,7 @@ import {
 	getJsonSchema,
 	SharedTree,
 	TreeViewConfiguration,
+	KeyEncodingOptions,
 	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/tree/internal";
 
@@ -127,7 +128,10 @@ describe("Makes TS type strings from schema", () => {
 		}) {}
 		assert.equal(
 			getPromptFriendlyTreeSchema(
-				getJsonSchema(Foo, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+				getJsonSchema(Foo, {
+					requireFieldsWithDefaults: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
+				}),
 			),
 			"interface Foo { x: number; y: string; z: null | undefined; }",
 		);
@@ -141,7 +145,10 @@ describe("Makes TS type strings from schema", () => {
 		}) {}
 		assert.equal(
 			getPromptFriendlyTreeSchema(
-				getJsonSchema(Foo, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+				getJsonSchema(Foo, {
+					requireFieldsWithDefaults: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
+				}),
 			),
 			"interface Foo { y: string; }",
 		);
@@ -157,7 +164,10 @@ describe("Makes TS type strings from schema", () => {
 		}) {}
 		assert.equal(
 			getPromptFriendlyTreeSchema(
-				getJsonSchema(Foo, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+				getJsonSchema(Foo, {
+					requireFieldsWithDefaults: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
+				}),
 			),
 			"interface Bar { z: number; } interface Foo { y: number | string | Bar; }",
 		);
@@ -170,7 +180,10 @@ describe("Makes TS type strings from schema", () => {
 		}) {}
 		assert.equal(
 			getPromptFriendlyTreeSchema(
-				getJsonSchema(Foo, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+				getJsonSchema(Foo, {
+					requireFieldsWithDefaults: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
+				}),
 			),
 			"interface Foo { y: number[]; }",
 		);
@@ -186,7 +199,10 @@ describe("Makes TS type strings from schema", () => {
 		}) {}
 		assert.equal(
 			getPromptFriendlyTreeSchema(
-				getJsonSchema(Foo, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+				getJsonSchema(Foo, {
+					requireFieldsWithDefaults: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
+				}),
 			),
 			"interface Foo { y: (number | (number | string[])[])[]; }",
 		);
@@ -195,7 +211,10 @@ describe("Makes TS type strings from schema", () => {
 	it("for objects in the demo schema", () => {
 		assert.equal(
 			getPromptFriendlyTreeSchema(
-				getJsonSchema(RootObject, { requireFieldsWithDefaults: false, useStoredKeys: false }),
+				getJsonSchema(RootObject, {
+					requireFieldsWithDefaults: false,
+					keys: KeyEncodingOptions.usePropertyKeys,
+				}),
 			),
 			"interface Vector { x: number; y: number; z: number | undefined; } interface RootObject { str: string; vectors: Vector[]; bools: boolean[]; }",
 		);

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -872,6 +872,13 @@ export interface JsonValidator {
     compile<Schema extends TSchema>(schema: Schema): SchemaValidationFunction<Schema>;
 }
 
+// @alpha @input
+export enum KeyEncodingOptions {
+    allStoredKeys = "allStoredKeys",
+    knownStoredKeys = "knownStoredKeys",
+    usePropertyKeys = "usePropertyKeys"
+}
+
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
@@ -1657,7 +1664,7 @@ export interface TreeAlpha {
         idCompressor?: IIdCompressor;
     } & ICodecOptions): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
     importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
+    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: TreeParsingOptions): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
     key2(node: TreeNode): string | number | undefined;
 }
 
@@ -1738,9 +1745,9 @@ export enum TreeCompressionStrategy {
     Uncompressed = 1
 }
 
-// @alpha
-export interface TreeEncodingOptions {
-    readonly useStoredKeys?: boolean;
+// @alpha @input
+export interface TreeEncodingOptions<TKeyOptions = KeyEncodingOptions> {
+    readonly keys?: TKeyOptions;
 }
 
 // @public
@@ -1834,6 +1841,9 @@ export type TreeNodeSchemaNonClass<Name extends string = string, Kind extends No
 // @public
 export type TreeObjectNode<T extends RestrictiveStringRecord<ImplicitFieldSchema>, TypeName extends string = string> = TreeNode & ObjectFromSchemaRecord<T> & WithType<TypeName, NodeKind.Object, T>;
 
+// @alpha @input
+export type TreeParsingOptions = TreeEncodingOptions<KeyEncodingOptions.usePropertyKeys | KeyEncodingOptions.knownStoredKeys>;
+
 // @alpha
 export interface TreeRecordNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeNode, Record<string, TreeNodeFromImplicitAllowedTypes<TAllowedTypes>> {
     [Symbol.iterator](): IterableIterator<[
@@ -1857,8 +1867,8 @@ export interface TreeSchema extends SimpleTreeSchema {
     readonly root: FieldSchemaAlpha;
 }
 
-// @alpha
-export interface TreeSchemaEncodingOptions extends TreeEncodingOptions {
+// @alpha @input
+export interface TreeSchemaEncodingOptions extends TreeParsingOptions {
     readonly requireFieldsWithDefaults?: boolean;
 }
 


### PR DESCRIPTION
## Description

Replace `useStoredKeys` Boolean with `keys` taking a `KeyEncodingOptions` enum.

This addresses the last of the issues tracked by [AB#43548](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/43548).

## Breaking Changes

This is a breaking change for code which uses alpha APIs that accept a `TreeEncodingOptions` and specify `useStoredKeys`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
