### PR TITLE
Use updated tenant steps in stress pipeline

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -383,7 +383,7 @@ stages:
           env:
             ${{ if and(ne(parameters.stageId, 'e2e_odsp'), ne(parameters.stageId, 'stress_tests_odsp')) }}:
               ${{ parameters.env }}
-            ${{ if or(eq(parameters.stageId, 'e2e_odsp'), eq(parameters.stageId, 'stress_tests_odsp')) }}:
+            ${{ else }}:
               login__odsp__test__tenants: $(tenantCreds)
               login__microsoft__clientId: $(appClientId)
           inputs:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -111,7 +111,7 @@ parameters:
 
 stages:
 - stage: ${{ parameters.stageId}}
-  ${{ if in(parameters.stageId, 'e2e_routerlicious', 'e2e_frs', 'stress_tests_odsp', 'stress_tests_odspdf', 'stress_tests_frs', 'stress_tests_frs_canary') }}:
+  ${{ if in(parameters.stageId, 'e2e_routerlicious', 'e2e_frs', 'stress_tests_odspdf', 'stress_tests_frs', 'stress_tests_frs_canary') }}:
     lockBehavior: sequential
   condition: ${{ parameters.condition }}
   displayName: ${{ parameters.stageDisplayName }}
@@ -347,7 +347,7 @@ stages:
               path: ${{ parameters.testWorkspace }}/node_modules/@fluid-private/test-version-utils/node_modules/.legacy/
 
         # Only check out tenants from the tenant pool if we are running tests against ODSP
-        - ${{ if eq(parameters.stageId, 'e2e_odsp') }}:
+        - ${{ if or(eq(parameters.stageId, 'e2e_odsp'), eq(parameters.stageId, 'stress_tests_odsp')) }}:
           # Retrieve a tenant from the tenant pool
           - task: AzureCLI@2
             displayName: 'Log in to retrieve tenant credentials'
@@ -381,9 +381,9 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ if ne(parameters.stageId, 'e2e_odsp') }}:
+            ${{ if and(ne(parameters.stageId, 'e2e_odsp'), ne(parameters.stageId, 'stress_tests_odsp')) }}:
               ${{ parameters.env }}
-            ${{ if eq(parameters.stageId, 'e2e_odsp') }}:
+            ${{ if or(eq(parameters.stageId, 'e2e_odsp'), eq(parameters.stageId, 'stress_tests_odsp')) }}:
               login__odsp__test__tenants: $(tenantCreds)
               login__microsoft__clientId: $(appClientId)
           inputs:
@@ -437,7 +437,7 @@ stages:
             continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
         # Only release tenants that were checked out from the tenant pool for ODSP tests
-        - ${{ if eq(parameters.stageId, 'e2e_odsp') }}:
+        - ${{ if or(eq(parameters.stageId, 'e2e_odsp'), eq(parameters.stageId, 'stress_tests_odsp')) }}:
           # Login to release tenant credentials
           # Currently, some of the compat tests run for longer than 60 minutes and exceed the average token lifetime:
           # https://learn.microsoft.com/en-us/entra/identity-platform/configurable-token-lifetimes#access-tokens

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -50,8 +50,6 @@ stages:
       testCommand: start:odsp
       skipTestResultPublishing: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
-      stageVariables:
-        - group: stress-odsp-lock
       env:
         login__microsoft__clientId: $(login-microsoft-clientId)
         login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)


### PR DESCRIPTION
Use the new tenants introduced in #23382 in the stress test pipeline for the ODSP prod stage. Largely follows the same steps as the E2E change and uses the infrastructure from that PR. This only deals with ODSP prod - the ODSPDF stage will be updated in a follow-up. 

[AB#48372](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/48372)