### PR TITLE
Make FaultInjectionDriver's offlineError retryable

### DIFF
--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -415,7 +415,7 @@ export class FaultInjectionDocumentStorageService implements IDocumentStorageSer
 function throwOfflineError(): never {
 	throw new FaultInjectionError(
 		"simulated offline error",
-		false,
+		true,
 		DriverErrorTypes.offlineError,
 	);
 }


### PR DESCRIPTION
[AB#47030](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47030)

The only place we use `offlineError` in production today is in odspUtils.ts, where it may be thrown as a `RetryableError`.

This PR would change the stress tests to also throw the error as retryable, both to better match production scenarios we want to test but also because it's a better match for offline (it's reasonable to retry network requests after coming back online).  This permits `RetriableDocumentStorageService` to retry requests via `runWithRetry`, similar to its natural behavior when using real odsp-driver in offline scenarios.

Similar for createBlob, which also uses `runWithRetry` but has no error handling in the case that it fails (uploadP in its pending blob tracking is never caught or awaited) - this probably results in unhandledRejection though I don't have an example in hand right now.

Also without this change, there's no meaningful testing of the "coming back online" scenario (`goOnline`), since either (A) the runner got lucky and never tried to do anything while offline and never knows it happened or (B) died as soon as a network request is made because the error is not retryable.