### PR TITLE
Use TreeNodeSchemaClass in ValidateRecursiveSchema

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1614,7 +1614,7 @@ export type UnsafeUnknownSchema = typeof UnsafeUnknownSchema;
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -695,7 +695,7 @@ export type UnionToTuple<Union, A extends unknown[] = [], First = PopUnion<Union
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -704,7 +704,7 @@ export type UnionToTuple<Union, A extends unknown[] = [], First = PopUnion<Union
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -629,7 +629,7 @@ export type UnionToIntersection<T> = (T extends T ? (k: T) => unknown : never) e
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -629,7 +629,7 @@ export type UnionToIntersection<T> = (T extends T ? (k: T) => unknown : never) e
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
@@ -11,6 +11,7 @@ import type {
 	TreeNode,
 	ImplicitAllowedTypes,
 	InsertableTreeNodeFromImplicitAllowedTypes,
+	TreeNodeSchemaClass,
 } from "../core/index.js";
 import type { InsertableObjectFromSchemaRecord } from "../node-kinds/index.js";
 import type { ImplicitFieldSchema } from "../fieldSchema.js";
@@ -136,50 +137,50 @@ import type { ImplicitFieldSchema } from "../fieldSchema.js";
  * TODO: this currently does not reject `any`, but ideally should.
  * @public
  */
-export type ValidateRecursiveSchema<
-	// Recursive types should always be using TreeNodeSchemaClass (not TreeNodeSchemaNonClass) as thats part of the requirements for the type to work across compilation boundaries correctly.
-	T extends ValidateRecursiveSchemaTemplate<T>,
-> = true;
+export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 /**
  * Validation logic used by {@link ValidateRecursiveSchema}.
+ * @privateRemarks
+ * Recursive types should always be using TreeNodeSchemaClass (not TreeNodeSchemaNonClass) as thats part of the requirements for the type to work across compilation boundaries correctly.
  * @system @public
  */
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<
-	// Name: This validator places no restrictions on the name other than that it's a string (as required by TreeNodeSchemaClass).
-	string,
-	// NodeKind: These are the NodeKinds which currently can be used recursively.
-	NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record,
-	// TNode: The produced node API. This is pretty minimal validation: more could be added if similar to how TInsertable works below if needed.
-	TreeNode & WithType<T["identifier"], T["kind"]>,
-	// TInsertable: What can be passed to the constructor. This should be enough to catch most issues with incorrect schema.
-	// These match whats defined in the recursive methods on `SchemaFactory` except they do not use `Unenforced`.
-	{
-		[NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema>
-			? InsertableObjectFromSchemaRecord<T["info"]>
-			: unknown;
-		[NodeKind.Array]: T["info"] extends ImplicitAllowedTypes
-			? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>>
-			: unknown;
-		[NodeKind.Map]: T["info"] extends ImplicitAllowedTypes
-			? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]>
-			: unknown;
-		[NodeKind.Record]: {
-			readonly [P in string]: InsertableTreeNodeFromImplicitAllowedTypes<T>;
-		};
-		[NodeKind.Leaf]: unknown;
-	}[T["kind"]],
-	// ImplicitlyConstructable: recursive types are currently not implicitly constructable.
-	false,
-	// Info: What's passed to the method to create the schema. Constraining these here should be about as effective as if the actual constraints existed on the actual method itself.
-	{
-		[NodeKind.Object]: RestrictiveStringRecord<ImplicitFieldSchema>;
-		[NodeKind.Array]: ImplicitAllowedTypes;
-		[NodeKind.Map]: ImplicitAllowedTypes;
-		[NodeKind.Record]: ImplicitAllowedTypes;
-		[NodeKind.Leaf]: unknown;
-	}[T["kind"]]
->;
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> =
+	TreeNodeSchemaClass<
+		// Name: This validator places no restrictions on the name other than that it's a string (as required by TreeNodeSchemaClass).
+		string,
+		// NodeKind: These are the NodeKinds which currently can be used recursively.
+		NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record,
+		// TNode: The produced node API. This is pretty minimal validation: more could be added if similar to how TInsertable works below if needed.
+		TreeNode & WithType<T["identifier"], T["kind"]>,
+		// TInsertable: What can be passed to the constructor. This should be enough to catch most issues with incorrect schema.
+		// These match whats defined in the recursive methods on `SchemaFactory` except they do not use `Unenforced`.
+		{
+			[NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema>
+				? InsertableObjectFromSchemaRecord<T["info"]>
+				: unknown;
+			[NodeKind.Array]: T["info"] extends ImplicitAllowedTypes
+				? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>>
+				: unknown;
+			[NodeKind.Map]: T["info"] extends ImplicitAllowedTypes
+				? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]>
+				: unknown;
+			[NodeKind.Record]: {
+				readonly [P in string]: InsertableTreeNodeFromImplicitAllowedTypes<T>;
+			};
+			[NodeKind.Leaf]: unknown;
+		}[T["kind"]],
+		// ImplicitlyConstructable: recursive types are currently not implicitly constructable.
+		false,
+		// Info: What's passed to the method to create the schema. Constraining these here should be about as effective as if the actual constraints existed on the actual method itself.
+		{
+			[NodeKind.Object]: RestrictiveStringRecord<ImplicitFieldSchema>;
+			[NodeKind.Array]: ImplicitAllowedTypes;
+			[NodeKind.Map]: ImplicitAllowedTypes;
+			[NodeKind.Record]: ImplicitAllowedTypes;
+			[NodeKind.Leaf]: unknown;
+		}[T["kind"]]
+	>;
 
 /**
  * Workaround for "Type instantiation is excessively deep and possibly infinite.ts" errors.
@@ -236,7 +237,7 @@ export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNode
  * This uses ValidateRecursiveSchemaTemplate since it was found to evaluate enough of the type to work.
  * @internal
  */
