### PR TITLE
test(client): e2e imports avoiding /internal

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
+++ b/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 const importInternalModulesAllowedForTest = [
 	// Allow import of Fluid Framework external API exports.
 	"@fluidframework/*/{beta,alpha,legacy}",

--- a/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
+++ b/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
@@ -2,6 +2,26 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+const importInternalModulesAllowedForTest = [
+	// Allow import of Fluid Framework external API exports.
+	"@fluidframework/*/{beta,alpha,legacy}",
+	"fluid-framework/{beta,alpha,legacy}",
+
+	// Allow import of Fluid Framework non-production test-utils APIs.
+	"@fluidframework/*/test-utils",
+
+	// Allow imports from sibling and ancestral sibling directories,
+	// but not from cousin directories. Parent is allowed but only
+	// because there isn't a known way to deny it.
+	"*/index.js",
+
+	// Should `telemetry-utils` provide support through `/test-utils` instead of `/internal`?
+	"@fluidframework/telemetry-utils/internal",
+
+	// Should `test-*utils` provide support through `/test-utils` instead of `/internal`?
+	"@fluidframework/test-utils/internal",
+	"@fluidframework/test-runtime-utils/internal",
+];
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
@@ -28,6 +48,12 @@ module.exports = {
 			rules: {
 				// Some deprecated APIs are permissible in tests; use `warn` to keep them visible
 				"import/no-deprecated": "warn",
+				"import/no-internal-modules": [
+					"error",
+					{
+						allow: importInternalModulesAllowedForTest,
+					},
+				],
 			},
 		},
 	],

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureClientFactory.ts
@@ -5,24 +5,22 @@
 
 import {
 	AzureClient,
-	type AzureClientPropsInternal,
 	type AzureLocalConnectionConfig,
 	type AzureRemoteConnectionConfig,
 	type ITelemetryBaseLogger,
-} from "@fluidframework/azure-client/internal";
+} from "@fluidframework/azure-client";
+// eslint-disable-next-line import/no-internal-modules -- TODO consider a test exposure to avoid /internal
+import type { AzureClientPropsInternal } from "@fluidframework/azure-client/internal";
 import {
 	AzureClient as AzureClientLegacy,
 	type AzureLocalConnectionConfig as AzureLocalConnectionConfigLegacy,
 	type AzureRemoteConnectionConfig as AzureRemoteConnectionConfigLegacy,
 	type ITelemetryBaseLogger as ITelemetryBaseLoggerLegacy,
 } from "@fluidframework/azure-client-legacy";
-import type { IRuntimeFactory } from "@fluidframework/container-definitions/internal";
+import type { IRuntimeFactory } from "@fluidframework/container-definitions/legacy";
 import type { IConfigProviderBase } from "@fluidframework/core-interfaces";
-import { ScopeType } from "@fluidframework/driver-definitions/internal";
-import type {
-	CompatibilityMode,
-	ContainerSchema,
-} from "@fluidframework/fluid-static/internal";
+import { ScopeType } from "@fluidframework/driver-definitions/legacy";
+import type { CompatibilityMode, ContainerSchema } from "@fluidframework/fluid-static";
 import {
 	type MockLogger,
 	createChildLogger,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ITokenProvider } from "@fluidframework/azure-client";
