### PR TITLE
Shared Signal rollback

### DIFF
--- a/packages/dds/legacy-dds/src/signal/sharedSignal.ts
+++ b/packages/dds/legacy-dds/src/signal/sharedSignal.ts
@@ -163,6 +163,11 @@ export class SharedSignalClass<T extends SerializableTypeForSharedSignal = any>
 		this.emit("notify", op.metadata, isLocal);
 	}
 
+	// Nothing to roll back. Allowing other DDSs to handle rollback if necessary.
+	public rollback(content: unknown, _localOpMetadata: unknown): void {
+		return;
+	}
+
 	protected applyStashedOp(_content: unknown): void {
 		const op = _content as ISignalOperation<T>;
 

--- a/packages/dds/legacy-dds/src/test/signal/signal.rollback.spec.ts
+++ b/packages/dds/legacy-dds/src/test/signal/signal.rollback.spec.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AttachState } from "@fluidframework/container-definitions";
+import {
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+	type MockContainerRuntime,
+} from "@fluidframework/test-runtime-utils/internal";
+
+// eslint-disable-next-line import/no-internal-modules
+import type { ISharedSignal } from "../../signal/interfaces.js";
+// eslint-disable-next-line import/no-internal-modules
+import { SharedSignalFactory } from "../../signal/sharedSignalFactory.js";
+
+interface RollbackTestSetup {
+	sharedSignal: ISharedSignal<number>;
+	containerRuntime: MockContainerRuntime;
+}
+const signalFactory = new SharedSignalFactory();
+
+function setupRollbackTest(): RollbackTestSetup {
+	const containerRuntimeFactory = new MockContainerRuntimeFactory({ flushMode: 1 }); // TurnBased
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: "1" });
+	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	const sharedSignal = signalFactory.create(dataStoreRuntime, "shared-signal-1");
+	dataStoreRuntime.setAttachState(AttachState.Attached);
+	sharedSignal.connect({
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	});
+	return {
+		sharedSignal,
+		containerRuntime,
+	};
+}
+
+describe("SharedSignal rollback", () => {
+	it("rollback should not throw", () => {
+		const { sharedSignal, containerRuntime } = setupRollbackTest();
+		sharedSignal.notify(0);
+		containerRuntime.rollback?.();
+	});
+});


### PR DESCRIPTION
Nothing to rollback in shared signal DDS since it does not hold any state. Mainly just returning to avoid throwing when doing rollback of other DDSs. 