### PR TITLE
Avoid reading ops from cache when a versioned document is opened

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -225,11 +225,11 @@ export class OdspDocumentService
 			async (from, to, telemetryProps, fetchReason) =>
 				service.get(from, to, telemetryProps, fetchReason),
 			// Get cachedOps Callback.
-			// TODO AB#44882: This condition will be removed when file version can be read from the cache entry for an op.
-			this.odspResolvedUrl.fileVersion !== undefined
-				? async () => []
-				: async (from, to) =>
-						((await this.opsCache?.get(from, to)) as ISequencedDocumentMessage[]) ?? [],
+			// TODO AB#47218: This condition will be removed when file version can be read from the cache entry for an op.
+			this.odspResolvedUrl.fileVersion === undefined
+				? async (from, to) =>
+						((await this.opsCache?.get(from, to)) as ISequencedDocumentMessage[]) ?? []
+				: async () => [],
 			// Ops requestFromSocket Callback.
 			(from, to) => {
 				const currentConnection = this.odspDelayLoadedDeltaStream?.currentDeltaConnection;

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -225,12 +225,11 @@ export class OdspDocumentService
 			async (from, to, telemetryProps, fetchReason) =>
 				service.get(from, to, telemetryProps, fetchReason),
 			// Get cachedOps Callback.
-			async (from, to) => {
-				if (this.odspResolvedUrl.fileVersion !== undefined) {
-					return [];
-				}
-				return ((await this.opsCache?.get(from, to)) as ISequencedDocumentMessage[]) ?? [];
-			},
+			// TODO AB#47218: This condition will be removed when file version can be read from the cache entry for an op.
+			this.odspResolvedUrl.fileVersion !== undefined
+				? async () => []
+				: async (from, to) =>
+						((await this.opsCache?.get(from, to)) as ISequencedDocumentMessage[]) ?? [],
 			// Ops requestFromSocket Callback.
 			(from, to) => {
 				const currentConnection = this.odspDelayLoadedDeltaStream?.currentDeltaConnection;

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -225,7 +225,7 @@ export class OdspDocumentService
 			async (from, to, telemetryProps, fetchReason) =>
 				service.get(from, to, telemetryProps, fetchReason),
 			// Get cachedOps Callback.
-			// TODO AB#47218: This condition will be removed when file version can be read from the cache entry for an op.
+			// TODO AB#44882: This condition will be removed when file version can be read from the cache entry for an op.
 			this.odspResolvedUrl.fileVersion !== undefined
 				? async () => []
 				: async (from, to) =>

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -226,8 +226,10 @@ export class OdspDocumentService
 				service.get(from, to, telemetryProps, fetchReason),
 			// Get cachedOps Callback.
 			async (from, to) => {
-				const res = await this.opsCache?.get(from, to);
-				return (res as ISequencedDocumentMessage[]) ?? [];
+				if (this.odspResolvedUrl.fileVersion !== undefined) {
+					return [];
+				}
+				return ((await this.opsCache?.get(from, to)) as ISequencedDocumentMessage[]) ?? [];
 			},
 			// Ops requestFromSocket Callback.
 			(from, to) => {


### PR DESCRIPTION
In some cases, a versioned document can read ops from the cache that are not associated with that version and are instead associated with the main document. To avoid this (as a temporary fix), do not read ops from cache when the document version is not the main document. 

[AB#47218](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47218)