### PR TITLE
ci: Bump benchmark pipeline timeout to account for new tests

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -101,7 +101,7 @@ stages:
     - job: perf_unit_tests_runtime
       displayName: Perf unit tests - runtime
       pool: ${{ parameters.poolBuild }}
-      timeoutInMinutes: 90
+      timeoutInMinutes: 120
       steps:
       - template: /tools/pipelines/templates/include-test-perf-benchmarks.yml@self
         parameters:


### PR DESCRIPTION
PR #25325 added more benchmark tests for `tree`, which has caused the benchmarks pipeline to start timing out. This PR bumps the timeout to account for the new tests.