### PR TITLE
tree-agent: Support GPT-5 & docs update

### DIFF
--- a/packages/framework/tree-agent/package.json
+++ b/packages/framework/tree-agent/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@langchain/anthropic": "^0.3.24",
 		"@langchain/google-genai": "^0.2.16",
-		"@langchain/openai": "^0.6.3",
+		"@langchain/openai": "^0.6.11",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/tree-agent/package.json
+++ b/packages/framework/tree-agent/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@langchain/anthropic": "^0.3.24",
 		"@langchain/google-genai": "^0.2.16",
-		"@langchain/openai": "^0.6.11",
+		"@langchain/openai": "^0.6.12",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/tree-agent/src/methodBinding.ts
+++ b/packages/framework/tree-agent/src/methodBinding.ts
@@ -133,13 +133,15 @@ export const exposeMethodsSymbol: unique symbol = Symbol("run");
  * An interface that SharedTree schema classes should implement to expose their methods to the LLM.
  *
  * @remarks
- * {@link getExposedMethods} will cause the method here to be called on the class passed to it.
+ * The `getExposedMethods` free function will cause the method here to be called on the class passed to it.
  *
  * @privateremarks
  * Implementing this interface correctly seems tricky?
  * To actually implement it in a way that satisfies TypeScript,
  * classes need to declare both a static version and an instance version of the method
  * (the instance one can just delegate to the static one).
+ *
+ * @alpha
  */
 export interface IExposedMethods {
 	[exposeMethodsSymbol](methods: ExposedMethods): void;

--- a/packages/framework/tree-agent/src/methodBinding.ts
+++ b/packages/framework/tree-agent/src/methodBinding.ts
@@ -130,8 +130,16 @@ export interface ExposedMethods {
 export const exposeMethodsSymbol: unique symbol = Symbol("run");
 
 /**
- * An interface for exposing schema class methods to the LLM.
- * @alpha
+ * An interface that SharedTree schema classes should implement to expose their methods to the LLM.
+ *
+ * @remarks
+ * {@link getExposedMethods} will cause the method here to be called on the class passed to it.
+ *
+ * @privateremarks
+ * Implementing this interface correctly seems tricky?
+ * To actually implement it in a way that satisfies TypeScript,
+ * classes need to declare both a static version and an instance version of the method
+ * (the instance one can just delegate to the static one).
  */
 export interface IExposedMethods {
 	[exposeMethodsSymbol](methods: ExposedMethods): void;

--- a/packages/framework/tree-agent/src/test/utils.ts
+++ b/packages/framework/tree-agent/src/test/utils.ts
@@ -63,14 +63,14 @@ export function createLlmClient(provider: LlmProvider): BaseChatModel {
 	switch (provider) {
 		case "openai": {
 			return new ChatOpenAI({
-				model: "o4-mini",
+				model: "gpt-5-2025-08-07",
 				apiKey:
 					process.env.OPENAI_API_KEY ??
 					failUsage("Missing OPENAI_API_KEY environment variable"),
 				reasoning: { effort: "high" },
 				maxTokens: 20000,
 				metadata: {
-					modelName: "o3 Mini",
+					modelName: "GPT 5",
 				},
 			});
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11699,10 +11699,10 @@ importers:
         version: link:../../dds/tree
       '@langchain/core':
         specifier: ^0.3.66
-        version: 0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+        version: 0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       langchain:
         specifier: ^0.3.30
-        version: 0.3.30(@langchain/anthropic@0.3.26(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))))(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))(@langchain/google-genai@0.2.16(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))))(axios@0.30.0)(handlebars@4.7.8)(openai@5.12.0(ws@8.18.0)(zod@3.25.76))(ws@8.18.0)
+        version: 0.3.30(@langchain/anthropic@0.3.26(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))))(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))(@langchain/google-genai@0.2.16(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))))(axios@0.30.0)(handlebars@4.7.8)(openai@5.12.2(ws@8.18.0)(zod@3.25.76))(ws@8.18.0)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -11739,13 +11739,13 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@langchain/anthropic':
         specifier: ^0.3.24
-        version: 0.3.26(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))
+        version: 0.3.26(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))
       '@langchain/google-genai':
         specifier: ^0.2.16
-        version: 0.2.16(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))
+        version: 0.2.16(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))
       '@langchain/openai':
