### PR TITLE
test(client): use Large-eastus2 for Service Client tests

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -262,8 +262,7 @@ describe(`Presence with AzureClient`, () => {
 	// Note that on slower systems 50+ clients may take too long to join.
 	const numClientsForAttendeeTests = [5, 20, 50, 100];
 	// TODO: AB#45620: "Presence: perf: update Join pattern for scale" may help, then remove .slice.
-	// TODO: 20 clients is too many on ADO pipeline agents and times out waiting for attendees.
-	for (const numClients of numClientsForAttendeeTests.slice(0, 1)) {
+	for (const numClients of numClientsForAttendeeTests.slice(0, 2)) {
 		assert(numClients > 1, "Must have at least two clients");
 
 		// Timeout duration used when waiting for response messages from child processes.

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -45,7 +45,7 @@ stages:
     parameters:
       stageId: e2e_azure_client_frs
       stageDisplayName: e2e - azure-client with AFR
-      poolBuild: Small-eastus2
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:azure
@@ -62,7 +62,7 @@ stages:
     parameters:
       stageId: e2e_azure_client_local_server
       stageDisplayName: e2e - azure-client with Azure local service
-      poolBuild: Small-eastus2
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:tinylicious


### PR DESCRIPTION
to allow moderate scalability testing
