### PR TITLE
fix(build-cli): Ensure generated rollup paths are explicitly relative

### DIFF
--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -414,10 +414,9 @@ function sourceContext(node: Node): string {
 }
 
 /**
- * Header injected into all generated files.
- * @privateRemarks Exported for testing.
+ * Header injected into generated d.ts files.
  */
-export const generatedHeader: string = `/*!
+const generatedHeader: string = `/*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -572,11 +572,15 @@ async function generateEntrypoints(
  * Create Node10 entrypoint file content.
  * @privateRemarks Exported for testing.
  */
-export function createNode10EntrypointFileContent(
-	dirPath: string,
-	sourceTypeRelPath: string,
-	isTypeOnly: boolean,
-): string {
+export function createNode10EntrypointFileContent({
+	dirPath,
+	sourceTypeRelPath,
+	isTypeOnly,
+}: {
+	readonly dirPath: string;
+	readonly sourceTypeRelPath: string;
+	readonly isTypeOnly: boolean;
+}): string {
 	let entrypointToTypeImportPath = path.posix.relative(dirPath, sourceTypeRelPath);
 
 	// If the path is not explicitly relative, make it so.
@@ -612,7 +616,11 @@ async function generateNode10TypeEntrypoints(
 		const dirPath = path.dirname(filePath);
 		await fs.ensureDir(dirPath);
 
-		const content = createNode10EntrypointFileContent(dirPath, sourceTypeRelPath, isTypeOnly);
+		const content = createNode10EntrypointFileContent({
+			dirPath,
+			sourceTypeRelPath,
+			isTypeOnly,
+		});
 
 		await fs.writeFile(filePath, content, "utf8");
 	}

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -601,6 +601,9 @@ export function createNode10EntrypointFileContent({
 	return `${generatedHeader}export * from "${jsImport}";\n`;
 }
 
+/**
+ * Create Node10 entrypoint file.
+ */
 async function createEntrypointFile({
 	filePath,
 	sourceTypeRelPath,

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -601,11 +601,15 @@ export function createNode10EntrypointFileContent({
 	return `${generatedHeader}export * from "${jsImport}";\n`;
 }
 
-async function createEntrypointFile(
-	filePath: string,
-	sourceTypeRelPath: string,
-	isTypeOnly: boolean,
-): Promise<void> {
+async function createEntrypointFile({
+	filePath,
+	sourceTypeRelPath,
+	isTypeOnly,
+}: {
+	filePath: string;
+	sourceTypeRelPath: string;
+	isTypeOnly: boolean;
+}): Promise<void> {
 	const dirPath = path.dirname(filePath);
 	await fs.ensureDir(dirPath);
 
@@ -632,7 +636,9 @@ async function generateNode10TypeEntrypoints(
 
 	for (const [outFile, { relPath, isTypeOnly }] of mapExportPathToData.entries()) {
 		log.info(`\tGenerating ${outFile}`);
-		fileSavePromises.push(createEntrypointFile(outFile, relPath, isTypeOnly));
+		fileSavePromises.push(
+			createEntrypointFile({ filePath: outFile, sourceTypeRelPath: relPath, isTypeOnly }),
+		);
 	}
 
 	if (fileSavePromises.length === 0) {

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -612,7 +612,7 @@ async function generateNode10TypeEntrypoints(
 		const dirPath = path.dirname(filePath);
 		await fs.ensureDir(dirPath);
 
-		const content = createNode10EntrypointFileContent(filePath, sourceTypeRelPath, isTypeOnly);
+		const content = createNode10EntrypointFileContent(dirPath, sourceTypeRelPath, isTypeOnly);
 
 		await fs.writeFile(filePath, content, "utf8");
 	}

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -54,26 +54,14 @@ describe("generateEntrypoints", () => {
 				).to.contain('export type * from "../lib/legacy.d.ts";\n');
 			});
 
-			describe("sourceTypeRelPath: nested", () => {
-				it("with leading ./", () => {
-					expect(
-						createNode10EntrypointFileContent({
-							dirPath: "",
-							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
-							isTypeOnly: true,
-						}),
-					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
-				});
-
-				it("without leading ./", () => {
-					expect(
-						createNode10EntrypointFileContent({
-							dirPath: "",
-							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
-							isTypeOnly: true,
-						}),
-					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
-				});
+			it("sourceTypeRelPath: nested", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "",
+						sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
+						isTypeOnly: true,
+					}),
+				).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
 			});
 
 			it("sourceTypeRelPath: file with leading .", () => {
@@ -108,26 +96,14 @@ describe("generateEntrypoints", () => {
 				).to.contain('export * from "../lib/legacy.js";\n');
 			});
 
-			describe("sourceTypeRelPath: nested", () => {
-				it("with leading ./", () => {
-					expect(
-						createNode10EntrypointFileContent({
-							dirPath: "",
-							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
-							isTypeOnly: false,
-						}),
-					).to.contain('export * from "./lib/legacy/alpha.js";\n');
-				});
-
-				it("without leading ./", () => {
-					expect(
-						createNode10EntrypointFileContent({
-							dirPath: "",
-							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
-							isTypeOnly: false,
-						}),
-					).to.contain('export * from "./lib/legacy/alpha.js";\n');
-				});
+			it("sourceTypeRelPath: nested", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "",
+						sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
+						isTypeOnly: false,
+					}),
+				).to.contain('export * from "./lib/legacy/alpha.js";\n');
 			});
 
 			it("sourceTypeRelPath: file with leading .", () => {

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -75,6 +75,16 @@ describe("generateEntrypoints", () => {
 					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
 				});
 			});
+
+			it("sourceTypeRelPath: file with leading .", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "",
+						sourceTypeRelPath: ".foo.d.ts",
+						isTypeOnly: true,
+					}),
+				).to.contain('export type * from "./.foo.d.ts";\n');
+			});
 		});
 
 		describe("non-type-only", () => {
@@ -108,6 +118,7 @@ describe("generateEntrypoints", () => {
 						}),
 					).to.contain('export * from "./lib/legacy/alpha.js";\n');
 				});
+
 				it("without leading ./", () => {
 					expect(
 						createNode10EntrypointFileContent({
@@ -117,6 +128,16 @@ describe("generateEntrypoints", () => {
 						}),
 					).to.contain('export * from "./lib/legacy/alpha.js";\n');
 				});
+			});
+
+			it("sourceTypeRelPath: file with leading .", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "",
+						sourceTypeRelPath: ".foo.d.ts",
+						isTypeOnly: false,
+					}),
+				).to.contain('export * from "./.foo.js";\n');
 			});
 		});
 	});

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -38,7 +38,7 @@ describe("generateEntrypoints", () => {
 				expect(
 					createNode10EntrypointFileContent({
 						dirPath: "",
-						sourceTypeRelPath: "lib/legacy.d.ts",
+						sourceTypeRelPath: "./lib/legacy.d.ts",
 						isTypeOnly: true,
 					}),
 				).to.contain('export type * from "./lib/legacy.d.ts";\n');
@@ -48,7 +48,7 @@ describe("generateEntrypoints", () => {
 				expect(
 					createNode10EntrypointFileContent({
 						dirPath: "rollups",
-						sourceTypeRelPath: "lib/legacy.d.ts",
+						sourceTypeRelPath: "./lib/legacy.d.ts",
 						isTypeOnly: true,
 					}),
 				).to.contain('export type * from "../lib/legacy.d.ts";\n');
@@ -92,7 +92,7 @@ describe("generateEntrypoints", () => {
 				expect(
 					createNode10EntrypointFileContent({
 						dirPath: "",
-						sourceTypeRelPath: "lib/legacy.d.ts",
+						sourceTypeRelPath: "./lib/legacy.d.ts",
 						isTypeOnly: false,
 					}),
 				).to.contain('export * from "./lib/legacy.js";\n');
@@ -101,8 +101,8 @@ describe("generateEntrypoints", () => {
 			it("dirPath: sub directory", () => {
 				expect(
 					createNode10EntrypointFileContent({
-						dirPath: "rollups",
-						sourceTypeRelPath: "lib/legacy.d.ts",
+						dirPath: "./rollups",
+						sourceTypeRelPath: "./lib/legacy.d.ts",
 						isTypeOnly: false,
 					}),
 				).to.contain('export * from "../lib/legacy.js";\n');

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -89,7 +89,7 @@ describe("generateEntrypoints", () => {
 			it("dirPath: sub directory", () => {
 				expect(
 					createNode10EntrypointFileContent({
-						dirPath: "./rollups",
+						dirPath: "rollups",
 						sourceTypeRelPath: "./lib/legacy.d.ts",
 						isTypeOnly: false,
 					}),

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -7,7 +7,6 @@ import { expect } from "chai";
 import { describe, it } from "mocha";
 import {
 	createNode10EntrypointFileContent,
-	generatedHeader,
 	optionDefaults,
 	readArgValues,
 } from "../../../library/commands/generateEntrypoints.js";
@@ -33,36 +32,36 @@ describe("generateEntrypoints", () => {
 	it("generateNode10EntrypointFileContent", () => {
 		// #region type-only
 
-		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", true)).to.equal(
-			`${generatedHeader}export type * from "./lib/legacy.d.ts";\n`,
+		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", true)).to.contain(
+			'export type * from "./lib/legacy.d.ts";\n',
 		);
 
 		// dirPath: sub directory
-		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", true)).to.equal(
-			`${generatedHeader}export type * from "../lib/legacy.d.ts";\n`,
+		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", true)).to.contain(
+			'export type * from "../lib/legacy.d.ts";\n',
 		);
 
 		// dirPath: package root
-		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", true)).to.equal(
-			`${generatedHeader}export type * from "./lib/legacy/alpha.d.ts";\n`,
+		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", true)).to.contain(
+			'export type * from "./lib/legacy/alpha.d.ts";\n',
 		);
 
 		// #endregion
 
 		// #region non-type-only
 
-		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", false)).to.equal(
-			`${generatedHeader}export * from "./lib/legacy.js";\n`,
+		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", false)).to.contain(
+			'export * from "./lib/legacy.js";\n',
 		);
 
 		// dirPath: sub directory
-		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", false)).to.equal(
-			`${generatedHeader}export * from "../lib/legacy.js";\n`,
+		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", false)).to.contain(
+			'export * from "../lib/legacy.js";\n',
 		);
 
 		// sourceTypeRelPath: nested
-		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", false)).to.equal(
-			`${generatedHeader}export * from "./lib/legacy/alpha.js";\n`,
+		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", false)).to.contain(
+			'export * from "./lib/legacy/alpha.js";\n',
 		);
 
 		// #endregion

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -32,37 +32,61 @@ describe("generateEntrypoints", () => {
 	it("generateNode10EntrypointFileContent", () => {
 		// #region type-only
 
-		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", true)).to.contain(
-			'export type * from "./lib/legacy.d.ts";\n',
-		);
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "",
+				sourceTypeRelPath: "lib/legacy.d.ts",
+				isTypeOnly: true,
+			}),
+		).to.contain('export type * from "./lib/legacy.d.ts";\n');
 
 		// dirPath: sub directory
-		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", true)).to.contain(
-			'export type * from "../lib/legacy.d.ts";\n',
-		);
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "rollups",
+				sourceTypeRelPath: "lib/legacy.d.ts",
+				isTypeOnly: true,
+			}),
+		).to.contain('export type * from "../lib/legacy.d.ts";\n');
 
 		// dirPath: package root
-		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", true)).to.contain(
-			'export type * from "./lib/legacy/alpha.d.ts";\n',
-		);
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "",
+				sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+				isTypeOnly: true,
+			}),
+		).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
 
 		// #endregion
 
 		// #region non-type-only
 
-		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", false)).to.contain(
-			'export * from "./lib/legacy.js";\n',
-		);
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "",
+				sourceTypeRelPath: "lib/legacy.d.ts",
+				isTypeOnly: false,
+			}),
+		).to.contain('export * from "./lib/legacy.js";\n');
 
 		// dirPath: sub directory
-		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", false)).to.contain(
-			'export * from "../lib/legacy.js";\n',
-		);
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "rollups",
+				sourceTypeRelPath: "lib/legacy.d.ts",
+				isTypeOnly: false,
+			}),
+		).to.contain('export * from "../lib/legacy.js";\n');
 
 		// sourceTypeRelPath: nested
