### PR TITLE
test(matrix,tree): Add batch column/row insertion/deletion table benchmarks

### DIFF
--- a/packages/dds/matrix/src/test/matrixBenchmarks.ts
+++ b/packages/dds/matrix/src/test/matrixBenchmarks.ts
@@ -322,137 +322,247 @@ export function runBenchmarkTestSuite(mode: "memory" | "execution-time"): Suite 
 
 				// Insert-related tests that are not limited by matrixSize
 				for (const count of operationCounts) {
-					describe(`Column insertion`, () => {
-						const scenarioName = `Insert a single column in the middle of the table ${count} times`;
-						runBenchmark({
-							title: scenarioName,
-							matrixSize,
-							initialCellValue,
-							operation: (matrix) => {
-								for (let i = 0; i < count; i++) {
-									matrix.insertCols(Math.floor(matrix.colCount / 2), 1);
-								}
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+					describe("Column insertion", () => {
+						describe("Single column insertion", () => {
+							const scenarioName = `Insert a single column in the middle of the table ${count} times`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									for (let i = 0; i < count; i++) {
+										matrix.insertCols(Math.floor(matrix.colCount / 2), 1);
+									}
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.insertCols(Math.floor(matrix.colCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.insertCols(Math.floor(matrix.colCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.redoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 
-						runBenchmark({
-							title: `Undo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.insertCols(Math.floor(matrix.colCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									undoRedoStack.undoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.undoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
-						});
+						describe("Batch column insertion", () => {
+							const scenarioName = `Insert a batch of ${count} columns in the middle of the table`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									matrix.insertCols(Math.floor(matrix.colCount / 2), count);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 
-						runBenchmark({
-							title: `Redo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.insertCols(Math.floor(matrix.colCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-								for (let i = 0; i < count; i++) {
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.insertCols(Math.floor(matrix.colCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.undoOperation();
-								}
-								assert.equal(undoRedoStack.undoStackLength, 0);
-								assert.equal(undoRedoStack.redoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.insertCols(Math.floor(matrix.colCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+									undoRedoStack.undoOperation();
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.redoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.redoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 					});
 
-					describe(`Row insertion`, () => {
-						const scenarioName = `Insert a single row in the middle of the table ${count} times`;
-						runBenchmark({
-							title: scenarioName,
-							matrixSize,
-							initialCellValue,
-							operation: (matrix) => {
-								for (let i = 0; i < count; i++) {
-									matrix.insertRows(Math.floor(matrix.rowCount / 2), 1);
-								}
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+					describe("Row insertion", () => {
+						describe("Single row insertion", () => {
+							const scenarioName = `Insert a single row in the middle of the table ${count} times`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									for (let i = 0; i < count; i++) {
+										matrix.insertRows(Math.floor(matrix.rowCount / 2), 1);
+									}
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.insertRows(Math.floor(matrix.rowCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.insertRows(Math.floor(matrix.rowCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.redoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 
-						runBenchmark({
-							title: `Undo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.insertRows(Math.floor(matrix.rowCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									undoRedoStack.undoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.undoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
-						});
+						describe("Batch row insertion", () => {
+							const scenarioName = `Insert a batch of ${count} rows in the middle of the table`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									matrix.insertRows(Math.floor(matrix.rowCount / 2), count);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 
-						runBenchmark({
-							title: `Redo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.insertRows(Math.floor(matrix.rowCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-								for (let i = 0; i < count; i++) {
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.insertRows(Math.floor(matrix.rowCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.undoOperation();
-								}
-								assert.equal(undoRedoStack.undoStackLength, 0);
-								assert.equal(undoRedoStack.redoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.insertRows(Math.floor(matrix.rowCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+									undoRedoStack.undoOperation();
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.redoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.redoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 					});
 
-					describe(`Column and row insertion`, () => {
+					describe(`Single column and row insertion`, () => {
 						const scenarioName = `Insert a single row and a single column in the middle of the table ${count} times`;
 						runBenchmark({
 							title: scenarioName,
@@ -522,133 +632,243 @@ export function runBenchmarkTestSuite(mode: "memory" | "execution-time"): Suite 
 
 				// Set/Remove-related tests that are limited by matrixSize
 				for (const count of validRemoveCounts) {
-					describe(`Column removal`, () => {
-						const scenarioName = `Remove the middle column ${count} times`;
-						runBenchmark({
-							title: scenarioName,
-							matrixSize,
-							initialCellValue,
-							operation: (matrix) => {
-								for (let i = 0; i < count; i++) {
-									matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
-								}
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+					describe("Column removal", () => {
+						describe("Single column removal", () => {
+							const scenarioName = `Remove the middle column ${count} times`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									for (let i = 0; i < count; i++) {
+										matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
+									}
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.redoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 
-						runBenchmark({
-							title: `Undo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									undoRedoStack.undoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.undoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
-						});
+						describe("Batch column removal", () => {
+							const scenarioName = `Remove ${count} columns from the middle of the table`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									matrix.removeCols(Math.floor(matrix.colCount / 2), count);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 
-						runBenchmark({
-							title: `Redo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-								for (let i = 0; i < count; i++) {
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.removeCols(Math.floor(matrix.colCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.undoOperation();
-								}
-								assert.equal(undoRedoStack.undoStackLength, 0);
-								assert.equal(undoRedoStack.redoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.removeCols(Math.floor(matrix.colCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+									undoRedoStack.undoOperation();
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.redoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.redoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 					});
 
-					describe(`Row removal`, () => {
-						const scenarioName = `Remove the middle row ${count} times`;
-						runBenchmark({
-							title: scenarioName,
-							matrixSize,
-							initialCellValue,
-							operation: (matrix) => {
-								for (let i = 0; i < count; i++) {
-									matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
-								}
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+					describe("Row removal", () => {
+						describe("Single row removal", () => {
+							const scenarioName = `Remove the middle row ${count} times`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									for (let i = 0; i < count; i++) {
+										matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
+									}
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
+									}
+									assert.equal(undoRedoStack.undoStackLength, count);
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.undoOperation();
+									}
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, count);
+								},
+								operation: (_matrix, undoRedoStack) => {
+									for (let i = 0; i < count; i++) {
+										undoRedoStack.redoOperation();
+									}
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 
-						runBenchmark({
-							title: `Undo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									undoRedoStack.undoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.undoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
-						});
+						describe("Batch row removal", () => {
+							const scenarioName = `Remove ${count} rows from the middle of the table`;
+							runBenchmark({
+								title: scenarioName,
+								matrixSize,
+								initialCellValue,
+								operation: (matrix) => {
+									matrix.removeRows(Math.floor(matrix.rowCount / 2), count);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 
-						runBenchmark({
-							title: `Redo: ${scenarioName}`,
-							matrixSize,
-							initialCellValue,
-							beforeOperation: (matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
-									matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
-								}
-								assert.equal(undoRedoStack.undoStackLength, count);
-								for (let i = 0; i < count; i++) {
+							runBenchmark({
+								title: `Undo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.removeRows(Math.floor(matrix.rowCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.undoOperation();
-								}
-								assert.equal(undoRedoStack.undoStackLength, 0);
-								assert.equal(undoRedoStack.redoStackLength, count);
-							},
-							operation: (_matrix, undoRedoStack) => {
-								for (let i = 0; i < count; i++) {
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.undoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
+
+							runBenchmark({
+								title: `Redo: ${scenarioName}`,
+								matrixSize,
+								initialCellValue,
+								beforeOperation: (matrix, undoRedoStack) => {
+									matrix.removeRows(Math.floor(matrix.rowCount / 2), count);
+									assert.equal(undoRedoStack.undoStackLength, 1);
+									undoRedoStack.undoOperation();
+									assert.equal(undoRedoStack.undoStackLength, 0);
+									assert.equal(undoRedoStack.redoStackLength, 1);
+								},
+								operation: (_matrix, undoRedoStack) => {
 									undoRedoStack.redoOperation();
-								}
-							},
-							afterOperation: (_matrix, undoRedoStack) => {
-								assert.equal(undoRedoStack.redoStackLength, 0);
-							},
-							maxBenchmarkDurationSeconds,
-							mode,
+								},
+								afterOperation: (_matrix, undoRedoStack) => {
+									assert.equal(undoRedoStack.redoStackLength, 0);
+								},
+								maxBenchmarkDurationSeconds,
+								mode,
+							});
 						});
 					});
 

--- a/packages/dds/tree/src/test/memory/tableTree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tableTree.spec.ts
@@ -124,9 +124,10 @@ describe("SharedTree table APIs memory usage", () => {
 		// Insert-related tests that are not limited by tableSize
 		for (const count of operationCounts) {
 			describe(`Column Insertion`, () => {
+				const scenarioName = `Insert a column in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for inserting a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Insert a column in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -142,7 +143,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the insertion of a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo insert column in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -164,7 +165,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for redoing the insertion of a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo insert column in the middle ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -190,9 +191,10 @@ describe("SharedTree table APIs memory usage", () => {
 			});
 
 			describe(`Row Insertion`, () => {
+				const scenarioName = `Insert a row in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for inserting a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Insert a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -205,7 +207,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the insertion of a row at the end for a given number of times.
 				runBenchmark({
-					title: `Undo insert row in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -224,7 +226,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for redoing the insertion of a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo insert row in the middle ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -247,10 +249,10 @@ describe("SharedTree table APIs memory usage", () => {
 			});
 
 			describe(`Column and Row Insertion`, () => {
+				const scenarioName = `Insert a column and a row in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for inserting a column and a row in the middle for a given number of times.
-
 				runBenchmark({
-					title: `Insert a column and a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -268,7 +270,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the insertion of a column and a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo insert column and row in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -295,45 +297,45 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the memory usage of the SharedTree for redoing the insertion of a column and a row in the middle for a given number of times.
-				// 	runBenchmark({
-				// 		title: `Redo insert column and row in the middle ${count} times`,
-				// 		tableSize,
-				// 		initialCellValue,
-				// 		beforeOperation: (table, undoRedoManager) => {
-				// 			for (let i = 0; i < count; i++) {
-				// 				const column = new Column({});
-				// 				table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
-				// 				const row = new Row({ id: `row-${i}`, cells: {} });
-				// 				table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
-				// 			}
-				// 			for (let i = 0; i < count; i++) {
-				// 				// Undo row insertion
-				// 				undoRedoManager.undo();
-				// 				// Undo column insertion
-				// 				undoRedoManager.undo();
-				// 			}
-				// 			assert(!undoRedoManager.canUndo);
-				// 		},
-				// 		operation: (table, undoRedoManager) => {
-				// 			for (let i = 0; i < count; i++) {
-				// 				// Redo column insertion
-				// 				undoRedoManager.redo();
-				// 				// Redo row insertion
-				// 				undoRedoManager.redo();
-				// 			}
-				// 			assert(!undoRedoManager.canRedo);
-				// 		},
+				// runBenchmark({
+				// 	title: `Redo: ${scenarioName}`,
+				// 	tableSize,
+				// 	initialCellValue,
+				// 	beforeOperation: (table, undoRedoManager) => {
+				// 		for (let i = 0; i < count; i++) {
+				// 			const column = new Column({});
+				// 			table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
+				// 			const row = new Row({ id: `row-${i}`, cells: {} });
+				// 			table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+				// 		}
+				// 		for (let i = 0; i < count; i++) {
+				// 			// Undo row insertion
+				// 			undoRedoManager.undo();
+				// 			// Undo column insertion
+				// 			undoRedoManager.undo();
+				// 		}
+				// 		assert(!undoRedoManager.canUndo);
 				// 	},
-				// );
+				// 	operation: (table, undoRedoManager) => {
+				// 		for (let i = 0; i < count; i++) {
+				// 			// Redo column insertion
+				// 			undoRedoManager.redo();
+				// 			// Redo row insertion
+				// 			undoRedoManager.redo();
+				// 		}
+				// 		assert(!undoRedoManager.canRedo);
+				// 	},
+				// });
 			});
 		}
 
 		// Set/Remove-related tests that are limited by treeSize
 		for (const count of validRemoveCounts) {
 			describe(`Column Removal`, () => {
+				const scenarioName = `Remove a column in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for removing a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a column in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -346,7 +348,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the removal of a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo remove column in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -365,34 +367,34 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the memory usage of the SharedTree for redoing the removal of a column in the middle for a given number of times.
-				// 	runBenchmark({
-				// 		title: `Redo remove column in the middle ${count} times`,
-				// 		tableSize,
-				// 		initialCellValue,
-				// 		beforeOperation: (table, undoRedoManager) => {
-				// 			for (let i = 0; i < count; i++) {
-				// 				const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 				table.removeColumns([column]);
-				// 			}
-				// 			for (let i = 0; i < count; i++) {
-				// 				undoRedoManager.undo();
-				// 			}
-				// 			assert(!undoRedoManager.canUndo);
-				// 		},
-				// 		operation: (table, undoRedoManager) => {
-				// 			for (let i = 0; i < count; i++) {
-				// 				undoRedoManager.redo();
-				// 			}
-				// 			assert(!undoRedoManager.canRedo);
-				// 		},
-				// 	}),
-				// );
+				// runBenchmark({
+				// 	title: `Redo: ${scenarioName}`,
+				// 	tableSize,
+				// 	initialCellValue,
+				// 	beforeOperation: (table, undoRedoManager) => {
+				// 		for (let i = 0; i < count; i++) {
+				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
+				// 			table.removeColumns([column]);
+				// 		}
+				// 		for (let i = 0; i < count; i++) {
+				// 			undoRedoManager.undo();
+				// 		}
+				// 		assert(!undoRedoManager.canUndo);
+				// 	},
+				// 	operation: (table, undoRedoManager) => {
+				// 		for (let i = 0; i < count; i++) {
+				// 			undoRedoManager.redo();
+				// 		}
+				// 		assert(!undoRedoManager.canRedo);
+				// 	},
+				// });
 			});
 
 			describe(`Row Removal`, () => {
+				const scenarioName = `Remove a row in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for removing a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -405,7 +407,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the removal of a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo remove row in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -424,7 +426,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for redoing the removal of a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo remove row in the middle ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -447,9 +449,10 @@ describe("SharedTree table APIs memory usage", () => {
 			});
 
 			describe(`Column and Row Removal`, () => {
+				const scenarioName = `Remove a column and a row in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for removing a column and a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a column and a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -464,7 +467,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the removal of a column and a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo remove column and row in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -488,42 +491,42 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the memory usage of the SharedTree for redoing the removal of a column and a row in the middle for a given number of times.
-				// 	runBenchmark({
-				// 		title: `Redo remove column and row in the middle ${count} times`,
-				// 		tableSize,
-				// 		initialCellValue,
-				// 		beforeOperation: (table, undoRedoManager) => {
-				// 			for (let i = 0; i < count; i++) {
-				// 				const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 				table.removeColumns([column]);
-				// 				const row = table.rows[Math.floor(table.rows.length / 2)];
-				// 				table.removeRows([row]);
-				// 			}
-				// 			for (let i = 0; i < count; i++) {
-				// 				// Undo row removal
-				// 				undoRedoManager.undo();
-				// 				// Undo column removal
-				// 				undoRedoManager.undo();
-				// 			}
-				// 			assert(!undoRedoManager.canUndo);
-				// 		},
-				// 		operation: (table, undoRedoManager) => {
-				// 			for (let i = 0; i < count; i++) {
-				// 				// Redo column removal
-				// 				undoRedoManager.redo();
-				// 				// Redo row removal
-				// 				undoRedoManager.redo();
-				// 			}
-				// 			assert(!undoRedoManager.canRedo);
-				// 		},
+				// runBenchmark({
+				// 	title: `Redo: ${scenarioName}`,
+				// 	tableSize,
+				// 	initialCellValue,
+				// 	beforeOperation: (table, undoRedoManager) => {
+				// 		for (let i = 0; i < count; i++) {
+				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
+				// 			table.removeColumns([column]);
+				// 			const row = table.rows[Math.floor(table.rows.length / 2)];
+				// 			table.removeRows([row]);
+				// 		}
+				// 		for (let i = 0; i < count; i++) {
+				// 			// Undo row removal
+				// 			undoRedoManager.undo();
+				// 			// Undo column removal
+				// 			undoRedoManager.undo();
+				// 		}
+				// 		assert(!undoRedoManager.canUndo);
 				// 	},
-				// );
+				// 	operation: (table, undoRedoManager) => {
+				// 		for (let i = 0; i < count; i++) {
+				// 			// Redo column removal
+				// 			undoRedoManager.redo();
+				// 			// Redo row removal
+				// 			undoRedoManager.redo();
+				// 		}
+				// 		assert(!undoRedoManager.canRedo);
+				// 	},
+				// });
 			});
 
 			describe(`Insert a column and a row and remove right away`, () => {
+				const scenarioName = `Insert a column and a row in the middle and remove right away ${count} times`;
 				// Test the memory usage of the SharedTree for inserting a column and a row in the middle and removing them right away for a given number of times.
 				runBenchmark({
-					title: `Insert a column and a row in the middle and remove right away ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -545,7 +548,7 @@ describe("SharedTree table APIs memory usage", () => {
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the memory usage of the SharedTree for undoing the insertion and removal of a column and a row in the middle for a given number of times.
 				// 	runBenchmark({
-				// 		title: `Undo insert and remove column and row in the middle ${count} times`,
+				// 		title: `Undo: ${scenarioName}`,
 				// 		tableSize,
 				// 		initialCellValue,
 				// 		beforeOperation: (table) => {
@@ -576,7 +579,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// // Test the memory usage of the SharedTree for redoing the insertion and removal of a column and a row in the middle for a given number of times.
 				// runBenchmark({
-				// 	title: `Redo insert and remove column and row in the middle ${count} times`,
+				// 	title: `Redo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -618,9 +621,10 @@ describe("SharedTree table APIs memory usage", () => {
 			});
 
 			describe(`Cell Value Setting`, () => {
+				const scenarioName = `Set cell value in the middle ${count} times`;
 				// Test the memory usage of the SharedTree for setting a cell value in the middle for a given number of times.
 				runBenchmark({
-					title: `Set cell value in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -640,7 +644,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for undoing the setting of a cell value in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo set cell value in the middle ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table) => {
@@ -666,7 +670,7 @@ describe("SharedTree table APIs memory usage", () => {
 
 				// Test the memory usage of the SharedTree for redoing the setting of a cell value in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo set cell value in the middle ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -710,11 +710,12 @@ describe("SharedTree table APIs execution time", () => {
 						title: `Undo: ${scenarioName}`,
 						tableSize,
 						initialCellValue,
-						beforeOperation: (table) => {
+						beforeOperation: (table, undoRedoManager) => {
 							for (let i = 0; i < count; i++) {
 								const row = table.rows[Math.floor(table.rows.length / 2)];
 								table.removeRows([row]);
 							}
+							assert(undoRedoManager.canUndo);
 						},
 						operation: (table, undoRedoManager) => {
 							for (let i = 0; i < count; i++) {

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -585,16 +585,19 @@ describe("SharedTree table APIs execution time", () => {
 					// 	title: `Undo: ${scenarioName}`,
 					// 	tableSize,
 					// 	initialCellValue,
-					// 	beforeOperation: (table) => {
+					// 	beforeOperation: (table, undoRedoManager) => {
 					// 		for (let i = 0; i < count; i++) {
 					// 			const column = table.columns[Math.floor(table.columns.length / 2)];
 					// 			table.removeColumns([column]);
 					// 		}
+					// 		assert(undoRedoManager.canUndo);
 					// 	},
 					// 	operation: (table, undoRedoManager) => {
 					// 		for (let i = 0; i < count; i++) {
 					// 			undoRedoManager.undo();
 					// 		}
+					// 	},
+					// 	afterOperation: (table, undoRedoManager) => {
 					// 		assert(!undoRedoManager.canUndo);
 					// 	},
 					// 	maxBenchmarkDurationSeconds,

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -116,9 +116,10 @@ describe("SharedTree table APIs execution time", () => {
 		// Insert-related tests that are not limited by tableSize
 		for (const count of operationCounts) {
 			describe(`Column Insertion`, () => {
+				const scenarioName = `Insert a column in the middle ${count} times`;
 				// Test the execute time of the SharedTree for inserting a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Insert a column in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -135,7 +136,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of undoing insert a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo insert the middle column ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -161,7 +162,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of the SharedTree for redoing an insert column in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo insert the middle column ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -191,9 +192,10 @@ describe("SharedTree table APIs execution time", () => {
 			});
 
 			describe(`Row Insertion`, () => {
+				const scenarioName = `Insert a row in the middle ${count} times`;
 				// Test the execute time of the SharedTree for inserting a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Insert a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -207,7 +209,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of undoing insert a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo insert the middle row ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -230,7 +232,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of the SharedTree for redoing an insert row in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo insert the middle row ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -257,9 +259,10 @@ describe("SharedTree table APIs execution time", () => {
 			});
 
 			describe(`Column and Row Insertion`, () => {
+				const scenarioName = `Insert a column and a row in the middle ${count} times`;
 				// Test the execute time of the SharedTree for inserting a row and a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Insert a column and a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -278,7 +281,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of undoing insert a row and a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo insert the middle column and row ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -310,7 +313,7 @@ describe("SharedTree table APIs execution time", () => {
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the execute time of the SharedTree for redoing a remove row and a column in the middle for a given number of times.
 				// runBenchmark({
-				// 	title: `Redo remove the middle column and row ${count} times`,
+				// 	title: `Redo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -345,9 +348,10 @@ describe("SharedTree table APIs execution time", () => {
 			});
 
 			describe(`Insert a column and a row and remove right away`, () => {
+				const scenarioName = `Insert a column and a row and remove them right away ${count} times`;
 				// Test the execute time of the SharedTree for inserting a row and a column and removing them right away for a given number of times.
 				runBenchmark({
-					title: `Insert a column and a row and remove them right away ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -369,7 +373,7 @@ describe("SharedTree table APIs execution time", () => {
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the execute time of undoing insert a row and a column and removing them right away for a given number of times.
 				// runBenchmark({
-				// 	title: `Undo insert the middle column and row ${count} times`,
+				// 	title: `Undo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -404,7 +408,7 @@ describe("SharedTree table APIs execution time", () => {
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the execute time of the SharedTree for redoing an insert row and a column and removing them right away for a given number of times.
 				// runBenchmark({
-				// 	title: `Redo insert the middle column and row ${count} times`,
+				// 	title: `Redo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -445,9 +449,10 @@ describe("SharedTree table APIs execution time", () => {
 		// Set/Remove-related tests that are limited by tableSize
 		for (const count of validRemoveCounts) {
 			describe(`Column Removal`, () => {
+				const scenarioName = `Remove a column in the middle ${count} times`;
 				// Test the execute time of the SharedTree for removing a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a column in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -463,7 +468,7 @@ describe("SharedTree table APIs execution time", () => {
 				// Test the execute time of undoing insert a row and a column and removing them right away for a given number of times.
 				// Test the execute time of undoing remove a column in the middle for a given number of times.
 				// runBenchmark({
-				// 	title: `Undo remove the middle column ${count} times`,
+				// 	title: `Undo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -487,7 +492,7 @@ describe("SharedTree table APIs execution time", () => {
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the execute time of the SharedTree for redoing a remove column in the middle for a given number of times.
 				// runBenchmark({
-				// 	title: `Redo remove the middle column ${count} times`,
+				// 	title: `Redo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -514,9 +519,10 @@ describe("SharedTree table APIs execution time", () => {
 			});
 
 			describe(`Row Removal`, () => {
+				const scenarioName = `Remove a row in the middle ${count} times`;
 				// Test the execute time of the SharedTree for removing a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -530,7 +536,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of undoing remove a row in the middle for a given number of times.
 				runBenchmark({
-					title: `Undo remove the middle row ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -553,7 +559,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of the SharedTree for redoing a remove row in the middle for a given number of times.
 				runBenchmark({
-					title: `Redo remove the middle row ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue,
 					beforeOperation: (table, undoRedoManager) => {
@@ -580,9 +586,10 @@ describe("SharedTree table APIs execution time", () => {
 			});
 
 			describe(`Column and Row Removal`, () => {
+				const scenarioName = `Remove a single column and a row in the middle ${count} times`;
 				// Test the execute time of the SharedTree for removing a row and a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a single column and a row in the middle ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
@@ -600,7 +607,7 @@ describe("SharedTree table APIs execution time", () => {
 				// Test the execute time of undoing insert a row and a column and removing them right away for a given number of times.
 				// Test the execute time of undoing remove a row and a column in the middle for a given number of times.
 				// runBenchmark({
-				// 	title: `Undo remove the middle column and row ${count} times`,
+				// 	title: `Undo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -629,7 +636,7 @@ describe("SharedTree table APIs execution time", () => {
 				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
 				// Test the execute time of the SharedTree for redoing a remove row and a column in the middle for a given number of times.
 				// runBenchmark({
-				// 	title: `Redo remove the middle column and row ${count} times`,
+				// 	title: `Redo: ${scenarioName}`,
 				// 	tableSize,
 				// 	initialCellValue,
 				// 	beforeOperation: (table, undoRedoManager) => {
@@ -662,9 +669,10 @@ describe("SharedTree table APIs execution time", () => {
 			});
 
 			describe(`Cell Value Setting`, () => {
+				const scenarioName = `Set a cell value ${count} times`;
 				// Test the execute time of the SharedTree for setting a string in a cell for a given number of times.
 				runBenchmark({
-					title: `Set a cell value ${count} times`,
+					title: scenarioName,
 					tableSize,
 					initialCellValue: "abc",
 					operation: (table) => {
@@ -685,7 +693,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of undoing set a cell value for a given number of times.
 				runBenchmark({
-					title: `Undo set a cell value ${count} times`,
+					title: `Undo: ${scenarioName}`,
 					tableSize,
 					initialCellValue: "abc",
 					beforeOperation: (table, undoRedoManager) => {
@@ -715,7 +723,7 @@ describe("SharedTree table APIs execution time", () => {
 
 				// Test the execute time of the SharedTree for redoing a set cell value for a given number of times.
 				runBenchmark({
-					title: `Redo set a cell value ${count} times`,
+					title: `Redo: ${scenarioName}`,
 					tableSize,
 					initialCellValue: "abc",
 					beforeOperation: (table, undoRedoManager) => {

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -115,150 +115,266 @@ describe("SharedTree table APIs execution time", () => {
 
 		// Insert-related tests that are not limited by tableSize
 		for (const count of operationCounts) {
-			describe(`Column Insertion`, () => {
-				const scenarioName = `Insert a column in the middle ${count} times`;
-				// Test the execute time of the SharedTree for inserting a column in the middle for a given number of times.
-				runBenchmark({
-					title: scenarioName,
-					tableSize,
-					initialCellValue,
-					operation: (table) => {
-						for (let i = 0; i < count; i++) {
-							const column = new Column({});
-							table.insertColumns({
-								index: Math.floor(table.columns.length / 2),
-								columns: [column],
-							});
-						}
-					},
-					maxBenchmarkDurationSeconds,
+			describe("Column insertion", () => {
+				describe("Single column insertion", () => {
+					const scenarioName = `Insert a column in the middle ${count} times`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							for (let i = 0; i < count; i++) {
+								const column = new Column({});
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
+							}
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								const column = new Column({});
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
+							}
+							assert(undoRedoManager.canUndo);
+						},
+						operation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.undo();
+							}
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								const column = new Column({});
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
+							}
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.undo();
+							}
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.redo();
+							}
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 				});
 
-				// Test the execute time of undoing insert a column in the middle for a given number of times.
-				runBenchmark({
-					title: `Undo: ${scenarioName}`,
-					tableSize,
-					initialCellValue,
-					beforeOperation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							const column = new Column({});
+				describe("Batch column insertion", () => {
+					const scenarioName = `Insert ${count} columns in the middle of the table`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
 							table.insertColumns({
 								index: Math.floor(table.columns.length / 2),
-								columns: [column],
+								columns: Array.from({ length: count }, () => new Column({})),
 							});
-						}
-						assert(undoRedoManager.canUndo);
-					},
-					operation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							undoRedoManager.undo();
-						}
-					},
-					afterOperation: (table, undoRedoManager) => {
-						assert(!undoRedoManager.canUndo);
-					},
-					maxBenchmarkDurationSeconds,
-				});
+						},
+						maxBenchmarkDurationSeconds,
+					});
 
-				// Test the execute time of the SharedTree for redoing an insert column in the middle for a given number of times.
-				runBenchmark({
-					title: `Redo: ${scenarioName}`,
-					tableSize,
-					initialCellValue,
-					beforeOperation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							const column = new Column({});
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
 							table.insertColumns({
 								index: Math.floor(table.columns.length / 2),
-								columns: [column],
+								columns: Array.from({ length: count }, () => new Column({})),
 							});
-						}
-						for (let i = 0; i < count; i++) {
+							assert(undoRedoManager.canUndo);
+						},
+						operation: (table, undoRedoManager) => {
 							undoRedoManager.undo();
-						}
-						assert(!undoRedoManager.canUndo);
-						assert(undoRedoManager.canRedo);
-					},
-					operation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: Array.from({ length: count }, () => new Column({})),
+							});
+							undoRedoManager.undo();
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
 							undoRedoManager.redo();
-						}
-					},
-					afterOperation: (table, undoRedoManager) => {
-						assert(!undoRedoManager.canRedo);
-					},
-					maxBenchmarkDurationSeconds,
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 				});
 			});
 
-			describe(`Row Insertion`, () => {
-				const scenarioName = `Insert a row in the middle ${count} times`;
-				// Test the execute time of the SharedTree for inserting a row in the middle for a given number of times.
-				runBenchmark({
-					title: scenarioName,
-					tableSize,
-					initialCellValue,
-					operation: (table) => {
-						for (let i = 0; i < count; i++) {
-							const row = new Row({ cells: {} });
-							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
-						}
-					},
-					maxBenchmarkDurationSeconds,
+			describe("Row insertion", () => {
+				describe("Single row insertion", () => {
+					const scenarioName = `Insert a row in the middle ${count} times`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							for (let i = 0; i < count; i++) {
+								const row = new Row({ cells: {} });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+							}
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								const row = new Row({ cells: {} });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+							}
+							assert(undoRedoManager.canUndo);
+						},
+						operation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.undo();
+							}
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								const row = new Row({ cells: {} });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+							}
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.undo();
+							}
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.redo();
+							}
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 				});
 
-				// Test the execute time of undoing insert a row in the middle for a given number of times.
-				runBenchmark({
-					title: `Undo: ${scenarioName}`,
-					tableSize,
-					initialCellValue,
-					beforeOperation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							const row = new Row({ cells: {} });
-							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
-						}
-						assert(undoRedoManager.canUndo);
-					},
-					operation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							undoRedoManager.undo();
-						}
-					},
-					afterOperation: (table, undoRedoManager) => {
-						assert(!undoRedoManager.canUndo);
-					},
-					maxBenchmarkDurationSeconds,
-				});
+				describe("Batch row insertion", () => {
+					const scenarioName = `Insert ${count} rows in the middle of the table`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							table.insertRows({
+								index: Math.floor(table.rows.length / 2),
+								rows: Array.from({ length: count }, () => new Row({ cells: {} })),
+							});
+						},
+						maxBenchmarkDurationSeconds,
+					});
 
-				// Test the execute time of the SharedTree for redoing an insert row in the middle for a given number of times.
-				runBenchmark({
-					title: `Redo: ${scenarioName}`,
-					tableSize,
-					initialCellValue,
-					beforeOperation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							const row = new Row({ cells: {} });
-							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
-						}
-						for (let i = 0; i < count; i++) {
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.insertRows({
+								index: Math.floor(table.rows.length / 2),
+								rows: Array.from({ length: count }, () => new Row({ cells: {} })),
+							});
+							assert(undoRedoManager.canUndo);
+						},
+						operation: (table, undoRedoManager) => {
 							undoRedoManager.undo();
-						}
-						assert(!undoRedoManager.canUndo);
-						assert(undoRedoManager.canRedo);
-					},
-					operation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.insertRows({
+								index: Math.floor(table.rows.length / 2),
+								rows: Array.from({ length: count }, () => new Row({ cells: {} })),
+							});
+							undoRedoManager.undo();
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
 							undoRedoManager.redo();
-						}
-					},
-					afterOperation: (table, undoRedoManager) => {
-						assert(!undoRedoManager.canRedo);
-					},
-					maxBenchmarkDurationSeconds,
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 				});
 			});
 
-			describe(`Column and Row Insertion`, () => {
+			describe(`Single column and row insertion`, () => {
 				const scenarioName = `Insert a column and a row in the middle ${count} times`;
 				// Test the execute time of the SharedTree for inserting a row and a column in the middle for a given number of times.
 				runBenchmark({
@@ -448,140 +564,249 @@ describe("SharedTree table APIs execution time", () => {
 
 		// Set/Remove-related tests that are limited by tableSize
 		for (const count of validRemoveCounts) {
-			describe(`Column Removal`, () => {
-				const scenarioName = `Remove a column in the middle ${count} times`;
-				// Test the execute time of the SharedTree for removing a column in the middle for a given number of times.
-				runBenchmark({
-					title: scenarioName,
-					tableSize,
-					initialCellValue,
-					operation: (table) => {
-						for (let i = 0; i < count; i++) {
-							const column = table.columns[Math.floor(table.columns.length / 2)];
-							table.removeColumns([column]);
-						}
-					},
-					maxBenchmarkDurationSeconds,
+			describe("Column removal", () => {
+				describe("Single column removal", () => {
+					const scenarioName = `Remove a column in the middle ${count} times`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							for (let i = 0; i < count; i++) {
+								const column = table.columns[Math.floor(table.columns.length / 2)];
+								table.removeColumns([column]);
+							}
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
+					// runBenchmark({
+					// 	title: `Undo: ${scenarioName}`,
+					// 	tableSize,
+					// 	initialCellValue,
+					// 	beforeOperation: (table) => {
+					// 		for (let i = 0; i < count; i++) {
+					// 			const column = table.columns[Math.floor(table.columns.length / 2)];
+					// 			table.removeColumns([column]);
+					// 		}
+					// 	},
+					// 	operation: (table, undoRedoManager) => {
+					// 		for (let i = 0; i < count; i++) {
+					// 			undoRedoManager.undo();
+					// 		}
+					// 		assert(!undoRedoManager.canUndo);
+					// 	},
+					// 	maxBenchmarkDurationSeconds,
+					// });
+
+					// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
+					// runBenchmark({
+					// 	title: `Redo: ${scenarioName}`,
+					// 	tableSize,
+					// 	initialCellValue,
+					// 	beforeOperation: (table, undoRedoManager) => {
+					// 		for (let i = 0; i < count; i++) {
+					// 			const column = table.columns[Math.floor(table.columns.length / 2)];
+					// 			table.removeColumns([column]);
+					// 		}
+					// 		for (let i = 0; i < count; i++) {
+					// 			undoRedoManager.undo();
+					// 		}
+					// 		assert(!undoRedoManager.canUndo);
+					// 		assert(undoRedoManager.canRedo);
+					// 	},
+					// 	operation: (table, undoRedoManager) => {
+					// 		for (let i = 0; i < count; i++) {
+					// 			undoRedoManager.redo();
+					// 		}
+					// 	},
+					// 	afterOperation: (table, undoRedoManager) => {
+					// 		assert(!undoRedoManager.canRedo);
+					// 	},
+					// 	maxBenchmarkDurationSeconds,
+					// });
 				});
 
-				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
-				// Test the execute time of undoing insert a row and a column and removing them right away for a given number of times.
-				// Test the execute time of undoing remove a column in the middle for a given number of times.
-				// runBenchmark({
-				// 	title: `Undo: ${scenarioName}`,
-				// 	tableSize,
-				// 	initialCellValue,
-				// 	beforeOperation: (table, undoRedoManager) => {
-				// 		for (let i = 0; i < count; i++) {
-				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			table.removeColumns([column]);
-				// 		}
-				// 		assert(undoRedoManager.canUndo);
-				// 	},
-				// 	operation: (table, undoRedoManager) => {
-				// 		for (let i = 0; i < count; i++) {
-				// 			undoRedoManager.undo();
-				// 		}
-				// 	},
-				// 	afterOperation: (table, undoRedoManager) => {
-				// 		assert(!undoRedoManager.canUndo);
-				// 	},
-				// 	maxBenchmarkDurationSeconds,
-				// });
+				describe("Batch column removal", () => {
+					const scenarioName = `Remove ${count} columns from the middle of the table`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							table.removeColumns(
+								Math.floor(table.columns.length / 2) - Math.floor(count / 2),
+								count,
+							);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 
-				// TODO: AB#43364: Enable these tests back after allowing SharedTree to support undo/redo for removing cells when a column is removed.
-				// Test the execute time of the SharedTree for redoing a remove column in the middle for a given number of times.
-				// runBenchmark({
-				// 	title: `Redo: ${scenarioName}`,
-				// 	tableSize,
-				// 	initialCellValue,
-				// 	beforeOperation: (table, undoRedoManager) => {
-				// 		for (let i = 0; i < count; i++) {
-				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			table.removeColumns([column]);
-				// 		}
-				// 		for (let i = 0; i < count; i++) {
-				// 			undoRedoManager.undo();
-				// 		}
-				// 		assert(!undoRedoManager.canUndo);
-				// 		assert(undoRedoManager.canRedo);
-				// 	},
-				// 	operation: (table, undoRedoManager) => {
-				// 		for (let i = 0; i < count; i++) {
-				// 			undoRedoManager.redo();
-				// 		}
-				// 	},
-				// 	afterOperation: (table, undoRedoManager) => {
-				// 		assert(!undoRedoManager.canRedo);
-				// 	},
-				// 	maxBenchmarkDurationSeconds,
-				// });
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.removeColumns(
+								Math.floor(table.columns.length / 2) - Math.floor(count / 2),
+								count,
+							);
+							assert(undoRedoManager.canUndo);
+						},
+						operation: (table, undoRedoManager) => {
+							undoRedoManager.undo();
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.removeColumns(
+								Math.floor(table.columns.length / 2) - Math.floor(count / 2),
+								count,
+							);
+							undoRedoManager.undo();
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
+							undoRedoManager.redo();
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+				});
 			});
 
-			describe(`Row Removal`, () => {
-				const scenarioName = `Remove a row in the middle ${count} times`;
-				// Test the execute time of the SharedTree for removing a row in the middle for a given number of times.
-				runBenchmark({
-					title: scenarioName,
-					tableSize,
-					initialCellValue,
-					operation: (table) => {
-						for (let i = 0; i < count; i++) {
-							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRows([row]);
-						}
-					},
-					maxBenchmarkDurationSeconds,
+			describe("Row removal", () => {
+				describe("Single row removal", () => {
+					const scenarioName = `Remove a row in the middle ${count} times`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							for (let i = 0; i < count; i++) {
+								const row = table.rows[Math.floor(table.rows.length / 2)];
+								table.removeRows([row]);
+							}
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table) => {
+							for (let i = 0; i < count; i++) {
+								const row = table.rows[Math.floor(table.rows.length / 2)];
+								table.removeRows([row]);
+							}
+						},
+						operation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.undo();
+							}
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								const row = table.rows[Math.floor(table.rows.length / 2)];
+								table.removeRows([row]);
+							}
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.undo();
+							}
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
+							for (let i = 0; i < count; i++) {
+								undoRedoManager.redo();
+							}
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 				});
 
-				// Test the execute time of undoing remove a row in the middle for a given number of times.
-				runBenchmark({
-					title: `Undo: ${scenarioName}`,
-					tableSize,
-					initialCellValue,
-					beforeOperation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRows([row]);
-						}
-						assert(undoRedoManager.canUndo);
-					},
-					operation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							undoRedoManager.undo();
-						}
-					},
-					afterOperation: (table, undoRedoManager) => {
-						assert(!undoRedoManager.canUndo);
-					},
-					maxBenchmarkDurationSeconds,
-				});
+				describe("Batch row removal", () => {
+					const scenarioName = `Remove ${count} rows from the middle of the table`;
+					runBenchmark({
+						title: scenarioName,
+						tableSize,
+						initialCellValue,
+						operation: (table) => {
+							table.removeRows(
+								Math.floor(table.rows.length / 2) - Math.floor(count / 2),
+								count,
+							);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 
-				// Test the execute time of the SharedTree for redoing a remove row in the middle for a given number of times.
-				runBenchmark({
-					title: `Redo: ${scenarioName}`,
-					tableSize,
-					initialCellValue,
-					beforeOperation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
-							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRows([row]);
-						}
-						for (let i = 0; i < count; i++) {
+					runBenchmark({
+						title: `Undo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.removeRows(
+								Math.floor(table.rows.length / 2) - Math.floor(count / 2),
+								count,
+							);
+							assert(undoRedoManager.canUndo);
+						},
+						operation: (table, undoRedoManager) => {
 							undoRedoManager.undo();
-						}
-						assert(!undoRedoManager.canUndo);
-						assert(undoRedoManager.canRedo);
-					},
-					operation: (table, undoRedoManager) => {
-						for (let i = 0; i < count; i++) {
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canUndo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
+
+					runBenchmark({
+						title: `Redo: ${scenarioName}`,
+						tableSize,
+						initialCellValue,
+						beforeOperation: (table, undoRedoManager) => {
+							table.removeRows(
+								Math.floor(table.rows.length / 2) - Math.floor(count / 2),
+								count,
+							);
+							undoRedoManager.undo();
+							assert(!undoRedoManager.canUndo);
+							assert(undoRedoManager.canRedo);
+						},
+						operation: (table, undoRedoManager) => {
 							undoRedoManager.redo();
-						}
-					},
-					afterOperation: (table, undoRedoManager) => {
-						assert(!undoRedoManager.canRedo);
-					},
-					maxBenchmarkDurationSeconds,
+						},
+						afterOperation: (table, undoRedoManager) => {
+							assert(!undoRedoManager.canRedo);
+						},
+						maxBenchmarkDurationSeconds,
+					});
 				});
 			});
 


### PR DESCRIPTION
Batch insertion and deletion of rows and columns is a common case, but was not previously captured by our table benchmarks. This PR adds those cases and does some misc. cleanup in the benchmarks.