### PR TITLE
fix(debugger): Fix `createFromServiceFactory`

### DIFF
--- a/packages/drivers/debugger/api-report/debugger.legacy.alpha.api.md
+++ b/packages/drivers/debugger/api-report/debugger.legacy.alpha.api.md
@@ -6,7 +6,7 @@
 
 // @beta @legacy (undocumented)
 export namespace FluidDebugger {
-    // @alpha @legacy (undocumented)
+    // @legacy (undocumented)
     export function createFromServiceFactory(documentServiceFactory: IDocumentServiceFactory): Promise<IDocumentServiceFactory>;
 }
 

--- a/packages/drivers/debugger/src/fluidDebugger.ts
+++ b/packages/drivers/debugger/src/fluidDebugger.ts
@@ -40,7 +40,7 @@ export namespace FluidDebugger {
 
 	/**
 	 * @legacy
-	 * @alpha
+	 * @beta
 	 */
 	export async function createFromServiceFactory(
 		documentServiceFactory: IDocumentServiceFactory,


### PR DESCRIPTION
Tagging was not updated alongside containing namespace.