### PR TITLE
Rollback Shared Array move op

### DIFF
--- a/packages/dds/legacy-dds/src/array/sharedArray.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArray.ts
@@ -438,8 +438,8 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 				inputEntry.isLocalPendingMove = 0;
 				const moveOp: IMoveOperation = {
 					type: OperationType.moveEntry,
-					entryId: oldEntryId,
-					changedToEntryId: newEntryId,
+					entryId: newEntryId,
+					changedToEntryId: oldEntryId,
 				};
 				this.emitValueChangedEvent(moveOp, true /* isLocal */);
 				break;

--- a/packages/dds/legacy-dds/src/array/sharedArray.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArray.ts
@@ -426,7 +426,24 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 				}
 				break;
 			}
-			case OperationType.moveEntry:
+			case OperationType.moveEntry: {
+				const { entryId: oldEntryId, changedToEntryId: newEntryId } = arrayOp;
+				if (this.getEntryForId(newEntryId).isDeleted) {
+					return;
+				}
+				this.updateLiveEntry(newEntryId, oldEntryId);
+				const inputEntry = this.getEntryForId(oldEntryId);
+				inputEntry.prevEntryId = undefined;
+				inputEntry.nextEntryId = undefined;
+				inputEntry.isLocalPendingMove = 0;
+				const moveOp: IMoveOperation = {
+					type: OperationType.moveEntry,
+					entryId: oldEntryId,
+					changedToEntryId: newEntryId,
+				};
+				this.emitValueChangedEvent(moveOp, true /* isLocal */);
+				break;
+			}
 			case OperationType.toggle:
 			case OperationType.toggleMove: {
 				throw new Error(`Rollback not implemented for ${arrayOp.type} operations`);

--- a/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
@@ -212,7 +212,7 @@ describe("SharedArray rollback", () => {
 		sharedArray.insert(2, 2); // [0,1,2]
 		containerRuntime.flush();
 		containerRuntimeFactory.processAllMessages();
-		sharedArray.move(0, 2); // this will be rolled back, expected [1,2,0]
+		sharedArray.move(0, 2); // this will be rolled back, expected [1, 0, 2]
 		assert.deepStrictEqual(
 			sharedArray.get(),
 			[1, 0, 2],
@@ -227,6 +227,43 @@ describe("SharedArray rollback", () => {
 		assert.deepStrictEqual(
 			sharedArray2.get(),
 			[0, 1, 2],
+			"Array should have expected entries post-rollback",
+		);
+	});
+
+	it("should rollback move ops in presence of remote changes", () => {
+		const { sharedArray, containerRuntimeFactory, containerRuntime } = setupRollbackTest();
+		// Create a second client
+		const { sharedArray: sharedArray2, containerRuntime: containerRuntime2 } =
+			createAdditionalClient(containerRuntimeFactory);
+		sharedArray.insert(0, 0); // [0]
+		sharedArray.insert(1, 1); // [0,1]
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		sharedArray.insert(2, 2); // this will be rolled back
+		sharedArray.insert(3, 3); // this will be rolled back
+		sharedArray.move(0, 3); // this will be rolled back
+
+		sharedArray2.insert(2, 3); // [0,1,3]
+		sharedArray2.delete(0); // [1,3]
+		sharedArray2.insert(1, 12); // [1,12,3]
+		sharedArray2.insert(0, 10); // [10,1,12,3]
+		containerRuntime2.flush();
+		containerRuntimeFactory.processAllMessages();
+		assert.deepStrictEqual(
+			sharedArray.get(),
+			[10, 1, 2, 3, 12, 3],
+			"Array should have expected entries pre-rollback",
+		);
+		containerRuntime.rollback?.();
+		assert.deepStrictEqual(
+			sharedArray.get(),
+			[10, 1, 12, 3],
+			"Array should have expected entries post-rollback",
+		);
+		assert.deepStrictEqual(
+			sharedArray2.get(),
+			[10, 1, 12, 3],
 			"Array should have expected entries post-rollback",
 		);
 	});

--- a/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
@@ -39,14 +39,14 @@ describe("SharedArray fuzz", () => {
 	createDDSFuzzSuite(
 		{
 			...baseSharedArrayModel,
-			workloadName: "insert and delete rollback",
+			workloadName: "insert, move and delete rollback",
 			generatorFactory: () =>
 				takeAsync(
 					100,
 					makeSharedArrayOperationGenerator({
 						insert: 5,
 						delete: 3,
-						move: 0,
+						move: 2,
 						insertBulkAfter: 1,
 						toggle: 0,
 						toggleMove: 0,


### PR DESCRIPTION
Implementing rollback to move operation in Shared Array.
Enabling corresponding fuzz testing.

Logic is recycled from toggleMove operation, more specifically `updateLiveEntry` which practically does what we want to accomplish when rolling back a move op. Only difference would be to unset local flags as we won't send a corresponding op.