### PR TITLE
docs(client): deprecate submitMessage on FluidDataStoreRuntime and MockFluidDataStoreRuntime

### DIFF
--- a/.changeset/loose-squids-battle.md
+++ b/.changeset/loose-squids-battle.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/datastore": minor
+"@fluidframework/test-runtime-utils": minor
+"__section": deprecation
+---
+Deprecate submitMessage on FluidDataStoreRuntime and MockFluidDataStoreRuntime
+
+As needed, access `submitMessage` via `IFluidDataStoreContext`/`IFluidParentContext`. See https://github.com/microsoft/FluidFramework/issues/24406 for details.

--- a/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
@@ -92,7 +92,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
-    // (undocumented)
+    // @deprecated
     submitMessage(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
     submitSignal(type: string, content: unknown, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1158,6 +1158,11 @@ export class FluidDataStoreRuntime
 		}
 	}
 
+	/**
+	 * Do not use.
+	 * @deprecated - Use `IFluidDataStoreContext.submitMessage` instead.
+	 * @see https://github.com/microsoft/FluidFramework/issues/24406
+	 */
 	public submitMessage(
 		type: DataStoreMessageType,
 		// TODO: use something other than `any` here (breaking change)

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1160,7 +1160,7 @@ export class FluidDataStoreRuntime
 
 	/**
 	 * Do not use.
-	 * @deprecated - Use `IFluidDataStoreContext.submitMessage` instead.
+	 * @deprecated Use `IFluidDataStoreContext.submitMessage` instead.
 	 * @see https://github.com/microsoft/FluidFramework/issues/24406
 	 */
 	public submitMessage(

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
@@ -496,7 +496,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     submitMessage(type: MessageType, content: any): null;
     // (undocumented)
     submitSignal(type: string, content: any): null;

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -1017,6 +1017,10 @@ export class MockFluidDataStoreRuntime
 		return null;
 	}
 
+	/**
+	 * @deprecated - Use `IFluidDataStoreContext.submitMessage` instead.
+	 * @see https://github.com/microsoft/FluidFramework/issues/24406
+	 */
 	public submitMessage(type: MessageType, content: any) {
 		return null;
 	}

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -1018,7 +1018,7 @@ export class MockFluidDataStoreRuntime
 	}
 
 	/**
-	 * @deprecated - Use `IFluidDataStoreContext.submitMessage` instead.
+	 * @deprecated Use `IFluidDataStoreContext.submitMessage` instead.
 	 * @see https://github.com/microsoft/FluidFramework/issues/24406
 	 */
 	public submitMessage(type: MessageType, content: any) {


### PR DESCRIPTION
As needed callers can, access `submitMessage` via `IFluidDataStoreContext`/`IFluidParentContext`.