### PR TITLE
SchemaFactory cleanup

### DIFF
--- a/.changeset/hot-experts-throw.md
+++ b/.changeset/hot-experts-throw.md
@@ -5,4 +5,4 @@
 ---
 SchemaFactoryAlpha.recordRecursive now supports metadata
 
-`SchemaFactoryAlpha.recordRecursive` now support metadata like `SchemaFactoryAlpha.recordAlpha` and the other TreeNodeSchema creation methods on `SchemaFactoryAlpha`.
+`SchemaFactoryAlpha.recordRecursive` now support metadata like `SchemaFactoryAlpha.recordAlpha` and the other `TreeNodeSchema` creation methods on `SchemaFactoryAlpha` (except for `SchemaFactoryAlpha.record` which does not support metadata).

--- a/.changeset/hot-experts-throw.md
+++ b/.changeset/hot-experts-throw.md
@@ -1,0 +1,8 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+SchemaFactoryAlpha.recordRecursive now supports metadata
+
+`SchemaFactoryAlpha.recordRecursive` now support metadata like `SchemaFactoryAlpha.recordAlpha` and the other TreeNodeSchema creation methods on `SchemaFactoryAlpha`.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -433,7 +433,7 @@ export namespace JsonAsTree {
     const // @system
     _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Record, TreeRecordNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Record, unknown>, {
         readonly [x: string]: string | number | JsonObject | Array | System_Unsafe.InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
-    }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
+    }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined, unknown>;
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     // @system
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
@@ -840,9 +840,9 @@ export class SchemaFactoryAlpha<out TScope extends string | undefined = string |
     record<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Record<${string}>`>, NodeKind.Record, TreeRecordNode<T> & WithType<ScopedSchemaName<TScope, `Record<${string}>`>, NodeKind.Record>, RecordNodeInsertableData<T>, true, T, undefined>;
     record<const Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Record, TreeRecordNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Record>, RecordNodeInsertableData<T>, true, T, undefined>;
     recordAlpha<const Name extends TName, const T extends ImplicitAnnotatedAllowedTypes, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): RecordNodeCustomizableSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata>;
-    recordRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Record, TreeRecordNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Record, unknown>, {
+    recordRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Record, TreeRecordNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Record, unknown>, {
         readonly [x: string]: System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
-    }, false, T, undefined>;
+    }, false, T, undefined, TCustomMetadata>;
     static readonly required: {
         <const T extends ImplicitAllowedTypes, const TCustomMetadata = unknown>(t: T, props?: Omit<FieldPropsAlpha<TCustomMetadata>, "defaultProvider"> | undefined): FieldSchemaAlpha<FieldKind.Required, T, TCustomMetadata>;
         <const T_1 extends ImplicitAnnotatedAllowedTypes, const TCustomMetadata_1 = unknown>(t: T_1, props?: Omit<FieldPropsAlpha<TCustomMetadata_1>, "defaultProvider"> | undefined): FieldSchemaAlpha<FieldKind.Required, UnannotateImplicitAllowedTypes<T_1>, TCustomMetadata_1>;

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -669,7 +669,7 @@ export class SchemaFactory<
 	>;
 
 	/**
-	 * Define (and add to this library) a {@link TreeNodeSchemaClass} for a {@link (TreeArrayNode:interface)}.
+	 * Define a {@link TreeNodeSchemaClass} for a {@link (TreeArrayNode:interface)}.
 	 *
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 * @param allowedTypes - The types that may appear in the array.

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
@@ -216,7 +216,7 @@ const schemaStaticsAlpha: SchemaStaticsAlpha = {
  * Some private methods on `SchemaFactory` are intentionally duplicated here to avoid increasing their exposure to `protected`.
  * If we were to do so, they would be exposed on the public API surface of `SchemaFactory`.
  *
- * When building schema, when `options` is not provided, `TCustomMetadata` infers to `unknown`.
+ * When building schema, when `options` is not provided, `TCustomMetadata` is inferred as `unknown`.
  * If desired, this could be made to infer `undefined` instead by adding overloads for everything,
  * but currently it is not worth the maintenance overhead as there is no use case which this is known to be helpful for.
  */

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
@@ -216,7 +216,7 @@ const schemaStaticsAlpha: SchemaStaticsAlpha = {
  * Some private methods on `SchemaFactory` are intentionally duplicated here to avoid increasing their exposure to `protected`.
  * If we were to do so, they would be exposed on the public API surface of `SchemaFactory`.
  *
- * When building schema, when `options` is not provided, TCustomMetadata infers to unknown.
+ * When building schema, when `options` is not provided, `TCustomMetadata` infers to `unknown`.
  * If desired, this could be made to infer `undefined` instead by adding overloads for everything,
  * but currently it is not worth the maintenance overhead as there is no use case which this is known to be helpful for.
  */

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
@@ -215,6 +215,10 @@ const schemaStaticsAlpha: SchemaStaticsAlpha = {
  *
  * Some private methods on `SchemaFactory` are intentionally duplicated here to avoid increasing their exposure to `protected`.
  * If we were to do so, they would be exposed on the public API surface of `SchemaFactory`.
+ *
+ * When building schema, when `options` is not provided, TCustomMetadata infers to unknown.
+ * If desired, this could be made to infer `undefined` instead by adding overloads for everything,
+ * but currently it is not worth the maintenance overhead as there is no use case which this is known to be helpful for.
  */
 export class SchemaFactoryAlpha<
 	out TScope extends string | undefined = string | undefined,
@@ -440,7 +444,7 @@ export class SchemaFactoryAlpha<
 	}
 
 	/**
-	 * Define (and add to this library) a {@link TreeNodeSchemaClass} for a {@link (TreeArrayNode:interface)}.
+	 * Define a {@link TreeNodeSchemaClass} for a {@link (TreeArrayNode:interface)}.
 	 *
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 * @param allowedTypes - The types that may appear in the array.
@@ -628,23 +632,24 @@ export class SchemaFactoryAlpha<
 	}
 
 	/**
-	 * Define a {@link TreeNodeSchema} for a {@link (TreeArrayNode:interface)}.
+	 * Define a {@link TreeNodeSchema} for a {@link (TreeRecordNode:interface)}.
 	 *
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 *
 	 * @remarks
-	 * This is not intended to be used directly, use the overload of `array` which takes a name instead.
-	 * This is only public to work around a compiler limitation.
+	 * This is not intended to be used directly, use the overload of `record` which takes a name instead.
 	 */
 	private namedRecord<
 		Name extends TName | string,
 		const T extends ImplicitAllowedTypes,
 		const ImplicitlyConstructable extends boolean,
+		const TCustomMetadata = unknown,
 	>(
 		name: Name,
 		allowedTypes: T,
 		customizable: boolean,
 		implicitlyConstructable: ImplicitlyConstructable,
+		options?: NodeSchemaOptionsAlpha<TCustomMetadata>,
 	): TreeNodeSchemaBoth<
 		/* Name */ ScopedSchemaName<TScope, Name>,
 		/* Kind */ NodeKind.Record,
@@ -660,6 +665,8 @@ export class SchemaFactoryAlpha<
 			info: allowedTypes,
 			customizable,
 			implicitlyConstructable,
+			metadata: options?.metadata,
+			persistedMetadata: options?.persistedMetadata,
 		});
 
 		return record as TreeNodeSchemaBoth<
@@ -716,7 +723,8 @@ export class SchemaFactoryAlpha<
 	public recordRecursive<
 		Name extends TName,
 		const T extends System_Unsafe.ImplicitAllowedTypesUnsafe,
-	>(name: Name, allowedTypes: T) {
+		const TCustomMetadata = unknown,
+	>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>) {
 		const RecordSchema = this.namedRecord(
 			name,
 			allowedTypes as T & ImplicitAllowedTypes,
@@ -724,6 +732,7 @@ export class SchemaFactoryAlpha<
 			// Setting this to true seems to work ok currently, but not for other node kinds.
 			// Supporting this could be fragile and might break other future changes, so it's being kept as false for now.
 			/* implicitlyConstructable */ false,
+			options,
 		);
 
 		return RecordSchema as TreeNodeSchemaClass<
@@ -740,7 +749,8 @@ export class SchemaFactoryAlpha<
 			},
 			/* ImplicitlyConstructable */ false,
 			/* Info */ T,
-			/* TConstructorExtra */ undefined
+			/* TConstructorExtra */ undefined,
+			/* TCustomMetadata */ TCustomMetadata
 		>;
 	}
 

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -54,6 +54,9 @@ import { getView, TestTreeProviderLite, validateUsageError } from "../../utils.j
 import type { SchematizingSimpleTreeView } from "../../../shared-tree/index.js";
 import { EmptyKey } from "../../../core/index.js";
 
+// Tests for the non-recursive API subset of SchemaFactory and SchemaFactoryAlpha.
+// Recursive APIs are tested in schemaFactoryRecursive.spec.ts
+
 {
 	const schema = new SchemaFactory("Blah");
 
@@ -389,6 +392,8 @@ describe("schemaFactory", () => {
 			// Ensure `Foo.metadata` is typed as we expect, and we can access its fields without casting.
 			const description = Foo.metadata.description;
 			const baz = Foo.metadata.custom.baz;
+			type _check1 = requireTrue<areSafelyAssignable<typeof description, string>>;
+			type _check2 = requireTrue<areSafelyAssignable<typeof baz, boolean>>;
 		});
 
 		it("Field schema metadata", () => {
@@ -623,6 +628,8 @@ describe("schemaFactory", () => {
 			// Ensure `Foo.metadata` is typed as we expect, and we can access its fields without casting.
 			const description = Foo.metadata.description;
 			const baz = Foo.metadata.custom.baz;
+			type _check1 = requireTrue<areSafelyAssignable<typeof description, string>>;
+			type _check2 = requireTrue<areSafelyAssignable<typeof baz, boolean>>;
 		});
 	});
 
@@ -692,6 +699,8 @@ describe("schemaFactory", () => {
 			// Ensure `Foo.metadata` is typed as we expect, and we can access its fields without casting.
 			const description = Foo.metadata.description;
 			const baz = Foo.metadata.custom.baz;
+			type _check1 = requireTrue<areSafelyAssignable<typeof description, string>>;
+			type _check2 = requireTrue<areSafelyAssignable<typeof baz, boolean>>;
 		});
 	});
 
@@ -738,6 +747,15 @@ describe("schemaFactory", () => {
 			const factory = new SchemaFactoryAlpha("test");
 			class NamedRecord extends factory.record("name", factory.number) {}
 			const namedInstance = new NamedRecord({ x: 5 });
+			const x: number = namedInstance.x;
+			// TODO: this should not compile as the typing is incorrect (y is undefined, not number)
+			const y: number = namedInstance.y;
+			delete namedInstance.x;
+
+			// TODO: this should throw a nicer error, which should be validated here.
+			assert.throws(() => {
+				delete namedInstance.z;
+			});
 		});
 
 		it("Node schema metadata", () => {
@@ -759,6 +777,8 @@ describe("schemaFactory", () => {
 			// Ensure `Foo.metadata` is typed as we expect, and we can access its fields without casting.
 			const description = Foo.metadata.description;
 			const baz = Foo.metadata.custom.baz;
+			type _check1 = requireTrue<areSafelyAssignable<typeof description, string>>;
+			type _check2 = requireTrue<areSafelyAssignable<typeof baz, boolean>>;
 		});
 	});
 

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -751,11 +751,6 @@ describe("schemaFactory", () => {
 			// TODO: this should not compile as the typing is incorrect (y is undefined, not number)
 			const y: number = namedInstance.y;
 			delete namedInstance.x;
-
-			// TODO: this should throw a nicer error, which should be validated here.
-			assert.throws(() => {
-				delete namedInstance.z;
-			});
 		});
 
 		it("Node schema metadata", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -748,7 +748,7 @@ describe("schemaFactory", () => {
 			class NamedRecord extends factory.record("name", factory.number) {}
 			const namedInstance = new NamedRecord({ x: 5 });
 			const x: number = namedInstance.x;
-			// TODO: this should not compile as the typing is incorrect (y is undefined, not number)
+			// TODO: AB#47136: this (and likely the line above as well) should not compile as the typing is incorrect (y is undefined, not number)
 			const y: number = namedInstance.y;
 			delete namedInstance.x;
 		});

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -45,6 +45,9 @@ import { hydrate } from "../utils.js";
 import { validateTypeError } from "../../utils.js";
 
 // Tests for SchemaFactoryRecursive.ts and the recursive API subset of SchemaFactory and SchemaFactoryAlpha.
+// It is a bit odd/non-conventional to put the tests for the recursive methods of SchemaFactory here:
+// while they could be combined, keeping them separated like this is somewhat nice due to the size of these test suites,
+// and how annoying the recursive ones are with intelliSense errors.
 
 // TODO:
 // Ensure the following have tests:

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -58,7 +58,7 @@ import { validateTypeError } from "../../utils.js";
 // Recursion through ImplicitAllowedTypes (part of co-recursion)
 // Recursion through ImplicitFieldSchema (part of union and as part of co-recursion)
 
-const sf = new SchemaFactory("recursive");
+const schemaFactory = new SchemaFactory("recursive");
 
 describe("SchemaFactory Recursive methods", () => {
 	describe("objectRecursive", () => {
@@ -118,8 +118,8 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("object with optional recursive field", () => {
-			class ObjectRecursive extends sf.objectRecursive("Object", {
-				x: sf.optionalRecursive([() => ObjectRecursive]),
+			class ObjectRecursive extends schemaFactory.objectRecursive("Object", {
+				x: SchemaFactory.optionalRecursive([() => ObjectRecursive]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof ObjectRecursive>;
@@ -177,8 +177,8 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("object with required recursive field", () => {
-			class ObjectRecursive extends sf.objectRecursive("Object", {
-				x: sf.requiredRecursive([() => ObjectRecursive, sf.number]),
+			class ObjectRecursive extends schemaFactory.objectRecursive("Object", {
+				x: SchemaFactory.requiredRecursive([() => ObjectRecursive, SchemaFactory.number]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof ObjectRecursive>;
@@ -195,7 +195,7 @@ describe("SchemaFactory Recursive methods", () => {
 			type Field4 = FlexListToUnion<XTypes>;
 			type _check1 = requireTrue<areSafelyAssignable<Field3, ObjectRecursive | number>>;
 			type _check2 = requireTrue<
-				areSafelyAssignable<Field4, typeof ObjectRecursive | typeof sf.number>
+				areSafelyAssignable<Field4, typeof ObjectRecursive | typeof SchemaFactory.number>
 			>;
 
 			type Insertable = InsertableTreeNodeFromImplicitAllowedTypes<typeof ObjectRecursive>;
@@ -237,16 +237,16 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("other under recursive object", () => {
-			class Other extends sf.object("Other", {
-				y: sf.number,
+			class Other extends schemaFactory.object("Other", {
+				y: schemaFactory.number,
 			}) {}
-			class ObjectRecursive extends sf.objectRecursive("Object", {
-				x: sf.optionalRecursive([() => ObjectRecursive]),
+			class ObjectRecursive extends schemaFactory.objectRecursive("Object", {
+				x: schemaFactory.optionalRecursive([() => ObjectRecursive]),
 				a: Other,
 				b: [Other],
 				c: [() => Other],
-				d: sf.optional(Other),
-				e: sf.optional([() => Other]),
+				d: schemaFactory.optional(Other),
+				e: schemaFactory.optional([() => Other]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof ObjectRecursive>;
@@ -280,14 +280,14 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("array under recursive object", () => {
-			class Other extends sf.array("Other", sf.number) {}
-			class ObjectRecursive extends sf.objectRecursive("Object", {
-				x: sf.optionalRecursive([() => ObjectRecursive]),
+			class Other extends schemaFactory.array("Other", schemaFactory.number) {}
+			class ObjectRecursive extends schemaFactory.objectRecursive("Object", {
+				x: schemaFactory.optionalRecursive([() => ObjectRecursive]),
 				a: Other,
 				b: [Other],
 				c: [() => Other],
-				d: sf.optional(Other),
-				e: sf.optional([() => Other]),
+				d: schemaFactory.optional(Other),
+				e: schemaFactory.optional([() => Other]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof ObjectRecursive>;
@@ -321,8 +321,8 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("object nested construction", () => {
-			class ObjectRecursive extends sf.objectRecursive("Object", {
-				x: sf.optionalRecursive([() => ObjectRecursive]),
+			class ObjectRecursive extends schemaFactory.objectRecursive("Object", {
+				x: schemaFactory.optionalRecursive([() => ObjectRecursive]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof ObjectRecursive>;
@@ -357,14 +357,14 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive objects with implicit field", () => {
-			class A extends sf.objectRecursive("A", {
-				a: sf.optionalRecursive([() => B]),
+			class A extends schemaFactory.objectRecursive("A", {
+				a: schemaFactory.optionalRecursive([() => B]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof A>;
 			}
 
-			class B extends sf.object("B", {
+			class B extends schemaFactory.object("B", {
 				// Implicit required field
 				b: A,
 			}) {}
@@ -396,15 +396,15 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive objects with explicit non-recursive field", () => {
-			class A extends sf.objectRecursive("A", {
-				a: sf.optionalRecursive([() => B]),
+			class A extends schemaFactory.objectRecursive("A", {
+				a: schemaFactory.optionalRecursive([() => B]),
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof A>;
 			}
 
-			class B extends sf.object("B", {
-				b: sf.optional(A),
+			class B extends schemaFactory.object("B", {
+				b: schemaFactory.optional(A),
 			}) {}
 
 			{
@@ -434,15 +434,15 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("recursive object with implicit recursive field", () => {
-			class A extends sf.objectRecursive("A", {
-				a: [() => B, sf.number],
+			class A extends schemaFactory.objectRecursive("A", {
+				a: [() => B, schemaFactory.number],
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof A>;
 			}
 
-			class B extends sf.object("B", {
-				b: sf.optional(A),
+			class B extends schemaFactory.object("B", {
+				b: schemaFactory.optional(A),
 			}) {}
 
 			{
@@ -487,19 +487,19 @@ describe("SchemaFactory Recursive methods", () => {
 	describe("ValidateRecursiveSchema", () => {
 		it("Valid cases", () => {
 			{
-				class Test extends sf.arrayRecursive("Test", [() => Test]) {}
+				class Test extends schemaFactory.arrayRecursive("Test", [() => Test]) {}
 				type _check = ValidateRecursiveSchema<typeof Test>;
 			}
 
 			{
-				class Test extends sf.objectRecursive("Test", {
-					x: sf.optionalRecursive([() => Test]),
+				class Test extends schemaFactory.objectRecursive("Test", {
+					x: schemaFactory.optionalRecursive([() => Test]),
 				}) {}
 				type _check = ValidateRecursiveSchema<typeof Test>;
 			}
 
 			{
-				class Test extends sf.mapRecursive("Test", [() => Test]) {}
+				class Test extends schemaFactory.mapRecursive("Test", [() => Test]) {}
 				type _check = ValidateRecursiveSchema<typeof Test>;
 			}
 		});
@@ -510,24 +510,28 @@ describe("SchemaFactory Recursive methods", () => {
 			if (false) {
 				{
 					// @ts-expect-error Missing [] around allowed types.
-					class Test extends sf.arrayRecursive("Test", () => Test) {}
+					class Test extends schemaFactory.arrayRecursive("Test", () => Test) {}
 					// @ts-expect-error Missing [] around allowed types.
 					type _check = ValidateRecursiveSchema<typeof Test>;
 				}
 
 				{
 					// @ts-expect-error Objects take a record type with fields, not a field directly.
-					class Test extends sf.objectRecursive("Test", sf.optionalRecursive([() => Test])) {}
+					class Test extends schemaFactory.objectRecursive(
+						"Test",
+						// @ts-expect-error Objects take a record type with fields, not a field directly.
+						schemaFactory.optionalRecursive([() => Test]),
+					) {}
 					// @ts-expect-error Objects take a record type with fields, not a field directly.
 					type _check = ValidateRecursiveSchema<typeof Test>;
 				}
 
 				{
 					// @ts-expect-error 'MapRecursive' is referenced directly or indirectly in its own base expression.
-					class MapRecursive extends sf.mapRecursive(
+					class MapRecursive extends schemaFactory.mapRecursive(
 						"Test",
 						// @ts-expect-error Maps accept allowed types, not field schema.
-						sf.optionalRecursive([() => MapRecursive]),
+						schemaFactory.optionalRecursive([() => MapRecursive]),
 					) {}
 					// @ts-expect-error Maps accept allowed types, not field schema.
 					type _check = ValidateRecursiveSchema<typeof MapRecursive>;
@@ -535,13 +539,13 @@ describe("SchemaFactory Recursive methods", () => {
 			}
 
 			{
-				class Test extends sf.arrayRecursive("Test", [() => {}]) {}
+				class Test extends schemaFactory.arrayRecursive("Test", [() => {}]) {}
 				// @ts-expect-error referenced type not a schema.
 				type _check = ValidateRecursiveSchema<typeof Test>;
 			}
 
 			{
-				class Test extends sf.arrayRecursive("Test", [() => ({ Test })]) {}
+				class Test extends schemaFactory.arrayRecursive("Test", [() => ({ Test })]) {}
 				// @ts-expect-error referenced type not a schema.
 				type _check = ValidateRecursiveSchema<typeof Test>;
 			}
@@ -549,18 +553,18 @@ describe("SchemaFactory Recursive methods", () => {
 
 		it("AllowUnused", () => {
 			{
-				class Test extends sf.arrayRecursive("Test", [() => Test]) {}
+				class Test extends schemaFactory.arrayRecursive("Test", [() => Test]) {}
 				allowUnused<ValidateRecursiveSchema<typeof Test>>();
 			}
 
 			{
-				class Test extends sf.arrayRecursive("Test", [() => {}]) {}
+				class Test extends schemaFactory.arrayRecursive("Test", [() => {}]) {}
 				// @ts-expect-error referenced type not a schema.
 				allowUnused<ValidateRecursiveSchema<typeof Test>>();
 			}
 
 			{
-				class Test extends sf.arrayRecursive("Test", [() => ({ Test })]) {}
+				class Test extends schemaFactory.arrayRecursive("Test", [() => ({ Test })]) {}
 				// @ts-expect-error referenced type not a schema.
 				type _check = ValidateRecursiveSchema<typeof Test>;
 			}
@@ -577,7 +581,9 @@ describe("SchemaFactory Recursive methods", () => {
 
 	describe("arrayRecursive", () => {
 		it("simple", () => {
-			class ArrayRecursive extends sf.arrayRecursive("List", [() => ArrayRecursive]) {}
+			class ArrayRecursive extends schemaFactory.arrayRecursive("List", [
+				() => ArrayRecursive,
+			]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof ArrayRecursive>;
 			}
@@ -608,11 +614,11 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive", () => {
-			class A extends sf.arrayRecursive("A", [() => B]) {}
+			class A extends schemaFactory.arrayRecursive("A", [() => B]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof A>;
 			}
-			class B extends sf.arrayRecursive("B", A) {}
+			class B extends schemaFactory.arrayRecursive("B", A) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof B>;
 			}
@@ -624,11 +630,11 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive with object", () => {
-			class A extends sf.arrayRecursive("A", [() => B]) {}
+			class A extends schemaFactory.arrayRecursive("A", [() => B]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof A>;
 			}
-			class B extends sf.objectRecursive("B", { x: A }) {}
+			class B extends schemaFactory.objectRecursive("B", { x: A }) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof B>;
 			}
@@ -640,14 +646,14 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive with object first", () => {
-			class B extends sf.objectRecursive("B", { x: [() => A] }) {}
+			class B extends schemaFactory.objectRecursive("B", { x: [() => A] }) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof B>;
 			}
 			// It is interesting this compiles using "array" and does not need to be "arrayRecursive".
 			// It is unclear if this should be considered supported, but it is currently working.
 			// TODO: Determine exactly which cases like this work, why, and document they are supported.
-			class A extends sf.array("A", B) {}
+			class A extends schemaFactory.array("A", B) {}
 			// Explicit constructor call
 			{
 				const data: A = hydrate(A, new A([]));
@@ -656,11 +662,11 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive object with out of line non-lazy subclassed array", () => {
-			class TheArray extends sf.arrayRecursive("FooList", [() => Foo]) {}
+			class TheArray extends schemaFactory.arrayRecursive("FooList", [() => Foo]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof TheArray>;
 			}
-			class Foo extends sf.objectRecursive("Foo", {
+			class Foo extends schemaFactory.objectRecursive("Foo", {
 				fooList: TheArray,
 			}) {}
 			{
@@ -669,7 +675,7 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("recursive with subclassed array", () => {
-			class FooList extends sf.arrayRecursive("FooList", [() => FooList]) {}
+			class FooList extends schemaFactory.arrayRecursive("FooList", [() => FooList]) {}
 		});
 
 		it("Node schema metadata", () => {
@@ -697,7 +703,7 @@ describe("SchemaFactory Recursive methods", () => {
 	});
 
 	describe("mapRecursive", () => {
-		class MapRecursive extends sf.mapRecursive("Map", [() => MapRecursive]) {}
+		class MapRecursive extends schemaFactory.mapRecursive("Map", [() => MapRecursive]) {}
 		{
 			type _check = ValidateRecursiveSchema<typeof MapRecursive>;
 		}
@@ -767,8 +773,10 @@ describe("SchemaFactory Recursive methods", () => {
 	});
 
 	describe("recordRecursive", () => {
-		const sfAlpha = new SchemaFactoryAlpha("recursive");
-		class RecordRecursive extends sfAlpha.recordRecursive("Record", [() => RecordRecursive]) {}
+		const schemaFactoryAlpha = new SchemaFactoryAlpha("recursive");
+		class RecordRecursive extends schemaFactoryAlpha.recordRecursive("Record", [
+			() => RecordRecursive,
+		]) {}
 		{
 			type _check = ValidateRecursiveSchema<typeof RecordRecursive>;
 		}
@@ -880,11 +888,13 @@ describe("SchemaFactory Recursive methods", () => {
 	});
 
 	it("recursive under non-recursive", () => {
-		class ArrayRecursive extends sf.arrayRecursive("List", [() => ArrayRecursive]) {}
+		class ArrayRecursive extends schemaFactory.arrayRecursive("List", [
+			() => ArrayRecursive,
+		]) {}
 		{
 			type _check = ValidateRecursiveSchema<typeof ArrayRecursive>;
 		}
-		class Root extends sf.object("Root", {
+		class Root extends schemaFactory.object("Root", {
 			r: ArrayRecursive,
 		}) {}
 
@@ -917,12 +927,12 @@ describe("SchemaFactory Recursive methods", () => {
 	 */
 	describe("Use of recursive schema without explicit sub-classing", () => {
 		it("recursive with non-subclassed array", () => {
-			const FooList = sf.arrayRecursive("FooList", [() => FooList]);
+			const FooList = schemaFactory.arrayRecursive("FooList", [() => FooList]);
 		});
 
 		it("co-recursive object with out of line non-lazy array", () => {
 			// @ts-expect-error co-recursive arrays without named subclass cause "referenced directly or indirectly in its own base expression" errors.
-			const TheArray = sf.arrayRecursive("FooList", [() => Foo]);
+			const TheArray = schemaFactory.arrayRecursive("FooList", [() => Foo]);
 			{
 				// In this case the error above does not cause ValidateRecursiveSchema to fail to compile.
 				// It's interesting that is not consistent with the other cases below,
@@ -932,7 +942,7 @@ describe("SchemaFactory Recursive methods", () => {
 			}
 
 			// @ts-expect-error due to error above
-			class Foo extends sf.objectRecursive("Foo", {
+			class Foo extends schemaFactory.objectRecursive("Foo", {
 				fooList: TheArray,
 			}) {}
 			{
@@ -943,9 +953,9 @@ describe("SchemaFactory Recursive methods", () => {
 
 		it("co-recursive object with inline array", () => {
 			// @ts-expect-error Inline co-recursive arrays without named subclass cause "referenced directly or indirectly in its own base expression" errors.
-			class Foo extends sf.objectRecursive("Foo", {
+			class Foo extends schemaFactory.objectRecursive("Foo", {
 				// @ts-expect-error due to error above
-				fooList: sf.arrayRecursive("FooList", [() => Foo]),
+				fooList: schemaFactory.arrayRecursive("FooList", [() => Foo]),
 			}) {}
 			{
 				// @ts-expect-error due to error above
@@ -955,9 +965,9 @@ describe("SchemaFactory Recursive methods", () => {
 
 		it("co-recursive object with inline array class ", () => {
 			// @ts-expect-error Inlining an anonymous class does not help
-			class Foo extends sf.objectRecursive("Foo", {
+			class Foo extends schemaFactory.objectRecursive("Foo", {
 				// @ts-expect-error Implicit any due to error above
-				fooList: class extends sf.arrayRecursive("FooList", [() => Foo]) {},
+				fooList: class extends schemaFactory.arrayRecursive("FooList", [() => Foo]) {},
 			}) {}
 			{
 				// @ts-expect-error due to error above
@@ -966,8 +976,8 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive object with inline array lazy", () => {
-			class Foo extends sf.objectRecursive("Foo", {
-				fooList: [() => sf.arrayRecursive("FooList", [() => Foo])],
+			class Foo extends schemaFactory.objectRecursive("Foo", {
+				fooList: [() => schemaFactory.arrayRecursive("FooList", [() => Foo])],
 			}) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof Foo>;
@@ -976,10 +986,10 @@ describe("SchemaFactory Recursive methods", () => {
 
 		it("co-recursive map with inline array", () => {
 			// @ts-expect-error Inline non-lazy co-recursive arrays cause "referenced directly or indirectly in its own base expression" errors.
-			class Foo extends sf.mapRecursive(
+			class Foo extends schemaFactory.mapRecursive(
 				"Foo",
 				// @ts-expect-error Implicit any due to error above
-				sf.arrayRecursive("FooList", [() => Foo]),
+				schemaFactory.arrayRecursive("FooList", [() => Foo]),
 			) {}
 			{
 				// @ts-expect-error due to error above
@@ -988,8 +998,8 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive map with inline array lazy", () => {
-			class Foo extends sf.mapRecursive("Foo", [
-				() => sf.arrayRecursive("FooList", [() => Foo]),
+			class Foo extends schemaFactory.mapRecursive("Foo", [
+				() => schemaFactory.arrayRecursive("FooList", [() => Foo]),
 			]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof Foo>;
@@ -998,10 +1008,10 @@ describe("SchemaFactory Recursive methods", () => {
 
 		it("co-recursive array with inline array", () => {
 			// @ts-expect-error Inline non-lazy co-recursive arrays cause "referenced directly or indirectly in its own base expression" errors.
-			class Foo extends sf.arrayRecursive(
+			class Foo extends schemaFactory.arrayRecursive(
 				"Foo",
 				// @ts-expect-error Implicit any due to error above
-				sf.arrayRecursive("FooList", [() => Foo]),
+				schemaFactory.arrayRecursive("FooList", [() => Foo]),
 			) {}
 			{
 				// @ts-expect-error due to error above
@@ -1010,8 +1020,8 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive array with inline array lazy", () => {
-			class Foo extends sf.arrayRecursive("Foo", [
-				() => sf.arrayRecursive("FooList", [() => Foo]),
+			class Foo extends schemaFactory.arrayRecursive("Foo", [
+				() => schemaFactory.arrayRecursive("FooList", [() => Foo]),
 			]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof Foo>;
@@ -1019,15 +1029,18 @@ describe("SchemaFactory Recursive methods", () => {
 		});
 
 		it("co-recursive map with inline map", () => {
-			class Foo extends sf.mapRecursive("Foo", sf.mapRecursive("FooList", [() => Foo])) {}
+			class Foo extends schemaFactory.mapRecursive(
+				"Foo",
+				schemaFactory.mapRecursive("FooList", [() => Foo]),
+			) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof Foo>;
 			}
 		});
 
 		it("co-recursive map with inline map lazy", () => {
-			class Foo extends sf.mapRecursive("Foo", [
-				() => sf.mapRecursive("FooList", [() => Foo]),
+			class Foo extends schemaFactory.mapRecursive("Foo", [
+				() => schemaFactory.mapRecursive("FooList", [() => Foo]),
 			]) {}
 			{
 				type _check = ValidateRecursiveSchema<typeof Foo>;

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1402,7 +1402,7 @@ export function validateError(
 				: !expectedErrorMsg.test(error.message)
 		) {
 			throw new Error(
-				`Unexpected TypeError thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
+				`Unexpected ${errorType.name} thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
 			);
 		}
 		return true;

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1382,14 +1382,25 @@ export class MockTreeCheckout implements ITreeCheckout {
 	}
 }
 
+/**
+ * {@link validateError} for `UsageError`.
+ */
 export function validateUsageError(expectedErrorMsg: string | RegExp): (error: Error) => true {
 	return validateError(expectedErrorMsg, UsageError);
 }
 
+/**
+ * {@link validateError} for `TypeError`.
+ */
 export function validateTypeError(expectedErrorMsg: string | RegExp): (error: Error) => true {
 	return validateError(expectedErrorMsg, TypeError);
 }
 
+/**
+ * Validates that a specific kind of error was thrown with the expected message.
+ *
+ * Intended for use with NodeJS's `assert.throws`.
+ */
 export function validateError(
 	expectedErrorMsg: string | RegExp,
 	errorType: new (...args: any[]) => Error = Error,

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1383,15 +1383,26 @@ export class MockTreeCheckout implements ITreeCheckout {
 }
 
 export function validateUsageError(expectedErrorMsg: string | RegExp): (error: Error) => true {
+	return validateError(expectedErrorMsg, UsageError);
+}
+
+export function validateTypeError(expectedErrorMsg: string | RegExp): (error: Error) => true {
+	return validateError(expectedErrorMsg, TypeError);
+}
+
+export function validateError(
+	expectedErrorMsg: string | RegExp,
+	errorType: new (...args: any[]) => Error = Error,
+): (error: Error) => true {
 	return (error: Error) => {
-		assert(error instanceof UsageError, `Expected UsageError, got ${error}`);
+		assert(error instanceof errorType, `Expected ${errorType.name}, got ${error}`);
 		if (
 			typeof expectedErrorMsg === "string"
 				? error.message !== expectedErrorMsg
 				: !expectedErrorMsg.test(error.message)
 		) {
 			throw new Error(
-				`Unexpected UsageError thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
+				`Unexpected TypeError thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
 			);
 		}
 		return true;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -776,7 +776,7 @@ export namespace JsonAsTree {
     const // @system
     _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Record, TreeRecordNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Record, unknown>, {
         readonly [x: string]: string | number | JsonObject | Array | System_Unsafe.InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
-    }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
+    }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined, unknown>;
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     // @system
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
@@ -1204,9 +1204,9 @@ export class SchemaFactoryAlpha<out TScope extends string | undefined = string |
     record<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Record<${string}>`>, NodeKind.Record, TreeRecordNode<T> & WithType<ScopedSchemaName<TScope, `Record<${string}>`>, NodeKind.Record>, RecordNodeInsertableData<T>, true, T, undefined>;
     record<const Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Record, TreeRecordNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Record>, RecordNodeInsertableData<T>, true, T, undefined>;
     recordAlpha<const Name extends TName, const T extends ImplicitAnnotatedAllowedTypes, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): RecordNodeCustomizableSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata>;
