### PR TITLE
Blob manager test improvements

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -129,7 +129,7 @@ export class BlobHandle
 // the contract explicit and reduces the amount of mocking required for tests.
 export type IBlobManagerRuntime = Pick<
 	IContainerRuntime,
-	"attachState" | "connected" | "baseLogger" | "clientDetails" | "disposed"
+	"attachState" | "baseLogger" | "disposed"
 > &
 	IEventProvider<IContainerRuntimeEvents>;
 
@@ -835,7 +835,7 @@ export class BlobManager {
 	 * The provided table must have exactly the same set of pseudo storage IDs as are found in the redirect table.
 	 * @param detachedStorageTable - A map of pseudo storage IDs to real storage IDs.
 	 */
-	public patchRedirectTable(detachedStorageTable: Map<string, string>): void {
+	public readonly patchRedirectTable = (detachedStorageTable: Map<string, string>): void => {
 		assert(
 			this.runtime.attachState === AttachState.Detached,
 			0x252 /* "redirect table can only be set in detached container" */,
@@ -858,7 +858,7 @@ export class BlobManager {
 			// set identity (id -> id) entry
 			this.setRedirection(newStorageId, newStorageId);
 		}
-	}
+	};
 
 	/**
 	 * To be used in getPendingLocalState flow. Get a serializable record of the blobs that are

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -634,25 +634,6 @@ for (const createBlobPayloadPending of [false, true]) {
 			assert.strictEqual(summaryData.redirectTable?.length, 1);
 		});
 
-		it.skip("upload fails and retries for retriable errors", async () => {
-			// Needs to use some sort of fake timer or write test in a different way as it is waiting
-			// for actual time which is causing timeouts.
-			await runtime.attach();
-			await runtime.connect();
-			const handleP = runtime.createBlob(textToBlob("blob"));
-			await runtime.processBlobs(false, true, 0);
-			// wait till next retry
-			await new Promise<void>((resolve) => setTimeout(resolve, 1));
-			// try again successfully
-			await runtime.processBlobs(true);
-			runtime.processOps();
-			await runtime.processHandles();
-			assert(handleP);
-			const summaryData = validateSummary(runtime);
-			assert.strictEqual(summaryData.ids.length, 1);
-			assert.strictEqual(summaryData.redirectTable?.length, 1);
-		});
-
 		it("completes after disconnection while op in flight", async () => {
 			await runtime.attach();
 			await runtime.connect();

--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -41,7 +41,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		assert.strictEqual(Object.values(pendingBlobs)[0].uploadTime, undefined);
 
 		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
+		assert.strictEqual(summaryData.ids?.length, 0);
 		assert.strictEqual(summaryData.redirectTable, undefined);
 
 		const runtime2 = new MockRuntime(
@@ -56,7 +56,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.processAll();
 
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.ids?.length, 1);
 		assert.strictEqual(summaryData2.redirectTable?.length, 1);
 	});
 
@@ -76,7 +76,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		assert.ok(Object.values(pendingBlobs)[0].uploadTime);
 
 		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
+		assert.strictEqual(summaryData.ids?.length, 0);
 		assert.strictEqual(summaryData.redirectTable, undefined);
 
 		const runtime2 = new MockRuntime(
@@ -91,7 +91,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.processAll();
 
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.ids?.length, 1);
 		assert.strictEqual(summaryData2.redirectTable?.length, 1);
 	});
 
@@ -112,7 +112,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		assert.strictEqual(Object.keys(pendingBlobs).length, 2);
 
 		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
+		assert.strictEqual(summaryData.ids?.length, 0);
 		assert.strictEqual(summaryData.redirectTable, undefined);
 
 		const runtime2 = new MockRuntime(
@@ -127,7 +127,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.processAll();
 
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 2);
+		assert.strictEqual(summaryData2.ids?.length, 2);
 		assert.strictEqual(summaryData2.redirectTable?.length, 2);
 	});
 
@@ -152,7 +152,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		assert.strictEqual(Object.keys(pendingBlobs).length, 3);
 
 		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
+		assert.strictEqual(summaryData.ids?.length, 0);
 		assert.strictEqual(summaryData.redirectTable, undefined);
 
 		const runtime2 = new MockRuntime(
@@ -167,7 +167,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.processAll();
 
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 3);
+		assert.strictEqual(summaryData2.ids?.length, 3);
 		assert.strictEqual(summaryData2.redirectTable?.length, 3);
 	});
 
@@ -186,7 +186,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		assert.strictEqual(Object.values(pendingBlobs)[0].uploadTime, undefined);
 
 		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
+		assert.strictEqual(summaryData.ids?.length, 0);
 		assert.strictEqual(summaryData.redirectTable, undefined);
 
 		const runtime2 = new MockRuntime(
@@ -200,7 +200,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.connect(0, true);
 		await runtime2.processAll();
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.ids?.length, 1);
 		assert.strictEqual(summaryData2.redirectTable?.length, 1);
 	});
 
@@ -232,7 +232,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.processAll();
 
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.ids?.length, 1);
 		assert.strictEqual(summaryData2.redirectTable?.length, 1);
 	});
 
@@ -264,7 +264,7 @@ describe.skip("getPendingLocalState with blobs", () => {
 		await runtime2.processAll();
 
 		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 1);
+		assert.strictEqual(summaryData2.ids?.length, 1);
 		assert.strictEqual(summaryData2.redirectTable?.length, 1);
 	});
 });


### PR DESCRIPTION
[AB#48377](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/48377)

Pulling these changes out of an ongoing change I'm working on to beef up the BlobManager tests, as they are probably pretty straightforward and should be a quick review, and some will probably be helpful for #25261

1. Couple tweaks to BlobManager to make it easier to mock and use patchRedirectTable as a callback function
2. Normalize on IBlobManagerLoadInfo where possible and align with its typing rather than having one-off literal types
3. Add textToBlob and blobToText helpers to get ahead of the [TS 5.9 break](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#lib.d.ts-changes)
4. Add an unpackHandle as a shared approach to extracting localId from the return value of createBlob (as opposed to e.g. the GC-specific helper in those tests).
5. Remove a long-skipped retry test (originally skipped in #18306).  This was testing a scenario that would never happen anyway, as retriable errors from storage never make it to the BlobManager, they are retried either within the driver layer for ODSP or else in the loader layer with RetriableDocumentStorageService so the only errors the BlobManager sees are non-retriable errors.