### PR TITLE
Use new tenants in performance benchmarks pipeline

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -31,6 +31,10 @@ parameters:
 - name: pathForTelemetryGeneratorInstall
   type: string
 
+# Name of the service that the tests are running against.
+- name: endpointName
+  type: string
+
 steps:
 - task: Bash@3
   displayName: Print parameter/variable values for troubleshooting
@@ -90,3 +94,33 @@ steps:
     workingDirectory: ${{ parameters.testWorkspace }}
     targetType: 'inline'
     script: 'npm install @ff-internal/aria-logger'
+
+- ${{ if eq(parameters.endpointName, 'odsp') }}:
+  # Log in to Azure to retrieve tenant credentials
+  - task: AzureCLI@2
+    displayName: 'Log in to retrieve tenant credentials'
+    inputs:
+      azureSubscription: 'Fluid Framework Tests'
+      # This injects environment variables into the below script. See https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines
+      addSpnToEnvironment: true
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        set -eu -o pipefail
+
+        az login --service-principal -u $servicePrincipalId -p $idToken --tenant $tenantId
+
+  # Obtain tenant credentials and store them in environment variables
+  - task: Bash@3
+    displayName: 'Run tenant setup script'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    inputs:
+      workingDirectory: ${{ parameters.testWorkspace }}
+      targetType: 'inline'
+      script: |
+        set -eu -o pipefail
+
+        # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
+        npx --package=@ff-internal/trips-setup@0.0.5 -- trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN
+        echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -34,6 +34,7 @@ parameters:
 # Name of the service that the tests are running against.
 - name: endpointName
   type: string
+  default: ''
 
 steps:
 - task: Bash@3

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -52,7 +52,6 @@ parameters:
   default:
   - endpointName: 'local'
   - endpointName: 'odsp'
-    # lockVariableGroupName: 'perf-odsp-lock'
     timeoutInMinutes: 360
   - endpointName: 'frs'
     lockVariableGroupName: 'perf-frs-lock'

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -539,9 +539,11 @@ stages:
             FLUID_BUILD_ID: $(Build.BuildId)
             FLUID_ENDPOINTNAME: ${{ endpointObject.endpointName }}
             FLUID_LOGGER_PROPS: '{ "hostName": "Benchmark", "displayName": "${{variables.pipelineIdentifierForTelemetry}}" }'
-            login__microsoft__clientId: $(login-microsoft-clientId)
-            # ${{ if eq( endpointObject.endpointName, 'odsp' ) }}:
-            #   login__odsp__test__tenants: $(automation-perf-login-odsp-test-tenants)
+            ${{ if eq(endpointObject.endpointName, 'odsp') }}:
+              login__odsp__test__tenants: $(tenantCreds)
+              login__microsoft__clientId: $(appClientId)
+            ${{ else }}:
+              login__microsoft__clientId: $(login-microsoft-clientId)
             ${{ if eq( endpointObject.endpointName, 'frs' ) }}:
               fluid__test__driver__frs: $(automation-fluid-test-driver-frs-perf-test)
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -52,7 +52,7 @@ parameters:
   default:
   - endpointName: 'local'
   - endpointName: 'odsp'
-    lockVariableGroupName: 'perf-odsp-lock'
+    # lockVariableGroupName: 'perf-odsp-lock'
     timeoutInMinutes: 360
   - endpointName: 'frs'
     lockVariableGroupName: 'perf-frs-lock'
@@ -441,7 +441,7 @@ stages:
       displayName: Perf e2e tests - ${{ endpointObject.endpointName }}
       dependsOn: []
       # If the stage needs locking, configure the lock behavior. Note that null gets coalesced into an empty string.
-      ${{ if ne(endpointObject.lockVariableGroupName, '') }}:
+      ${{ if and(ne(endpointObject.lockVariableGroupName, ''), ne(endpointObject.endpointName, 'odsp')) }}:
         lockBehavior: sequential
       variables:
         # Use contention-lock variable groups when appropriate. Note that null gets coalesced into an empty string.
@@ -471,6 +471,7 @@ stages:
             testFilesPath: $(testFilesPath)
             testWorkspace: $(testWorkspace)
             pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
+            endpointName: ${{ endpointObject.endpointName }}
 
         # Download and install package with performance tests
         - template: /tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml@self
@@ -539,8 +540,8 @@ stages:
             FLUID_ENDPOINTNAME: ${{ endpointObject.endpointName }}
             FLUID_LOGGER_PROPS: '{ "hostName": "Benchmark", "displayName": "${{variables.pipelineIdentifierForTelemetry}}" }'
             login__microsoft__clientId: $(login-microsoft-clientId)
-            ${{ if eq( endpointObject.endpointName, 'odsp' ) }}:
-              login__odsp__test__tenants: $(automation-perf-login-odsp-test-tenants)
+            # ${{ if eq( endpointObject.endpointName, 'odsp' ) }}:
+            #   login__odsp__test__tenants: $(automation-perf-login-odsp-test-tenants)
             ${{ if eq( endpointObject.endpointName, 'frs' ) }}:
               fluid__test__driver__frs: $(automation-fluid-test-driver-frs-perf-test)
 
@@ -600,6 +601,32 @@ stages:
               ls -laR ${{ variables.memoryUsageTestOutputFolder }};
               echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
               rm -rf ${{ variables.memoryUsageTestOutputFolder }};
+
+        # Cleanup of tenant credentials for odsp tests
+        - ${{ if eq( endpointObject.endpointName, 'odsp' ) }}:
+          - task: AzureCLI@2
+            displayName: 'Log in to release tenant credentials'
+            inputs:
+              azureSubscription: 'Fluid Framework Tests'
+              addSpnToEnvironment: true
+              scriptType: 'bash'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                set -eu -o pipefail
+
+                az login --service-principal -u $servicePrincipalId -p $idToken --tenant $tenantId
+            condition: eq(variables['tenantSetupSuccess'], 'true')
+
+          # Release the tenant back to the tenant pool
+          - task: Bash@3
+            displayName: 'Release tenant credentials'
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -eu -o pipefail
+
+                npx --package=@ff-internal/trips-setup@0.0.5 -- trips-cleanup --reservationId=$(stringBearerToken)
+            condition: eq(variables['tenantSetupSuccess'], 'true')
 
         - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
 


### PR DESCRIPTION
Continue removing uses of the old tenants and migrating to the new tenant system. 

[AB#45635](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45635)