### PR TITLE
improvement(test-runtime-utils): Add `flushSomeMessages()` to `MockContainerRuntime`

### DIFF
--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
@@ -73,6 +73,7 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
     // (undocumented)
     finalizeIdRange(range: IdCreationRange): void;
     flush(): void;
+    flushSomeMessages(numMessages: number): void;
     // (undocumented)
     get isDirty(): boolean;
     protected maybeProcessIdAllocationMessage(message: ISequencedDocumentMessage): boolean;

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -153,7 +153,17 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_MockFluidDataStoreRuntime": {
+				"forwardCompat": false
+			},
+			"Class_MockContainerRuntimeForReconnection": {
+				"forwardCompat": false
+			},
+			"Class_MockContainerRuntime": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -378,6 +378,9 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 	 * This can be useful when simulating staging mode, and we only want to flush certain messages.
 	 */
 	public flushSomeMessages(numMessages: number): void {
+		if (!Number.isInteger(numMessages) || numMessages < 0) {
+			throw new Error("flushSomeMessages: numMessages must be a non-negative integer");
+		}
 		if (this.runtimeOptions.flushMode !== FlushMode.TurnBased) {
 			return;
 		}

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -373,6 +373,54 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 	}
 
 	/**
+	 * If flush mode is set to FlushMode.TurnBased, it will send the specified number of messages queued since
+	 * the last time this method was called. Otherwise, calling the method does nothing.
+	 * This can be useful when simulating staging mode, and we only want to flush certain messages.
+	 */
+	public flushSomeMessages(numMessages: number): void {
+		if (this.runtimeOptions.flushMode !== FlushMode.TurnBased) {
+			return;
+		}
+
+		// This mimics the runtime behavior of the IdCompressor by generating an IdAllocationOp
+		// and sticking it in front of any op that might rely on that id. It differs slightly in that
+		// in the actual runtime it would get put in its own separate batch
+		const idAllocationOp = this.generateIdAllocationOp();
+		if (idAllocationOp !== undefined) {
+			this.idAllocationOutbox.push(idAllocationOp);
+		}
+
+		// As with the runtime behavior, we need to send the idAllocationOps first
+		const allMessages = this.idAllocationOutbox.concat(this.outbox);
+		const messagesToSubmit = allMessages.slice(0, numMessages);
+
+		// Remove the processed messages from the outboxes
+		const idAllocationCount = this.idAllocationOutbox.length;
+		if (numMessages >= idAllocationCount) {
+			// All id allocation messages and some regular messages are being processed
+			this.idAllocationOutbox.length = 0;
+			this.outbox.splice(0, numMessages - idAllocationCount);
+		} else {
+			// Only some id allocation messages are being processed
+			this.idAllocationOutbox.splice(0, numMessages);
+		}
+
+		let fakeClientSequenceNumber = 1;
+		messagesToSubmit.forEach((message) => {
+			this.submitInternal(
+				message,
+				// When grouped batching is used, the ops within the same grouped batch will have
+				// fake sequence numbers when they're ungrouped. The submit function will still
+				// return the clientSequenceNumber but this will ensure that the readers will always
+				// read the fake client sequence numbers.
+				this.runtimeOptions.enableGroupedBatching
+					? fakeClientSequenceNumber++
+					: this.deltaManager.clientSequenceNumber,
+			);
+		});
+	}
+
+	/**
 	 * If flush mode is set to FlushMode.TurnBased, it will rebase the current batch by resubmitting them
 	 * to the data stores. Otherwise, calling the method does nothing.
 	 *

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -40,6 +40,7 @@ declare type current_as_old_for_Class_MockAudience = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_MockContainerRuntime": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntime = requireAssignableTo<TypeOnly<old.MockContainerRuntime>, TypeOnly<current.MockContainerRuntime>>
 
 /*
@@ -94,6 +95,7 @@ declare type current_as_old_for_Class_MockContainerRuntimeFactoryForReconnection
  * typeValidation.broken:
  * "Class_MockContainerRuntimeForReconnection": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntimeForReconnection = requireAssignableTo<TypeOnly<old.MockContainerRuntimeForReconnection>, TypeOnly<current.MockContainerRuntimeForReconnection>>
 
 /*
@@ -184,6 +186,7 @@ declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<old.MockFluidDataStoreRuntime>, TypeOnly<current.MockFluidDataStoreRuntime>>
 
 /*


### PR DESCRIPTION
## Description

This PR adds `flushSomeMessages()` to `MockContainerRuntime`. Similar to `flush` but will only flush the specified number of messages queued since the last time `flush` or `flushSomeMessages` was called. This is intended to help simulate staging mode scenarios where we may want to flush the pending ops queued prior to entering staging mode and not flush the ops queued since entering staging mode.