### PR TITLE
improvement(client-presence): improve join response scalability and reliability

### DIFF
--- a/.changeset/floppy-sides-hammer.md
+++ b/.changeset/floppy-sides-hammer.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/presence": minor
+"__section": feature
+---
+Improved join scalability
+
+Protocol for attendees joining has been updated to more efficiently accommodate a larger number of attendees, including when few-to-none have write access.

--- a/examples/apps/presence-tracker/tests/presenceTracker.test.ts
+++ b/examples/apps/presence-tracker/tests/presenceTracker.test.ts
@@ -178,7 +178,7 @@ describe("presence-tracker", () => {
 								expected: Record<string, string>,
 							) => boolean
 						)(expectation),
-					{ timeout: 100 },
+					{ timeout: 300 },
 					expected,
 				)
 				.catch(async () => {

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -91,7 +91,7 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 		this.attendees = this.systemWorkspace;
 
 		runtime.events.on("joined", ({ clientId: joinedClientId }: { clientId: string }) => {
-			this.onConnect(joinedClientId);
+			this.onJoin(joinedClientId);
 		});
 
 		runtime.events.on("disconnected", () => {
@@ -99,6 +99,7 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 			if (currentClientId !== undefined) {
 				this.removeClientConnectionId(currentClientId);
 			}
+			this.datastoreManager.onDisconnected();
 		});
 
 		runtime.getAudience().on("removeMember", this.removeClientConnectionId.bind(this));
@@ -111,11 +112,11 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 		// always trigger an initial connect.
 		const clientId = runtime.getClientId();
 		if (clientId !== undefined && runtime.getJoinedStatus() !== "disconnected") {
-			this.onConnect(clientId);
+			this.onJoin(clientId);
 		}
 	}
 
-	private onConnect(clientConnectionId: ClientConnectionId): void {
+	private onJoin(clientConnectionId: ClientConnectionId): void {
 		this.systemWorkspace.onConnectionAdded(clientConnectionId);
 		this.datastoreManager.joinSession(clientConnectionId);
 	}

--- a/packages/framework/presence/src/protocol.ts
+++ b/packages/framework/presence/src/protocol.ts
@@ -54,7 +54,16 @@ interface DatastoreUpdateMessage {
 		sendTimestamp: number;
 		avgLatency: number;
 		acknowledgementId?: AcknowledgmentId;
+		/**
+		 * When present (always true), this message contains complete data
+		 * for all attendees in the system.
+		 */
 		isComplete?: true;
+		/**
+		 * List of client connection ids for which this message will satisfy
+		 * their join catch up responses.
+		 */
+		joinResponseFor?: ClientConnectionId[];
 		data: DatastoreMessageContent;
 	};
 }

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -34,6 +34,7 @@
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7071 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
 		"test:realsvc:tinylicious:run": "npm run test:realsvc:azure:run -- --driver=t9s",
+		"test:realsvc:tinylicious:scale": "cross-env FLUID_TEST_SCALE=true npm run test:realsvc:tinylicious",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=msgs npm run test:realsvc",
 		"test:realsvc:veryverbose": "cross-env FLUID_TEST_VERBOSE=msgs+telem npm run test:realsvc"
 	},

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -248,6 +248,15 @@ class MessageHandler {
 
 	private readonly logger: ITelemetryBaseLogger = {
 		send: (event: ITelemetryBaseEvent, logLevel?: LogLevel) => {
+			// Special case unexpected telemetry event
+			if (event.eventName.endsWith(":JoinResponseWhenAlone")) {
+				this.send({
+					event: "error",
+					error: `Unexpected ClientJoin response. Details: ${JSON.stringify(event.details)}`,
+				});
+				// Keep going
+			}
+
 			const interest = telemetryEventInterestLevel(event.eventName);
 			if (interest === "none") {
 				return;

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 # test-real-service-e2e pipeline
+# pipeline: https://dev.azure.com/fluidframework/internal/_build?definitionId=56
 
 name: $(Build.BuildId)
 

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -57,6 +57,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
+        FLUID_TEST_SCALE: true # run longer duration tests
         FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains createTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
         azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)
@@ -74,6 +75,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
+        FLUID_TEST_SCALE: true # run longer duration tests
         FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains createTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
         # Disable colorization for tinylicious logs (not useful when printing to a file)
@@ -91,6 +93,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
+        FLUID_TEST_SCALE: true # run longer duration tests
         FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains createTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
         odsp__client__clientId: $(odsp-client-clientId)


### PR DESCRIPTION
- In broadcast join responses:
  - include list of Client Connection Ids that the broadcast response covers. This will prevent hole where existing client sees a broadcast result too soon after a Join message and assumes it contains all sufficient and timely data.
  - potential join respondents will only reply if they have received a join response (or appear to have same or more requests that other audience members indicating complete knowledge)
- Increase trust of Audience (dictated by service) and select some of its member for named (primary) join responders when no Quorum members are known.
- Delay Join response messages for scalability
  - *Important* Do not broadcast a join response immediately even when selected as a named responder. Wait 200ms for others that may join.
- Add telemetry events for join handling:
  - `JoinRequested` - client has broadcast Join signal
  - `JoinResponse` - client is responding to join request
  Each event includes attendee and connection ids. `JoinResponse` additionally contains lists for whom they are responding to.

Update tests for higher client counts and delayed join responses and enable previously failing test. Limit higher client count (longer duration) tests to dedicated CI pipelines.

[AB#45620](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45620)