### PR TITLE
refactor(tree): Misc. cleanup in table schema APIs

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, fail } from "@fluidframework/core-utils/internal";
+import { fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { Tree, TreeAlpha } from "./shared-tree/index.js";

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -769,30 +769,19 @@ export namespace System_TableSchema {
 						// Note, throwing an error within a transaction will abort the entire transaction.
 						// So if we throw an error here for any column, no columns will be removed.
 						for (const columnToRemove of columnsToRemove) {
-							this._removeColumn(columnToRemove);
+							// Remove the corresponding cell from all rows.
+							for (const row of this.rows) {
+								// TypeScript is unable to narrow the row type correctly here, hence the cast.
+								// See: https://github.com/microsoft/TypeScript/issues/52144
+								(row as RowValueType).removeCell(columnToRemove);
+							}
+
+							// We have already validated that all of the columns exist above, so this is safe.
+							this.columns.removeAt(this.columns.indexOf(columnToRemove));
 						}
 					});
 					return columnsToRemove;
 				}
-			}
-
-			private _removeColumn(columnOrId: string | ColumnValueType): ColumnValueType {
-				const column = this._getColumn(columnOrId);
-				const index = this.columns.indexOf(column);
-				assert(index !== -1, "Column should exist");
-
-				this._applyEditsInBatch(() => {
-					// Remove the corresponding cell from all rows.
-					for (const row of this.rows) {
-						// TypeScript is unable to narrow the row type correctly here, hence the cast.
-						// See: https://github.com/microsoft/TypeScript/issues/52144
-						(row as RowValueType).removeCell(column);
-					}
-
-					this.columns.removeAt(index);
-				});
-
-				return column;
 			}
 
 			public removeRows(
@@ -834,20 +823,11 @@ export namespace System_TableSchema {
 					// Note, throwing an error within a transaction will abort the entire transaction.
 					// So if we throw an error here for any row, no rows will be removed.
 					for (const rowToRemove of rowsToRemove) {
-						this._removeRow(rowToRemove);
+						// We have already validated that all of the rows exist above, so this is safe.
+						this.rows.removeAt(this.rows.indexOf(rowToRemove));
 					}
 				});
 				return rowsToRemove;