-import type { ScopeType } from "@fluidframework/driver-definitions/internal";
+import type { ScopeType } from "@fluidframework/driver-definitions/legacy";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 
 export function createAzureTokenProvider(

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -5,16 +5,17 @@
 
 import type { SignalListener } from "@fluid-experimental/data-objects";
 import { EventEmitter } from "@fluid-internal/client-utils";
+// eslint-disable-next-line import/no-internal-modules -- TODO consider a test exposure to avoid /internal
+import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import {
 	DataObject,
 	DataObjectFactory,
 	type IDataObjectProps,
-	createDataObjectKind,
-} from "@fluidframework/aqueduct/internal";
+} from "@fluidframework/aqueduct/legacy";
 import type { IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
-import { SharedCounter } from "@fluidframework/counter/internal";
-import type { Jsonable } from "@fluidframework/datastore-definitions/internal";
-import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
+import { SharedCounter } from "@fluidframework/counter/legacy";
+import type { Jsonable } from "@fluidframework/datastore-definitions/legacy";
+import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/legacy";
 
 class TestDataObjectClass extends DataObject {
 	public static readonly Name = "@fluid-example/test-data-object";

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
@@ -9,7 +9,7 @@ import type { AzureClient, AzureContainerServices } from "@fluidframework/azure-
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
-import { SharedMap } from "@fluidframework/map/internal";
+import { SharedMap } from "@fluidframework/map/legacy";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import type { AxiosResponse } from "axios";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -13,18 +13,19 @@ import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-inte
 import {
 	MessageType,
 	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+} from "@fluidframework/driver-definitions/legacy";
+// eslint-disable-next-line import/no-internal-modules -- TODO consider a test exposure to avoid /internal
+import { isTreeContainerSchema } from "@fluidframework/fluid-static/internal";
 import {
 	type ContainerSchema,
 	createTreeContainerRuntimeFactory,
-	isTreeContainerSchema,
 	type IFluidContainer,
-} from "@fluidframework/fluid-static/internal";
-import { SharedMap } from "@fluidframework/map/internal";
+} from "@fluidframework/fluid-static/legacy";
+import { SharedMap } from "@fluidframework/map/legacy";
 import { SharedMap as SharedMapLegacy } from "@fluidframework/map-legacy";
 import { MockLogger, UsageError } from "@fluidframework/telemetry-utils/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
-import { SharedTree } from "@fluidframework/tree/internal";
+import { SharedTree } from "@fluidframework/tree/legacy";
 import type { AxiosResponse } from "axios";
 import type { SinonSandbox } from "sinon";
 import { createSandbox } from "sinon";

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/ddsTests.spec.ts
@@ -9,7 +9,7 @@ import type { AzureClient } from "@fluidframework/azure-client";
 import { ConnectionState } from "@fluidframework/container-loader";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
-import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
+import { type ISharedMap, SharedMap } from "@fluidframework/map/legacy";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import type { AxiosResponse } from "axios";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.ts
@@ -22,7 +22,6 @@ import {
 	type LatestRaw,
 	type LatestMapRaw,
 	type StatesWorkspace,
-	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/presence/beta";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
@@ -32,15 +31,10 @@ import { createAzureTokenProvider } from "../AzureTokenFactory.js";
 import { TestDataObject } from "../TestDataObject.js";
 import type { configProvider } from "../utils.js";
 
-import type { MessageFromChild, MessageToChild } from "./messageTypes.js";
+import type { MessageFromChild, MessageToChild, UserIdAndName } from "./messageTypes.js";
 
 type MessageFromParent = MessageToChild;
 type MessageToParent = Required<MessageFromChild>;
-interface UserIdAndName {
-	id: string;
-	name: string;
-}
-
 const connectTimeoutMs = 10_000;
 // Identifier given to child process
 const process_id = process.argv[2];

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -3,10 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import type { AzureUser } from "@fluidframework/azure-client/internal";
-import type { JsonSerializable } from "@fluidframework/core-interfaces/internal";
 // eslint-disable-next-line import/no-internal-modules
+import type { JsonSerializable } from "@fluidframework/core-interfaces/internal";
 import type { AttendeeId } from "@fluidframework/presence/beta";
+
+export interface UserIdAndName {
+	id: string;
+	name: string;
+}
 
 /**
  * Message types sent from the orchestrator to the child processes
@@ -35,7 +39,7 @@ interface PingCommand {
  */
 export interface ConnectCommand {
 	command: "connect";
-	user: AzureUser;
+	user: UserIdAndName;
 	/**
 	 * The ID of the Fluid container to connect to.
 	 * If not provided, a new Fluid container will be created.

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -5,7 +5,6 @@
 
 import { fork, type ChildProcess } from "node:child_process";
 
-// eslint-disable-next-line import/no-internal-modules
 import type { AttendeeId } from "@fluidframework/presence/beta";
 import { timeoutAwait, timeoutPromise } from "@fluidframework/test-utils/internal";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "node:assert";
 import type { ChildProcess } from "node:child_process";
 
-// eslint-disable-next-line import/no-internal-modules
 import type { AttendeeId } from "@fluidframework/presence/beta";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
@@ -9,16 +9,10 @@ import type { AzureClient } from "@fluidframework/azure-client";
 import { ConnectionState } from "@fluidframework/container-loader";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
-import { TreeViewConfiguration, SchemaFactory, type TreeView } from "@fluidframework/tree";
-import {
-	allowUnused,
-	asTreeViewAlpha,
-	SharedTree,
-	Tree,
-	TreeStatus,
-	type Revertible,
-	type ValidateRecursiveSchema,
-} from "@fluidframework/tree/internal";
+import type { Revertible, TreeView, ValidateRecursiveSchema } from "@fluidframework/tree";
+import { SchemaFactory, Tree, TreeStatus, TreeViewConfiguration } from "@fluidframework/tree";
+import { allowUnused, asTreeViewAlpha } from "@fluidframework/tree/alpha";
+import { SharedTree } from "@fluidframework/tree/legacy";
 import type { AxiosResponse } from "axios";
 
 import {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/utils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/utils.ts
@@ -6,7 +6,7 @@
 import type { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import type { IMember } from "@fluidframework/fluid-static";
-import type { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
+import type { ISharedMap, IValueChanged } from "@fluidframework/map/legacy";
 
 export const waitForMember = async (
 	audience: IAzureAudience,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "node:assert";
 import type { AzureClient } from "@fluidframework/azure-client";
 import { ConnectionState } from "@fluidframework/container-loader";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
-import { SharedMap } from "@fluidframework/map/internal";
+import { SharedMap } from "@fluidframework/map/legacy";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import type { AxiosResponse } from "axios";
 


### PR DESCRIPTION
apart from explicit test utils and some exceptions.

Explicitly allow /alpha, /beta, and /legacy without lint suppression.