### PR TITLE
poc(data-migration): Add migration machinery to FluidDataStoreContext which swaps out entire factories

### DIFF
--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
@@ -50,6 +50,26 @@ export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
     runtimeOptions?: IContainerRuntimeOptions;
 }
 
+// @beta @legacy (undocumented)
+export interface CreateDataObjectProps<TObj extends PureDataObject, I extends DataObjectTypes> {
+    // (undocumented)
+    context: IFluidDataStoreContext;
+    // (undocumented)
+    ctor: new (props: IDataObjectProps<I>) => TObj;
+    // (undocumented)
+    existing: boolean;
+    // (undocumented)
+    initialState?: I["InitialState"];
+    // (undocumented)
+    optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>;
+    // (undocumented)
+    policies?: Partial<IFluidDataStorePolicies>;
+    // (undocumented)
+    runtimeClassArg: typeof FluidDataStoreRuntime;
+    // (undocumented)
+    sharedObjectRegistry: ISharedObjectRegistry;
+}
+
 // @beta @legacy
 export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> extends PureDataObject<I> {
     protected getUninitializedErrorString(item: string): string;
@@ -119,7 +139,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 }
 
 // @beta @legacy
-export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
+export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements Partial<IProvideFluidDataStoreRegistry> {
     constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects?: readonly IChannelFactory[], optionalProviders?: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
     constructor(props: DataObjectFactoryProps<TObj, I>);
     createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
@@ -130,6 +150,8 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     // (undocumented)
     protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
+    // (undocumented)
+    protected readonly createProps: Omit<CreateDataObjectProps<TObj, I>, "existing" | "context">;
     // @deprecated
     createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: I["InitialState"]): Promise<TObj>;
     get IFluidDataStoreFactory(): this;

--- a/packages/framework/aqueduct/src/data-object-factories/index.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/index.ts
@@ -5,6 +5,8 @@
 
 export { DataObjectFactory } from "./dataObjectFactory.js";
 export {
+	//* TODO: Can we avoid adding this new export?
+	type CreateDataObjectProps,
 	type DataObjectFactoryProps,
 	PureDataObjectFactory,
 } from "./pureDataObjectFactory.js";

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -228,6 +228,7 @@ export class PureDataObjectFactory<
 		runtimeClass?: typeof FluidDataStoreRuntime,
 	);
 	public constructor(
+		//* TODO: Define a MigrationSourceProps or something rather than inline this ammendment
 		props: DataObjectFactoryProps<TObj, I> & { migrationInfo?: IMigrationInfo },
 	);
 	public constructor(
@@ -298,6 +299,10 @@ export class PureDataObjectFactory<
 		return [this.type, Promise.resolve(this)];
 	}
 
+	//* TODO: Once IMigratableFluidDataStoreFactory is split, move this to a "Migration Source" subclass
+	/**
+	 * If defined, this factory should be migrated away from according to this info.
+	 */
 	public readonly migrationInfo: IMigrationInfo | undefined;
 
 	/**
@@ -312,17 +317,16 @@ export class PureDataObjectFactory<
 		return runtime;
 	}
 
-	//* NOTE: impls should _either_ use migrationInfo _or_ be ready to initialize from portableData
+	//* TODO: Once IMigratableFluidDataStoreFactory is split, move this to a "Migration Target" subclass
 	public async instantiateForMigration(
 		context: IFluidDataStoreContext,
-		_existing: true,
 		portableData: I["InitialState"],
 	): Promise<IFluidDataStoreChannel> {
 		const { runtime } = await createDataObject({
 			...this.createProps,
 			context,
 			existing: true,
-			initialState: portableData, //* A bit hacky: Overloading the InitialState, distinguished from InitialState for create by the 'existing' param
+			initialState: portableData, //* A bit hacky: Overloading the InitialState, would be distinguished from the type used for creating new ones by the value of 'existing'
 		});
 
 		return runtime;

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -24,11 +24,12 @@ import type {
 	IFluidDataStoreContextDetached,
 	IFluidDataStorePolicies,
 	IFluidDataStoreRegistry,
-	IMigratableFluidDataStoreFactory,
 	IProvideFluidDataStoreRegistry,
 	IMigrationInfo,
 	NamedFluidDataStoreRegistryEntries,
 	NamedFluidDataStoreRegistryEntry,
+	IMigrationSourceFluidDataStoreFactory,
+	IMigrationTargetFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions/internal";
 import type {
 	AsyncFluidObjectProvider,
@@ -203,8 +204,11 @@ export interface DataObjectFactoryProps<
 export class PureDataObjectFactory<
 	TObj extends PureDataObject<I>,
 	I extends DataObjectTypes = DataObjectTypes,
-	//* TODO: Insert new subclass that implements IMigratableFluidDataStoreFactory rather than modifying PureDataObjectFactory
-> implements IMigratableFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry>
+	//* TODO: Add 2 new subclasses that implement IMigrationSourceFluidDataStoreFactory and IMigrationTargetFluidDataStoreFactory respectively
+> implements
+		IMigrationSourceFluidDataStoreFactory,
+		IMigrationTargetFluidDataStoreFactory,
+		Partial<IProvideFluidDataStoreRegistry>
 {
 	private readonly registry: IFluidDataStoreRegistry | undefined;
 	private readonly createProps: Omit<CreateDataObjectProps<TObj, I>, "existing" | "context">;
@@ -299,7 +303,7 @@ export class PureDataObjectFactory<
 		return [this.type, Promise.resolve(this)];
 	}
 
-	//* TODO: Once IMigratableFluidDataStoreFactory is split, move this to a "Migration Source" subclass
+	//* TODO: Move this to a "Migration Source" subclass.  No factory should be both a source and target.
 	/**
 	 * If defined, this factory should be migrated away from according to this info.
 	 */
