### PR TITLE
test(client): support read-only clients

### DIFF
--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -46,7 +46,7 @@ export class InsecureTokenProvider implements ITokenProvider {
 		 *
 		 * @remarks Common use of this parameter is to allow write for container
 		 * attach and just read for all other access. Effectively can create a
-		 * create and then read-only client.
+		 * container and then read-only client.
 		 *
 		 * @param attachContainerScopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
 		 *

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -41,7 +41,7 @@ export class InsecureTokenProvider implements ITokenProvider {
 
 		/**
 		 * Optional. Override of attach container scopes. If a param is not provided,
-		 * InsecureTokenProvider will use the value of {@link scopes}.
+		 * InsecureTokenProvider will use the value of {@link InsecureTokenProvider.scopes}.
 		 *
 		 * @remarks Common use of this parameter is to allow write for container
 		 * attach and just read for all other access. Effectively can create a
@@ -49,7 +49,7 @@ export class InsecureTokenProvider implements ITokenProvider {
 		 *
 		 * @param attachContainerScopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
 		 *
-		 * @defaultValue {@link scopes}
+		 * @defaultValue {@link InsecureTokenProvider.scopes}
 		 */
 		private readonly attachContainerScopes?: ScopeType[],
 	) {}

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -15,6 +15,7 @@ import { IInsecureUser } from "./insecureUsers.js";
  *
  * As the name implies, this is not secure and should not be used in production.
  * It simply makes examples where authentication is not relevant easier to bootstrap.
+ * @sealed
  * @internal
  */
 export class InsecureTokenProvider implements ITokenProvider {
@@ -54,10 +55,7 @@ export class InsecureTokenProvider implements ITokenProvider {
 		private readonly attachContainerScopes?: ScopeType[],
 	) {}
 
-	private readonly fetchToken = async (
-		tenantId: string,
-		documentId?: string,
-	): Promise<ITokenResponse> => {
+	private async fetchToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
 		const generalScopes = this.scopes ?? [
 			ScopeType.DocRead,
 			ScopeType.DocWrite,
@@ -68,9 +66,9 @@ export class InsecureTokenProvider implements ITokenProvider {
 			fromCache: true,
 			jwt: generateToken(tenantId, this.tenantKey, scopes, documentId, this.user),
 		};
-	};
+	}
 
-	public readonly fetchOrdererToken = this.fetchToken;
+	public readonly fetchOrdererToken = this.fetchToken.bind(this);
 
-	public readonly fetchStorageToken = this.fetchToken;
+	public readonly fetchStorageToken = this.fetchToken.bind(this);
 }

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
@@ -11,6 +11,7 @@ export function createAzureTokenProvider(
 	id: string,
 	name: string,
 	scopes?: ScopeType[],
+	attachScopes?: ScopeType[],
 ): ITokenProvider {
 	const key = process.env.azure__fluid__relay__service__key as string;
 	if (key) {
@@ -18,7 +19,7 @@ export function createAzureTokenProvider(
 			id,
 			name,
 		};
-		return new InsecureTokenProvider(key, userConfig, scopes);
+		return new InsecureTokenProvider(key, userConfig, scopes, attachScopes);
 	} else {
 		throw new Error("Cannot create token provider.");
 	}

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -5,6 +5,7 @@
 
 // eslint-disable-next-line import/no-internal-modules
 import type { JsonSerializable } from "@fluidframework/core-interfaces/internal";
+import type { ScopeType } from "@fluidframework/driver-definitions/legacy";
 import type { AttendeeId } from "@fluidframework/presence/beta";
 
 export interface UserIdAndName {
@@ -40,6 +41,8 @@ interface PingCommand {
 export interface ConnectCommand {
 	command: "connect";
 	user: UserIdAndName;
+	scopes: ScopeType[];
+	createScopes?: ScopeType[];
 	/**
 	 * The ID of the Fluid container to connect to.
 	 * If not provided, a new Fluid container will be created.

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -149,7 +149,10 @@ export async function connectChildProcesses(
 			attendeeIdPromises.push(Promise.resolve(containerCreatorAttendeeId));
 			continue;
 		}
-		const message = composeConnectMessage(index);
+		// TODO: AB#45620: "Presence: perf: update Join pattern for scale" can handle
+		// larger counts of read-only attendees. Without protocol changes tests with
+		// 20+ attendees exceed current limits.
+		const message = composeConnectMessage(index, [ScopeType.DocWrite]);
 		message.containerId = containerId;
 		attendeeIdPromises.push(
 			new Promise<AttendeeId>((resolve, reject) => {


### PR DESCRIPTION
Update presence multi-client testing to have tests with a single writer and all others read only.

Add test infrastructure support to have uniquely reader clients in a session. Token provider need only specify write scope during attach.

```
  Presence with AzureClient
    ✔ announces 'attendeeConnected' when remote client joins session [5 clients, 5 writers]
    ✔ announces 'attendeeDisconnected' when remote client disconnects [5 clients, 5 writers]
    ✔ announces 'attendeeConnected' when remote client joins session [5 clients, 1 writers]
    ✔ announces 'attendeeDisconnected' when remote client disconnects [5 clients, 1 writers]
    ✔ announces 'attendeeConnected' when remote client joins session [20 clients, 20 writers]
    ✔ announces 'attendeeDisconnected' when remote client disconnects [20 clients, 20 writers]
    ✔ announces 'attendeeConnected' when remote client joins session [20 clients, 1 writers]
    - announces 'attendeeDisconnected' when remote client disconnects [20 clients, 1 writers]
```