### PR TITLE
Add a test case for record node support in tree-agent package

### DIFF
--- a/packages/framework/tree-agent/src/test/domains/index.ts
+++ b/packages/framework/tree-agent/src/test/domains/index.ts
@@ -15,3 +15,4 @@ export {
 	stringifyPage,
 } from "./text.js";
 export { Conference, Day, Days, Session, SessionType, Sessions } from "./conference.js";
+export { User, Users } from "./users.js";

--- a/packages/framework/tree-agent/src/test/domains/users.ts
+++ b/packages/framework/tree-agent/src/test/domains/users.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SchemaFactoryAlpha } from "@fluidframework/tree/internal";
+
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable jsdoc/require-jsdoc */
+
+const sf = new SchemaFactoryAlpha("com.microsoft.fluid.tree-agent.users");
+
+export class User extends sf.objectAlpha(
+	"User",
+	{
+		name: sf.required(sf.string, {
+			metadata: {
+				description: "The user's full name",
+			},
+		}),
+		created: sf.required(sf.string, {
+			metadata: {
+				description: "The ISO-8601 timestamp when the user was created",
+			},
+		}),
+		email: sf.optional(sf.string, {
+			metadata: {
+				description: "The user's email address",
+			},
+		}),
+	},
+	{
+		metadata: {
+			description: "A user in the system",
+		},
+	},
+) {}
+
+export class Users extends sf.recordAlpha("Users", User, {
+	metadata: {
+		description: `A collection of users in the system. The keys are user IDs. A user ID is always the first two letters of the user's first name followed by their full last name. For example, the user ID for "Alex Pardes" is "alpardes".`,
+	},
+}) {}

--- a/packages/framework/tree-agent/src/test/integration.spec.ts
+++ b/packages/framework/tree-agent/src/test/integration.spec.ts
@@ -5,10 +5,11 @@
 
 import type { UnsafeUnknownSchema } from "@fluidframework/tree/alpha";
 
-import { addCommentTest, smokeTest } from "./scenarios/index.js";
+import { addCommentTest, addUsersTest, smokeTest } from "./scenarios/index.js";
 import { describeIntegrationTests, type LLMIntegrationTest } from "./utils.js";
 
 describeIntegrationTests([
 	addCommentTest,
+	addUsersTest,
 	smokeTest,
 ] as unknown as LLMIntegrationTest<UnsafeUnknownSchema>[]);

--- a/packages/framework/tree-agent/src/test/scenarios/addUsers.ts
+++ b/packages/framework/tree-agent/src/test/scenarios/addUsers.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Users } from "../domains/index.js";
+import { scoreSymbol, type LLMIntegrationTest, type ScorableVerboseTree } from "../utils.js";
+
+// We start with two users (alpardes and mapardes) and add two more (jodoe and ansmith).
+// We only score on the presence of the four correct user IDs and their name fields; timestamps/emails are ignored.
+const expected: ScorableVerboseTree = {
+	type: "com.microsoft.fluid.tree-agent.users.Users",
+	[scoreSymbol]: (actual): number => {
+		if (typeof actual !== "object" || actual === null || Array.isArray(actual.fields)) {
+			return 0;
+		}
+		const required = new Map<string, string>([
+			["alpardes", "Alex Pardes"],
+			["rymagani", "Ryan Magani"],
+			["tawilliams", "Taylor Williams"],
+			["chdog", "Chewy Dog"],
+		]);
+		let score = 1;
+		for (const [id, name] of required) {
+			const user = actual.fields[id];
+			if (
+				typeof user !== "object" ||
+				user === null ||
+				Array.isArray(user.fields) ||
+				user.type !== "com.microsoft.fluid.tree-agent.users.User"
+			) {
+				score -= 1 / required.size;
+				continue;
+			}
+			if (
+				typeof user.fields.name !== "string" ||
+				user.fields.name.toLowerCase() !== name.toLowerCase()
+			) {
+				score -= 1 / required.size;
+				continue;
+			}
+		}
+		// Penalize if there are more than 4 users (encourage precision)
+		const actualKeys = Object.keys(actual.fields);
+		if (actualKeys.length > required.size) {
+			// simple linear penalty
+			score *= required.size / actualKeys.length;
+		}
+		return score;
+	},
+};
+
+/**
+ * Scenario: Add two new users to an existing set of users.
+ */
+export const addUsersTest = {
+	name: "Add users",
+	schema: Users,
+	initialTree: () => ({
+		alpardes: {
+			name: "Alex Pardes",
+			created: "2024-01-01T00:00:00.000Z",
+			email: "pardesio@gmail.com",
+		},
+		rymagani: {
+			name: "Ryan Magani",
+			created: "2024-02-01T00:00:00.000Z",
+			email: "ringom@gmail.com",
+		},
+	}),
+	prompt: "Please add two new users to this database: Taylor Williams and Chewy Dog.",
+	expected,
+} as const satisfies LLMIntegrationTest<typeof Users>;

--- a/packages/framework/tree-agent/src/test/scenarios/index.ts
+++ b/packages/framework/tree-agent/src/test/scenarios/index.ts
@@ -4,4 +4,5 @@
  */
 
 export { addCommentTest } from "./addComment.js";
+export { addUsersTest } from "./addUsers.js";
 export { smokeTest } from "./whiteSmoke.js";

--- a/packages/framework/tree-agent/src/typeGeneration.ts
+++ b/packages/framework/tree-agent/src/typeGeneration.ts
@@ -138,24 +138,28 @@ function getOrCreateType(
 				return z.object(properties).describe(simpleNodeSchema.metadata?.description ?? "");
 			}
 			case NodeKind.Record: {
-				return z.record(
-					getTypeForAllowedTypes(
-						definitionMap,
-						simpleNodeSchema.allowedTypesIdentifiers,
-						objectCache,
-						treeSchemaMap,
-					),
-				);
+				return z
+					.record(
+						getTypeForAllowedTypes(
+							definitionMap,
+							simpleNodeSchema.allowedTypesIdentifiers,
+							objectCache,
+							treeSchemaMap,
+						),
+					)
+					.describe(simpleNodeSchema.metadata?.description ?? "");
 			}
 			case NodeKind.Array: {
-				return z.array(
-					getTypeForAllowedTypes(
-						definitionMap,
-						simpleNodeSchema.allowedTypesIdentifiers,
-						objectCache,
-						treeSchemaMap,
-					),
-				);
+				return z
+					.array(
+						getTypeForAllowedTypes(
+							definitionMap,
+							simpleNodeSchema.allowedTypesIdentifiers,
+							objectCache,
+							treeSchemaMap,
+						),
+					)
+					.describe(simpleNodeSchema.metadata?.description ?? "");
 			}
 			case NodeKind.Leaf: {
 				switch (simpleNodeSchema.leafKind) {


### PR DESCRIPTION
This also updates type generation to include node metadata for records and arrays.