### PR TITLE
Use error.cause in Breakable

### DIFF
--- a/packages/dds/tree/src/test/util/breakable.spec.ts
+++ b/packages/dds/tree/src/test/util/breakable.spec.ts
@@ -69,6 +69,15 @@ Error: BreakFoo`;
 
 		assert.throws(() => foo.read(1), validateUsageError(message));
 		assert.throws(() => foo.canBreak(1), validateUsageError(message));
+
+		// Check ".cause" is set
+		assert.throws(
+			() => foo.canBreak(1),
+			(error: Error) => {
+				assert.equal((error as unknown as { cause: unknown }).cause, breakError);
+				return true;
+			},
+		);
 	});
 
 	it("reentrant", () => {

--- a/packages/dds/tree/src/test/util/breakable.spec.ts
+++ b/packages/dds/tree/src/test/util/breakable.spec.ts
@@ -74,7 +74,8 @@ Error: BreakFoo`;
 		assert.throws(
 			() => foo.canBreak(1),
 			(error: Error) => {
-				assert.equal((error as unknown as { cause: unknown }).cause, breakError);
+				// TODO: remove cast when targeting ES2022 lib or later.
+				assert.equal((error as { cause?: unknown }).cause, breakError);
 				return true;
 			},
 		);

--- a/packages/dds/tree/src/util/breakable.ts
+++ b/packages/dds/tree/src/util/breakable.ts
@@ -38,8 +38,8 @@ export class Breakable {
 			// This "cause" field is added in ES2022, but using if even without that built in support, it is still helpful.
 			// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
 			// TODO: remove this cast when targeting ES2022 lib or later.
-			(error as unknown as { cause: unknown }).cause =
-				(this.brokenBy as unknown as { cause: unknown }).cause ?? this.brokenBy;
+			(error as { cause?: unknown }).cause =
+				(this.brokenBy as { cause?: unknown }).cause ?? this.brokenBy;
 
 			throw error;
 		}

--- a/packages/dds/tree/src/util/breakable.ts
+++ b/packages/dds/tree/src/util/breakable.ts
@@ -31,9 +31,17 @@ export class Breakable {
 	 */
 	public use(): void {
 		if (this.brokenBy !== undefined) {
-			throw new UsageError(
+			const error = new UsageError(
 				`Invalid use of ${this.name} after it was put into an invalid state by another error.\nOriginal Error:\n${this.brokenBy}`,
 			);
+
+			// This "cause" field is added in ES2022, but using if even without that built in support, it is still helpful.
+			// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+			// TODO: remove this cast when targeting ES2022 lib or later.
+			(error as unknown as { cause: unknown }).cause =
+				(this.brokenBy as unknown as { cause: unknown }).cause ?? this.brokenBy;
+
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
## Description

Use error.cause in Breakable to preserve source of errors better.

API is standardized in es2022, but works regardless and might help with debugging.

## Breaking Changes

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
