### PR TITLE
Update typetests

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -95,7 +95,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.1",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.53.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -143,7 +143,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.53.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.60.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.53.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -125,7 +125,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.53.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.53.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.53.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.53.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.60.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -131,7 +131,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.53.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.53.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -161,7 +161,7 @@
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.53.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -154,7 +154,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.53.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.53.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.53.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -170,7 +170,7 @@
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.53.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
@@ -198,24 +198,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Interface_IInterval": {
-				"backCompat": false
-			},
-			"Interface_ISerializableInterval": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"Interface_SequenceInterval": {
-				"backCompat": false
-			},
-			"TypeAlias_IntervalRevertible": {
-				"backCompat": false
-			},
-			"TypeAlias_SharedStringRevertible": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -265,7 +265,6 @@ declare type old_as_current_for_Interface_IInterval = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Interface_IInterval": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IInterval = requireAssignableTo<TypeOnly<current.IInterval>, TypeOnly<old.IInterval>>
 
 /*
@@ -375,26 +374,6 @@ declare type old_as_current_for_Interface_ISequenceOverlappingIntervalsIndex = r
  * "Interface_ISequenceOverlappingIntervalsIndex": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_ISequenceOverlappingIntervalsIndex = requireAssignableTo<TypeOnly<current.ISequenceOverlappingIntervalsIndex>, TypeOnly<old.ISequenceOverlappingIntervalsIndex>>
-
-/*
- * Validate forward compatibility by using the old type in place of the current type.
- * If this test starts failing, it indicates a change that is not forward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "Interface_ISerializableInterval": {"forwardCompat": false}
- */
-// @ts-expect-error compatibility expected to be broken
-declare type old_as_current_for_Interface_ISerializableInterval = requireAssignableTo<TypeOnly<old.ISerializableInterval>, TypeOnly<current.ISerializableInterval>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "Interface_ISerializableInterval": {"backCompat": false}
- */
-// @ts-expect-error compatibility expected to be broken
-declare type current_as_old_for_Interface_ISerializableInterval = requireAssignableTo<TypeOnly<current.ISerializableInterval>, TypeOnly<old.ISerializableInterval>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -565,7 +544,6 @@ declare type old_as_current_for_Interface_SequenceInterval = requireAssignableTo
  * typeValidation.broken:
  * "Interface_SequenceInterval": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_SequenceInterval = requireAssignableTo<TypeOnly<current.SequenceInterval>, TypeOnly<old.SequenceInterval>>
 
 /*
@@ -656,7 +634,6 @@ declare type old_as_current_for_TypeAlias_IntervalRevertible = requireAssignable
  * typeValidation.broken:
  * "TypeAlias_IntervalRevertible": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IntervalRevertible = requireAssignableTo<TypeOnly<current.IntervalRevertible>, TypeOnly<old.IntervalRevertible>>
 
 /*
@@ -765,7 +742,6 @@ declare type old_as_current_for_TypeAlias_SharedStringRevertible = requireAssign
  * typeValidation.broken:
  * "TypeAlias_SharedStringRevertible": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_SharedStringRevertible = requireAssignableTo<TypeOnly<current.SharedStringRevertible>, TypeOnly<old.SharedStringRevertible>>
 
 /*

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.53.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.53.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.53.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.60.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -196,7 +196,7 @@
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.53.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",

--- a/packages/dds/tree/src/test/types/validateTreePrevious.generated.ts
+++ b/packages/dds/tree/src/test/types/validateTreePrevious.generated.ts
@@ -322,13 +322,13 @@ declare type current_as_old_for_Interface_NodeInDocumentConstraint = requireAssi
 declare type current_as_old_for_Interface_NodeSchemaMetadata = requireAssignableTo<TypeOnly<current.NodeSchemaMetadata>, TypeOnly<old.NodeSchemaMetadata>>
 
 /*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "Interface_NodeSchemaOptions": {"backCompat": false}
+ * "Interface_NodeSchemaOptions": {"forwardCompat": false}
  */
