### PR TITLE
test(client): debuggability via console or debugger

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -35,7 +35,8 @@
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7071 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
 		"test:realsvc:tinylicious:run": "npm run test:realsvc:azure:run -- --driver=t9s",
-		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
+		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=msgs npm run test:realsvc",
+		"test:realsvc:veryverbose": "cross-env FLUID_TEST_VERBOSE=msgs+telem npm run test:realsvc"
 	},
 	"c8": {
 		"all": true,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -33,7 +33,7 @@ const childLoggingVerbosity = process.env.FLUID_TEST_VERBOSE ?? "none";
 /**
  * Capture console./warn/error before test infrastructure alters it.
  */
-const testConsole = {
+export const testConsole = {
 	log: console.log,
 	warn: console.warn,
 	error: console.error,


### PR DESCRIPTION
Console logging updates:
- Log extra error from test process to console without mocha redirection
- Use FLUID_TEST_VERBOSE to control child logging to optionally output messaging and select telemetry

Under debugger updates:
- For longer test cases, modify that case's timeout without impacting general timeouts.
- Detect when debugger is attached and alter timeouts to increase by x1000