-		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", false)).to.contain(
-			'export * from "./lib/legacy/alpha.js";\n',
-		);
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "",
+				sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+				isTypeOnly: false,
+			}),
+		).to.contain('export * from "./lib/legacy/alpha.js";\n');
 
 		// #endregion
 	});

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -6,6 +6,8 @@
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import {
+	createNode10EntrypointFileContent,
+	generatedHeader,
 	optionDefaults,
 	readArgValues,
 } from "../../../library/commands/generateEntrypoints.js";
@@ -26,5 +28,43 @@ describe("generateEntrypoints", () => {
 			...optionDefaults,
 			outDir: "./lib",
 		});
+	});
+
+	it("generateNode10EntrypointFileContent", () => {
+		// #region type-only
+
+		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", true)).to.equal(
+			`${generatedHeader}export type * from "./lib/legacy.d.ts";\n`,
+		);
+
+		// dirPath: sub directory
+		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", true)).to.equal(
+			`${generatedHeader}export type * from "../lib/legacy.d.ts";\n`,
+		);
+
+		// dirPath: package root
+		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", true)).to.equal(
+			`${generatedHeader}export type * from "./lib/legacy/alpha.d.ts";\n`,
+		);
+
+		// #endregion
+
+		// #region non-type-only
+
+		expect(createNode10EntrypointFileContent("", "lib/legacy.d.ts", false)).to.equal(
+			`${generatedHeader}export * from "./lib/legacy.js";\n`,
+		);
+
+		// dirPath: sub directory
+		expect(createNode10EntrypointFileContent("rollups", "lib/legacy.d.ts", false)).to.equal(
+			`${generatedHeader}export * from "../lib/legacy.js";\n`,
+		);
+
+		// sourceTypeRelPath: nested
+		expect(createNode10EntrypointFileContent("", "lib/legacy/alpha.d.ts", false)).to.equal(
+			`${generatedHeader}export * from "./lib/legacy/alpha.js";\n`,
+		);
+
+		// #endregion
 	});
 });

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -59,7 +59,7 @@ describe("generateEntrypoints", () => {
 					expect(
 						createNode10EntrypointFileContent({
 							dirPath: "",
-							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
 							isTypeOnly: true,
 						}),
 					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
@@ -69,7 +69,7 @@ describe("generateEntrypoints", () => {
 					expect(
 						createNode10EntrypointFileContent({
 							dirPath: "",
-							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
+							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
 							isTypeOnly: true,
 						}),
 					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
@@ -103,17 +103,16 @@ describe("generateEntrypoints", () => {
 					expect(
 						createNode10EntrypointFileContent({
 							dirPath: "",
-							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
 							isTypeOnly: false,
 						}),
 					).to.contain('export * from "./lib/legacy/alpha.js";\n');
 				});
-
 				it("without leading ./", () => {
 					expect(
 						createNode10EntrypointFileContent({
 							dirPath: "",
-							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
+							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
 							isTypeOnly: false,
 						}),
 					).to.contain('export * from "./lib/legacy/alpha.js";\n');

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -49,11 +49,18 @@ describe("generateEntrypoints", () => {
 			}),
 		).to.contain('export type * from "../lib/legacy.d.ts";\n');
 
-		// dirPath: package root
+		// sourceTypeRelPath: nested (with and without leading ./)
 		expect(
 			createNode10EntrypointFileContent({
 				dirPath: "",
 				sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+				isTypeOnly: true,
+			}),
+		).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "",
+				sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
 				isTypeOnly: true,
 			}),
 		).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
@@ -79,11 +86,18 @@ describe("generateEntrypoints", () => {
 			}),
 		).to.contain('export * from "../lib/legacy.js";\n');
 
-		// sourceTypeRelPath: nested
+		// sourceTypeRelPath: nested (with and without leading ./)
 		expect(
 			createNode10EntrypointFileContent({
 				dirPath: "",
 				sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+				isTypeOnly: false,
+			}),
+		).to.contain('export * from "./lib/legacy/alpha.js";\n');
+		expect(
+			createNode10EntrypointFileContent({
+				dirPath: "",
+				sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
 				isTypeOnly: false,
 			}),
 		).to.contain('export * from "./lib/legacy/alpha.js";\n');

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+// Too restrictive for test suite hierarchy
+/* eslint-disable max-nested-callbacks */
+
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import {
@@ -29,79 +32,93 @@ describe("generateEntrypoints", () => {
 		});
 	});
 
-	it("generateNode10EntrypointFileContent", () => {
-		// #region type-only
+	describe("generateNode10EntrypointFileContent", () => {
+		describe("type-only", () => {
+			it("dirPath: package root", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "",
+						sourceTypeRelPath: "lib/legacy.d.ts",
+						isTypeOnly: true,
+					}),
+				).to.contain('export type * from "./lib/legacy.d.ts";\n');
+			});
 
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "",
-				sourceTypeRelPath: "lib/legacy.d.ts",
-				isTypeOnly: true,
-			}),
-		).to.contain('export type * from "./lib/legacy.d.ts";\n');
+			it("dirPath: sub directory", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "rollups",
+						sourceTypeRelPath: "lib/legacy.d.ts",
+						isTypeOnly: true,
+					}),
+				).to.contain('export type * from "../lib/legacy.d.ts";\n');
+			});
 