-    recordRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Record, TreeRecordNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Record, unknown>, {
+    recordRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Record, TreeRecordNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Record, unknown>, {
         readonly [x: string]: System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
-    }, false, T, undefined>;
+    }, false, T, undefined, TCustomMetadata>;
     static readonly required: {
         <const T extends ImplicitAllowedTypes, const TCustomMetadata = unknown>(t: T, props?: Omit<FieldPropsAlpha<TCustomMetadata>, "defaultProvider"> | undefined): FieldSchemaAlpha<FieldKind.Required, T, TCustomMetadata>;
         <const T_1 extends ImplicitAnnotatedAllowedTypes, const TCustomMetadata_1 = unknown>(t: T_1, props?: Omit<FieldPropsAlpha<TCustomMetadata_1>, "defaultProvider"> | undefined): FieldSchemaAlpha<FieldKind.Required, UnannotateImplicitAllowedTypes<T_1>, TCustomMetadata_1>;


### PR DESCRIPTION
## Description

Misc cleanup of schema factory comments and tests.

As part of testing the recursive record API, it was noticed that it lacked metadata support, so this was fixed.

## Breaking Changes

SchemaFactoryAlpha.record's default inferred custom metadata type is now unknown instead of undefined when not used. It seems extremely unlikely for this to break any real code, but its technically possible. It is however also an alpha API, so such breaks are permissible.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


