### PR TITLE
improvement(task-manager): Ignore stashed ops

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "@fluid-internal/client-utils";
 import type { ReadOnlyInfo } from "@fluidframework/container-definitions/internal";
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -750,23 +750,9 @@ export class TaskManagerClass
 	}
 
 	protected applyStashedOp(content: unknown): void {
-		const taskOp: ITaskManagerOperation = content as ITaskManagerOperation;
-		switch (taskOp.type) {
-			case "abandon": {
-				this.abandon(taskOp.taskId);
-				break;
-			}
-			case "complete": {
-				this.complete(taskOp.taskId);
-				break;
-			}
-			case "volunteer": {
-				this.subscribeToTask(taskOp.taskId);
-				break;
-			}
-			default: {
-				unreachableCase(taskOp);
-			}
-		}
+		// We don't apply any stashed ops since during the rehydration process. Since we lose any assigned tasks
+		// during rehydration we cannot be assigned any tasks. Additionally, without the in-memory state of the
+		// previous dds, we also cannot re-volunteer based on a previous subscribeToTask() call. Since we are
+		// unable to be assigned to any tasks, there is no reason to process abandon/complete ops either.
 	}
 }

--- a/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
@@ -79,7 +79,7 @@ const defaultOptions: Required<OperationGenerationConfig> = {
 	taskPoolSize: 3,
 	taskStringLength: 5,
 	validateInterval: 10,
-	testCount: 10,
+	testCount: 100,
 	operations: 100,
 };
 
@@ -255,21 +255,7 @@ describe("TaskManager fuzz testing", () => {
 
 	createDDSFuzzSuite(model, {
 		validationStrategy: { type: "fixedInterval", interval: defaultOptions.validateInterval },
-		// AB#3985: TaskManager has some eventual consistency issue with reconnect enabled.
-		// To make this configuration similar to pre-generic DDS fuzz harness refactor, this constant
-		// should be 0.2.
-		// Leaving the tests enabled without reconnect on mimics previous behavior (and provides more coverage
-		// than skipping them)
-		reconnectProbability: 0,
 		rollbackProbability: 0,
-		detachedStartOptions: {
-			numOpsBeforeAttach: 5,
-			// similar to reconnect there are eventual consistency errors when we enter attaching before rehydrate
-			// when fixed, detachedStartOptions can be removed from this config, and attachingBeforeRehydrateDisable
-			// can be completely removed, as it is only used by this test. Rather than file more bugs. I'll just combine
-			// this with AB#3985, as it looks like the dds has fundamental issue around lifecycle handling
-			attachingBeforeRehydrateDisable: true,
-		},
 		clientJoinOptions: {
 			maxNumberOfClients: 6,
 			clientAddProbability: 0.05,
@@ -310,10 +296,6 @@ describe("TaskManager fuzz testing with rebasing", () => {
 		},
 		defaultTestCount: defaultOptions.testCount,
 		saveFailures: { directory: path.join(_dirname, "../../src/test/results") },
-		// AB#5341: enabling 'start from detached' within the fuzz harness demonstrates eventual consistency failures.
-		detachedStartOptions: {
-			numOpsBeforeAttach: 0,
-		},
 		rollbackProbability: 0,
 		// Uncomment this line to replay a specific seed:
 		// replay: 0,


### PR DESCRIPTION
## Description

This PR updates TaskManager to no longer process stashed ops. This is because any ops that were submitted are no longer "valid" due to TaskManager limitations around offline behavior. This is similar to the resubmit scenario (TaskManager does not resubmit ops at all). For each op, here is the justification as to why we shouldn't process stashed ops:

- `volunteer` - Going offline while waiting for a task assignment will cause the volunteer promise to automatically `reject`. Similar to reconnect scenarios, we should let the app developer re-volunteer in this scenario.
- `abandon`/`complete` - These ops only makes sense to apply for tasks that the client is assigned to. Since going offline will lose any task assignments, we can safely ignore any abandon ops.

## Misc
[AB#44704](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/44704)
Fixes [AB#5341](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5341)
Fixes [AB#3985](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3985)