### PR TITLE
Mark ForestOptions input and beta

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -252,12 +252,12 @@ export enum FluidClientVersion {
     v2_52 = 2.052
 }
 
-// @alpha
+// @beta @input
 export interface ForestOptions {
     readonly forest?: ForestType;
 }
 
-// @alpha @sealed
+// @beta @sealed
 export interface ForestType extends ErasedType_2<"ForestType"> {
 }
 
@@ -903,7 +903,7 @@ export interface SchemaValidationFunction<Schema extends TSchema> {
 // @public @system
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
-// @alpha
+// @alpha @input
 export interface SharedTreeFormatOptions {
     formatVersion: SharedTreeFormatVersion[keyof SharedTreeFormatVersion];
     treeEncodeType: TreeCompressionStrategy;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -112,6 +112,15 @@ type FlexList<Item = unknown> = readonly LazyItem<Item>[];
 // @public @system
 type FlexListToUnion<TList extends FlexList> = ExtractItemType<TList[number]>;
 
+// @beta @input
+export interface ForestOptions {
+    readonly forest?: ForestType;
+}
+
+// @beta @sealed
+export interface ForestType extends ErasedType_2<"ForestType"> {
+}
+
 // @public
 export type ImplicitAllowedTypes = AllowedTypes | TreeNodeSchema;
 

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -648,6 +648,9 @@ export interface SharedTreeFormatOptionsInternal
  * They should all have the same behavior, but may differ in performance and debuggability.
  *
  * Current options are {@link ForestTypeReference}, {@link ForestTypeOptimized} and {@link ForestTypeExpensiveDebug}.
+ * @privateRemarks
+ * Implement using {@link toForestType}.
+ * Consume using {@link buildConfiguredForest}.
  * @sealed @beta
  */
 export interface ForestType extends ErasedType<"ForestType"> {}

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -645,7 +645,7 @@ export interface SharedTreeFormatOptionsInternal
  * Used to distinguish between different forest types.
  * @remarks
  * The "Forest" is the internal data structure used to store all the trees (the main tree and any removed ones) for a given view or branch.
- * They should all have the same behavior, but may differ in performance and debuggability.
+ * ForestTypes should all have the same behavior, but may differ in performance and debuggability.
  *
  * Current options are {@link ForestTypeReference}, {@link ForestTypeOptimized} and {@link ForestTypeExpensiveDebug}.
  * @privateRemarks

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -644,7 +644,7 @@ export interface SharedTreeFormatOptionsInternal
 /**
  * Used to distinguish between different forest types.
  * @remarks
- * The "Forest" is the internal data structure use to store all the tree (the main tree and any removed ones) for a given view or branch.
+ * The "Forest" is the internal data structure used to store all the trees (the main tree and any removed ones) for a given view or branch.
  * They should all have the same behavior, but may differ in performance and debuggability.
  *
  * Current options are {@link ForestTypeReference}, {@link ForestTypeOptimized} and {@link ForestTypeExpensiveDebug}.

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -603,7 +603,7 @@ export interface SharedTreeOptionsInternal
 }
 /**
  * Configuration options for SharedTree's internal tree storage.
- * @alpha
+ * @beta @input
  */
 export interface ForestOptions {
 	/**
@@ -614,7 +614,7 @@ export interface ForestOptions {
 
 /**
  * Options for configuring the persisted format SharedTree uses.
- * @alpha
+ * @alpha @input
  */
 export interface SharedTreeFormatOptions {
 	/**
@@ -644,8 +644,11 @@ export interface SharedTreeFormatOptionsInternal
 /**
  * Used to distinguish between different forest types.
  * @remarks
+ * The "Forest" is the internal data structure use to store all the tree (the main tree and any removed ones) for a given view or branch.
+ * They should all have the same behavior, but may differ in performance and debuggability.
+ *
  * Current options are {@link ForestTypeReference}, {@link ForestTypeOptimized} and {@link ForestTypeExpensiveDebug}.
- * @sealed @alpha
+ * @sealed @beta
  */
 export interface ForestType extends ErasedType<"ForestType"> {}
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -308,12 +308,12 @@ export type FluidObject<T = unknown> = {
 // @public
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
-// @alpha
+// @beta @input
 export interface ForestOptions {
     readonly forest?: ForestType;
 }
 
-// @alpha @sealed
+// @beta @sealed
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
@@ -1275,7 +1275,7 @@ export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedTyp
 // @public
 export const SharedTree: SharedObjectKind<ITree>;
 
-// @alpha
+// @alpha @input
 export interface SharedTreeFormatOptions {
     formatVersion: SharedTreeFormatVersion[keyof SharedTreeFormatVersion];
     treeEncodeType: TreeCompressionStrategy;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -165,6 +165,15 @@ export type FluidObject<T = unknown> = {
 // @public
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
+// @beta @input
+export interface ForestOptions {
+    readonly forest?: ForestType;
+}
+
+// @beta @sealed
+export interface ForestType extends ErasedType<"ForestType"> {
+}
+
 // @public
 export interface IConnection {
     readonly id: string;


### PR DESCRIPTION
## Description

Mark ForestOptions  as input and beta.

Note that this should have no impact on what beta users can do currently for two reasons:

- None of the ForestTypes are beta, so you can't actually use it to opt into anything unless also importing an alpha ForestType
- None of the APIs which accept ForestOptions are beta, so there is nothing to do with it.

This is still a useful change as it is progress toward making some of the APIs which can optionally include ForestOptions (like IndependentView and configuredSharedTree) available as beta, even if users of them won't be able to customize which forest is used (as the ForestType options are alpha).

Note that ForestType is a sealed opaque type, so stabilizing this really only pins down its name and semantics, not anything about the implementation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
