### PR TITLE
Bump client package versions to 2.60.1 and update typetests

### DIFF
--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-local-service",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Local implementation of the Azure Fluid Relay service for testing/development use",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-service-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Helper service-side utilities for connecting to Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -95,7 +95,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.57.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.53.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/ai-collab",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example app that showcases the experimental package for AI collaboration in Fluid-based applications.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/blobs",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example of using blobs in Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/collaborative-textarea",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "A minimal example using the react collaborative-textarea",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/contact-collection",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example of using a Fluid Object as a collection of items",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/data-object-grid",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Data object grid creates child data objects from a registry and lays them out in a grid.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/presence-tracker",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example application that tracks page focus and mouse position using the Fluid Framework presence features.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/staging",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Using the experimental staging feature.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/task-selection",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example demonstrating selecting a unique task amongst connected Fluid clients",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-cli-app/package.json
+++ b/examples/apps/tree-cli-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-cli-app",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "SharedTree CLI app demo",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-comparison",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Comparing API usage in legacy SharedTree and new SharedTree.",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-baseline",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-common",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/experimental-tree/package.json
+++ b/examples/benchmarks/bubblebench/experimental-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-experimental-tree",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-ot",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/shared-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-shared-tree",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/odspsnapshotfetch-perftestapp",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Benchmark binary vs. json download",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/tablebench",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Table focused benchmarks",
 	"homepage": "https://fluidframework.com",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-insights-logger",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Provides a simple Fluid application with a UI view written in React to test the Fluid App Insights telemetry logger that will route typical Fluid telemetry to configured Azure App Insights",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/canvas",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Fluid ink canvas",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/clicker",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal Fluid component sample to implement a collaborative counter.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/codemirror",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/diceroller",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Object sample to implement a collaborative dice roller.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/inventory-app",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal sample of SharedTree/React integration.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/monaco",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Monaco code editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-model",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Constellation model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-view",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-container",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Container for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-model",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Coordinate model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-interface",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Interface for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-plot-coordinate-view",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-slider-coordinate-view",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-triangle-view",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/prosemirror",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "ProseMirror",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/smde",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-document",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Chaincode component containing a table's data",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/examples/data-objects/table-tree/package.json
+++ b/examples/data-objects/table-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-tree",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Simple table example app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/todo",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Simple todo canvas.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webflow",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Collaborative markdown editor.",
 	"homepage": "https://fluidframework.com",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-data",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Integrating an external data source with Fluid data.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-controller",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/todo-list/package.json
+++ b/examples/service-clients/azure-client/todo-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/azure-client-todo-list",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal Fluid Container sample demonstrating the use of SharedTree and nested DDSs via a simple to-do list application.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/shared-tree-demo",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "A shared tree demo using react and odsp client",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bundle-size-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "A package for understanding the bundle size of Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Shared utilities used by examples.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/import-testing",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "import-testing",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/migration-tools",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Tools for migrating data",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webpack-fluid-loader",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Fluid object loader for webpack-dev-server",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-live-schema-upgrade",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example application that demonstrates how to add a data object to a live container.",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-same-container",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in the same container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-separate-container",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in a new container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-shim",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Migrating from legacy SharedTree to new SharedTree using a tree shim.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-container-views",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal Fluid Container & data store sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-views",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/view-framework-sampler",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Example of integrating a Fluid data object with a variety of view frameworks.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-changeset",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "property changeset definitions and related functionalities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-common",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "common functions used in properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/platform-dependent",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Helper package that separates code for browser and server.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-dds",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "definition of the property distributed data store",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-properties",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "definitions of properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ot",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/src/packageVersion.ts
+++ b/experimental/dds/ot/ot/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ot";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sharejs-json1",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
+++ b/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sharejs-json1";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sequence-deprecated",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Deprecated distributed sequences",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/sequence-deprecated/src/packageVersion.ts
+++ b/experimental/dds/sequence-deprecated/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sequence-deprecated";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/tree",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-objects",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A collection of ready to use Fluid Data Objects",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/last-edited",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Tracks the last edited information in the Container.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/tree-react-api",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Experimental SharedTree API for React integration.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "client-release-group-root",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/client-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Not intended for use outside the Fluid Framework.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -143,7 +143,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.53.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.60.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.53.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid container definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -125,7 +125,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.53.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-interfaces",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid object interfaces",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Not intended for use outside the Fluid client repo.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.53.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.53.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid driver definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.53.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.60.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/cell",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed data structure for a single value",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/src/packageVersion.ts
+++ b/packages/dds/cell/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/cell";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/counter",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Counter DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -131,7 +131,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.53.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/dds/counter/src/packageVersion.ts
+++ b/packages/dds/counter/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/counter";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ink",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Ink DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ink/src/packageVersion.ts
+++ b/packages/dds/ink/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ink";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/legacy-dds/package.json
+++ b/packages/dds/legacy-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/legacy-dds",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Legacy DDSs for the Fluid Framework. These are not intended for use in new code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/legacy-dds/src/packageVersion.ts
+++ b/packages/dds/legacy-dds/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/legacy-dds";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.53.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/map",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed map",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/map/src/packageVersion.ts
+++ b/packages/dds/map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/map";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -161,7 +161,7 @@
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.53.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/matrix",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed matrix",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/matrix/src/packageVersion.ts
+++ b/packages/dds/matrix/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/matrix";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/merge-tree",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Merge tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -154,7 +154,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.53.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.53.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ordered-collection",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Consensus Collection",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/src/packageVersion.ts
+++ b/packages/dds/ordered-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/ordered-collection";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/pact-map",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed data structure for key-value pairs using pact consensus",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/pact-map/src/packageVersion.ts
+++ b/packages/dds/pact-map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/pact-map";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/register-collection",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Consensus Register",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.53.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/register-collection/src/packageVersion.ts
+++ b/packages/dds/register-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/register-collection";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/sequence",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed sequence",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -170,7 +170,7 @@
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.53.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
@@ -198,24 +198,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Interface_IInterval": {
-				"backCompat": false
-			},
-			"Interface_ISerializableInterval": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"Interface_SequenceInterval": {
-				"backCompat": false
-			},
-			"TypeAlias_IntervalRevertible": {
-				"backCompat": false
-			},
-			"TypeAlias_SharedStringRevertible": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/sequence/src/packageVersion.ts
+++ b/packages/dds/sequence/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/sequence";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -265,7 +265,6 @@ declare type old_as_current_for_Interface_IInterval = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Interface_IInterval": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IInterval = requireAssignableTo<TypeOnly<current.IInterval>, TypeOnly<old.IInterval>>
 
 /*
@@ -375,26 +374,6 @@ declare type old_as_current_for_Interface_ISequenceOverlappingIntervalsIndex = r
  * "Interface_ISequenceOverlappingIntervalsIndex": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_ISequenceOverlappingIntervalsIndex = requireAssignableTo<TypeOnly<current.ISequenceOverlappingIntervalsIndex>, TypeOnly<old.ISequenceOverlappingIntervalsIndex>>
-
-/*
- * Validate forward compatibility by using the old type in place of the current type.
- * If this test starts failing, it indicates a change that is not forward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "Interface_ISerializableInterval": {"forwardCompat": false}
- */
-// @ts-expect-error compatibility expected to be broken
-declare type old_as_current_for_Interface_ISerializableInterval = requireAssignableTo<TypeOnly<old.ISerializableInterval>, TypeOnly<current.ISerializableInterval>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "Interface_ISerializableInterval": {"backCompat": false}
- */
-// @ts-expect-error compatibility expected to be broken
-declare type current_as_old_for_Interface_ISerializableInterval = requireAssignableTo<TypeOnly<current.ISerializableInterval>, TypeOnly<old.ISerializableInterval>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -565,7 +544,6 @@ declare type old_as_current_for_Interface_SequenceInterval = requireAssignableTo
  * typeValidation.broken:
  * "Interface_SequenceInterval": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_SequenceInterval = requireAssignableTo<TypeOnly<current.SequenceInterval>, TypeOnly<old.SequenceInterval>>
 
 /*
@@ -656,7 +634,6 @@ declare type old_as_current_for_TypeAlias_IntervalRevertible = requireAssignable
  * typeValidation.broken:
  * "TypeAlias_IntervalRevertible": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IntervalRevertible = requireAssignableTo<TypeOnly<current.IntervalRevertible>, TypeOnly<old.IntervalRevertible>>
 
 /*
@@ -765,7 +742,6 @@ declare type old_as_current_for_TypeAlias_SharedStringRevertible = requireAssign
  * typeValidation.broken:
  * "TypeAlias_SharedStringRevertible": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_SharedStringRevertible = requireAssignableTo<TypeOnly<current.SharedStringRevertible>, TypeOnly<old.SharedStringRevertible>>
 
 /*

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-object-base",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid base class for shared distributed data structures",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.53.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-object-base/src/packageVersion.ts
+++ b/packages/dds/shared-object-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-object-base";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.53.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-summary-block",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A DDS that does not generate ops but is part of summary",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-summary-block/src/packageVersion.ts
+++ b/packages/dds/shared-summary-block/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-summary-block";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.53.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/task-manager",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed data structure for queueing exclusive tasks",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/task-manager/src/packageVersion.ts
+++ b/packages/dds/task-manager/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/task-manager";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-dds-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid DDS test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -196,7 +196,7 @@
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.53.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",

--- a/packages/dds/tree/src/packageVersion.ts
+++ b/packages/dds/tree/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tree";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/dds/tree/src/test/types/validateTreePrevious.generated.ts
+++ b/packages/dds/tree/src/test/types/validateTreePrevious.generated.ts
@@ -322,13 +322,13 @@ declare type current_as_old_for_Interface_NodeInDocumentConstraint = requireAssi
 declare type current_as_old_for_Interface_NodeSchemaMetadata = requireAssignableTo<TypeOnly<current.NodeSchemaMetadata>, TypeOnly<old.NodeSchemaMetadata>>
 
 /*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "Interface_NodeSchemaOptions": {"backCompat": false}
+ * "Interface_NodeSchemaOptions": {"forwardCompat": false}
  */
