### PR TITLE
DataStoreRuntime: Remove redundent attachGraph in getAttachmentSummary

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1128,6 +1128,11 @@ export class FluidDataStoreRuntime
 	private visitLocalBoundContextsDuringAttach(
 		visitor: (contextId: string, context: LocalChannelContextBase) => void,
 	): void {
+		assert(
+			this.visibilityState === VisibilityState.LocallyVisible,
+			"The data store should be locally visible when generating attach summary",
+		);
+
 		const visitedContexts = new Set<string>();
 		let visitedLength = -1;
 		while (visitedLength !== visitedContexts.size) {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1128,26 +1128,6 @@ export class FluidDataStoreRuntime
 	private visitLocalBoundContextsDuringAttach(
 		visitor: (contextId: string, context: LocalChannelContextBase) => void,
 	): void {
-		/**
-		 * back-compat 0.59.1000 - getAttachSummary() is called when making a data store globally visible (previously
-		 * attaching state). Ideally, attachGraph() should have already be called making it locally visible. However,
-		 * before visibility state was added, this may not have been the case and getAttachSummary() could be called:
-		 *
-		 * 1. Before attaching the data store - When a detached container is attached.
-		 *
-		 * 2. After attaching the data store - When a data store is created and bound in an attached container.
-		 *
-		 * The basic idea is that all local object should become locally visible before they are globally visible.
-		 */
-		this.attachGraph();
-
-		// This assert cannot be added now due to back-compat. To be uncommented when the following issue is fixed -
-		// https://github.com/microsoft/FluidFramework/issues/9688.
-		//
-		// assert(this.visibilityState === VisibilityState.LocallyVisible,
-		//  "The data store should be locally visible when generating attach summary",
-		// );
-
 		const visitedContexts = new Set<string>();
 		let visitedLength = -1;
 		while (visitedLength !== visitedContexts.size) {


### PR DESCRIPTION
Per the comment and the code, the call the attachGraph on the contexts should be redundant. I also believe we have sufficient test coverage for this case given our attach lifecycle tests, binding tests, and local server stress.  If reviewers believe there isn't sufficient coverage for this case I can add more tests, but i believe it is well covered. 


This change is a pre-cursor change to returning detached but referenced datastore in pending local state while under staging mode. There are additional issues that block that specific case, so we can't test it yet. This causes problems in that staging mode specifically because we defer attach, and don't support sending attach ops while in staging mode which the triggering of attachGraph attempts to do. 