### PR TITLE
docs(local-driver): Promote `LocalDocumentServiceFactory` to `@legacy @beta`

### DIFF
--- a/packages/drivers/local-driver/api-extractor/api-extractor-lint-bundle.json
+++ b/packages/drivers/local-driver/api-extractor/api-extractor-lint-bundle.json
@@ -1,5 +1,14 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.json",
-	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts"
+	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+	// Bundle local dependencies so we can validate cross-package relationships
+	"bundledPackages": [
+		// Note: excluding server packages until we can update their tags (and release new server versions)
+		"@fluidframework/!(server-local-server)",
+		"@fluid-internal/*",
+		"@fluid-experimental/*",
+		"@fluid-private/*",
+		"@fluid-tools/*"
+	]
 }

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.alpha.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.alpha.api.md
@@ -7,7 +7,7 @@
 // @beta @legacy (undocumented)
 export function createLocalResolverCreateNewRequest(documentId: string): IRequest;
 
-// @alpha @legacy
+// @beta @legacy
 export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
     constructor(localDeltaConnectionServer: ILocalDeltaConnectionServer, policies?: IDocumentServicePolicies | undefined, innerDocumentService?: IDocumentService | undefined);
     // (undocumented)

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -22,7 +22,7 @@ import { localDriverCompatDetailsForLoader } from "./localLayerCompatState.js";
 
 /**
  * Implementation of document service factory for local use.
- * @legacy @alpha
+ * @legacy @beta
  */
 export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
 	// A map of clientId to LocalDocumentService.


### PR DESCRIPTION
This type was not bumped previously (#25256) because of tag incompatibility with a type it imports from `@fluidframework/server-local-server`.

The server packages are currently configured to use release tags, but their exports do not respect them for API access control. For this reason, their APIs can be considered implicitly public, regardless of tagging. In the future, we need to update the server packages to either 
a. not use release tags
b. match client's release tag -> export path scheme (this would be a breaking change and therefore require a major version bump to those packages).

Once those packages have been updated to follow the same release tag / export schema as the client packages, then we can resume linting tag compatibility across the client/server boundary. Until then, we will need to add exceptions.