-declare type current_as_old_for_Interface_NodeSchemaOptions = requireAssignableTo<TypeOnly<current.NodeSchemaOptions>, TypeOnly<old.NodeSchemaOptions>>
+declare type old_as_current_for_Interface_NodeSchemaOptions = requireAssignableTo<TypeOnly<old.NodeSchemaOptions>, TypeOnly<current.NodeSchemaOptions>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -94,7 +94,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.53.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/debugger",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid Debugger - a tool to play through history of a file",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-base",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Shared driver code for Fluid driver implementations",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -111,7 +111,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.53.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/driver-base/src/packageVersion.ts
+++ b/packages/drivers/driver-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-base";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -101,7 +101,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.53.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-web-cache",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Implementation of the driver caching API for a web browser",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-web-cache/src/packageVersion.ts
+++ b/packages/drivers/driver-web-cache/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-web-cache";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.53.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/file-driver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A driver that reads/write from/to local file storage.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/local-driver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid local driver",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -141,7 +141,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.53.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/local-driver/src/packageVersion.ts
+++ b/packages/drivers/local-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/local-driver";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.53.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.53.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-driver/src/packageVersion.ts
+++ b/packages/drivers/odsp-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-driver";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.53.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-urlresolver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Url Resolver for odsp urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/replay-driver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Document replay version of Socket.IO implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.53.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-driver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Socket.IO + Git implementation of Fluid service API",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.53.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-driver";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-urlresolver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Url Resolver for routerlicious urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.53.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-driver",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Driver for tinylicious",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -99,7 +99,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.53.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/agent-scheduler",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Built in runtime object for distributing agents across instances of a container",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -103,7 +103,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.57.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.53.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/framework/ai-collab/package.json
+++ b/packages/framework/ai-collab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ai-collab",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Experimental package to simplify integrating AI into Fluid-based applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.57.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.53.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/aqueduct",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A set of implementations for Fluid Framework interfaces.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/attributor",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Operation attributor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -93,7 +93,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.57.0",
-		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.53.0",
+		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/app-insights-logger",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Contains a Fluid logging client that sends telemetry events to Azure App Insights",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-telemetry",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Customer facing Fluid telemetry types and classes for both producing and consuming said telemetry",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-object-base",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Data object base for synchronously and lazily loaded object scenarios",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/dds-interceptions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Distributed Data Structures that support an interception callback",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluid-framework",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "The main entry point into Fluid Framework public packages",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-static",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A tool to enable consumption of Fluid Data Objects without requiring custom container code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -139,7 +139,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.53.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.60.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/oldest-client-observer",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Data object to determine if the local client is the oldest amongst connected clients",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/presence",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A component for lightweight data sharing within a single session",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/request-handler",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A simple request handling library for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.53.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.53.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/synthesize",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A library for synthesizing scope objects.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent/package.json
+++ b/packages/framework/tree-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Experimental package to simplify integrating AI into Fluid-based applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/undo-redo",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Undo Redo",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.53.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -190,7 +190,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.53.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-loader",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid container loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/container-loader/src/packageVersion.ts
+++ b/packages/loader/container-loader/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-loader";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -131,7 +131,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.53.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Collection of utility functions for Fluid drivers",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/driver-utils/src/packageVersion.ts
+++ b/packages/loader/driver-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-utils";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-loader-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Mocks and other test utilities for the Fluid Framework Loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.53.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid container runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -197,7 +197,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.53.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/container-runtime/src/packageVersion.ts
+++ b/packages/runtime/container-runtime/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-runtime";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid data store definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.53.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -137,7 +137,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.53.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid data store implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore/src/packageVersion.ts
+++ b/packages/runtime/datastore/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/datastore";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.53.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/id-compressor",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "ID compressor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/id-compressor/src/packageVersion.ts
+++ b/packages/runtime/id-compressor/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/id-compressor";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -98,7 +98,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.53.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.53.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Collection of utility functions for Fluid Runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-utils/src/packageVersion.ts
+++ b/packages/runtime/runtime-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/runtime-utils";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-runtime-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid runtime test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.53.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
@@ -153,17 +153,7 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_MockFluidDataStoreRuntime": {
-				"forwardCompat": false
-			},
-			"Class_MockContainerRuntimeForReconnection": {
-				"forwardCompat": false
-			},
-			"Class_MockContainerRuntime": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -40,7 +40,6 @@ declare type current_as_old_for_Class_MockAudience = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_MockContainerRuntime": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntime = requireAssignableTo<TypeOnly<old.MockContainerRuntime>, TypeOnly<current.MockContainerRuntime>>
 
 /*
@@ -95,7 +94,6 @@ declare type current_as_old_for_Class_MockContainerRuntimeFactoryForReconnection
  * typeValidation.broken:
  * "Class_MockContainerRuntimeForReconnection": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntimeForReconnection = requireAssignableTo<TypeOnly<old.MockContainerRuntimeForReconnection>, TypeOnly<current.MockContainerRuntimeForReconnection>>
 
 /*
@@ -186,7 +184,6 @@ declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<old.MockFluidDataStoreRuntime>, TypeOnly<current.MockFluidDataStoreRuntime>>
 
 /*

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-client",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.57.0",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.53.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.60.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-end-to-end-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Azure client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/odsp-end-to-end-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Odsp client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-client",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the ODSP service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -109,7 +109,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.53.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-client",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Tinylicious service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/functional-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Functional tests",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-stress-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Stress tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/mocha-test-setup",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/mocha-test-setup/src/packageVersion.ts
+++ b/packages/test/mocha-test-setup/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/mocha-test-setup";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-snapshots",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Comprehensive test of snapshot logic.",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/snapshots/src/packageVersion.ts
+++ b/packages/test/snapshots/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-snapshots";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/stochastic-test-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Utilities for stochastic tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-driver-definitions",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-drivers",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/src/packageVersion.ts
+++ b/packages/test/test-drivers/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-drivers";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-end-to-end-tests",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-end-to-end-tests";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-pairwise-generator",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-service-load",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Service load tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/src/packageVersion.ts
+++ b/packages/test/test-service-load/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-service-load";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.53.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/test/test-utils/src/packageVersion.ts
+++ b/packages/test/test-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-utils";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-version-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-version-utils/src/packageVersion.ts
+++ b/packages/test/test-version-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-version-utils";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/test/types_jest-environment-puppeteer/package.json
+++ b/packages/test/types_jest-environment-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types/jest-environment-puppeteer",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "TypeScript `globals` definitions fix-up for jest-environment-puppeteer",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/changelog-generator-wrapper/package.json
+++ b/packages/tools/changelog-generator-wrapper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/changelog-generator-wrapper",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-browser-extension",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "A browser extension for visualizing Fluid Framework stats and operations",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -139,7 +139,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.53.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools-core",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid Framework developer tools core functionality",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-core/src/packageVersion.ts
+++ b/packages/tools/devtools/devtools-core/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/devtools-core";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/tools/devtools/devtools-test-app/package.json
+++ b/packages/tools/devtools/devtools-test-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/devtools-test-app",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "An example application demonstrating how Fluid's devtools can be integrated into an application",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-view",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Contains a visualization suite for use alongside the Fluid Devtools",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Fluid Framework developer tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -127,7 +127,7 @@
 		"@fluid-tools/build-cli": "^0.57.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.53.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.57.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.53.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/fetch-tool",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Console tool to fetch Fluid data from relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-runner",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Utility for running various functionality inside a Fluid Framework environment",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.53.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/replay-tool",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "A tool that lets the user to replay ops.",
 	"homepage": "https://fluidframework.com",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.53.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/isomorphic-fetch": "^0.0.39",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-doclib-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "ODSP utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/odsp-doclib-utils/src/packageVersion.ts
+++ b/packages/utils/odsp-doclib-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-doclib-utils";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/telemetry-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Collection of telemetry relates utilities for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.53.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -113,7 +113,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.57.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.53.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tool-utils",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"description": "Common utilities for Fluid tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/src/packageVersion.ts
+++ b/packages/utils/tool-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tool-utils";
-export const pkgVersion = "2.60.0";
+export const pkgVersion = "2.60.1";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30531,9 +30531,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -36464,33 +36464,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36504,13 +36504,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@2.53.0
-        version: '@fluidframework/azure-service-utils@2.53.0'
+        specifier: npm:@fluidframework/azure-service-utils@2.60.0
+        version: '@fluidframework/azure-service-utils@2.60.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -7367,8 +7367,8 @@ importers:
         specifier: ~1.9.3
         version: 1.9.4
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@2.53.0
-        version: '@fluid-internal/client-utils@2.53.0'
+        specifier: npm:@fluid-internal/client-utils@2.60.0
+        version: '@fluid-internal/client-utils@2.60.0'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7494,8 +7494,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@2.53.0
-        version: '@fluidframework/container-definitions@2.53.0'
+        specifier: npm:@fluidframework/container-definitions@2.60.0
+        version: '@fluidframework/container-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7536,8 +7536,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@2.53.0
-        version: '@fluidframework/core-interfaces@2.53.0'
+        specifier: npm:@fluidframework/core-interfaces@2.60.0
+        version: '@fluidframework/core-interfaces@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7602,8 +7602,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@2.53.0
-        version: '@fluidframework/core-utils@2.53.0'
+        specifier: npm:@fluidframework/core-utils@2.60.0
+        version: '@fluidframework/core-utils@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7675,8 +7675,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@2.53.0
-        version: '@fluidframework/driver-definitions@2.53.0'
+        specifier: npm:@fluidframework/driver-definitions@2.60.0
+        version: '@fluidframework/driver-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7745,8 +7745,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@2.53.0
-        version: '@fluidframework/cell@2.53.0'
+        specifier: npm:@fluidframework/cell@2.60.0
+        version: '@fluidframework/cell@2.60.0'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7839,8 +7839,8 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@2.53.0
-        version: '@fluidframework/counter@2.53.0'
+        specifier: npm:@fluidframework/counter@2.60.0
+        version: '@fluidframework/counter@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8148,8 +8148,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@2.53.0
-        version: '@fluidframework/map@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/map@2.60.0
+        version: '@fluidframework/map@2.60.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8272,8 +8272,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@2.53.0
-        version: '@fluidframework/matrix@2.53.0'
+        specifier: npm:@fluidframework/matrix@2.60.0
+        version: '@fluidframework/matrix@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8393,8 +8393,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@2.53.0
-        version: '@fluidframework/merge-tree@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/merge-tree@2.60.0
+        version: '@fluidframework/merge-tree@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8499,8 +8499,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@2.53.0
-        version: '@fluidframework/ordered-collection@2.53.0'
+        specifier: npm:@fluidframework/ordered-collection@2.60.0
+        version: '@fluidframework/ordered-collection@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8684,8 +8684,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@2.53.0
-        version: '@fluidframework/register-collection@2.53.0'
+        specifier: npm:@fluidframework/register-collection@2.60.0
+        version: '@fluidframework/register-collection@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8799,8 +8799,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@2.53.0
-        version: '@fluidframework/sequence@2.53.0'
+        specifier: npm:@fluidframework/sequence@2.60.0
+        version: '@fluidframework/sequence@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8917,8 +8917,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@2.53.0
-        version: '@fluidframework/shared-object-base@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/shared-object-base@2.60.0
+        version: '@fluidframework/shared-object-base@2.60.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9020,8 +9020,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@2.53.0
-        version: '@fluidframework/shared-summary-block@2.53.0'
+        specifier: npm:@fluidframework/shared-summary-block@2.60.0
+        version: '@fluidframework/shared-summary-block@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9129,8 +9129,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@2.53.0
-        version: '@fluidframework/task-manager@2.53.0'
+        specifier: npm:@fluidframework/task-manager@2.60.0
+        version: '@fluidframework/task-manager@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9368,8 +9368,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@2.53.0
-        version: '@fluidframework/tree@2.53.0'
+        specifier: npm:@fluidframework/tree@2.60.0
+        version: '@fluidframework/tree@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9465,8 +9465,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@2.53.0
-        version: '@fluidframework/debugger@2.53.0'
+        specifier: npm:@fluidframework/debugger@2.60.0
+        version: '@fluidframework/debugger@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9532,8 +9532,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@2.53.0
-        version: '@fluidframework/driver-base@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-base@2.60.0
+        version: '@fluidframework/driver-base@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9611,8 +9611,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@2.53.0
-        version: '@fluidframework/driver-web-cache@2.53.0'
+        specifier: npm:@fluidframework/driver-web-cache@2.60.0
+        version: '@fluidframework/driver-web-cache@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9687,8 +9687,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@2.53.0
-        version: '@fluidframework/file-driver@2.53.0'
+        specifier: npm:@fluidframework/file-driver@2.60.0
+        version: '@fluidframework/file-driver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9781,8 +9781,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@2.53.0
-        version: '@fluidframework/local-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/local-driver@2.60.0
+        version: '@fluidframework/local-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9884,8 +9884,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@2.53.0
-        version: '@fluidframework/odsp-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-driver@2.60.0
+        version: '@fluidframework/odsp-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9954,8 +9954,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@2.53.0
-        version: '@fluidframework/odsp-driver-definitions@2.53.0'
+        specifier: npm:@fluidframework/odsp-driver-definitions@2.60.0
+        version: '@fluidframework/odsp-driver-definitions@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.14.1)
@@ -10021,8 +10021,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@2.53.0
-        version: '@fluidframework/odsp-urlresolver@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-urlresolver@2.60.0
+        version: '@fluidframework/odsp-urlresolver@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10097,8 +10097,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@2.53.0
-        version: '@fluidframework/replay-driver@2.53.0'
+        specifier: npm:@fluidframework/replay-driver@2.60.0
+        version: '@fluidframework/replay-driver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10188,8 +10188,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@2.53.0
-        version: '@fluidframework/routerlicious-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/routerlicious-driver@2.60.0
+        version: '@fluidframework/routerlicious-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10279,8 +10279,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@2.53.0
-        version: '@fluidframework/routerlicious-urlresolver@2.53.0'
+        specifier: npm:@fluidframework/routerlicious-urlresolver@2.60.0
+        version: '@fluidframework/routerlicious-urlresolver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10364,8 +10364,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@2.53.0
-        version: '@fluidframework/tinylicious-driver@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-driver@2.60.0
+        version: '@fluidframework/tinylicious-driver@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10449,8 +10449,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@2.53.0
-        version: '@fluidframework/agent-scheduler@2.53.0'
+        specifier: npm:@fluidframework/agent-scheduler@2.60.0
+        version: '@fluidframework/agent-scheduler@2.60.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10643,8 +10643,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@2.53.0
-        version: '@fluidframework/aqueduct@2.53.0'
+        specifier: npm:@fluidframework/aqueduct@2.60.0
+        version: '@fluidframework/aqueduct@2.60.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10828,8 +10828,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
-        specifier: npm:@fluidframework/app-insights-logger@2.53.0
-        version: '@fluidframework/app-insights-logger@2.53.0(tslib@1.14.1)'
+        specifier: npm:@fluidframework/app-insights-logger@2.60.0
+        version: '@fluidframework/app-insights-logger@2.60.0(tslib@1.14.1)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11295,8 +11295,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@2.53.0
-        version: '@fluidframework/fluid-static@2.53.0'
+        specifier: npm:@fluidframework/fluid-static@2.60.0
+        version: '@fluidframework/fluid-static@2.60.0'
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11556,8 +11556,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@2.53.0
-        version: '@fluidframework/request-handler@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/request-handler@2.60.0
+        version: '@fluidframework/request-handler@2.60.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11638,8 +11638,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@2.53.0
-        version: '@fluidframework/synthesize@2.53.0'
+        specifier: npm:@fluidframework/synthesize@2.60.0
+        version: '@fluidframework/synthesize@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11832,8 +11832,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@2.53.0
-        version: '@fluidframework/undo-redo@2.53.0'
+        specifier: npm:@fluidframework/undo-redo@2.60.0
+        version: '@fluidframework/undo-redo@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11941,8 +11941,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@2.53.0
-        version: '@fluidframework/container-loader@2.53.0'
+        specifier: npm:@fluidframework/container-loader@2.60.0
+        version: '@fluidframework/container-loader@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12044,8 +12044,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@2.53.0
-        version: '@fluidframework/driver-utils@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-utils@2.60.0
+        version: '@fluidframework/driver-utils@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12226,8 +12226,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@2.53.0
-        version: '@fluidframework/container-runtime@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/container-runtime@2.60.0
+        version: '@fluidframework/container-runtime@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12317,8 +12317,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@2.53.0
-        version: '@fluidframework/container-runtime-definitions@2.53.0'
+        specifier: npm:@fluidframework/container-runtime-definitions@2.60.0
+        version: '@fluidframework/container-runtime-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12399,8 +12399,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@2.53.0
-        version: '@fluidframework/datastore@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/datastore@2.60.0
+        version: '@fluidframework/datastore@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12487,8 +12487,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@2.53.0
-        version: '@fluidframework/datastore-definitions@2.53.0'
+        specifier: npm:@fluidframework/datastore-definitions@2.60.0
+        version: '@fluidframework/datastore-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12560,8 +12560,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@2.53.0
-        version: '@fluidframework/id-compressor@2.53.0'
+        specifier: npm:@fluidframework/id-compressor@2.60.0
+        version: '@fluidframework/id-compressor@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12636,8 +12636,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@2.53.0
-        version: '@fluidframework/runtime-definitions@2.53.0'
+        specifier: npm:@fluidframework/runtime-definitions@2.60.0
+        version: '@fluidframework/runtime-definitions@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.14.1)
@@ -12715,8 +12715,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@2.53.0
-        version: '@fluidframework/runtime-utils@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/runtime-utils@2.60.0
+        version: '@fluidframework/runtime-utils@2.60.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12833,8 +12833,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@2.53.0
-        version: '@fluidframework/test-runtime-utils@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-runtime-utils@2.60.0
+        version: '@fluidframework/test-runtime-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12912,8 +12912,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@2.53.0
-        version: '@fluidframework/azure-client@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/azure-client@2.60.0
+        version: '@fluidframework/azure-client@2.60.0(encoding@0.1.13)'
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13390,8 +13390,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@2.53.0
-        version: '@fluidframework/tinylicious-client@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-client@2.60.0
+        version: '@fluidframework/tinylicious-client@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -14717,8 +14717,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@2.53.0
-        version: '@fluidframework/test-utils@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-utils@2.60.0
+        version: '@fluidframework/test-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -15023,8 +15023,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@2.53.0
-        version: '@fluidframework/devtools@2.53.0'
+        specifier: npm:@fluidframework/devtools@2.60.0
+        version: '@fluidframework/devtools@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15346,8 +15346,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@22.14.1)
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@2.53.0
-        version: '@fluidframework/devtools-core@2.53.0'
+        specifier: npm:@fluidframework/devtools-core@2.60.0
+        version: '@fluidframework/devtools-core@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15835,8 +15835,8 @@ importers:
         specifier: ^0.57.0
         version: 0.57.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@2.53.0
-        version: '@fluid-tools/fetch-tool@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluid-tools/fetch-tool@2.60.0
+        version: '@fluid-tools/fetch-tool@2.60.0(encoding@0.1.13)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -15917,8 +15917,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@2.53.0
-        version: '@fluidframework/fluid-runner@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/fluid-runner@2.60.0
+        version: '@fluidframework/fluid-runner@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16129,8 +16129,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@2.53.0
-        version: '@fluidframework/odsp-doclib-utils@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-doclib-utils@2.60.0
+        version: '@fluidframework/odsp-doclib-utils@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16214,8 +16214,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@2.53.0
-        version: '@fluidframework/telemetry-utils@2.53.0'
+        specifier: npm:@fluidframework/telemetry-utils@2.60.0
+        version: '@fluidframework/telemetry-utils@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16308,8 +16308,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@2.53.0
-        version: '@fluidframework/tool-utils@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tool-utils@2.60.0
+        version: '@fluidframework/tool-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -17442,14 +17442,14 @@ packages:
       '@types/react': '>=16.8.0 <19.0.0'
       react: '>=16.8.0 <19.0.0'
 
-  '@fluid-internal/client-utils@2.53.0':
-    resolution: {integrity: sha512-jP7VhFqxuSOc03VU/IRBYdt9pVs3gQrilvA72kY1tfD4UqGWW5gT9Azsb3hY4TunHpXUUKYYi1nIF2EIbFav8A==}
+  '@fluid-internal/client-utils@2.60.0':
+    resolution: {integrity: sha512-CeitAFYQvbEPpheSkdTEqMNk02nMrZRWJJso+613+AeWUjt2JJV5DwhxHG4qf5UnM4tJSOgL+A8GhPbd/7nnHg==}
 
   '@fluid-internal/eslint-plugin-fluid@0.1.5':
     resolution: {integrity: sha512-p0nVeMiEfLL2deQJQaRUxid08jgV5wEkh9h9WXNosR1BRq9nFCjD8nZpC1K+YhjwQZEvgGDE+s+28VR2lAg61Q==}
 
-  '@fluid-internal/test-driver-definitions@2.53.0':
-    resolution: {integrity: sha512-8aUZxDVXyhghZj+BmthJ4WUva0qUEeuft23JnvXFzmMXFgbK/OaQow9QwR9aWxox0pa49aNBTKY+76eHQeilwg==}
+  '@fluid-internal/test-driver-definitions@2.60.0':
+    resolution: {integrity: sha512-TJV5kd5UnLIhrFhUmEeD2SL89+uHWn2SwaN+PIKhQO+PDpsbtFdBrvYdFhfCocUjoMEo0t+KVMllO5lPnTmQow==}
 
   '@fluid-tools/benchmark@0.51.0':
     resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
@@ -17463,8 +17463,8 @@ packages:
     resolution: {integrity: sha512-b2Iw8tG1x/odBMldYG9oIH8OtU3RAX56mNcXOs6zWDNvZeA/xCIJNA2LWVki53yUnyICxLjQSlqS+oeX5BBARg==}
     hasBin: true
 
-  '@fluid-tools/fetch-tool@2.53.0':
-    resolution: {integrity: sha512-pvE3DEqU8g+J4O3G08xXiWo9k8GTAr/EGbgXoAufi/7EHEiJLbBUYdvtYd6naCRB3QK6VhcHUVj3OPQWaJ585w==}
+  '@fluid-tools/fetch-tool@2.60.0':
+    resolution: {integrity: sha512-ayu9Yl1j+4EdaSf0p8pb11+CrXTsxDbGQB33yZWQYEW6as5x2gxxLj2NC0N8uCMyJfAIHDh/HnvFFomvKhuFzg==}
     hasBin: true
 
   '@fluid-tools/version-tools@0.57.0':
@@ -17472,26 +17472,26 @@ packages:
     engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/agent-scheduler@2.53.0':
-    resolution: {integrity: sha512-rPlZnG7UFymb5YZS+Uo7kJNAIgpZCimyF22hrWPLAR+HeuomFWMlgK0+Uks6kZ3SSAK8fsqGONEBx20TAyOs3g==}
+  '@fluidframework/agent-scheduler@2.60.0':
+    resolution: {integrity: sha512-Amwq8AsY4ZKQ+JqCrd5yGsY9xUVbS+d/45jXJttd28HuurWV3R3xAioBDcYlADHAtTDNhrbBlcTRcmQMdrcbiw==}
 
-  '@fluidframework/app-insights-logger@2.53.0':
-    resolution: {integrity: sha512-1AFJotPLoATKZiMg+ATW1d3C807AWhoihmD2hWcS3oY8Qi/9ub+p4pkQOYAlMGU2ngymTdYxzoSY7HhSrr1Mrg==}
+  '@fluidframework/app-insights-logger@2.60.0':
+    resolution: {integrity: sha512-9BcDqcanYtPjugUq7HeawcQfuhIomL2N3T9cfgSZIeidIv+XPngXGwKyNvZEQYGTxKNNWA7wNB891MIbY68ciQ==}
 
   '@fluidframework/aqueduct@1.4.0':
     resolution: {integrity: sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==}
 
-  '@fluidframework/aqueduct@2.53.0':
-    resolution: {integrity: sha512-BvsadzAml8/wOTLE4ceQa5kycNZH9jF3UXbTkN3px8X/O/C3i1wqv+MxzX/FoSqmGd5zVB/9oaSw0Qrp+8036w==}
+  '@fluidframework/aqueduct@2.60.0':
+    resolution: {integrity: sha512-Nh0pyDRLQY8vU02ay7RQ7CNdhIBZcK3GV+I65hTi/G6wiDL09ofjmmTopnQ+Jpf9+p9UofXc5e+SROvOHtEQGw==}
 
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
 
-  '@fluidframework/azure-client@2.53.0':
-    resolution: {integrity: sha512-VVfpftNzLos5guN2b2Jp26uLiPse1q30xvAISwVTdHuAcHzCzWymbUFS5Okq5xKENl/AIJ6QepVhZD/4mCAcNg==}
+  '@fluidframework/azure-client@2.60.0':
+    resolution: {integrity: sha512-XTxEShhDzEdYi5IZ1o1xt04AXGRa9GCqqZczqMf64WC+nCZFeHSEvglgMroNn0do5OOsCs/C4ha4KWk5erFb3Q==}
 
-  '@fluidframework/azure-service-utils@2.53.0':
-    resolution: {integrity: sha512-KXm8i30XQ2+ZNj2aevFuz6rccxLO0wu7QEUbVVVw9Bz5LeqXZH5CMRELCFTcf4GZg4ygwwPcwXrOYYkV+rXBWQ==}
+  '@fluidframework/azure-service-utils@2.60.0':
+    resolution: {integrity: sha512-3RvCoaQMyTndkiIkZY0pCTp7cNZ/2TIVMDov3/o6lIT+UarMTeN434qLtvKS0l5JMBI2PiLKOnQ8cOyrn07bcw==}
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
@@ -17505,8 +17505,8 @@ packages:
   '@fluidframework/bundle-size-tools@0.57.0':
     resolution: {integrity: sha512-kPKm02xhVgwXX7X+UbvhsX3N/QO4Tc88fr7Xe6suXyzP3MCovFRkaktVM8i684g83oi9cL51fnTYES5q8r99sg==}
 
-  '@fluidframework/cell@2.53.0':
-    resolution: {integrity: sha512-L7uUAPMGZodkzKxZFwuuisddJPYlWvFciJk2FYzPT5IaRfaXWCbmdZ3EwIzX0t25E09eHxRomUcL6DWD/HSiOQ==}
+  '@fluidframework/cell@2.60.0':
+    resolution: {integrity: sha512-HGZTcac4RcEZ1tC45MqxeR1gCOcHansaF3zrTiyoT6ke8K8ADjSTJPlP3glWEa5fFTy1sQLpvw0dlfEpdKrrQA==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -17526,26 +17526,26 @@ packages:
   '@fluidframework/container-definitions@1.4.0':
     resolution: {integrity: sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==}
 
-  '@fluidframework/container-definitions@2.53.0':
-    resolution: {integrity: sha512-ESCohJoCpWDvm8drjXnah+MJ3VpxOexSZUddCixom2U2nApKiRJjrUam9TUUhvNAHq2XTFa9xfY9xN+QkrjeLw==}
+  '@fluidframework/container-definitions@2.60.0':
+    resolution: {integrity: sha512-mN5gGodT8NrmavsXSXhhBb8hcPyurZHex6MkBQ2pSveeitMBNA2TksTom+1jPRyQEPUf4ee2zWsaMtxCGY3nRw==}
 
   '@fluidframework/container-loader@1.4.0':
     resolution: {integrity: sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==}
 
-  '@fluidframework/container-loader@2.53.0':
-    resolution: {integrity: sha512-SicVJn3lN4J6ievb+6iP/AAzoTK525C6zgfA1UyHZUT50A7WkEerKGYP+ZflUXAgQL7HR3pAnqu8/sbYoO6cPA==}
+  '@fluidframework/container-loader@2.60.0':
+    resolution: {integrity: sha512-Yqh0nklNMtu2hpJBgb0RBccmbHKJfPPZYxbYMFEpAmWxsshkZzXdg5cbu6ZG1g2pH42IqaKDE8ziD3ChTurEFw==}
 
   '@fluidframework/container-runtime-definitions@1.4.0':
     resolution: {integrity: sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==}
 
-  '@fluidframework/container-runtime-definitions@2.53.0':
-    resolution: {integrity: sha512-GxcVZx8izyOHf46e9o41hDO58uFzarOTieOprVHjGobsgGlbC/aZre3RL2JdW0R+IMsatSGNRw2RMH5w1gczAQ==}
+  '@fluidframework/container-runtime-definitions@2.60.0':
+    resolution: {integrity: sha512-PIScG79w2SadO1ew8iqhnQp7QEglPvTP5vP8C4ZVGXcsKhCNJB9s20KymBbqWVrtMiXhdugcB1lUZOyFYLCzsg==}
 
   '@fluidframework/container-runtime@1.4.0':
     resolution: {integrity: sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==}
 
-  '@fluidframework/container-runtime@2.53.0':
-    resolution: {integrity: sha512-gI4HxTjdLXA+e+IKsiEt/GJ4otje9T3vhnb8yscX20uqlmawXjvOyuT8jYMdguVx1jmo8DRTiUPAL4Q3+WQGCw==}
+  '@fluidframework/container-runtime@2.60.0':
+    resolution: {integrity: sha512-691sK36eW+sroQoPma6NjeTLGr4T5IaD4DHLWzAtvOHYIFyzkI7LybVYcIerAjTguNf8hFoTZGcF1gOnT0VgBg==}
 
   '@fluidframework/container-utils@1.4.0':
     resolution: {integrity: sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==}
@@ -17553,72 +17553,72 @@ packages:
   '@fluidframework/core-interfaces@1.4.0':
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
 
-  '@fluidframework/core-interfaces@2.53.0':
-    resolution: {integrity: sha512-9bxWFcMs6/S025B2c86mWPTqwQ8WaYDAsEeYXUbOJuo/yfJgFFvqVLSOve+5ugay9shUWS9OC4rB0/IxKkkIGQ==}
+  '@fluidframework/core-interfaces@2.60.0':
+    resolution: {integrity: sha512-8+ccjnDnHbeLjBhYot6AMQTJJk2MgMMGQQNxDkeNlI8Eh7xneY0I5O1l3j3DnhR6r4yggMq/MlbRyhvrPAkeNw==}
 
-  '@fluidframework/core-utils@2.53.0':
-    resolution: {integrity: sha512-h+PiFdJb7dMB5dT50AYZP7tJxpcZpkICRpILr3zzSBJsPo38rWFBuf0hq9N0V6vc6SKNLSqApYqolLRgVgYGxA==}
+  '@fluidframework/core-utils@2.60.0':
+    resolution: {integrity: sha512-KnjuKPhRru/HpP7mLrjuH/riLO04K4ZakTYi9pJBbLy/H/gd5sLnMNqVe0tF3HPYSrr1sJVxndmj090aE0aLEw==}
 
-  '@fluidframework/counter@2.53.0':
-    resolution: {integrity: sha512-TTAy7ME2a+uoyT1y5mCS2nTq5BvHVimj1sVIzVzOltg6TXh5JjizvksjbYsoPhRMs2GGolodrtQ8cC1cgCrwVQ==}
+  '@fluidframework/counter@2.60.0':
+    resolution: {integrity: sha512-vk+3+5coimFM0uqpmT6+WSuKYLiKpblVVz2bIF+BGqdBSDRWFAkH4Fcj/kjDUA4kuBkdqz0tNcMBw5coylMPXQ==}
 
   '@fluidframework/datastore-definitions@1.4.0':
     resolution: {integrity: sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==}
 
-  '@fluidframework/datastore-definitions@2.53.0':
-    resolution: {integrity: sha512-COtjg/8/3dt8P5m62VDS1uAJztRjfdnQCLPftZhXUlDqj4GG3c+TOnbQLNL/IcS5Rgi9pwVSeccjCpmOwwvDkg==}
+  '@fluidframework/datastore-definitions@2.60.0':
+    resolution: {integrity: sha512-Dy4z9pbgjbvaSwETbwHBSbF6Qdc95lY6RxQ6xUFVYczJZh6e++74jGFPehEM6o7iocFWvRryG8VzDSZ5bBf+7w==}
 
   '@fluidframework/datastore@1.4.0':
     resolution: {integrity: sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==}
 
-  '@fluidframework/datastore@2.53.0':
-    resolution: {integrity: sha512-NS8JFjhTqqotEvncyJOApPgb5jnCf5bF8lzklCi5Gy58Zw+EwyLE7A+uLX+FHrihb9miXTyh6w2J0Y4H2X4TSw==}
+  '@fluidframework/datastore@2.60.0':
+    resolution: {integrity: sha512-Q7B1ZfoSy1Rl0GF++/IQ0nOSxrL163z34p/RqAqXmbjLntwocS+3yU/b4mu0iBgzb2gB7kJM6hZc93PHP6t07w==}
 
-  '@fluidframework/debugger@2.53.0':
-    resolution: {integrity: sha512-cWCsEV6zFkOOxs3cack5rvCGSAat+ek6v8Rs/GsjeJoUDRu6/Tkit0TTlMh7WkvYB37FeRUL7oYsViN6lUlVcw==}
+  '@fluidframework/debugger@2.60.0':
+    resolution: {integrity: sha512-YGYSplboKSBQedx6FDhnn7Fxms9VGKEKp966trLHWeaafCuf1z1rrEkhst5bTV9USuE0hJ3UI137PojTzmjudw==}
 
-  '@fluidframework/devtools-core@2.53.0':
-    resolution: {integrity: sha512-bm6EiAgCsMrHPT+fQxmD2XnjciWmNW5iBUkxQi/sxmNUIukU+tPG0ZbTHmUC2ae7+yi0eYO5Bn7C16DuwIOdVA==}
+  '@fluidframework/devtools-core@2.60.0':
+    resolution: {integrity: sha512-YlducYcTMczDnXyhXilHIXFZhN+uUYU6VwMmjAWumvAoM3AwCHW9WAb470lq6ujt6Fimw9oS8WdTknfA8Qh72w==}
 
-  '@fluidframework/devtools@2.53.0':
-    resolution: {integrity: sha512-uaFJkRaJEaMPZkCALbwi+w+SQqIR8QwG+J97uzp2Fqwym6cjZMFMrqSPkTcsXU2V+te8kdMI8NWCzHnr9SxB+w==}
+  '@fluidframework/devtools@2.60.0':
+    resolution: {integrity: sha512-lb297QwzvPnwvDVTK68S9xjmlzm11+GtsUrXMrlxSuJEOLn+M4OYXqdz3lTshqXb0iDco8K53Y1BAlfGWP7UjA==}
 
   '@fluidframework/driver-base@1.4.0':
     resolution: {integrity: sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==}
 
-  '@fluidframework/driver-base@2.53.0':
-    resolution: {integrity: sha512-gVIkp3ZDQ2T4gSFWyh4nh3MsXKEiKnPB9Si9pBAXB/6dEBJZe0BLaK0OrOcQSMEf3s2EFjuFODIjARHnb0flXg==}
+  '@fluidframework/driver-base@2.60.0':
+    resolution: {integrity: sha512-BjjnDHmSEZ+W9ZaXde5+GweGl9Z8xLCrPVnPLrFHQy5VyD8toS6HJAgPASgAyLDEVxPiGTj7Bna4OR+N1m3VfA==}
 
   '@fluidframework/driver-definitions@1.4.0':
     resolution: {integrity: sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==}
 
-  '@fluidframework/driver-definitions@2.53.0':
-    resolution: {integrity: sha512-b+7tnBJpIweRpZrLCqlBPHmfHewrwWdb6R3RBW7erkUjP8I9InapBbe7xN3lQ5EfE6XB5cF1jprAvqihvs6SBQ==}
+  '@fluidframework/driver-definitions@2.60.0':
+    resolution: {integrity: sha512-GrFaeewL0EnYQhGX/OicPP7GCtf+zNecIDYfLlUlQKsQu2+tJCE4LA8Xda5AXamJZ/3bGnyeWluwJHS3zsmFMQ==}
 
   '@fluidframework/driver-utils@1.4.0':
     resolution: {integrity: sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==}
 
-  '@fluidframework/driver-utils@2.53.0':
-    resolution: {integrity: sha512-VmEwUAf8vBIRNixeZJuZR8XdNFBC6+G9Yt4QW8+JgWtWv4h6Tu5FP4nDqr20qKOFVbIz+fkiyhykSeBwidxXwg==}
+  '@fluidframework/driver-utils@2.60.0':
+    resolution: {integrity: sha512-UPOe7pZfz6di84D1rB4CIukMMbs8pb0YNA+Mx8GXqIK/PWwqTv4/byuB68fvEWUHM3weptA92sweyJHhofH1bg==}
 
-  '@fluidframework/driver-web-cache@2.53.0':
-    resolution: {integrity: sha512-a5onIHIvJQqDdzpeiY6W0z3C8mXY0LLhHVxLD30ptKYQF0cHXQkoECw8uHfjqKkSvV1Gf8BY8amSRjMcKmnZhw==}
+  '@fluidframework/driver-web-cache@2.60.0':
+    resolution: {integrity: sha512-go3Bk3XcwTLVy2Dbb8eYiGchD7t9sehORbom5P1KFXUSqvwleOTLrsfdJ7qROWeiLlUYC4vuc1INqeirxPUFeg==}
 
   '@fluidframework/eslint-config-fluid@6.0.0':
     resolution: {integrity: sha512-RdbEYUQmLkW8zQ6GZXx1T/t5g9k7iA5K6vPZdvsIK4keb5VXcVCHDluvc7AtOXEVOb5Bt2XyM16NWz2Rlho5NA==}
 
-  '@fluidframework/file-driver@2.53.0':
-    resolution: {integrity: sha512-DrekmFsY59Kp8ZZOexu365I2Y5Hagh+EoKTwW9CQIBn+1Fci1AKhKGlXuczLz6/w9LhtWZ7XxCW9yEx4AQwkMA==}
+  '@fluidframework/file-driver@2.60.0':
+    resolution: {integrity: sha512-l7AM6Isp5BOrLEc3aOu76TFcCIukkPTbNeP7kcjJ3oRj65ziWxvHg14qFQINZgIlX7VmqZVlfRdZOmhSJHni3w==}
 
-  '@fluidframework/fluid-runner@2.53.0':
-    resolution: {integrity: sha512-BruzoouWBzkuMNo9yUB6sS1q+PNeWjtoJJng8Md0DxiOE8s5fXH8zRVTOF1+lHjNCbVLW90YsU49xQ7ABxMOpQ==}
+  '@fluidframework/fluid-runner@2.60.0':
+    resolution: {integrity: sha512-WDEY2Djwa4niop753zZ6U/Jv59ltdLh4ZLMlzz8Dj7GJvWN/ffxCJ+JH/xSXJczbIEpt9IrkRVv7MHxChaJ84w==}
     hasBin: true
 
   '@fluidframework/fluid-static@1.4.0':
     resolution: {integrity: sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==}
 
-  '@fluidframework/fluid-static@2.53.0':
-    resolution: {integrity: sha512-87hQYbIPoSpvqspDdIJU/h5abhCHDmkaajg7Ie3B1vpl2WY95WRuTLlifLX7cVyxXjBFb+dxtcJpG4dR1NSBCg==}
+  '@fluidframework/fluid-static@2.60.0':
+    resolution: {integrity: sha512-Xbk/4Rx//uWNPvZPr5jlTYYe5sZhOOiR3DSfubloFbiW4x9Ln80akuuVtZUMQs5jYDqQih7cV70RV4nBZVnOrg==}
 
   '@fluidframework/garbage-collector@1.4.0':
     resolution: {integrity: sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==}
@@ -17629,38 +17629,38 @@ packages:
   '@fluidframework/gitresources@7.0.0':
     resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
 
-  '@fluidframework/id-compressor@2.53.0':
-    resolution: {integrity: sha512-ZVsPgWohUsM0n3tHbNqSI6pmNbOAYAlUT4dhhGwZM/6bjaxAs+DrS7YsMmhepuyGzxPUZn4BzfdDRFsgeeNz6A==}
+  '@fluidframework/id-compressor@2.60.0':
+    resolution: {integrity: sha512-xFF/Bgs3Z+Ndc/nrhnUXms/pSRP2yKTWdq0eFKjfcheG7yCQaxx3/U5F8k8Zi6D4oc6jEhWunODtG3JJtYXXHw==}
 
-  '@fluidframework/local-driver@2.53.0':
-    resolution: {integrity: sha512-vrW72D2VT+7B332BgOoOo1tOvGl2jhsyOzEM8ne0ZklrsvAp51f1pBZj3v4Greww76Y2gjzK1xf/h7QPmOMu2Q==}
+  '@fluidframework/local-driver@2.60.0':
+    resolution: {integrity: sha512-rgXOFJyuwzXA9/89IUC80ajfI760u42YQT8ZI5d2ADAxMe7Vs40ithS0AEKFSbwE6oYu2MJvlYX8Kx/oogzutw==}
 
   '@fluidframework/map@1.4.0':
     resolution: {integrity: sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==}
 
-  '@fluidframework/map@2.53.0':
-    resolution: {integrity: sha512-ZBLzCITfa+xTxlqb1lwwE1YupkuGBkL8iD1E9OUSfLbqdGQTWXOcZhBado1EKMExHlg6C63GrH6uvmQPawJk/w==}
+  '@fluidframework/map@2.60.0':
+    resolution: {integrity: sha512-8IAxs6ynG2vFsgN5UZ8VJWEQEOR0LyVqCUWsgNphsJxeTbk0+3LWMj8cZE1pOkjq4vr8S2ur2guIl6lV+rmrcQ==}
 
-  '@fluidframework/matrix@2.53.0':
-    resolution: {integrity: sha512-PoUR+RxDgd/TqRUZuBy5pL4igxfMXM4Qs4g35EvTSzR2k99TlgJ1k0agF0FTAomrFdIA4G+bw6DeIoaixy5IYA==}
+  '@fluidframework/matrix@2.60.0':
+    resolution: {integrity: sha512-Wrxm/JK/L6opbIXHJSXUSJ62e1fZdsEWPjmsNdOiK6RxECErX0TqTziDvPLlCnY/hiPsc+uXVeCZfVZGLTFtWA==}
 
-  '@fluidframework/merge-tree@2.53.0':
-    resolution: {integrity: sha512-L+WKYTada7J0sHddXyQHM1Rx3e+yjgoS0uC+0akM9YY9bAqVZcmc8UTDRADfCa6QEMFsKSTprK8Ow1uAuU1xQg==}
+  '@fluidframework/merge-tree@2.60.0':
+    resolution: {integrity: sha512-FGnxVecmMCUufM4RjKz5xQ3YTXhy2ndqXA+guoVcCfDoOfH7/idvgTov6Zb0EszVH/A8rGxqA7m6UhQx+5wxRg==}
 
-  '@fluidframework/odsp-doclib-utils@2.53.0':
-    resolution: {integrity: sha512-KfNYw/168jzH7KJcjPboA3bq5OObpF1mLm4xrpv43J/ti1tzuizJ4PoUNf1sn+4AXWpLcSXdZ+2i5kRJ4i4jtw==}
+  '@fluidframework/odsp-doclib-utils@2.60.0':
+    resolution: {integrity: sha512-vZMUtPzYIdBcBU69JUJRmmT4Q/54LqQ0rrDyTxiHTaw0Ol1EFmZ1YjTu5M9TAN31QDVE1wbyA9qU5O5xMgtgrw==}
 
-  '@fluidframework/odsp-driver-definitions@2.53.0':
-    resolution: {integrity: sha512-RvqqF2ZwlKRacxv2IYK+SFZgbSQXJSLhGyYE01OIu9DeeGRf01iigUHZwLC0ISMfMS2y6nILialYRn0n7HP13g==}
+  '@fluidframework/odsp-driver-definitions@2.60.0':
+    resolution: {integrity: sha512-O28QNkus+ASyX2aFx9fiaozjMKza638i9CeMmp836AwQvItAY8ETr2LUe+BCZ/I34TjzBvuf3vK88PgesSqDdQ==}
 
-  '@fluidframework/odsp-driver@2.53.0':
-    resolution: {integrity: sha512-DjIOk5O6l0nZaczPk6rfUla63g/XP617FDxB0Aq455eqxgEhsU3HBDJ4Fyrhu5A6SnJNm6Y/iSJ5XRaujZD8PA==}
+  '@fluidframework/odsp-driver@2.60.0':
+    resolution: {integrity: sha512-6tv6LYkTbRV18UIlhR20gUY0zaX4DDMxI+kbkGWZnyp0T+AI4O/qTuw06dirJo+4qE9PEfChqnP3WDUlfsJjnA==}
 
-  '@fluidframework/odsp-urlresolver@2.53.0':
-    resolution: {integrity: sha512-INUN5Uo9kOfD9N80eqLepzy9GlwTFGZM3Lr+kml9zb5psBX3twHRL3p4FtkBHyBkOZKQKZf3sJjCNXEfW78sQg==}
+  '@fluidframework/odsp-urlresolver@2.60.0':
+    resolution: {integrity: sha512-ol/HViUQC0FBq29wl+Yg2iEZVHN4PZrjnD02kOX3hynv6YlUuxHaDmjUGEPQpOxCYUTwsJt/8+sCxwF4enIhww==}
 
-  '@fluidframework/ordered-collection@2.53.0':
-    resolution: {integrity: sha512-6wSXsjg2+qQtIq2g1xHMYpxAjnJqfJCO3XS3Bdxe1TWk0p1eNRIm6BaSBdNyoNQ/y3DnKkF7G8jeLL6GheZJTw==}
+  '@fluidframework/ordered-collection@2.60.0':
+    resolution: {integrity: sha512-E1w79UHKwfixTlKrysdFJhvcc3karW8h6tI3kGX2EkfhUCUJAGPbb4lmgRdtxDhppT+qmnLaItLElpERZHzpDA==}
 
   '@fluidframework/protocol-base@0.1036.5002':
     resolution: {integrity: sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==}
@@ -17677,41 +17677,41 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  '@fluidframework/register-collection@2.53.0':
-    resolution: {integrity: sha512-V1OIXmmKECPPml7IQ3FLK7jrvsDq7ckVIkwu0e2XAKaPUS1JhdGCTQxko7OLNvhwgKXzWY8FXmlYI9wlkUxAeA==}
+  '@fluidframework/register-collection@2.60.0':
+    resolution: {integrity: sha512-oMqWeGmvu9yl4lmj044/FL+JC99b/W6W/3y88dUIzbiTP0bE2qq4aqB0Vay+zLeIY5mKHZ2CxBDjJHAu1YV6hQ==}
 
-  '@fluidframework/replay-driver@2.53.0':
-    resolution: {integrity: sha512-+4AXRYoQtjvQHopl/OG9PH4stkujmPQGVtEcUMfKBjcbAepAnxRcBcS/H9Wpr14OpvacvL+SiocvL2zjorI3/A==}
+  '@fluidframework/replay-driver@2.60.0':
+    resolution: {integrity: sha512-P1s069acb+R0VoqV3oAdtTEHInkPkDquTccuNg1ffdsO2/9cfFxa0OItYKIMJcKCAG8dbdfNAey6ULjr5LXH4A==}
 
   '@fluidframework/request-handler@1.4.0':
     resolution: {integrity: sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==}
 
-  '@fluidframework/request-handler@2.53.0':
-    resolution: {integrity: sha512-x04C5ZINoCQ/KIhL5gCiIrF0CFN1Ofj5PZgD9TZ/EPHtyGwLFYmu3E6h0bhJ2kbiL5Mij4frT49JtlEM+8wY5A==}
+  '@fluidframework/request-handler@2.60.0':
+    resolution: {integrity: sha512-3SA0o8ZOxZXbrPURBW6WBH/IEZJCNAQeVFmZsqPeVzqaGh7B7axVORyNEUPMVZC/pzLiF+4roRnDVqQ8GhKvLA==}
 
   '@fluidframework/routerlicious-driver@1.4.0':
     resolution: {integrity: sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==}
 
-  '@fluidframework/routerlicious-driver@2.53.0':
-    resolution: {integrity: sha512-IvyFWKHCwGrvEk8k1ne9TvZLPilPIYMeoD//o2N2jySVq9VHqS3nJMIbHpZK74hXZV1ehcfdoLIUGrHn8ejpNw==}
+  '@fluidframework/routerlicious-driver@2.60.0':
+    resolution: {integrity: sha512-uY1jHgVN3i1IOaE3rIja31ze3cFrFmlACYja81MaHXzy25F13geqKv5REEXmEW36KEZ/iZOUXRFCWeQPsGPngA==}
 
-  '@fluidframework/routerlicious-urlresolver@2.53.0':
-    resolution: {integrity: sha512-LZLe5jYcpTmvgDrfRkgnFXz7qSmzTmtV9NdllvlK4Or03tBuLHOR+5g6f6Jy1zBq0OjCiD7U4E2022X9KLY0IQ==}
+  '@fluidframework/routerlicious-urlresolver@2.60.0':
+    resolution: {integrity: sha512-QvGjc8bM4G36cVQTvUG51WCbtKMgikbl7d+VqD0U5sSIIjefd/LRGik87kV0zPdk9tYXkgCERYJVnuFj0itmXA==}
 
   '@fluidframework/runtime-definitions@1.4.0':
     resolution: {integrity: sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==}
 
-  '@fluidframework/runtime-definitions@2.53.0':
-    resolution: {integrity: sha512-X2ltLjrerq2ONPd5eD2ccZ5mZDF2kQqJQ9jZ2umgzw937UxsW0N05QTri8HRmWEOUh0g01KtbVI5smhJKuVyxw==}
+  '@fluidframework/runtime-definitions@2.60.0':
+    resolution: {integrity: sha512-9TX1GuKy9zYil95hwhWfafVvA6Rn7NxcagZatEYPFNcuMp452ZqokQ/6upTiY8w8u6CgGE+ye/R/l+EsMmUtYg==}
 
   '@fluidframework/runtime-utils@1.4.0':
     resolution: {integrity: sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==}
 
-  '@fluidframework/runtime-utils@2.53.0':
-    resolution: {integrity: sha512-46bjEZV2HMsPEbsXx0H0jJDX09QlpQFiA2H8Y0jVPkzpAGVW3aFIVboVw4opFC4dCh0BJaZz562h1jo1ypIpSw==}
+  '@fluidframework/runtime-utils@2.60.0':
+    resolution: {integrity: sha512-bM9ArMEhchp4UARzCjY/j07Wy2DOhnYRcREXTsSQus2eDswC1vuQqTUY+YIbBX43DOv9noS1HSfiOB79Fmb/vA==}
 
-  '@fluidframework/sequence@2.53.0':
-    resolution: {integrity: sha512-6bHeWVAn1DxTZfqyMleTIApK6WSeAr/GKRw/YyFz0BiEPkBtWeMJzz7CiNmyKo4bNnY4Uv6mSm5lNpzYZBjajw==}
+  '@fluidframework/sequence@2.60.0':
+    resolution: {integrity: sha512-lUykZS/pGeV1gQegDpA5FcgHcc0r7awViYB1V26jD2UbiDLPgZIWeUCZ4PERTxQbmJUdtufrlfJVp9marSzVlw==}
 
   '@fluidframework/server-lambdas-driver@7.0.0':
     resolution: {integrity: sha512-HNXeXUWYIR+jjGMAB61gCWsryuwqysA2o7/bwvdZuM4avqfm75dJUheB6N04uG5GfRfvesMHU68452YHIf6FYQ==}
@@ -17749,51 +17749,51 @@ packages:
   '@fluidframework/shared-object-base@1.4.0':
     resolution: {integrity: sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==}
 
-  '@fluidframework/shared-object-base@2.53.0':
-    resolution: {integrity: sha512-UeEM5IMQOEG/ume2bH7XKr802WwXs32DlRUX3DsugXuFeEtv2neyjZVXtBgxFiVR/Qq1/q+tBqouTkFf+hqnzQ==}
+  '@fluidframework/shared-object-base@2.60.0':
+    resolution: {integrity: sha512-9RaruFHJcFBakUwwhmC1quQ4/Uu0z1w6fDdJZ8PZhbInDq6ZYp6Oi5tUzXyKK3k7sm5/rJdugr9Agzv1GG3IRA==}
 
-  '@fluidframework/shared-summary-block@2.53.0':
-    resolution: {integrity: sha512-z6Ieogk0t/z9rz/xX4EJNrS/kaqqDMfAXCo3bEyAZQwSp175pm0JDuuT0d3ux+LvspHAEtxNKopN2lVTejfzww==}
+  '@fluidframework/shared-summary-block@2.60.0':
+    resolution: {integrity: sha512-jA0HpJiPCTcX60Zcv/7n+xaI95PRA0EpAQaBbp/bLU4PSH0ixCWo2kp5iO4QqX735WObRv6VktgTr0uWAeuW8Q==}
 
   '@fluidframework/synthesize@1.4.0':
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
 
-  '@fluidframework/synthesize@2.53.0':
-    resolution: {integrity: sha512-nmZ0N0PPjZcLRFgtDnSlBRoLBRWFBn1nP7YJItv8487u2W+qQV5WCYXDBcrb3BJS4gilLC+SIUW86e46GG35Jg==}
+  '@fluidframework/synthesize@2.60.0':
+    resolution: {integrity: sha512-KBkX4kOaZKNEwMq69N/RyJhiSK7UiFvQuhzbL/nK3YMehARgFmjwBnYzLM5X5+aQwgbetf1iwJLBifouOi3qbw==}
 
-  '@fluidframework/task-manager@2.53.0':
-    resolution: {integrity: sha512-ciLspVEZcyfC6HlGcWFJG2yjoylu2jYvPhe+ktIhjnA35bEWwHymWEIJUHRWjyN9nTnwqa2d4Z5grvXhtKOibg==}
+  '@fluidframework/task-manager@2.60.0':
+    resolution: {integrity: sha512-Fft1lpIv3rDS424ztw878FN6lnVOlfd4Lx0bsM+43VdfCzlsaF2ucwl/SuRTXMzTFuK3gCJrJcEpgN2kwPgbeg==}
 
   '@fluidframework/telemetry-utils@1.4.0':
     resolution: {integrity: sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==}
 
-  '@fluidframework/telemetry-utils@2.53.0':
-    resolution: {integrity: sha512-9OajKA95JrlNh9LGRk+fkXYXa4ckx3NkZEKvKXInr39YIW4ejYfkl5INB0dJtIx8CQ2XK8g/1PiZane0bfa2jQ==}
+  '@fluidframework/telemetry-utils@2.60.0':
+    resolution: {integrity: sha512-TN1DQUHGUYfAb+f1vjGP5zwDdJv7L9Oy8FOIZXW9fm0K3hcYQ0cE79w3r4r0iQ34ORyUkEaTgnJF2xubc8Mlnw==}
 
-  '@fluidframework/test-runtime-utils@2.53.0':
-    resolution: {integrity: sha512-snOf3vO5r0V9VlsC40V+1+nCb7MQyu9XaCDyt2pR6Y8fbeKgU03ujzOGl9myZxI0OK2j/iPTAj6/EcRxcGHCVA==}
+  '@fluidframework/test-runtime-utils@2.60.0':
+    resolution: {integrity: sha512-lHdITyTLQ9qiUihvmWyQ7Vqs20Dh4iQZUMq/4u50mM4xWJn7A5MMlqeiWOkv4RRPiGSokypOchyBUQ+cTPIF1A==}
 
   '@fluidframework/test-tools@1.0.195075':
     resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
 
-  '@fluidframework/test-utils@2.53.0':
-    resolution: {integrity: sha512-c7GpEr0rHNRwvjvXR1jVoSVov1qCJFfrn8/pIUXUgQuMxLJioMQzG9deZAfm4BgVouAA3gMAEsyQEOJZbYWZ1g==}
+  '@fluidframework/test-utils@2.60.0':
+    resolution: {integrity: sha512-9pkGz2WKfKe9AOF3LSYGio51T7Lfxce7o5/thLC6kL6cMzcGTcYUiS/7cUYYQ2kFkr7+pi31hVP7AyVn/bfPBw==}
 
-  '@fluidframework/tinylicious-client@2.53.0':
-    resolution: {integrity: sha512-wE1mm5X5apQm9HaNv+cVUUym7o+RConvnKXNCQPtSTvYgIaxek2pztqrk+z/M3FLqOhsy2dvnEw3+N9Bdq/o3Q==}
+  '@fluidframework/tinylicious-client@2.60.0':
+    resolution: {integrity: sha512-IIHBVuow5HX7y6SJBfw1nGBVQYS6b1XuApDu/BoZNTPJ+iUlih0Vpc4j2rvCEmAz+zcRBg4vPYS2U72C/Te+JA==}
 
-  '@fluidframework/tinylicious-driver@2.53.0':
-    resolution: {integrity: sha512-+rxKFLV0hLfXakv/tyRNCrDUQ2pd/uyqWMkveOQDlEbrTRFIXhV/2JNq9SjaUYb+HbFnjRu6sS4mkBgKI/IwFw==}
+  '@fluidframework/tinylicious-driver@2.60.0':
+    resolution: {integrity: sha512-is/DbdDQV1Dc8VFpfffum8z5jEabKGZgQr0Se7UNljQoDybW1pZ6jPzH+Is6RqFlI/bZwSmFolOcQ3zuEQILdQ==}
 
-  '@fluidframework/tool-utils@2.53.0':
-    resolution: {integrity: sha512-qN5ek3d16O6uwyeNHon0AAAUm3w5Fp18HQvEGRACG/qQTgT3GetZrREcXG2JhfngvD0iCbY1Np4BgkyOAQSFSA==}
+  '@fluidframework/tool-utils@2.60.0':
+    resolution: {integrity: sha512-WJqtRvRaKe/YM8PPxOMN85QBAcC80t4KDejvZaHlFxOUoCfSTo9Wx6EgWtboM/Ku1nWn4tBQuJTnNGSqsWHtdQ==}
 
-  '@fluidframework/tree@2.53.0':
-    resolution: {integrity: sha512-rUBb1pq/jUatNeJWJ4mbmZRf/cY1MfHPK7LKzMBd0/DbR3ibubAJWTU7u5Gjj5zevzN1UbSezrH/b7jnS5d7AA==}
+  '@fluidframework/tree@2.60.0':
+    resolution: {integrity: sha512-CKa7FfeqefnLMKzFfWW6ft1m54ErZmuS8RmwRDWqS6WNFAoJFnEvjiFB6sGFVkInQGlq8fTH9uQF+JR/t2KS6w==}
 
-  '@fluidframework/undo-redo@2.53.0':
-    resolution: {integrity: sha512-7AfYbFZMDG6zx5TZCZFMGmae11gf5caDoTtwNYo2CXlSzXkLOQ5tqV4P3qVzs3xTIJR41PGdW2VGxIAgKHNVYA==}
+  '@fluidframework/undo-redo@2.60.0':
+    resolution: {integrity: sha512-PB5gHg46Tz1KViksK2uIc3+ydvVlGpQHpoEx5Zyh3+M83TdeTw4Oyc7hUDWzptZr9q/w6yJlSr85I7Eoi4llQA==}
 
   '@fluidframework/view-interfaces@1.4.0':
     resolution: {integrity: sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==}
@@ -29596,10 +29596,10 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluid-internal/client-utils@2.53.0':
+  '@fluid-internal/client-utils@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
       '@types/events_pkg': '@types/events@3.0.3'
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -29616,10 +29616,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-internal/test-driver-definitions@2.53.0':
+  '@fluid-internal/test-driver-definitions@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
 
   '@fluid-tools/benchmark@0.51.0':
     dependencies:
@@ -29838,24 +29838,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/fetch-tool@2.53.0(encoding@0.1.13)':
+  '@fluid-tools/fetch-tool@2.60.0(encoding@0.1.13)':
     dependencies:
       '@azure/identity': 4.5.0
       '@azure/identity-cache-persistence': 1.1.1
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/odsp-doclib-utils': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/odsp-urlresolver': 2.53.0(encoding@0.1.13)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/routerlicious-urlresolver': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/tool-utils': 2.53.0(encoding@0.1.13)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/odsp-doclib-utils': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/odsp-urlresolver': 2.60.0(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-urlresolver': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/tool-utils': 2.60.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -29911,27 +29911,27 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/agent-scheduler@2.53.0':
+  '@fluidframework/agent-scheduler@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/register-collection': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/register-collection': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/app-insights-logger@2.53.0(tslib@1.14.1)':
+  '@fluidframework/app-insights-logger@2.60.0(tslib@1.14.1)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
       '@microsoft/applicationinsights-web': 2.8.18(tslib@1.14.1)
       '@ungap/structured-clone': 1.2.1
     transitivePeerDependencies:
@@ -29959,24 +29959,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/aqueduct@2.53.0':
+  '@fluidframework/aqueduct@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/request-handler': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/synthesize': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tree': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/request-handler': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/synthesize': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tree': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30005,16 +30005,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-client@2.53.0(encoding@0.1.13)':
+  '@fluidframework/azure-client@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.53.0
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.60.0
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30022,9 +30022,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-service-utils@2.53.0':
+  '@fluidframework/azure-service-utils@2.60.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/driver-definitions': 2.60.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
 
@@ -30146,15 +30146,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/cell@2.53.0':
+  '@fluidframework/cell@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30201,10 +30201,10 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       events: 3.3.0
 
-  '@fluidframework/container-definitions@2.53.0':
+  '@fluidframework/container-definitions@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
 
   '@fluidframework/container-loader@1.4.0':
     dependencies:
@@ -30228,15 +30228,15 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-loader@2.53.0':
+  '@fluidframework/container-loader@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@types/events_pkg': '@types/events@3.0.3'
       '@ungap/structured-clone': 1.2.1
       debug: 4.4.0(supports-color@8.1.1)
@@ -30255,13 +30255,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/container-runtime-definitions@2.53.0':
+  '@fluidframework/container-runtime-definitions@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30289,20 +30289,20 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-runtime@2.53.0(debug@4.4.0)':
+  '@fluidframework/container-runtime@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       double-ended-queue: 2.1.0-0
       lz4js: 0.2.0
@@ -30324,19 +30324,19 @@ snapshots:
 
   '@fluidframework/core-interfaces@1.4.0': {}
 
-  '@fluidframework/core-interfaces@2.53.0': {}
+  '@fluidframework/core-interfaces@2.60.0': {}
 
-  '@fluidframework/core-utils@2.53.0': {}
+  '@fluidframework/core-utils@2.60.0': {}
 
-  '@fluidframework/counter@2.53.0':
+  '@fluidframework/counter@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30350,13 +30350,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/datastore-definitions@2.53.0':
+  '@fluidframework/datastore-definitions@2.60.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30382,64 +30382,66 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/datastore@2.53.0(debug@4.4.0)':
+  '@fluidframework/datastore@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/debugger@2.53.0':
+  '@fluidframework/debugger@2.60.0':
     dependencies:
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.53.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.60.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools-core@2.53.0':
+  '@fluidframework/devtools-core@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/aqueduct': 2.53.0
-      '@fluidframework/cell': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/counter': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/sequence': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tree': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/aqueduct': 2.60.0
+      '@fluidframework/cell': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/counter': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/sequence': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tree': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools@2.53.0':
+  '@fluidframework/devtools@2.60.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/devtools-core': 2.53.0
-      '@fluidframework/fluid-static': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/devtools-core': 2.60.0
+      '@fluidframework/fluid-static': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30456,14 +30458,14 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-base@2.53.0(debug@4.4.0)':
+  '@fluidframework/driver-base@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30474,9 +30476,9 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/driver-definitions@2.53.0':
+  '@fluidframework/driver-definitions@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
 
   '@fluidframework/driver-utils@1.4.0':
     dependencies:
@@ -30494,13 +30496,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-utils@2.53.0(debug@4.4.0)':
+  '@fluidframework/driver-utils@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       axios: 1.8.4(debug@4.4.0)
       lz4js: 0.2.0
       uuid: 11.1.0
@@ -30508,12 +30510,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-web-cache@2.53.0':
+  '@fluidframework/driver-web-cache@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -30529,9 +30531,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -30547,28 +30549,28 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/file-driver@2.53.0':
+  '@fluidframework/file-driver@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-runner@2.53.0(encoding@0.1.13)':
+  '@fluidframework/fluid-runner@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/aqueduct': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/aqueduct': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       '@json2csv/plainjs': 7.0.6
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -30596,24 +30598,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-static@2.53.0':
+  '@fluidframework/fluid-static@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/aqueduct': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/request-handler': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tree': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/aqueduct': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/request-handler': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tree': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30628,32 +30630,32 @@ snapshots:
 
   '@fluidframework/gitresources@7.0.0': {}
 
-  '@fluidframework/id-compressor@2.53.0':
+  '@fluidframework/id-compressor@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/local-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/local-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
       '@fluidframework/protocol-base': 7.0.0
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
       '@fluidframework/server-local-server': 7.0.0
       '@fluidframework/server-services-client': 7.0.0
       '@fluidframework/server-services-core': 7.0.0
       '@fluidframework/server-test-utils': 7.0.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/telemetry-utils': 2.60.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -30680,37 +30682,36 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/map@2.53.0(debug@4.4.0)':
+  '@fluidframework/map@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/matrix@2.53.0':
+  '@fluidframework/matrix@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/merge-tree': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       double-ended-queue: 2.1.0-0
       tslib: 1.14.1
@@ -30718,52 +30719,52 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/merge-tree@2.53.0(debug@4.4.0)':
+  '@fluidframework/merge-tree@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/odsp-doclib-utils@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-doclib-utils@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - debug
       - encoding
       - supports-color
 
-  '@fluidframework/odsp-driver-definitions@2.53.0':
+  '@fluidframework/odsp-driver-definitions@2.60.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/driver-definitions': 2.60.0
 
-  '@fluidframework/odsp-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       socket.io-client: 4.7.5
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -30773,14 +30774,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/odsp-urlresolver@2.53.0(encoding@0.1.13)':
+  '@fluidframework/odsp-urlresolver@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30788,17 +30789,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/ordered-collection@2.53.0':
+  '@fluidframework/ordered-collection@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
@@ -30828,28 +30829,28 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
-  '@fluidframework/register-collection@2.53.0':
+  '@fluidframework/register-collection@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/replay-driver@2.53.0':
+  '@fluidframework/replay-driver@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30864,13 +30865,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/request-handler@2.53.0(debug@4.4.0)':
+  '@fluidframework/request-handler@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30900,16 +30901,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/routerlicious-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
       '@fluidframework/server-services-client': 7.0.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/telemetry-utils': 2.60.0
       cross-fetch: 3.1.8(encoding@0.1.13)
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.5
@@ -30921,11 +30922,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-urlresolver@2.53.0':
+  '@fluidframework/routerlicious-urlresolver@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
       nconf: 0.12.1
 
   '@fluidframework/runtime-definitions@1.4.0':
@@ -30937,13 +30938,13 @@ snapshots:
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/runtime-definitions@2.53.0':
+  '@fluidframework/runtime-definitions@2.60.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30963,35 +30964,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/runtime-utils@2.53.0(debug@4.4.0)':
+  '@fluidframework/runtime-utils@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       semver-ts: 1.0.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/sequence@2.53.0':
+  '@fluidframework/sequence@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/merge-tree': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       double-ended-queue: 2.1.0-0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -31240,54 +31241,54 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/shared-object-base@2.53.0(debug@4.4.0)':
+  '@fluidframework/shared-object-base@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/shared-summary-block@2.53.0':
+  '@fluidframework/shared-summary-block@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
   '@fluidframework/synthesize@1.4.0': {}
 
-  '@fluidframework/synthesize@2.53.0':
+  '@fluidframework/synthesize@2.60.0':
     dependencies:
-      '@fluidframework/core-utils': 2.53.0
+      '@fluidframework/core-utils': 2.60.0
 
-  '@fluidframework/task-manager@2.53.0':
+  '@fluidframework/task-manager@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -31302,32 +31303,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/telemetry-utils@2.53.0':
+  '@fluidframework/telemetry-utils@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
       debug: 4.4.0(supports-color@8.1.1)
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/test-runtime-utils@2.53.0(encoding@0.1.13)':
+  '@fluidframework/test-runtime-utils@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -31339,28 +31340,28 @@ snapshots:
 
   '@fluidframework/test-tools@1.0.195075': {}
 
-  '@fluidframework/test-utils@2.53.0(encoding@0.1.13)':
+  '@fluidframework/test-utils@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/test-driver-definitions': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/local-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/request-handler': 2.53.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/test-driver-definitions': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/local-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/request-handler': 2.60.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       best-random: 1.0.3
       debug: 4.4.0(supports-color@8.1.1)
       mocha: 10.8.2
@@ -31371,20 +31372,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-client@2.53.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-client@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tinylicious-driver': 2.53.0(encoding@0.1.13)
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tinylicious-driver': 2.60.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -31392,12 +31393,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-driver@2.53.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-driver@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
       jsrsasign: 11.1.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -31407,12 +31408,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tool-utils@2.53.0(encoding@0.1.13)':
+  '@fluidframework/tool-utils@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.53.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.60.0(debug@4.4.0)(encoding@0.1.13)
       async-mutex: 0.3.2
       debug: 4.4.0(supports-color@8.1.1)
       proper-lockfile: 4.1.2
@@ -31420,19 +31421,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@fluidframework/tree@2.53.0':
+  '@fluidframework/tree@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@sinclair/typebox': 0.34.13
       '@tylerbu/sorted-btree-es6': 1.8.0
       '@types/ungap__structured-clone': 1.2.0
@@ -31442,13 +31443,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/undo-redo@2.53.0':
+  '@fluidframework/undo-redo@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.53.0
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/sequence': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.60.0
+      '@fluidframework/merge-tree': 2.60.0
+      '@fluidframework/sequence': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -36463,33 +36464,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36503,13 +36504,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/markdown-magic",
-	"version": "2.60.0",
+	"version": "2.60.1",
 	"private": true,
 	"description": "Contains shared utilities for Markdown content generation and embedding using markdown-magic.",
 	"homepage": "https://fluidframework.com",


### PR DESCRIPTION
This PR bumps client packages to 2.60.1 following the 2.60.0 and updates typetests following the release. Used `pnpm flub release -g client` to bump the package versions and the following to update typetests:
`pnpm exec flub typetests -g client --reset --normalize --previous`
`pnpm install --no-frozen-lockfile`
`pnpm run build`