-		// dirPath: sub directory
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "rollups",
-				sourceTypeRelPath: "lib/legacy.d.ts",
-				isTypeOnly: true,
-			}),
-		).to.contain('export type * from "../lib/legacy.d.ts";\n');
+			describe("sourceTypeRelPath: nested", () => {
+				it("with leading ./", () => {
+					expect(
+						createNode10EntrypointFileContent({
+							dirPath: "",
+							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+							isTypeOnly: true,
+						}),
+					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
+				});
 
-		// sourceTypeRelPath: nested (with and without leading ./)
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "",
-				sourceTypeRelPath: "lib/legacy/alpha.d.ts",
-				isTypeOnly: true,
-			}),
-		).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "",
-				sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
-				isTypeOnly: true,
-			}),
-		).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
+				it("without leading ./", () => {
+					expect(
+						createNode10EntrypointFileContent({
+							dirPath: "",
+							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
+							isTypeOnly: true,
+						}),
+					).to.contain('export type * from "./lib/legacy/alpha.d.ts";\n');
+				});
+			});
+		});
 
-		// #endregion
+		describe("non-type-only", () => {
+			it("dirPath: package root", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "",
+						sourceTypeRelPath: "lib/legacy.d.ts",
+						isTypeOnly: false,
+					}),
+				).to.contain('export * from "./lib/legacy.js";\n');
+			});
 
