### PR TITLE
(compat) Removed deprecated properties from IContainerStorageService and IRuntimeStorageService

### DIFF
--- a/.changeset/heavy-bugs-thank.md
+++ b/.changeset/heavy-bugs-thank.md
@@ -1,0 +1,26 @@
+---
+"@fluidframework/container-definitions": minor
+"@fluidframework/runtime-definitions": minor
+"__section": breaking
+---
+Removed deprecated properties from "IRuntimeStorageService" and "IContainerStorageService"
+
+The following deprecated properties have been removed from `IRuntimeStorageService`:
+
+- `disposed`
+- `dispose`
+- `policies`
+- `getSnapshotTree`
+- `getSnapshot`
+- `getVersions`
+- `createBlob`
+- `uploadSummaryWithContext`
+- `downloadSummary`
+
+The following deprecated properties have been removed from `IContainerStorageService`:
+
+- `downloadSummary`
+- `disposed`
+- `dispose`
+
+The deprecations were announced in release 2.52.0 [here](https://github.com/microsoft/FluidFramework/releases/tag/client_v2.52.0).

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -209,12 +209,6 @@ export type IContainerPolicies = {
 // @beta @legacy
 export interface IContainerStorageService {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
-    // @deprecated
-    dispose?(error?: Error): void;
-    // @deprecated
-    readonly disposed?: boolean;
-    // @deprecated
-    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
     getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
     getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
     getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -110,7 +110,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IContainerContext": {
+				"backCompat": false
+			},
+			"Interface_IContainerStorageService": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -26,7 +26,6 @@ import type {
 	ISnapshotFetchOptions,
 	FetchSource,
 	IDocumentStorageServicePolicies,
-	ISummaryHandle,
 } from "@fluidframework/driver-definitions/internal";
 
 import type { IAudience } from "./audience.js";
@@ -144,25 +143,6 @@ export interface IBatchMessage {
  */
 export interface IContainerStorageService {
 	/**
-	 * Whether or not the object has been disposed.
-	 * If true, the object should be considered invalid, and its other state should be disregarded.
-	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the Runtime layer.
-	 */
-	readonly disposed?: boolean;
-
-	/**
-	 * Dispose of the object and its resources.
-	 * @param error - Optional error indicating the reason for the disposal, if the object was
-	 * disposed as the result of an error.
-	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the Runtime layer.
-	 */
-	dispose?(error?: Error): void;
-
-	/**
 	 * Policies implemented/instructed by driver.
 	 *
 	 * @deprecated - This will be removed in a future release. The Runtime layer only needs `maximumCacheDurationMs`
@@ -230,15 +210,6 @@ export interface IContainerStorageService {
 	 * Returns the uploaded summary handle.
 	 */
 	uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
-
-	/**
-	 * Retrieves the commit that matches the packfile handle. If the packfile has already been committed and the
-	 * server has deleted it this call may result in a broken promise.
-	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the Runtime and below layers.
-	 */
-	downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
 }
 
 /**

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -211,6 +211,7 @@ declare type old_as_current_for_Interface_IContainerContext = requireAssignableT
  * typeValidation.broken:
  * "Interface_IContainerContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerContext = requireAssignableTo<TypeOnly<current.IContainerContext>, TypeOnly<old.IContainerContext>>
 
 /*
@@ -265,6 +266,7 @@ declare type old_as_current_for_Interface_IContainerStorageService = requireAssi
  * typeValidation.broken:
  * "Interface_IContainerStorageService": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerStorageService = requireAssignableTo<TypeOnly<current.IContainerStorageService>, TypeOnly<old.IContainerStorageService>>
 
 /*

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -154,7 +154,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IDataObjectProps": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -319,4 +319,5 @@ declare type old_as_current_for_Interface_IDataObjectProps = requireAssignableTo
  * typeValidation.broken:
  * "Interface_IDataObjectProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IDataObjectProps = requireAssignableTo<TypeOnly<current.IDataObjectProps>, TypeOnly<old.IDataObjectProps>>

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -32,6 +32,7 @@ import type {
 	ReadOnlyInfo,
 	ILoader,
 	ILoaderOptions,
+	IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { isFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import {
@@ -54,7 +55,6 @@ import {
 import {
 	type IDocumentService,
 	type IDocumentServiceFactory,
-	type IDocumentStorageService,
 	type IResolvedUrl,
 	type ISnapshot,
 	type IThrottlingWarning,
@@ -1886,7 +1886,7 @@ export class Container
 
 	private async initializeProtocolStateFromSnapshot(
 		attributes: IDocumentAttributes,
-		storage: IDocumentStorageService,
+		storage: IContainerStorageService,
 		snapshot: ISnapshotTree | undefined,
 	): Promise<void> {
 		const quorumSnapshot: IQuorumSnapshot = {

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -10,7 +10,7 @@ import type {
 } from "@fluidframework/container-definitions/internal";
 import type { IDisposable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import type { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import type {
 	FetchSource,
 	IDocumentService,
@@ -250,16 +250,6 @@ export class ContainerStorageAdapter
 
 	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
 		return this._storageService.createBlob(file);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.downloadSummary}.
-	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the Runtime and below layers.
-	 */
-	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
-		return this._storageService.downloadSummary(handle);
 	}
 }
 

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -101,7 +101,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IContainerRuntime": {
+				"backCompat": false
+			},
+			"Interface_IContainerRuntimeWithResolveHandle_Deprecated": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
@@ -22,6 +22,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Interface_IContainerRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerRuntime = requireAssignableTo<TypeOnly<current.IContainerRuntime>, TypeOnly<old.IContainerRuntime>>
 
 /*
@@ -49,6 +50,7 @@ declare type old_as_current_for_Interface_IContainerRuntimeWithResolveHandle_Dep
  * typeValidation.broken:
  * "Interface_IContainerRuntimeWithResolveHandle_Deprecated": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerRuntimeWithResolveHandle_Deprecated = requireAssignableTo<TypeOnly<current.IContainerRuntimeWithResolveHandle_Deprecated>, TypeOnly<old.IContainerRuntimeWithResolveHandle_Deprecated>>
 
 /*

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -218,7 +218,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_LoadContainerRuntimeParams": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
+++ b/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
@@ -3,20 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type {
-	FetchSource,
-	ICreateBlobResponse,
-	IDocumentStorageServicePolicies,
-	ISnapshot,
-	ISnapshotFetchOptions,
-	ISnapshotTree,
-	ISummaryContext,
-	ISummaryHandle,
-	ISummaryTree,
-	IVersion,
-} from "@fluidframework/driver-definitions/internal";
 import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * IRuntimeStorageService proxy which intercepts requests if they can be satisfied by the blobs received in the
@@ -28,14 +15,6 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		private readonly attachBlobs: Map<string, ArrayBufferLike>,
 	) {}
 
-	/**
-	 * {@link IRuntimeStorageService.policies}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public get policies(): IDocumentStorageServicePolicies | undefined {
-		return this.internalStorageService.policies;
-	}
-
 	public async readBlob(id: string): Promise<ArrayBufferLike> {
 		const blob = this.attachBlobs.get(id);
 		if (blob !== undefined) {
@@ -45,76 +24,5 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		// Note that it is intentional not to cache the result of this readBlob - we'll trust the real
 		// IRuntimeStorageService to cache appropriately, no need to double-cache.
 		return this.internalStorageService.readBlob(id);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.getSnapshotTree}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public async getSnapshotTree(
-		version?: IVersion,
-		scenarioName?: string,
-		// eslint-disable-next-line @rushstack/no-new-null
-	): Promise<ISnapshotTree | null> {
-		return this.internalStorageService.getSnapshotTree(version, scenarioName);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.getSnapshot}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public async getSnapshot(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot> {
-		if (this.internalStorageService.getSnapshot !== undefined) {
-			return this.internalStorageService.getSnapshot(snapshotFetchOptions);
-		}
-		throw new UsageError(
-			"getSnapshot api should exist on internal storage in documentStorageServiceProxy class",
-		);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.getVersions}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public async getVersions(
-		// eslint-disable-next-line @rushstack/no-new-null
-		versionId: string | null,
-		count: number,
-		scenarioName?: string,
-		fetchSource?: FetchSource,
-	): Promise<IVersion[]> {
-		return this.internalStorageService.getVersions(
-			versionId,
-			count,
-			scenarioName,
-			fetchSource,
-		);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.uploadSummaryWithContext}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public async uploadSummaryWithContext(
-		summary: ISummaryTree,
-		context: ISummaryContext,
-	): Promise<string> {
-		return this.internalStorageService.uploadSummaryWithContext(summary, context);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.createBlob}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
-		return this.internalStorageService.createBlob(file);
-	}
-
-	/**
-	 * {@link IRuntimeStorageService.downloadSummary}.
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
-	 */
-	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
-		return this.internalStorageService.downloadSummary(handle);
 	}
 }

