### PR TITLE
refactor(examples): Use type-only imports and exports where appropriate

### DIFF
--- a/examples/apps/ai-collab/src/app/presence.ts
+++ b/examples/apps/ai-collab/src/app/presence.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-	Presence,
+	type Presence,
 	StateFactory,
 	type Attendee,
 	type StatesWorkspace,

--- a/examples/apps/ai-collab/src/app/tinylicious.ts
+++ b/examples/apps/ai-collab/src/app/tinylicious.ts
@@ -4,7 +4,7 @@
  */
 
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
-import { IFluidContainer, type ContainerSchema } from "fluid-framework";
+import type { IFluidContainer, ContainerSchema } from "fluid-framework";
 
 const tinyliciousClient = new TinyliciousClient({});
 

--- a/examples/apps/ai-collab/src/components/TaskCard.tsx
+++ b/examples/apps/ai-collab/src/components/TaskCard.tsx
@@ -39,8 +39,8 @@ import React, { useState, type ReactNode, type SetStateAction } from "react";
 
 import { getOpenAiClient } from "@/infra/openAiClient";
 import {
-	SharedTreeTask,
-	SharedTreeTaskGroup,
+	type SharedTreeTask,
+	type SharedTreeTaskGroup,
 	SharedTreeAppState,
 	TaskPriorities,
 	type TaskPriority,

--- a/examples/apps/ai-collab/src/components/TaskGroup.tsx
+++ b/examples/apps/ai-collab/src/components/TaskGroup.tsx
@@ -42,7 +42,7 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
-import { type TreeView } from "fluid-framework";
+import type { TreeView } from "fluid-framework";
 import { useSnackbar } from "notistack";
 import React, { useEffect, useState } from "react";
 
@@ -52,7 +52,7 @@ import { getOpenAiClient } from "@/infra/openAiClient";
 import {
 	aiCollabLlmTreeNodeValidator,
 	SharedTreeAppState,
-	SharedTreeTaskGroup,
+	type SharedTreeTaskGroup,
 } from "@/types/sharedTreeAppSchema";
 import { useSharedTreeRerender } from "@/useSharedTreeRerender";
 

--- a/examples/apps/ai-collab/src/infra/authHelper.ts
+++ b/examples/apps/ai-collab/src/infra/authHelper.ts
@@ -6,7 +6,7 @@
 "use client";
 
 import {
-	AccountInfo,
+	type AccountInfo,
 	PublicClientApplication,
 	type AuthenticationResult,
 } from "@azure/msal-browser";

--- a/examples/apps/ai-collab/src/infra/graphHelper.ts
+++ b/examples/apps/ai-collab/src/infra/graphHelper.ts
@@ -11,11 +11,11 @@
 
 "use client";
 
-import { PublicClientApplication, InteractionType, AccountInfo } from "@azure/msal-browser";
+import { type PublicClientApplication, InteractionType, type AccountInfo } from "@azure/msal-browser";
 import { Client } from "@microsoft/microsoft-graph-client";
 import {
 	AuthCodeMSALBrowserAuthenticationProvider,
-	AuthCodeMSALBrowserAuthenticationProviderOptions,
+	type AuthCodeMSALBrowserAuthenticationProviderOptions,
 	// eslint-disable-next-line import/no-internal-modules -- Not exported in the public API; docs use this pattern.
 } from "@microsoft/microsoft-graph-client/authProviders/authCodeMsalBrowser";
 import type { Site } from "@microsoft/microsoft-graph-types";

--- a/examples/apps/ai-collab/src/infra/graphHelper.ts
+++ b/examples/apps/ai-collab/src/infra/graphHelper.ts
@@ -11,7 +11,11 @@
 
 "use client";
 
-import { type PublicClientApplication, InteractionType, type AccountInfo } from "@azure/msal-browser";
+import {
+	type PublicClientApplication,
+	InteractionType,
+	type AccountInfo,
+} from "@azure/msal-browser";
 import { Client } from "@microsoft/microsoft-graph-client";
 import {
 	AuthCodeMSALBrowserAuthenticationProvider,

--- a/examples/apps/ai-collab/src/infra/tokenProvider.ts
+++ b/examples/apps/ai-collab/src/infra/tokenProvider.ts
@@ -6,11 +6,11 @@
 "use client";
 
 import {
-	AuthenticationResult,
+	type AuthenticationResult,
 	InteractionRequiredAuthError,
-	PublicClientApplication,
+	type PublicClientApplication,
 } from "@azure/msal-browser";
-import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
+import type { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
 
 // Sample implementation of the IOdspTokenProvider interface.
 // Provides the token that the Fluid service expects when asked for the Fluid container and for the WebSocket connection.

--- a/examples/apps/ai-collab/src/useFluidContainerNextjs.ts
+++ b/examples/apps/ai-collab/src/useFluidContainerNextjs.ts
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { IFluidContainer, type ContainerSchema } from "fluid-framework";
+import type { IFluidContainer, ContainerSchema } from "fluid-framework";
 import { useEffect, useState } from "react";
 
 /**

--- a/examples/apps/ai-collab/src/useSharedTreeRerender.ts
+++ b/examples/apps/ai-collab/src/useSharedTreeRerender.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Tree, TreeNode } from "fluid-framework";
+import { Tree, type TreeNode } from "fluid-framework";
 import { useEffect, useState } from "react";
 
 /**

--- a/examples/apps/blobs/src/container/blobCollection/index.ts
+++ b/examples/apps/blobs/src/container/blobCollection/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { BlobCollectionFactory } from "./blobCollection.js";
-export {
+export type {
 	IBlobCollection,
 	IBlobCollectionEvents,
 	IBlobRecord,

--- a/examples/apps/blobs/src/container/index.ts
+++ b/examples/apps/blobs/src/container/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
+export type {
 	IBlobCollection,
 	IBlobCollectionEvents,
 	IBlobRecord,

--- a/examples/apps/collaborative-textarea/src/app.ts
+++ b/examples/apps/collaborative-textarea/src/app.ts
@@ -9,7 +9,7 @@ import ReactDOM from "react-dom";
 
 import {
 	CollaborativeTextContainerRuntimeFactory,
-	ICollaborativeTextAppModel,
+	type ICollaborativeTextAppModel,
 } from "./container.js";
 import { CollaborativeTextView } from "./view.js";
 

--- a/examples/apps/collaborative-textarea/src/container.ts
+++ b/examples/apps/collaborative-textarea/src/container.ts
@@ -7,8 +7,8 @@ import {
 	ModelContainerRuntimeFactory,
 	getDataStoreEntryPoint,
 } from "@fluid-example/example-utils";
-import { IContainer } from "@fluidframework/container-definitions/legacy";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
+import type { IContainer } from "@fluidframework/container-definitions/legacy";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
 
 import { CollaborativeText } from "./fluid-object/index.js";
 

--- a/examples/apps/collaborative-textarea/src/fluid-object/index.ts
+++ b/examples/apps/collaborative-textarea/src/fluid-object/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedString, type ISharedString } from "@fluidframework/sequence/legacy";
 
 /**

--- a/examples/apps/collaborative-textarea/src/view.tsx
+++ b/examples/apps/collaborative-textarea/src/view.tsx
@@ -4,7 +4,7 @@
  */
 
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-example/example-utils";
-import { SharedString } from "@fluidframework/sequence/legacy";
+import type { SharedString } from "@fluidframework/sequence/legacy";
 import React from "react";
 
 interface CollaborativeTextProps {

--- a/examples/apps/contact-collection/src/app.ts
+++ b/examples/apps/contact-collection/src/app.ts
@@ -7,7 +7,7 @@ import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example
 
 import {
 	ContactCollectionContainerRuntimeFactory,
-	IContactCollectionAppModel,
+	type IContactCollectionAppModel,
 } from "./containerCode.js";
 import { renderContact, renderContactCollection } from "./view.js";
 

--- a/examples/apps/contact-collection/src/containerCode.ts
+++ b/examples/apps/contact-collection/src/containerCode.ts
@@ -7,10 +7,10 @@ import {
 	ModelContainerRuntimeFactory,
 	getDataStoreEntryPoint,
 } from "@fluid-example/example-utils";
-import { IContainer } from "@fluidframework/container-definitions/legacy";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
+import type { IContainer } from "@fluidframework/container-definitions/legacy";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
 
-import { ContactCollectionInstantiationFactory, IContactCollection } from "./dataObject.js";
+import { ContactCollectionInstantiationFactory, type IContactCollection } from "./dataObject.js";
 
 const contactCollectionId = "contactCollection";
 

--- a/examples/apps/contact-collection/src/containerCode.ts
+++ b/examples/apps/contact-collection/src/containerCode.ts
@@ -10,7 +10,10 @@ import {
 import type { IContainer } from "@fluidframework/container-definitions/legacy";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
 
-import { ContactCollectionInstantiationFactory, type IContactCollection } from "./dataObject.js";
+import {
+	ContactCollectionInstantiationFactory,
+	type IContactCollection,
+} from "./dataObject.js";
 
 const contactCollectionId = "contactCollection";
 

--- a/examples/apps/contact-collection/src/view.ts
+++ b/examples/apps/contact-collection/src/view.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IContact, IContactCollection } from "./dataObject.js";
+import type { IContact, IContactCollection } from "./dataObject.js";
 
 function makeContactDiv(contact: IContact): HTMLDivElement {
 	const contactDiv = document.createElement("div");

--- a/examples/apps/data-object-grid/src/app.ts
+++ b/examples/apps/data-object-grid/src/app.ts
@@ -9,7 +9,7 @@ import ReactDOM from "react-dom";
 
 import {
 	DataObjectGridContainerRuntimeFactory,
-	IDataObjectGridAppModel,
+	type IDataObjectGridAppModel,
 } from "./container.js";
 import { DataObjectGridAppView } from "./dataObjectGridView.js";
 

--- a/examples/apps/data-object-grid/src/container.ts
+++ b/examples/apps/data-object-grid/src/container.ts
@@ -7,10 +7,10 @@ import {
 	ModelContainerRuntimeFactory,
 	getDataStoreEntryPoint,
 } from "@fluid-example/example-utils";
-import { IContainer } from "@fluidframework/container-definitions/legacy";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
+import type { IContainer } from "@fluidframework/container-definitions/legacy";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
 
-import { DataObjectGrid, IDataObjectGrid } from "./dataObjectGrid.js";
+import { DataObjectGrid, type IDataObjectGrid } from "./dataObjectGrid.js";
 import type { ISingleHandleItem } from "./dataObjectRegistry.js";
 
 /**

--- a/examples/apps/data-object-grid/src/dataObjectGrid.ts
+++ b/examples/apps/data-object-grid/src/dataObjectGrid.ts
@@ -5,9 +5,9 @@
 
 import type { EventEmitter } from "@fluid-example/example-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { Serializable } from "@fluidframework/datastore-definitions/legacy";
+import type { Serializable } from "@fluidframework/datastore-definitions/legacy";
 import type React from "react";
-import { Layout } from "react-grid-layout";
+import type { Layout } from "react-grid-layout";
 import { v4 as uuid } from "uuid";
 
 import {

--- a/examples/apps/data-object-grid/src/dataObjectGridView.tsx
+++ b/examples/apps/data-object-grid/src/dataObjectGridView.tsx
@@ -4,11 +4,11 @@
  */
 
 import React from "react";
-import RGL, { WidthProvider, Layout } from "react-grid-layout";
+import RGL, { WidthProvider, type Layout } from "react-grid-layout";
 
-import { IDataObjectGrid, IDataObjectGridItem } from "./dataObjectGrid.js";
+import type { IDataObjectGrid, IDataObjectGridItem } from "./dataObjectGrid.js";
 import {
-	IDataObjectGridItemEntry,
+	type IDataObjectGridItemEntry,
 	dataObjectRegistry,
 	type ISingleHandleItem,
 } from "./dataObjectRegistry.js";

--- a/examples/apps/data-object-grid/src/dataObjectRegistry.ts
+++ b/examples/apps/data-object-grid/src/dataObjectRegistry.ts
@@ -4,12 +4,12 @@
  */
 
 import {
-	Clicker,
+	type Clicker,
 	ClickerInstantiationFactory,
 	ClickerReactView,
 } from "@fluid-example/clicker";
 import {
-	CodeMirrorComponent,
+	type CodeMirrorComponent,
 	CodeMirrorReactView,
 	SmdeFactory,
 } from "@fluid-example/codemirror";
@@ -20,13 +20,13 @@ import {
 import { Coordinate } from "@fluid-example/multiview-coordinate-model";
 import { SliderCoordinateView } from "@fluid-example/multiview-slider-coordinate-view";
 import {
-	ProseMirror,
+	type ProseMirror,
 	ProseMirrorFactory,
 	ProseMirrorReactView,
 } from "@fluid-example/prosemirror";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { Serializable } from "@fluidframework/datastore-definitions/legacy";
-import {
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { Serializable } from "@fluidframework/datastore-definitions/legacy";
+import type {
 	IFluidDataStoreContext,
 	IFluidDataStoreFactory,
 	NamedFluidDataStoreRegistryEntries,

--- a/examples/apps/data-object-grid/src/toolbar.tsx
+++ b/examples/apps/data-object-grid/src/toolbar.tsx
@@ -8,7 +8,7 @@ import { ChevronDownFilled, ChevronUpFilled, TargetEditFilled } from "@fluentui/
 import React from "react";
 
 import { Collapsible } from "./collapsible.cjs";
-import { IDataObjectGridItemEntry, type ISingleHandleItem } from "./dataObjectRegistry.js";
+import type { IDataObjectGridItemEntry, ISingleHandleItem } from "./dataObjectRegistry.js";
 import { iconMap } from "./icons.js";
 import "./toolbar.css";
 

--- a/examples/benchmarks/bubblebench/baseline/src/index.ts
+++ b/examples/benchmarks/bubblebench/baseline/src/index.ts
@@ -7,7 +7,7 @@ import { AppView } from "@fluid-example/bubblebench-common";
 import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import React from "react";
 
-import { Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
+import { type Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
 export { Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
 
 const bubblebenchViewCallback = (model: Bubblebench): React.ReactElement =>

--- a/examples/benchmarks/bubblebench/baseline/src/state.ts
+++ b/examples/benchmarks/bubblebench/baseline/src/state.ts
@@ -4,9 +4,9 @@
  */
 
 import {
-	IAppState,
-	IBubble,
-	SimpleClient,
+	type IAppState,
+	type IBubble,
+	type SimpleClient,
 	makeBubble,
 	makeClient,
 } from "@fluid-example/bubblebench-common";

--- a/examples/benchmarks/bubblebench/common/src/index.ts
+++ b/examples/benchmarks/bubblebench/common/src/index.ts
@@ -4,6 +4,13 @@
  */
 
 export { AppView, type IAppProps } from "./view/index.js";
-export { type IAppState, type IBubble, type IClient, makeBubble, makeClient, type SimpleClient } from "./types.js";
+export {
+	type IAppState,
+	type IBubble,
+	type IClient,
+	makeBubble,
+	makeClient,
+	type SimpleClient,
+} from "./types.js";
 export { normal, randomColor, rnd } from "./rnd.js";
 export { Stats } from "./stats.js";

--- a/examples/benchmarks/bubblebench/common/src/index.ts
+++ b/examples/benchmarks/bubblebench/common/src/index.ts
@@ -4,6 +4,6 @@
  */
 
 export { AppView, type IAppProps } from "./view/index.js";
-export { IAppState, IBubble, IClient, makeBubble, makeClient, SimpleClient } from "./types.js";
+export { type IAppState, type IBubble, type IClient, makeBubble, makeClient, type SimpleClient } from "./types.js";
 export { normal, randomColor, rnd } from "./rnd.js";
 export { Stats } from "./stats.js";

--- a/examples/benchmarks/bubblebench/common/src/view/app.tsx
+++ b/examples/benchmarks/bubblebench/common/src/view/app.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from "react";
 
 import { Stats } from "../stats.js";
-import { IAppState, IBubble } from "../types.js";
+import type { IAppState, IBubble } from "../types.js";
 
 import { StageView } from "./stage.js";
 import { useResizeObserver } from "./useResizeObserver.cjs";

--- a/examples/benchmarks/bubblebench/common/src/view/bubble.tsx
+++ b/examples/benchmarks/bubblebench/common/src/view/bubble.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 
-import { IBubble } from "../types.js";
+import type { IBubble } from "../types.js";
 
 export type IBubbleProps = Pick<IBubble, "x" | "y" | "r">;
 

--- a/examples/benchmarks/bubblebench/common/src/view/stage.tsx
+++ b/examples/benchmarks/bubblebench/common/src/view/stage.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 
-import { IAppState } from "../types.js";
+import type { IAppState } from "../types.js";
 
 import { BubbleView } from "./bubble.js";
 

--- a/examples/benchmarks/bubblebench/experimental-tree/src/index.ts
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/index.ts
@@ -7,7 +7,7 @@ import { AppView } from "@fluid-example/bubblebench-common";
 import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import React from "react";
 
-import { Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
+import { type Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
 export { Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
 
 const bubblebenchViewCallback = (model: Bubblebench): React.ReactElement =>

--- a/examples/benchmarks/bubblebench/experimental-tree/src/main.tsx
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/main.tsx
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IClient } from "@fluid-example/bubblebench-common";
+import type { IClient } from "@fluid-example/bubblebench-common";
 import { SharedTree, WriteFormat } from "@fluid-experimental/tree";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import { TreeObjectProxy } from "./proxy/index.js";
 import { AppState } from "./state.js";

--- a/examples/benchmarks/bubblebench/experimental-tree/src/proxy/tree.ts
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/proxy/tree.ts
@@ -5,12 +5,12 @@
 
 import {
 	Change,
-	ChangeNode,
-	NodeId,
-	SharedTree,
+	type ChangeNode,
+	type NodeId,
+	type SharedTree,
 	StablePlace,
 	StableRange,
-	TraitLabel,
+	type TraitLabel,
 } from "@fluid-experimental/tree";
 import { Serializable } from "@fluidframework/datastore-definitions/legacy";
 

--- a/examples/benchmarks/bubblebench/experimental-tree/src/proxy/treeutils.ts
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/proxy/treeutils.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ChangeNode, Definition, NodeIdContext } from "@fluid-experimental/tree";
-import { Serializable } from "@fluidframework/datastore-definitions/legacy";
+import type { ChangeNode, Definition, NodeIdContext } from "@fluid-experimental/tree";
+import type { Serializable } from "@fluidframework/datastore-definitions/legacy";
 
 export const enum NodeKind {
 	scalar = "s",

--- a/examples/benchmarks/bubblebench/experimental-tree/src/state.ts
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/state.ts
@@ -4,16 +4,16 @@
  */
 
 import {
-	IAppState,
-	IClient,
+	type IAppState,
+	type IClient,
 	makeBubble,
 	makeClient,
-	SimpleClient,
+	type SimpleClient,
 	type IBubble,
 } from "@fluid-example/bubblebench-common";
-import { Change, SharedTree } from "@fluid-experimental/tree";
+import type { Change, SharedTree } from "@fluid-experimental/tree";
 
-import { TreeArrayProxy, TreeObjectProxy, fromJson } from "./proxy/index.js";
+import { type TreeArrayProxy, TreeObjectProxy, fromJson } from "./proxy/index.js";
 
 interface IApp {
 	readonly clients: SimpleClient[];

--- a/examples/benchmarks/bubblebench/ot/src/index.ts
+++ b/examples/benchmarks/bubblebench/ot/src/index.ts
@@ -7,7 +7,7 @@ import { AppView } from "@fluid-example/bubblebench-common";
 import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import React from "react";
 
-import { Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
+import { type Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
 export { Bubblebench, BubblebenchInstantiationFactory } from "./main.js";
 
 const bubblebenchViewCallback = (model: Bubblebench): React.ReactElement =>

--- a/examples/benchmarks/bubblebench/ot/src/main.ts
+++ b/examples/benchmarks/bubblebench/ot/src/main.ts
@@ -5,7 +5,7 @@
 
 import { SharedJson1 } from "@fluid-experimental/sharejs-json1";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import { AppState } from "./state.js";
 

--- a/examples/benchmarks/bubblebench/shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/bubblebench.ts
@@ -4,8 +4,8 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ITree, type TreeView } from "@fluidframework/tree";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { ITree, TreeView } from "@fluidframework/tree";
 import { SharedTree } from "@fluidframework/tree/legacy";
 
 import { AppState } from "./appState.js";

--- a/examples/benchmarks/bubblebench/shared-tree/src/index.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/index.ts
@@ -7,7 +7,7 @@ import { AppView } from "@fluid-example/bubblebench-common";
 import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import React from "react";
 
-import { Bubblebench, BubblebenchInstantiationFactory } from "./bubblebench.js";
+import { type Bubblebench, BubblebenchInstantiationFactory } from "./bubblebench.js";
 
 const bubblebenchViewCallback = (model: Bubblebench): React.ReactElement =>
 	React.createElement(AppView, { app: model.appState });

--- a/examples/client-logger/app-insights-logger/src/components/App.tsx
+++ b/examples/client-logger/app-insights-logger/src/components/App.tsx
@@ -4,15 +4,15 @@
  */
 
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-example/example-utils";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/legacy";
-import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { type ISharedMap, SharedMap } from "@fluidframework/map/legacy";
 import { SharedString } from "@fluidframework/sequence/legacy";
 import React from "react";
 
 import {
-	ContainerInfo,
+	type ContainerInfo,
 	createFluidContainer,
 	loadExistingFluidContainer,
 } from "./ClientUtilities.js";

--- a/examples/client-logger/app-insights-logger/src/components/ClientUtilities.ts
+++ b/examples/client-logger/app-insights-logger/src/components/ClientUtilities.ts
@@ -5,10 +5,10 @@
 
 import { createLogger } from "@fluidframework/app-insights-logger/beta";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import {
 	TinyliciousClient,
-	TinyliciousContainerServices,
+	type TinyliciousContainerServices,
 } from "@fluidframework/tinylicious-client";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 

--- a/examples/data-objects/canvas/src/canvas.ts
+++ b/examples/data-objects/canvas/src/canvas.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IInk, Ink } from "@fluid-experimental/ink";
+import { type IInk, Ink } from "@fluid-experimental/ink";
 import { DataObject } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 export class Canvas extends DataObject {
 	private _ink: IInk | undefined;

--- a/examples/data-objects/canvas/src/view.tsx
+++ b/examples/data-objects/canvas/src/view.tsx
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IColor, InkCanvas } from "@fluid-experimental/ink";
+import { type IColor, InkCanvas } from "@fluid-experimental/ink";
 import React, { useEffect, useRef, useState } from "react";
 
-import { Canvas } from "./canvas.js";
+import type { Canvas } from "./canvas.js";
 // eslint-disable-next-line import/no-unassigned-import
 import "./style.less";
 

--- a/examples/data-objects/inventory-app/src/view/inventoryList.tsx
+++ b/examples/data-objects/inventory-app/src/view/inventoryList.tsx
@@ -6,7 +6,7 @@
 import { useTree } from "@fluid-experimental/tree-react-api";
 import * as React from "react";
 
-import { Inventory } from "../schema.js";
+import type { Inventory } from "../schema.js";
 
 import { Counter } from "./counter.js";
 

--- a/examples/data-objects/monaco/src/dataObject.ts
+++ b/examples/data-objects/monaco/src/dataObject.ts
@@ -5,7 +5,7 @@
 
 // inspiration for this example taken from https://github.com/agentcooper/typescript-play
 import { DataObject } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedString } from "@fluidframework/sequence/legacy";
 
 /**

--- a/examples/data-objects/monaco/src/view.tsx
+++ b/examples/data-objects/monaco/src/view.tsx
@@ -6,8 +6,8 @@
 // inspiration for this example taken from https://github.com/agentcooper/typescript-play
 import {
 	MergeTreeDeltaType,
-	SequenceDeltaEvent,
-	SharedString,
+	type SequenceDeltaEvent,
+	type SharedString,
 	TextSegment,
 } from "@fluidframework/sequence/legacy";
 import * as monaco from "monaco-editor";

--- a/examples/data-objects/multiview/constellation-model/src/model.ts
+++ b/examples/data-objects/multiview/constellation-model/src/model.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { IConstellation, ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type {
+	IConstellation,
+	ICoordinate,
+} from "@fluid-example/multiview-coordinate-interface";
 import { Coordinate } from "@fluid-example/multiview-coordinate-model";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";

--- a/examples/data-objects/multiview/constellation-model/src/model.ts
+++ b/examples/data-objects/multiview/constellation-model/src/model.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IConstellation, ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { IConstellation, ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import { Coordinate } from "@fluid-example/multiview-coordinate-model";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { IValueChanged } from "@fluidframework/map/legacy";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IValueChanged } from "@fluidframework/map/legacy";
 
 const starListKey = "stars";
 const constellationName = "@fluid-example/constellation";

--- a/examples/data-objects/multiview/container/src/container.tsx
+++ b/examples/data-objects/multiview/container/src/container.tsx
@@ -4,16 +4,16 @@
  */
 
 import {
-	IFluidMountableViewEntryPoint,
+	type IFluidMountableViewEntryPoint,
 	MountableView,
 	getDataStoreEntryPoint,
 } from "@fluid-example/example-utils";
 import { Constellation } from "@fluid-example/multiview-constellation-model";
-import { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import { Coordinate } from "@fluid-example/multiview-coordinate-model";
 import { BaseContainerRuntimeFactory } from "@fluidframework/aqueduct/legacy";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
-import { FluidObject } from "@fluidframework/core-interfaces";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
+import type { FluidObject } from "@fluidframework/core-interfaces";
 import * as React from "react";
 
 import { DefaultView } from "./defaultView.js";

--- a/examples/data-objects/multiview/container/src/defaultView.tsx
+++ b/examples/data-objects/multiview/container/src/defaultView.tsx
@@ -4,7 +4,7 @@
  */
 
 import { ConstellationView } from "@fluid-example/multiview-constellation-view";
-import { IConstellation, ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { IConstellation, ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import { PlotCoordinateView } from "@fluid-example/multiview-plot-coordinate-view";
 import { SliderCoordinateView } from "@fluid-example/multiview-slider-coordinate-view";
 import { TriangleView } from "@fluid-example/multiview-triangle-view";

--- a/examples/data-objects/multiview/container/src/defaultView.tsx
+++ b/examples/data-objects/multiview/container/src/defaultView.tsx
@@ -4,7 +4,10 @@
  */
 
 import { ConstellationView } from "@fluid-example/multiview-constellation-view";
-import type { IConstellation, ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type {
+	IConstellation,
+	ICoordinate,
+} from "@fluid-example/multiview-coordinate-interface";
 import { PlotCoordinateView } from "@fluid-example/multiview-plot-coordinate-view";
 import { SliderCoordinateView } from "@fluid-example/multiview-slider-coordinate-view";
 import { TriangleView } from "@fluid-example/multiview-triangle-view";

--- a/examples/data-objects/multiview/coordinate-model/src/model.ts
+++ b/examples/data-objects/multiview/coordinate-model/src/model.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
-import { IValueChanged } from "@fluidframework/map/legacy";
+import type { IValueChanged } from "@fluidframework/map/legacy";
 
 const xKey = "x";
 const yKey = "y";

--- a/examples/data-objects/multiview/plot-coordinate-view/src/view.tsx
+++ b/examples/data-objects/multiview/plot-coordinate-view/src/view.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import React from "react";
 
 // eslint-disable-next-line import/no-unassigned-import

--- a/examples/data-objects/multiview/slider-coordinate-view/src/view.tsx
+++ b/examples/data-objects/multiview/slider-coordinate-view/src/view.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import React from "react";
 
 // eslint-disable-next-line import/no-unassigned-import

--- a/examples/data-objects/multiview/triangle-view/src/view.tsx
+++ b/examples/data-objects/multiview/triangle-view/src/view.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
+import type { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 import React from "react";
 
 // eslint-disable-next-line import/no-unassigned-import

--- a/examples/data-objects/table-tree/src/react/tableHeaderView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableHeaderView.tsx
@@ -13,7 +13,7 @@ import {
 	Option,
 } from "@fluentui/react-components";
 import { Add24Regular, Checkmark24Regular, Delete24Regular } from "@fluentui/react-icons";
-import React, { DragEvent, useState } from "react";
+import React, { type DragEvent, useState } from "react";
 
 import { Column } from "../schema.js";
 

--- a/examples/data-objects/table-tree/src/react/tableRowView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableRowView.tsx
@@ -5,9 +5,9 @@
 
 import { TableRow, TableCell, Input, Button, Checkbox } from "@fluentui/react-components";
 import { Delete24Regular } from "@fluentui/react-icons";
-import React, { DragEvent } from "react";
+import React, { type DragEvent } from "react";
 
-import { type Column, type Row } from "../schema.js";
+import type { Column, Row } from "../schema.js";
 
 /**
  * Props for the `TableRowView` component, which renders a single row in the table.

--- a/examples/data-objects/table-tree/src/react/tableView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableView.tsx
@@ -5,10 +5,10 @@
 
 import { Table, TableBody, Button } from "@fluentui/react-components";
 import { Add24Regular } from "@fluentui/react-icons";
-import React, { useState, DragEvent } from "react";
+import React, { useState, type DragEvent } from "react";
 
-import { TableDataObject } from "../dataObject.js";
-import { Column, Row } from "../schema.js";
+import type { TableDataObject } from "../dataObject.js";
+import { type Column, Row } from "../schema.js";
 
 import { TableHeaderView } from "./tableHeaderView.js";
 import { TableRowView } from "./tableRowView.js";

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { Server } from "node:http";
+import type { Server } from "node:http";
 
 import cors from "cors";
 import express from "express";
 
-import { ITaskData, assertValidTaskData } from "../model-interface/index.js";
+import { type ITaskData, assertValidTaskData } from "../model-interface/index.js";
 import { ClientManager } from "../utilities/index.js";
 
 /**

--- a/examples/external-data/src/mock-external-data-service/externalDataSource.ts
+++ b/examples/external-data/src/mock-external-data-service/externalDataSource.ts
@@ -6,7 +6,7 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IEvent } from "@fluidframework/core-interfaces";
 
-import { ITaskData, ITaskListData } from "../model-interface/index.js";
+import type { ITaskData, ITaskListData } from "../model-interface/index.js";
 
 const taskList1: ITaskData = {
 	12: {

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { Server } from "node:http";
+import type { Server } from "node:http";
 
 import cors from "cors";
 import express from "express";
 import { isWebUri } from "valid-url";
 
-import { ITaskData, assertValidTaskData } from "../model-interface/index.js";
+import { type ITaskData, assertValidTaskData } from "../model-interface/index.js";
 
 import { ExternalDataSource } from "./externalDataSource.js";
 import { MockWebhook } from "./webhook.js";

--- a/examples/external-data/src/mock-external-data-service/start.ts
+++ b/examples/external-data/src/mock-external-data-service/start.ts
@@ -4,11 +4,11 @@
  */
 
 import { externalDataServicePort } from "../mock-external-data-service-interface/index.js";
-import { ITaskData } from "../model-interface/index.js";
+import type { ITaskData } from "../model-interface/index.js";
 
 import { ExternalDataSource } from "./externalDataSource.js";
 import { initializeExternalDataService } from "./service.js";
-import { MockWebhook } from "./webhook.js";
+import type { MockWebhook } from "./webhook.js";
 
 /**
  * Initializes the mock external data service on its {@link externalDataServicePort | default port}.

--- a/examples/external-data/src/model-interface/index.ts
+++ b/examples/external-data/src/model-interface/index.ts
@@ -4,8 +4,8 @@
  */
 
 import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
-import { IResolvedUrl } from "@fluidframework/driver-definitions/legacy";
-import { SharedString } from "@fluidframework/sequence/legacy";
+import type { IResolvedUrl } from "@fluidframework/driver-definitions/legacy";
+import type { SharedString } from "@fluidframework/sequence/legacy";
 
 /**
  * Interface for interacting with external task data stored in root {@link @fluidframework/map#SharedDirectory}.
@@ -216,4 +216,4 @@ export interface IBaseDocument extends IEventProvider<IBaseDocumentEvents> {
 	readonly setLeader: (newLeader: string) => void;
 }
 
-export { assertValidTaskData, ITaskListData, ITaskData } from "./TaskData.js";
+export { assertValidTaskData, type ITaskListData, type ITaskData } from "./TaskData.js";

--- a/examples/external-data/src/model/appModel.ts
+++ b/examples/external-data/src/model/appModel.ts
@@ -4,9 +4,9 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IContainer } from "@fluidframework/container-definitions/legacy";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
-import { IResolvedUrl } from "@fluidframework/driver-definitions/legacy";
+import type { IContainer } from "@fluidframework/container-definitions/legacy";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
+import type { IResolvedUrl } from "@fluidframework/driver-definitions/legacy";
 
 import type { IAppModel, IAppModelEvents, IBaseDocument } from "../model-interface/index.js";
 

--- a/examples/external-data/src/model/taskList.ts
+++ b/examples/external-data/src/model/taskList.ts
@@ -6,9 +6,9 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 // eslint-disable-next-line import/no-internal-modules -- #26903: `cell` internals used in examples
-import { ISharedCell, SharedCell } from "@fluidframework/cell/internal";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { IResolvedUrl } from "@fluidframework/driver-definitions/legacy";
+import { type ISharedCell, SharedCell } from "@fluidframework/cell/internal";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IResolvedUrl } from "@fluidframework/driver-definitions/legacy";
 import { type ISharedMap, SharedMap } from "@fluidframework/map/legacy";
 import { SharedString } from "@fluidframework/sequence/legacy";
 

--- a/examples/external-data/src/view/index.ts
+++ b/examples/external-data/src/view/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { IAppViewProps, AppView } from "./appView.js";
+export { type IAppViewProps, AppView } from "./appView.js";
 export { DebugView } from "./debugView.js";
-export { ITaskListViewProps, TaskListView } from "./taskListView.js";
+export { type ITaskListViewProps, TaskListView } from "./taskListView.js";

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -11,11 +11,11 @@ import express from "express";
 import { initializeCustomerService } from "../src/mock-customer-service/index.js";
 import { customerServicePort } from "../src/mock-customer-service-interface/index.js";
 import {
-	MockWebhook,
+	type MockWebhook,
 	initializeExternalDataService,
 } from "../src/mock-external-data-service/index.js";
 import { externalDataServicePort } from "../src/mock-external-data-service-interface/index.js";
-import { ITaskData } from "../src/model-interface/index.js";
+import type { ITaskData } from "../src/model-interface/index.js";
 
 import { closeServer, delay } from "./utilities.js";
 

--- a/examples/external-data/tests/externalDataService.test.ts
+++ b/examples/external-data/tests/externalDataService.test.ts
@@ -11,11 +11,11 @@ import request from "supertest";
 
 import {
 	ExternalDataSource,
-	MockWebhook,
+	type MockWebhook,
 	initializeExternalDataService,
 } from "../src/mock-external-data-service/index.js";
 import { externalDataServicePort } from "../src/mock-external-data-service-interface/index.js";
-import { ITaskData, assertValidTaskData } from "../src/model-interface/index.js";
+import { type ITaskData, assertValidTaskData } from "../src/model-interface/index.js";
 
 import { closeServer, delay } from "./utilities.js";
 

--- a/examples/external-data/tests/taskData.test.ts
+++ b/examples/external-data/tests/taskData.test.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITaskData, assertValidTaskData } from "../src/model-interface/index.js";
+import { type ITaskData, assertValidTaskData } from "../src/model-interface/index.js";
 
 /**
  * {@link ITaskData} unit tests.

--- a/examples/external-data/tests/utilities.ts
+++ b/examples/external-data/tests/utilities.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Server } from "node:http";
+import type { Server } from "node:http";
 
 /**
  * "Promisifies" `Server.close`.

--- a/examples/service-clients/azure-client/external-controller/src/AzureFunctionTokenProvider.ts
+++ b/examples/service-clients/azure-client/external-controller/src/AzureFunctionTokenProvider.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember } from "@fluidframework/azure-client";
-import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import type { AzureMember } from "@fluidframework/azure-client";
+import type { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 import axios from "axios";
 
 /**

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { AzureClient, AzureContainerServices } from "@fluidframework/azure-client";
+import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
 import { createDevtoolsLogger, initializeDevtools } from "@fluidframework/devtools/beta";
 import { getPresence } from "@fluidframework/presence/beta";
 import { createChildLogger } from "@fluidframework/telemetry-utils/legacy";
-import { type IFluidContainer } from "fluid-framework";
+import type { IFluidContainer } from "fluid-framework";
 
 import { DiceRollerController, type DieValue } from "./controller.js";
 import {
@@ -18,7 +18,7 @@ import {
 	type DiceRollerContainerSchema,
 } from "./fluid.js";
 import { buildDicePresence } from "./presence.js";
-import { TwoDiceApp } from "./schema.js";
+import type { TwoDiceApp } from "./schema.js";
 import { makeAppView } from "./view.js";
 
 async function start(): Promise<void> {

--- a/examples/service-clients/azure-client/external-controller/src/fluid.ts
+++ b/examples/service-clients/azure-client/external-controller/src/fluid.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	AzureLocalConnectionConfig,
 	AzureRemoteConnectionConfig,
 } from "@fluidframework/azure-client";

--- a/examples/service-clients/azure-client/external-controller/src/presence.ts
+++ b/examples/service-clients/azure-client/external-controller/src/presence.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-	Presence,
+	type Presence,
 	StateFactory,
 	type StatesWorkspace,
 	type StatesWorkspaceSchema,

--- a/examples/service-clients/azure-client/external-controller/src/view.ts
+++ b/examples/service-clients/azure-client/external-controller/src/view.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
+import type { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 import type { LatestRaw, Presence } from "@fluidframework/presence/beta";
 
-import { IDiceRollerController } from "./controller.js";
-import { ICustomUserDetails } from "./fluid.js";
+import type { IDiceRollerController } from "./controller.js";
+import type { ICustomUserDetails } from "./fluid.js";
 import type { DiceValues } from "./presence.js";
 
 function makeDiceRollerView(diceRoller: IDiceRollerController): HTMLDivElement {

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-client/beta";
+import type { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-client/beta";
 
 import { OdspTestTokenProvider } from "./tokenProvider.js";
 

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
-import { ContainerSchema, IFluidContainer, SharedTree } from "fluid-framework";
+import { OdspClient, type OdspContainerServices } from "@fluidframework/odsp-client/beta";
+import { type ContainerSchema, type IFluidContainer, SharedTree } from "fluid-framework";
 
 import { clientProps } from "./clientProps.js";
 

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -6,9 +6,9 @@
 /* eslint-disable prefer-template */
 
 import { Tree, type TreeView } from "fluid-framework";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { type ReactNode, useEffect, useState } from "react";
 
-import { App, Letter } from "./schema.js";
+import type { App, Letter } from "./schema.js";
 
 export function Explanation(): JSX.Element {
 	return (

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import { PublicClientApplication } from "@azure/msal-browser";
-import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
+import type { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
 
 // Helper function to authenticate the user
 export async function createMsalInstance(): Promise<PublicClientApplication> {

--- a/examples/utils/migration-tools/src/compositeRuntime/index.ts
+++ b/examples/utils/migration-tools/src/compositeRuntime/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { IEntryPointPiece } from "./interfaces.js";
+export type { IEntryPointPiece } from "./interfaces.js";
 export {
 	CompositeEntryPoint,
 	loadCompositeRuntime,

--- a/examples/utils/migration-tools/src/compositeRuntime/loadCompositeRuntime.ts
+++ b/examples/utils/migration-tools/src/compositeRuntime/loadCompositeRuntime.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IContainerContext, IRuntime } from "@fluidframework/container-definitions/legacy";
+import type { IContainerContext, IRuntime } from "@fluidframework/container-definitions/legacy";
 import {
-	IContainerRuntimeOptions,
+	type IContainerRuntimeOptions,
 	loadContainerRuntime,
 } from "@fluidframework/container-runtime/legacy";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/legacy";
 import type { FluidObject } from "@fluidframework/core-interfaces";
 import type {
 	NamedFluidDataStoreRegistryEntries,

--- a/examples/utils/migration-tools/src/compositeRuntime/loadCompositeRuntime.ts
+++ b/examples/utils/migration-tools/src/compositeRuntime/loadCompositeRuntime.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { IContainerContext, IRuntime } from "@fluidframework/container-definitions/legacy";
+import type {
+	IContainerContext,
+	IRuntime,
+} from "@fluidframework/container-definitions/legacy";
 import {
 	type IContainerRuntimeOptions,
 	loadContainerRuntime,

--- a/examples/utils/migration-tools/src/index.ts
+++ b/examples/utils/migration-tools/src/index.ts
@@ -11,24 +11,24 @@
 
 export {
 	CompositeEntryPoint,
-	IEntryPointPiece,
+	type IEntryPointPiece,
 	loadCompositeRuntime,
 } from "./compositeRuntime/index.js";
-export {
+export type {
 	IAcceptedMigrationDetails,
 	MigrationState,
 } from "./migrationTool/index.js";
 export {
-	CreateDetachedContainerCallback,
-	ExportDataCallback,
-	IMigrator,
-	IMigratorEntryPoint,
-	IMigratorEvents,
-	ImportDataCallback,
-	LoadSourceContainerCallback,
+	type CreateDetachedContainerCallback,
+	type ExportDataCallback,
+	type IMigrator,
+	type IMigratorEntryPoint,
+	type IMigratorEvents,
+	type ImportDataCallback,
+	type LoadSourceContainerCallback,
 	makeCreateDetachedContainerCallback,
 	makeSeparateContainerMigrationCallback,
 	makeMigratorEntryPointPiece,
-	MigrationCallback,
-	SeparateContainerMigrationResult,
+	type MigrationCallback,
+	type SeparateContainerMigrationResult,
 } from "./migrator/index.js";

--- a/examples/utils/migration-tools/src/migrationTool/index.ts
+++ b/examples/utils/migration-tools/src/migrationTool/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
+export type {
 	IAcceptedMigrationDetails,
 	IMigrationTool,
 	IMigrationToolEvents,

--- a/examples/utils/migration-tools/src/migrationTool/migrationTool.ts
+++ b/examples/utils/migration-tools/src/migrationTool/migrationTool.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPactMap, PactMap } from "@fluid-experimental/pact-map";
+import { type IPactMap, PactMap } from "@fluid-experimental/pact-map";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type {
 	FluidObject,
@@ -18,7 +18,7 @@ import type {
 } from "@fluidframework/datastore-definitions/legacy";
 import {
 	ConsensusRegisterCollection,
-	IConsensusRegisterCollection,
+	type IConsensusRegisterCollection,
 } from "@fluidframework/register-collection/legacy";
 import type {
 	IFluidDataStoreChannel,

--- a/examples/utils/migration-tools/src/migrator/index.ts
+++ b/examples/utils/migration-tools/src/migrator/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
+export type {
 	ExportDataCallback,
 	IMigrator,
 	IMigratorEntryPoint,
@@ -14,9 +14,9 @@ export {
 export { makeMigratorEntryPointPiece } from "./makeMigratorEntryPointPiece.js";
 export { Migrator } from "./migrator.js";
 export {
-	CreateDetachedContainerCallback,
-	ImportDataCallback,
+	type CreateDetachedContainerCallback,
+	type ImportDataCallback,
 	makeCreateDetachedContainerCallback,
 	makeSeparateContainerMigrationCallback,
-	SeparateContainerMigrationResult,
+	type SeparateContainerMigrationResult,
 } from "./separateContainerCallbackHelpers.js";

--- a/examples/version-migration/separate-container/src/modelInterfaces.ts
+++ b/examples/version-migration/separate-container/src/modelInterfaces.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitter } from "@fluid-example/example-utils";
-import { SharedString } from "@fluidframework/sequence/legacy";
+import type { EventEmitter } from "@fluid-example/example-utils";
+import type { SharedString } from "@fluidframework/sequence/legacy";
 
 /**
  * For demo purposes this is a super-simple interface, but in a real scenario this should have all relevant surface

--- a/examples/version-migration/separate-container/src/view/index.ts
+++ b/examples/version-migration/separate-container/src/view/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export { IDebugViewProps, DebugView } from "./debugView.js";
-export { IInventoryListAppViewProps, InventoryListAppView } from "./appView.js";
+export { type IDebugViewProps, DebugView } from "./debugView.js";
+export { type IInventoryListAppViewProps, InventoryListAppView } from "./appView.js";


### PR DESCRIPTION
Pre-fixes violations of new eslint rules added to our shared eslint config.

Auto-fixed via `npm run eslint:fix`