### PR TITLE
refactor(container-loader): Use type-only imports and exports as appropriate

### DIFF
--- a/packages/loader/container-loader/src/attachment.ts
+++ b/packages/loader/container-loader/src/attachment.ts
@@ -5,9 +5,9 @@
 
 import { AttachState } from "@fluidframework/container-definitions";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
-import { CombinedAppAndProtocolSummary } from "@fluidframework/driver-utils/internal";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
+import type { CombinedAppAndProtocolSummary } from "@fluidframework/driver-utils/internal";
 
 import type { MemoryDetachedBlobStorage } from "./memoryBlobStorage.js";
 import type { SnapshotWithBlobs } from "./serializedStateManager.js";

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -4,10 +4,10 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IAudienceEvents, ISelf } from "@fluidframework/container-definitions";
-import { IAudienceOwner } from "@fluidframework/container-definitions/internal";
+import type { IAudienceEvents, ISelf } from "@fluidframework/container-definitions";
+import type { IAudienceOwner } from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import { IClient } from "@fluidframework/driver-definitions";
+import type { IClient } from "@fluidframework/driver-definitions";
 
 /**
  * Audience represents all clients connected to the op stream.

--- a/packages/loader/container-loader/src/catchUpMonitor.ts
+++ b/packages/loader/container-loader/src/catchUpMonitor.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IDeltaManager } from "@fluidframework/container-definitions/internal";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import type { IDisposable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 /**
  * @see {@link CatchUpMonitor} for usage.

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -4,32 +4,39 @@
  */
 
 import { TypedEventEmitter, performanceNow } from "@fluid-internal/client-utils";
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import { IDeltaQueue, ReadOnlyInfo } from "@fluidframework/container-definitions/internal";
+import type { ICriticalContainerError } from "@fluidframework/container-definitions";
+import type {
+	IDeltaQueue,
+	ReadOnlyInfo,
+} from "@fluidframework/container-definitions/internal";
 import {
-	IDisposable,
-	ITelemetryBaseProperties,
+	type IDisposable,
+	type ITelemetryBaseProperties,
 	LogLevel,
 } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ConnectionMode, IClient, IClientDetails } from "@fluidframework/driver-definitions";
