### PR TITLE
test(tree): Run TableSchema tests in both hydrated and unhydrated modes

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -1874,6 +1874,8 @@ describe("treeNodeApi", () => {
 				assert.equal(a2DeepChanges, 1, `treeChanged should fire once.`);
 			});
 
+			// Extra events are fired for move operation within unhydrated array nodes.
+			// TODO:AB#47457: Fix and re-enable this test in unhydrated mode.
 			if (hydrated) {
 				it(`all operations on the node trigger 'nodeChanged' and 'treeChanged' the correct number of times`, () => {
 					const testSchema = sb.array("listRoot", sb.number);

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -1340,7 +1340,8 @@ describe("TableFactory unit tests", () => {
 			assert.equal(eventCount, 4);
 		});
 
-		// TODO:AB#47404: Fix column removal for unhydrated table trees and re-enable in unhydrated mode.
+		// Extra events are fired for move operation within unhydrated array nodes.
+		// TODO:AB#47457: Fix and re-enable this test in unhydrated mode.
 		if (hydrated) {
 			it("Responding to column list changes", () => {
 				const table = initializeTree(Table, Table.empty());

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -836,10 +836,7 @@ describe("TableFactory unit tests", () => {
 					],
 				});
 			});
-		}
 
-		// TODO:AB#47404: Fix column removal for unhydrated table trees and re-enable in unhydrated mode.
-		if (hydrated) {
 			it("Remove multiple columns", () => {
 				const column0 = new Column({ id: "column-0", props: {} });
 				const column1 = new Column({ id: "column-1", props: {} });

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -5,15 +5,12 @@
 
 import { strict as assert, fail } from "node:assert";
 
-import { createIdCompressor } from "@fluidframework/id-compressor/internal";
-
-import { independentView, Tree, TreeAlpha } from "../shared-tree/index.js";
+import { Tree, TreeAlpha } from "../shared-tree/index.js";
 import {
 	allowUnused,
 	getJsonSchema,
 	KeyEncodingOptions,
 	SchemaFactoryAlpha,
-	TreeViewConfiguration,
 	type ConciseTree,
 	type TreeNode,
 } from "../simple-tree/index.js";
@@ -25,75 +22,48 @@ import type {
 } from "../util/index.js";
 import { validateUsageError } from "./utils.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshots/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { describeHydration } from "./simple-tree/utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
+class Cell extends schemaFactory.object("table-cell", {
+	value: schemaFactory.string,
+}) {}
+
+class ColumnProps extends schemaFactory.object("table-column-props", {
+	/**
+	 * Label text for the column.
+	 */
+	label: schemaFactory.optional(schemaFactory.string),
+}) {}
+class Column extends TableSchema.column({
+	schemaFactory,
+	cell: Cell,
+	props: ColumnProps,
+}) {}
+
+class RowProps extends schemaFactory.object("table-row-props", {
+	/**
+	 * Whether or not the row is selectable.
+	 * @defaultValue `true`
+	 */
+	selectable: schemaFactory.optional(schemaFactory.boolean),
+}) {}
+class Row extends TableSchema.row({
+	schemaFactory,
+	cell: Cell,
+	props: schemaFactory.optional(RowProps),
+}) {}
+
+class Table extends TableSchema.table({
+	schemaFactory,
+	cell: Cell,
+	column: Column,
+	row: Row,
+}) {}
+
 describe("TableFactory unit tests", () => {
-	function createTableSchema() {
-		class Cell extends schemaFactory.object("table-cell", {
-			value: schemaFactory.string,
-		}) {}
-
-		class ColumnProps extends schemaFactory.object("table-column-props", {
-			/**
-			 * Label text for the column.
-			 */
-			label: schemaFactory.optional(schemaFactory.string),
-		}) {}
-		class Column extends TableSchema.column({
-			schemaFactory,
-			cell: Cell,
-			props: ColumnProps,
-		}) {}
-
-		class RowProps extends schemaFactory.object("table-row-props", {
-			/**
-			 * Whether or not the row is selectable.
-			 * @defaultValue `true`
-			 */
-			selectable: schemaFactory.optional(schemaFactory.boolean),
-		}) {}
-		class Row extends TableSchema.row({
-			schemaFactory,
-			cell: Cell,
-			props: schemaFactory.optional(RowProps),
-		}) {}
-
-		class Table extends TableSchema.table({
-			schemaFactory,
-			cell: Cell,
-			column: Column,
-			row: Row,
-		}) {}
-
-		return {
-			Cell,
-			Column,
-			Row,
-			Table,
-		};
-	}
-
-	function createTableTree() {
-		const { Cell, Column, Row, Table } = createTableSchema();
-
-		const treeView = independentView(
-			new TreeViewConfiguration({
-				schema: Table,
-				enableSchemaValidation: true,
-			}),
-			{ idCompressor: createIdCompressor() },
-		);
-
-		return {
-			Cell,
-			Column,
-			Row,
-			Table,
-			treeView,
-		};
-	}
-
 	/**
 	 * Compares a tree with an expected "concise" tree representation.
 	 * Fails if they are not equivalent.
@@ -103,31 +73,32 @@ describe("TableFactory unit tests", () => {
 		assert.deepEqual(actualVerbose, expected);
 	}
 
-	describe("Column Schema", () => {
+	describeHydration("Column Schema", (initializeTree) => {
 		it("Can create without props", () => {
-			class Column extends TableSchema.column({ schemaFactory, cell: schemaFactory.string }) {}
-			const column = new Column({ id: "column-0" });
+			class MyColumn extends TableSchema.column({
+				schemaFactory,
+				cell: schemaFactory.string,
+			}) {}
+			const column = new MyColumn({ id: "column-0" });
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
 			// For now, it is at least an optional property and cannot be set to anything meaningful.
-			type _test = requireTrue<areSafelyAssignable<undefined, Column["props"]>>;
+			type _test = requireTrue<areSafelyAssignable<undefined, MyColumn["props"]>>;
 			assert.equal(column.props, undefined);
 		});
 
 		it("Can create with props", () => {
-			class Column extends TableSchema.column({
+			class MyColumn extends TableSchema.column({
 				schemaFactory,
 				cell: schemaFactory.string,
 				props: schemaFactory.string,
 			}) {}
-			const column = new Column({ id: "column-0", props: "Column 0" });
+			const column = new MyColumn({ id: "column-0", props: "Column 0" });
 			assert.equal(column.props, "Column 0");
 		});
 
 		it("getCells", () => {
-			const { treeView, Table, Column } = createTableTree();
-			treeView.initialize(Table.empty());
-			const table = treeView.root;
+			const table = initializeTree(Table, Table.empty());
 
 			// Calling `getCells` on a column that has not been inserted into the table throws an error.
 			const column0 = new Column({ id: "column-0", props: {} });
@@ -172,37 +143,36 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Row Schema", () => {
+	describeHydration("Row Schema", (initializeTree) => {
 		it("Can create without props", () => {
-			class Cell extends schemaFactory.object("table-cell", {
+			class MyCell extends schemaFactory.object("table-cell", {
 				value: schemaFactory.string,
 			}) {}
-			class Row extends TableSchema.row({ schemaFactory, cell: Cell }) {}
-			const row = new Row({ id: "row-0", cells: {} });
+			class MyRow extends TableSchema.row({ schemaFactory, cell: MyCell }) {}
+			const row = new MyRow({ id: "row-0", cells: {} });
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
 			// For now, it is at least an optional property and cannot be set to anything meaningful.
-			type _test = requireTrue<areSafelyAssignable<undefined, Row["props"]>>;
+			type _test = requireTrue<areSafelyAssignable<undefined, MyRow["props"]>>;
 			assert.equal(row.props, undefined);
 		});
 
 		it("Can create with props", () => {
-			class Cell extends schemaFactory.object("table-cell", {
+			class MyCell extends schemaFactory.object("table-cell", {
 				value: schemaFactory.string,
 			}) {}
-			class Row extends TableSchema.row({
+			class MyRow extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
+				cell: MyCell,
 				props: schemaFactory.string,
 			}) {}
-			const column = new Row({ id: "row-0", cells: {}, props: "Row 0" });
+
+			const column = initializeTree(MyRow, { id: "row-0", cells: {}, props: "Row 0" });
 			assert.equal(column.props, "Row 0");
 		});
 
 		it("getCells", () => {
-			const { treeView, Table, Row } = createTableTree();
-			treeView.initialize(Table.empty());
-			const table = treeView.root;
+			const table = initializeTree(Table, Table.empty());
 
 			const row = new Row({ id: "row-0", cells: {} });
 			table.insertRows({ rows: [row] });
@@ -243,92 +213,92 @@ describe("TableFactory unit tests", () => {
 
 	describe("Table Schema", () => {
 		it("Can create without custom column/row schema", () => {
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
 				cell: schemaFactory.string,
 			}) {}
 
-			const _table = new Table({
+			const _table = new MyTable({
 				columns: [{ id: "column-0" }],
 				rows: [{ id: "row-0", cells: {} }],
 			});
 		});
 
 		it("Can create with custom column schema", () => {
-			const Cell = schemaFactory.string;
-			class Column extends TableSchema.column({
+			const MyCell = schemaFactory.string;
+			class MyColumn extends TableSchema.column({
 				schemaFactory,
-				cell: Cell,
+				cell: MyCell,
 				props: schemaFactory.object("column-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
-				cell: Cell,
-				column: Column,
+				cell: MyCell,
+				column: MyColumn,
 			}) {}
 
-			const _table = new Table({
+			const _table = new MyTable({
 				columns: [{ id: "column-0", props: { label: "Column 0" } }],
 				rows: [{ id: "row-0", cells: {} }],
 			});
 		});
 
 		it("Can create with custom row schema", () => {
-			const Cell = schemaFactory.string;
-			class Row extends TableSchema.row({
+			const MyCell = schemaFactory.string;
+			class MyRow extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
+				cell: MyCell,
 				props: schemaFactory.object("row-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
 				cell: schemaFactory.string,
-				row: Row,
+				row: MyRow,
 			}) {}
 
-			const _table = new Table({
+			const _table = new MyTable({
 				columns: [{ id: "column-0" }],
 				rows: [{ id: "row-0", props: { label: "Row 0" }, cells: {} }],
 			});
 		});
 
 		it("Can create with custom column and row schema", () => {
-			const Cell = schemaFactory.string;
-			class Column extends TableSchema.column({
+			const MyCell = schemaFactory.string;
+			class MyColumn extends TableSchema.column({
 				schemaFactory,
-				cell: Cell,
+				cell: MyCell,
 				props: schemaFactory.object("column-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
-			class Row extends TableSchema.row({
+			class MyRow extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
+				cell: MyCell,
 				props: schemaFactory.object("row-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
 				cell: schemaFactory.string,
-				column: Column,
-				row: Row,
+				column: MyColumn,
+				row: MyRow,
 			}) {}
 
-			const _table = new Table({
+			const _table = new MyTable({
 				columns: [{ id: "column-0", props: { label: "Column 0" } }],
 				rows: [{ id: "row-0", props: { label: "Row 0" }, cells: {} }],
 			});
 		});
 	});
 
-	describe("Initialization", () => {
+	describeHydration("Initialization", (initializeTree) => {
 		it("Empty", () => {
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
 				cell: schemaFactory.string,
 			}) {
@@ -337,15 +307,14 @@ describe("TableFactory unit tests", () => {
 				public customProp: string = "Hello world!";
 			}
 
-			const table: Table = Table.empty();
+			const table = initializeTree(MyTable, MyTable.empty());
 			assertEqualTrees(table, { columns: [], rows: [] });
 			assert(table.customProp === "Hello world!");
 		});
 
 		it("Non-empty", () => {
-			const { treeView, Table, Column } = createTableTree();
-
-			treeView.initialize(
+			const table = initializeTree(
+				Table,
 				new Table({
 					columns: [
 						new Column({
@@ -368,7 +337,7 @@ describe("TableFactory unit tests", () => {
 				}),
 			);
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-0",
@@ -397,24 +366,22 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("insertColumns", () => {
+	describeHydration("insertColumns", (initializeTree) => {
 		it("Insert empty columns list", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
+			const tree = initializeTree(Table, Table.empty());
 
-			treeView.root.insertColumns({ index: 0, columns: [] });
+			tree.insertColumns({ index: 0, columns: [] });
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(tree, {
 				columns: [],
 				rows: [],
 			});
 		});
 
 		it("Insert single column into empty list", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
+			const table = initializeTree(Table, Table.empty());
 
-			treeView.root.insertColumns({
+			table.insertColumns({
 				index: 0,
 				columns: [
 					{
@@ -424,7 +391,7 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-0",
@@ -436,8 +403,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Insert columns into non-empty list", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-a",
@@ -451,7 +417,7 @@ describe("TableFactory unit tests", () => {
 				rows: [],
 			});
 
-			treeView.root.insertColumns({
+			table.insertColumns({
 				index: 1,
 				columns: [
 					{
@@ -465,7 +431,7 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-a",
@@ -489,8 +455,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Append columns", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-a",
@@ -504,7 +469,7 @@ describe("TableFactory unit tests", () => {
 				rows: [],
 			});
 
-			treeView.root.insertColumns({
+			table.insertColumns({
 				columns: [
 					{
 						id: "column-c",
@@ -517,7 +482,7 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-a",
@@ -541,24 +506,22 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("insertRows", () => {
+	describeHydration("insertRows", (initializeTree) => {
 		it("Insert empty rows list", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
+			const table = initializeTree(Table, Table.empty());
 
-			treeView.root.insertRows({ index: 0, rows: [] });
+			table.insertRows({ index: 0, rows: [] });
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [],
 			});
 		});
 
 		it("Insert single row into empty list", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
+			const table = initializeTree(Table, Table.empty());
 
-			treeView.root.insertRows({
+			table.insertRows({
 				index: 0,
 				rows: [
 					{
@@ -569,7 +532,7 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [
 					{
@@ -582,8 +545,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Insert rows into non-empty list", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				rows: [
 					{
 						id: "row-a",
@@ -599,7 +561,7 @@ describe("TableFactory unit tests", () => {
 				columns: [],
 			});
 
-			treeView.root.insertRows({
+			table.insertRows({
 				index: 1,
 				rows: [
 					{
@@ -615,7 +577,7 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [
 					{
@@ -643,8 +605,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Append rows", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				rows: [
 					{
 						id: "row-a",
@@ -660,7 +621,7 @@ describe("TableFactory unit tests", () => {
 				columns: [],
 			});
 
-			treeView.root.insertRows({
+			table.insertRows({
 				rows: [
 					{
 						id: "row-c",
@@ -675,7 +636,7 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [
 					{
@@ -703,10 +664,9 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("setCell", () => {
+	describeHydration("setCell", (initializeTree) => {
 		it("Set cell in a valid location", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-0",
@@ -723,7 +683,7 @@ describe("TableFactory unit tests", () => {
 			});
 
 			// By not specifying an index, the column should be appended to the end of the list.
-			treeView.root.setCell({
+			table.setCell({
 				key: {
 					row: "row-0",
 					column: "column-0",
@@ -731,7 +691,7 @@ describe("TableFactory unit tests", () => {
 				cell: { value: "Hello world!" },
 			});
 
-			assertEqualTrees(treeView.root, {
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-0",
@@ -753,8 +713,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Setting cell in an invalid location errors", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-0",
@@ -773,7 +732,7 @@ describe("TableFactory unit tests", () => {
 			// Invalid row
 			assert.throws(
 				() =>
-					treeView.root.setCell({
+					table.setCell({
 						key: {
 							row: "row-1",
 							column: "column-0",
@@ -786,7 +745,7 @@ describe("TableFactory unit tests", () => {
 			// Invalid column
 			assert.throws(
 				() =>
-					treeView.root.setCell({
+					table.setCell({
 						key: {
 							row: "row-0",
 							column: "column-1",
@@ -798,10 +757,9 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("removeColumns", () => {
+	describeHydration("removeColumns", (initializeTree, hydrated) => {
 		it("Remove empty list", () => {
-			const { treeView, Column, Row } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					new Column({
 						id: "column-0",
@@ -819,8 +777,8 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			treeView.root.removeColumns([]);
-			assertEqualTrees(treeView.root, {
+			table.removeColumns([]);
+			assertEqualTrees(table, {
 				columns: [{ id: "column-0", props: {} }],
 				rows: [
 					{
@@ -834,164 +792,165 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		it("Remove single column", () => {
-			const { treeView, Column, Row } = createTableTree();
-			const column0 = new Column({ id: "column-0", props: {} });
-			const column1 = new Column({ id: "column-1", props: {} });
-			treeView.initialize({
-				columns: [column0, column1],
-				rows: [
-					new Row({
-						id: "row-0",
-						cells: {
-							"column-0": { value: "Hello world!" },
+		// TODO:AB#47404: Fix column removal for unhydrated table trees and re-enable in unhydrated mode.
+		if (hydrated) {
+			it("Remove single column", () => {
+				const column0 = new Column({ id: "column-0", props: {} });
+				const column1 = new Column({ id: "column-1", props: {} });
+				const table = initializeTree(Table, {
+					columns: [column0, column1],
+					rows: [
+						new Row({
+							id: "row-0",
+							cells: {
+								"column-0": { value: "Hello world!" },
+							},
+							props: {},
+						}),
+					],
+				});
+
+				// Remove column0 (by node)
+				table.removeColumns([column0]);
+				assertEqualTrees(table, {
+					columns: [{ id: "column-1", props: {} }],
+					rows: [
+						{
+							id: "row-0",
+							cells: {},
+							props: {},
 						},
-						props: {},
-					}),
-				],
-			});
+					],
+				});
 
-			// Remove column0 (by node)
-			treeView.root.removeColumns([column0]);
-			assertEqualTrees(treeView.root, {
-				columns: [{ id: "column-1", props: {} }],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-
-			// Remove column1 (by ID)
-			treeView.root.removeColumns(["column-1"]);
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-		});
-
-		it("Remove multiple columns", () => {
-			const { treeView, Column, Row } = createTableTree();
-			const column0 = new Column({ id: "column-0", props: {} });
-			const column1 = new Column({ id: "column-1", props: {} });
-			const column2 = new Column({ id: "column-2", props: {} });
-			const column3 = new Column({ id: "column-3", props: {} });
-			treeView.initialize({
-				columns: [column0, column1, column2, column3],
-				rows: [
-					new Row({
-						id: "row-0",
-						cells: {
-							"column-0": { value: "Hello world!" },
+				// Remove column1 (by ID)
+				table.removeColumns(["column-1"]);
+				assertEqualTrees(table, {
+					columns: [],
+					rows: [
+						{
+							id: "row-0",
+							cells: {},
+							props: {},
 						},
-						props: {},
-					}),
-				],
+					],
+				});
 			});
+		}
 
-			const table = treeView.root;
+		// TODO:AB#47404: Fix column removal for unhydrated table trees and re-enable in unhydrated mode.
+		if (hydrated) {
+			it("Remove multiple columns", () => {
+				const column0 = new Column({ id: "column-0", props: {} });
+				const column1 = new Column({ id: "column-1", props: {} });
+				const column2 = new Column({ id: "column-2", props: {} });
+				const column3 = new Column({ id: "column-3", props: {} });
+				const table = initializeTree(Table, {
+					columns: [column0, column1, column2, column3],
+					rows: [
+						new Row({
+							id: "row-0",
+							cells: {
+								"column-0": { value: "Hello world!" },
+							},
+							props: {},
+						}),
+					],
+				});
 
-			// Remove columns 1 and 3 (by node)
-			table.removeColumns([column1, column3]);
-			assertEqualTrees(table, {
-				columns: [
-					{ id: "column-0", props: {} },
-					{ id: "column-2", props: {} },
-				],
-				rows: [
-					{
-						id: "row-0",
-						cells: {
-							"column-0": { value: "Hello world!" },
+				// Remove columns 1 and 3 (by node)
+				table.removeColumns([column1, column3]);
+				assertEqualTrees(table, {
+					columns: [
+						{ id: "column-0", props: {} },
+						{ id: "column-2", props: {} },
+					],
+					rows: [
+						{
+							id: "row-0",
+							cells: {
+								"column-0": { value: "Hello world!" },
+							},
+							props: {},
 						},
-						props: {},
-					},
-				],
+					],
+				});
+
+				// Remove columns 2 and 0 (by ID)
+				table.removeColumns([column2.id, column0.id]);
+				assertEqualTrees(table, {
+					columns: [],
+					rows: [
+						{
+							id: "row-0",
+							cells: {},
+							props: {},
+						},
+					],
+				});
 			});
 
-			// Remove columns 2 and 0 (by ID)
-			treeView.root.removeColumns([column2.id, column0.id]);
-			assertEqualTrees(table, {
-				columns: [],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-		});
+			it("Removing a single column that doesn't exist on table errors", () => {
+				const table = initializeTree(Table, {
+					columns: [],
+					rows: [],
+				});
 
-		it("Removing a single column that doesn't exist on table errors", () => {
-			const { treeView, Column } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [],
+				assert.throws(
+					() => table.removeColumns([new Column({ id: "column-0", props: {} })]),
+					validateUsageError(
+						/Specified column with ID "column-0" does not exist in the table./,
+					),
+				);
 			});
 
-			assert.throws(
-				() => treeView.root.removeColumns([new Column({ id: "column-0", props: {} })]),
-				validateUsageError(/Specified column with ID "column-0" does not exist in the table./),
-			);
-		});
+			it("Removing multiple columns errors if at least one column doesn't exist", () => {
+				const column0 = new Column({ id: "column-0", props: {} });
+				const table = initializeTree(Table, {
+					columns: [column0],
+					rows: [],
+				});
 
-		it("Removing multiple columns errors if at least one column doesn't exist", () => {
-			const { treeView, Column } = createTableTree();
-			const column0 = new Column({ id: "column-0", props: {} });
-			treeView.initialize({
-				columns: [column0],
-				rows: [],
+				assert.throws(
+					() => table.removeColumns([column0, new Column({ id: "column-1", props: {} })]),
+					validateUsageError(
+						/Specified column with ID "column-1" does not exist in the table./,
+					),
+				);
+
+				// Additionally, `column-0` should not have been removed.
+				assert(table.columns.length === 1);
 			});
-
-			assert.throws(
-				() =>
-					treeView.root.removeColumns([column0, new Column({ id: "column-1", props: {} })]),
-				validateUsageError(/Specified column with ID "column-1" does not exist in the table./),
-			);
-
-			// Additionally, `column-0` should not have been removed.
-			assert(treeView.root.columns.length === 1);
-		});
+		}
 	});
 
-	describe("removeColumns", () => {
+	describeHydration("removeColumns", (initializeTree) => {
 		it("Remove empty range", () => {
-			const { treeView, Column } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [new Column({ id: "column-0", props: {} })],
 				rows: [],
 			});
 
-			treeView.root.removeColumns(0, 0);
-			assertEqualTrees(treeView.root, {
+			table.removeColumns(0, 0);
+			assertEqualTrees(table, {
 				columns: [{ id: "column-0", props: {} }],
 				rows: [],
 			});
 		});
 
 		it("Remove by index range", () => {
-			const { treeView, Column } = createTableTree();
 			const column0 = new Column({ id: "column-0", props: {} });
 			const column1 = new Column({ id: "column-1", props: {} });
 			const column2 = new Column({ id: "column-2", props: {} });
 			const column3 = new Column({ id: "column-3", props: {} });
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [column0, column1, column2, column3],
 				rows: [],
 			});
 
 			// Remove columns 1-2
-			treeView.root.removeColumns(1, 2);
-			assertEqualTrees(treeView.root, {
+			table.removeColumns(1, 2);
+			assertEqualTrees(table, {
 				columns: [
 					{ id: "column-0", props: {} },
 					{ id: "column-3", props: {} },
@@ -1001,42 +960,40 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Removing by range fails for invalid ranges", () => {
-			const { treeView, Column } = createTableTree();
 			const column0 = new Column({ id: "column-0", props: {} });
 			const column1 = new Column({ id: "column-1", props: {} });
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [column0, column1],
 				rows: [],
 			});
 
 			assert.throws(
-				() => treeView.root.removeColumns(-1, undefined),
+				() => table.removeColumns(-1, undefined),
 				validateUsageError(
 					/Start index out of bounds. Expected index to be on \[0, 1], but got -1/,
 				),
 			);
 
 			assert.throws(
-				() => treeView.root.removeColumns(1, -1),
+				() => table.removeColumns(1, -1),
 				validateUsageError(/Expected non-negative count. Got -1./),
 			);
 
 			assert.throws(
-				() => treeView.root.removeColumns(0, 5),
+				() => table.removeColumns(0, 5),
 				validateUsageError(
 					/End index out of bounds. Expected end to be on \[0, 2], but got 5/,
 				),
 			);
 
 			// Additionally, no columns should have been removed.
-			assert(treeView.root.columns.length === 2);
+			assert(table.columns.length === 2);
 		});
 	});
 
-	describe("removeRows", () => {
+	describeHydration("removeRows", (initializeTree, hydrated) => {
 		it("Remove empty list", () => {
-			const { treeView, Row } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [],
 				rows: [
 					new Row({
@@ -1046,8 +1003,8 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			treeView.root.removeRows([]);
-			assertEqualTrees(treeView.root, {
+			table.removeRows([]);
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [
 					{
@@ -1058,125 +1015,122 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		it("Remove single row", () => {
-			const { treeView, Row } = createTableTree();
-			const row0 = new Row({ id: "row-0", cells: {}, props: {} });
-			const row1 = new Row({ id: "row-1", cells: {}, props: {} });
-			treeView.initialize({
-				columns: [],
-				rows: [row0, row1],
+		// TODO:AB#47404: Fix row removal for unhydrated table trees and re-enable in unhydrated mode.
+		if (hydrated) {
+			it("Remove single row", () => {
+				const row0 = new Row({ id: "row-0", cells: {}, props: {} });
+				const row1 = new Row({ id: "row-1", cells: {}, props: {} });
+				const table = initializeTree(Table, {
+					columns: [],
+					rows: [row0, row1],
+				});
+
+				// Remove row0 (by node)
+				table.removeRows([row0]);
+				assertEqualTrees(table, {
+					columns: [],
+					rows: [{ id: "row-1", cells: {}, props: {} }],
+				});
+
+				// Remove row1 (by ID)
+				table.removeRows(["row-1"]);
+				assertEqualTrees(table, {
+					columns: [],
+					rows: [],
+				});
 			});
 
-			// Remove row0 (by node)
-			treeView.root.removeRows([row0]);
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [{ id: "row-1", cells: {}, props: {} }],
+			it("Remove multiple rows", () => {
+				const row0 = new Row({ id: "row-0", cells: {}, props: {} });
+				const row1 = new Row({ id: "row-1", cells: {}, props: {} });
+				const row2 = new Row({ id: "row-2", cells: {}, props: {} });
+				const row3 = new Row({ id: "row-3", cells: {}, props: {} });
+				const table = initializeTree(Table, {
+					columns: [],
+					rows: [row0, row1, row2, row3],
+				});
+
+				// Remove rows 1 and 3 (by node)
+				table.removeRows([row1, row3]);
+				assertEqualTrees(table, {
+					columns: [],
+					rows: [
+						{
+							id: "row-0",
+							cells: {},
+							props: {},
+						},
+						{
+							id: "row-2",
+							cells: {},
+							props: {},
+						},
+					],
+				});
+
+				// Remove rows 2 and 0 (by ID)
+				table.removeRows([row2.id, row0.id]);
+				assertEqualTrees(table, {
+					columns: [],
+					rows: [],
+				});
 			});
 
-			// Remove row1 (by ID)
-			treeView.root.removeRows(["row-1"]);
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [],
-			});
-		});
+			it("Removing single row that doesn't exist on table errors", () => {
+				const table = initializeTree(Table, {
+					columns: [],
+					rows: [],
+				});
 
-		it("Remove multiple rows", () => {
-			const { treeView, Row } = createTableTree();
-			const row0 = new Row({ id: "row-0", cells: {}, props: {} });
-			const row1 = new Row({ id: "row-1", cells: {}, props: {} });
-			const row2 = new Row({ id: "row-2", cells: {}, props: {} });
-			const row3 = new Row({ id: "row-3", cells: {}, props: {} });
-			treeView.initialize({
-				columns: [],
-				rows: [row0, row1, row2, row3],
+				assert.throws(
+					() => table.removeRows([new Row({ id: "row-0", cells: {}, props: {} })]),
+					validateUsageError(/Specified row with ID "row-0" does not exist in the table./),
+				);
 			});
 
-			// Remove rows 1 and 3 (by node)
-			treeView.root.removeRows([row1, row3]);
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-					{
-						id: "row-2",
-						cells: {},
-						props: {},
-					},
-				],
+			it("Removing multiple rows errors if at least one row doesn't exist", () => {
+				const row0 = new Row({ id: "row-0", cells: {}, props: {} });
+				const table = initializeTree(Table, {
+					columns: [],
+					rows: [row0],
+				});
+
+				assert.throws(
+					() => table.removeRows([row0, new Row({ id: "row-1", cells: {}, props: {} })]),
+					validateUsageError(/Specified row with ID "row-1" does not exist in the table./),
+				);
+
+				// Additionally, `row-0` should not have been removed.
+				assert(table.rows.length === 1);
 			});
-
-			// Remove rows 2 and 0 (by ID)
-			treeView.root.removeRows([row2.id, row0.id]);
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [],
-			});
-		});
-
-		it("Removing single row that doesn't exist on table errors", () => {
-			const { treeView, Row } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [],
-			});
-
-			assert.throws(
-				() => treeView.root.removeRows([new Row({ id: "row-0", cells: {}, props: {} })]),
-				validateUsageError(/Specified row with ID "row-0" does not exist in the table./),
-			);
-		});
-
-		it("Removing multiple rows errors if at least one row doesn't exist", () => {
-			const { treeView, Row } = createTableTree();
-			const row0 = new Row({ id: "row-0", cells: {}, props: {} });
-			treeView.initialize({
-				columns: [],
-				rows: [row0],
-			});
-
-			assert.throws(
-				() => treeView.root.removeRows([row0, new Row({ id: "row-1", cells: {}, props: {} })]),
-				validateUsageError(/Specified row with ID "row-1" does not exist in the table./),
-			);
-
-			// Additionally, `row-0` should not have been removed.
-			assert(treeView.root.rows.length === 1);
-		});
+		}
 
 		it("Remove empty range", () => {
-			const { treeView, Row } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [],
 				rows: [new Row({ id: "row-0", cells: {}, props: {} })],
 			});
 
-			treeView.root.removeRows(0, 0);
-			assertEqualTrees(treeView.root, {
+			table.removeRows(0, 0);
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [{ id: "row-0", cells: {}, props: {} }],
 			});
 		});
 
 		it("Remove by index range", () => {
-			const { treeView, Row } = createTableTree();
 			const row0 = new Row({ id: "row-0", cells: {}, props: {} });
 			const row1 = new Row({ id: "row-1", cells: {}, props: {} });
 			const row2 = new Row({ id: "row-2", cells: {}, props: {} });
 			const row3 = new Row({ id: "row-3", cells: {}, props: {} });
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [],
 				rows: [row0, row1, row2, row3],
 			});
 
 			// Remove rows 1-2
-			treeView.root.removeRows(1, 2);
-			assertEqualTrees(treeView.root, {
+			table.removeRows(1, 2);
+			assertEqualTrees(table, {
 				columns: [],
 				rows: [
 					{
@@ -1194,42 +1148,40 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Removing by range fails for invalid ranges", () => {
-			const { treeView, Row } = createTableTree();
 			const row0 = new Row({ id: "row-0", cells: {}, props: {} });
 			const row1 = new Row({ id: "row-1", cells: {}, props: {} });
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [],
 				rows: [row0, row1],
 			});
 
 			assert.throws(
-				() => treeView.root.removeRows(-1, undefined),
+				() => table.removeRows(-1, undefined),
 				validateUsageError(
 					/Start index out of bounds. Expected index to be on \[0, 1], but got -1/,
 				),
 			);
 
 			assert.throws(
-				() => treeView.root.removeRows(1, -1),
+				() => table.removeRows(1, -1),
 				validateUsageError(/Expected non-negative count. Got -1./),
 			);
 
 			assert.throws(
-				() => treeView.root.removeRows(0, 5),
+				() => table.removeRows(0, 5),
 				validateUsageError(
 					/End index out of bounds. Expected end to be on \[0, 2], but got 5/,
 				),
 			);
 
 			// Additionally, no rows should have been removed.
-			assert(treeView.root.rows.length === 2);
+			assert(table.rows.length === 2);
 		});
 	});
 
-	describe("removeCell", () => {
+	describeHydration("removeCell", (initializeTree) => {
 		it("Remove cell in valid location with existing data", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-0",
@@ -1248,12 +1200,12 @@ describe("TableFactory unit tests", () => {
 				row: "row-0",
 				column: "column-0",
 			};
-			treeView.root.setCell({
+			table.setCell({
 				key: cellKey,
 				cell: { value: "Hello world!" },
 			});
-			treeView.root.removeCell(cellKey);
-			assertEqualTrees(treeView.root, {
+			table.removeCell(cellKey);
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-0",
@@ -1271,8 +1223,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Remove cell in valid location with no data", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-0",
@@ -1291,8 +1242,8 @@ describe("TableFactory unit tests", () => {
 				row: "row-0",
 				column: "column-0",
 			};
-			treeView.root.removeCell(cellKey);
-			assertEqualTrees(treeView.root, {
+			table.removeCell(cellKey);
+			assertEqualTrees(table, {
 				columns: [
 					{
 						id: "column-0",
@@ -1310,8 +1261,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Removing cell from nonexistent row and column errors", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			const table = initializeTree(Table, {
 				columns: [
 					{
 						id: "column-0",
@@ -1330,7 +1280,7 @@ describe("TableFactory unit tests", () => {
 			// Invalid row
 			assert.throws(
 				() =>
-					treeView.root.removeCell({
+					table.removeCell({
 						row: "row-1",
 						column: "column-0",
 					}),
@@ -1340,7 +1290,7 @@ describe("TableFactory unit tests", () => {
 			// Invalid column
 			assert.throws(
 				() =>
-					treeView.root.removeCell({
+					table.removeCell({
 						row: "row-0",
 						column: "column-1",
 					}),
@@ -1349,36 +1299,32 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Responding to changes", () => {
+	describeHydration("Responding to changes", (initializeTree, hydrated) => {
 		it("Responding to any changes in the table", () => {
-			const { treeView, Row } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [],
-			});
+			const table = initializeTree(Table, Table.empty());
 
 			let eventCount = 0;
 
 			// Bind listener to the table.
 			// The "treeChanged" event will fire when the associated node or any of its descendants change.
-			Tree.on(treeView.root, "treeChanged", () => {
+			Tree.on(table, "treeChanged", () => {
 				eventCount++;
 			});
 
 			// Add a row
-			treeView.root.insertRows({
+			table.insertRows({
 				rows: [new Row({ id: "row-0", cells: {}, props: {} })],
 			});
 			assert.equal(eventCount, 1);
 
 			// Add a column
-			treeView.root.insertColumns({
+			table.insertColumns({
 				columns: [{ id: "column-0", props: {} }],
 			});
 			assert.equal(eventCount, 2);
 
 			// Set a cell
-			treeView.root.setCell({
+			table.setCell({
 				key: {
 					row: "row-0",
 					column: "column-0",
@@ -1389,7 +1335,7 @@ describe("TableFactory unit tests", () => {
 
 			// Update cell value
 			const cell =
-				treeView.root.getCell({
+				table.getCell({
 					row: "row-0",
 					column: "column-0",
 				}) ?? fail("Cell not found");
@@ -1397,76 +1343,72 @@ describe("TableFactory unit tests", () => {
 			assert.equal(eventCount, 4);
 		});
 
-		it("Responding to column list changes", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [],
+		// TODO:AB#47404: Fix column removal for unhydrated table trees and re-enable in unhydrated mode.
+		if (hydrated) {
+			it("Responding to column list changes", () => {
+				const table = initializeTree(Table, Table.empty());
+
+				let eventCount = 0;
+
+				// Bind listener to the columns list, so we know when a column is added or removed.
+				// The "nodeChanged" event will fire only when the specified node itself changes (i.e., its own properties change).
+				Tree.on(table.columns, "nodeChanged", () => {
+					eventCount++;
+				});
+
+				// Add columns
+				table.insertColumns({
+					columns: [
+						{ id: "column-0", props: {} },
+						{ id: "column-0", props: {} },
+					],
+				});
+				assert.equal(eventCount, 1);
+
+				// Update column props
+				table.columns[0].props = { label: "Column 0" };
+				assert.equal(eventCount, 1); // Event should not have fired for column node changes
+
+				// Insert a row
+				table.insertRows({ rows: [{ id: "row-0", cells: {}, props: {} }] });
+				assert.equal(eventCount, 1); // Event should not have fired for row insertion
+
+				// Re-order columns
+				table.columns.moveToEnd(0);
+				assert.equal(eventCount, 2);
+
+				// Remove column
+				table.removeColumns(["column-0"]);
+				assert.equal(eventCount, 3);
 			});
-
-			const table = treeView.root;
-
-			let eventCount = 0;
-
-			// Bind listener to the columns list, so we know when a column is added or removed.
-			// The "nodeChanged" event will fire only when the specified node itself changes (i.e., its own properties change).
-			Tree.on(table.columns, "nodeChanged", () => {
-				eventCount++;
-			});
-
-			// Add columns
-			table.insertColumns({
-				columns: [
-					{ id: "column-0", props: {} },
-					{ id: "column-0", props: {} },
-				],
-			});
-			assert.equal(eventCount, 1);
-
-			// Update column props
-			table.columns[0].props = { label: "Column 0" };
-			assert.equal(eventCount, 1); // Event should not have fired for column node changes
-
-			// Insert a row
-			table.insertRows({ rows: [{ id: "row-0", cells: {}, props: {} }] });
-			assert.equal(eventCount, 1); // Event should not have fired for row insertion
-
-			// Re-order columns
-			table.columns.moveToEnd(0);
-			assert.equal(eventCount, 2);
-
-			// Remove column
-			table.removeColumns(["column-0"]);
-			assert.equal(eventCount, 3);
-		});
+		}
 	});
 
-	it("Gets proper table elements with getter methods", () => {
-		const { treeView, Column, Row, Cell } = createTableTree();
+	describeHydration("Reading values", (initializeTree) => {
+		it("Gets proper table elements with getter methods", () => {
+			const cell0 = new Cell({ value: "Hello World!" });
+			const column0 = new Column({ id: "column-0", props: {} });
+			const row0 = new Row({ id: "row-0", cells: { "column-0": cell0 }, props: {} });
 
-		const cell0 = new Cell({ value: "Hello World!" });
-		const column0 = new Column({ id: "column-0", props: {} });
-		const row0 = new Row({ id: "row-0", cells: { "column-0": cell0 }, props: {} });
+			const table = initializeTree(Table, {
+				columns: [column0],
+				rows: [row0],
+			});
 
-		treeView.initialize({
-			columns: [column0],
-			rows: [row0],
+			const cell = table.getCell({ column: "column-0", row: "row-0" });
+			const column = table.getColumn("column-0");
+			const row = table.getRow("row-0");
+
+			assert.equal(cell, cell0);
+			assert.equal(row, row0);
+			assert.equal(column, column0);
 		});
-
-		const cell = treeView.root.getCell({ column: "column-0", row: "row-0" });
-		const column = treeView.root.getColumn("column-0");
-		const row = treeView.root.getRow("row-0");
-
-		assert.equal(cell, cell0);
-		assert.equal(row, row0);
-		assert.equal(column, column0);
 	});
 
 	describe("JSON serialization", () => {
 		useSnapshotDirectory("table-schema-json");
 
 		it("schema", () => {
-			const { Table } = createTableSchema();
 			takeJsonSnapshot(
 				getJsonSchema(Table, {
 					requireFieldsWithDefaults: false,
@@ -1476,34 +1418,30 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("data (verbose)", () => {
-			const { treeView, Cell, Column, Row } = createTableTree();
-
 			const cell0 = new Cell({ value: "Hello World!" });
 			const column0 = new Column({ id: "column-0", props: {} });
 			const row0 = new Row({ id: "row-0", cells: { "column-0": cell0 }, props: {} });
-			treeView.initialize({
+			const table = new Table({
 				columns: [column0],
 				rows: [row0],
 			});
 
 			takeJsonSnapshot(
-				TreeAlpha.exportVerbose(treeView.root, {}) as unknown as JsonCompatibleReadOnly,
+				TreeAlpha.exportVerbose(table, {}) as unknown as JsonCompatibleReadOnly,
 			);
 		});
 
 		it("data (concise)", () => {
-			const { treeView, Cell, Column, Row } = createTableTree();
-
 			const cell0 = new Cell({ value: "Hello World!" });
 			const column0 = new Column({ id: "column-0", props: {} });
 			const row0 = new Row({ id: "row-0", cells: { "column-0": cell0 }, props: {} });
-			treeView.initialize({
+			const table = new Table({
 				columns: [column0],
 				rows: [row0],
 			});
 
 			takeJsonSnapshot(
-				TreeAlpha.exportConcise(treeView.root, {}) as unknown as JsonCompatibleReadOnly,
+				TreeAlpha.exportConcise(table, {}) as unknown as JsonCompatibleReadOnly,
 			);
 		});
 	});
@@ -1527,8 +1465,6 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("TableSchema: Customizing Column and Row schema", () => {
-			const Cell = schemaFactory.string;
-
 			class MyColumn extends TableSchema.column({
 				schemaFactory,
 				cell: Cell,
@@ -1565,12 +1501,12 @@ describe("TableFactory unit tests", () => {
 		it("TableSchema: Listening for changes in the table", () => {
 			// #region Don't include this in the example docs.
 
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
 				cell: schemaFactory.string,
 			}) {}
 
-			const table = new Table({
+			const table = new MyTable({
 				columns: [{ id: "column-0" }],
 				rows: [{ id: "row-0", cells: {} }],
 			});
@@ -1587,12 +1523,12 @@ describe("TableFactory unit tests", () => {
 		it("TableSchema: Listening for changes to the rows list only", () => {
 			// #region Don't include this in the example docs.
 
-			class Table extends TableSchema.table({
+			class MyTable extends TableSchema.table({
 				schemaFactory,
 				cell: schemaFactory.string,
 			}) {}
 
-			const table = new Table({
+			const table = new MyTable({
 				columns: [{ id: "column-0" }],
 				rows: [{ id: "row-0", cells: {} }],
 			});


### PR DESCRIPTION
Some of TableSchema's operations currently fail for unhydrated trees. The TableSchema unit tests previously only ran on hydrated trees. This PR updates them to also run on unhydrated trees, and disables the cases that currently fail.

[AB#47404](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47404) tracks fixing the underlying issues and re-enabling the tests.
[AB#47457](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47457) tracks fixing an unrelated issue with events fired from unhydrated array nodes.