### PR TITLE
fix(directory): Fix `SharedDirectory.forEach()`

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1607,7 +1607,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	): void {
 		this.throwIfDisposed();
 		for (const [key, localValue] of this.internalIterator()) {
-			callback((localValue as { value: unknown }).value, key, this);
+			callback(localValue, key, this);
 		}
 	}
 

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -1048,6 +1048,36 @@ describe("Directory", () => {
 				assert.equal(directory2.get("testKey2"), undefined);
 			});
 
+			it(".forEach() should iterate over all keys in the directory", () => {
+				const values = [
+					["a", "b"],
+					["c", "d"],
+					["e", "f"],
+				];
+
+				for (const [key, value] of values) {
+					directory1.set(key, value);
+				}
+				containerRuntimeFactory.processAllMessages();
+
+				let i = 0;
+				// eslint-disable-next-line unicorn/no-array-for-each
+				directory1.forEach((value, key) => {
+					assert(i < values.length, "forEach() should not have iterated more than i times");
+					assert.strictEqual(key, values[i][0], "key should match");
+					assert.strictEqual(value, values[i][1], "value should match");
+					i++;
+				});
+				i = 0;
+				// eslint-disable-next-line unicorn/no-array-for-each
+				directory2.forEach((value, key) => {
+					assert(i < values.length, "forEach() should not have iterated more than i times");
+					assert.strictEqual(key, values[i][0], "key should match");
+					assert.strictEqual(value, values[i][1], "value should match");
+					i++;
+				});
+			});
+
 			it("Shouldn't clear value if there is pending set", () => {
 				const valuesChanged: IDirectoryValueChanged[] = [];
 				let clearCount = 0;


### PR DESCRIPTION
## Description

This PR fixes `SharedDirectory.forEach()` as it no longer tries to unbox the value. It also adds a test to prevent this regression in the future.