-			}
-
-			private _removeRow(rowOrId: string | RowValueType): RowValueType {
-				const rowToRemove = this._getRow(rowOrId);
-
-				const index = this.rows.indexOf(rowToRemove);
-				assert(index !== -1, "Row should exist");
-
-				this.rows.removeAt(index);
-				return rowToRemove;
 			}
 
 			public removeCell(

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -928,24 +928,24 @@ export namespace System_TableSchema {
 			}
 
 			/**
-			 * Attempts to resolve a Column node or ID to a Column node.
-			 * If a node is provided, it is returned as-is.
-			 * If an ID is provided, we check the table for the corresponding Column node and return it if it exists, otherwise undefined.
+			 * Attempts to resolve the provided Column node or ID to a Column node in the table.
+			 * Returns `undefined` if there is no match.
+			 * @remarks Searches for a match based strictly on the ID and returns that result.
 			 */
 			private _tryGetColumn(
 				columnOrId: string | ColumnValueType,
 			): ColumnValueType | undefined {
-				return typeof columnOrId === "string" ? this.getColumn(columnOrId) : columnOrId;
+				const columnId = this._getColumnId(columnOrId);
+				return this.getColumn(columnId);
 			}
 
 			/**
-			 * Attempts to resolve a Column node or ID to a Column node.
-			 * If a node is provided, it is returned as-is.
-			 * If an ID is provided, we check the table for the corresponding Column node and return it if it exists, otherwise we throw an exception.
+			 * Attempts to resolve the provided Column node or ID to a Column node in the table.
+			 * @throws Throws a `UsageError` if there is no match.
+			 * @remarks Searches for a match based strictly on the ID and returns that result.
 			 */
 			private _getColumn(columnOrId: string | ColumnValueType): ColumnValueType {
-				const column =
-					typeof columnOrId === "string" ? this.getColumn(columnOrId) : columnOrId;
+				const column = this._tryGetColumn(columnOrId);
 				if (column === undefined) {
 					this._throwMissingColumnError(this._getColumnId(columnOrId));
 				}
@@ -1001,21 +1001,22 @@ export namespace System_TableSchema {
 			}
 
 			/**
-			 * Attempts to resolve a Row node or ID to a Row node.
-			 * If a node is provided, it is returned as-is.
-			 * If an ID is provided, we check the table for the corresponding Row node and return it if it exists, otherwise undefined.
+			 * Attempts to resolve the provided Row node or ID to a Row node in the table.
+			 * Returns `undefined` if there is no match.
+			 * @remarks Searches for a match based strictly on the ID and returns that result.
 			 */
 			private _tryGetRow(rowOrId: string | RowValueType): RowValueType | undefined {
-				return typeof rowOrId === "string" ? this.getRow(rowOrId) : rowOrId;
+				const rowId = this._getRowId(rowOrId);
+				return this.getRow(rowId);
 			}
 
 			/**
-			 * Attempts to resolve a Row node or ID to a Row node.
-			 * If a node is provided, it is returned as-is.
-			 * If an ID is provided, we check the table for the corresponding Row node and return it if it exists, otherwise we throw an exception.
+			 * Attempts to resolve the provided Row node or ID to a Row node in the table.
+			 * @throws Throws a `UsageError` if there is no match.
+			 * @remarks Searches for a match based strictly on the ID and returns that result.
 			 */
 			private _getRow(rowOrId: string | RowValueType): RowValueType {
-				const row = typeof rowOrId === "string" ? this.getRow(rowOrId) : rowOrId;
+				const row = this._tryGetRow(rowOrId);
 				if (row === undefined) {
 					this._throwMissingRowError(this._getRowId(rowOrId));
 				}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -958,24 +958,10 @@ export namespace System_TableSchema {
 			}
 
 			/**
-			 * Attempts to resolve a Column node or ID to its index in the table.
-			 * Returns undefined if the Column does not exist in the table.
-			 */
-			private _getColumnIndex(columnOrId: string | ColumnValueType): number | undefined {
-				const column = this._tryGetColumn(columnOrId);
-				if (column === undefined) {
-					return undefined;
-				}
-
-				const index = this.columns.indexOf(column);
-				return index === -1 ? undefined : index;
-			}
-
-			/**
 			 * Checks if a Column with the specified ID exists in the table.
 			 */
 			private _containsColumnWithId(columnId: string): boolean {
-				return this._getColumnIndex(columnId) !== undefined;
+				return this._tryGetColumn(columnId) !== undefined;
 			}
 
 			/**
@@ -1015,26 +1001,6 @@ export namespace System_TableSchema {
 			 */
 			private _getRowId(rowOrId: string | RowValueType): string {
 				return typeof rowOrId === "string" ? rowOrId : rowOrId.id;
-			}
-
-			/**
-			 * Attempts to resolve a Row node or ID to its index in the table.
-			 * Returns undefined if the Row does not exist in the table.
-			 */
-			private _getRowIndex(rowOrId: string | RowValueType): number | undefined {
-				const row = this._tryGetRow(rowOrId);
-				if (row === undefined) {
-					return undefined;
-				}
-				const index = this.rows.indexOf(row);
-				return index === -1 ? undefined : index;
-			}
-
-			/**
-			 * Checks if a Column with the specified ID exists in the table.
-			 */
-			private _containsRowWithId(rowId: string): boolean {
-				return this._getRowIndex(rowId) !== undefined;
 			}
 
 			/**


### PR DESCRIPTION
Removes a few private methods that really aren't needed, clears up some semantics regarding node id resolution, and removes nested transactions in column deletion.