### PR TITLE
refactor(packages/framework): Update client packages to use `@legacy @beta` instead of `@legacy @alpha`

### DIFF
--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -28,8 +28,7 @@ export const snapshotKey = "snapshot";
 export const snapshotWithLoadingGroupIdKey = "snapshotWithLoadingGroupId";
 
 /**
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export type CacheContentType = "snapshot" | "ops" | "snapshotWithLoadingGroupId";
 
@@ -39,8 +38,7 @@ export type CacheContentType = "snapshot" | "ops" | "snapshotWithLoadingGroupId"
  * to implement storage / identify files.
  */
 /**
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export interface IFileEntry {
 	/**
@@ -59,8 +57,7 @@ export interface IFileEntry {
 
 /**
  * Cache entry. Identifies file that this entry belongs to, and type of content stored in it.
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export interface IEntry {
 	/**
@@ -83,8 +80,7 @@ export interface IEntry {
 
 /**
  * Cache entry. Identifies file that this entry belongs to, and type of content stored in it.
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export interface ICacheEntry extends IEntry {
 	/**
@@ -99,8 +95,7 @@ export interface ICacheEntry extends IEntry {
  * cache implementation that does not survive across sessions. Snapshot entires stored in the
  * IPersistedCache will be considered stale and removed after 2 days. Read the README for more
  * information.
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export interface IPersistedCache {
 	/**

--- a/packages/drivers/odsp-driver-definitions/src/sessionProvider.ts
+++ b/packages/drivers/odsp-driver-definitions/src/sessionProvider.ts
@@ -76,8 +76,7 @@ export interface ISensitivityLabel {
 /**
  * An interface that allows a concrete instance of a driver factory to interrogate itself
  * to find out if it is session aware.
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export interface IProvideSessionAwareDriverFactory {
 	readonly IRelaySessionAwareDriverFactory: IRelaySessionAwareDriverFactory;
@@ -86,8 +85,7 @@ export interface IProvideSessionAwareDriverFactory {
 /**
  * An interface that allows a concrete instance of a driver factory to call the `getRelayServiceSessionInfo`
  * function if it session aware.
- * @legacy
- * @beta
+ * @legacy @beta
  */
 export interface IRelaySessionAwareDriverFactory extends IProvideSessionAwareDriverFactory {
 	getRelayServiceSessionInfo(

--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
@@ -63,7 +63,7 @@ export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectT
     constructor(props: DataObjectFactoryProps<TObj, I>);
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface DataObjectFactoryProps<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> {
     readonly ctor: new (props: IDataObjectProps<I>) => TObj;
     readonly optionalProviders?: FluidObjectSymbolProvider<I["OptionalProviders"]>;
@@ -74,14 +74,14 @@ export interface DataObjectFactoryProps<TObj extends PureDataObject<I>, I extend
     readonly type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface DataObjectTypes {
     Events?: IEvent;
     InitialState?: any;
     OptionalProviders?: FluidObject;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
     // (undocumented)
     readonly context: IFluidDataStoreContext;
@@ -93,7 +93,7 @@ export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
     readonly runtime: IFluidDataStoreRuntime;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends TypedEventEmitter<I["Events"] & IEvent> implements IFluidLoadable, IProvideFluidHandle {
     constructor(props: IDataObjectProps<I>);
     protected readonly context: IFluidDataStoreContext;
@@ -118,7 +118,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     protected readonly runtime: IFluidDataStoreRuntime;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
     constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects?: readonly IChannelFactory[], optionalProviders?: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
     constructor(props: DataObjectFactoryProps<TObj, I>);
@@ -139,14 +139,14 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     readonly type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export abstract class TreeDataObject<TDataObjectTypes extends DataObjectTypes = DataObjectTypes> extends PureDataObject<TDataObjectTypes> {
     // (undocumented)
     initializeInternal(existing: boolean): Promise<void>;
     protected get tree(): ITree;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class TreeDataObjectFactory<TDataObject extends TreeDataObject<TDataObjectTypes>, TDataObjectTypes extends DataObjectTypes = DataObjectTypes> extends PureDataObjectFactory<TDataObject, TDataObjectTypes> {
     constructor(props: DataObjectFactoryProps<TDataObject, TDataObjectTypes>);
 }

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -145,8 +145,7 @@ async function createDataObject<
  * registry entries, and the runtime class to use for the data object.
  * @typeParam TObj - DataObject (concrete type)
  * @typeParam I - The input types for the DataObject
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface DataObjectFactoryProps<
 	TObj extends PureDataObject<I>,
@@ -198,8 +197,7 @@ export interface DataObjectFactoryProps<
  *
  * @typeParam TObj - DataObject (concrete type)
  * @typeParam I - The input types for the DataObject
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class PureDataObjectFactory<
 	TObj extends PureDataObject<I>,

--- a/packages/framework/aqueduct/src/data-object-factories/treeDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/treeDataObjectFactory.ts
@@ -18,7 +18,7 @@ import {
  * @typeParam TDataObject - The concrete TreeDataObject implementation.
  * @typeParam TDataObjectTypes - The input types for the DataObject
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export class TreeDataObjectFactory<
 	TDataObject extends TreeDataObject<TDataObjectTypes>,

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -31,8 +31,7 @@ import type { DataObjectTypes, IDataObjectProps } from "./types.js";
  * you are creating another base data store class.
  *
  * @typeParam I - The optional input types used to strongly type the data object
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes>
 	extends TypedEventEmitter<I["Events"] & IEvent>

--- a/packages/framework/aqueduct/src/data-objects/treeDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/treeDataObject.ts
@@ -57,7 +57,7 @@ const uninitializedErrorString =
  * }
  * ```
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export abstract class TreeDataObject<
 	TDataObjectTypes extends DataObjectTypes = DataObjectTypes,

--- a/packages/framework/aqueduct/src/data-objects/types.ts
+++ b/packages/framework/aqueduct/src/data-objects/types.ts
@@ -13,8 +13,7 @@ import type { AsyncFluidObjectProvider } from "@fluidframework/synthesize/intern
 
 /**
  * This type is used as the base generic input to DataObject and PureDataObject.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface DataObjectTypes {
 	/**
@@ -34,8 +33,7 @@ export interface DataObjectTypes {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
 	readonly runtime: IFluidDataStoreRuntime;

--- a/packages/framework/synthesize/api-report/synthesize.legacy.alpha.api.md
+++ b/packages/framework/synthesize/api-report/synthesize.legacy.alpha.api.md
@@ -4,15 +4,15 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export type AsyncFluidObjectProvider<O, R = undefined> = AsyncOptionalFluidObjectProvider<O> & AsyncRequiredFluidObjectProvider<R>;
 
-// @alpha @legacy
+// @beta @legacy
 export type AsyncOptionalFluidObjectProvider<T> = T extends undefined ? Record<string, never> : {
     [P in keyof T]?: Promise<T[P] | undefined>;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export type AsyncRequiredFluidObjectProvider<T> = T extends undefined ? Record<string, never> : {
     [P in keyof T]: Promise<NonNullable<Exclude<T[P], undefined | null>>>;
 };
@@ -28,24 +28,24 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
     unregister(type: keyof TMap): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type FluidObjectProvider<T> = NonNullable<T> | Promise<NonNullable<T>> | ((dependencyContainer: IFluidDependencySynthesizer) => NonNullable<T>) | ((dependencyContainer: IFluidDependencySynthesizer) => Promise<NonNullable<T>>);
 
-// @alpha @legacy
+// @beta @legacy
 export type FluidObjectSymbolProvider<T> = {
     [P in keyof T]?: P;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const IFluidDependencySynthesizer: keyof IProvideFluidDependencySynthesizer;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDependencySynthesizer extends IProvideFluidDependencySynthesizer {
     has(type: string): boolean;
     synthesize<O, R = undefined | Record<string, never>>(optionalTypes: FluidObjectSymbolProvider<O>, requiredTypes: Required<FluidObjectSymbolProvider<R>>): AsyncFluidObjectProvider<O, R>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideFluidDependencySynthesizer {
     // (undocumented)
     IFluidDependencySynthesizer: IFluidDependencySynthesizer;

--- a/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
+++ b/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
@@ -6,15 +6,13 @@
 import type { AsyncFluidObjectProvider, FluidObjectSymbolProvider } from "./types.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IFluidDependencySynthesizer: keyof IProvideFluidDependencySynthesizer =
 	"IFluidDependencySynthesizer";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideFluidDependencySynthesizer {
 	IFluidDependencySynthesizer: IFluidDependencySynthesizer;
@@ -24,8 +22,7 @@ export interface IProvideFluidDependencySynthesizer {
  * IFluidDependencySynthesizer can generate FluidObjects based on the IProvideFluidObject pattern.
  * It allow for registering providers and uses synthesize to generate a new object with the optional
  * and required types.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDependencySynthesizer extends IProvideFluidDependencySynthesizer {
 	/**

--- a/packages/framework/synthesize/src/types.ts
+++ b/packages/framework/synthesize/src/types.ts
@@ -15,8 +15,7 @@ import type { IFluidDependencySynthesizer } from "./IFluidDependencySynthesizer.
  * ```typescript
  * { IFoo: "IFoo" }
  * ```
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type FluidObjectSymbolProvider<T> = {
 	[P in keyof T]?: P;
@@ -26,8 +25,7 @@ export type FluidObjectSymbolProvider<T> = {
  * This is a condensed version of Record that requires the object has all
  * the FluidObject properties as its type mapped to an object that implements
  * the property.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type AsyncRequiredFluidObjectProvider<T> = T extends undefined
 	? Record<string, never>
@@ -40,8 +38,7 @@ export type AsyncRequiredFluidObjectProvider<T> = T extends undefined
  * This is a condensed version of Record that requires the object has all
  * the FluidObject properties as its type, mapped to an object that implements
  * the property or undefined.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type AsyncOptionalFluidObjectProvider<T> = T extends undefined
 	? Record<string, never>
@@ -51,16 +48,14 @@ export type AsyncOptionalFluidObjectProvider<T> = T extends undefined
 
 /**
  * Combined type for Optional and Required Async Fluid object Providers
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type AsyncFluidObjectProvider<O, R = undefined> = AsyncOptionalFluidObjectProvider<O> &
 	AsyncRequiredFluidObjectProvider<R>;
 
 /**
  * Multiple ways to provide a Fluid object.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type FluidObjectProvider<T> =
 	| NonNullable<T>

--- a/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, IContainerRuntimeBaseWithCombinedEvents {
     readonly attachState: AttachState;
     // (undocumented)
@@ -27,10 +27,10 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     readonly storage: IContainerStorageService;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase & IEventProvider<IContainerRuntimeEvents>;
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents, ISummarizerEvents {
     // (undocumented)
     (event: "dirty" | "disconnected" | "saved" | "attached", listener: () => void): any;
@@ -38,7 +38,7 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents, IS
     (event: "connected", listener: (clientId: string) => void): any;
 }
 
-// @alpha @deprecated @legacy (undocumented)
+// @beta @deprecated @legacy (undocumented)
 export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContainerRuntime {
     // (undocumented)
     readonly IFluidHandleContext: IFluidHandleContext;
@@ -46,7 +46,7 @@ export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContaine
     resolveHandle(request: IRequest): Promise<IResponse>;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export interface ISummarizeEventProps {
     // (undocumented)
     currentAttempt: number;
@@ -60,7 +60,7 @@ export interface ISummarizeEventProps {
     result: "success" | "failure" | "canceled";
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export interface ISummarizerEvents extends IEvent {
     // (undocumented)
     (event: "summarize", listener: (props: ISummarizeEventProps & ISummarizerObservabilityProps) => void): any;
@@ -81,7 +81,7 @@ export interface ISummarizerEvents extends IEvent {
     } & ISummarizerObservabilityProps) => void): any;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export interface ISummarizerObservabilityProps {
     // (undocumented)
     numUnsummarizedNonRuntimeOps: number;
@@ -89,7 +89,7 @@ export interface ISummarizerObservabilityProps {
     numUnsummarizedRuntimeOps: number;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export type SummarizerStopReason =
 /**
 * Summarizer client failed to summarize in all attempts.

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -32,8 +32,7 @@ import type { ContainerExtensionStore } from "./containerExtension.js";
 
 /**
  * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContainerRuntime {
 	readonly IFluidHandleContext: IFluidHandleContext;
@@ -42,8 +41,7 @@ export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContaine
 
 /**
  * Events emitted by {@link IContainerRuntime}.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface IContainerRuntimeEvents
@@ -54,8 +52,7 @@ export interface IContainerRuntimeEvents
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export type SummarizerStopReason =
@@ -93,8 +90,7 @@ export type SummarizerStopReason =
 	| "latestSummaryStateStale";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface ISummarizeEventProps {
@@ -114,8 +110,7 @@ export interface ISummarizeEventProps {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface ISummarizerObservabilityProps {
@@ -124,8 +119,7 @@ export interface ISummarizerObservabilityProps {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface ISummarizerEvents extends IEvent {
@@ -159,8 +153,7 @@ export interface ISummarizerEvents extends IEvent {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase &
@@ -168,8 +161,7 @@ export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase &
 
 /**
  * Represents the runtime of the container. Contains helper functions/state of the container.
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface IContainerRuntime

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -7,7 +7,7 @@
 // @alpha @legacy
 export const AllowTombstoneRequestHeaderKey = "allowTombstone";
 
-// @alpha @legacy
+// @beta @legacy
 export enum CompressionAlgorithms {
     // (undocumented)
     lz4 = "lz4"
@@ -32,7 +32,7 @@ export enum ContainerMessageType {
     Rejoin = "rejoin"
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ContainerRuntimeOptions {
     readonly chunkSizeInBytes: number;
     readonly compressionOptions: ICompressionRuntimeOptions;
@@ -108,16 +108,16 @@ export interface IClientSummaryWatcher extends IDisposable {
     watchSummary(clientSequenceNumber: number): ISummary;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ICompressionRuntimeOptions {
     readonly compressionAlgorithm: CompressionAlgorithms;
     readonly minimumBatchSizeInBytes: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type IContainerRuntimeOptions = Partial<ContainerRuntimeOptions>;
 
-// @alpha @legacy
+// @beta @legacy
 export type IdCompressorMode = "on" | "delayed" | undefined;
 
 // @alpha @legacy
@@ -153,7 +153,7 @@ export interface IFluidDataStoreAttributes2 extends OmitAttributesVersions<IFlui
     readonly summaryFormatVersion: 2;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IGCRuntimeOptions {
     [key: string]: any;
     enableGCSweep?: true;
@@ -189,7 +189,7 @@ export interface INackSummaryResult {
     readonly summaryNackOp: ISummaryNackMessage;
 }
 
-// @alpha @deprecated @legacy
+// @beta @deprecated @legacy
 export const InactiveResponseHeaderKey = "isInactive";
 
 // @alpha @legacy (undocumented)
@@ -257,7 +257,7 @@ export interface ISummaryAckMessage extends ISequencedDocumentMessage {
     type: MessageType.SummaryAck;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummaryBaseConfiguration {
     initialSummarizerDelayMs: number;
     maxAckWaitTime: number;
@@ -270,22 +270,22 @@ export interface ISummaryCollectionOpEvents extends IEvent {
     (event: OpActionEventName, listener: OpActionEventListener): any;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type ISummaryConfiguration = ISummaryConfigurationDisableSummarizer | ISummaryConfigurationDisableHeuristics | ISummaryConfigurationHeuristics;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
     // (undocumented)
     state: "disableHeuristics";
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummaryConfigurationDisableSummarizer {
     // (undocumented)
     state: "disabled";
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
     maxIdleTime: number;
     maxOps: number;
@@ -315,7 +315,7 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
     type: MessageType.Summarize;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummaryRuntimeOptions {
     // @deprecated
     initialSummarizerDelayMs?: number;
@@ -330,10 +330,10 @@ export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "
     readonly uploadDuration: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function loadContainerRuntime(params: LoadContainerRuntimeParams): Promise<IContainerRuntime & IRuntime>;
 
-// @alpha @legacy
+// @beta @legacy
 export interface LoadContainerRuntimeParams {
     containerScope?: FluidObject;
     context: IContainerContext;
@@ -407,7 +407,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
 // @alpha @legacy
 export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 
-// @alpha @legacy
+// @beta @legacy
 export const TombstoneResponseHeaderKey = "isTombstoned";
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/container-runtime/src/compressionDefinitions.ts
+++ b/packages/runtime/container-runtime/src/compressionDefinitions.ts
@@ -5,8 +5,7 @@
 
 /**
  * Available compression algorithms for op compression.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum CompressionAlgorithms {
 	lz4 = "lz4",
@@ -14,8 +13,7 @@ export enum CompressionAlgorithms {
 
 /**
  * Options for op compression.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICompressionRuntimeOptions {
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -348,8 +348,7 @@ function getUnknownMessageTypeError(
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryRuntimeOptions {
 	/**
@@ -382,8 +381,7 @@ export interface ISummaryRuntimeOptions {
  * compat configuration info.
  * If neither of the above is done, then the build will fail to compile.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ContainerRuntimeOptions {
 	readonly summaryOptions: ISummaryRuntimeOptions;
@@ -463,8 +461,7 @@ export interface ContainerRuntimeOptions {
 /**
  * Options for container runtime.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IContainerRuntimeOptions = Partial<ContainerRuntimeOptions>;
 
@@ -512,14 +509,12 @@ export type IContainerRuntimeOptionsInternal = Partial<ContainerRuntimeOptionsIn
 export const DeletedResponseHeaderKey = "wasDeleted";
 /**
  * Tombstone error responses will have this header set to true
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const TombstoneResponseHeaderKey = "isTombstoned";
 /**
  * Inactive error responses will have this header set to true
- * @legacy
- * @alpha
+ * @legacy @beta
  *
  * @deprecated this header is deprecated and will be removed in the future. The functionality corresponding
  * to this was experimental and is no longer supported.
@@ -727,8 +722,7 @@ type UnsequencedSignalEnvelope = Omit<ISignalEnvelope, "clientBroadcastSignalSeq
 
 /**
  * This object holds the parameters necessary for the {@link loadContainerRuntime} function.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface LoadContainerRuntimeParams {
 	/**
@@ -788,8 +782,7 @@ export interface LoadContainerRuntimeParams {
  * This is meant to be used by a {@link @fluidframework/container-definitions#IRuntimeFactory} to instantiate a container runtime.
  * @param params - An object which specifies all required and optional params necessary to instantiate a runtime.
  * @returns A runtime which provides all the functionality necessary to bind with the loader layer via the {@link @fluidframework/container-definitions#IRuntime} interface and provide a runtime environment via the {@link @fluidframework/container-runtime-definitions#IContainerRuntime} interface.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export async function loadContainerRuntime(
 	params: LoadContainerRuntimeParams,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -510,8 +510,7 @@ export interface IGarbageCollectorCreateParams {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IGCRuntimeOptions {
 	/**

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -30,8 +30,7 @@ export type DocumentSchemaValueType = string | string[] | true | number | undefi
  * undefined - ID compressor is not loaded.
  * While IContainerRuntime.generateDocumentUniqueId() is available, it will produce long IDs that are do not compress well.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IdCompressorMode = "on" | "delayed" | undefined;
 

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -675,8 +675,7 @@ export interface ISummarizeRunnerTelemetry extends ITelemetryLoggerPropertyBag {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryBaseConfiguration {
 	/**
@@ -698,8 +697,7 @@ export interface ISummaryBaseConfiguration {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
 	state: "enabled";
@@ -762,24 +760,21 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryConfigurationDisableSummarizer {
 	state: "disabled";
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
 	state: "disableHeuristics";
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ISummaryConfiguration =
 	| ISummaryConfigurationDisableSummarizer

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum DataStoreMessageType {
     // (undocumented)
     Attach = "attach",
@@ -12,7 +12,7 @@ export enum DataStoreMessageType {
     ChannelOp = "op"
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRuntimeEvents> implements IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     constructor(dataStoreContext: IFluidDataStoreContext, sharedObjectRegistry: ISharedObjectRegistry, existing: boolean, provideEntryPoint: (runtime: IFluidDataStoreRuntime) => Promise<FluidObject>, policies?: Partial<IFluidDataStorePolicies>);
     // (undocumented)
@@ -120,7 +120,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> extends Flui
     protected readonly value: T | Promise<T>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISharedObjectRegistry {
     // (undocumented)
     get(name: string): IChannelFactory | undefined;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -126,8 +126,7 @@ function contextSupportsFeature<K extends keyof IFluidDataStoreContextFeaturesTo
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum DataStoreMessageType {
 	// Creates a new channel
@@ -136,8 +135,7 @@ export enum DataStoreMessageType {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISharedObjectRegistry {
 	// TODO consider making this async. A consequence is that either the creation of a distributed data type
@@ -167,8 +165,7 @@ function initializePendingOpCount(): { value: number } {
 
 /**
  * Base data store class
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class FluidDataStoreRuntime
 	extends TypedEventEmitter<IFluidDataStoreRuntimeEvents>

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
 // @beta @legacy
@@ -21,11 +21,11 @@ export interface CommitStagedChangesOptionsExperimental {
     squash?: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
 getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>) => ISummarizerNodeWithGC;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type CreateChildSummarizerNodeParam = {
     type: CreateSummarizerNodeSource.FromSummary;
 } | {
@@ -36,7 +36,7 @@ export type CreateChildSummarizerNodeParam = {
     type: CreateSummarizerNodeSource.Local;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum CreateSummarizerNodeSource {
     // (undocumented)
     FromAttach = 1,
@@ -53,10 +53,10 @@ export interface DetachedAttributionKey {
     type: "detached";
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type FluidDataStoreRegistryEntry = Readonly<Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>>;
 
-// @alpha @legacy
+// @beta @legacy
 export enum FlushMode {
     // @deprecated
     Immediate = 0,
@@ -70,7 +70,7 @@ export interface IAttachMessage {
     type: string;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents> {
     // (undocumented)
     readonly baseLogger: ITelemetryBaseLogger;
@@ -95,7 +95,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
-// @alpha @sealed @legacy (undocumented)
+// @beta @sealed @legacy (undocumented)
 export interface IContainerRuntimeBaseEvents extends IEvent {
     (event: "batchBegin", listener: (op: Omit<ISequencedDocumentMessage, "contents">) => void): any;
     (event: "batchEnd", listener: (error: unknown, op: Omit<ISequencedDocumentMessage, "contents">) => void): any;
@@ -114,7 +114,7 @@ export interface IContainerRuntimeBaseExperimental extends IContainerRuntimeBase
     readonly inStagingMode?: boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDataStore {
     readonly entryPoint: IFluidHandleInternal<FluidObject>;
     trySetAlias(alias: string): Promise<AliasResult>;
@@ -133,7 +133,7 @@ export interface IExperimentalIncrementalSummaryContext {
     readonly summarySequenceNumber: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDataStoreChannel extends IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
@@ -157,7 +157,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     updateUsedRoutes(usedRoutes: string[]): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDataStoreContext extends IFluidParentContext {
     // (undocumented)
     readonly baseSnapshot: ISnapshotTree | undefined;
@@ -172,15 +172,15 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
     readonly packagePath: PackagePath;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {
     attachRuntime(factory: IProvideFluidDataStoreFactory, dataStoreRuntime: IFluidDataStoreChannel): Promise<IDataStore>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
     createDataStore?(context: IFluidDataStoreContext): {
         readonly runtime: IFluidDataStoreChannel;
@@ -189,21 +189,21 @@ export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
     type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDataStorePolicies {
     readonly readonlyInStagingMode: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry {
     get(name: string): Promise<FluidDataStoreRegistryEntry | undefined>;
     getSync?(name: string): FluidDataStoreRegistryEntry | undefined;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidParentContext extends IProvideFluidHandleContext, Partial<IProvideFluidDataStoreRegistry> {
     addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
     readonly attachState: AttachState;
@@ -256,7 +256,7 @@ export interface IGarbageCollectionData {
     };
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IGarbageCollectionDetailsBase {
     gcData?: IGarbageCollectionData;
     usedRoutes?: string[];
@@ -273,13 +273,13 @@ export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
     snapshot: IAttachMessage["snapshot"] | null;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideFluidDataStoreFactory {
     // (undocumented)
     readonly IFluidDataStoreFactory: IFluidDataStoreFactory;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideFluidDataStoreRegistry {
     // (undocumented)
     readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
@@ -299,7 +299,7 @@ export interface IRuntimeMessagesContent {
     readonly localOpMetadata: unknown;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRuntimeStorageService {
     // @deprecated (undocumented)
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
@@ -325,14 +325,14 @@ export interface IRuntimeStorageService {
 // @beta @legacy
 export type ISequencedMessageEnvelope = Omit<ISequencedDocumentMessage, "contents" | "clientSequenceNumber">;
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummarizeInternalResult extends ISummarizeResult {
     // (undocumented)
     id: string;
     pathPartsForChildren?: string[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummarizeResult {
     // (undocumented)
     stats: ISummaryStats;
@@ -340,7 +340,7 @@ export interface ISummarizeResult {
     summary: SummaryTree;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummarizerNode {
     // (undocumented)
     createChild(
@@ -359,17 +359,17 @@ export interface ISummarizerNode {
     updateBaseSummaryState(snapshot: ISnapshotTree): void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummarizerNodeConfig {
     readonly canReuseHandle?: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
     readonly gcDisabled?: boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // (undocumented)
     createChild(
@@ -418,16 +418,16 @@ export interface LocalAttributionKey {
     type: "local";
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
-// @alpha @legacy
+// @beta @legacy
 export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreRegistryEntry2>;
 
-// @alpha @legacy
+// @beta @legacy
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 
-// @alpha @legacy
+// @beta @legacy
 export type NamedFluidDataStoreRegistryEntry2 = [
 string,
 Promise<FluidDataStoreRegistryEntry> | FluidDataStoreRegistryEntry
@@ -439,7 +439,7 @@ export interface OpAttributionKey {
     type: "op";
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type PackagePath = readonly string[];
 
 // @alpha @sealed @deprecated @legacy (undocumented)
@@ -448,17 +448,17 @@ export interface StageControlsExperimental {
     readonly discardChanges: () => void;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
 
-// @alpha @legacy
+// @beta @legacy
 export const VisibilityState: {
     NotVisible: string;
     LocallyVisible: string;
     GloballyVisible: string;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
@@ -6,8 +6,7 @@
 /**
  * String in a valid semver format of a specific version at least specifying minor.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type MinimumVersionForCollab =
 	| `${1 | 2}.${bigint}.${bigint}`

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -51,8 +51,7 @@ import type {
 
 /**
  * Runtime flush mode handling
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum FlushMode {
 	/**
@@ -89,8 +88,7 @@ export enum FlushModeExperimental {
 /**
  * This tells the visibility state of a Fluid object. It basically tracks whether the object is not visible, visible
  * locally within the container only or visible globally to all clients.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const VisibilityState = {
 	/**
@@ -117,14 +115,12 @@ export const VisibilityState = {
 	GloballyVisible: "GloballyVisible",
 };
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface IContainerRuntimeBaseEvents extends IEvent {
@@ -162,8 +158,7 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
  * and will be garbage collected. The current datastore cannot be aliased to a different value.
  *
  * 'AlreadyAliased' - the datastore has already been previously bound to another alias name.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
@@ -179,8 +174,7 @@ export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
  * @privateRemarks
  * TODO: These docs should define what a "data store" is, and not do so by just referencing "data store".
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDataStore {
 	/**
@@ -204,8 +198,7 @@ export interface IDataStore {
  * A reduced set of functionality of {@link @fluidframework/container-runtime-definitions#IContainerRuntime} that a data store context/data store runtime will need.
  * @privateRemarks
  * TODO: this should be merged into IFluidDataStoreContext
- * @legacy
- * @alpha
+ * @legacy @beta
  * @sealed
  */
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents> {
@@ -377,8 +370,7 @@ export interface IContainerRuntimeBaseExperimental extends IContainerRuntimeBase
  * Policies allow data store authors to define specific behaviors or constraints for their data stores.
  * These settings can impact how the data store interacts with the runtime and other components.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStorePolicies {
 	/**
@@ -396,8 +388,7 @@ export interface IFluidDataStorePolicies {
  *
  * Functionality include attach, snapshot, op/signal processing, request routes, expose an entryPoint,
  * and connection state notifications
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreChannel extends IDisposable {
 	/**
@@ -517,8 +508,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type CreateChildSummarizerNodeFn = (
 	summarizeInternal: SummarizeInternalFn,
@@ -550,8 +540,7 @@ export interface IPendingMessagesState {
  * @privateRemarks
  * In addition to the use for datastores via IFluidDataStoreContext, this is implemented by ContainerRuntime to provide context to the ChannelCollection.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidParentContext
 	extends IProvideFluidHandleContext,
@@ -683,8 +672,7 @@ export interface IFluidParentContext
  * Each string in the array is the "identifier" to pick a specific {@link NamedFluidDataStoreRegistryEntry2} within a {@link NamedFluidDataStoreRegistryEntries}.
  *
  * Due to some usages joining this array with "/", it is recommended to avoid using "/" in the strings.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type PackagePath = readonly string[];
 
@@ -694,8 +682,7 @@ export type PackagePath = readonly string[];
  * @remarks
  * This context is provided to the implementation of {@link IFluidDataStoreChannel} which powers the datastore.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreContext extends IFluidParentContext {
 	readonly id: string;
@@ -756,8 +743,7 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {
 	/**

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -6,15 +6,13 @@
 import type { IFluidDataStoreChannel, IFluidDataStoreContext } from "./dataStoreContext.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory =
 	"IFluidDataStoreFactory";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideFluidDataStoreFactory {
 	readonly IFluidDataStoreFactory: IFluidDataStoreFactory;
@@ -34,8 +32,7 @@ export interface IProvideFluidDataStoreFactory {
  * The factory is responsible for creating new instances of data stores and loading existing ones.
  * The factory ensures that the data store is correctly initialized.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
 	/**

--- a/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
@@ -8,8 +8,7 @@ import type { IProvideFluidDataStoreFactory } from "./dataStoreFactory.js";
 /**
  * A single registry entry that may be used to create data stores
  * It has to have either factory or registry, or both.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type FluidDataStoreRegistryEntry = Readonly<
 	Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>
@@ -17,16 +16,14 @@ export type FluidDataStoreRegistryEntry = Readonly<
 /**
  * An associated pair of an identifier and registry entry.
  * Registry entries may be dynamically loaded.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 
 /**
  * An associated pair of an identifier and registry entry.
  * Registry entries may be dynamically loaded.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type NamedFluidDataStoreRegistryEntry2 = [
 	string,
@@ -34,21 +31,18 @@ export type NamedFluidDataStoreRegistryEntry2 = [
 ];
 /**
  * An iterable identifier/registry entry pair list
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreRegistryEntry2>;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry =
 	"IFluidDataStoreRegistry";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideFluidDataStoreRegistry {
 	readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
@@ -57,8 +51,7 @@ export interface IProvideFluidDataStoreRegistry {
 /**
  * An association of identifiers to data store registry entries, where the
  * entries can be used to create data stores.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry {
 	/**

--- a/packages/runtime/runtime-definitions/src/garbageCollectionDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollectionDefinitions.ts
@@ -48,8 +48,7 @@ export interface IGarbageCollectionData {
 
 /**
  * GC details provided to each node during creation.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IGarbageCollectionDetailsBase {
 	/**

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -138,8 +138,7 @@ export interface IRuntimeMessageCollection {
 /**
  * Interface to provide access to snapshot blobs to DataStore layer.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRuntimeStorageService {
 	/**

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -52,8 +52,7 @@ export interface ISummaryTreeWithStats {
 
 /**
  * Represents a summary at a current sequence number.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummarizeResult {
 	stats: ISummaryStats;
@@ -74,8 +73,7 @@ export interface ISummarizeResult {
  *   ...
  *     "path1":
  * ```
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummarizeInternalResult extends ISummarizeResult {
 	id: string;
@@ -114,8 +112,7 @@ export interface IExperimentalIncrementalSummaryContext {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SummarizeInternalFn = (
 	fullTree: boolean,
@@ -125,8 +122,7 @@ export type SummarizeInternalFn = (
 ) => Promise<ISummarizeInternalResult>;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummarizerNodeConfig {
 	/**
@@ -137,8 +133,7 @@ export interface ISummarizerNodeConfig {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 	/**
@@ -149,8 +144,7 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum CreateSummarizerNodeSource {
 	FromSummary,
@@ -158,8 +152,7 @@ export enum CreateSummarizerNodeSource {
 	Local,
 }
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type CreateChildSummarizerNodeParam =
 	| {
@@ -175,8 +168,7 @@ export type CreateChildSummarizerNodeParam =
 	  };
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummarizerNode {
 	/**
@@ -268,8 +260,7 @@ export interface ISummarizerNode {
  * `isReferenced`: This tells whether this node is referenced in the document or not.
  *
  * `updateUsedRoutes`: Used to notify this node of routes that are currently in use in it.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
 	createChild(


### PR DESCRIPTION
## Description

This commit resolves API extractor build failures by systematically updating JSDoc release tags from @legacy @alpha to @legacy @beta across packages/framework packages. Updated the following symbols from @legacy @alpha to @legacy @beta in the container-runtime and odsp driver package as well since they are references of APIs in packages/framework. 

[containerRuntime.ts](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Updated ISummaryRuntimeOptions interface
[gcDefinitions.ts](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Updated IGCRuntimeOptions interface
[compressionDefinitions.ts](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Updated:
[CompressionAlgorithms](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) enum
[ICompressionRuntimeOptions](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface
[documentSchema.ts](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Updated [IdCompressorMode](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type
[summarizerTypes.ts](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Updated [ISummaryConfiguration](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type