### PR TITLE
Add FormatValidator to replace JsonValidator

### DIFF
--- a/.changeset/cute-kids-bake.md
+++ b/.changeset/cute-kids-bake.md
@@ -1,0 +1,9 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+FormatValidator added to replace JsonValidator
+
+The existing `@alpha` type [`JsonValidator`](https://fluidframework.com/docs/api/fluid-framework/jsonvalidator-interface) has a new type erased alternative, `FormatValidator`, which is planned to be stabilized to `@beta` in the future and replaces `JsonValidator` in `ICodecOptions`.
+Existing code using `ICodecOptions` should migrate to use `FormatValidator`, but this is not required for adopting this release as `JsonValidator` is still supported.

--- a/.changeset/cute-kids-bake.md
+++ b/.changeset/cute-kids-bake.md
@@ -5,5 +5,6 @@
 ---
 FormatValidator added to replace JsonValidator
 
-The existing `@alpha` type [`JsonValidator`](https://fluidframework.com/docs/api/fluid-framework/jsonvalidator-interface) has a new type erased alternative, `FormatValidator`, which is planned to be stabilized to `@beta` in the future and replaces `JsonValidator` in `ICodecOptions`.
+The existing `@alpha` type [`JsonValidator`](https://fluidframework.com/docs/api/fluid-framework/jsonvalidator-interface) has a new type-erased alternative, `FormatValidator`, which is planned to be stabilized to `@beta` in the future.
+It replaces `JsonValidator` in `ICodecOptions`.
 Existing code using `ICodecOptions` should migrate to use `FormatValidator`, but this is not required for adopting this release as `JsonValidator` is still supported.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -270,6 +270,16 @@ export const ForestTypeOptimized: ForestType;
 // @alpha
 export const ForestTypeReference: ForestType;
 
+// @alpha @sealed
+export interface FormatValidator extends ErasedType_2<"FormatValidator"> {
+}
+
+// @alpha
+export const FormatValidatorBasic: FormatValidator_2;
+
+// @alpha
+export const FormatValidatorNoOp: FormatValidator;
+
 // @alpha
 export function generateSchemaFromSimpleSchema(simple: SimpleTreeSchema): TreeSchema;
 
@@ -290,7 +300,7 @@ export type HandleConverter<TCustom> = (data: IFluidHandle) => TCustom;
 
 // @alpha @input
 export interface ICodecOptions {
-    readonly jsonValidator: JsonValidator;
+    readonly jsonValidator: JsonValidator | FormatValidator;
 }
 
 // @alpha

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -3,12 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import type { ErasedType } from "@fluidframework/core-interfaces/internal";
 import { IsoBuffer, bufferToString } from "@fluid-internal/client-utils";
 import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { Static, TAnySchema, TSchema } from "@sinclair/typebox";
 
 import type { ChangeEncodingContext } from "../core/index.js";
 import type { JsonCompatibleReadOnly } from "../util/index.js";
+import { noopValidator } from "./noopValidator.js";
 
 /**
  * Translates decoded data to encoded data.
@@ -45,6 +47,45 @@ export interface SchemaValidationFunction<Schema extends TSchema> {
 }
 
 /**
+ * A kind of validator for SharedTree's internal data formats.
+ * @remarks
+ * Assuming not data corruption or type confusion, such validation should never fail due to careful format versioning.
+ * However, persisted data can sometimes be corrupted, bugs can produce invalid data, or users can mix up which data is compatible with which APIs.
+ * In such cases, a format validator can help catch issues.
+ *
+ * Current options are {@link FormatValidatorNoOp} and {@link FormatValidatorBasic}.
+ * @privateRemarks
+ * Implement using {@link toFormatValidator}.
+ * Consume using {@link extractJsonValidator}.
+ *
+ * Exposing this as the stable API entry point (instead of {@link JsonValidator}) means that we avoid leaking the reference to TypeBox to the API surface.
+ * Additionally, if we adopt non JSON formats, we can just update the validators as needed without breaking the API.
+ * This also allows us to avoid stabilizing or documenting how handles interact with JSON validation since that is not exposed through this type.
+ * @sealed @alpha
+ */
+export interface FormatValidator extends ErasedType<"FormatValidator"> {}
+
+/**
+ * A {@link FormatValidator} which does no validation.
+ * @alpha
+ */
+export const FormatValidatorNoOp = toFormatValidator(noopValidator);
+
+/**
+ * Type erase a {@link JsonValidator} to a {@link FormatValidator}.
+ */
+export function toFormatValidator(factory: JsonValidator): FormatValidator {
+	return factory as unknown as FormatValidator;
+}
+
+/**
+ * Un-type-erase the {@link FormatValidator}.
+ */
+export function extractJsonValidator(input: FormatValidator | JsonValidator): JsonValidator {
+	return input as unknown as JsonValidator;
+}
+
+/**
  * JSON schema validator compliant with draft 6 schema. See https://json-schema.org.
  * @alpha @input
  */
@@ -69,19 +110,22 @@ export interface JsonValidator {
  */
 export interface ICodecOptions {
 	/**
-	 * {@link JsonValidator} which SharedTree uses to validate persisted data it reads & writes
+	 * {@link FormatValidator} which SharedTree uses to validate persisted data it reads & writes
 	 * matches the expected encoded format (i.e. the wire format for ops and summaries).
-	 *
-	 * See {@link noopValidator} and {@link typeboxValidator} for out-of-the-box implementations.
+	 * @remarks
+	 * See {@link FormatValidatorNoOp} and {@link FormatValidatorBasic} for out-of-the-box implementations.
 	 *
 	 * This option is not "on-by-default" because JSON schema validation comes with a small but noticeable
 	 * runtime performance cost, and popular schema validation libraries have relatively large bundle size.
 	 *
-	 * SharedTree users are still encouraged to use a non-trivial validator (i.e. not `noopValidator`)
+	 * SharedTree users are still encouraged to use a non-trivial validator (i.e. not `FormatValidatorNoOp`)
 	 * whenever reasonable: it gives better fail-fast behavior when unexpected encoded data is found,
 	 * which reduces the risk of unrecoverable data corruption.
+	 *
+	 * Use of {@link JsonValidator} here is deprecated and will be removed:
+	 * it is recommended to use {@link FormatValidator} instead.
 	 */
-	readonly jsonValidator: JsonValidator;
+	readonly jsonValidator: JsonValidator | FormatValidator;
 }
 
 /**
@@ -326,12 +370,12 @@ export function withSchemaValidation<
 >(
 	schema: EncodedSchema,
 	codec: IJsonCodec<TInMemoryFormat, TEncodedFormat, TValidate, TContext>,
-	validator?: JsonValidator,
+	validator?: JsonValidator | FormatValidator,
 ): IJsonCodec<TInMemoryFormat, TEncodedFormat, TValidate, TContext> {
 	if (!validator) {
 		return codec;
 	}
-	const compiledFormat = validator.compile(schema);
+	const compiledFormat = extractJsonValidator(validator).compile(schema);
 	return {
 		encode: (obj: TInMemoryFormat, context: TContext): TEncodedFormat => {
 			const encoded = codec.encode(obj, context);

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -49,7 +49,8 @@ export interface SchemaValidationFunction<Schema extends TSchema> {
 /**
  * A kind of validator for SharedTree's internal data formats.
  * @remarks
- * Assuming not data corruption or type confusion, such validation should never fail due to careful format versioning.
+ * Assuming no data corruption or type confusion, such validation should never fail.
+ * Any client version compatibility issues should instead be detected by the data format versioning which Shared Tree does internally independent of data format validation.
  * However, persisted data can sometimes be corrupted, bugs can produce invalid data, or users can mix up which data is compatible with which APIs.
  * In such cases, a format validator can help catch issues.
  *

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -21,6 +21,10 @@ export {
 	withSchemaValidation,
 	FluidClientVersion,
 	currentVersion,
+	toFormatValidator,
+	FormatValidatorNoOp,
+	type FormatValidator,
+	extractJsonValidator,
 } from "./codec.js";
 export {
 	DiscriminatedUnionDispatcher,

--- a/packages/dds/tree/src/external-utilities/index.ts
+++ b/packages/dds/tree/src/external-utilities/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { typeboxValidator } from "./typeboxValidator.js";
+export { typeboxValidator, FormatValidatorBasic } from "./typeboxValidator.js";

--- a/packages/dds/tree/src/external-utilities/typeboxValidator.ts
+++ b/packages/dds/tree/src/external-utilities/typeboxValidator.ts
@@ -8,7 +8,7 @@ import type { Static, TSchema } from "@sinclair/typebox";
 // eslint-disable-next-line import/no-internal-modules
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 
-import type { JsonValidator } from "../codec/index.js";
+import { toFormatValidator, type JsonValidator } from "../codec/index.js";
 
 /**
  * A {@link JsonValidator} implementation which uses TypeBox's JSON schema validator.
@@ -29,3 +29,9 @@ export const typeboxValidator: JsonValidator = {
 		};
 	},
 };
+
+/**
+ * A {@link FormatValidator} implementation which uses TypeBox's JSON schema validator.
+ * @alpha
+ */
+export const FormatValidatorBasic = toFormatValidator(typeboxValidator);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -12,6 +12,7 @@ import {
 	type IJsonCodec,
 	type IMultiFormatCodec,
 	type SchemaValidationFunction,
+	extractJsonValidator,
 	makeCodecFamily,
 	withSchemaValidation,
 } from "../../codec/index.js";
@@ -128,7 +129,7 @@ function makeModularChangeCodec(
 		return {
 			codec,
 			compiledSchema: codec.json.encodedSchema
-				? codecOptions.jsonValidator.compile(codec.json.encodedSchema)
+				? extractJsonValidator(codecOptions.jsonValidator).compile(codec.json.encodedSchema)
 				: undefined,
 		};
 	};

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -280,9 +280,11 @@ export {
 	type JsonValidator,
 	type SchemaValidationFunction,
 	FluidClientVersion,
+	type FormatValidator,
+	FormatValidatorNoOp,
 } from "./codec/index.js";
 export { noopValidator } from "./codec/index.js";
-export { typeboxValidator } from "./external-utilities/index.js";
+export { typeboxValidator, FormatValidatorBasic } from "./external-utilities/index.js";
 
 export type {
 	// Type Testing

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -326,6 +326,16 @@ export const ForestTypeOptimized: ForestType;
 // @alpha
 export const ForestTypeReference: ForestType;
 
+// @alpha @sealed
+export interface FormatValidator extends ErasedType<"FormatValidator"> {
+}
+
+// @alpha
+export const FormatValidatorBasic: FormatValidator_2;
+
+// @alpha
+export const FormatValidatorNoOp: FormatValidator;
+
 // @alpha
 export function generateSchemaFromSimpleSchema(simple: SimpleTreeSchema): TreeSchema;
 
@@ -346,7 +356,7 @@ export type HandleConverter<TCustom> = (data: IFluidHandle) => TCustom;
 
 // @alpha @input
 export interface ICodecOptions {
-    readonly jsonValidator: JsonValidator;
+    readonly jsonValidator: JsonValidator | FormatValidator;
 }
 
 // @public


### PR DESCRIPTION
## Description

This is intended as work toward stabilizing ICodecOptions as beta without committing to details of how we validate data.

Doing this as a two part change (with removal of JsonValidator from ICodecOptions, and moving ICodecOptions to beta would be next sometime after the next release) will better accommodate the existing use of these APIs in at least one known app.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