-export type FixRecursiveRecursionLimit<T extends TreeNodeSchema> =
+export type FixRecursiveRecursionLimit<T extends TreeNodeSchemaClass> =
 	T extends ValidateRecursiveSchemaTemplate<T> ? undefined : undefined;
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
@@ -142,7 +142,7 @@ export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>
 /**
  * Validation logic used by {@link ValidateRecursiveSchema}.
  * @privateRemarks
- * Recursive types should always be using TreeNodeSchemaClass (not TreeNodeSchemaNonClass) as thats part of the requirements for the type to work across compilation boundaries correctly.
+ * Recursive types should always be using TreeNodeSchemaClass (not TreeNodeSchemaNonClass) as that's part of the requirements for the type to work across compilation boundaries correctly.
  * @system @public
  */
 export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> =

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2000,7 +2000,7 @@ export type UnsafeUnknownSchema = typeof UnsafeUnknownSchema;
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -1075,7 +1075,7 @@ export type UnionToTuple<Union, A extends unknown[] = [], First = PopUnion<Union
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -1433,7 +1433,7 @@ export type UnionToTuple<Union, A extends unknown[] = [], First = PopUnion<Union
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -1043,7 +1043,7 @@ export type UnionToIntersection<T> = (T extends T ? (k: T) => unknown : never) e
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -1009,7 +1009,7 @@ export type UnionToIntersection<T> = (T extends T ? (k: T) => unknown : never) e
 export type ValidateRecursiveSchema<T extends ValidateRecursiveSchemaTemplate<T>> = true;
 
 // @public @system
-export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchema> = TreeNodeSchema<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
+export type ValidateRecursiveSchemaTemplate<T extends TreeNodeSchemaClass> = TreeNodeSchemaClass<string, NodeKind.Array | NodeKind.Map | NodeKind.Object | NodeKind.Record, TreeNode & WithType<T["identifier"], T["kind"]>, {
     [NodeKind.Object]: T["info"] extends RestrictiveStringRecord<ImplicitFieldSchema> ? InsertableObjectFromSchemaRecord<T["info"]> : unknown;
     [NodeKind.Array]: T["info"] extends ImplicitAllowedTypes ? Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>> : unknown;
     [NodeKind.Map]: T["info"] extends ImplicitAllowedTypes ? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]> : unknown;


### PR DESCRIPTION
## Description

All recursive schema types are instances of TreeNodeSchemaClass. This was documented on ValidateRecursiveSchema's implementation, but not used in its typing.

Since TreeNodeSchema is implemented as a union of TreeNodeSchemaClass and TreeNodeSchemaNonClass, this change makes ValidateRecursiveSchema slightly stricter, but in a way all recursive schema will pass, and also simpler, since TypeScript no longer has to infer which kind of schema the input is.

In practice, this should not impact any users of the API, buts just now a little more robust and gives slightly better errors.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
