### PR TITLE
refactor(packages/loader): Update client packages to use `@legacy @beta` instead of `@legacy @alpha`

### DIFF
--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -12,10 +12,10 @@ export enum ConnectionState {
     EstablishingConnection = 3
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)
     readonly attributes: IDocumentAttributes;
@@ -33,12 +33,12 @@ export interface IBaseProtocolHandler {
     snapshot(): IQuorumSnapshot;
 }
 
-// @alpha @deprecated @legacy (undocumented)
+// @beta @deprecated @legacy (undocumented)
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
     load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ICreateAndLoadContainerProps {
     readonly allowReconnect?: boolean | undefined;
     readonly clientDetailsOverride?: IClientDetails | undefined;
@@ -52,18 +52,18 @@ export interface ICreateAndLoadContainerProps {
     readonly urlResolver: IUrlResolver;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerProps {
     readonly codeDetails: IFluidCodeDetails;
 }
 
-// @alpha @deprecated @legacy (undocumented)
+// @beta @deprecated @legacy (undocumented)
 export interface IFluidModuleWithDetails {
     details: IFluidCodeDetails;
     module: IFluidModule;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILoaderProps {
     readonly codeLoader: ICodeDetailsLoader;
     readonly configProvider?: IConfigProviderBase;
@@ -75,7 +75,7 @@ export interface ILoaderProps {
     readonly urlResolver: IUrlResolver;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILoaderServices {
     readonly codeLoader: ICodeDetailsLoader;
     readonly documentServiceFactory: IDocumentServiceFactory;
@@ -86,13 +86,13 @@ export interface ILoaderServices {
     readonly urlResolver: IUrlResolver;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProps {
     readonly pendingLocalState?: string | undefined;
     readonly request: IRequest;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IParsedUrl {
     id: string;
     path: string;
@@ -100,7 +100,7 @@ export interface IParsedUrl {
     version: string | undefined;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProtocolHandler extends IBaseProtocolHandler {
     // (undocumented)
     readonly audience: IAudienceOwner;
@@ -108,7 +108,7 @@ export interface IProtocolHandler extends IBaseProtocolHandler {
     processSignal(message: ISignalMessage): any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IQuorumSnapshot {
     // (undocumented)
     members: QuorumClientsSnapshot;
@@ -118,12 +118,12 @@ export interface IQuorumSnapshot {
     values: QuorumProposalsSnapshot["values"];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRehydrateDetachedContainerProps extends ICreateAndLoadContainerProps {
     readonly serializedState: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IScribeProtocolState {
     // (undocumented)
     members: [string, ISequencedClient][];
@@ -137,7 +137,7 @@ export interface IScribeProtocolState {
     values: [string, ICommittedProposal][];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class Loader implements IHostLoader {
     constructor(loaderProps: ILoaderProps);
     // (undocumented)
@@ -156,31 +156,31 @@ export class Loader implements IHostLoader {
     readonly services: ILoaderServices;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;
 
-// @alpha @legacy
+// @beta @legacy
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
 
-// @alpha @legacy
+// @beta @legacy
 export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
-// @alpha @legacy
+// @beta @legacy
 export type QuorumProposalsSnapshot = {
     proposals: [number, ISequencedProposal, string[]][];
     values: [string, ICommittedProposal][];
 };
 
-// @alpha @legacy
+// @beta @legacy
 export function rehydrateDetachedContainer(rehydrateDetachedContainerProps: IRehydrateDetachedContainerProps): Promise<IContainer>;
 
 // @alpha @legacy
 export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger): Promise<T>;
 
-// @alpha @legacy
+// @beta @legacy
 export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined;
 
-// @alpha @legacy
+// @beta @legacy
 export function waitContainerToCatchUp(container: IContainer): Promise<boolean>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -272,8 +272,7 @@ export interface IContainerCreateProps {
  * but it maybe still behind.
  *
  * @throws an error beginning with `"Container closed"` if the container is closed before it catches up.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export async function waitContainerToCatchUp(container: IContainer): Promise<boolean> {
 	// Make sure we stop waiting if container is closed.

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -26,8 +26,7 @@ import { ProtocolHandlerBuilder } from "./protocol.js";
 
 /**
  * Properties necessary for creating and loading a container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICreateAndLoadContainerProps {
 	/**
@@ -89,8 +88,7 @@ export interface ICreateAndLoadContainerProps {
 
 /**
  * Props used to load a container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProps {
 	/**
@@ -106,8 +104,7 @@ export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProp
 
 /**
  * Props used to create a detached container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerProps {
 	/**
@@ -118,8 +115,7 @@ export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerPr
 
 /**
  * Props used to rehydrate a detached container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRehydrateDetachedContainerProps extends ICreateAndLoadContainerProps {
 	/**
@@ -132,8 +128,7 @@ export interface IRehydrateDetachedContainerProps extends ICreateAndLoadContaine
  * Creates a new container using the specified code details but in an unattached state. While unattached, all
  * updates will only be local until the user explicitly attaches the container to a service provider.
  * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export async function createDetachedContainer(
 	createDetachedContainerProps: ICreateDetachedContainerProps,
@@ -149,8 +144,7 @@ export async function createDetachedContainer(
  * Creates a new container using the specified snapshot but in an unattached state. While unattached, all
  * updates will only be local until the user explicitly attaches the container to a service provider.
  * @param rehydrateDetachedContainerProps - Services and properties necessary for rehydrating detached container from a previously serialized container's state.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export async function rehydrateDetachedContainer(
 	rehydrateDetachedContainerProps: IRehydrateDetachedContainerProps,
@@ -168,8 +162,7 @@ export async function rehydrateDetachedContainer(
 /**
  * Loads a container with an existing snapshot from the service.
  * @param loadExistingContainerProps - Services and properties necessary for loading an existing container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export async function loadExistingContainer(
 	loadExistingContainerProps: ILoadExistingContainerProps,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -94,8 +94,7 @@ export class RelativeLoader implements ILoader {
  * {@link @fluidframework/container-definitions#IFluidModuleWithDetails}
  * to have all the code loading modules in one package. #8193
  * Encapsulates a module entry point with corresponding code details.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidModuleWithDetails {
 	/**
@@ -115,8 +114,7 @@ export interface IFluidModuleWithDetails {
  * to have code loading modules in one package. #8193
  * Fluid code loader resolves a code module matching the document schema, i.e. code details, such as
  * a package name and package version range.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
 	/**
@@ -130,8 +128,7 @@ export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComp
 
 /**
  * Services and properties necessary for creating a loader
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILoaderProps {
 	/**
@@ -183,8 +180,7 @@ export interface ILoaderProps {
 
 /**
  * Services and properties used by and exposed by the loader
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILoaderServices {
 	/**
@@ -231,8 +227,7 @@ export interface ILoaderServices {
 
 /**
  * Manages Fluid resource loading
- * @legacy
- * @alpha
+ * @legacy @beta
  *
  * @remarks The Loader class is deprecated and will be removed in a future release. Use the free-form functions instead (See issue #24450 for more details).
  */

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -25,8 +25,7 @@ export enum SignalType {
 
 /**
  * Function to be used for creating a protocol handler.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ProtocolHandlerBuilder = (
 	attributes: IDocumentAttributes,
@@ -37,8 +36,7 @@ export type ProtocolHandlerBuilder = (
 ) => IProtocolHandler;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProtocolHandler extends IBaseProtocolHandler {
 	readonly audience: IAudienceOwner;

--- a/packages/loader/container-loader/src/protocol/protocol.ts
+++ b/packages/loader/container-loader/src/protocol/protocol.ts
@@ -20,8 +20,7 @@ import {
 import { IQuorumSnapshot, Quorum } from "./quorum.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IScribeProtocolState {
 	sequenceNumber: number;
@@ -32,8 +31,7 @@ export interface IScribeProtocolState {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProtocolHandler {
 	readonly quorum: IQuorum;

--- a/packages/loader/container-loader/src/protocol/quorum.ts
+++ b/packages/loader/container-loader/src/protocol/quorum.ts
@@ -30,15 +30,13 @@ class PendingProposal implements ISequencedProposal {
 
 /**
  * Snapshot format for a QuorumClients
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
 /**
  * Snapshot format for a QuorumProposals
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type QuorumProposalsSnapshot = {
@@ -48,8 +46,7 @@ export type QuorumProposalsSnapshot = {
 
 /**
  * Snapshot format for a Quorum
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IQuorumSnapshot {
 	members: QuorumClientsSnapshot;

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -51,8 +51,7 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
  * Interface to represent the parsed parts of IResolvedUrl.url to help
  * in getting info about different parts of the url.
  * May not be compatible or relevant for any Url Resolver
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IParsedUrl {
 	/**
@@ -81,8 +80,7 @@ export interface IParsedUrl {
  * with urls of type: protocol://<string>/.../..?<querystring>
  * @param url - This is the IResolvedUrl.url part of the resolved url.
  * @returns The IParsedUrl representing the input URL, or undefined if the format was not supported
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined {
 	const parsed = new URL(url);

--- a/packages/loader/driver-utils/api-report/driver-utils.legacy.alpha.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.legacy.alpha.api.md
@@ -12,7 +12,7 @@ export interface ICompressionStorageConfig {
     minSizeToCompress: number;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export class RateLimiter {
     constructor(maxRequests: number);
     // (undocumented)

--- a/packages/loader/driver-utils/src/rateLimiter.ts
+++ b/packages/loader/driver-utils/src/rateLimiter.ts
@@ -6,8 +6,7 @@
 import { assert } from "@fluidframework/core-utils/internal";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class RateLimiter {
 	private readonly tasks: (() => void)[] = [];


### PR DESCRIPTION
## Description
All of the APIs in our client packages (packages under the following directories: "packages", "examples", "experimental", "common/lib") should be updated to convert any APIs tagged as @legacy and @alpha to be @legacy and @beta.

Build Results
✅ All API Extractor tasks now pass successfully:

api-extractor run --local
api-extractor run --local --config api-extractor/api-extractor.legacy.json
api-extractor run --config api-extractor/api-extractor-lint-bundle.json
api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json
api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json