### PR TITLE
refactor(experimental): Use type-only imports and exports where appropriate

### DIFF
--- a/experimental/framework/last-edited/src/index.ts
+++ b/experimental/framework/last-edited/src/index.ts
@@ -5,8 +5,8 @@
 
 export {
 	IFluidLastEditedTracker,
-	ILastEditDetails,
-	IProvideFluidLastEditedTracker,
+	type ILastEditDetails,
+	type IProvideFluidLastEditedTracker,
 } from "./interfaces.js";
 export { LastEditedTracker } from "./lastEditedTracker.js";
 export { LastEditedTrackerDataObject } from "./lastEditedTrackerDataObject.js";

--- a/experimental/framework/last-edited/src/interfaces.ts
+++ b/experimental/framework/last-edited/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IUser } from "@fluidframework/driver-definitions";
+import type { IUser } from "@fluidframework/driver-definitions";
 
 /**
  * @internal

--- a/experimental/framework/last-edited/src/lastEditedTracker.ts
+++ b/experimental/framework/last-edited/src/lastEditedTracker.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { SharedSummaryBlock } from "@fluidframework/shared-summary-block/internal";
+import type { SharedSummaryBlock } from "@fluidframework/shared-summary-block/internal";
 
-import { IFluidLastEditedTracker, ILastEditDetails } from "./interfaces.js";
+import type { IFluidLastEditedTracker, ILastEditDetails } from "./interfaces.js";
 
 /**
  * Tracks the last edit details such as the last edited user details and the last edited timestamp. The last edited

--- a/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
+++ b/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
@@ -4,10 +4,10 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedSummaryBlock } from "@fluidframework/shared-summary-block/internal";
 
-import { IProvideFluidLastEditedTracker } from "./interfaces.js";
+import type { IProvideFluidLastEditedTracker } from "./interfaces.js";
 import { LastEditedTracker } from "./lastEditedTracker.js";
 
 /**

--- a/experimental/framework/last-edited/src/setup.ts
+++ b/experimental/framework/last-edited/src/setup.ts
@@ -4,11 +4,11 @@
  */
 
 import { ContainerMessageType } from "@fluidframework/container-runtime/internal";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
-import { IQuorumClients } from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
+import type { IQuorumClients } from "@fluidframework/driver-definitions";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
-import { IFluidLastEditedTracker, ILastEditDetails } from "./interfaces.js";
+import type { IFluidLastEditedTracker, ILastEditDetails } from "./interfaces.js";
 
 /**
  * Default implementation of {@link setupLastEditedTrackerForContainer}'s `shouldDiscardMessageFn` parameter,


### PR DESCRIPTION
Pre-fixes violations of new eslint rules added to our shared eslint config.

Auto-fixed via `npm run eslint:fix`