### PR TITLE
bump(build-tools): Workspace version to `0.58.1` to match recently bumped package versions

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "build-tools-release-group-root",
-	"version": "0.58.0",
+	"version": "0.58.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
#25343 Missed bumping the root workspace version to match the updated package versions.