+import type {
+	ConnectionMode,
+	IClient,
+	IClientDetails,
+} from "@fluidframework/driver-definitions";
 import {
-	IDocumentDeltaConnection,
-	IDocumentDeltaConnectionEvents,
-	IDocumentService,
+	type IDocumentDeltaConnection,
+	type IDocumentDeltaConnectionEvents,
+	type IDocumentService,
 	DriverErrorTypes,
-	IAnyDriverError,
-	IClientConfiguration,
-	IDocumentMessage,
-	INack,
-	INackContent,
-	ISequencedDocumentSystemMessage,
-	ISignalClient,
-	ITokenClaims,
+	type IAnyDriverError,
+	type IClientConfiguration,
+	type IDocumentMessage,
+	type INack,
+	type INackContent,
+	type ISequencedDocumentSystemMessage,
+	type ISignalClient,
+	type ITokenClaims,
 	MessageType,
 	ScopeType,
-	ISequencedDocumentMessage,
-	ISignalMessage,
+	type ISequencedDocumentMessage,
+	type ISignalMessage,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	calculateMaxWaitTime,
@@ -43,7 +50,7 @@ import {
 	type ThrottlingError,
 } from "@fluidframework/driver-utils/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	GenericError,
 	UsageError,
 	formatTick,
@@ -53,10 +60,10 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 
 import {
-	IConnectionDetailsInternal,
-	IConnectionManager,
-	IConnectionManagerFactoryArgs,
-	IConnectionStateChangeReason,
+	type IConnectionDetailsInternal,
+	type IConnectionManager,
+	type IConnectionManagerFactoryArgs,
+	type IConnectionStateChangeReason,
 	ReconnectMode,
 } from "./contracts.js";
 import { DeltaQueue } from "./deltaQueue.js";

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { IDeltaManager } from "@fluidframework/container-definitions/internal";
-import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { assert, Timer } from "@fluidframework/core-utils/internal";
-import { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
-import { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
+import type { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
+import type { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import {
 	type TelemetryEventCategory,
-	ITelemetryLoggerExt,
-	MonitoringContext,
+	type ITelemetryLoggerExt,
+	type MonitoringContext,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { CatchUpMonitor, ICatchUpMonitor } from "./catchUpMonitor.js";
+import { CatchUpMonitor, type ICatchUpMonitor } from "./catchUpMonitor.js";
 import { ConnectionState } from "./connectionState.js";
-import { IConnectionDetailsInternal, IConnectionStateChangeReason } from "./contracts.js";
-import { IProtocolHandler } from "./protocol.js";
+import type { IConnectionDetailsInternal, IConnectionStateChangeReason } from "./contracts.js";
+import type { IProtocolHandler } from "./protocol.js";
 
 // Based on recent data, it looks like majority of cases where we get stuck are due to really slow or
 // timing out ops fetches. So attempt recovery infrequently. Also fetch uses 30 second timeout, so

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -12,8 +12,8 @@ import {
 } from "@fluid-internal/client-utils";
 import {
 	AttachState,
-	IAudience,
-	ICriticalContainerError,
+	type IAudience,
+	type ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 import type {
 	ContainerWarning,
@@ -35,41 +35,41 @@ import type {
 } from "@fluidframework/container-definitions/internal";
 import { isFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import {
-	FluidObject,
-	IEvent,
-	IRequest,
-	ITelemetryBaseProperties,
+	type FluidObject,
+	type IEvent,
+	type IRequest,
+	type ITelemetryBaseProperties,
 	LogLevel,
 } from "@fluidframework/core-interfaces";
-import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
+import type { ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
 import { assert, isPromiseLike, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
-	IClient,
-	IClientDetails,
-	IQuorumClients,
-	ISequencedClient,
-	ISummaryTree,
+	type IClient,
+	type IClientDetails,
+	type IQuorumClients,
+	type ISequencedClient,
+	type ISummaryTree,
 	SummaryType,
 } from "@fluidframework/driver-definitions";
 import {
-	IDocumentService,
-	IDocumentServiceFactory,
-	IDocumentStorageService,
-	IResolvedUrl,
-	ISnapshot,
-	IThrottlingWarning,
-	IUrlResolver,
-	ICommittedProposal,
-	IDocumentAttributes,
-	IDocumentMessage,
-	IQuorumProposals,
-	ISequencedProposal,
-	ISnapshotTree,
-	ISummaryContent,
-	IVersion,
+	type IDocumentService,
+	type IDocumentServiceFactory,
+	type IDocumentStorageService,
+	type IResolvedUrl,
+	type ISnapshot,
+	type IThrottlingWarning,
+	type IUrlResolver,
+	type ICommittedProposal,
+	type IDocumentAttributes,
+	type IDocumentMessage,
+	type IQuorumProposals,
+	type ISequencedProposal,
+	type ISnapshotTree,
+	type ISummaryContent,
+	type IVersion,
 	MessageType,
-	ISequencedDocumentMessage,
-	ISignalMessage,
+	type ISequencedDocumentMessage,
+	type ISignalMessage,
 	type ConnectionMode,
 } from "@fluidframework/driver-definitions/internal";
 import {
@@ -84,11 +84,11 @@ import {
 } from "@fluidframework/driver-utils/internal";
 import {
 	type TelemetryEventCategory,
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	EventEmitterWithErrorHandling,
 	GenericError,
-	IFluidErrorBase,
-	MonitoringContext,
+	type IFluidErrorBase,
+	type MonitoringContext,
 	PerformanceEvent,
 	UsageError,
 	connectedEventName,
@@ -105,27 +105,27 @@ import structuredClone from "@ungap/structured-clone";
 import { v4 as uuid } from "uuid";
 
 import {
-	AttachProcessProps,
-	AttachmentData,
+	type AttachProcessProps,
+	type AttachmentData,
 	runRetriableAttachProcess,
 } from "./attachment.js";
 import { Audience } from "./audience.js";
 import { ConnectionManager } from "./connectionManager.js";
 import { ConnectionState } from "./connectionState.js";
 import {
-	IConnectionStateHandler,
+	type IConnectionStateHandler,
 	createConnectionStateHandler,
 } from "./connectionStateHandler.js";
 import { ContainerContext } from "./containerContext.js";
 import { ContainerStorageAdapter } from "./containerStorageAdapter.js";
 import {
-	IConnectionDetailsInternal,
-	IConnectionManagerFactoryArgs,
-	IConnectionStateChangeReason,
+	type IConnectionDetailsInternal,
+	type IConnectionManagerFactoryArgs,
+	type IConnectionStateChangeReason,
 	ReconnectMode,
 	getPackageName,
 } from "./contracts.js";
-import { DeltaManager, IConnectionArgs } from "./deltaManager.js";
+import { DeltaManager, type IConnectionArgs } from "./deltaManager.js";
 import { RelativeLoader } from "./loader.js";
 import {
 	validateDriverCompatibility,
@@ -138,11 +138,11 @@ import {
 } from "./memoryBlobStorage.js";
 import { NoopHeuristic } from "./noopHeuristic.js";
 import { pkgVersion } from "./packageVersion.js";
-import { IQuorumSnapshot } from "./protocol/index.js";
+import type { IQuorumSnapshot } from "./protocol/index.js";
 import {
-	IProtocolHandler,
+	type IProtocolHandler,
 	ProtocolHandler,
-	ProtocolHandlerBuilder,
+	type ProtocolHandlerBuilder,
 	protocolHandlerShouldProcessSignal,
 } from "./protocol.js";
 import { initQuorumValuesFromCodeDetails } from "./quorum.js";
@@ -152,7 +152,7 @@ import {
 	SerializedStateManager,
 } from "./serializedStateManager.js";
 import {
-	ISnapshotTreeWithBlobContents,
+	type ISnapshotTreeWithBlobContents,
 	combineAppAndProtocolSummary,
 	combineSnapshotTreeAndSnapshotBlobs,
 	getDetachedContainerStateFromSerializedContainer,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -7,23 +7,23 @@ import type {
 	ILayerCompatDetails,
 	IProvideLayerCompatDetails,
 } from "@fluid-internal/client-utils";
-import {
+import type {
 	AttachState,
 	IAudience,
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
-import {
+import type {
 	IBatchMessage,
 	IContainerContext,
 	ILoader,
 	ILoaderOptions,
 	IDeltaManager,
-	type IContainerStorageService,
+	IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
-import { type FluidObject } from "@fluidframework/core-interfaces";
-import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
-import { IClientDetails, IQuorumClients } from "@fluidframework/driver-definitions";
-import {
+import type { FluidObject } from "@fluidframework/core-interfaces";
+import type { ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
+import type { IClientDetails, IQuorumClients } from "@fluidframework/driver-definitions";
+import type {
 	ISnapshot,
 	IDocumentMessage,
 	ISnapshotTree,
@@ -32,7 +32,7 @@ import {
 	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { ConnectionState } from "./connectionState.js";
 import { loaderCompatDetailsForRuntime } from "./loaderLayerCompatState.js";

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -4,14 +4,14 @@
  */
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import {
+import type {
 	ISnapshotTreeWithBlobContents,
-	type IContainerStorageService,
+	IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
-import {
+import type { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
 	FetchSource,
 	IDocumentService,
 	IDocumentStorageService,
@@ -24,7 +24,7 @@ import {
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import { isInstanceOfISnapshot, UsageError } from "@fluidframework/driver-utils/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { MemoryDetachedBlobStorage } from "./memoryBlobStorage.js";
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService.js";

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -3,17 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
+import type { ICriticalContainerError } from "@fluidframework/container-definitions";
 import {
-	IDeltaQueue,
-	ReadOnlyInfo,
-	IFluidCodeDetails,
+	type IDeltaQueue,
+	type ReadOnlyInfo,
+	type IFluidCodeDetails,
 	isFluidPackage,
-	IConnectionDetails,
+	type IConnectionDetails,
 } from "@fluidframework/container-definitions/internal";
-import { IErrorBase, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-import { ConnectionMode, IClientDetails } from "@fluidframework/driver-definitions";
-import {
+import type { IErrorBase, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type { ConnectionMode, IClientDetails } from "@fluidframework/driver-definitions";
+import type {
 	IContainerPackageInfo,
 	IClientConfiguration,
 	IDocumentMessage,

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -3,26 +3,26 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IContainer,
 	ICodeDetailsLoader,
 	IFluidCodeDetails,
-	type IContainerPolicies,
+	IContainerPolicies,
 } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	FluidObject,
 	IConfigProviderBase,
 	IRequest,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { IClientDetails } from "@fluidframework/driver-definitions";
-import {
+import type { IClientDetails } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentServiceFactory,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 
 import { Loader } from "./loader.js";
-import { ProtocolHandlerBuilder } from "./protocol.js";
+import type { ProtocolHandlerBuilder } from "./protocol.js";
 
 /**
  * Properties necessary for creating and loading a container.

--- a/packages/loader/container-loader/src/debugLogger.ts
+++ b/packages/loader/container-loader/src/debugLogger.ts
@@ -4,14 +4,14 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import {
+import type {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
 import {
-	ITelemetryLoggerExt,
-	ITelemetryLoggerPropertyBags,
+	type ITelemetryLoggerExt,
+	type ITelemetryLoggerPropertyBags,
 	createMultiSinkLogger,
 	eventNamespaceSeparator,
 	formatTick,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -3,30 +3,30 @@
  * Licensed under the MIT License.
  */
 
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import {
+import type { ICriticalContainerError } from "@fluidframework/container-definitions";
+import type {
 	IDeltaManagerEvents,
 	IDeltaManagerFull,
 	IDeltaQueue,
-	type IDeltaSender,
-	type ReadOnlyInfo,
+	IDeltaSender,
+	ReadOnlyInfo,
 } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	IEventProvider,
-	type ITelemetryBaseEvent,
+	ITelemetryBaseEvent,
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
-import { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
+import type { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ConnectionMode } from "@fluidframework/driver-definitions";
+import type { ConnectionMode } from "@fluidframework/driver-definitions";
 import {
-	IDocumentDeltaStorageService,
-	IDocumentService,
+	type IDocumentDeltaStorageService,
+	type IDocumentService,
 	DriverErrorTypes,
-	IDocumentMessage,
+	type IDocumentMessage,
 	MessageType,
-	ISequencedDocumentMessage,
-	ISignalMessage,
+	type ISequencedDocumentMessage,
+	type ISignalMessage,
 	type IClientDetails,
 	type IClientConfiguration,
 } from "@fluidframework/driver-definitions/internal";
@@ -34,7 +34,7 @@ import { NonRetryableError, isRuntimeMessage } from "@fluidframework/driver-util
 import {
 	type ITelemetryErrorEventExt,
 	type ITelemetryGenericEventExt,
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	DataCorruptionError,
 	DataProcessingError,
 	UsageError,
@@ -46,7 +46,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import {
+import type {
 	IConnectionDetailsInternal,
 	IConnectionManager,
 	IConnectionManagerFactoryArgs,

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -4,7 +4,7 @@
  */
 
 import { TypedEventEmitter, performanceNow } from "@fluid-internal/client-utils";
-import {
+import type {
 	IDeltaQueue,
 	IDeltaQueueEvents,
 } from "@fluidframework/container-definitions/internal";

--- a/packages/loader/container-loader/src/disposal.ts
+++ b/packages/loader/container-loader/src/disposal.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces";
 
 /**
  * Returns a wrapper around the provided function, which will only invoke the inner function if the provided

--- a/packages/loader/container-loader/src/error.ts
+++ b/packages/loader/container-loader/src/error.ts
@@ -4,11 +4,11 @@
  */
 
 import { ContainerErrorTypes } from "@fluidframework/container-definitions/internal";
-import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-import { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
+import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
 import {
-	IFluidErrorBase,
-	ITelemetryLoggerExt,
+	type IFluidErrorBase,
+	type ITelemetryLoggerExt,
 	LoggingError,
 	wrapErrorAndLog,
 } from "@fluidframework/telemetry-utils/internal";

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -4,21 +4,21 @@
  */
 
 export { ConnectionState } from "./connectionState.js";
-export { IContainerExperimental, waitContainerToCatchUp } from "./container.js";
+export { type IContainerExperimental, waitContainerToCatchUp } from "./container.js";
 export {
 	createDetachedContainer,
 	loadExistingContainer,
 	rehydrateDetachedContainer,
-	ICreateAndLoadContainerProps,
-	ICreateDetachedContainerProps,
-	ILoadExistingContainerProps,
-	IRehydrateDetachedContainerProps,
+	type ICreateAndLoadContainerProps,
+	type ICreateDetachedContainerProps,
+	type ILoadExistingContainerProps,
+	type IRehydrateDetachedContainerProps,
 } from "./createAndLoadContainerUtils.js";
 export {
-	ICodeDetailsLoader,
-	IFluidModuleWithDetails,
-	ILoaderProps,
-	ILoaderServices,
+	type ICodeDetailsLoader,
+	type IFluidModuleWithDetails,
+	type ILoaderProps,
+	type ILoaderServices,
 	Loader,
 } from "./loader.js";
 export {
@@ -32,12 +32,12 @@ export {
 	isLocationRedirectionError,
 	resolveWithLocationRedirectionHandling,
 } from "./location-redirection-utilities/index.js";
-export { IProtocolHandler, ProtocolHandlerBuilder } from "./protocol.js";
+export type { IProtocolHandler, ProtocolHandlerBuilder } from "./protocol.js";
 export {
 	tryParseCompatibleResolvedUrl,
-	IParsedUrl,
+	type IParsedUrl,
 } from "./utils.js";
-export {
+export type {
 	IBaseProtocolHandler,
 	IScribeProtocolState,
 	IQuorumSnapshot,

--- a/packages/loader/container-loader/src/loadPaused.ts
+++ b/packages/loader/container-loader/src/loadPaused.ts
@@ -8,13 +8,12 @@ import {
 	LoaderHeader,
 	type IContainer,
 } from "@fluidframework/container-definitions/internal";
-import { IRequest } from "@fluidframework/core-interfaces";
-import type { IErrorBase } from "@fluidframework/core-interfaces";
+import type { IRequest, IErrorBase } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { GenericError } from "@fluidframework/telemetry-utils/internal";
 
 import { loadExistingContainer } from "./createAndLoadContainerUtils.js";
-import { type ILoaderProps } from "./loader.js";
+import type { ILoaderProps } from "./loader.js";
 
 /* eslint-disable jsdoc/check-indentation */
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -4,30 +4,30 @@
  */
 
 import {
-	IContainer,
-	IFluidCodeDetails,
-	IFluidModule,
-	IHostLoader,
-	ILoader,
-	ILoaderOptions,
-	IProvideFluidCodeDetailsComparer,
+	type IContainer,
+	type IFluidCodeDetails,
+	type IFluidModule,
+	type IHostLoader,
+	type ILoader,
+	type ILoaderOptions,
+	type IProvideFluidCodeDetailsComparer,
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	FluidObject,
 	IConfigProviderBase,
 	IRequest,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { IClientDetails } from "@fluidframework/driver-definitions";
-import {
+import type { IClientDetails } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentServiceFactory,
 	IResolvedUrl,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
-	MonitoringContext,
+	type ITelemetryLoggerExt,
+	type MonitoringContext,
 	PerformanceEvent,
 	createChildMonitoringContext,
 	mixinMonitoringContext,
@@ -38,7 +38,7 @@ import { v4 as uuid } from "uuid";
 import { Container } from "./container.js";
 import { DebugLogger } from "./debugLogger.js";
 import { pkgVersion } from "./packageVersion.js";
-import { ProtocolHandlerBuilder } from "./protocol.js";
+import type { ProtocolHandlerBuilder } from "./protocol.js";
 import type { IPendingContainerState } from "./serializedStateManager.js";
 import {
 	getAttachedContainerStateFromSerializedContainer,

--- a/packages/loader/container-loader/src/location-redirection-utilities/resolveWithLocationRedirection.ts
+++ b/packages/loader/container-loader/src/location-redirection-utilities/resolveWithLocationRedirection.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { IRequest, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import {
-	ILocationRedirectionError,
-	IUrlResolver,
+	type ILocationRedirectionError,
+	type IUrlResolver,
 	DriverErrorTypes,
 } from "@fluidframework/driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";

--- a/packages/loader/container-loader/src/noopHeuristic.ts
+++ b/packages/loader/container-loader/src/noopHeuristic.ts
@@ -4,9 +4,9 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IEvent } from "@fluidframework/core-interfaces";
+import type { IEvent } from "@fluidframework/core-interfaces";
 import { assert, Timer } from "@fluidframework/core-utils/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 
 const defaultNoopTimeFrequency = 2000;

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -3,18 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { IAudienceOwner } from "@fluidframework/container-definitions/internal";
+import type { IAudienceOwner } from "@fluidframework/container-definitions/internal";
 import {
-	IDocumentAttributes,
-	IProcessMessageResult,
-	ISignalClient,
+	type IDocumentAttributes,
+	type IProcessMessageResult,
+	type ISignalClient,
 	MessageType,
-	ISequencedDocumentMessage,
-	ISignalMessage,
+	type ISequencedDocumentMessage,
+	type ISignalMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { canBeCoalescedByService } from "@fluidframework/driver-utils/internal";
 
-import { IBaseProtocolHandler, IQuorumSnapshot, ProtocolOpHandler } from "./protocol/index.js";
+import {
+	type IBaseProtocolHandler,
+	type IQuorumSnapshot,
+	ProtocolOpHandler,
+} from "./protocol/index.js";
 
 // ADO: #1986: Start using enum from protocol-base.
 export enum SignalType {

--- a/packages/loader/container-loader/src/protocol/index.ts
+++ b/packages/loader/container-loader/src/protocol/index.ts
@@ -4,13 +4,13 @@
  */
 
 export {
-	IProtocolHandler as IBaseProtocolHandler,
+	type IProtocolHandler as IBaseProtocolHandler,
 	ProtocolOpHandler,
-	IScribeProtocolState,
+	type IScribeProtocolState,
 } from "./protocol.js";
 export {
-	IQuorumSnapshot,
+	type IQuorumSnapshot,
 	Quorum,
-	QuorumClientsSnapshot,
-	QuorumProposalsSnapshot,
+	type QuorumClientsSnapshot,
+	type QuorumProposalsSnapshot,
 } from "./quorum.js";

--- a/packages/loader/container-loader/src/protocol/protocol.ts
+++ b/packages/loader/container-loader/src/protocol/protocol.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedClient } from "@fluidframework/driver-definitions";
+import type { ISequencedClient } from "@fluidframework/driver-definitions";
 import {
-	ISequencedDocumentMessage,
-	IDocumentAttributes,
-	IClientJoin,
-	ICommittedProposal,
-	IProcessMessageResult,
-	IProposal,
-	IQuorum,
-	ISequencedDocumentSystemMessage,
-	ISequencedProposal,
+	type ISequencedDocumentMessage,
+	type IDocumentAttributes,
+	type IClientJoin,
+	type ICommittedProposal,
+	type IProcessMessageResult,
+	type IProposal,
+	type IQuorum,
+	type ISequencedDocumentSystemMessage,
+	type ISequencedProposal,
 	MessageType,
 } from "@fluidframework/driver-definitions/internal";
 
-import { IQuorumSnapshot, Quorum } from "./quorum.js";
+import { type IQuorumSnapshot, Quorum } from "./quorum.js";
 
 /**
  * @legacy @beta

--- a/packages/loader/container-loader/src/protocol/quorum.ts
+++ b/packages/loader/container-loader/src/protocol/quorum.ts
@@ -5,8 +5,8 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
-import { IQuorumClients, ISequencedClient } from "@fluidframework/driver-definitions";
-import {
+import type { IQuorumClients, ISequencedClient } from "@fluidframework/driver-definitions";
+import type {
 	ISequencedDocumentMessage,
 	ICommittedProposal,
 	IQuorum,

--- a/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import {
+import type { IDisposable } from "@fluidframework/core-interfaces";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentStorageService,
 	ISummaryContext,
-	type IDocumentStorageServicePolicies,
+	IDocumentStorageServicePolicies,
 } from "@fluidframework/driver-definitions/internal";
 
 /**

--- a/packages/loader/container-loader/src/quorum.ts
+++ b/packages/loader/container-loader/src/quorum.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { ICommittedProposal } from "@fluidframework/driver-definitions/internal";
+import type { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
+import type { ICommittedProposal } from "@fluidframework/driver-definitions/internal";
 
 export function initQuorumValuesFromCodeDetails(
 	source: IFluidCodeDetails,

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
-import {
+import type { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
 	FetchSource,
 	IDocumentStorageService,
 	IDocumentStorageServicePolicies,
@@ -19,7 +19,7 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { runWithRetry } from "@fluidframework/driver-utils/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	GenericError,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -4,7 +4,7 @@
  */
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import { IRuntime } from "@fluidframework/container-definitions/internal";
+import type { IRuntime } from "@fluidframework/container-definitions/internal";
 import type {
 	IEventProvider,
 	IEvent,
@@ -14,17 +14,17 @@ import type {
 import { Timer, assert } from "@fluidframework/core-utils/internal";
 import {
 	FetchSource,
-	IDocumentStorageService,
-	IResolvedUrl,
-	ISnapshot,
+	type IDocumentStorageService,
+	type IResolvedUrl,
+	type ISnapshot,
 	type IDocumentAttributes,
-	ISnapshotTree,
-	IVersion,
-	ISequencedDocumentMessage,
+	type ISnapshotTree,
+	type IVersion,
+	type ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
 import {
-	MonitoringContext,
+	type MonitoringContext,
 	PerformanceEvent,
 	UsageError,
 	createChildMonitoringContext,
@@ -32,7 +32,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 
 import {
-	ISerializableBlobContents,
+	type ISerializableBlobContents,
 	getBlobContentsFromTree,
 } from "./containerStorageAdapter.js";
 import { convertSnapshotToSnapshotInfo, getDocumentAttributes } from "./utils.js";

--- a/packages/loader/container-loader/src/test/attachment.spec.ts
+++ b/packages/loader/container-loader/src/test/attachment.spec.ts
@@ -8,19 +8,19 @@ import { strict as assert } from "node:assert";
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { SummaryType } from "@fluidframework/driver-definitions";
-import {
+import type {
 	IDocumentStorageService,
-	type ICreateBlobResponse,
+	ICreateBlobResponse,
 } from "@fluidframework/driver-definitions/internal";
 import { v4 as uuid } from "uuid";
 
 import {
-	AttachProcessProps,
-	AttachingDataWithBlobs,
-	AttachingDataWithoutBlobs,
-	AttachmentData,
-	DetachedDataWithOutstandingBlobs,
-	DetachedDefaultData,
+	type AttachProcessProps,
+	type AttachingDataWithBlobs,
+	type AttachingDataWithoutBlobs,
+	type AttachmentData,
+	type DetachedDataWithOutstandingBlobs,
+	type DetachedDefaultData,
 	runRetriableAttachProcess,
 } from "../attachment.js";
 import { combineAppAndProtocolSummary } from "../utils.js";

--- a/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
+++ b/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import {
+import type {
 	IDeltaManager,
 	IDeltaManagerEvents,
 } from "@fluidframework/container-definitions/internal";

--- a/packages/loader/container-loader/src/test/connectionManager.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionManager.spec.ts
@@ -10,12 +10,12 @@ import {
 	MockDocumentService,
 } from "@fluid-private/test-loader-utils";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import { IClient } from "@fluidframework/driver-definitions";
+import type { IClient } from "@fluidframework/driver-definitions";
 import {
 	DriverErrorTypes,
-	IAnyDriverError,
-	IDocumentService,
-	INack,
+	type IAnyDriverError,
+	type IDocumentService,
+	type INack,
 	NackErrorType,
 } from "@fluidframework/driver-definitions/internal";
 import { NonRetryableError, RetryableError } from "@fluidframework/driver-utils/internal";
@@ -23,7 +23,7 @@ import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import { stub, type SinonFakeTimers, useFakeTimers } from "sinon";
 
 import { ConnectionManager } from "../connectionManager.js";
-import { IConnectionManagerFactoryArgs, ReconnectMode } from "../contracts.js";
+import { type IConnectionManagerFactoryArgs, ReconnectMode } from "../contracts.js";
 import { pkgVersion } from "../packageVersion.js";
 
 describe("connectionManager", () => {

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -6,31 +6,35 @@
 import { strict as assert } from "node:assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import {
+import type {
 	IDeltaManager,
 	IDeltaManagerEvents,
 } from "@fluidframework/container-definitions/internal";
-import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-import { ConnectionMode, IClient, ISequencedClient } from "@fluidframework/driver-definitions";
-import {
+import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type {
+	ConnectionMode,
+	IClient,
+	ISequencedClient,
+} from "@fluidframework/driver-definitions";
+import type {
 	IClientConfiguration,
 	ITokenClaims,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	TelemetryEventCategory,
+	type TelemetryEventCategory,
 	createChildLogger,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
-import { SinonFakeTimers, useFakeTimers } from "sinon";
+import { type SinonFakeTimers, useFakeTimers } from "sinon";
 
 import { Audience } from "../audience.js";
 import { ConnectionState } from "../connectionState.js";
 import {
-	IConnectionStateHandler,
-	IConnectionStateHandlerInputs,
+	type IConnectionStateHandler,
+	type IConnectionStateHandlerInputs,
 	createConnectionStateHandlerCore,
 } from "../connectionStateHandler.js";
-import { IConnectionDetailsInternal } from "../contracts.js";
+import type { IConnectionDetailsInternal } from "../contracts.js";
 import { ProtocolHandler } from "../protocol.js";
 
 class MockDeltaManagerForCatchingUp

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -6,16 +6,16 @@
 import { strict as assert } from "node:assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { AttachState, IAudience } from "@fluidframework/container-definitions/";
-import {
+import type { AttachState, IAudience } from "@fluidframework/container-definitions/";
+import type {
 	IContainer,
 	IContainerEvents,
 	IDeltaManager,
 	IDeltaManagerEvents,
 	ReadOnlyInfo,
 } from "@fluidframework/container-definitions/internal";
-import { IClient } from "@fluidframework/driver-definitions";
-import {
+import type { IClient } from "@fluidframework/driver-definitions";
+import type {
 	IResolvedUrl,
 	IDocumentMessage,
 	ISequencedDocumentMessage,

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -10,24 +10,24 @@ import {
 	MockDocumentDeltaConnection,
 	MockDocumentService,
 } from "@fluid-private/test-loader-utils";
-import { IClient } from "@fluidframework/driver-definitions";
+import type { IClient } from "@fluidframework/driver-definitions";
 import {
-	IDocumentDeltaStorageService,
-	IDocumentMessage,
+	type IDocumentDeltaStorageService,
+	type IDocumentMessage,
 	MessageType,
-	ISequencedDocumentMessage,
+	type ISequencedDocumentMessage,
 	type IStream,
 	type IStreamResult,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	MockLogger,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
-import { SinonFakeTimers, useFakeTimers } from "sinon";
+import { type SinonFakeTimers, useFakeTimers } from "sinon";
 
 import { ConnectionManager } from "../connectionManager.js";
-import { IConnectionManagerFactoryArgs } from "../contracts.js";
+import type { IConnectionManagerFactoryArgs } from "../contracts.js";
 import { DeltaManager } from "../deltaManager.js";
 import { NoopHeuristic } from "../noopHeuristic.js";
 

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -8,10 +8,10 @@ import { strict as assert } from "node:assert";
 import type { IProvideLayerCompatDetails } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { FluidErrorTypes, type ConfigTypes } from "@fluidframework/core-interfaces/internal";
-import {
-	type IDocumentServiceFactory,
-	type IResolvedUrl,
-	type IUrlResolver,
+import type {
+	IDocumentServiceFactory,
+	IResolvedUrl,
+	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	isFluidError,

--- a/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
+++ b/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
@@ -14,10 +14,7 @@ import {
 	FluidErrorTypes,
 	type ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces/internal";
-import {
-	type IResolvedUrl,
-	type IUrlResolver,
-} from "@fluidframework/driver-definitions/internal";
+import type { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions/internal";
 import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 import Sinon from "sinon";
 

--- a/packages/loader/container-loader/src/test/locationRedirectionTests.spec.ts
+++ b/packages/loader/container-loader/src/test/locationRedirectionTests.spec.ts
@@ -5,10 +5,10 @@
 
 import { strict as assert } from "node:assert";
 
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import {
-	IResolvedUrl,
-	IUrlResolver,
+	type IResolvedUrl,
+	type IUrlResolver,
 	DriverErrorTypes,
 } from "@fluidframework/driver-definitions/internal";
 

--- a/packages/loader/container-loader/src/test/protocol.spec.ts
+++ b/packages/loader/container-loader/src/test/protocol.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type IClientDetails, type IUser } from "@fluidframework/driver-definitions";
+import type { IClientDetails, IUser } from "@fluidframework/driver-definitions";
 import {
 	MessageType,
 	type ISequencedDocumentMessage,

--- a/packages/loader/container-loader/src/test/quorum.spec.ts
+++ b/packages/loader/container-loader/src/test/quorum.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import { ISequencedClient } from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedClient } from "@fluidframework/driver-definitions";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 import { Quorum } from "../protocol/index.js";
 

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -6,22 +6,22 @@
 import { strict as assert } from "node:assert";
 
 import { EventEmitter, stringToBuffer } from "@fluid-internal/client-utils";
-import {
+import type {
 	IGetPendingLocalStateProps,
 	IRuntime,
 } from "@fluidframework/container-definitions/internal";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import {
-	FetchSource,
-	IResolvedUrl,
-	ISnapshot,
-	ISnapshotFetchOptions,
-	IDocumentAttributes,
-	ISnapshotTree,
-	IVersion,
+	type FetchSource,
+	type IResolvedUrl,
+	type ISnapshot,
+	type ISnapshotFetchOptions,
+	type IDocumentAttributes,
+	type ISnapshotTree,
+	type IVersion,
 	MessageType,
-	ISequencedDocumentMessage,
+	type ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
 import { MockLogger, mixinMonitoringContext } from "@fluidframework/telemetry-utils/internal";

--- a/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import { type ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 
 import {
 	combineAppAndProtocolSummary,

--- a/packages/loader/container-loader/src/test/testProxies.ts
+++ b/packages/loader/container-loader/src/test/testProxies.ts
@@ -15,7 +15,7 @@ import type {
 } from "@fluidframework/container-definitions/internal";
 import {
 	SummaryType,
-	IDocumentServiceFactory,
+	type IDocumentServiceFactory,
 	type IDocumentService,
 	type IDocumentStorageService,
 	type IResolvedUrl,

--- a/packages/loader/container-loader/src/test/utils.spec.ts
+++ b/packages/loader/container-loader/src/test/utils.spec.ts
@@ -6,9 +6,9 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import {
+import type {
 	IDocumentStorageService,
-	type ISnapshot,
+	ISnapshot,
 	IDocumentAttributes,
 	ISnapshotTree,
 } from "@fluidframework/driver-definitions/internal";

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -9,19 +9,17 @@ import {
 	stringToBuffer,
 } from "@fluid-internal/client-utils";
 import { assert, compareArrays, unreachableCase } from "@fluidframework/core-utils/internal";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import { type ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import {
 	DriverErrorTypes,
-	IDocumentAttributes,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
-import {
-	IDocumentStorageService,
+	type IDocumentAttributes,
+	type ISnapshotTree,
+	type IDocumentStorageService,
 	type ISnapshot,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	CombinedAppAndProtocolSummary,
-	DeltaStreamConnectionForbiddenError,
+	type CombinedAppAndProtocolSummary,
+	type DeltaStreamConnectionForbiddenError,
 	isCombinedAppAndProtocolSummary,
 	readAndParse,
 } from "@fluidframework/driver-utils/internal";
@@ -32,7 +30,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import { ISerializableBlobContents } from "./containerStorageAdapter.js";
+import type { ISerializableBlobContents } from "./containerStorageAdapter.js";
 import type {
 	IPendingContainerState,
 	IPendingDetachedContainerState,


### PR DESCRIPTION
Pre-fixes violations of new eslint rules added to our shared eslint config.

Auto-fixed via `npm run eslint:fix`