### PR TITLE
Only update manifest if at least one publishing stage succeeded

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -126,7 +126,12 @@ stages:
       and(
         in(dependencies.publish_npm_public.result, 'Succeeded', 'Skipped'),
         in(dependencies.publish_npm_internal_test.result, 'Succeeded', 'Skipped'),
-        in(dependencies.publish_npm_internal_build.result, 'Succeeded', 'Skipped')
+        in(dependencies.publish_npm_internal_build.result, 'Succeeded', 'Skipped'),
+        or(
+          eq(dependencies.publish_npm_public.result, 'Succeeded'),
+          eq(dependencies.publish_npm_internal_test.result, 'Succeeded'),
+          eq(dependencies.publish_npm_internal_build.result, 'Succeeded')
+        )
       )
     # Note dev feed packages do not get manifests as we don't intend them to be consumed publicly, so no need for that to be a dependency here.
     variables:


### PR DESCRIPTION
## Description

Some recent CI runs have not published any packages due to flaky tests. However, the manifest upload step was still happening due to this incorrect condition.