### PR TITLE
Minor: Removed extra minVersionForCollab declaration from IFluidDataStoreContext (already on base interface)

### DIFF
--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -169,7 +169,6 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
     // (undocumented)
     readonly id: string;
     readonly isLocalDataStore: boolean;
-    readonly minVersionForCollab?: MinimumVersionForCollab;
     readonly packagePath: PackagePath;
 }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -744,13 +744,6 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
 	createChildDataStore?<T extends IFluidDataStoreFactory>(
 		childFactory: T,
 	): ReturnType<Exclude<T["createDataStore"], undefined>>;
-
-	/**
-	 * Minimum version of the FF runtime that is required to collaborate on new documents.
-	 * Consumed by {@link @fluidframework/datastore#FluidDataStoreRuntime}.
-	 * See {@link @fluidframework/container-runtime#LoadContainerRuntimeParams.minVersionForCollab} for more details.
-	 */
-	readonly minVersionForCollab?: MinimumVersionForCollab;
 }
 
 /**


### PR DESCRIPTION
Quick follow-up for https://github.com/microsoft/FluidFramework/pull/25130. `minVersionForCollab` already exists on `IFluidParentContext`, which `IFluidDataStoreContext` extends.