### PR TITLE
Update fetch snapshot event to include file version

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -294,6 +294,7 @@ async function fetchLatestSnapshotCore(
 		const internalFarmType = checkForKnownServerFarmType(odspResolvedUrl.siteUrl);
 		const isRedemptionNonDurable: boolean =
 			odspResolvedUrl.shareLinkInfo?.isRedemptionNonDurable === true;
+		const fileVersion = odspResolvedUrl.fileVersion ?? undefined;
 
 		const perfEvent = {
 			eventName,
@@ -547,6 +548,7 @@ async function fetchLatestSnapshotCore(
 				useLegacyFlowWithoutGroups:
 					useLegacyFlowWithoutGroupsForSnapshotFetch(loadingGroupIds),
 				userOps: snapshot.ops?.filter((op) => isRuntimeMessage(op)).length ?? 0,
+				fileVersion,
 				// Measures time to make fetch call. Should be similar to
 				// fetchStartToResponseEndTime - receiveContentTime, i.e. it looks like it's time till first byte /
 				// end of response headers


### PR DESCRIPTION
In order to identify when a versioned document is loaded from the telemetry, add the file version to the existing event for fetch snapshot. 

[AB#44882](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/44882)