@@ -317,7 +321,7 @@ export class PureDataObjectFactory<
 		return runtime;
 	}
 
-	//* TODO: Once IMigratableFluidDataStoreFactory is split, move this to a "Migration Target" subclass
+	//* TODO: Move this to a "Migration Target" subclass.  No factory should be both a source and target.
 	public async instantiateForMigration(
 		context: IFluidDataStoreContext,
 		portableData: I["InitialState"],

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -20,6 +20,7 @@
 
 export {
 	DataObjectFactory,
+	type CreateDataObjectProps,
 	type DataObjectFactoryProps,
 	PureDataObjectFactory,
 	TreeDataObjectFactory,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -55,6 +55,8 @@ import {
 	type IFluidDataStoreContextDetached,
 	type IFluidDataStoreRegistry,
 	type IGarbageCollectionDetailsBase,
+	type IMigrationSourceFluidDataStoreFactory,
+	type IMigrationTargetFluidDataStoreFactory,
 	type IProvideFluidDataStoreFactory,
 	type ISummarizeInternalResult,
 	type ISummarizeResult,
@@ -68,10 +70,6 @@ import {
 	type PackagePath,
 	type IRuntimeStorageService,
 	type MinimumVersionForCollab,
-} from "@fluidframework/runtime-definitions/internal";
-import type {
-	IMigrationInfo,
-	IMigratableFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	addBlobToSummary,
@@ -727,8 +725,7 @@ export abstract class FluidDataStoreContext
 			return initialChannel;
 		}
 
-		const migrationInfo = (factory as unknown as { migrationInfo?: IMigrationInfo })
-			.migrationInfo;
+		const migrationInfo = (factory as IMigrationSourceFluidDataStoreFactory).migrationInfo;
 		if (migrationInfo === undefined) {
 			// No migration needed if factory doesn't request it
 			return initialChannel;
@@ -771,9 +768,9 @@ export abstract class FluidDataStoreContext
 				initialChannel.dispose();
 
 				// Lookup new factory with updated package path
-				//* TODO: Use proper type guard instead of cast
+				//* TODO: Use proper type guard (that asserts) instead of cast
 				const newFactory =
-					(await this.factoryFromPackagePath()) as IMigratableFluidDataStoreFactory;
+					(await this.factoryFromPackagePath()) as IMigrationTargetFluidDataStoreFactory;
 
 				const migratedChannel = await newFactory.instantiateForMigration(this, portableData);
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -752,7 +752,7 @@ export abstract class FluidDataStoreContext
 			return initialChannel;
 		}
 
-		const portableData = await migrationInfo.getPortableData();
+		const portableData = await migrationInfo.getPortableData(initialChannel);
 
 		const newPkgJoined = migrationInfo.newPackagePath.join("/");
 		assert(newPkgJoined !== oldPkg, "No-op migration not allowed");

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -69,6 +69,10 @@ import {
 	type IRuntimeStorageService,
 	type MinimumVersionForCollab,
 } from "@fluidframework/runtime-definitions/internal";
+import type {
+	IRuntimeMigrationInfo,
+	IMigratableFluidDataStoreFactory,
+} from "@fluidframework/runtime-definitions/internal";
 import {
 	addBlobToSummary,
 	isSnapshotFetchRequiredForLoadingGroupId,
@@ -101,21 +105,6 @@ import {
 	hasIsolatedChannels,
 	wrapSummaryInChannelsTree,
 } from "./summary/index.js";
-// Migration interfaces (new) imported from runtime-definitions
-// Local re-import of migration interfaces (runtime-definitions adds them). If not present in older builds,
-// declare minimal local shapes to compile.
-// Local migration interfaces (scoped to container-runtime implementation). Will move to definitions later.
-interface IRuntimeMigrationInfo {
-	readonly newPackagePath: readonly string[];
-	readonly portableData: unknown;
-}
-interface IMigratableFluidDataStoreFactory extends IFluidDataStoreFactory {
-	instantiateForMigration?(
-		context: FluidDataStoreContext,
-		existing: boolean,
-		portableData: unknown,
-	): Promise<IFluidDataStoreChannel>;
-}
 
 function createAttributes(
 	pkg: readonly string[],

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -142,6 +142,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     makeVisibleAndAttachGraph(): void;
+    readonly migrationInfo?: IMigrationInfo;
     notifyReadOnlyState?(readonly: boolean): void;
     readonly policies?: IFluidDataStorePolicies;
     processMessages(messageCollection: IRuntimeMessageCollection): void;
@@ -267,6 +268,22 @@ export interface IGarbageCollectionDetailsBase {
 export interface IInboundSignalMessage<TMessage extends TypedMessage = TypedMessage> extends ISignalMessage<TMessage> {
     // (undocumented)
     readonly type: TMessage["type"];
+}
+
+// @beta
+export interface IMigrationInfo {
+    readonly getPortableData: () => Promise<unknown>;
+    readonly newPackagePath: readonly string[];
+}
+
+// @beta @legacy
+export interface IMigrationSourceFluidDataStoreFactory extends IFluidDataStoreFactory {
+    migrationInfo: IMigrationInfo | undefined;
+}
+
+// @beta @legacy
+export interface IMigrationTargetFluidDataStoreFactory extends IFluidDataStoreFactory {
+    instantiateForMigration(context: IFluidDataStoreContext, portableData: unknown): Promise<IFluidDataStoreChannel>;
 }
 
 // @beta @legacy

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -270,9 +270,9 @@ export interface IInboundSignalMessage<TMessage extends TypedMessage = TypedMess
     readonly type: TMessage["type"];
 }
 
-// @beta
+// @beta @legacy
 export interface IMigrationInfo {
-    readonly getPortableData: () => Promise<unknown>;
+    readonly getPortableData: (runtime: IFluidDataStoreChannel) => Promise<unknown>;
     readonly newPackagePath: readonly string[];
 }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -31,7 +31,7 @@ import type { MinimumVersionForCollab } from "./compatibilityDefinitions.js";
 import type {
 	IFluidDataStoreFactory,
 	IProvideFluidDataStoreFactory,
-	IRuntimeMigrationInfo,
+	IMigrationInfo,
 } from "./dataStoreFactory.js";
 import type { IProvideFluidDataStoreRegistry } from "./dataStoreRegistry.js";
 import type {
@@ -407,7 +407,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	 *
 	 * TODO: Strengthen typing / validation of portableData once the format is finalized.
 	 */
-	readonly migrationInfo?: IRuntimeMigrationInfo;
+	readonly migrationInfo?: IMigrationInfo;
 
 	/**
 	 * Makes the data store channel visible in the container. Also, runs through its graph and attaches all

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -31,6 +31,7 @@ import type { MinimumVersionForCollab } from "./compatibilityDefinitions.js";
 import type {
 	IFluidDataStoreFactory,
 	IProvideFluidDataStoreFactory,
+	IRuntimeMigrationInfo,
 } from "./dataStoreFactory.js";
 import type { IProvideFluidDataStoreRegistry } from "./dataStoreRegistry.js";
 import type {
@@ -394,6 +395,19 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	 * These policies influence the behavior of the data store, such as its readonly state in specific modes.
 	 */
 	readonly policies?: IFluidDataStorePolicies;
+
+	/**
+	 * If defined immediately after instantiation (prior to binding), indicates that the channel wishes the
+	 * context to migrate to a newer implementation. The context will dispose this unbound channel and swap in
+	 * a new runtime produced via `instantiateForMigration` on the target factory referenced by
+	 * `migrationInfo.newPackagePath`.
+	 *
+	 * Only honored during the first realization of an existing data store (one hop per load). Newly created
+	 * data stores MUST NOT request migration.
+	 *
+	 * TODO: Strengthen typing / validation of portableData once the format is finalized.
+	 */
+	readonly migrationInfo?: IRuntimeMigrationInfo;
 
 	/**
 	 * Makes the data store channel visible in the container. Also, runs through its graph and attaches all

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -19,7 +19,7 @@ import type { IFluidDataStoreChannel, IFluidDataStoreContext } from "./dataStore
  *
  * TODO: Add strong typing / versioning for portableData once the format stabilizes.
  *
- * @beta
+ * @legacy @beta
  */
 export interface IMigrationInfo {
 	/**
@@ -31,7 +31,7 @@ export interface IMigrationInfo {
 	 * Opaque portable state required by the target factory to rehydrate the runtime
 	 * in the new implementation.
 	 */
-	readonly getPortableData: () => Promise<unknown>; //* Maybe can use the "initial state" generic type?
+	readonly getPortableData: (runtime: IFluidDataStoreChannel) => Promise<unknown>;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -34,17 +34,27 @@ export interface IMigrationInfo {
 	readonly getPortableData: () => Promise<unknown>; //* Maybe can use the "initial state" generic type?
 }
 
-//* TODO:  Split this into:
-// - IMigrationSourceFluidDataStoreFactory (with migrationInfo)
-// - IMigrationTargetFluidDataStoreFactory (with instantiateForMigration)
-// This would clarify the intent and make it less likely that a single factory
-// tries to be both a source and target of migration.
-export interface IMigratableFluidDataStoreFactory extends IFluidDataStoreFactory {
+/**
+ * A factory that indicates it should be migrated away from.
+ *
+ * This interface carries the migration metadata produced by an older implementation.
+ *
+ * @legacy @beta
+ */
+export interface IMigrationSourceFluidDataStoreFactory extends IFluidDataStoreFactory {
 	/**
 	 * If defined, this factory should be migrated away from according to this info.
 	 */
 	migrationInfo: IMigrationInfo | undefined;
+}
 
+/**
+ * A factory that can act as a migration target by instantiating a runtime from
+ * portable migration data produced by a previous implementation.
+ *
+ * @legacy @beta
+ */
+export interface IMigrationTargetFluidDataStoreFactory extends IFluidDataStoreFactory {
 	/**
 	 * Instantiate a runtime using portable migration data produced by a previous implementation.
 	 * @param context - Datastore context (same as regular instantiation).

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -34,15 +34,11 @@ export interface IMigrationInfo {
 	readonly getPortableData: () => Promise<unknown>; //* Maybe can use the "initial state" generic type?
 }
 
-/**
- * Extension of {@link IFluidDataStoreFactory} supporting instantiation from portable migration data.
- *
- * Factories that wish to be targets of migration MUST implement this interface. The context will
- * detect the presence of `instantiateForMigration` and use it instead of the normal load path when
- * a prior implementation exposes migration info.
- *
- * @beta
- */
+//* TODO:  Split this into:
+// - IMigrationSourceFluidDataStoreFactory (with migrationInfo)
+// - IMigrationTargetFluidDataStoreFactory (with instantiateForMigration)
+// This would clarify the intent and make it less likely that a single factory
+// tries to be both a source and target of migration.
 export interface IMigratableFluidDataStoreFactory extends IFluidDataStoreFactory {
 	/**
 	 * If defined, this factory should be migrated away from according to this info.
@@ -52,14 +48,11 @@ export interface IMigratableFluidDataStoreFactory extends IFluidDataStoreFactory
 	/**
 	 * Instantiate a runtime using portable migration data produced by a previous implementation.
 	 * @param context - Datastore context (same as regular instantiation).
-	 * @param existing - Always true for migration (we are loading an existing store).
 	 * @param portableData - Opaque data captured from the old runtime.
 	 */
 	instantiateForMigration(
 		context: IFluidDataStoreContext,
-		existing: boolean, //* TODO: Remove, it must be true
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		portableData: any,
+		portableData: unknown,
 	): Promise<IFluidDataStoreChannel>;
 }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -58,7 +58,7 @@ export interface IMigratableFluidDataStoreFactory extends IFluidDataStoreFactory
 	 */
 	instantiateForMigration(
 		context: IFluidDataStoreContext,
-		existing: boolean,
+		existing: boolean, //* TODO: Remove, it must be true
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		portableData: any,
 	): Promise<IFluidDataStoreChannel>;

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -21,7 +21,7 @@ import type { IFluidDataStoreChannel, IFluidDataStoreContext } from "./dataStore
  *
  * @beta
  */
-export interface IRuntimeMigrationInfo {
+export interface IMigrationInfo {
 	/**
 	 * The new package path (final target) to which this data store should be migrated.
 	 * This MUST differ from the current package path or migration will fail.
@@ -31,13 +31,7 @@ export interface IRuntimeMigrationInfo {
 	 * Opaque portable state required by the target factory to rehydrate the runtime
 	 * in the new implementation.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Deliberately opaque initially
-	readonly portableData: any; // unknown would force excess casting inside factories; keep broad for now
-	/**
-	 * Placeholder for future barrier op sequence number or other coordination metadata.
-	 * Not used yet.
-	 */
-	readonly barrierSequenceNumber?: number;
+	readonly getPortableData: () => Promise<unknown>; //* Maybe can use the "initial state" generic type?
 }
 
 /**
@@ -50,6 +44,11 @@ export interface IRuntimeMigrationInfo {
  * @beta
  */
 export interface IMigratableFluidDataStoreFactory extends IFluidDataStoreFactory {
+	/**
+	 * If defined, this factory should be migrated away from according to this info.
+	 */
+	migrationInfo: IMigrationInfo | undefined;
+
 	/**
 	 * Instantiate a runtime using portable migration data produced by a previous implementation.
 	 * @param context - Datastore context (same as regular instantiation).

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -30,7 +30,7 @@ export type {
 export { FlushMode, FlushModeExperimental, VisibilityState } from "./dataStoreContext.js";
 export type {
 	IProvideFluidDataStoreFactory,
-	IRuntimeMigrationInfo,
+	IMigrationInfo,
 	IMigratableFluidDataStoreFactory,
 } from "./dataStoreFactory.js";
 export { IFluidDataStoreFactory } from "./dataStoreFactory.js";

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -28,7 +28,11 @@ export type {
 	PackagePath,
 } from "./dataStoreContext.js";
 export { FlushMode, FlushModeExperimental, VisibilityState } from "./dataStoreContext.js";
-export type { IProvideFluidDataStoreFactory } from "./dataStoreFactory.js";
+export type {
+	IProvideFluidDataStoreFactory,
+	IRuntimeMigrationInfo,
+	IMigratableFluidDataStoreFactory,
+} from "./dataStoreFactory.js";
 export { IFluidDataStoreFactory } from "./dataStoreFactory.js";
 export type {
 	FluidDataStoreRegistryEntry,

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -31,7 +31,8 @@ export { FlushMode, FlushModeExperimental, VisibilityState } from "./dataStoreCo
 export type {
 	IProvideFluidDataStoreFactory,
 	IMigrationInfo,
-	IMigratableFluidDataStoreFactory,
+	IMigrationSourceFluidDataStoreFactory,
+	IMigrationTargetFluidDataStoreFactory,
 } from "./dataStoreFactory.js";
 export { IFluidDataStoreFactory } from "./dataStoreFactory.js";
 export type {


### PR DESCRIPTION
## Description

Copilot's summary of the change after we chatted about it a bit:

Implement one-hop, load-time datastore migration during first realization only. Old factory exposes migrationInfo (with portableData + newPackagePath). Context detects it, lets the old runtime catch up then gets its portable data and disposes it without binding. Next it swaps pkg, loads new factory via an extended migratable factory interface, instantiates new runtime with instantiateForMigration, binds it, and and proceeds normally. Summaries then carry new package path.

## Breaking Changes

Some short-term back compat will be needed across the datastore / runtime boundary.

## Reviewer Guidance

Proof of concept, plenty of gaps/todo's.