-		// #region non-type-only
+			it("dirPath: sub directory", () => {
+				expect(
+					createNode10EntrypointFileContent({
+						dirPath: "rollups",
+						sourceTypeRelPath: "lib/legacy.d.ts",
+						isTypeOnly: false,
+					}),
+				).to.contain('export * from "../lib/legacy.js";\n');
+			});
 
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "",
-				sourceTypeRelPath: "lib/legacy.d.ts",
-				isTypeOnly: false,
-			}),
-		).to.contain('export * from "./lib/legacy.js";\n');
+			describe("sourceTypeRelPath: nested", () => {
+				it("with leading ./", () => {
+					expect(
+						createNode10EntrypointFileContent({
+							dirPath: "",
+							sourceTypeRelPath: "lib/legacy/alpha.d.ts",
+							isTypeOnly: false,
+						}),
+					).to.contain('export * from "./lib/legacy/alpha.js";\n');
+				});
 
-		// dirPath: sub directory
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "rollups",
-				sourceTypeRelPath: "lib/legacy.d.ts",
-				isTypeOnly: false,
-			}),
-		).to.contain('export * from "../lib/legacy.js";\n');
-
-		// sourceTypeRelPath: nested (with and without leading ./)
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "",
-				sourceTypeRelPath: "lib/legacy/alpha.d.ts",
-				isTypeOnly: false,
-			}),
-		).to.contain('export * from "./lib/legacy/alpha.js";\n');
-		expect(
-			createNode10EntrypointFileContent({
-				dirPath: "",
-				sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
-				isTypeOnly: false,
-			}),
-		).to.contain('export * from "./lib/legacy/alpha.js";\n');
-
-		// #endregion
+				it("without leading ./", () => {
+					expect(
+						createNode10EntrypointFileContent({
+							dirPath: "",
+							sourceTypeRelPath: "./lib/legacy/alpha.d.ts",
+							isTypeOnly: false,
+						}),
+					).to.contain('export * from "./lib/legacy/alpha.js";\n');
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
Ensures that Node10 rollup files are generated with export syntax that uses explicitly relative file paths.

[AB#47852](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47852)