### PR TITLE
Expose createSemanticAgent function

### DIFF
--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -9,7 +9,8 @@
  * @packageDocumentation
  */
 
-export type { Log, SharedTreeSemanticAgent, createSemanticAgent } from "./agent.js";
+export { createSemanticAgent } from "./agent.js";
+export type { Log, SharedTreeSemanticAgent } from "./agent.js";
 export type { TreeView, llmDefault, instanceOf } from "./utils.js";
 export {
 	buildFunc,


### PR DESCRIPTION
## Description

This removes the type-only export from `createSemanticAgent` so that it can be used by consumers.