### PR TITLE
fix(build-cli): Fix `readArgValues` in `generateEntrypoints`

### DIFF
--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -67,7 +67,11 @@ interface Options {
 	readonly outFileSuffix: string;
 }
 
-const optionDefaults = {
+/**
+ * {@link Options} defaults.
+ * @privateRemarks Exported for testing.
+ */
+export const optionDefaults = {
 	mainEntrypoint: "./src/index.ts",
 	outDir: "./lib",
 	outFilePrefix: "",
@@ -367,16 +371,16 @@ function getOutputConfiguration(
  * @param commandLine - command line to extract from
  * @param argQuery - record of arguments to read (keys) with default values
  * @returns record of argument values extracted or given default value
+ * @privateRemarks Exported for testing.
  */
-function readArgValues(commandLine: string, argQuery: Options): Options {
-	const values: Record<string, string | undefined> = {};
+export function readArgValues(commandLine: string, argQuery: Options): Options {
 	const args = commandLine.split(" ");
 
 	const argValues: Record<string, string | undefined> = {};
 	for (const argName of Object.keys(argQuery)) {
 		const indexOfArgValue = args.indexOf(`--${argName}`) + 1;
 		if (0 < indexOfArgValue && indexOfArgValue < args.length) {
-			values[argName] = args[indexOfArgValue];
+			argValues[argName] = args[indexOfArgValue];
 		}
 	}
 	return {

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+	optionDefaults,
+	readArgValues,
+} from "../../../library/commands/generateEntrypoints.js";
+
+describe("generateEntrypoints", () => {
+	it("readArgValues", () => {
+		expect(readArgValues("", optionDefaults)).to.deep.equal(optionDefaults);
+
+		expect(
+			readArgValues("--outFileLegacyBeta legacy   --outDir ./dist", optionDefaults),
+		).to.deep.equal({
+			...optionDefaults,
+			outDir: "./dist",
+			outFileLegacyBeta: "legacy",
+		});
+
+		expect(readArgValues("--outDir ./lib", optionDefaults)).to.deep.equal({
+			...optionDefaults,
+			outDir: "./lib",
+		});
+	});
+});


### PR DESCRIPTION
This bug was introduced in `0.58.0`. `readArgValues` incorrectly dropped input arguments, always falling back to the script defaults. This is now fixed.

With regression tests.

Cherry picks #25340