### PR TITLE
fix(tree): Guard against reverts during change notifications

### DIFF
--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -883,6 +883,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	}
 
 	private revertRevertible(revision: RevisionTag, kind: CommitKind): RevertMetrics {
+		this.editLock.checkUnlocked("Reverting a commit");
 		if (this.transaction.isInProgress()) {
 			throw new UsageError("Undo is not yet supported during transactions.");
 		}

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -1339,6 +1339,22 @@ describe("sharedTreeView", () => {
 			});
 		});
 
+		it("revert a commit", () => {
+			let revertible: Revertible | undefined;
+			expectErrorDuringEdit({
+				setup: (view) => {
+					const unsubscribe = view.events.on("changed", (_, getRevertible) => {
+						revertible = getRevertible?.();
+					});
+					view.root.number = 4;
+					unsubscribe();
+					assert(revertible !== undefined, "Expected revertible to be created.");
+				},
+				duringEdit: (view) => revertible?.revert(),
+				error: "Reverting a commit is forbidden during a nodeChanged or treeChanged event",
+			});
+		});
+
 		it("dispose", () => {
 			let branch: TreeBranch | undefined;
 			expectErrorDuringEdit({


### PR DESCRIPTION
## Description

This change ensures that attempts at reverting commits during change notifications will trigger a usage error with a helpful message instead of an assert.

## Breaking Changes

None