--- a/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
@@ -6,9 +6,11 @@
 import { strict as assert } from "node:assert";
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { AttachState } from "@fluidframework/container-definitions/internal";
+import {
+	AttachState,
+	type IContainerStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { BlobManager, type IBlobManagerRuntime } from "../blobManager/index.js";
@@ -80,7 +82,7 @@ describe("BlobHandles", () => {
 			stashedBlobs: {},
 			localBlobIdGenerator: () => "localId",
 			isBlobDeleted: () => false,
-			storage: failProxy<IRuntimeStorageService>({
+			storage: failProxy<Pick<IContainerStorageService, "createBlob" | "readBlob">>({
 				createBlob: async () => {
 					return { id: "blobId" };
 				},
@@ -119,7 +121,7 @@ describe("BlobHandles", () => {
 			},
 			stashedBlobs: {},
 			localBlobIdGenerator: () => "localId",
-			storage: failProxy<IRuntimeStorageService>({
+			storage: failProxy<Pick<IContainerStorageService, "createBlob" | "readBlob">>({
 				createBlob: async () => {
 					count++;
 					return { id: "blobId", minTTLInSeconds: count < 3 ? -1 : undefined };

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -11,7 +11,10 @@ import {
 	bufferToString,
 	gitHashFile,
 } from "@fluid-internal/client-utils";
-import { AttachState } from "@fluidframework/container-definitions/internal";
+import {
+	AttachState,
+	type IContainerStorageService,
+} from "@fluidframework/container-definitions/internal";
 import type { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions/internal";
 import type {
 	ConfigTypes,
@@ -24,10 +27,7 @@ import type {
 } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { type IClientDetails, SummaryType } from "@fluidframework/driver-definitions";
-import type {
-	IRuntimeStorageService,
-	ISequencedMessageEnvelope,
-} from "@fluidframework/runtime-definitions/internal";
+import type { ISequencedMessageEnvelope } from "@fluidframework/runtime-definitions/internal";
 import {
 	isFluidHandleInternalPayloadPending,
 	isFluidHandlePayloadPending,
@@ -55,7 +55,7 @@ import {
 
 const MIN_TTL = 24 * 60 * 60; // same as ODSP
 abstract class BaseMockBlobStorage
-	implements Pick<IRuntimeStorageService, "readBlob" | "createBlob">
+	implements Pick<IContainerStorageService, "readBlob" | "createBlob">
 {
 	public blobs: Map<string, ArrayBufferLike> = new Map();
 	public abstract createBlob(blob: ArrayBufferLike);
@@ -117,16 +117,16 @@ export class MockRuntime
 
 	public disposed: boolean = false;
 
-	public get storage(): IRuntimeStorageService {
+	public get storage(): IContainerStorageService {
 		return (this.attachState === AttachState.Detached
 			? this.detachedStorage
-			: this.attachedStorage) as unknown as IRuntimeStorageService;
+			: this.attachedStorage) as unknown as IContainerStorageService;
 	}
 
 	private processing = false;
 	public unprocessedBlobs = new Set();
 
-	public getStorage(): IRuntimeStorageService {
+	public getStorage(): IContainerStorageService {
 		return {
 			createBlob: async (blob: ArrayBufferLike) => {
 				if (this.processing) {
@@ -147,7 +147,7 @@ export class MockRuntime
 				return P;
 			},
 			readBlob: async (id: string) => this.storage.readBlob(id),
-		} as unknown as IRuntimeStorageService;
+		} as unknown as IContainerStorageService;
 	}
 
 	public sendBlobAttachOp(localId: string, blobId?: string): void {

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -18,6 +18,7 @@ import {
 	ContainerErrorTypes,
 	type IContainerContext,
 	type IBatchMessage,
+	type IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type {
@@ -241,7 +242,7 @@ describe("Runtime", () => {
 	const mockClientId = "mockClientId";
 
 	// Mock the storage layer so "submitSummary" works.
-	const defaultMockStorage: Partial<IRuntimeStorageService> = {
+	const defaultMockStorage: Partial<IContainerStorageService> = {
 		uploadSummaryWithContext: async (summary: ISummaryTree, context: ISummaryContext) => {
 			return "fakeHandle";
 		},
@@ -250,7 +251,7 @@ describe("Runtime", () => {
 		params: {
 			settings?: Record<string, ConfigTypes>;
 			logger?: ITelemetryBaseLogger;
-			mockStorage?: Partial<IRuntimeStorageService>;
+			mockStorage?: Partial<IContainerStorageService>;
 			loadedFromVersion?: IVersion;
 			baseSnapshot?: ISnapshotTree;
 			connected?: boolean;
@@ -297,7 +298,7 @@ describe("Runtime", () => {
 			},
 			clientId,
 			connected,
-			storage: mockStorage as IRuntimeStorageService,
+			storage: mockStorage as IContainerStorageService,
 			baseSnapshot,
 		} satisfies Partial<IContainerContext>;
 

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -679,6 +679,7 @@ declare type old_as_current_for_Interface_LoadContainerRuntimeParams = requireAs
  * typeValidation.broken:
  * "Interface_LoadContainerRuntimeParams": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_LoadContainerRuntimeParams = requireAssignableTo<TypeOnly<current.LoadContainerRuntimeParams>, TypeOnly<old.LoadContainerRuntimeParams>>
 
 /*

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -301,25 +301,7 @@ export interface IRuntimeMessagesContent {
 
 // @beta @legacy
 export interface IRuntimeStorageService {
-    // @deprecated (undocumented)
-    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
-    // @deprecated
-    dispose?(error?: Error): void;
-    // @deprecated
-    readonly disposed?: boolean;
-    // @deprecated (undocumented)
-    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
-    // @deprecated (undocumented)
-    getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
-    // @deprecated (undocumented)
-    getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
-    // @deprecated (undocumented)
-    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
-    // @deprecated (undocumented)
-    readonly policies?: IDocumentStorageServicePolicies | undefined;
     readBlob(id: string): Promise<ArrayBufferLike>;
-    // @deprecated (undocumented)
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 }
 
 // @beta @legacy

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -107,7 +107,20 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"Interface_IFluidDataStoreContextDetached": {
+				"backCompat": false
+			},
+			"Interface_IFluidParentContext": {
+				"backCompat": false
+			},
+			"Interface_IRuntimeStorageService": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -8,16 +8,6 @@ import type {
 	ITree,
 	ISignalMessage,
 	ISequencedDocumentMessage,
-	IDocumentStorageServicePolicies,
-	IVersion,
-	ISnapshotTree,
-	ISnapshotFetchOptions,
-	ISnapshot,
-	FetchSource,
-	ICreateBlobResponse,
-	ISummaryTree,
-	ISummaryHandle,
-	ISummaryContext,
 } from "@fluidframework/driver-definitions/internal";
 
 /**
@@ -142,73 +132,4 @@ export interface IRuntimeStorageService {
 	 * Reads the object with the given ID, returns content in arrayBufferLike
 	 */
 	readBlob(id: string): Promise<ArrayBufferLike>;
-
-	/**
-	 * Whether or not the object has been disposed.
-	 * If true, the object should be considered invalid, and its other state should be disregarded.
-	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	readonly disposed?: boolean;
-
-	/**
-	 * Dispose of the object and its resources.
-	 * @param error - Optional error indicating the reason for the disposal, if the object was
-	 * disposed as the result of an error.
-	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	dispose?(error?: Error): void;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	readonly policies?: IDocumentStorageServicePolicies | undefined;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	// eslint-disable-next-line @rushstack/no-new-null
-	getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	getVersions(
-		// TODO: use `undefined` instead.
-		// eslint-disable-next-line @rushstack/no-new-null
-		versionId: string | null,
-		count: number,
-		scenarioName?: string,
-		fetchSource?: FetchSource,
-	): Promise<IVersion[]>;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
-
-	/**
-	 * @deprecated - This will be removed in a future release. No replacement is planned as
-	 * it is unused in the DataStore layer.
-	 */
-	downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -229,6 +229,7 @@ declare type old_as_current_for_Interface_IFluidDataStoreContext = requireAssign
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContext = requireAssignableTo<TypeOnly<current.IFluidDataStoreContext>, TypeOnly<old.IFluidDataStoreContext>>
 
 /*
@@ -247,6 +248,7 @@ declare type old_as_current_for_Interface_IFluidDataStoreContextDetached = requi
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContextDetached": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContextDetached = requireAssignableTo<TypeOnly<current.IFluidDataStoreContextDetached>, TypeOnly<old.IFluidDataStoreContextDetached>>
 
 /*
@@ -319,6 +321,7 @@ declare type old_as_current_for_Interface_IFluidParentContext = requireAssignabl
  * typeValidation.broken:
  * "Interface_IFluidParentContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidParentContext = requireAssignableTo<TypeOnly<current.IFluidParentContext>, TypeOnly<old.IFluidParentContext>>
 
 /*
@@ -445,6 +448,7 @@ declare type old_as_current_for_Interface_IRuntimeStorageService = requireAssign
  * typeValidation.broken:
  * "Interface_IRuntimeStorageService": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IRuntimeStorageService = requireAssignableTo<TypeOnly<current.IRuntimeStorageService>, TypeOnly<old.IRuntimeStorageService>>
 
 /*

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -153,7 +153,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_MockFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"ClassStatics_MockFluidDataStoreContext": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -175,6 +175,7 @@ declare type old_as_current_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssignableTo<TypeOnly<current.MockFluidDataStoreContext>, TypeOnly<old.MockFluidDataStoreContext>>
 
 /*
@@ -364,6 +365,7 @@ declare type current_as_old_for_ClassStatics_MockDeltaQueue = requireAssignableT
  * typeValidation.broken:
  * "ClassStatics_MockFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_MockFluidDataStoreContext = requireAssignableTo<TypeOnly<typeof current.MockFluidDataStoreContext>, TypeOnly<typeof old.MockFluidDataStoreContext>>
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -10,6 +10,7 @@ import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import type { SharedCounter } from "@fluidframework/counter/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
@@ -542,9 +543,11 @@ describeCompat(
 					"Storage should be present in detached data store",
 				);
 				let success1: boolean | undefined;
-				await defaultDataStore.context.storage.getSnapshotTree(undefined).catch((err) => {
-					success1 = false;
-				});
+				await (defaultDataStore.context.containerRuntime as IContainerRuntime).storage
+					.getSnapshotTree(undefined)
+					.catch((err) => {
+						success1 = false;
+					});
 				assert(
 					success1 === false,
 					"Snapshot fetch should not be allowed in detached data store",
@@ -559,9 +562,11 @@ describeCompat(
 					"Storage should be present in rehydrated data store",
 				);
 				let success2: boolean | undefined;
-				await defaultDataStore2.context.storage.getSnapshotTree(undefined).catch((err) => {
-					success2 = false;
-				});
+				await (defaultDataStore2.context.containerRuntime as IContainerRuntime).storage
+					.getSnapshotTree(undefined)
+					.catch((err) => {
+						success2 = false;
+					});
 				assert(
 					success2 === false,
 					"Snapshot fetch should not be allowed in rehydrated data store",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -162,7 +162,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IProvideTestFluidObject": {
+				"backCompat": false
+			},
+			"Interface_ITestFluidObject": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -85,6 +85,7 @@ declare type old_as_current_for_Interface_IProvideTestFluidObject = requireAssig
  * typeValidation.broken:
  * "Interface_IProvideTestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IProvideTestFluidObject = requireAssignableTo<TypeOnly<current.IProvideTestFluidObject>, TypeOnly<old.IProvideTestFluidObject>>
 
 /*
@@ -103,4 +104,5 @@ declare type old_as_current_for_Interface_ITestFluidObject = requireAssignableTo
  * typeValidation.broken:
  * "Interface_ITestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ITestFluidObject = requireAssignableTo<TypeOnly<current.ITestFluidObject>, TypeOnly<old.ITestFluidObject>>


### PR DESCRIPTION
## Description

Removed deprecated properties from "IRuntimeStorageService" and "IContainerStorageService"

The following deprecated properties have been removed from `IRuntimeStorageService`:

- `disposed`
- `dispose`
- `policies`
- `getSnapshotTree`
- `getSnapshot`
- `getVersions`
- `createBlob`
- `uploadSummaryWithContext`
- `downloadSummary`

The following deprecated properties have been removed from `IContainerStorageService`:

- `downloadSummary`
- `disposed`
- `dispose`

## Breaking Changes

This is a breaking change. The deprecations were announced in release 2.52.0 [here](https://github.com/microsoft/FluidFramework/releases/tag/client_v2.52.0).