### PR TITLE
Fix build issues with MigrationDataObject prototype

### DIFF
--- a/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
@@ -122,6 +122,25 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> extends Flui
     protected readonly value: T | Promise<T>;
 }
 
+// @beta @legacy
+export interface IChannelContext {
+    // (undocumented)
+    applyStashedOp(content: unknown): unknown;
+    // (undocumented)
+    getChannel(): Promise<IChannel>;
+    getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
+    processMessages(messageCollection: IRuntimeMessageCollection): void;
+    // (undocumented)
+    reSubmit(content: unknown, localOpMetadata: unknown, squash?: boolean): void;
+    // (undocumented)
+    rollback(message: unknown, localOpMetadata: unknown): void;
+    // (undocumented)
+    setConnectionState(connected: boolean, clientId?: string): any;
+    // (undocumented)
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
+    updateUsedRoutes(usedRoutes: string[]): void;
+}
+
 // @beta @legacy (undocumented)
 export interface ISharedObjectRegistry {
     // (undocumented)

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -37,7 +37,7 @@ export const attributesBlobKey = ".attributes";
 /**
  * TODO
  * @legacy
- * @alpha
+ * @beta
  */
 export interface IChannelContext {
 	getChannel(): Promise<IChannel>;

--- a/packages/runtime/datastore/src/index.ts
+++ b/packages/runtime/datastore/src/index.ts
@@ -16,4 +16,4 @@ export {
 	dataStoreCompatDetailsForRuntime,
 	runtimeSupportRequirementsForDataStore,
 } from "./dataStoreLayerCompatState.js";
-export { IChannelContext } from "./channelContext.js";
+export type { IChannelContext } from "./channelContext.js";


### PR DESCRIPTION
Fix build issues with MigrationDataObject prototype, by switching an API from alpha to beta, and switching to a type export.