### PR TITLE
test(client): update scopes and timeouts for AFR

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -114,7 +114,7 @@ function composeConnectMessage(
 			name: `test-user-name-${id}`,
 		},
 		scopes,
-		createScopes: [ScopeType.DocWrite],
+		createScopes: [ScopeType.DocWrite, ScopeType.DocRead],
 	};
 }
 
@@ -156,9 +156,10 @@ export async function connectChildProcesses(
 		// Note that DocWrite is used to have this attendee be the "leader".
 		// DocRead would also be valid as DocWrite is specified for attach when there
 		// is no document id (container id).
-		const connectContainerCreator = composeConnectMessage(0, [
-			writeClients > 0 ? ScopeType.DocWrite : ScopeType.DocRead,
-		]);
+		const connectContainerCreator = composeConnectMessage(
+			0,
+			writeClients > 0 ? [ScopeType.DocWrite, ScopeType.DocRead] : [ScopeType.DocRead],
+		);
 		firstChild.send(connectContainerCreator);
 	}
 	const { containerCreatorAttendeeId, containerId } = await timeoutAwait(
@@ -175,9 +176,10 @@ export async function connectChildProcesses(
 			attendeeIdPromises.push(Promise.resolve(containerCreatorAttendeeId));
 			continue;
 		}
-		const message = composeConnectMessage(index, [
-			index < writeClients ? ScopeType.DocWrite : ScopeType.DocRead,
-		]);
+		const message = composeConnectMessage(
+			index,
+			index < writeClients ? [ScopeType.DocWrite, ScopeType.DocRead] : [ScopeType.DocRead],
+		);
 		message.containerId = containerId;
 		attendeeIdPromises.push(
 			new Promise<AttendeeId>((resolve, reject) => {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -24,12 +24,17 @@ import {
 	waitForLatestValueUpdates,
 } from "./orchestratorUtils.js";
 
+const useAzure = process.env.FLUID_CLIENT === "azure";
+
+/**
+ * Detects if the debugger is attached (when code loaded).
+ */
 const debuggerAttached = inspector.url() !== undefined;
 
 /**
  * Set this to a high number when debugging to avoid timeouts from debugging time.
  */
-const timeoutMultiplier = debuggerAttached ? 1000 : 1;
+const timeoutMultiplier = debuggerAttached ? 1000 : useAzure ? 3 : 1;
 
 /**
  * Sets the timeout for the given test context.


### PR DESCRIPTION
AFR requires read scope with write scope
AFR also takes longer. Use the timeout multiplier to adjust when running against azure.