### PR TITLE
Always ensure directory exists before attempting file write

### DIFF
--- a/packages/tools/fluid-runner/src/logger/baseFileLogger.ts
+++ b/packages/tools/fluid-runner/src/logger/baseFileLogger.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from "fs";
+import * as path from "path";
 
 import type { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 
@@ -44,6 +45,8 @@ export abstract class BaseFileLogger implements IFileLogger {
 	protected async flush(): Promise<void> {
 		if (this.events.length > 0) {
 			const contentToWrite = this.events.map((it) => JSON.stringify(it)).join(",");
+			const dirName = path.dirname(this.filePath);
+			fs.mkdirSync(dirName, { recursive: true });
 			if (this.hasWrittenToFile) {
 				fs.appendFileSync(this.filePath, `,${contentToWrite}`);
 			} else {

--- a/packages/tools/fluid-runner/src/logger/csvFileLogger.ts
+++ b/packages/tools/fluid-runner/src/logger/csvFileLogger.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from "fs";
+import * as path from "path";
 
 import type { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import { Parser } from "@json2csv/plainjs";
@@ -46,6 +47,8 @@ export class CSVFileLogger extends BaseFileLogger {
 			// Orders columns based on order of the set, which puts most recently seen fields from send at the end.
 			fields: Array.from(this.columns),
 		});
+		const dirName = path.dirname(this.filePath);
+		fs.mkdirSync(dirName, { recursive: true });
 		fs.writeFileSync(this.filePath, parser.parse(this.events));
 	}
 }

--- a/packages/tools/fluid-runner/src/logger/jsonFileLogger.ts
+++ b/packages/tools/fluid-runner/src/logger/jsonFileLogger.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from "fs";
+import * as path from "path";
 
 import { BaseFileLogger } from "./baseFileLogger.js";
 
@@ -18,11 +19,15 @@ export class JSONFileLogger extends BaseFileLogger {
 		defaultProps?: Record<string, string | number>,
 	) {
 		super(filePath, eventsPerFlush, defaultProps);
+		const dirName = path.dirname(this.filePath);
+		fs.mkdirSync(dirName, { recursive: true });
 		fs.appendFileSync(this.filePath, "[");
 	}
 
 	public async close(): Promise<void> {
 		await super.close();
+		const dirName = path.dirname(this.filePath);
+		fs.mkdirSync(dirName, { recursive: true });
 		fs.appendFileSync(this.filePath, "]");
 	}
 }

--- a/packages/tools/fluid-runner/src/test/fileLogger.spec.ts
+++ b/packages/tools/fluid-runner/src/test/fileLogger.spec.ts
@@ -40,10 +40,6 @@ describe("fileLogger", () => {
 		logger.send({ eventName: "event4", category: "category2", prop2: "value4" });
 	}
 
-	beforeEach(() => {
-		fs.mkdirSync(outputFolder);
-	});
-
 	afterEach(() => {
 		fs.rmdirSync(outputFolder, { recursive: true });
 	});


### PR DESCRIPTION
While debugging some tests that use fluid-runner's exportFile, I was hitting "ENOENT: no such file or directory" errors, as they were trying to write to a directory that did not exist.

In normal runs they would have created the directory as a precondition, but in the erroneous case I was debugging the directory was not getting created for some reason, resulting in this red herring.

Although writeFileSync/appendFileSync will implicitly create the file if it doesn't exist, they can't create subdirectories if needed.  This change would first ensure the subdirectory is created before attempting to write to it, which makes exportFile a little easier to use too.