-declare type current_as_old_for_Interface_NodeSchemaOptions = requireAssignableTo<TypeOnly<current.NodeSchemaOptions>, TypeOnly<old.NodeSchemaOptions>>
+declare type old_as_current_for_Interface_NodeSchemaOptions = requireAssignableTo<TypeOnly<old.NodeSchemaOptions>, TypeOnly<current.NodeSchemaOptions>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -94,7 +94,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.53.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -111,7 +111,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.53.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -101,7 +101,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.53.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.53.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -141,7 +141,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.53.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.53.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.53.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.53.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.53.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.53.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.53.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -99,7 +99,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.53.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -103,7 +103,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.1",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.53.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.1",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.53.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -93,7 +93,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.1",
-		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.53.0",
+		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -139,7 +139,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.53.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.60.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.53.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.53.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.53.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -190,7 +190,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.53.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -131,7 +131,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.53.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.53.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -197,7 +197,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.53.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.53.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -137,7 +137,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.53.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.53.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -98,7 +98,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.53.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.53.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.53.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
@@ -153,17 +153,7 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_MockFluidDataStoreRuntime": {
-				"forwardCompat": false
-			},
-			"Class_MockContainerRuntimeForReconnection": {
-				"forwardCompat": false
-			},
-			"Class_MockContainerRuntime": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -40,7 +40,6 @@ declare type current_as_old_for_Class_MockAudience = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_MockContainerRuntime": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntime = requireAssignableTo<TypeOnly<old.MockContainerRuntime>, TypeOnly<current.MockContainerRuntime>>
 
 /*
@@ -95,7 +94,6 @@ declare type current_as_old_for_Class_MockContainerRuntimeFactoryForReconnection
  * typeValidation.broken:
  * "Class_MockContainerRuntimeForReconnection": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntimeForReconnection = requireAssignableTo<TypeOnly<old.MockContainerRuntimeForReconnection>, TypeOnly<current.MockContainerRuntimeForReconnection>>
 
 /*
@@ -186,7 +184,6 @@ declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<old.MockFluidDataStoreRuntime>, TypeOnly<current.MockFluidDataStoreRuntime>>
 
 /*

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.1",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.53.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.60.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -109,7 +109,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.53.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.53.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -139,7 +139,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.53.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -127,7 +127,7 @@
 		"@fluid-tools/build-cli": "^0.58.1",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.53.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.60.0",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.1",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.53.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.53.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.53.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/isomorphic-fetch": "^0.0.39",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.53.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -113,7 +113,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.1",
 		"@fluidframework/eslint-config-fluid": "^6.0.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.53.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.60.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@2.53.0
-        version: '@fluidframework/azure-service-utils@2.53.0'
+        specifier: npm:@fluidframework/azure-service-utils@2.60.0
+        version: '@fluidframework/azure-service-utils@2.60.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -7037,7 +7037,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@22.14.1)
+        version: 0.58.1(@types/node@18.19.86)
       '@fluidframework/container-loader':
         specifier: workspace:~
         version: link:../../../packages/loader/container-loader
@@ -7058,7 +7058,7 @@ importers:
         version: link:../../../packages/framework/undo-redo
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.14.1)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
       '@types/chai':
         specifier: ^4.0.0
         version: 4.3.20
@@ -7367,8 +7367,8 @@ importers:
         specifier: ~1.9.3
         version: 1.9.4
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@2.53.0
-        version: '@fluid-internal/client-utils@2.53.0'
+        specifier: npm:@fluid-internal/client-utils@2.60.0
+        version: '@fluid-internal/client-utils@2.60.0'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7494,8 +7494,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@2.53.0
-        version: '@fluidframework/container-definitions@2.53.0'
+        specifier: npm:@fluidframework/container-definitions@2.60.0
+        version: '@fluidframework/container-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7536,8 +7536,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@2.53.0
-        version: '@fluidframework/core-interfaces@2.53.0'
+        specifier: npm:@fluidframework/core-interfaces@2.60.0
+        version: '@fluidframework/core-interfaces@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7602,8 +7602,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@2.53.0
-        version: '@fluidframework/core-utils@2.53.0'
+        specifier: npm:@fluidframework/core-utils@2.60.0
+        version: '@fluidframework/core-utils@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7675,8 +7675,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@2.53.0
-        version: '@fluidframework/driver-definitions@2.53.0'
+        specifier: npm:@fluidframework/driver-definitions@2.60.0
+        version: '@fluidframework/driver-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7745,8 +7745,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@2.53.0
-        version: '@fluidframework/cell@2.53.0'
+        specifier: npm:@fluidframework/cell@2.60.0
+        version: '@fluidframework/cell@2.60.0'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7839,8 +7839,8 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@2.53.0
-        version: '@fluidframework/counter@2.53.0'
+        specifier: npm:@fluidframework/counter@2.60.0
+        version: '@fluidframework/counter@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8148,8 +8148,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@2.53.0
-        version: '@fluidframework/map@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/map@2.60.0
+        version: '@fluidframework/map@2.60.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8272,8 +8272,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@2.53.0
-        version: '@fluidframework/matrix@2.53.0'
+        specifier: npm:@fluidframework/matrix@2.60.0
+        version: '@fluidframework/matrix@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8393,8 +8393,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@2.53.0
-        version: '@fluidframework/merge-tree@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/merge-tree@2.60.0
+        version: '@fluidframework/merge-tree@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8499,8 +8499,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@2.53.0
-        version: '@fluidframework/ordered-collection@2.53.0'
+        specifier: npm:@fluidframework/ordered-collection@2.60.0
+        version: '@fluidframework/ordered-collection@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8684,8 +8684,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@2.53.0
-        version: '@fluidframework/register-collection@2.53.0'
+        specifier: npm:@fluidframework/register-collection@2.60.0
+        version: '@fluidframework/register-collection@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8799,8 +8799,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@2.53.0
-        version: '@fluidframework/sequence@2.53.0'
+        specifier: npm:@fluidframework/sequence@2.60.0
+        version: '@fluidframework/sequence@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8917,8 +8917,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@2.53.0
-        version: '@fluidframework/shared-object-base@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/shared-object-base@2.60.0
+        version: '@fluidframework/shared-object-base@2.60.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9020,8 +9020,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@2.53.0
-        version: '@fluidframework/shared-summary-block@2.53.0'
+        specifier: npm:@fluidframework/shared-summary-block@2.60.0
+        version: '@fluidframework/shared-summary-block@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9129,8 +9129,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@2.53.0
-        version: '@fluidframework/task-manager@2.53.0'
+        specifier: npm:@fluidframework/task-manager@2.60.0
+        version: '@fluidframework/task-manager@2.60.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9368,8 +9368,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@2.53.0
-        version: '@fluidframework/tree@2.53.0'
+        specifier: npm:@fluidframework/tree@2.60.0
+        version: '@fluidframework/tree@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9465,8 +9465,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@2.53.0
-        version: '@fluidframework/debugger@2.53.0'
+        specifier: npm:@fluidframework/debugger@2.60.0
+        version: '@fluidframework/debugger@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9532,8 +9532,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@2.53.0
-        version: '@fluidframework/driver-base@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-base@2.60.0
+        version: '@fluidframework/driver-base@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9611,8 +9611,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@2.53.0
-        version: '@fluidframework/driver-web-cache@2.53.0'
+        specifier: npm:@fluidframework/driver-web-cache@2.60.0
+        version: '@fluidframework/driver-web-cache@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9687,8 +9687,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@2.53.0
-        version: '@fluidframework/file-driver@2.53.0'
+        specifier: npm:@fluidframework/file-driver@2.60.0
+        version: '@fluidframework/file-driver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9781,8 +9781,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@2.53.0
-        version: '@fluidframework/local-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/local-driver@2.60.0
+        version: '@fluidframework/local-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9884,8 +9884,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@2.53.0
-        version: '@fluidframework/odsp-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-driver@2.60.0
+        version: '@fluidframework/odsp-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9954,8 +9954,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@2.53.0
-        version: '@fluidframework/odsp-driver-definitions@2.53.0'
+        specifier: npm:@fluidframework/odsp-driver-definitions@2.60.0
+        version: '@fluidframework/odsp-driver-definitions@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.14.1)
@@ -10021,8 +10021,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@2.53.0
-        version: '@fluidframework/odsp-urlresolver@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-urlresolver@2.60.0
+        version: '@fluidframework/odsp-urlresolver@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10097,8 +10097,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@2.53.0
-        version: '@fluidframework/replay-driver@2.53.0'
+        specifier: npm:@fluidframework/replay-driver@2.60.0
+        version: '@fluidframework/replay-driver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10188,8 +10188,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@2.53.0
-        version: '@fluidframework/routerlicious-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/routerlicious-driver@2.60.0
+        version: '@fluidframework/routerlicious-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10279,8 +10279,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@2.53.0
-        version: '@fluidframework/routerlicious-urlresolver@2.53.0'
+        specifier: npm:@fluidframework/routerlicious-urlresolver@2.60.0
+        version: '@fluidframework/routerlicious-urlresolver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10364,8 +10364,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@2.53.0
-        version: '@fluidframework/tinylicious-driver@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-driver@2.60.0
+        version: '@fluidframework/tinylicious-driver@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10449,8 +10449,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@2.53.0
-        version: '@fluidframework/agent-scheduler@2.53.0'
+        specifier: npm:@fluidframework/agent-scheduler@2.60.0
+        version: '@fluidframework/agent-scheduler@2.60.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10643,8 +10643,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@2.53.0
-        version: '@fluidframework/aqueduct@2.53.0'
+        specifier: npm:@fluidframework/aqueduct@2.60.0
+        version: '@fluidframework/aqueduct@2.60.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10828,8 +10828,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
-        specifier: npm:@fluidframework/app-insights-logger@2.53.0
-        version: '@fluidframework/app-insights-logger@2.53.0(tslib@1.14.1)'
+        specifier: npm:@fluidframework/app-insights-logger@2.60.0
+        version: '@fluidframework/app-insights-logger@2.60.0(tslib@1.14.1)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11295,8 +11295,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@2.53.0
-        version: '@fluidframework/fluid-static@2.53.0'
+        specifier: npm:@fluidframework/fluid-static@2.60.0
+        version: '@fluidframework/fluid-static@2.60.0'
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11556,8 +11556,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@2.53.0
-        version: '@fluidframework/request-handler@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/request-handler@2.60.0
+        version: '@fluidframework/request-handler@2.60.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11638,8 +11638,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@2.53.0
-        version: '@fluidframework/synthesize@2.53.0'
+        specifier: npm:@fluidframework/synthesize@2.60.0
+        version: '@fluidframework/synthesize@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11832,8 +11832,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@2.53.0
-        version: '@fluidframework/undo-redo@2.53.0'
+        specifier: npm:@fluidframework/undo-redo@2.60.0
+        version: '@fluidframework/undo-redo@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11941,8 +11941,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@2.53.0
-        version: '@fluidframework/container-loader@2.53.0'
+        specifier: npm:@fluidframework/container-loader@2.60.0
+        version: '@fluidframework/container-loader@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12044,8 +12044,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@2.53.0
-        version: '@fluidframework/driver-utils@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-utils@2.60.0
+        version: '@fluidframework/driver-utils@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12226,8 +12226,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@2.53.0
-        version: '@fluidframework/container-runtime@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/container-runtime@2.60.0
+        version: '@fluidframework/container-runtime@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12317,8 +12317,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@2.53.0
-        version: '@fluidframework/container-runtime-definitions@2.53.0'
+        specifier: npm:@fluidframework/container-runtime-definitions@2.60.0
+        version: '@fluidframework/container-runtime-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12399,8 +12399,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@2.53.0
-        version: '@fluidframework/datastore@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/datastore@2.60.0
+        version: '@fluidframework/datastore@2.60.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12487,8 +12487,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@2.53.0
-        version: '@fluidframework/datastore-definitions@2.53.0'
+        specifier: npm:@fluidframework/datastore-definitions@2.60.0
+        version: '@fluidframework/datastore-definitions@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12560,8 +12560,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@2.53.0
-        version: '@fluidframework/id-compressor@2.53.0'
+        specifier: npm:@fluidframework/id-compressor@2.60.0
+        version: '@fluidframework/id-compressor@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12636,8 +12636,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@2.53.0
-        version: '@fluidframework/runtime-definitions@2.53.0'
+        specifier: npm:@fluidframework/runtime-definitions@2.60.0
+        version: '@fluidframework/runtime-definitions@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.14.1)
@@ -12715,8 +12715,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@2.53.0
-        version: '@fluidframework/runtime-utils@2.53.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/runtime-utils@2.60.0
+        version: '@fluidframework/runtime-utils@2.60.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12833,8 +12833,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@2.53.0
-        version: '@fluidframework/test-runtime-utils@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-runtime-utils@2.60.0
+        version: '@fluidframework/test-runtime-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12912,8 +12912,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@2.53.0
-        version: '@fluidframework/azure-client@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/azure-client@2.60.0
+        version: '@fluidframework/azure-client@2.60.0(encoding@0.1.13)'
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13390,8 +13390,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@2.53.0
-        version: '@fluidframework/tinylicious-client@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-client@2.60.0
+        version: '@fluidframework/tinylicious-client@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -14717,8 +14717,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@2.53.0
-        version: '@fluidframework/test-utils@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-utils@2.60.0
+        version: '@fluidframework/test-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -15023,8 +15023,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@2.53.0
-        version: '@fluidframework/devtools@2.53.0'
+        specifier: npm:@fluidframework/devtools@2.60.0
+        version: '@fluidframework/devtools@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15346,8 +15346,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@22.14.1)
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@2.53.0
-        version: '@fluidframework/devtools-core@2.53.0'
+        specifier: npm:@fluidframework/devtools-core@2.60.0
+        version: '@fluidframework/devtools-core@2.60.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15835,8 +15835,8 @@ importers:
         specifier: ^0.58.1
         version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@2.53.0
-        version: '@fluid-tools/fetch-tool@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluid-tools/fetch-tool@2.60.0
+        version: '@fluid-tools/fetch-tool@2.60.0(encoding@0.1.13)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -15917,8 +15917,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@2.53.0
-        version: '@fluidframework/fluid-runner@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/fluid-runner@2.60.0
+        version: '@fluidframework/fluid-runner@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16129,8 +16129,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@2.53.0
-        version: '@fluidframework/odsp-doclib-utils@2.53.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-doclib-utils@2.60.0
+        version: '@fluidframework/odsp-doclib-utils@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16214,8 +16214,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@2.53.0
-        version: '@fluidframework/telemetry-utils@2.53.0'
+        specifier: npm:@fluidframework/telemetry-utils@2.60.0
+        version: '@fluidframework/telemetry-utils@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16308,8 +16308,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@2.53.0
-        version: '@fluidframework/tool-utils@2.53.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tool-utils@2.60.0
+        version: '@fluidframework/tool-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -17442,14 +17442,14 @@ packages:
       '@types/react': '>=16.8.0 <19.0.0'
       react: '>=16.8.0 <19.0.0'
 
-  '@fluid-internal/client-utils@2.53.0':
-    resolution: {integrity: sha512-jP7VhFqxuSOc03VU/IRBYdt9pVs3gQrilvA72kY1tfD4UqGWW5gT9Azsb3hY4TunHpXUUKYYi1nIF2EIbFav8A==}
+  '@fluid-internal/client-utils@2.60.0':
+    resolution: {integrity: sha512-CeitAFYQvbEPpheSkdTEqMNk02nMrZRWJJso+613+AeWUjt2JJV5DwhxHG4qf5UnM4tJSOgL+A8GhPbd/7nnHg==}
 
   '@fluid-internal/eslint-plugin-fluid@0.1.5':
     resolution: {integrity: sha512-p0nVeMiEfLL2deQJQaRUxid08jgV5wEkh9h9WXNosR1BRq9nFCjD8nZpC1K+YhjwQZEvgGDE+s+28VR2lAg61Q==}
 
-  '@fluid-internal/test-driver-definitions@2.53.0':
-    resolution: {integrity: sha512-8aUZxDVXyhghZj+BmthJ4WUva0qUEeuft23JnvXFzmMXFgbK/OaQow9QwR9aWxox0pa49aNBTKY+76eHQeilwg==}
+  '@fluid-internal/test-driver-definitions@2.60.0':
+    resolution: {integrity: sha512-TJV5kd5UnLIhrFhUmEeD2SL89+uHWn2SwaN+PIKhQO+PDpsbtFdBrvYdFhfCocUjoMEo0t+KVMllO5lPnTmQow==}
 
   '@fluid-tools/benchmark@0.51.0':
     resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
@@ -17463,8 +17463,8 @@ packages:
     resolution: {integrity: sha512-6TWr9SM5G49X6sKqjzec5B5lK1H3LEylgmIHUGhXQnvw8ura2YFvcIHERptRgNjjl9AZIw/fPCBrDk5sNZM2yg==}
     hasBin: true
 
-  '@fluid-tools/fetch-tool@2.53.0':
-    resolution: {integrity: sha512-pvE3DEqU8g+J4O3G08xXiWo9k8GTAr/EGbgXoAufi/7EHEiJLbBUYdvtYd6naCRB3QK6VhcHUVj3OPQWaJ585w==}
+  '@fluid-tools/fetch-tool@2.60.0':
+    resolution: {integrity: sha512-ayu9Yl1j+4EdaSf0p8pb11+CrXTsxDbGQB33yZWQYEW6as5x2gxxLj2NC0N8uCMyJfAIHDh/HnvFFomvKhuFzg==}
     hasBin: true
 
   '@fluid-tools/version-tools@0.57.0':
@@ -17477,26 +17477,26 @@ packages:
     engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/agent-scheduler@2.53.0':
-    resolution: {integrity: sha512-rPlZnG7UFymb5YZS+Uo7kJNAIgpZCimyF22hrWPLAR+HeuomFWMlgK0+Uks6kZ3SSAK8fsqGONEBx20TAyOs3g==}
+  '@fluidframework/agent-scheduler@2.60.0':
+    resolution: {integrity: sha512-Amwq8AsY4ZKQ+JqCrd5yGsY9xUVbS+d/45jXJttd28HuurWV3R3xAioBDcYlADHAtTDNhrbBlcTRcmQMdrcbiw==}
 
-  '@fluidframework/app-insights-logger@2.53.0':
-    resolution: {integrity: sha512-1AFJotPLoATKZiMg+ATW1d3C807AWhoihmD2hWcS3oY8Qi/9ub+p4pkQOYAlMGU2ngymTdYxzoSY7HhSrr1Mrg==}
+  '@fluidframework/app-insights-logger@2.60.0':
+    resolution: {integrity: sha512-9BcDqcanYtPjugUq7HeawcQfuhIomL2N3T9cfgSZIeidIv+XPngXGwKyNvZEQYGTxKNNWA7wNB891MIbY68ciQ==}
 
   '@fluidframework/aqueduct@1.4.0':
     resolution: {integrity: sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==}
 
-  '@fluidframework/aqueduct@2.53.0':
-    resolution: {integrity: sha512-BvsadzAml8/wOTLE4ceQa5kycNZH9jF3UXbTkN3px8X/O/C3i1wqv+MxzX/FoSqmGd5zVB/9oaSw0Qrp+8036w==}
+  '@fluidframework/aqueduct@2.60.0':
+    resolution: {integrity: sha512-Nh0pyDRLQY8vU02ay7RQ7CNdhIBZcK3GV+I65hTi/G6wiDL09ofjmmTopnQ+Jpf9+p9UofXc5e+SROvOHtEQGw==}
 
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
 
-  '@fluidframework/azure-client@2.53.0':
-    resolution: {integrity: sha512-VVfpftNzLos5guN2b2Jp26uLiPse1q30xvAISwVTdHuAcHzCzWymbUFS5Okq5xKENl/AIJ6QepVhZD/4mCAcNg==}
+  '@fluidframework/azure-client@2.60.0':
+    resolution: {integrity: sha512-XTxEShhDzEdYi5IZ1o1xt04AXGRa9GCqqZczqMf64WC+nCZFeHSEvglgMroNn0do5OOsCs/C4ha4KWk5erFb3Q==}
 
-  '@fluidframework/azure-service-utils@2.53.0':
-    resolution: {integrity: sha512-KXm8i30XQ2+ZNj2aevFuz6rccxLO0wu7QEUbVVVw9Bz5LeqXZH5CMRELCFTcf4GZg4ygwwPcwXrOYYkV+rXBWQ==}
+  '@fluidframework/azure-service-utils@2.60.0':
+    resolution: {integrity: sha512-3RvCoaQMyTndkiIkZY0pCTp7cNZ/2TIVMDov3/o6lIT+UarMTeN434qLtvKS0l5JMBI2PiLKOnQ8cOyrn07bcw==}
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
@@ -17513,8 +17513,8 @@ packages:
   '@fluidframework/bundle-size-tools@0.58.1':
     resolution: {integrity: sha512-45wsb8o9vQe9yMX7zr34pHJUPEtgpoZ0gIYlbcbic2GoQGgIhvquqoZ4TXn1KjJrdZZImmfR4yGs/bSb55Qnag==}
 
-  '@fluidframework/cell@2.53.0':
-    resolution: {integrity: sha512-L7uUAPMGZodkzKxZFwuuisddJPYlWvFciJk2FYzPT5IaRfaXWCbmdZ3EwIzX0t25E09eHxRomUcL6DWD/HSiOQ==}
+  '@fluidframework/cell@2.60.0':
+    resolution: {integrity: sha512-HGZTcac4RcEZ1tC45MqxeR1gCOcHansaF3zrTiyoT6ke8K8ADjSTJPlP3glWEa5fFTy1sQLpvw0dlfEpdKrrQA==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -17534,26 +17534,26 @@ packages:
   '@fluidframework/container-definitions@1.4.0':
     resolution: {integrity: sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==}
 
-  '@fluidframework/container-definitions@2.53.0':
-    resolution: {integrity: sha512-ESCohJoCpWDvm8drjXnah+MJ3VpxOexSZUddCixom2U2nApKiRJjrUam9TUUhvNAHq2XTFa9xfY9xN+QkrjeLw==}
+  '@fluidframework/container-definitions@2.60.0':
+    resolution: {integrity: sha512-mN5gGodT8NrmavsXSXhhBb8hcPyurZHex6MkBQ2pSveeitMBNA2TksTom+1jPRyQEPUf4ee2zWsaMtxCGY3nRw==}
 
   '@fluidframework/container-loader@1.4.0':
     resolution: {integrity: sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==}
 
-  '@fluidframework/container-loader@2.53.0':
-    resolution: {integrity: sha512-SicVJn3lN4J6ievb+6iP/AAzoTK525C6zgfA1UyHZUT50A7WkEerKGYP+ZflUXAgQL7HR3pAnqu8/sbYoO6cPA==}
+  '@fluidframework/container-loader@2.60.0':
+    resolution: {integrity: sha512-Yqh0nklNMtu2hpJBgb0RBccmbHKJfPPZYxbYMFEpAmWxsshkZzXdg5cbu6ZG1g2pH42IqaKDE8ziD3ChTurEFw==}
 
   '@fluidframework/container-runtime-definitions@1.4.0':
     resolution: {integrity: sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==}
 
-  '@fluidframework/container-runtime-definitions@2.53.0':
-    resolution: {integrity: sha512-GxcVZx8izyOHf46e9o41hDO58uFzarOTieOprVHjGobsgGlbC/aZre3RL2JdW0R+IMsatSGNRw2RMH5w1gczAQ==}
+  '@fluidframework/container-runtime-definitions@2.60.0':
+    resolution: {integrity: sha512-PIScG79w2SadO1ew8iqhnQp7QEglPvTP5vP8C4ZVGXcsKhCNJB9s20KymBbqWVrtMiXhdugcB1lUZOyFYLCzsg==}
 
   '@fluidframework/container-runtime@1.4.0':
     resolution: {integrity: sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==}
 
-  '@fluidframework/container-runtime@2.53.0':
-    resolution: {integrity: sha512-gI4HxTjdLXA+e+IKsiEt/GJ4otje9T3vhnb8yscX20uqlmawXjvOyuT8jYMdguVx1jmo8DRTiUPAL4Q3+WQGCw==}
+  '@fluidframework/container-runtime@2.60.0':
+    resolution: {integrity: sha512-691sK36eW+sroQoPma6NjeTLGr4T5IaD4DHLWzAtvOHYIFyzkI7LybVYcIerAjTguNf8hFoTZGcF1gOnT0VgBg==}
 
   '@fluidframework/container-utils@1.4.0':
     resolution: {integrity: sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==}
@@ -17561,72 +17561,72 @@ packages:
   '@fluidframework/core-interfaces@1.4.0':
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
 
-  '@fluidframework/core-interfaces@2.53.0':
-    resolution: {integrity: sha512-9bxWFcMs6/S025B2c86mWPTqwQ8WaYDAsEeYXUbOJuo/yfJgFFvqVLSOve+5ugay9shUWS9OC4rB0/IxKkkIGQ==}
+  '@fluidframework/core-interfaces@2.60.0':
+    resolution: {integrity: sha512-8+ccjnDnHbeLjBhYot6AMQTJJk2MgMMGQQNxDkeNlI8Eh7xneY0I5O1l3j3DnhR6r4yggMq/MlbRyhvrPAkeNw==}
 
-  '@fluidframework/core-utils@2.53.0':
-    resolution: {integrity: sha512-h+PiFdJb7dMB5dT50AYZP7tJxpcZpkICRpILr3zzSBJsPo38rWFBuf0hq9N0V6vc6SKNLSqApYqolLRgVgYGxA==}
+  '@fluidframework/core-utils@2.60.0':
+    resolution: {integrity: sha512-KnjuKPhRru/HpP7mLrjuH/riLO04K4ZakTYi9pJBbLy/H/gd5sLnMNqVe0tF3HPYSrr1sJVxndmj090aE0aLEw==}
 
-  '@fluidframework/counter@2.53.0':
-    resolution: {integrity: sha512-TTAy7ME2a+uoyT1y5mCS2nTq5BvHVimj1sVIzVzOltg6TXh5JjizvksjbYsoPhRMs2GGolodrtQ8cC1cgCrwVQ==}
+  '@fluidframework/counter@2.60.0':
+    resolution: {integrity: sha512-vk+3+5coimFM0uqpmT6+WSuKYLiKpblVVz2bIF+BGqdBSDRWFAkH4Fcj/kjDUA4kuBkdqz0tNcMBw5coylMPXQ==}
 
   '@fluidframework/datastore-definitions@1.4.0':
     resolution: {integrity: sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==}
 
-  '@fluidframework/datastore-definitions@2.53.0':
-    resolution: {integrity: sha512-COtjg/8/3dt8P5m62VDS1uAJztRjfdnQCLPftZhXUlDqj4GG3c+TOnbQLNL/IcS5Rgi9pwVSeccjCpmOwwvDkg==}
+  '@fluidframework/datastore-definitions@2.60.0':
+    resolution: {integrity: sha512-Dy4z9pbgjbvaSwETbwHBSbF6Qdc95lY6RxQ6xUFVYczJZh6e++74jGFPehEM6o7iocFWvRryG8VzDSZ5bBf+7w==}
 
   '@fluidframework/datastore@1.4.0':
     resolution: {integrity: sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==}
 
-  '@fluidframework/datastore@2.53.0':
-    resolution: {integrity: sha512-NS8JFjhTqqotEvncyJOApPgb5jnCf5bF8lzklCi5Gy58Zw+EwyLE7A+uLX+FHrihb9miXTyh6w2J0Y4H2X4TSw==}
+  '@fluidframework/datastore@2.60.0':
+    resolution: {integrity: sha512-Q7B1ZfoSy1Rl0GF++/IQ0nOSxrL163z34p/RqAqXmbjLntwocS+3yU/b4mu0iBgzb2gB7kJM6hZc93PHP6t07w==}
 
-  '@fluidframework/debugger@2.53.0':
-    resolution: {integrity: sha512-cWCsEV6zFkOOxs3cack5rvCGSAat+ek6v8Rs/GsjeJoUDRu6/Tkit0TTlMh7WkvYB37FeRUL7oYsViN6lUlVcw==}
+  '@fluidframework/debugger@2.60.0':
+    resolution: {integrity: sha512-YGYSplboKSBQedx6FDhnn7Fxms9VGKEKp966trLHWeaafCuf1z1rrEkhst5bTV9USuE0hJ3UI137PojTzmjudw==}
 
-  '@fluidframework/devtools-core@2.53.0':
-    resolution: {integrity: sha512-bm6EiAgCsMrHPT+fQxmD2XnjciWmNW5iBUkxQi/sxmNUIukU+tPG0ZbTHmUC2ae7+yi0eYO5Bn7C16DuwIOdVA==}
+  '@fluidframework/devtools-core@2.60.0':
+    resolution: {integrity: sha512-YlducYcTMczDnXyhXilHIXFZhN+uUYU6VwMmjAWumvAoM3AwCHW9WAb470lq6ujt6Fimw9oS8WdTknfA8Qh72w==}
 
-  '@fluidframework/devtools@2.53.0':
-    resolution: {integrity: sha512-uaFJkRaJEaMPZkCALbwi+w+SQqIR8QwG+J97uzp2Fqwym6cjZMFMrqSPkTcsXU2V+te8kdMI8NWCzHnr9SxB+w==}
+  '@fluidframework/devtools@2.60.0':
+    resolution: {integrity: sha512-lb297QwzvPnwvDVTK68S9xjmlzm11+GtsUrXMrlxSuJEOLn+M4OYXqdz3lTshqXb0iDco8K53Y1BAlfGWP7UjA==}
 
   '@fluidframework/driver-base@1.4.0':
     resolution: {integrity: sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==}
 
-  '@fluidframework/driver-base@2.53.0':
-    resolution: {integrity: sha512-gVIkp3ZDQ2T4gSFWyh4nh3MsXKEiKnPB9Si9pBAXB/6dEBJZe0BLaK0OrOcQSMEf3s2EFjuFODIjARHnb0flXg==}
+  '@fluidframework/driver-base@2.60.0':
+    resolution: {integrity: sha512-BjjnDHmSEZ+W9ZaXde5+GweGl9Z8xLCrPVnPLrFHQy5VyD8toS6HJAgPASgAyLDEVxPiGTj7Bna4OR+N1m3VfA==}
 
   '@fluidframework/driver-definitions@1.4.0':
     resolution: {integrity: sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==}
 
-  '@fluidframework/driver-definitions@2.53.0':
-    resolution: {integrity: sha512-b+7tnBJpIweRpZrLCqlBPHmfHewrwWdb6R3RBW7erkUjP8I9InapBbe7xN3lQ5EfE6XB5cF1jprAvqihvs6SBQ==}
+  '@fluidframework/driver-definitions@2.60.0':
+    resolution: {integrity: sha512-GrFaeewL0EnYQhGX/OicPP7GCtf+zNecIDYfLlUlQKsQu2+tJCE4LA8Xda5AXamJZ/3bGnyeWluwJHS3zsmFMQ==}
 
   '@fluidframework/driver-utils@1.4.0':
     resolution: {integrity: sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==}
 
-  '@fluidframework/driver-utils@2.53.0':
-    resolution: {integrity: sha512-VmEwUAf8vBIRNixeZJuZR8XdNFBC6+G9Yt4QW8+JgWtWv4h6Tu5FP4nDqr20qKOFVbIz+fkiyhykSeBwidxXwg==}
+  '@fluidframework/driver-utils@2.60.0':
+    resolution: {integrity: sha512-UPOe7pZfz6di84D1rB4CIukMMbs8pb0YNA+Mx8GXqIK/PWwqTv4/byuB68fvEWUHM3weptA92sweyJHhofH1bg==}
 
-  '@fluidframework/driver-web-cache@2.53.0':
-    resolution: {integrity: sha512-a5onIHIvJQqDdzpeiY6W0z3C8mXY0LLhHVxLD30ptKYQF0cHXQkoECw8uHfjqKkSvV1Gf8BY8amSRjMcKmnZhw==}
+  '@fluidframework/driver-web-cache@2.60.0':
+    resolution: {integrity: sha512-go3Bk3XcwTLVy2Dbb8eYiGchD7t9sehORbom5P1KFXUSqvwleOTLrsfdJ7qROWeiLlUYC4vuc1INqeirxPUFeg==}
 
   '@fluidframework/eslint-config-fluid@6.0.0':
     resolution: {integrity: sha512-RdbEYUQmLkW8zQ6GZXx1T/t5g9k7iA5K6vPZdvsIK4keb5VXcVCHDluvc7AtOXEVOb5Bt2XyM16NWz2Rlho5NA==}
 
-  '@fluidframework/file-driver@2.53.0':
-    resolution: {integrity: sha512-DrekmFsY59Kp8ZZOexu365I2Y5Hagh+EoKTwW9CQIBn+1Fci1AKhKGlXuczLz6/w9LhtWZ7XxCW9yEx4AQwkMA==}
+  '@fluidframework/file-driver@2.60.0':
+    resolution: {integrity: sha512-l7AM6Isp5BOrLEc3aOu76TFcCIukkPTbNeP7kcjJ3oRj65ziWxvHg14qFQINZgIlX7VmqZVlfRdZOmhSJHni3w==}
 
-  '@fluidframework/fluid-runner@2.53.0':
-    resolution: {integrity: sha512-BruzoouWBzkuMNo9yUB6sS1q+PNeWjtoJJng8Md0DxiOE8s5fXH8zRVTOF1+lHjNCbVLW90YsU49xQ7ABxMOpQ==}
+  '@fluidframework/fluid-runner@2.60.0':
+    resolution: {integrity: sha512-WDEY2Djwa4niop753zZ6U/Jv59ltdLh4ZLMlzz8Dj7GJvWN/ffxCJ+JH/xSXJczbIEpt9IrkRVv7MHxChaJ84w==}
     hasBin: true
 
   '@fluidframework/fluid-static@1.4.0':
     resolution: {integrity: sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==}
 
-  '@fluidframework/fluid-static@2.53.0':
-    resolution: {integrity: sha512-87hQYbIPoSpvqspDdIJU/h5abhCHDmkaajg7Ie3B1vpl2WY95WRuTLlifLX7cVyxXjBFb+dxtcJpG4dR1NSBCg==}
+  '@fluidframework/fluid-static@2.60.0':
+    resolution: {integrity: sha512-Xbk/4Rx//uWNPvZPr5jlTYYe5sZhOOiR3DSfubloFbiW4x9Ln80akuuVtZUMQs5jYDqQih7cV70RV4nBZVnOrg==}
 
   '@fluidframework/garbage-collector@1.4.0':
     resolution: {integrity: sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==}
@@ -17637,38 +17637,38 @@ packages:
   '@fluidframework/gitresources@7.0.0':
     resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
 
-  '@fluidframework/id-compressor@2.53.0':
-    resolution: {integrity: sha512-ZVsPgWohUsM0n3tHbNqSI6pmNbOAYAlUT4dhhGwZM/6bjaxAs+DrS7YsMmhepuyGzxPUZn4BzfdDRFsgeeNz6A==}
+  '@fluidframework/id-compressor@2.60.0':
+    resolution: {integrity: sha512-xFF/Bgs3Z+Ndc/nrhnUXms/pSRP2yKTWdq0eFKjfcheG7yCQaxx3/U5F8k8Zi6D4oc6jEhWunODtG3JJtYXXHw==}
 
-  '@fluidframework/local-driver@2.53.0':
-    resolution: {integrity: sha512-vrW72D2VT+7B332BgOoOo1tOvGl2jhsyOzEM8ne0ZklrsvAp51f1pBZj3v4Greww76Y2gjzK1xf/h7QPmOMu2Q==}
+  '@fluidframework/local-driver@2.60.0':
+    resolution: {integrity: sha512-rgXOFJyuwzXA9/89IUC80ajfI760u42YQT8ZI5d2ADAxMe7Vs40ithS0AEKFSbwE6oYu2MJvlYX8Kx/oogzutw==}
 
   '@fluidframework/map@1.4.0':
     resolution: {integrity: sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==}
 
-  '@fluidframework/map@2.53.0':
-    resolution: {integrity: sha512-ZBLzCITfa+xTxlqb1lwwE1YupkuGBkL8iD1E9OUSfLbqdGQTWXOcZhBado1EKMExHlg6C63GrH6uvmQPawJk/w==}
+  '@fluidframework/map@2.60.0':
+    resolution: {integrity: sha512-8IAxs6ynG2vFsgN5UZ8VJWEQEOR0LyVqCUWsgNphsJxeTbk0+3LWMj8cZE1pOkjq4vr8S2ur2guIl6lV+rmrcQ==}
 
-  '@fluidframework/matrix@2.53.0':
-    resolution: {integrity: sha512-PoUR+RxDgd/TqRUZuBy5pL4igxfMXM4Qs4g35EvTSzR2k99TlgJ1k0agF0FTAomrFdIA4G+bw6DeIoaixy5IYA==}
+  '@fluidframework/matrix@2.60.0':
+    resolution: {integrity: sha512-Wrxm/JK/L6opbIXHJSXUSJ62e1fZdsEWPjmsNdOiK6RxECErX0TqTziDvPLlCnY/hiPsc+uXVeCZfVZGLTFtWA==}
 
-  '@fluidframework/merge-tree@2.53.0':
-    resolution: {integrity: sha512-L+WKYTada7J0sHddXyQHM1Rx3e+yjgoS0uC+0akM9YY9bAqVZcmc8UTDRADfCa6QEMFsKSTprK8Ow1uAuU1xQg==}
+  '@fluidframework/merge-tree@2.60.0':
+    resolution: {integrity: sha512-FGnxVecmMCUufM4RjKz5xQ3YTXhy2ndqXA+guoVcCfDoOfH7/idvgTov6Zb0EszVH/A8rGxqA7m6UhQx+5wxRg==}
 
-  '@fluidframework/odsp-doclib-utils@2.53.0':
-    resolution: {integrity: sha512-KfNYw/168jzH7KJcjPboA3bq5OObpF1mLm4xrpv43J/ti1tzuizJ4PoUNf1sn+4AXWpLcSXdZ+2i5kRJ4i4jtw==}
+  '@fluidframework/odsp-doclib-utils@2.60.0':
+    resolution: {integrity: sha512-vZMUtPzYIdBcBU69JUJRmmT4Q/54LqQ0rrDyTxiHTaw0Ol1EFmZ1YjTu5M9TAN31QDVE1wbyA9qU5O5xMgtgrw==}
 
-  '@fluidframework/odsp-driver-definitions@2.53.0':
-    resolution: {integrity: sha512-RvqqF2ZwlKRacxv2IYK+SFZgbSQXJSLhGyYE01OIu9DeeGRf01iigUHZwLC0ISMfMS2y6nILialYRn0n7HP13g==}
+  '@fluidframework/odsp-driver-definitions@2.60.0':
+    resolution: {integrity: sha512-O28QNkus+ASyX2aFx9fiaozjMKza638i9CeMmp836AwQvItAY8ETr2LUe+BCZ/I34TjzBvuf3vK88PgesSqDdQ==}
 
-  '@fluidframework/odsp-driver@2.53.0':
-    resolution: {integrity: sha512-DjIOk5O6l0nZaczPk6rfUla63g/XP617FDxB0Aq455eqxgEhsU3HBDJ4Fyrhu5A6SnJNm6Y/iSJ5XRaujZD8PA==}
+  '@fluidframework/odsp-driver@2.60.0':
+    resolution: {integrity: sha512-6tv6LYkTbRV18UIlhR20gUY0zaX4DDMxI+kbkGWZnyp0T+AI4O/qTuw06dirJo+4qE9PEfChqnP3WDUlfsJjnA==}
 
-  '@fluidframework/odsp-urlresolver@2.53.0':
-    resolution: {integrity: sha512-INUN5Uo9kOfD9N80eqLepzy9GlwTFGZM3Lr+kml9zb5psBX3twHRL3p4FtkBHyBkOZKQKZf3sJjCNXEfW78sQg==}
+  '@fluidframework/odsp-urlresolver@2.60.0':
+    resolution: {integrity: sha512-ol/HViUQC0FBq29wl+Yg2iEZVHN4PZrjnD02kOX3hynv6YlUuxHaDmjUGEPQpOxCYUTwsJt/8+sCxwF4enIhww==}
 
-  '@fluidframework/ordered-collection@2.53.0':
-    resolution: {integrity: sha512-6wSXsjg2+qQtIq2g1xHMYpxAjnJqfJCO3XS3Bdxe1TWk0p1eNRIm6BaSBdNyoNQ/y3DnKkF7G8jeLL6GheZJTw==}
+  '@fluidframework/ordered-collection@2.60.0':
+    resolution: {integrity: sha512-E1w79UHKwfixTlKrysdFJhvcc3karW8h6tI3kGX2EkfhUCUJAGPbb4lmgRdtxDhppT+qmnLaItLElpERZHzpDA==}
 
   '@fluidframework/protocol-base@0.1036.5002':
     resolution: {integrity: sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==}
@@ -17685,41 +17685,41 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  '@fluidframework/register-collection@2.53.0':
-    resolution: {integrity: sha512-V1OIXmmKECPPml7IQ3FLK7jrvsDq7ckVIkwu0e2XAKaPUS1JhdGCTQxko7OLNvhwgKXzWY8FXmlYI9wlkUxAeA==}
+  '@fluidframework/register-collection@2.60.0':
+    resolution: {integrity: sha512-oMqWeGmvu9yl4lmj044/FL+JC99b/W6W/3y88dUIzbiTP0bE2qq4aqB0Vay+zLeIY5mKHZ2CxBDjJHAu1YV6hQ==}
 
-  '@fluidframework/replay-driver@2.53.0':
-    resolution: {integrity: sha512-+4AXRYoQtjvQHopl/OG9PH4stkujmPQGVtEcUMfKBjcbAepAnxRcBcS/H9Wpr14OpvacvL+SiocvL2zjorI3/A==}
+  '@fluidframework/replay-driver@2.60.0':
+    resolution: {integrity: sha512-P1s069acb+R0VoqV3oAdtTEHInkPkDquTccuNg1ffdsO2/9cfFxa0OItYKIMJcKCAG8dbdfNAey6ULjr5LXH4A==}
 
   '@fluidframework/request-handler@1.4.0':
     resolution: {integrity: sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==}
 
-  '@fluidframework/request-handler@2.53.0':
-    resolution: {integrity: sha512-x04C5ZINoCQ/KIhL5gCiIrF0CFN1Ofj5PZgD9TZ/EPHtyGwLFYmu3E6h0bhJ2kbiL5Mij4frT49JtlEM+8wY5A==}
+  '@fluidframework/request-handler@2.60.0':
+    resolution: {integrity: sha512-3SA0o8ZOxZXbrPURBW6WBH/IEZJCNAQeVFmZsqPeVzqaGh7B7axVORyNEUPMVZC/pzLiF+4roRnDVqQ8GhKvLA==}
 
   '@fluidframework/routerlicious-driver@1.4.0':
     resolution: {integrity: sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==}
 
-  '@fluidframework/routerlicious-driver@2.53.0':
-    resolution: {integrity: sha512-IvyFWKHCwGrvEk8k1ne9TvZLPilPIYMeoD//o2N2jySVq9VHqS3nJMIbHpZK74hXZV1ehcfdoLIUGrHn8ejpNw==}
+  '@fluidframework/routerlicious-driver@2.60.0':
+    resolution: {integrity: sha512-uY1jHgVN3i1IOaE3rIja31ze3cFrFmlACYja81MaHXzy25F13geqKv5REEXmEW36KEZ/iZOUXRFCWeQPsGPngA==}
 
-  '@fluidframework/routerlicious-urlresolver@2.53.0':
-    resolution: {integrity: sha512-LZLe5jYcpTmvgDrfRkgnFXz7qSmzTmtV9NdllvlK4Or03tBuLHOR+5g6f6Jy1zBq0OjCiD7U4E2022X9KLY0IQ==}
+  '@fluidframework/routerlicious-urlresolver@2.60.0':
+    resolution: {integrity: sha512-QvGjc8bM4G36cVQTvUG51WCbtKMgikbl7d+VqD0U5sSIIjefd/LRGik87kV0zPdk9tYXkgCERYJVnuFj0itmXA==}
 
   '@fluidframework/runtime-definitions@1.4.0':
     resolution: {integrity: sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==}
 
-  '@fluidframework/runtime-definitions@2.53.0':
-    resolution: {integrity: sha512-X2ltLjrerq2ONPd5eD2ccZ5mZDF2kQqJQ9jZ2umgzw937UxsW0N05QTri8HRmWEOUh0g01KtbVI5smhJKuVyxw==}
+  '@fluidframework/runtime-definitions@2.60.0':
+    resolution: {integrity: sha512-9TX1GuKy9zYil95hwhWfafVvA6Rn7NxcagZatEYPFNcuMp452ZqokQ/6upTiY8w8u6CgGE+ye/R/l+EsMmUtYg==}
 
   '@fluidframework/runtime-utils@1.4.0':
     resolution: {integrity: sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==}
 
-  '@fluidframework/runtime-utils@2.53.0':
-    resolution: {integrity: sha512-46bjEZV2HMsPEbsXx0H0jJDX09QlpQFiA2H8Y0jVPkzpAGVW3aFIVboVw4opFC4dCh0BJaZz562h1jo1ypIpSw==}
+  '@fluidframework/runtime-utils@2.60.0':
+    resolution: {integrity: sha512-bM9ArMEhchp4UARzCjY/j07Wy2DOhnYRcREXTsSQus2eDswC1vuQqTUY+YIbBX43DOv9noS1HSfiOB79Fmb/vA==}
 
-  '@fluidframework/sequence@2.53.0':
-    resolution: {integrity: sha512-6bHeWVAn1DxTZfqyMleTIApK6WSeAr/GKRw/YyFz0BiEPkBtWeMJzz7CiNmyKo4bNnY4Uv6mSm5lNpzYZBjajw==}
+  '@fluidframework/sequence@2.60.0':
+    resolution: {integrity: sha512-lUykZS/pGeV1gQegDpA5FcgHcc0r7awViYB1V26jD2UbiDLPgZIWeUCZ4PERTxQbmJUdtufrlfJVp9marSzVlw==}
 
   '@fluidframework/server-lambdas-driver@7.0.0':
     resolution: {integrity: sha512-HNXeXUWYIR+jjGMAB61gCWsryuwqysA2o7/bwvdZuM4avqfm75dJUheB6N04uG5GfRfvesMHU68452YHIf6FYQ==}
@@ -17757,51 +17757,51 @@ packages:
   '@fluidframework/shared-object-base@1.4.0':
     resolution: {integrity: sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==}
 
-  '@fluidframework/shared-object-base@2.53.0':
-    resolution: {integrity: sha512-UeEM5IMQOEG/ume2bH7XKr802WwXs32DlRUX3DsugXuFeEtv2neyjZVXtBgxFiVR/Qq1/q+tBqouTkFf+hqnzQ==}
+  '@fluidframework/shared-object-base@2.60.0':
+    resolution: {integrity: sha512-9RaruFHJcFBakUwwhmC1quQ4/Uu0z1w6fDdJZ8PZhbInDq6ZYp6Oi5tUzXyKK3k7sm5/rJdugr9Agzv1GG3IRA==}
 
-  '@fluidframework/shared-summary-block@2.53.0':
-    resolution: {integrity: sha512-z6Ieogk0t/z9rz/xX4EJNrS/kaqqDMfAXCo3bEyAZQwSp175pm0JDuuT0d3ux+LvspHAEtxNKopN2lVTejfzww==}
+  '@fluidframework/shared-summary-block@2.60.0':
+    resolution: {integrity: sha512-jA0HpJiPCTcX60Zcv/7n+xaI95PRA0EpAQaBbp/bLU4PSH0ixCWo2kp5iO4QqX735WObRv6VktgTr0uWAeuW8Q==}
 
   '@fluidframework/synthesize@1.4.0':
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
 
-  '@fluidframework/synthesize@2.53.0':
-    resolution: {integrity: sha512-nmZ0N0PPjZcLRFgtDnSlBRoLBRWFBn1nP7YJItv8487u2W+qQV5WCYXDBcrb3BJS4gilLC+SIUW86e46GG35Jg==}
+  '@fluidframework/synthesize@2.60.0':
+    resolution: {integrity: sha512-KBkX4kOaZKNEwMq69N/RyJhiSK7UiFvQuhzbL/nK3YMehARgFmjwBnYzLM5X5+aQwgbetf1iwJLBifouOi3qbw==}
 
-  '@fluidframework/task-manager@2.53.0':
-    resolution: {integrity: sha512-ciLspVEZcyfC6HlGcWFJG2yjoylu2jYvPhe+ktIhjnA35bEWwHymWEIJUHRWjyN9nTnwqa2d4Z5grvXhtKOibg==}
+  '@fluidframework/task-manager@2.60.0':
+    resolution: {integrity: sha512-Fft1lpIv3rDS424ztw878FN6lnVOlfd4Lx0bsM+43VdfCzlsaF2ucwl/SuRTXMzTFuK3gCJrJcEpgN2kwPgbeg==}
 
   '@fluidframework/telemetry-utils@1.4.0':
     resolution: {integrity: sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==}
 
-  '@fluidframework/telemetry-utils@2.53.0':
-    resolution: {integrity: sha512-9OajKA95JrlNh9LGRk+fkXYXa4ckx3NkZEKvKXInr39YIW4ejYfkl5INB0dJtIx8CQ2XK8g/1PiZane0bfa2jQ==}
+  '@fluidframework/telemetry-utils@2.60.0':
+    resolution: {integrity: sha512-TN1DQUHGUYfAb+f1vjGP5zwDdJv7L9Oy8FOIZXW9fm0K3hcYQ0cE79w3r4r0iQ34ORyUkEaTgnJF2xubc8Mlnw==}
 
-  '@fluidframework/test-runtime-utils@2.53.0':
-    resolution: {integrity: sha512-snOf3vO5r0V9VlsC40V+1+nCb7MQyu9XaCDyt2pR6Y8fbeKgU03ujzOGl9myZxI0OK2j/iPTAj6/EcRxcGHCVA==}
+  '@fluidframework/test-runtime-utils@2.60.0':
+    resolution: {integrity: sha512-lHdITyTLQ9qiUihvmWyQ7Vqs20Dh4iQZUMq/4u50mM4xWJn7A5MMlqeiWOkv4RRPiGSokypOchyBUQ+cTPIF1A==}
 
   '@fluidframework/test-tools@1.0.195075':
     resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
 
-  '@fluidframework/test-utils@2.53.0':
-    resolution: {integrity: sha512-c7GpEr0rHNRwvjvXR1jVoSVov1qCJFfrn8/pIUXUgQuMxLJioMQzG9deZAfm4BgVouAA3gMAEsyQEOJZbYWZ1g==}
+  '@fluidframework/test-utils@2.60.0':
+    resolution: {integrity: sha512-9pkGz2WKfKe9AOF3LSYGio51T7Lfxce7o5/thLC6kL6cMzcGTcYUiS/7cUYYQ2kFkr7+pi31hVP7AyVn/bfPBw==}
 
-  '@fluidframework/tinylicious-client@2.53.0':
-    resolution: {integrity: sha512-wE1mm5X5apQm9HaNv+cVUUym7o+RConvnKXNCQPtSTvYgIaxek2pztqrk+z/M3FLqOhsy2dvnEw3+N9Bdq/o3Q==}
+  '@fluidframework/tinylicious-client@2.60.0':
+    resolution: {integrity: sha512-IIHBVuow5HX7y6SJBfw1nGBVQYS6b1XuApDu/BoZNTPJ+iUlih0Vpc4j2rvCEmAz+zcRBg4vPYS2U72C/Te+JA==}
 
-  '@fluidframework/tinylicious-driver@2.53.0':
-    resolution: {integrity: sha512-+rxKFLV0hLfXakv/tyRNCrDUQ2pd/uyqWMkveOQDlEbrTRFIXhV/2JNq9SjaUYb+HbFnjRu6sS4mkBgKI/IwFw==}
+  '@fluidframework/tinylicious-driver@2.60.0':
+    resolution: {integrity: sha512-is/DbdDQV1Dc8VFpfffum8z5jEabKGZgQr0Se7UNljQoDybW1pZ6jPzH+Is6RqFlI/bZwSmFolOcQ3zuEQILdQ==}
 
-  '@fluidframework/tool-utils@2.53.0':
-    resolution: {integrity: sha512-qN5ek3d16O6uwyeNHon0AAAUm3w5Fp18HQvEGRACG/qQTgT3GetZrREcXG2JhfngvD0iCbY1Np4BgkyOAQSFSA==}
+  '@fluidframework/tool-utils@2.60.0':
+    resolution: {integrity: sha512-WJqtRvRaKe/YM8PPxOMN85QBAcC80t4KDejvZaHlFxOUoCfSTo9Wx6EgWtboM/Ku1nWn4tBQuJTnNGSqsWHtdQ==}
 
-  '@fluidframework/tree@2.53.0':
-    resolution: {integrity: sha512-rUBb1pq/jUatNeJWJ4mbmZRf/cY1MfHPK7LKzMBd0/DbR3ibubAJWTU7u5Gjj5zevzN1UbSezrH/b7jnS5d7AA==}
+  '@fluidframework/tree@2.60.0':
+    resolution: {integrity: sha512-CKa7FfeqefnLMKzFfWW6ft1m54ErZmuS8RmwRDWqS6WNFAoJFnEvjiFB6sGFVkInQGlq8fTH9uQF+JR/t2KS6w==}
 
-  '@fluidframework/undo-redo@2.53.0':
-    resolution: {integrity: sha512-7AfYbFZMDG6zx5TZCZFMGmae11gf5caDoTtwNYo2CXlSzXkLOQ5tqV4P3qVzs3xTIJR41PGdW2VGxIAgKHNVYA==}
+  '@fluidframework/undo-redo@2.60.0':
+    resolution: {integrity: sha512-PB5gHg46Tz1KViksK2uIc3+ydvVlGpQHpoEx5Zyh3+M83TdeTw4Oyc7hUDWzptZr9q/w6yJlSr85I7Eoi4llQA==}
 
   '@fluidframework/view-interfaces@1.4.0':
     resolution: {integrity: sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==}
@@ -29604,10 +29604,10 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluid-internal/client-utils@2.53.0':
+  '@fluid-internal/client-utils@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
       '@types/events_pkg': '@types/events@3.0.3'
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -29624,10 +29624,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-internal/test-driver-definitions@2.53.0':
+  '@fluid-internal/test-driver-definitions@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
 
   '@fluid-tools/benchmark@0.51.0':
     dependencies:
@@ -29846,24 +29846,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/fetch-tool@2.53.0(encoding@0.1.13)':
+  '@fluid-tools/fetch-tool@2.60.0(encoding@0.1.13)':
     dependencies:
       '@azure/identity': 4.5.0
       '@azure/identity-cache-persistence': 1.1.1
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/odsp-doclib-utils': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/odsp-urlresolver': 2.53.0(encoding@0.1.13)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/routerlicious-urlresolver': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/tool-utils': 2.53.0(encoding@0.1.13)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/odsp-doclib-utils': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/odsp-urlresolver': 2.60.0(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-urlresolver': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/tool-utils': 2.60.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -29903,6 +29903,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@fluid-tools/version-tools@0.58.1(@types/node@18.19.86)':
+    dependencies:
+      '@oclif/core': 4.0.36
+      '@oclif/plugin-autocomplete': 3.2.13
+      '@oclif/plugin-commands': 4.1.13
+      '@oclif/plugin-help': 6.2.19
+      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.86)
+      semver: 7.7.1
+      table: 6.9.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
   '@fluid-tools/version-tools@0.58.1(@types/node@22.14.1)':
     dependencies:
       '@oclif/core': 4.0.36
@@ -29919,27 +29935,27 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/agent-scheduler@2.53.0':
+  '@fluidframework/agent-scheduler@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/register-collection': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/register-collection': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/app-insights-logger@2.53.0(tslib@1.14.1)':
+  '@fluidframework/app-insights-logger@2.60.0(tslib@1.14.1)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
       '@microsoft/applicationinsights-web': 2.8.18(tslib@1.14.1)
       '@ungap/structured-clone': 1.2.1
     transitivePeerDependencies:
@@ -29967,24 +29983,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/aqueduct@2.53.0':
+  '@fluidframework/aqueduct@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/request-handler': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/synthesize': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tree': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/request-handler': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/synthesize': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tree': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30013,16 +30029,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-client@2.53.0(encoding@0.1.13)':
+  '@fluidframework/azure-client@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.53.0
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.60.0
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30030,9 +30046,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-service-utils@2.53.0':
+  '@fluidframework/azure-service-utils@2.60.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/driver-definitions': 2.60.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
 
@@ -30041,6 +30057,40 @@ snapshots:
   '@fluidframework/build-tools@0.58.1(@types/node@18.19.67)':
     dependencies:
       '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.67)
+      '@manypkg/get-packages': 2.2.2
+      async: 3.2.6
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      date-fns: 2.30.0
+      debug: 4.4.0(supports-color@8.1.1)
+      detect-indent: 6.1.0
+      find-up: 7.0.0
+      fs-extra: 11.3.0
+      glob: 7.2.3
+      globby: 11.1.0
+      ignore: 5.3.2
+      json5: 2.2.3
+      lodash.isequal: 4.5.0
+      multimatch: 5.0.0
+      picocolors: 1.1.1
+      picomatch: 2.3.1
+      picospinner: 2.0.0
+      rimraf: 4.4.1
+      semver: 7.7.1
+      sort-package-json: 1.57.0
+      ts-deepmerge: 7.0.2
+      type-fest: 2.19.0
+      typescript: 5.4.5
+      yaml: 2.6.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/build-tools@0.58.1(@types/node@18.19.86)':
+    dependencies:
+      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.86)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -30134,15 +30184,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/cell@2.53.0':
+  '@fluidframework/cell@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30189,10 +30239,10 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       events: 3.3.0
 
-  '@fluidframework/container-definitions@2.53.0':
+  '@fluidframework/container-definitions@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
 
   '@fluidframework/container-loader@1.4.0':
     dependencies:
@@ -30216,15 +30266,15 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-loader@2.53.0':
+  '@fluidframework/container-loader@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@types/events_pkg': '@types/events@3.0.3'
       '@ungap/structured-clone': 1.2.1
       debug: 4.4.0(supports-color@8.1.1)
@@ -30243,13 +30293,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/container-runtime-definitions@2.53.0':
+  '@fluidframework/container-runtime-definitions@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30277,20 +30327,20 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-runtime@2.53.0(debug@4.4.0)':
+  '@fluidframework/container-runtime@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       double-ended-queue: 2.1.0-0
       lz4js: 0.2.0
@@ -30312,19 +30362,19 @@ snapshots:
 
   '@fluidframework/core-interfaces@1.4.0': {}
 
-  '@fluidframework/core-interfaces@2.53.0': {}
+  '@fluidframework/core-interfaces@2.60.0': {}
 
-  '@fluidframework/core-utils@2.53.0': {}
+  '@fluidframework/core-utils@2.60.0': {}
 
-  '@fluidframework/counter@2.53.0':
+  '@fluidframework/counter@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30338,13 +30388,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/datastore-definitions@2.53.0':
+  '@fluidframework/datastore-definitions@2.60.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30370,64 +30420,66 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/datastore@2.53.0(debug@4.4.0)':
+  '@fluidframework/datastore@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/debugger@2.53.0':
+  '@fluidframework/debugger@2.60.0':
     dependencies:
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.53.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.60.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools-core@2.53.0':
+  '@fluidframework/devtools-core@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/aqueduct': 2.53.0
-      '@fluidframework/cell': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/counter': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/sequence': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tree': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/aqueduct': 2.60.0
+      '@fluidframework/cell': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/counter': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/sequence': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tree': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools@2.53.0':
+  '@fluidframework/devtools@2.60.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/devtools-core': 2.53.0
-      '@fluidframework/fluid-static': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/devtools-core': 2.60.0
+      '@fluidframework/fluid-static': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30444,14 +30496,14 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-base@2.53.0(debug@4.4.0)':
+  '@fluidframework/driver-base@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30462,9 +30514,9 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/driver-definitions@2.53.0':
+  '@fluidframework/driver-definitions@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
 
   '@fluidframework/driver-utils@1.4.0':
     dependencies:
@@ -30482,13 +30534,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-utils@2.53.0(debug@4.4.0)':
+  '@fluidframework/driver-utils@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       axios: 1.8.4(debug@4.4.0)
       lz4js: 0.2.0
       uuid: 11.1.0
@@ -30496,12 +30548,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-web-cache@2.53.0':
+  '@fluidframework/driver-web-cache@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -30517,9 +30569,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -30535,28 +30587,28 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/file-driver@2.53.0':
+  '@fluidframework/file-driver@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-runner@2.53.0(encoding@0.1.13)':
+  '@fluidframework/fluid-runner@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/aqueduct': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/aqueduct': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       '@json2csv/plainjs': 7.0.6
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -30584,24 +30636,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-static@2.53.0':
+  '@fluidframework/fluid-static@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/aqueduct': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/request-handler': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tree': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/aqueduct': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/request-handler': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tree': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30616,32 +30668,32 @@ snapshots:
 
   '@fluidframework/gitresources@7.0.0': {}
 
-  '@fluidframework/id-compressor@2.53.0':
+  '@fluidframework/id-compressor@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/local-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/local-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
       '@fluidframework/protocol-base': 7.0.0
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
       '@fluidframework/server-local-server': 7.0.0
       '@fluidframework/server-services-client': 7.0.0
       '@fluidframework/server-services-core': 7.0.0
       '@fluidframework/server-test-utils': 7.0.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/telemetry-utils': 2.60.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -30668,37 +30720,36 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/map@2.53.0(debug@4.4.0)':
+  '@fluidframework/map@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/matrix@2.53.0':
+  '@fluidframework/matrix@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/merge-tree': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       double-ended-queue: 2.1.0-0
       tslib: 1.14.1
@@ -30706,52 +30757,52 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/merge-tree@2.53.0(debug@4.4.0)':
+  '@fluidframework/merge-tree@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/odsp-doclib-utils@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-doclib-utils@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - debug
       - encoding
       - supports-color
 
-  '@fluidframework/odsp-driver-definitions@2.53.0':
+  '@fluidframework/odsp-driver-definitions@2.60.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/driver-definitions': 2.60.0
 
-  '@fluidframework/odsp-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       socket.io-client: 4.7.5
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -30761,14 +30812,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/odsp-urlresolver@2.53.0(encoding@0.1.13)':
+  '@fluidframework/odsp-urlresolver@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.60.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30776,17 +30827,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/ordered-collection@2.53.0':
+  '@fluidframework/ordered-collection@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
@@ -30816,28 +30867,28 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
-  '@fluidframework/register-collection@2.53.0':
+  '@fluidframework/register-collection@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/replay-driver@2.53.0':
+  '@fluidframework/replay-driver@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30852,13 +30903,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/request-handler@2.53.0(debug@4.4.0)':
+  '@fluidframework/request-handler@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30888,16 +30939,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-driver@2.53.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/routerlicious-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
       '@fluidframework/server-services-client': 7.0.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/telemetry-utils': 2.60.0
       cross-fetch: 3.1.8(encoding@0.1.13)
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.5
@@ -30909,11 +30960,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-urlresolver@2.53.0':
+  '@fluidframework/routerlicious-urlresolver@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
       nconf: 0.12.1
 
   '@fluidframework/runtime-definitions@1.4.0':
@@ -30925,13 +30976,13 @@ snapshots:
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/runtime-definitions@2.53.0':
+  '@fluidframework/runtime-definitions@2.60.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30951,35 +31002,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/runtime-utils@2.53.0(debug@4.4.0)':
+  '@fluidframework/runtime-utils@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/telemetry-utils': 2.60.0
       semver-ts: 1.0.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/sequence@2.53.0':
+  '@fluidframework/sequence@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/merge-tree': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       double-ended-queue: 2.1.0-0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -31228,54 +31279,54 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/shared-object-base@2.53.0(debug@4.4.0)':
+  '@fluidframework/shared-object-base@2.60.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/shared-summary-block@2.53.0':
+  '@fluidframework/shared-summary-block@2.60.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
   '@fluidframework/synthesize@1.4.0': {}
 
-  '@fluidframework/synthesize@2.53.0':
+  '@fluidframework/synthesize@2.60.0':
     dependencies:
-      '@fluidframework/core-utils': 2.53.0
+      '@fluidframework/core-utils': 2.60.0
 
-  '@fluidframework/task-manager@2.53.0':
+  '@fluidframework/task-manager@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -31290,32 +31341,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/telemetry-utils@2.53.0':
+  '@fluidframework/telemetry-utils@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
       debug: 4.4.0(supports-color@8.1.1)
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/test-runtime-utils@2.53.0(encoding@0.1.13)':
+  '@fluidframework/test-runtime-utils@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -31327,28 +31378,28 @@ snapshots:
 
   '@fluidframework/test-tools@1.0.195075': {}
 
-  '@fluidframework/test-utils@2.53.0(encoding@0.1.13)':
+  '@fluidframework/test-utils@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/test-driver-definitions': 2.53.0
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore': 2.53.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/local-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/request-handler': 2.53.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/test-driver-definitions': 2.60.0
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore': 2.60.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/local-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/request-handler': 2.60.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       best-random: 1.0.3
       debug: 4.4.0(supports-color@8.1.1)
       mocha: 10.8.2
@@ -31359,20 +31410,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-client@2.53.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-client@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.53.0
-      '@fluidframework/container-loader': 2.53.0
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
-      '@fluidframework/tinylicious-driver': 2.53.0(encoding@0.1.13)
+      '@fluidframework/container-definitions': 2.60.0
+      '@fluidframework/container-loader': 2.60.0
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
+      '@fluidframework/tinylicious-driver': 2.60.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -31380,12 +31431,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-driver@2.53.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-driver@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.53.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.60.0(debug@4.4.0)(encoding@0.1.13)
       jsrsasign: 11.1.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -31395,12 +31446,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tool-utils@2.53.0(encoding@0.1.13)':
+  '@fluidframework/tool-utils@2.60.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/driver-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.53.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/driver-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.60.0(debug@4.4.0)(encoding@0.1.13)
       async-mutex: 0.3.2
       debug: 4.4.0(supports-color@8.1.1)
       proper-lockfile: 4.1.2
@@ -31408,19 +31459,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@fluidframework/tree@2.53.0':
+  '@fluidframework/tree@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/container-runtime': 2.53.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.53.0
-      '@fluidframework/core-utils': 2.53.0
-      '@fluidframework/datastore-definitions': 2.53.0
-      '@fluidframework/driver-definitions': 2.53.0
-      '@fluidframework/id-compressor': 2.53.0
-      '@fluidframework/runtime-definitions': 2.53.0
-      '@fluidframework/runtime-utils': 2.53.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.53.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/container-runtime': 2.60.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.60.0
+      '@fluidframework/core-utils': 2.60.0
+      '@fluidframework/datastore-definitions': 2.60.0
+      '@fluidframework/driver-definitions': 2.60.0
+      '@fluidframework/id-compressor': 2.60.0
+      '@fluidframework/runtime-definitions': 2.60.0
+      '@fluidframework/runtime-utils': 2.60.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.60.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.60.0
       '@sinclair/typebox': 0.34.13
       '@tylerbu/sorted-btree-es6': 1.8.0
       '@types/ungap__structured-clone': 1.2.0
@@ -31430,13 +31481,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/undo-redo@2.53.0':
+  '@fluidframework/undo-redo@2.60.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.53.0
-      '@fluidframework/map': 2.53.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.53.0
-      '@fluidframework/merge-tree': 2.53.0(debug@4.4.0)
-      '@fluidframework/sequence': 2.53.0
+      '@fluid-internal/client-utils': 2.60.0
+      '@fluidframework/map': 2.60.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.60.0
+      '@fluidframework/merge-tree': 2.60.0
+      '@fluidframework/sequence': 2.60.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -31526,6 +31577,15 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/checkbox@4.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/figures': 1.0.8
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+
   '@inquirer/checkbox@4.0.3(@types/node@22.14.1)':
     dependencies:
       '@inquirer/core': 10.1.1(@types/node@22.14.1)
@@ -31552,6 +31612,12 @@ snapshots:
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
       '@types/node': 18.19.67
 
+  '@inquirer/confirm@5.1.0(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
+
   '@inquirer/confirm@5.1.0(@types/node@22.14.1)':
     dependencies:
       '@inquirer/core': 10.1.1(@types/node@22.14.1)
@@ -31562,6 +31628,20 @@ snapshots:
     dependencies:
       '@inquirer/figures': 1.0.8
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@inquirer/core@10.1.1(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/figures': 1.0.8
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -31632,6 +31712,13 @@ snapshots:
       '@types/node': 18.19.67
       external-editor: 3.1.0
 
+  '@inquirer/editor@4.2.0(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
+      external-editor: 3.1.0
+
   '@inquirer/editor@4.2.0(@types/node@22.14.1)':
     dependencies:
       '@inquirer/core': 10.1.1(@types/node@22.14.1)
@@ -31651,6 +31738,13 @@ snapshots:
       '@inquirer/core': 10.1.1(@types/node@18.19.67)
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
       '@types/node': 18.19.67
+      yoctocolors-cjs: 2.1.2
+
+  '@inquirer/expand@4.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/expand@4.0.3(@types/node@22.14.1)':
@@ -31679,6 +31773,12 @@ snapshots:
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
       '@types/node': 18.19.67
 
+  '@inquirer/input@4.1.0(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
+
   '@inquirer/input@4.1.0(@types/node@22.14.1)':
     dependencies:
       '@inquirer/core': 10.1.1(@types/node@22.14.1)
@@ -31690,6 +31790,12 @@ snapshots:
       '@inquirer/core': 10.1.1(@types/node@18.19.67)
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
       '@types/node': 18.19.67
+
+  '@inquirer/number@3.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
 
   '@inquirer/number@3.0.3(@types/node@22.14.1)':
     dependencies:
@@ -31709,6 +31815,13 @@ snapshots:
       '@inquirer/core': 10.1.1(@types/node@18.19.67)
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
       '@types/node': 18.19.67
+      ansi-escapes: 4.3.2
+
+  '@inquirer/password@4.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
       ansi-escapes: 4.3.2
 
   '@inquirer/password@4.0.3(@types/node@22.14.1)':
@@ -31744,6 +31857,20 @@ snapshots:
       '@inquirer/select': 4.0.3(@types/node@18.19.67)
       '@types/node': 18.19.67
 
+  '@inquirer/prompts@7.2.0(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/checkbox': 4.0.3(@types/node@18.19.86)
+      '@inquirer/confirm': 5.1.0(@types/node@18.19.86)
+      '@inquirer/editor': 4.2.0(@types/node@18.19.86)
+      '@inquirer/expand': 4.0.3(@types/node@18.19.86)
+      '@inquirer/input': 4.1.0(@types/node@18.19.86)
+      '@inquirer/number': 3.0.3(@types/node@18.19.86)
+      '@inquirer/password': 4.0.3(@types/node@18.19.86)
+      '@inquirer/rawlist': 4.0.3(@types/node@18.19.86)
+      '@inquirer/search': 3.0.3(@types/node@18.19.86)
+      '@inquirer/select': 4.0.3(@types/node@18.19.86)
+      '@types/node': 18.19.86
+
   '@inquirer/prompts@7.2.0(@types/node@22.14.1)':
     dependencies:
       '@inquirer/checkbox': 4.0.3(@types/node@22.14.1)
@@ -31771,6 +31898,13 @@ snapshots:
       '@types/node': 18.19.67
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/rawlist@4.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
+      yoctocolors-cjs: 2.1.2
+
   '@inquirer/rawlist@4.0.3(@types/node@22.14.1)':
     dependencies:
       '@inquirer/core': 10.1.1(@types/node@22.14.1)
@@ -31784,6 +31918,14 @@ snapshots:
       '@inquirer/figures': 1.0.8
       '@inquirer/type': 3.0.1(@types/node@18.19.67)
       '@types/node': 18.19.67
+      yoctocolors-cjs: 2.1.2
+
+  '@inquirer/search@3.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/figures': 1.0.8
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/search@3.0.3(@types/node@22.14.1)':
@@ -31819,6 +31961,15 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/select@4.0.3(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/figures': 1.0.8
+      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@types/node': 18.19.86
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+
   '@inquirer/select@4.0.3(@types/node@22.14.1)':
     dependencies:
       '@inquirer/core': 10.1.1(@types/node@22.14.1)
@@ -31839,6 +31990,10 @@ snapshots:
   '@inquirer/type@3.0.1(@types/node@18.19.67)':
     dependencies:
       '@types/node': 18.19.67
+
+  '@inquirer/type@3.0.1(@types/node@18.19.86)':
+    dependencies:
+      '@types/node': 18.19.86
 
   '@inquirer/type@3.0.1(@types/node@22.14.1)':
     dependencies:
@@ -32247,6 +32402,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor-model@7.30.6(@types/node@18.19.86)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor-model@7.30.6(@types/node@22.14.1)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
@@ -32264,6 +32427,24 @@ snapshots:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.15.3(@types/node@18.19.67)
       '@rushstack/ts-command-line': 5.0.1(@types/node@18.19.67)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.6(@types/node@18.19.86)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.15.3(@types/node@18.19.86)
+      '@rushstack/ts-command-line': 5.0.1(@types/node@18.19.86)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -32680,6 +32861,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@oclif/plugin-not-found@3.2.30(@types/node@18.19.86)':
+    dependencies:
+      '@inquirer/prompts': 7.2.0(@types/node@18.19.86)
+      '@oclif/core': 4.0.36
+      ansis: 3.3.2
+      fast-levenshtein: 3.0.0
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@oclif/plugin-not-found@3.2.30(@types/node@22.14.1)':
     dependencies:
       '@inquirer/prompts': 7.2.0(@types/node@22.14.1)
@@ -33044,6 +33234,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.67
 
+  '@rushstack/node-core-library@5.13.1(@types/node@18.19.86)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 18.19.86
+
   '@rushstack/node-core-library@5.13.1(@types/node@22.14.1)':
     dependencies:
       ajv: 8.13.0
@@ -33076,6 +33279,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.67
 
+  '@rushstack/terminal@0.15.3(@types/node@18.19.86)':
+    dependencies:
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 18.19.86
+
   '@rushstack/terminal@0.15.3(@types/node@22.14.1)':
     dependencies:
       '@rushstack/node-core-library': 5.13.1(@types/node@22.14.1)
@@ -33097,6 +33307,15 @@ snapshots:
   '@rushstack/ts-command-line@5.0.1(@types/node@18.19.67)':
     dependencies:
       '@rushstack/terminal': 0.15.3(@types/node@18.19.67)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@rushstack/ts-command-line@5.0.1(@types/node@18.19.86)':
+    dependencies:
+      '@rushstack/terminal': 0.15.3(@types/node@18.19.86)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -36283,33 +36502,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36323,13 +36542,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,13 +381,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -402,7 +402,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -423,7 +423,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -447,7 +447,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -508,13 +508,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -532,7 +532,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -553,7 +553,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -574,7 +574,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -635,13 +635,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -656,7 +656,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -677,7 +677,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -698,7 +698,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -795,13 +795,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -816,7 +816,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/prop-types':
         specifier: ^15
         version: 15.7.14
@@ -852,7 +852,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -949,13 +949,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -970,7 +970,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -985,7 +985,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1012,7 +1012,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -1097,13 +1097,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1118,7 +1118,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -1142,7 +1142,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1166,7 +1166,7 @@ importers:
         version: 4.0.0(webpack@5.97.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -1230,13 +1230,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1251,7 +1251,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1266,7 +1266,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1287,7 +1287,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -1333,7 +1333,7 @@ importers:
         version: link:../../../packages/test/mocha-test-setup
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1342,7 +1342,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1430,13 +1430,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1451,7 +1451,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -1475,7 +1475,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1499,7 +1499,7 @@ importers:
         version: 4.0.0(webpack@5.97.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -1727,7 +1727,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1742,7 +1742,7 @@ importers:
         version: link:../../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -1757,7 +1757,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1775,7 +1775,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -1839,7 +1839,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1854,7 +1854,7 @@ importers:
         version: link:../../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -1869,7 +1869,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1887,7 +1887,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -1942,7 +1942,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -1957,7 +1957,7 @@ importers:
         version: link:../../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -1972,7 +1972,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -1993,7 +1993,7 @@ importers:
         version: 5.0.0(webpack@5.97.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -2048,13 +2048,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -2066,7 +2066,7 @@ importers:
         version: 9.0.13
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/webpack-hot-middleware':
         specifier: ^2.25.9
         version: 2.25.9(webpack-cli@5.1.4)
@@ -2157,7 +2157,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -2169,7 +2169,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2378,7 +2378,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -2393,7 +2393,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -2411,7 +2411,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -2493,7 +2493,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -2511,7 +2511,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -2526,7 +2526,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -2544,7 +2544,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -2620,7 +2620,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -2629,7 +2629,7 @@ importers:
         version: 5.60.7
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -2693,7 +2693,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -2708,7 +2708,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -2723,7 +2723,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -2741,7 +2741,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -3103,7 +3103,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -3118,7 +3118,7 @@ importers:
         version: link:../../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -3139,7 +3139,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -3160,7 +3160,7 @@ importers:
         version: 4.0.0(webpack@5.97.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -3445,13 +3445,13 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/orderedmap':
         specifier: ^1.0.0
         version: 1.0.0
@@ -3650,13 +3650,13 @@ importers:
         version: link:../../../packages/test/test-version-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -3668,7 +3668,7 @@ importers:
         version: link:../../../packages/test/test-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.12
@@ -3677,7 +3677,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -3759,7 +3759,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -3777,7 +3777,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -3798,7 +3798,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -3886,7 +3886,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -3904,7 +3904,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -3925,7 +3925,7 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -4022,7 +4022,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -4040,7 +4040,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -4094,7 +4094,7 @@ importers:
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+        version: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -4354,7 +4354,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../../../packages/common/container-definitions
@@ -4393,7 +4393,7 @@ importers:
         version: link:../../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -4408,7 +4408,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -4438,7 +4438,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -4508,7 +4508,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../../../packages/common/container-definitions
@@ -4547,7 +4547,7 @@ importers:
         version: link:../../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -4571,7 +4571,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -4604,7 +4604,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -4656,19 +4656,19 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -4692,7 +4692,7 @@ importers:
         version: 4.4.1
       tailwindcss:
         specifier: ^3.3.2
-        version: 3.4.16(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 3.4.16(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -4765,13 +4765,13 @@ importers:
         version: 2.3.0(webpack@5.97.1)
       '@fluid-tools/version-tools':
         specifier: ^0.57.0
-        version: 0.57.0(@types/node@18.19.86)
+        version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/bundle-size-tools':
         specifier: ^0.57.0
         version: 0.57.0(webpack-cli@5.1.4)
@@ -4786,7 +4786,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
@@ -4974,7 +4974,7 @@ importers:
         version: link:../../../packages/test/mocha-test-setup
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -4983,7 +4983,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -5192,13 +5192,13 @@ importers:
         version: link:../../../packages/test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -5213,7 +5213,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -5301,13 +5301,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -5322,7 +5322,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5337,7 +5337,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -5358,7 +5358,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -5452,13 +5452,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -5473,7 +5473,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -5500,7 +5500,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -5524,7 +5524,7 @@ importers:
         version: 4.0.0(webpack@5.97.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -5630,13 +5630,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -5651,7 +5651,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -5678,7 +5678,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -5702,7 +5702,7 @@ importers:
         version: 4.0.0(webpack@5.97.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -5920,13 +5920,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -5941,7 +5941,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -5962,7 +5962,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -5980,7 +5980,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -6065,13 +6065,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -6086,7 +6086,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -6107,7 +6107,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -6128,7 +6128,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -6186,13 +6186,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -6207,7 +6207,7 @@ importers:
         version: link:../../../packages/test/types_jest-environment-puppeteer
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -6228,7 +6228,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -6249,7 +6249,7 @@ importers:
         version: 4.4.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -6307,7 +6307,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@types/lodash':
         specifier: ^4.14.118
         version: 4.17.13
@@ -6316,7 +6316,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0
@@ -6398,13 +6398,13 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/chai':
         specifier: ^4.0.0
         version: 4.3.20
@@ -6419,7 +6419,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0
@@ -6534,13 +6534,13 @@ importers:
         version: link:../../../../packages/test/test-drivers
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-loader':
         specifier: workspace:~
         version: link:../../../../packages/loader/container-loader
@@ -6567,7 +6567,7 @@ importers:
         version: link:../../../../packages/test/test-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/lodash':
         specifier: ^4.14.118
         version: 4.17.13
@@ -6576,7 +6576,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -6646,13 +6646,13 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -6725,13 +6725,13 @@ importers:
         version: link:../../../../packages/dds/test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -6740,13 +6740,13 @@ importers:
         version: link:../../../../packages/runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       best-random:
         specifier: ^1.0.0
         version: 1.0.3
@@ -6816,13 +6816,13 @@ importers:
         version: link:../../../../../packages/dds/test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -6831,13 +6831,13 @@ importers:
         version: link:../../../../../packages/runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       best-random:
         specifier: ^1.0.0
         version: 1.0.3
@@ -6904,13 +6904,13 @@ importers:
         version: link:../../../packages/dds/test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -6919,7 +6919,7 @@ importers:
         version: link:../../../packages/runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -6928,7 +6928,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7143,22 +7143,22 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -7210,22 +7210,22 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -7280,13 +7280,13 @@ importers:
         version: link:../../../packages/test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7295,13 +7295,13 @@ importers:
         version: link:../../../packages/service-clients/tinylicious-client
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -7358,7 +7358,7 @@ importers:
         version: events@3.3.0
       sha.js:
         specifier: ^2.4.11
-        version: 2.4.12
+        version: 2.4.11
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -7374,19 +7374,19 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/base64-js':
         specifier: ^1.3.0
         version: 1.3.2
@@ -7401,7 +7401,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/rewire':
         specifier: ^2.5.28
         version: 2.5.30
@@ -7431,7 +7431,7 @@ importers:
         version: 9.0.0(eslint@8.55.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -7461,10 +7461,10 @@ importers:
         version: 18.0.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+        version: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -7528,13 +7528,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/core-interfaces-previous':
         specifier: npm:@fluidframework/core-interfaces@2.60.0
         version: '@fluidframework/core-interfaces@2.60.0'
@@ -7543,13 +7543,13 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7594,13 +7594,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/core-utils-previous':
         specifier: npm:@fluidframework/core-utils@2.60.0
         version: '@fluidframework/core-utils@2.60.0'
@@ -7609,13 +7609,13 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -7737,13 +7737,13 @@ importers:
         version: link:../test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/cell-previous':
         specifier: npm:@fluidframework/cell@2.60.0
         version: '@fluidframework/cell@2.60.0'
@@ -7758,13 +7758,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7828,13 +7828,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7849,13 +7849,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7919,13 +7919,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7937,13 +7937,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8022,13 +8022,13 @@ importers:
         version: link:../test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -8040,7 +8040,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/jest':
         specifier: 29.5.3
         version: 29.5.3
@@ -8049,7 +8049,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8134,13 +8134,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -8155,13 +8155,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/path-browserify':
         specifier: ^1.0.0
         version: 1.0.3
@@ -8258,13 +8258,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -8279,7 +8279,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@tiny-calc/micro':
         specifier: 0.0.0-alpha.5
         version: 0.0.0-alpha.5
@@ -8291,7 +8291,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       best-random:
         specifier: ^1.0.0
         version: 1.0.3
@@ -8324,7 +8324,7 @@ importers:
         version: 4.4.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+        version: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -8382,13 +8382,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8400,7 +8400,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -8409,7 +8409,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8488,13 +8488,13 @@ importers:
         version: link:../test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8506,13 +8506,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8582,13 +8582,13 @@ importers:
         version: link:../test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8597,13 +8597,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8673,13 +8673,13 @@ importers:
         version: link:../test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8691,13 +8691,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8785,13 +8785,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -8806,7 +8806,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -8818,7 +8818,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8906,13 +8906,13 @@ importers:
         version: link:../../test/test-pairwise-generator
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -8924,7 +8924,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/benchmark':
         specifier: ^2.1.0
         version: 2.1.5
@@ -8933,7 +8933,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -8969,7 +8969,7 @@ importers:
         version: 18.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+        version: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -9006,13 +9006,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -9027,7 +9027,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/benchmark':
         specifier: ^2.1.0
         version: 2.1.5
@@ -9036,7 +9036,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
@@ -9118,13 +9118,13 @@ importers:
         version: link:../test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9136,13 +9136,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9224,25 +9224,25 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9345,13 +9345,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -9372,7 +9372,7 @@ importers:
         version: '@fluidframework/tree@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -9384,7 +9384,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
@@ -9457,13 +9457,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/debugger-previous':
         specifier: npm:@fluidframework/debugger@2.60.0
         version: '@fluidframework/debugger@2.60.0'
@@ -9472,10 +9472,10 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -9524,13 +9524,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-base-previous':
         specifier: npm:@fluidframework/driver-base@2.60.0
         version: '@fluidframework/driver-base@2.60.0(debug@4.4.0)'
@@ -9539,13 +9539,13 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9603,13 +9603,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-web-cache-previous':
         specifier: npm:@fluidframework/driver-web-cache@2.60.0
         version: '@fluidframework/driver-web-cache@2.60.0'
@@ -9618,13 +9618,13 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/jest':
         specifier: 29.5.3
         version: 29.5.3
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -9639,7 +9639,7 @@ importers:
         version: 3.1.4
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9676,13 +9676,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9691,10 +9691,10 @@ importers:
         version: '@fluidframework/file-driver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -9770,13 +9770,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9785,7 +9785,7 @@ importers:
         version: '@fluidframework/local-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/jsrsasign':
         specifier: ^10.5.12
         version: 10.5.15
@@ -9794,7 +9794,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9873,13 +9873,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9888,13 +9888,13 @@ importers:
         version: '@fluidframework/odsp-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -10010,13 +10010,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10025,13 +10025,13 @@ importers:
         version: '@fluidframework/odsp-urlresolver@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10086,13 +10086,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10101,13 +10101,13 @@ importers:
         version: '@fluidframework/replay-driver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/nock':
         specifier: ^9.3.0
         version: 9.3.1
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10177,13 +10177,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10192,7 +10192,7 @@ importers:
         version: '@fluidframework/routerlicious-driver@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -10201,7 +10201,7 @@ importers:
         version: 9.3.1
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -10268,13 +10268,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10283,7 +10283,7 @@ importers:
         version: '@fluidframework/routerlicious-urlresolver@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -10292,7 +10292,7 @@ importers:
         version: 0.10.7
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       assert:
         specifier: ^2.0.0
         version: 2.1.0
@@ -10353,13 +10353,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10368,7 +10368,7 @@ importers:
         version: '@fluidframework/tinylicious-driver@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/jsrsasign':
         specifier: ^10.5.12
         version: 10.5.15
@@ -10377,7 +10377,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10447,7 +10447,7 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
         specifier: npm:@fluidframework/agent-scheduler@2.60.0
         version: '@fluidframework/agent-scheduler@2.60.0'
@@ -10456,16 +10456,16 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10523,13 +10523,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10541,13 +10541,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10641,7 +10641,7 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
         specifier: npm:@fluidframework/aqueduct@2.60.0
         version: '@fluidframework/aqueduct@2.60.0'
@@ -10650,19 +10650,19 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10747,13 +10747,13 @@ importers:
         version: link:../../test/stochastic-test-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -10768,13 +10768,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10826,7 +10826,7 @@ importers:
         version: link:../../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
         specifier: npm:@fluidframework/app-insights-logger@2.60.0
         version: '@fluidframework/app-insights-logger@2.60.0(tslib@1.14.1)'
@@ -10835,16 +10835,16 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -10868,7 +10868,7 @@ importers:
         version: 9.0.0(eslint@8.55.0)
       eslint-plugin-jest:
         specifier: ~27.4.2
-        version: 27.4.3(@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 27.4.3(@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.33.2
         version: 7.33.2(eslint@8.55.0)
@@ -11029,22 +11029,22 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -11090,13 +11090,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -11105,7 +11105,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -11114,7 +11114,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11190,22 +11190,22 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -11284,13 +11284,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -11305,13 +11305,13 @@ importers:
         version: link:../../dds/sequence
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11369,22 +11369,22 @@ importers:
         version: link:../../dds/test-dds-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -11454,13 +11454,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-definitions':
         specifier: workspace:~
         version: link:../../common/driver-definitions
@@ -11475,13 +11475,13 @@ importers:
         version: link:../../test/test-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -11545,13 +11545,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -11560,7 +11560,7 @@ importers:
         version: '@fluidframework/request-handler@2.60.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -11569,7 +11569,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11618,13 +11618,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/core-interfaces':
         specifier: workspace:~
         version: link:../../common/core-interfaces
@@ -11642,13 +11642,13 @@ importers:
         version: '@fluidframework/synthesize@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11718,13 +11718,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -11745,13 +11745,13 @@ importers:
         version: 0.6.3(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/uuid':
         specifier: ^9.0.2
         version: 9.0.8
@@ -11818,13 +11818,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -11836,7 +11836,7 @@ importers:
         version: '@fluidframework/undo-redo@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/diff':
         specifier: ^3.5.1
         version: 3.5.8
@@ -11845,7 +11845,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11933,13 +11933,13 @@ importers:
         version: link:../test-loader-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-loader-previous':
         specifier: npm:@fluidframework/container-loader@2.60.0
         version: '@fluidframework/container-loader@2.60.0'
@@ -11948,7 +11948,7 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.12
@@ -11960,7 +11960,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -12036,13 +12036,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-utils-previous':
         specifier: npm:@fluidframework/driver-utils@2.60.0
         version: '@fluidframework/driver-utils@2.60.0(debug@4.4.0)'
@@ -12051,13 +12051,13 @@ importers:
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -12218,13 +12218,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-runtime-previous':
         specifier: npm:@fluidframework/container-runtime@2.60.0
         version: '@fluidframework/container-runtime@2.60.0(debug@4.4.0)'
@@ -12236,7 +12236,7 @@ importers:
         version: link:../test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/double-ended-queue':
         specifier: ^2.1.0
         version: 2.1.7
@@ -12248,7 +12248,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -12391,13 +12391,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/datastore-previous':
         specifier: npm:@fluidframework/datastore@2.60.0
         version: '@fluidframework/datastore@2.60.0(debug@4.4.0)'
@@ -12409,7 +12409,7 @@ importers:
         version: link:../test-runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/lodash':
         specifier: ^4.14.118
         version: 4.17.13
@@ -12418,7 +12418,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -12549,13 +12549,13 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12564,13 +12564,13 @@ importers:
         version: '@fluidframework/id-compressor@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12704,13 +12704,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12719,13 +12719,13 @@ importers:
         version: '@fluidframework/runtime-utils@2.60.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -12758,7 +12758,7 @@ importers:
         version: 18.0.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+        version: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -12822,13 +12822,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12837,7 +12837,7 @@ importers:
         version: '@fluidframework/test-runtime-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/jsrsasign':
         specifier: ^10.5.12
         version: 10.5.15
@@ -12846,7 +12846,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12910,7 +12910,7 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
         specifier: npm:@fluidframework/azure-client@2.60.0
         version: '@fluidframework/azure-client@2.60.0(encoding@0.1.13)'
@@ -12922,7 +12922,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-runtime':
         specifier: workspace:~
         version: link:../../runtime/container-runtime
@@ -12937,13 +12937,13 @@ importers:
         version: link:../../test/test-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -13082,7 +13082,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/driver-definitions':
         specifier: workspace:~
         version: link:../../../common/driver-definitions
@@ -13097,7 +13097,7 @@ importers:
         version: 9.3.1
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -13191,7 +13191,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -13203,7 +13203,7 @@ importers:
         version: 9.3.1
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13273,13 +13273,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -13288,13 +13288,13 @@ importers:
         version: link:../../test/test-utils
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13367,7 +13367,7 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct':
         specifier: workspace:~
         version: link:../../framework/aqueduct
@@ -13376,7 +13376,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-runtime':
         specifier: workspace:~
         version: link:../../runtime/container-runtime
@@ -13394,13 +13394,13 @@ importers:
         version: '@fluidframework/tinylicious-client@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -13445,13 +13445,13 @@ importers:
         version: link:../../loader/test-loader-utils
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/cell':
         specifier: workspace:~
         version: link:../../dds/cell
@@ -13514,7 +13514,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -13583,7 +13583,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -13665,7 +13665,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13716,7 +13716,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -13788,7 +13788,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13840,25 +13840,25 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -13952,13 +13952,13 @@ importers:
         version: link:../mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -13967,7 +13967,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14016,25 +14016,25 @@ importers:
         version: 0.51.0
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/path-browserify':
         specifier: ^1.0.0
         version: 1.0.3
@@ -14167,7 +14167,7 @@ importers:
         version: link:../../utils/tool-utils
       agentkeepalive:
         specifier: ^4.5.0
-        version: 4.6.0
+        version: 4.5.0
       axios:
         specifier: ^1.8.4
         version: 1.8.4(debug@4.4.0)
@@ -14186,22 +14186,22 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -14391,13 +14391,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -14412,7 +14412,7 @@ importers:
         version: 9.3.1
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14449,25 +14449,25 @@ importers:
         version: link:../mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14582,13 +14582,13 @@ importers:
         version: link:../mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -14597,7 +14597,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14706,13 +14706,13 @@ importers:
         version: link:../mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -14721,7 +14721,7 @@ importers:
         version: '@fluidframework/test-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.12
@@ -14733,7 +14733,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14778,7 +14778,7 @@ importers:
         version: link:../test-drivers
       '@fluid-tools/version-tools':
         specifier: ^0.57.0
-        version: 0.57.0(@types/node@18.19.86)
+        version: 0.57.0(@types/node@18.19.67)
       '@fluidframework/agent-scheduler':
         specifier: workspace:~
         version: link:../../framework/agent-scheduler
@@ -14872,19 +14872,19 @@ importers:
         version: link:../mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -14893,7 +14893,7 @@ importers:
         version: 9.3.1
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0
@@ -15118,7 +15118,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../../common/container-definitions
@@ -15163,7 +15163,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/proxyquire':
         specifier: ^1.3.28
         version: 1.3.31
@@ -15220,7 +15220,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -15253,7 +15253,7 @@ importers:
         version: 3.0.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -15664,13 +15664,13 @@ importers:
         version: link:../../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15679,7 +15679,7 @@ importers:
         version: link:../../../dds/shared-object-base
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -15700,7 +15700,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -15736,7 +15736,7 @@ importers:
         version: 9.0.0(eslint@8.55.0)
       eslint-plugin-jest:
         specifier: ~27.4.2
-        version: 27.4.3(@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 27.4.3(@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.33.2
         version: 7.33.2(eslint@8.55.0)
@@ -15748,7 +15748,7 @@ importers:
         version: 13.2.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -15772,7 +15772,7 @@ importers:
         version: 3.27.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -15833,7 +15833,7 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
         specifier: npm:@fluid-tools/fetch-tool@2.60.0
         version: '@fluid-tools/fetch-tool@2.60.0(encoding@0.1.13)'
@@ -15842,13 +15842,13 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -15906,13 +15906,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15921,13 +15921,13 @@ importers:
         version: '@fluidframework/fluid-runner@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/yargs':
         specifier: ^17.0.32
         version: 17.0.33
@@ -16051,13 +16051,13 @@ importers:
         version: 1.9.4
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -16066,7 +16066,7 @@ importers:
         version: 1.1.0
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -16118,13 +16118,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -16133,7 +16133,7 @@ importers:
         version: '@fluidframework/odsp-doclib-utils@2.60.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/isomorphic-fetch':
         specifier: ^0.0.39
         version: 0.0.39
@@ -16142,7 +16142,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -16203,13 +16203,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -16218,7 +16218,7 @@ importers:
         version: '@fluidframework/telemetry-utils@2.60.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.12
@@ -16227,7 +16227,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -16297,13 +16297,13 @@ importers:
         version: link:../../test/mocha-test-setup
       '@fluid-tools/build-cli':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
+        version: 0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.58.1
-        version: 0.58.1(@types/node@18.19.86)
+        version: 0.58.1(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.55.0)(typescript@5.4.5)
@@ -16312,7 +16312,7 @@ importers:
         version: '@fluidframework/tool-utils@2.60.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+        version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.12
@@ -16321,7 +16321,7 @@ importers:
         version: 10.0.10
       '@types/node':
         specifier: ^18.19.0
-        version: 18.19.86
+        version: 18.19.67
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -16614,6 +16614,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.26.9':
+    resolution: {integrity: sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.27.0':
     resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
@@ -17397,7 +17401,6 @@ packages:
 
   '@fluentui/react-virtualizer@9.0.0-alpha.88':
     resolution: {integrity: sha512-tInMU1BjpGkkLDXbaCHVtPi9iX4PQoR0VEy4xULLGSqAqnlfcFgPHFibZKlqrbeIQWfql+U77RHaRIgntGIt0w==}
-    deprecated: Deprecating react-virtualizer in Fluent core - migrating to fluentui-contrib repo for stable release
     peerDependencies:
       '@types/react': '>=16.14.0 <19.0.0'
       '@types/react-dom': '>=16.9.0 <19.0.0'
@@ -18625,6 +18628,9 @@ packages:
     resolution: {integrity: sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==}
     engines: {node: '>= 18'}
 
+  '@octokit/openapi-types@22.2.0':
+    resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
+
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
 
@@ -18690,6 +18696,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@13.6.2':
+    resolution: {integrity: sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==}
 
   '@parcel/watcher-android-arm64@2.5.0':
     resolution: {integrity: sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==}
@@ -19319,6 +19328,9 @@ packages:
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
 
+  '@types/node@18.19.67':
+    resolution: {integrity: sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==}
+
   '@types/node@18.19.86':
     resolution: {integrity: sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==}
 
@@ -19818,6 +19830,10 @@ packages:
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.5.0:
+    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
+    engines: {node: '>= 8.0.0'}
 
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
@@ -24487,7 +24503,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
@@ -25395,7 +25410,6 @@ packages:
   puppeteer@23.10.3:
     resolution: {integrity: sha512-ODG+L9vCSPkQ1j+yDtNDdkSsWt2NXNrQO5C8MlwkYgE2hYnXdqVRbBpsHnoP7+EULJJKbWyR2Q4BdfohjQor3A==}
     engines: {node: '>=18'}
-    deprecated: < 24.9.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:
@@ -26028,9 +26042,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sha.js@2.4.12:
-    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
-    engines: {node: '>= 0.10'}
+  sha.js@2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
     hasBin: true
 
   shallow-clone@3.0.1:
@@ -26493,12 +26506,11 @@ packages:
   superagent@3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supertest@3.4.2:
     resolution: {integrity: sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==}
     engines: {node: '>=6.0.0'}
-    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -26690,10 +26702,6 @@ packages:
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
-
-  to-buffer@1.2.1:
-    resolution: {integrity: sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==}
-    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -28013,6 +28021,10 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/runtime@7.26.9':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/runtime@7.27.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -28254,7 +28266,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.25.9
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -28285,7 +28297,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -28311,7 +28323,7 @@ snapshots:
 
   '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/react': 11.14.0(@types/react@18.3.15)(react@18.3.1)
@@ -29600,7 +29612,7 @@ snapshots:
       base64-js: 1.5.1
       buffer: 6.0.3
       events_pkg: events@3.3.0
-      sha.js: 2.4.12
+      sha.js: 2.4.11
 
   '@fluid-internal/eslint-plugin-fluid@0.1.5(eslint@8.55.0)(typescript@5.4.5)':
     dependencies:
@@ -29628,23 +29640,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluid-tools/build-cli@0.58.1(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)':
+  '@fluid-tools/build-cli@0.58.1(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.58.1(@types/node@18.19.86)
-      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.86)
-      '@fluidframework/build-tools': 0.58.1(@types/node@18.19.86)
+      '@fluid-tools/build-infrastructure': 0.58.1(@types/node@18.19.67)
+      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.67)
+      '@fluidframework/build-tools': 0.58.1(@types/node@18.19.67)
       '@fluidframework/bundle-size-tools': 0.58.1(webpack-cli@5.1.4)
-      '@inquirer/prompts': 7.2.0(@types/node@18.19.86)
-      '@microsoft/api-extractor': 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
+      '@inquirer/prompts': 7.2.0(@types/node@18.19.67)
+      '@microsoft/api-extractor': 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
       '@oclif/core': 4.0.36
       '@oclif/plugin-autocomplete': 3.2.13
       '@oclif/plugin-commands': 4.1.13
       '@oclif/plugin-help': 6.2.19
-      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.86)
+      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.67)
       '@octokit/core': 5.2.0
       '@octokit/rest': 21.0.2
-      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.67)
       async: 3.2.6
       azure-devops-node-api: 11.2.0
       change-case: 3.1.0
@@ -29669,7 +29681,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       minimatch: 7.4.6
       npm-check-updates: 16.14.20
-      oclif: 4.16.2(@types/node@18.19.86)
+      oclif: 4.16.2(@types/node@18.19.67)
       picocolors: 1.1.1
       prettier: 3.2.5
       prompts: 2.4.2
@@ -29782,9 +29794,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.58.1(@types/node@18.19.86)':
+  '@fluid-tools/build-infrastructure@0.58.1(@types/node@18.19.67)':
     dependencies:
-      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.86)
+      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.67)
       '@manypkg/get-packages': 2.2.2
       '@oclif/core': 4.0.36
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -29793,7 +29805,7 @@ snapshots:
       fs-extra: 11.3.0
       globby: 11.1.0
       micromatch: 4.0.8
-      oclif: 4.16.2(@types/node@18.19.86)
+      oclif: 4.16.2(@types/node@18.19.67)
       picocolors: 1.1.1
       read-pkg-up: 7.0.1
       semver: 7.7.1
@@ -29859,13 +29871,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.57.0(@types/node@18.19.86)':
+  '@fluid-tools/version-tools@0.57.0(@types/node@18.19.67)':
     dependencies:
       '@oclif/core': 4.0.36
       '@oclif/plugin-autocomplete': 3.2.13
       '@oclif/plugin-commands': 4.1.13
       '@oclif/plugin-help': 6.2.19
-      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.86)
+      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.67)
       semver: 7.7.1
       table: 6.9.0
     transitivePeerDependencies:
@@ -29875,13 +29887,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.58.1(@types/node@18.19.86)':
+  '@fluid-tools/version-tools@0.58.1(@types/node@18.19.67)':
     dependencies:
       '@oclif/core': 4.0.36
       '@oclif/plugin-autocomplete': 3.2.13
       '@oclif/plugin-commands': 4.1.13
       '@oclif/plugin-help': 6.2.19
-      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.86)
+      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.67)
       semver: 7.7.1
       table: 6.9.0
     transitivePeerDependencies:
@@ -30042,9 +30054,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.58.1(@types/node@18.19.86)':
+  '@fluidframework/build-tools@0.58.1(@types/node@18.19.67)':
     dependencies:
-      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.86)
+      '@fluid-tools/version-tools': 0.58.1(@types/node@18.19.67)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -30197,7 +30209,7 @@ snapshots:
       buffer: 6.0.3
       events: 3.3.0
       lodash: 4.17.21
-      sha.js: 2.4.12
+      sha.js: 2.4.11
 
   '@fluidframework/common-utils@1.1.1':
     dependencies:
@@ -30207,7 +30219,7 @@ snapshots:
       buffer: 6.0.3
       events: 3.3.0
       lodash: 4.17.21
-      sha.js: 2.4.12
+      sha.js: 2.4.11
 
   '@fluidframework/common-utils@3.1.0':
     dependencies:
@@ -30217,7 +30229,7 @@ snapshots:
       buffer: 6.0.3
       events: 3.3.0
       lodash: 4.17.21
-      sha.js: 2.4.12
+      sha.js: 2.4.11
 
   '@fluidframework/container-definitions@1.4.0':
     dependencies:
@@ -30557,9 +30569,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -31063,7 +31075,7 @@ snapshots:
       opossum: 8.5.0
       semver: 7.7.1
       serialize-error: 8.1.0
-      sha.js: 2.4.12
+      sha.js: 2.4.11
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
@@ -31100,7 +31112,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/double-ended-queue': 2.1.7
       '@types/lodash': 4.17.13
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       '@types/ws': 6.0.4
       assert: 2.1.0
       debug: 4.4.0(supports-color@8.1.1)
@@ -31158,7 +31170,7 @@ snapshots:
       '@fluidframework/server-services-client': 7.0.0
       '@fluidframework/server-services-telemetry': 7.0.0
       '@types/nconf': 0.10.7
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       debug: 4.4.0(supports-color@8.1.1)
       events: 3.3.0
       nconf: 0.12.1
@@ -31556,12 +31568,12 @@ snapshots:
       chalk: 4.1.2
       figures: 3.2.0
 
-  '@inquirer/checkbox@4.0.3(@types/node@18.19.86)':
+  '@inquirer/checkbox@4.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
       '@inquirer/figures': 1.0.8
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
@@ -31594,11 +31606,11 @@ snapshots:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/confirm@5.1.0(@types/node@18.19.86)':
+  '@inquirer/confirm@5.1.0(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
 
   '@inquirer/confirm@5.1.0(@types/node@18.19.86)':
     dependencies:
@@ -31612,10 +31624,10 @@ snapshots:
       '@inquirer/type': 3.0.1(@types/node@22.14.1)
       '@types/node': 22.14.1
 
-  '@inquirer/core@10.1.1(@types/node@18.19.86)':
+  '@inquirer/core@10.1.1(@types/node@18.19.67)':
     dependencies:
       '@inquirer/figures': 1.0.8
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -31693,11 +31705,11 @@ snapshots:
       chalk: 4.1.2
       external-editor: 3.1.0
 
-  '@inquirer/editor@4.2.0(@types/node@18.19.86)':
+  '@inquirer/editor@4.2.0(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       external-editor: 3.1.0
 
   '@inquirer/editor@4.2.0(@types/node@18.19.86)':
@@ -31721,11 +31733,11 @@ snapshots:
       chalk: 4.1.2
       figures: 3.2.0
 
-  '@inquirer/expand@4.0.3(@types/node@18.19.86)':
+  '@inquirer/expand@4.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/expand@4.0.3(@types/node@18.19.86)':
@@ -31755,11 +31767,11 @@ snapshots:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/input@4.1.0(@types/node@18.19.86)':
+  '@inquirer/input@4.1.0(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
 
   '@inquirer/input@4.1.0(@types/node@18.19.86)':
     dependencies:
@@ -31773,11 +31785,11 @@ snapshots:
       '@inquirer/type': 3.0.1(@types/node@22.14.1)
       '@types/node': 22.14.1
 
-  '@inquirer/number@3.0.3(@types/node@18.19.86)':
+  '@inquirer/number@3.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
 
   '@inquirer/number@3.0.3(@types/node@18.19.86)':
     dependencies:
@@ -31798,11 +31810,11 @@ snapshots:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
 
-  '@inquirer/password@4.0.3(@types/node@18.19.86)':
+  '@inquirer/password@4.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       ansi-escapes: 4.3.2
 
   '@inquirer/password@4.0.3(@types/node@18.19.86)':
@@ -31831,19 +31843,19 @@ snapshots:
       '@inquirer/rawlist': 1.2.16
       '@inquirer/select': 1.3.3
 
-  '@inquirer/prompts@7.2.0(@types/node@18.19.86)':
+  '@inquirer/prompts@7.2.0(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/checkbox': 4.0.3(@types/node@18.19.86)
-      '@inquirer/confirm': 5.1.0(@types/node@18.19.86)
-      '@inquirer/editor': 4.2.0(@types/node@18.19.86)
-      '@inquirer/expand': 4.0.3(@types/node@18.19.86)
-      '@inquirer/input': 4.1.0(@types/node@18.19.86)
-      '@inquirer/number': 3.0.3(@types/node@18.19.86)
-      '@inquirer/password': 4.0.3(@types/node@18.19.86)
-      '@inquirer/rawlist': 4.0.3(@types/node@18.19.86)
-      '@inquirer/search': 3.0.3(@types/node@18.19.86)
-      '@inquirer/select': 4.0.3(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/checkbox': 4.0.3(@types/node@18.19.67)
+      '@inquirer/confirm': 5.1.0(@types/node@18.19.67)
+      '@inquirer/editor': 4.2.0(@types/node@18.19.67)
+      '@inquirer/expand': 4.0.3(@types/node@18.19.67)
+      '@inquirer/input': 4.1.0(@types/node@18.19.67)
+      '@inquirer/number': 3.0.3(@types/node@18.19.67)
+      '@inquirer/password': 4.0.3(@types/node@18.19.67)
+      '@inquirer/rawlist': 4.0.3(@types/node@18.19.67)
+      '@inquirer/search': 3.0.3(@types/node@18.19.67)
+      '@inquirer/select': 4.0.3(@types/node@18.19.67)
+      '@types/node': 18.19.67
 
   '@inquirer/prompts@7.2.0(@types/node@18.19.86)':
     dependencies:
@@ -31879,11 +31891,11 @@ snapshots:
       '@inquirer/type': 1.5.5
       chalk: 4.1.2
 
-  '@inquirer/rawlist@4.0.3(@types/node@18.19.86)':
+  '@inquirer/rawlist@4.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/rawlist@4.0.3(@types/node@18.19.86)':
@@ -31900,12 +31912,12 @@ snapshots:
       '@types/node': 22.14.1
       yoctocolors-cjs: 2.1.2
 
-  '@inquirer/search@3.0.3(@types/node@18.19.86)':
+  '@inquirer/search@3.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
       '@inquirer/figures': 1.0.8
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/search@3.0.3(@types/node@18.19.86)':
@@ -31940,12 +31952,12 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
-  '@inquirer/select@4.0.3(@types/node@18.19.86)':
+  '@inquirer/select@4.0.3(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/core': 10.1.1(@types/node@18.19.86)
+      '@inquirer/core': 10.1.1(@types/node@18.19.67)
       '@inquirer/figures': 1.0.8
-      '@inquirer/type': 3.0.1(@types/node@18.19.86)
-      '@types/node': 18.19.86
+      '@inquirer/type': 3.0.1(@types/node@18.19.67)
+      '@types/node': 18.19.67
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
@@ -31975,9 +31987,9 @@ snapshots:
     dependencies:
       mute-stream: 1.0.0
 
-  '@inquirer/type@3.0.1(@types/node@18.19.86)':
+  '@inquirer/type@3.0.1(@types/node@18.19.67)':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@inquirer/type@3.0.1(@types/node@18.19.86)':
     dependencies:
@@ -32019,21 +32031,21 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -32061,14 +32073,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.4.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -32203,7 +32215,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -32317,7 +32329,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@types/node': 18.19.86
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -32328,7 +32340,7 @@ snapshots:
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -32382,11 +32394,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.30.6(@types/node@18.19.86)':
+  '@microsoft/api-extractor-model@7.30.6(@types/node@18.19.67)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.67)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -32406,15 +32418,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)':
+  '@microsoft/api-extractor@7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.6(@types/node@18.19.86)
+      '@microsoft/api-extractor-model': 7.30.6(@types/node@18.19.67)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.67)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.3(@types/node@18.19.86)
-      '@rushstack/ts-command-line': 5.0.1(@types/node@18.19.86)
+      '@rushstack/terminal': 0.15.3(@types/node@18.19.67)
+      '@rushstack/ts-command-line': 5.0.1(@types/node@18.19.67)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -32525,7 +32537,7 @@ snapshots:
 
   '@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.5.0)(@azure/msal-browser@3.27.0)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       tslib: 2.8.1
     optionalDependencies:
       '@azure/identity': 4.5.0
@@ -32577,7 +32589,7 @@ snapshots:
 
   '@mui/base@5.0.0-beta.58(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.21(@types/react@18.3.15)
       '@mui/utils': 6.0.0-rc.0(@types/react@18.3.15)(react@18.3.1)
@@ -32593,7 +32605,7 @@ snapshots:
 
   '@mui/icons-material@6.2.1(@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/material': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
@@ -32601,7 +32613,7 @@ snapshots:
 
   '@mui/lab@6.0.0-beta.9(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/base': 5.0.0-beta.58(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/material': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1)
@@ -32618,7 +32630,7 @@ snapshots:
 
   '@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/core-downloads-tracker': 6.3.1
       '@mui/system': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1)
       '@mui/types': 7.2.21(@types/react@18.3.15)
@@ -32639,7 +32651,7 @@ snapshots:
 
   '@mui/private-theming@6.3.1(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/utils': 6.3.1(@types/react@18.3.15)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
@@ -32648,7 +32660,7 @@ snapshots:
 
   '@mui/styled-engine@6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -32661,7 +32673,7 @@ snapshots:
 
   '@mui/system@6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/private-theming': 6.3.1(@types/react@18.3.15)(react@18.3.1)
       '@mui/styled-engine': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.15)(react@18.3.1))(@types/react@18.3.15)(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.21(@types/react@18.3.15)
@@ -32681,7 +32693,7 @@ snapshots:
 
   '@mui/utils@6.0.0-rc.0(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/types': 7.2.21(@types/react@18.3.15)
       '@types/prop-types': 15.7.14
       clsx: 2.1.1
@@ -32693,7 +32705,7 @@ snapshots:
 
   '@mui/utils@6.3.1(@types/react@18.3.15)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@mui/types': 7.2.21(@types/react@18.3.15)
       '@types/prop-types': 15.7.14
       clsx: 2.1.1
@@ -32840,9 +32852,9 @@ snapshots:
     dependencies:
       '@oclif/core': 4.0.36
 
-  '@oclif/plugin-not-found@3.2.30(@types/node@18.19.86)':
+  '@oclif/plugin-not-found@3.2.30(@types/node@18.19.67)':
     dependencies:
-      '@inquirer/prompts': 7.2.0(@types/node@18.19.86)
+      '@inquirer/prompts': 7.2.0(@types/node@18.19.67)
       '@oclif/core': 4.0.36
       ansis: 3.3.2
       fast-levenshtein: 3.0.0
@@ -32915,7 +32927,7 @@ snapshots:
       '@octokit/graphql': 8.1.1
       '@octokit/request': 9.1.3
       '@octokit/request-error': 6.1.5
-      '@octokit/types': 13.10.0
+      '@octokit/types': 13.6.2
       before-after-hook: 3.0.2
       universal-user-agent: 7.0.2
 
@@ -32941,12 +32953,14 @@ snapshots:
       '@octokit/types': 13.10.0
       universal-user-agent: 7.0.2
 
+  '@octokit/openapi-types@22.2.0': {}
+
   '@octokit/openapi-types@24.2.0': {}
 
   '@octokit/plugin-paginate-rest@11.3.6(@octokit/core@6.1.2)':
     dependencies:
       '@octokit/core': 6.1.2
-      '@octokit/types': 13.10.0
+      '@octokit/types': 13.6.2
 
   '@octokit/plugin-paginate-rest@11.4.4-cjs.2(@octokit/core@5.2.0)':
     dependencies:
@@ -32964,7 +32978,7 @@ snapshots:
   '@octokit/plugin-rest-endpoint-methods@13.2.6(@octokit/core@6.1.2)':
     dependencies:
       '@octokit/core': 6.1.2
-      '@octokit/types': 13.10.0
+      '@octokit/types': 13.6.2
 
   '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1(@octokit/core@5.2.0)':
     dependencies:
@@ -33012,6 +33026,10 @@ snapshots:
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@13.6.2':
+    dependencies:
+      '@octokit/openapi-types': 22.2.0
 
   '@parcel/watcher-android-arm64@2.5.0':
     optional: true
@@ -33203,7 +33221,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
 
-  '@rushstack/node-core-library@5.13.1(@types/node@18.19.86)':
+  '@rushstack/node-core-library@5.13.1(@types/node@18.19.67)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -33214,7 +33232,7 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@rushstack/node-core-library@5.13.1(@types/node@18.19.86)':
     dependencies:
@@ -33254,12 +33272,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
 
-  '@rushstack/terminal@0.15.3(@types/node@18.19.86)':
+  '@rushstack/terminal@0.15.3(@types/node@18.19.67)':
     dependencies:
-      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.86)
+      '@rushstack/node-core-library': 5.13.1(@types/node@18.19.67)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@rushstack/terminal@0.15.3(@types/node@18.19.86)':
     dependencies:
@@ -33286,9 +33304,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@5.0.1(@types/node@18.19.86)':
+  '@rushstack/ts-command-line@5.0.1(@types/node@18.19.67)':
     dependencies:
-      '@rushstack/terminal': 0.15.3(@types/node@18.19.86)
+      '@rushstack/terminal': 0.15.3(@types/node@18.19.67)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -33446,7 +33464,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -33457,7 +33475,7 @@ snapshots:
   '@testing-library/jest-dom@5.17.0':
     dependencies:
       '@adobe/css-tools': 4.4.1
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@types/testing-library__jest-dom': 5.14.9
       aria-query: 5.3.2
       chalk: 3.0.0
@@ -33468,7 +33486,7 @@ snapshots:
 
   '@testing-library/react@16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       '@testing-library/dom': 10.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -33604,7 +33622,7 @@ snapshots:
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/chai@4.3.20': {}
 
@@ -33624,7 +33642,7 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.0.2
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/connect@3.4.38':
     dependencies:
@@ -33634,7 +33652,7 @@ snapshots:
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/d3-array@3.2.1': {}
 
@@ -33723,7 +33741,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/glob@7.2.0':
     dependencies:
@@ -33779,7 +33797,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       '@types/tough-cookie': 4.0.5
       parse5: 7.2.1
 
@@ -33827,16 +33845,20 @@ snapshots:
 
   '@types/nock@9.3.1':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       form-data: 4.0.4
 
   '@types/node-forge@1.3.11':
     dependencies:
       '@types/node': 18.19.86
+
+  '@types/node@18.19.67':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@18.19.86':
     dependencies:
@@ -33926,12 +33948,12 @@ snapshots:
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       '@types/send': 0.17.4
 
   '@types/sha.js@2.4.4':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/simplemde@1.11.11': {}
 
@@ -33948,7 +33970,7 @@ snapshots:
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/stack-utils@2.0.3': {}
 
@@ -33995,7 +34017,7 @@ snapshots:
 
   '@types/ws@8.5.13':
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -34485,6 +34507,10 @@ snapshots:
       - supports-color
 
   agent-base@7.1.3: {}
+
+  agentkeepalive@4.5.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -35672,13 +35698,13 @@ snapshots:
     dependencies:
       semver: 7.7.1
 
-  create-jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -35897,7 +35923,7 @@ snapshots:
 
   date-fns@2.30.0:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
 
   dayjs@1.11.13: {}
 
@@ -36101,7 +36127,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       csstype: 3.1.3
 
   dom-serializer@1.4.1:
@@ -36476,33 +36502,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36516,13 +36542,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -36533,13 +36559,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.4.3(@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5):
+  eslint-plugin-jest@27.4.3(@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.7.5(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0)(typescript@5.4.5)
-      jest: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -38217,7 +38243,7 @@ snapshots:
       path-browserify: 1.0.1
       pify: 4.0.1
       readable-stream: 3.6.2
-      sha.js: 2.4.12
+      sha.js: 2.4.11
       simple-get: 4.0.1
 
   issue-parser@7.0.1:
@@ -38322,16 +38348,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -38360,7 +38386,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -38385,13 +38411,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.86
-      ts-node: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+      '@types/node': 18.19.67
+      ts-node: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -38416,7 +38442,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       ts-node: 10.9.2(@types/node@22.14.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -38491,7 +38517,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -38505,7 +38531,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -38704,7 +38730,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -38743,12 +38769,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40514,7 +40540,7 @@ snapshots:
 
   obuf@1.1.2: {}
 
-  oclif@4.16.2(@types/node@18.19.86):
+  oclif@4.16.2(@types/node@18.19.67):
     dependencies:
       '@aws-sdk/client-cloudfront': empty-npm-package@1.0.0
       '@aws-sdk/client-s3': empty-npm-package@1.0.0
@@ -40523,7 +40549,7 @@ snapshots:
       '@inquirer/select': 2.5.0
       '@oclif/core': 4.0.36
       '@oclif/plugin-help': 6.2.19
-      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.86)
+      '@oclif/plugin-not-found': 3.2.30(@types/node@18.19.67)
       '@oclif/plugin-warn-if-update-available': 3.1.26
       async-retry: 1.3.3
       chalk: 4.1.2
@@ -40613,10 +40639,10 @@ snapshots:
 
   openai@4.76.1(encoding@0.1.13)(zod@3.25.76):
     dependencies:
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
+      agentkeepalive: 4.5.0
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -41066,13 +41092,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.3
 
-  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.6.1
     optionalDependencies:
       postcss: 8.5.3
-      ts-node: 10.9.2(@types/node@18.19.86)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.3):
     dependencies:
@@ -41554,7 +41580,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -41929,7 +41955,7 @@ snapshots:
 
   rtl-css-js@1.16.1:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.26.9
 
   run-async@2.4.1: {}
 
@@ -42165,11 +42191,10 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sha.js@2.4.12:
+  sha.js@2.4.11:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
-      to-buffer: 1.2.1
 
   shallow-clone@3.0.1:
     dependencies:
@@ -42866,7 +42891,7 @@ snapshots:
       keyborg: 2.6.0
       tslib: 2.8.1
 
-  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)):
+  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -42885,7 +42910,7 @@ snapshots:
       postcss: 8.5.3
       postcss-import: 15.1.0(postcss@8.5.3)
       postcss-js: 4.0.1(postcss@8.5.3)
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       postcss-nested: 6.2.0(postcss@8.5.3)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -43037,7 +43062,7 @@ snapshots:
       '@fluidframework/server-services-telemetry': 7.0.0
       '@fluidframework/server-services-utils': 7.0.0
       '@fluidframework/server-test-utils': 7.0.0
-      agentkeepalive: 4.6.0
+      agentkeepalive: 4.5.0
       axios: 1.8.4(debug@4.4.0)
       body-parser: 1.20.3
       charwise: 3.0.1
@@ -43073,12 +43098,6 @@ snapshots:
       os-tmpdir: 1.0.2
 
   tmpl@1.0.5: {}
-
-  to-buffer@1.2.1:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
 
   to-regex-range@5.0.1:
     dependencies:
@@ -43141,12 +43160,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.86)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -43199,14 +43218,14 @@ snapshots:
       '@ts-morph/common': 0.23.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@types/node@18.19.86)(typescript@5.4.5):
+  ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.86
+      '@types/node': 18.19.67
       acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
This PR updates typetests following the 2.60.0 release. The following commands were used to generate the changes:
```
pnpm exec flub typetests -g client --reset --normalize --previous
pnpm install --no-frozen-lockfile
pnpm run typetests:gen
```