### PR TITLE
build(client): Include re-exports in API reports

### DIFF
--- a/azure/packages/azure-service-utils/api-report/azure-service-utils.beta.api.md
+++ b/azure/packages/azure-service-utils/api-report/azure-service-utils.beta.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```

--- a/azure/packages/azure-service-utils/api-report/azure-service-utils.legacy.beta.api.md
+++ b/azure/packages/azure-service-utils/api-report/azure-service-utils.legacy.beta.api.md
@@ -7,8 +7,16 @@
 // @beta @legacy
 export function generateToken(tenantId: string, key: string, scopes: ScopeType[], documentId?: string, user?: IUser, lifetime?: number, ver?: string): string;
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
-export { ScopeType }
+// @beta @legacy
+export enum ScopeType {
+    DocRead = "doc:read",
+    DocWrite = "doc:write",
+    SummaryWrite = "summary:write"
+}
 
 ```

--- a/azure/packages/azure-service-utils/api-report/azure-service-utils.legacy.public.api.md
+++ b/azure/packages/azure-service-utils/api-report/azure-service-utils.legacy.public.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```

--- a/azure/packages/azure-service-utils/api-report/azure-service-utils.public.api.md
+++ b/azure/packages/azure-service-utils/api-report/azure-service-utils.public.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```

--- a/common/build/build-common/api-extractor-report-base.esm.json
+++ b/common/build/build-common/api-extractor-report-base.esm.json
@@ -17,7 +17,7 @@
 
 			// TODO: consider if we want to enforce completeness of cross-package re-exports
 			"ae-forgotten-export": {
-				"logLevel": "none",
+				"logLevel": "none"
 			}
 		}
 	},

--- a/common/build/build-common/api-extractor-report-base.esm.json
+++ b/common/build/build-common/api-extractor-report-base.esm.json
@@ -13,7 +13,20 @@
 			// It will be enabled for `model` generation, which is used for generating API documentation for the entire suite.
 			"ae-unresolved-link": {
 				"logLevel": "none"
+			},
+
+			// TODO: consider if we want to enforce completeness of cross-package re-exports
+			"ae-forgotten-export": {
+				"logLevel": "none",
 			}
 		}
-	}
+	},
+	// Bundle local dependencies so we can review changes to re-exports
+	"bundledPackages": [
+		"@fluidframework/*",
+		"@fluid-internal/*",
+		"@fluid-experimental/*",
+		"@fluid-private/*",
+		"@fluid-tools/*"
+	]
 }

--- a/packages/common/container-definitions/api-report/container-definitions.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.beta.api.md
@@ -43,9 +43,16 @@ export interface IAudienceEvents extends IEvent {
 }
 
 // @public
-export type ICriticalContainerError = IErrorBase_2;
+export type ICriticalContainerError = IErrorBase;
 