-        specifier: ^0.6.3
-        version: 0.6.3(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
+        specifier: ^0.6.11
+        version: 0.6.12(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.86)
@@ -18179,11 +18179,11 @@ packages:
     peerDependencies:
       '@langchain/core': '>=0.3.58 <0.4.0'
 
-  '@langchain/openai@0.6.3':
-    resolution: {integrity: sha512-dSNuXDTJitDzN8D2wFNqWVELDbBRhMpJiFeiWpHjfPuq7R6wSjzNNY/Uk6x+FLpvbOs/zKNWy5+0q0p3KrCjRQ==}
+  '@langchain/openai@0.6.12':
+    resolution: {integrity: sha512-xc81QFQ2E5IuwCOYN91TG2prsbsxH2jAqMbZx2nRO+3XUzqH5RNqxSHvJKFmh9793KcPw3PE3vEvBQ8oO+3iOA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': '>=0.3.58 <0.4.0'
+      '@langchain/core': '>=0.3.68 <0.4.0'
 
   '@langchain/textsplitters@0.1.0':
     resolution: {integrity: sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==}
@@ -24711,8 +24711,8 @@ packages:
       zod:
         optional: true
 
-  openai@5.12.0:
-    resolution: {integrity: sha512-vUdt02xiWgOHiYUmW0Hj1Qu9OKAiVQu5Bd547ktVCiMKC1BkB5L3ImeEnCyq3WpRKR6ZTaPgekzqdozwdPs7Lg==}
+  openai@5.12.2:
+    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -32115,20 +32115,20 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/anthropic@0.3.26(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))':
+  '@langchain/anthropic@0.3.26(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))':
     dependencies:
       '@anthropic-ai/sdk': 0.56.0
-      '@langchain/core': 0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       fast-xml-parser: 4.5.3
 
-  '@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))':
+  '@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.3.52(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+      langsmith: 0.3.52(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -32141,24 +32141,24 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/google-genai@0.2.16(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))':
+  '@langchain/google-genai@0.2.16(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))':
     dependencies:
       '@google/generative-ai': 0.24.1
-      '@langchain/core': 0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       uuid: 11.1.0
 
-  '@langchain/openai@0.6.3(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)':
+  '@langchain/openai@0.6.12(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)':
     dependencies:
-      '@langchain/core': 0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.20
-      openai: 5.12.0(ws@8.18.0)(zod@3.25.76)
+      openai: 5.12.2(ws@8.18.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))':
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.20
 
   '@leichtgewicht/ip-codec@2.0.5': {}
@@ -38760,23 +38760,23 @@ snapshots:
 
   ky@1.7.3: {}
 
-  langchain@0.3.30(@langchain/anthropic@0.3.26(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))))(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))(@langchain/google-genai@0.2.16(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))))(axios@0.30.0)(handlebars@4.7.8)(openai@5.12.0(ws@8.18.0)(zod@3.25.76))(ws@8.18.0):
+  langchain@0.3.30(@langchain/anthropic@0.3.26(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))))(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))(@langchain/google-genai@0.2.16(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))))(axios@0.30.0)(handlebars@4.7.8)(openai@5.12.2(ws@8.18.0)(zod@3.25.76))(ws@8.18.0):
     dependencies:
-      '@langchain/core': 0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
-      '@langchain/openai': 0.6.3(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))
+      '@langchain/core': 0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
+      '@langchain/openai': 0.6.12(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))
       js-tiktoken: 1.0.20
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langsmith: 0.3.52(openai@5.12.0(ws@8.18.0)(zod@3.25.76))
+      langsmith: 0.3.52(openai@5.12.2(ws@8.18.0)(zod@3.25.76))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
       yaml: 2.6.1
       zod: 3.25.76
     optionalDependencies:
-      '@langchain/anthropic': 0.3.26(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))
-      '@langchain/google-genai': 0.2.16(@langchain/core@0.3.66(openai@5.12.0(ws@8.18.0)(zod@3.25.76)))
+      '@langchain/anthropic': 0.3.26(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))
+      '@langchain/google-genai': 0.2.16(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))
       axios: 0.30.0(debug@4.4.0)
       handlebars: 4.7.8
     transitivePeerDependencies:
@@ -38786,7 +38786,7 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.3.52(openai@5.12.0(ws@8.18.0)(zod@3.25.76)):
+  langsmith@0.3.52(openai@5.12.2(ws@8.18.0)(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -38796,7 +38796,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.12.0(ws@8.18.0)(zod@3.25.76)
+      openai: 5.12.2(ws@8.18.0)(zod@3.25.76)
 
   latest-version@7.0.0:
     dependencies:
@@ -40349,7 +40349,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@5.12.0(ws@8.18.0)(zod@3.25.76):
+  openai@5.12.2(ws@8.18.0)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.0
       zod: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11744,7 +11744,7 @@ importers:
         specifier: ^0.2.16
         version: 0.2.16(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))
       '@langchain/openai':
-        specifier: ^0.6.11
+        specifier: ^0.6.12
         version: 0.6.12(@langchain/core@0.3.66(openai@5.12.2(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
       '@microsoft/api-extractor':
         specifier: 7.52.11


### PR DESCRIPTION
## Description

The main change is to update `@langchain/openai` to support using gpt-5, which is now the default model when testing against OpenAI. Also fixes the `metadata.modelName` which apparently didn't match the model actually being used (o4mini vs o3mini).

Finally, adds some docs on `IExposedMethods` based on my learning while using it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