-export { IErrorBase }
+// @public
+export interface IErrorBase extends Partial<Error> {
+    readonly errorType: string;
+    getTelemetryProperties?(): ITelemetryBaseProperties;
+    readonly message: string;
+    readonly name?: string;
+    readonly stack?: string;
+}
 
 // @public
 export interface ISelf {

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
@@ -40,7 +40,7 @@ export const ContainerErrorTypes: {
 export type ContainerErrorTypes = (typeof ContainerErrorTypes)[keyof typeof ContainerErrorTypes];
 
 // @beta @legacy
-export interface ContainerWarning extends IErrorBase_2 {
+export interface ContainerWarning extends IErrorBase {
     logged?: boolean;
 }
 
@@ -226,7 +226,7 @@ export interface IContainerStorageService {
 }
 
 // @public
-export type ICriticalContainerError = IErrorBase_2;
+export type ICriticalContainerError = IErrorBase;
 
 // @beta @sealed @legacy
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender {
@@ -259,7 +259,7 @@ export interface IDeltaManagerEvents extends IEvent {
     (event: "disconnect", listener: (reason: string, error?: IAnyDriverError) => void): any;
     (event: "readonly", listener: (readonly: boolean, readonlyConnectionReason?: {
         reason: string;
-        error?: IErrorBase_2;
+        error?: IErrorBase;
     }) => void): any;
 }
 
@@ -290,7 +290,14 @@ export interface IDeltaSender {
     flush(): void;
 }
 
-export { IErrorBase }
+// @public
+export interface IErrorBase extends Partial<Error> {
+    readonly errorType: string;
+    getTelemetryProperties?(): ITelemetryBaseProperties;
+    readonly message: string;
+    readonly name?: string;
+    readonly stack?: string;
+}
 
 // @beta @legacy
 export interface IFluidBrowserPackage extends IFluidPackage {
@@ -454,7 +461,12 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
     };
 }
 
-export { IThrottlingWarning }
+// @beta @legacy
+export interface IThrottlingWarning extends IErrorBase {
+    readonly errorType: typeof FluidErrorTypes.throttlingError;
+    // (undocumented)
+    readonly retryAfterSeconds: number;
+}
 
 // @beta @legacy
 export enum LoaderHeader {

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.public.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.public.api.md
@@ -43,9 +43,16 @@ export interface IAudienceEvents extends IEvent {
 }
 
 // @public
-export type ICriticalContainerError = IErrorBase_2;
+export type ICriticalContainerError = IErrorBase;
 
-export { IErrorBase }
+// @public
+export interface IErrorBase extends Partial<Error> {
+    readonly errorType: string;
+    getTelemetryProperties?(): ITelemetryBaseProperties;
+    readonly message: string;
+    readonly name?: string;
+    readonly stack?: string;
+}
 
 // @public
 export interface ISelf {

--- a/packages/common/container-definitions/api-report/container-definitions.public.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.public.api.md
@@ -43,9 +43,16 @@ export interface IAudienceEvents extends IEvent {
 }
 
 // @public
-export type ICriticalContainerError = IErrorBase_2;
+export type ICriticalContainerError = IErrorBase;
 
-export { IErrorBase }
+// @public
+export interface IErrorBase extends Partial<Error> {
+    readonly errorType: string;
+    getTelemetryProperties?(): ITelemetryBaseProperties;
+    readonly message: string;
+    readonly name?: string;
+    readonly stack?: string;
+}
 
 // @public
 export interface ISelf {

--- a/packages/dds/legacy-dds/api-report/legacy-dds.legacy.beta.api.md
+++ b/packages/dds/legacy-dds/api-report/legacy-dds.legacy.beta.api.md
@@ -133,7 +133,7 @@ export const SharedArray: ISharedObjectKind<ISharedArray<SerializableTypeForShar
 export const SharedArrayBuilder: <T extends SerializableTypeForSharedArray>() => ISharedObjectKind<ISharedArray<T>> & SharedObjectKind<ISharedArray<T>>;
 
 // @beta @legacy
-export const SharedSignal: ISharedObjectKind<ISharedSignal<any>> & SharedObjectKind<ISharedSignal<any>>;
+export const SharedSignal: ISharedObjectKind_2<ISharedSignal<any>> & SharedObjectKind_2<ISharedSignal<any>>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/dds/sequence/api-report/sequence.legacy.beta.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.beta.api.md
@@ -19,7 +19,40 @@ export function appendIntervalPropertyChangedToRevertibles(interval: SequenceInt
 // @beta @legacy
 export function appendSharedStringDeltaToRevertibles(string: ISharedString, delta: SequenceDeltaEvent, revertibles: SharedStringRevertible[]): void;
 
-export { BaseSegment }
+// @beta @legacy (undocumented)
+export abstract class BaseSegment implements ISegment {
+    constructor(properties?: PropertySet);
+    // (undocumented)
+    protected addSerializedProps(jseg: IJSONSegment): void;
+    // (undocumented)
+    append(other: ISegment): void;
+    // (undocumented)
+    attribution?: IAttributionCollection<AttributionKey>;
+    // (undocumented)
+    cachedLength: number;
+    // (undocumented)
+    canAppend(segment: ISegment): boolean;
+    // (undocumented)
+    abstract clone(): ISegment;
+    // (undocumented)
+    protected cloneInto(b: ISegment): void;
+    // (undocumented)
+    protected abstract createSplitSegmentAt(pos: number): BaseSegment | undefined;
+    // (undocumented)
+    hasProperty(key: string): boolean;
+    // (undocumented)
+    isLeaf(): this is ISegment;
+    // (undocumented)
+    properties?: PropertySet;
+    // (undocumented)
+    splitAt(pos: number): ISegment | undefined;
+    // (undocumented)
+    abstract toJSONObject(): any;
+    // (undocumented)
+    readonly trackingCollection: TrackingGroupCollection;
+    // (undocumented)
+    abstract readonly type: string;
+}
 
 // @beta @legacy (undocumented)
 export function createOverlappingIntervalsIndex(sharedString: ISharedString): ISequenceOverlappingIntervalsIndex;
@@ -39,7 +72,13 @@ export interface IInterval {
     overlaps(b: IInterval): boolean;
 }
 
-export { InteriorSequencePlace }
+// @beta @legacy
+export interface InteriorSequencePlace {
+    // (undocumented)
+    pos: number;
+    // (undocumented)
+    side: Side;
+}
 
 // @beta @legacy
 export const IntervalOpType: {
@@ -105,7 +144,28 @@ export enum IntervalType {
     SlideOnRemove = 2,// SlideOnRemove is default behavior - all intervals are SlideOnRemove
 }
 
-export { ISegment }
+// @beta @legacy
+export interface ISegment {
+    // (undocumented)
+    append(segment: ISegment): void;
+    attribution?: IAttributionCollection<AttributionKey>;
+    cachedLength: number;
+    // (undocumented)
+    canAppend(segment: ISegment): boolean;
+    // (undocumented)
+    clone(): ISegment;
+    // (undocumented)
+    isLeaf(): this is ISegment;
+    properties?: PropertySet;
+    // (undocumented)
+    splitAt(pos: number): ISegment | undefined;
+    // (undocumented)
+    toJSONObject(): any;
+    // (undocumented)
+    readonly trackingCollection: TrackingGroupCollection;
+    // (undocumented)
+    readonly type: string;
+}
 
 // @beta @legacy
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
@@ -250,21 +310,102 @@ export interface ISharedString extends ISharedSegmentSequence<SharedStringSegmen
     searchForMarker(startPos: number, markerLabel: string, forwards?: boolean): Marker | undefined;
 }
 
-export { LocalReferencePosition }
+// @beta @sealed @legacy (undocumented)
+export interface LocalReferencePosition extends ReferencePosition {
+    // (undocumented)
+    addProperties(newProps: PropertySet): void;
+    // (undocumented)
+    callbacks?: Partial<Record<"beforeSlide" | "afterSlide", (ref: LocalReferencePosition) => void>>;
+    readonly canSlideToEndpoint?: boolean;
+    // (undocumented)
+    readonly trackingCollection: TrackingGroupCollection;
+}
 
-export { MapLike }
+// @beta @legacy
+export interface MapLike<T> {
+    // (undocumented)
+    [index: string]: T;
+}
 
-export { Marker }
+// @beta @legacy
+export class Marker extends BaseSegment implements ReferencePosition, ISegment {
+    constructor(refType: ReferenceType, props?: PropertySet);
+    // (undocumented)
+    append(): void;
+    // (undocumented)
+    canAppend(segment: ISegment): boolean;
+    // (undocumented)
+    clone(): Marker;
+    // (undocumented)
+    protected createSplitSegmentAt(pos: number): undefined;
+    // (undocumented)
+    static fromJSONObject(spec: IJSONSegment): Marker | undefined;
+    // (undocumented)
+    getId(): string | undefined;
+    // (undocumented)
+    getOffset(): number;
+    // (undocumented)
+    getProperties(): PropertySet | undefined;
+    // (undocumented)
+    getSegment(): Marker;
+    // (undocumented)
+    static is(segment: ISegment): segment is Marker;
+    // (undocumented)
+    static make(refType: ReferenceType, props?: PropertySet): Marker;
+    // (undocumented)
+    refType: ReferenceType;
+    // (undocumented)
+    toJSONObject(): IJSONMarkerSegment;
+    // (undocumented)
+    toString(): string;
+    // (undocumented)
+    static readonly type = "Marker";
+    // (undocumented)
+    readonly type = "Marker";
+}
 
-export { MergeTreeDeltaType }
+// @beta @legacy (undocumented)
+export const MergeTreeDeltaType: {
+    readonly INSERT: 0;
+    readonly REMOVE: 1;
+    readonly ANNOTATE: 2;
+    readonly GROUP: 3;
+    readonly OBLITERATE: 4;
+    readonly OBLITERATE_SIDED: 5;
+};
 
-export { PropertySet }
+// @beta @legacy (undocumented)
+export type MergeTreeDeltaType = (typeof MergeTreeDeltaType)[keyof typeof MergeTreeDeltaType];
 
-export { ReferencePosition }
+// @beta @legacy
+export type PropertySet = MapLike<any>;
 
-export { ReferenceType }
+// @beta @legacy
+export interface ReferencePosition {
+    getOffset(): number;
+    getSegment(): ISegment | undefined;
+    // (undocumented)
+    isLeaf(): this is ISegment;
+    properties?: PropertySet;
+    // (undocumented)
+    refType: ReferenceType;
+    slidingPreference?: SlidingPreference;
+}
 
-export { reservedMarkerIdKey }
+// @beta @legacy
+export enum ReferenceType {
+    RangeBegin = 16,
+    RangeEnd = 32,
+    // (undocumented)
+    Simple = 0,
+    SlideOnRemove = 64,
+    StayOnRemove = 128,
+    Tile = 1,
+    Transient = 256
+}
+
+// @beta @legacy
+export const reservedMarkerIdKey = "markerId";
 
 // @beta @legacy
 export function revertSharedStringRevertibles(sharedString: ISharedString, revertibles: SharedStringRevertible[]): void;
@@ -324,7 +465,8 @@ export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMainten
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
 }
 
-export { SequencePlace }
+// @beta @legacy
+export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
 // @beta @legacy
 export const SharedString: ISharedObjectKind<ISharedString> & SharedObjectKind<ISharedString>;
@@ -338,10 +480,56 @@ export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertib
 // @beta @legacy (undocumented)
 export type SharedStringSegment = TextSegment | Marker;
 
-export { Side }
+// @beta @legacy
+export enum Side {
+    // (undocumented)
+    After = 1,
+    // (undocumented)
+    Before = 0
+}
 
-export { TextSegment }
+// @beta @legacy (undocumented)
+export class TextSegment extends BaseSegment {
+    constructor(text: string, props?: PropertySet);
+    // (undocumented)
+    append(segment: ISegment): void;
+    // (undocumented)
+    canAppend(segment: ISegment): boolean;
+    // (undocumented)
+    clone(start?: number, end?: number): TextSegment;
+    // (undocumented)
+    protected createSplitSegmentAt(pos: number): TextSegment | undefined;
+    // (undocumented)
+    static fromJSONObject(spec: string | IJSONSegment): TextSegment | undefined;
+    // (undocumented)
+    static is(segment: ISegment): segment is TextSegment;
+    // (undocumented)
+    static make(text: string, props?: PropertySet): TextSegment;
+    // (undocumented)
+    text: string;
+    // (undocumented)
+    toJSONObject(): IJSONTextSegment | string;
+    // (undocumented)
+    toString(): string;
+    // (undocumented)
+    static readonly type = "TextSegment";
+    // (undocumented)
+    readonly type = "TextSegment";
+}
 
-export { TrackingGroup }
+// @beta @legacy (undocumented)
+export class TrackingGroup implements ITrackingGroup {
+    constructor();
+    // (undocumented)
+    has(trackable: Trackable): boolean;
+    // (undocumented)
+    link(trackable: Trackable): void;
+    // (undocumented)
+    get size(): number;
+    // (undocumented)
+    get tracked(): readonly Trackable[];
+    // (undocumented)
+    unlink(trackable: Trackable): boolean;
+}
 
 ```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -258,7 +258,7 @@ export interface ForestOptions {
 }
 
 // @beta @sealed
-export interface ForestType extends ErasedType_2<"ForestType"> {
+export interface ForestType extends ErasedType<"ForestType"> {
 }
 
 // @alpha
@@ -271,7 +271,7 @@ export const ForestTypeOptimized: ForestType;
 export const ForestTypeReference: ForestType;
 
 // @alpha @sealed
-export interface FormatValidator extends ErasedType_2<"FormatValidator"> {
+export interface FormatValidator extends ErasedType<"FormatValidator"> {
 }
 
 // @alpha
@@ -323,7 +323,7 @@ export function independentInitializedView<const TSchema extends ImplicitFieldSc
 
 // @alpha
 export function independentView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & {
-    idCompressor?: IIdCompressor_2 | undefined;
+    idCompressor?: IIdCompressor | undefined;
 }): TreeViewAlpha<TSchema>;
 
 // @public @system
@@ -791,11 +791,11 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     readonly boolean: LeafSchema<"boolean", boolean>;
     static readonly boolean: LeafSchema<"boolean", boolean>;
     protected getStructuralType(fullName: string, types: TreeNodeSchema | readonly TreeNodeSchema[], builder: () => TreeNodeSchema): TreeNodeSchema;
-    readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
-    static readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
+    readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
+    static readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
     get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
-    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
-    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
+    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
+    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     mapRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, System_Unsafe.TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map, unknown>, {
@@ -830,8 +830,8 @@ export class SchemaFactoryAlpha<out TScope extends string | undefined = string |
     arrayAlpha<const Name extends TName, const T extends ImplicitAnnotatedAllowedTypes, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): ArrayNodeCustomizableSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata>;
     arrayRecursive<const Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): ArrayNodeCustomizableSchemaUnsafe<ScopedSchemaName<TScope, Name>, T, TCustomMetadata>;
     static readonly identifier: <const TCustomMetadata = unknown>(props?: Omit<FieldProps<TCustomMetadata>, "defaultProvider"> | undefined) => FieldSchemaAlpha<FieldKind.Identifier, LeafSchema<"string", string> & SimpleLeafNodeSchema, TCustomMetadata>;
-    static readonly leaves: readonly [LeafSchema<"string", string> & SimpleLeafNodeSchema, LeafSchema<"number", number> & SimpleLeafNodeSchema, LeafSchema<"boolean", boolean> & SimpleLeafNodeSchema, LeafSchema<"null", null> & SimpleLeafNodeSchema, LeafSchema<"handle", IFluidHandle<unknown>> & SimpleLeafNodeSchema];
-    readonly leaves: readonly [LeafSchema<"string", string> & SimpleLeafNodeSchema, LeafSchema<"number", number> & SimpleLeafNodeSchema, LeafSchema<"boolean", boolean> & SimpleLeafNodeSchema, LeafSchema<"null", null> & SimpleLeafNodeSchema, LeafSchema<"handle", IFluidHandle<unknown>> & SimpleLeafNodeSchema];
+    static readonly leaves: readonly [LeafSchema<"string", string> & SimpleLeafNodeSchema, LeafSchema<"number", number> & SimpleLeafNodeSchema, LeafSchema<"boolean", boolean> & SimpleLeafNodeSchema, LeafSchema<"null", null> & SimpleLeafNodeSchema, LeafSchema<"handle", IFluidHandle_2<unknown>> & SimpleLeafNodeSchema];
+    readonly leaves: readonly [LeafSchema<"string", string> & SimpleLeafNodeSchema, LeafSchema<"number", number> & SimpleLeafNodeSchema, LeafSchema<"boolean", boolean> & SimpleLeafNodeSchema, LeafSchema<"null", null> & SimpleLeafNodeSchema, LeafSchema<"handle", IFluidHandle_2<unknown>> & SimpleLeafNodeSchema];
     mapAlpha<Name extends TName, const T extends ImplicitAnnotatedAllowedTypes, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): MapNodeCustomizableSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata>;
     mapRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe, const TCustomMetadata = unknown>(name: Name, allowedTypes: T, options?: NodeSchemaOptionsAlpha<TCustomMetadata>): MapNodeCustomizableSchemaUnsafe<ScopedSchemaName<TScope, Name>, T, TCustomMetadata>;
     objectAlpha<const Name extends TName, const T extends RestrictiveStringRecord<ImplicitAnnotatedFieldSchema>, const TCustomMetadata = unknown>(name: Name, fields: T, options?: SchemaFactoryObjectOptions<TCustomMetadata>): ObjectNodeSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata> & {
@@ -1662,7 +1662,7 @@ export interface ViewableTree {
 
 // @alpha
 export interface ViewContent {
-    readonly idCompressor: IIdCompressor_2;
+    readonly idCompressor: IIdCompressor;
     readonly schema: JsonCompatible;
     readonly tree: JsonCompatible<IFluidHandle>;
 }

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -118,7 +118,7 @@ export interface ForestOptions {
 }
 
 // @beta @sealed
-export interface ForestType extends ErasedType_2<"ForestType"> {
+export interface ForestType extends ErasedType<"ForestType"> {
 }
 
 // @public
@@ -350,11 +350,11 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     readonly boolean: LeafSchema<"boolean", boolean>;
     static readonly boolean: LeafSchema<"boolean", boolean>;
     protected getStructuralType(fullName: string, types: TreeNodeSchema | readonly TreeNodeSchema[], builder: () => TreeNodeSchema): TreeNodeSchema;
-    readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
-    static readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
+    readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
+    static readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
     get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
-    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
-    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
+    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
+    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     mapRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, System_Unsafe.TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map, unknown>, {

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -118,7 +118,7 @@ export interface ForestOptions {
 }
 
 // @beta @sealed
-export interface ForestType extends ErasedType_2<"ForestType"> {
+export interface ForestType extends ErasedType<"ForestType"> {
 }
 
 // @public
@@ -350,11 +350,11 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     readonly boolean: LeafSchema<"boolean", boolean>;
     static readonly boolean: LeafSchema<"boolean", boolean>;
     protected getStructuralType(fullName: string, types: TreeNodeSchema | readonly TreeNodeSchema[], builder: () => TreeNodeSchema): TreeNodeSchema;
-    readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
-    static readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
+    readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
+    static readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
     get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
-    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
-    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
+    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
+    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     mapRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, System_Unsafe.TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map, unknown>, {

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -311,11 +311,11 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     readonly boolean: LeafSchema<"boolean", boolean>;
     static readonly boolean: LeafSchema<"boolean", boolean>;
     protected getStructuralType(fullName: string, types: TreeNodeSchema | readonly TreeNodeSchema[], builder: () => TreeNodeSchema): TreeNodeSchema;
-    readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
-    static readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
+    readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
+    static readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
     get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
-    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
-    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
+    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
+    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     mapRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, System_Unsafe.TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map, unknown>, {

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -311,11 +311,11 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     readonly boolean: LeafSchema<"boolean", boolean>;
     static readonly boolean: LeafSchema<"boolean", boolean>;
     protected getStructuralType(fullName: string, types: TreeNodeSchema | readonly TreeNodeSchema[], builder: () => TreeNodeSchema): TreeNodeSchema;
-    readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
-    static readonly handle: LeafSchema<"handle", IFluidHandle<unknown>>;
+    readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
+    static readonly handle: LeafSchema<"handle", IFluidHandle_2<unknown>>;
     get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
-    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
-    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle<unknown>>];
+    readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
+    static readonly leaves: readonly [LeafSchema<"string", string>, LeafSchema<"number", number>, LeafSchema<"boolean", boolean>, LeafSchema<"null", null>, LeafSchema<"handle", IFluidHandle_2<unknown>>];
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchemaNonClass<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map>, MapNodeInsertableData<T>, true, T, undefined>;
     mapRecursive<Name extends TName, const T extends System_Unsafe.ImplicitAllowedTypesUnsafe>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, System_Unsafe.TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map, unknown>, {

--- a/packages/drivers/local-driver/api-extractor/api-extractor.current.json
+++ b/packages/drivers/local-driver/api-extractor/api-extractor.current.json
@@ -1,5 +1,14 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.current.json",
-	"mainEntryPointFilePath": "<projectFolder>/lib/public.d.ts"
+	"mainEntryPointFilePath": "<projectFolder>/lib/public.d.ts",
+	// Note: excluding server packages until we can update their tags (and release new server versions)
+	// TODO: remove this override once server dependencies have been updated.
+	"bundledPackages": [
+		"@fluidframework/!(server-local-server)",
+		"@fluid-internal/*",
+		"@fluid-experimental/*",
+		"@fluid-private/*",
+		"@fluid-tools/*"
+	]
 }

--- a/packages/drivers/local-driver/api-extractor/api-extractor.legacy.json
+++ b/packages/drivers/local-driver/api-extractor/api-extractor.legacy.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.legacy.json"
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.legacy.json",
+	// Note: excluding server packages until we can update their tags (and release new server versions)
+	// TODO: remove this override once server dependencies have been updated.
+	"bundledPackages": [
+		"@fluidframework/!(server-local-server)",
+		"@fluid-internal/*",
+		"@fluid-experimental/*",
+		"@fluid-private/*",
+		"@fluid-tools/*"
+	]
 }

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.beta.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.beta.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 // @beta @legacy (undocumented)
 export function createLocalResolverCreateNewRequest(documentId: string): IRequest;
 

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.beta.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.beta.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // @beta @legacy (undocumented)
 export function createLocalResolverCreateNewRequest(documentId: string): IRequest;
 

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.public.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.public.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.public.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.public.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
@@ -143,7 +143,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
 export abstract class TreeDataObject<TDataObjectTypes extends DataObjectTypes = DataObjectTypes> extends PureDataObject<TDataObjectTypes> {
     // (undocumented)
     initializeInternal(existing: boolean): Promise<void>;
-    protected get tree(): ITree;
+    protected get tree(): ITree_2;
 }
 
 // @beta @legacy

--- a/packages/framework/fluid-framework/api-extractor/api-extractor.current.json
+++ b/packages/framework/fluid-framework/api-extractor/api-extractor.current.json
@@ -2,7 +2,6 @@
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.current.json",
 	"mainEntryPointFilePath": "<projectFolder>/lib/alpha.d.ts",
-	"bundledPackages": ["@fluidframework/*"],
 	"apiReport": {
 		// The base config omits alpha. Explicitly opt into alpha reports (in addition to public/beta) for this package.
 		"reportVariants": ["public", "beta", "alpha"]

--- a/packages/framework/fluid-framework/api-extractor/api-extractor.legacy.json
+++ b/packages/framework/fluid-framework/api-extractor/api-extractor.legacy.json
@@ -1,5 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.legacy.json",
-	"bundledPackages": ["@fluidframework/*"]
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.legacy.json"
 }

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -346,7 +346,8 @@ export interface LoadContainerRuntimeParams {
     runtimeOptions?: IContainerRuntimeOptions;
 }
 
-export { MinimumVersionForCollab }
+// @beta @legacy
+export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
 // @beta @deprecated @legacy (undocumented)
 export type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -73,19 +73,42 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-export { CompatibilityMode }
+// @public
+export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 
-export { ITelemetryBaseEvent }
+// @public
+export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
+    // (undocumented)
+    category: string;
+    // (undocumented)
+    eventName: string;
+}
 
-export { ITelemetryBaseLogger }
+// @public
+export interface ITelemetryBaseLogger {
+    minLogLevel?: LogLevel;
+    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
+}
 
-export { ITokenProvider }
+// @public
+export interface ITokenProvider {
+    documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
+    fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
+    fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
+}
 
-export { ITokenResponse }
+// @public (undocumented)
+export interface ITokenResponse {
+    fromCache?: boolean;
+    jwt: string;
+}
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
@@ -73,19 +73,42 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-export { CompatibilityMode }
+// @public
+export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 
-export { ITelemetryBaseEvent }
+// @public
+export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
+    // (undocumented)
+    category: string;
+    // (undocumented)
+    eventName: string;
+}
 
-export { ITelemetryBaseLogger }
+// @public
+export interface ITelemetryBaseLogger {
+    minLogLevel?: LogLevel;
+    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
+}
 
-export { ITokenProvider }
+// @public
+export interface ITokenProvider {
+    documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
+    fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
+    fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
+}
 
-export { ITokenResponse }
+// @public (undocumented)
+export interface ITokenResponse {
+    fromCache?: boolean;
+    jwt: string;
+}
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -73,19 +73,42 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-export { CompatibilityMode }
+// @public
+export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 
-export { ITelemetryBaseEvent }
+// @public
+export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
+    // (undocumented)
+    category: string;
+    // (undocumented)
+    eventName: string;
+}
 
-export { ITelemetryBaseLogger }
+// @public
+export interface ITelemetryBaseLogger {
+    minLogLevel?: LogLevel;
+    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
+}
 
-export { ITokenProvider }
+// @public
+export interface ITokenProvider {
+    documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
+    fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
+    fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
+}
 
-export { ITokenResponse }
+// @public (undocumented)
+export interface ITokenResponse {
+    fromCache?: boolean;
+    jwt: string;
+}
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -73,19 +73,42 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-export { CompatibilityMode }
+// @public
+export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 
-export { ITelemetryBaseEvent }
+// @public
+export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
+    // (undocumented)
+    category: string;
+    // (undocumented)
+    eventName: string;
+}
 
-export { ITelemetryBaseLogger }
+// @public
+export interface ITelemetryBaseLogger {
+    minLogLevel?: LogLevel;
+    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
+}
 
-export { ITokenProvider }
+// @public
+export interface ITokenProvider {
+    documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
+    fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
+    fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
+}
 
-export { ITokenResponse }
+// @public (undocumented)
+export interface ITokenResponse {
+    fromCache?: boolean;
+    jwt: string;
+}
 
-export { IUser }
+// @public
+export interface IUser {
+    id: string;
+}
 
 ```


### PR DESCRIPTION
Updates our API-Extractor configurations for report generation to include other local packages' exports in the generation. This makes reviewing the cross-package implications of API changes easier to review.