### PR TITLE
Add map support to tree-agent

### DIFF
--- a/packages/framework/tree-agent/src/test/domains/users.ts
+++ b/packages/framework/tree-agent/src/test/domains/users.ts
@@ -36,7 +36,7 @@ export class User extends sf.objectAlpha(
 	},
 ) {}
 
-export class Users extends sf.recordAlpha("Users", User, {
+export class Users extends sf.mapAlpha("Users", User, {
 	metadata: {
 		description: `A collection of users in the system. The keys are user IDs. A user ID is always the first two letters of the user's first name followed by their full last name. For example, the user ID for "Alex Pardes" is "alpardes".`,
 	},

--- a/packages/framework/tree-agent/src/test/scenarios/addUsers.ts
+++ b/packages/framework/tree-agent/src/test/scenarios/addUsers.ts
@@ -19,6 +19,7 @@ const expected: ScorableVerboseTree = {
 			["rymagani", "Ryan Magani"],
 			["tawilliams", "Taylor Williams"],
 			["chdog", "Chewy Dog"],
+			["timagani", "Timmy Magani"],
 		]);
 		let score = 1;
 		for (const [id, name] of required) {
@@ -39,6 +40,16 @@ const expected: ScorableVerboseTree = {
 				score -= 1 / required.size;
 				continue;
 			}
+		}
+		const timmy = actual.fields.timagani;
+		if (
+			timmy !== undefined &&
+			(typeof timmy !== "object" ||
+				timmy === null ||
+				Array.isArray(timmy.fields) ||
+				timmy.fields.email !== "ringom@gmail.com")
+		) {
+			score *= 2 / 3;
 		}
 		// Penalize if there are more than 4 users (encourage precision)
 		const actualKeys = Object.keys(actual.fields);
@@ -68,6 +79,7 @@ export const addUsersTest = {
 			email: "ringom@gmail.com",
 		},
 	}),
-	prompt: "Please add two new users to this database: Taylor Williams and Chewy Dog.",
+	prompt:
+		"Please add two new users to this database: Taylor Williams and Chewy Dog. Then, add one more user for Ryan's little brother. His name is Timmy, and he has the same email as Ryan.",
 	expected,
 } as const satisfies LLMIntegrationTest<typeof Users>;

--- a/packages/framework/tree-agent/src/typeGeneration.ts
+++ b/packages/framework/tree-agent/src/typeGeneration.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import {
 	FieldKind,
@@ -137,6 +137,19 @@ function getOrCreateType(
 				}
 				return z.object(properties).describe(simpleNodeSchema.metadata?.description ?? "");
 			}
+			case NodeKind.Map: {
+				return z
+					.map(
+						z.string(),
+						getTypeForAllowedTypes(
+							definitionMap,
+							simpleNodeSchema.allowedTypesIdentifiers,
+							objectCache,
+							treeSchemaMap,
+						),
+					)
+					.describe(simpleNodeSchema.metadata?.description ?? "");
+			}
 			case NodeKind.Record: {
 				return z
 					.record(
@@ -181,7 +194,7 @@ function getOrCreateType(
 				}
 			}
 			default: {
-				throw new Error(`Unsupported node kind ${NodeKind[simpleNodeSchema.kind]}.`);
+				return unreachableCase(simpleNodeSchema, "Unknown node kind");
 			}
 		}
 	});

--- a/packages/framework/tree-agent/src/utils.ts
+++ b/packages/framework/tree-agent/src/utils.ts
@@ -280,6 +280,9 @@ export function getZodSchemaAsTypeScript(schema: Record<string, z.ZodType>): str
 			case z.ZodFirstPartyTypeKind.ZodRecord: {
 				return appendRecordType(type);
 			}
+			case z.ZodFirstPartyTypeKind.ZodMap: {
+				return appendMapType(type);
+			}
 			case z.ZodFirstPartyTypeKind.ZodLiteral: {
 				return appendLiteral((type._def as z.ZodLiteralDef).value);
 			}
@@ -419,6 +422,14 @@ export function getZodSchemaAsTypeScript(schema: Record<string, z.ZodType>): str
 		appendType((recordType._def as z.ZodRecordDef).keyType);
 		append(", ");
 		appendType((recordType._def as z.ZodRecordDef).valueType);
+		append(">");
+	}
+
+	function appendMapType(mapType: z.ZodType) {
+		append("Map<");
+		appendType((mapType._def as z.ZodMapDef).keyType);
+		append(", ");
+		appendType((mapType._def as z.ZodMapDef).valueType);
 		append(">");
 	}
 


### PR DESCRIPTION
## Description

This adds support for SharedTree maps to the tree-agent LLM library. Maps are given special treatment when serializing and, like arrays, have special consideration in the system prompt. This may or may not be the long term solution for maps, but it means we are now at parity - all SharedTree nodes types are supported. 

Map nodes are serialized in a record-like fashion with an in-line comment noting that they are maps, not objects/records, to avoid confusion for the reader/LLM. A new section on editing maps has been added to the system prompt, just like we have for editing arrays. The system prompt has had some general reorganization done as well.

Alongside adding the necessary support for map nodes through type/id generation code, this PR also replaces a few sketchy type checks with the proper SharedTree APIs now that they are available. 

The "Users" test scenario has also been updated to work (for now) against maps - basic writing and reading of maps has been successful on all runs. Below is a log of an example run.

----

# Fluid Framework SharedTree AI Agent Log

Agent created: **Monday, September 15, 2025 at 3:15:10 PM**

Model: **o3 Mini**

## System Prompt

You are a collaborative agent who assists a user with editing and analyzing a JSON tree.
The tree is a JSON object with the following Typescript schema:

```typescript
// A user in the system
interface User {
    name: string; // The user's full name
    created: string; // The ISO-8601 timestamp when the user was created
    email?: string; // The user's email address
}

// A collection of users in the system. The keys are user IDs. A user ID is always the first two letters of the user's first name followed by their full last name. For example, the user ID for "Alex Pardes" is "alpardes".
type Users = Map<string, User>;

```

The current state of the tree (a `Users`) is:

```JSON
{
  // Note: This is a map that has been serialized to JSON. It is not a key-value object/record but is being printed as such.,
  "alpardes": {
    "name": "Alex Pardes",
    "created": "2024-01-01T00:00:00.000Z",
    "email": "pardesio@gmail.com"
  },
  "rymagani": {
    "name": "Ryan Magani",
    "created": "2024-02-01T00:00:00.000Z",
    "email": "ringom@gmail.com"
  }
}
```

If the user asks you a question about the tree, you should inspect the state of the tree and answer the question.
If the user asks you to edit the tree, you should use the "GenerateTreeEditingCode" tool to accomplish the user-specified goal, following the instructions for editing detailed below.
After editing the tree, review the latest state of the tree to see if it satisfies the user's request.
If it does not, or if you receive an error, you may try again with a different approach.
Once the tree is in the desired state, you should inform the user that the request has been completed.

### Editing

If the user asks you to edit the data, you will use the "GenerateTreeEditingCode" tool to write a JavaScript function that mutates the data in-place to achieve the user's goal.
The function must be named "editTree".
It may be synchronous or asynchronous.
The editTree function must have a first parameter which has a `root` property.
This `root` property holds the current state of the tree as shown above.
You may mutate any part of the tree as necessary, taking into account the caveats around arrays and maps detailed below.
You may also set the `root` property to be an entirely new value as long as it is one of the types allowed at the root of the tree (`Users`).

#### Editing Arrays

The arrays in the tree are somewhat different than normal JS `Array`s.
Read-only operations are generally the same - you can create them, read via index, and call non-mutating methods like `concat`, `map`, `filter`, `find`, `forEach`, `indexOf`, `slice`, `join`, etc.
However, write operations (e.g. index assignment, `push`, `pop`, `splice`, etc.) are not supported.
Instead, you must use the methods on the following interface to mutate the array:

```typescript
/** A special type of array which implements 'readonly T[]' (i.e. it supports all read-only JS array methods) and provides custom array mutation APIs. */
export interface TreeArray<T> extends ReadonlyArray<T> {
	/**
	 * Inserts new item(s) at a specified location.
	 * @param index - The index at which to insert `value`.
	 * @param value - The content to insert.
	 * @throws Throws if `index` is not in the range [0, `array.length`).
	 */
	insertAt(index: number, ...value: readonly T[]): void;

	/**
	 * Removes the item at the specified location.
	 * @param index - The index at which to remove the item.
	 * @throws Throws if `index` is not in the range [0, `array.length`).
	 */
	removeAt(index: number): void;

	/**
	 * Removes all items between the specified indices.
	 * @param start - The starting index of the range to remove (inclusive). Defaults to the start of the array.
	 * @param end - The ending index of the range to remove (exclusive). Defaults to `array.length`.
	 * @throws Throws if `start` is not in the range [0, `array.length`].
	 * @throws Throws if `end` is less than `start`.
	 * If `end` is not supplied or is greater than the length of the array, all items after `start` are removed.
	 *
	 * @remarks
	 * The default values for start and end are computed when this is called,
	 * and thus the behavior is the same as providing them explicitly, even with respect to merge resolution with concurrent edits.
	 * For example, two concurrent transactions both emptying the array with `node.removeRange()` then inserting an item,
	 * will merge to result in the array having both inserted items.
	 */
	removeRange(start?: number, end?: number): void;

	/**
	 * Moves the specified item to the desired location in the array.
	 *
	 * WARNING - This API is easily misused.
	 * Please read the documentation for the `destinationGap` parameter carefully.
	 *
	 * @param destinationGap - The location *between* existing items that the moved item should be moved to.
	 *
	 * WARNING - `destinationGap` describes a location between existing items *prior to applying the move operation*.
	 *
	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationGap` must be one of the following:
	 *
	 * - `0` (between the start of the array and `A`'s original position)
	 * - `1` (between `A`'s original position and `B`'s original position)
	 * - `2` (between `B`'s original position and `C`'s original position)
	 * - `3` (between `C`'s original position and the end of the array)
	 *
	 * So moving `A` between `B` and `C` would require `destinationGap` to be `2`.
	 *
	 * This interpretation of `destinationGap` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
	 * or relative to the start or end of the array:
	 *
	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
	 * - Move to before some item X: `array.moveToIndex(indexOfX, ...)`
	 * - Move to after some item X: `array.moveToIndex(indexOfX + 1`, ...)
	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
	 *
	 * This interpretation of `destinationGap` does however make it less obvious how to move an item relative to its current position:
	 *
	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
	 *
	 * Notice the asymmetry between `-1` and `+2` in the above examples.
	 * In such scenarios, it can often be easier to approach such edits by swapping adjacent items:
	 * If items A and B are adjacent, such that A precedes B,
	 * then they can be swapped with `array.moveToIndex(indexOfA, indexOfB)`.
	 *
	 * @param sourceIndex - The index of the item to move.
	 * @param source - The optional source array to move the item out of (defaults to this array).
	 * @throws Throws if any of the source index is not in the range [0, `array.length`),
	 * or if the index is not in the range [0, `array.length`].
	 */
	moveToIndex(destinationGap: number, sourceIndex: number, source?: TreeArray<T>): void;

	/**
	 * Moves the specified items to the desired location within the array.
	 *
	 * WARNING - This API is easily misused.
	 * Please read the documentation for the `destinationGap` parameter carefully.
	 *
	 * @param destinationGap - The location *between* existing items that the moved item should be moved to.
	 *
	 * WARNING - `destinationGap` describes a location between existing items *prior to applying the move operation*.
	 *
	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationGap` must be one of the following:
	 *
	 * - `0` (between the start of the array and `A`'s original position)
	 * - `1` (between `A`'s original position and `B`'s original position)
	 * - `2` (between `B`'s original position and `C`'s original position)
	 * - `3` (between `C`'s original position and the end of the array)
	 *
	 * So moving `A` between `B` and `C` would require `destinationGap` to be `2`.
	 *
	 * This interpretation of `destinationGap` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
	 * or relative to the start or end of the array:
	 *
	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
	 * - Move to before some item X: `array.moveToIndex(indexOfX, ...)`
	 * - Move to after some item X: `array.moveToIndex(indexOfX + 1`, ...)
	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
	 *
	 * This interpretation of `destinationGap` does however make it less obvious how to move an item relative to its current position:
	 *
	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
	 *
	 * Notice the asymmetry between `-1` and `+2` in the above examples.
	 * In such scenarios, it can often be easier to approach such edits by swapping adjacent items:
	 * If items A and B are adjacent, such that A precedes B,
	 * then they can be swapped with `array.moveToIndex(indexOfA, indexOfB)`.
	 *
	 * @param sourceStart - The starting index of the range to move (inclusive).
	 * @param sourceEnd - The ending index of the range to move (exclusive)
	 * @param source - The optional source array to move items out of (defaults to this array).
	 * @throws Throws if the types of any of the items being moved are not allowed in the destination array,
	 * if any of the input indices are not in the range [0, `array.length`], or if `sourceStart` is greater than `sourceEnd`.
	 */
	moveRangeToIndex(
		destinationGap: number,
		sourceStart: number,
		sourceEnd: number,
		source?: TreeArray<T>,
	): void;
}
```

#### Editing Maps

The maps in the tree are somewhat different than normal JS `Map`s.
Map keys are always strings.
Read-only operations are generally the same - you can create them, read via `get`, and call non-mutating methods like `has`, `forEach`, `entries`, `keys`, `values`, etc. (note the subtle differences around return values and iteration order).
However, write operations (e.g. `set`, `delete`, etc.) are not supported.
Instead, you must use the methods on the following interface to mutate the map:

```typescript
/**
 * A map of string keys to tree objects.
 */
export interface TreeMap<T> extends ReadonlyMap<string, T> {
	/**
	 * Adds or updates an entry in the map with a specified `key` and a `value`.
	 *
	 * @param key - The key of the element to add to the map.
	 * @param value - The value of the element to add to the map.
	 *
	 * @remarks
	 * Setting the value at a key to `undefined` is equivalent to calling {@link TreeMap.delete} with that key.
	 */
	set(key: string, value: T | undefined): void;

	/**
	 * Removes the specified element from this map by its `key`.
	 *
	 * @remarks
	 * Note: unlike JavaScript's Map API, this method does not return a flag indicating whether or not the value was
	 * deleted.
	 *
	 * @param key - The key of the element to remove from the map.
	 */
	delete(key: string): void;

	/**
	 * Returns an iterable of keys in the map.
	 *
	 * @remarks
	 * Note: no guarantees are made regarding the order of the keys returned.
	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
	 */
	keys(): IterableIterator<string>;

	/**
	 * Returns an iterable of values in the map.
	 *
	 * @remarks
	 * Note: no guarantees are made regarding the order of the values returned.
	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
	 */
	values(): IterableIterator<T>;

	/**
	 * Returns an iterable of key/value pairs for every entry in the map.
	 *
	 * @remarks
	 * Note: no guarantees are made regarding the order of the entries returned.
	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
	 */
	entries(): IterableIterator<[string, T]>;

	/**
	 * Executes the provided function once per each key/value pair in this map.
	 *
	 * @remarks
	 * Note: no guarantees are made regarding the order in which the function is called with respect to the map's entries.
	 * If your usage scenario depends on consistent ordering, you will need to sort these yourself.
	 */
	forEach(
		callbackfn: (
			value: T,
			key: string,
			map: ReadonlyMap<string, T>,
		) => void,
		thisArg?: any,
	): void;
}
```

### Additional Notes

Before outputting the editTree function, you should check that it is valid according to both the application tree's schema and the restrictions of the editing language (e.g. the array methods you are allowed to use).

When possible, ensure that the edits preserve the identity of objects already in the tree (for example, prefer `array.moveToIndex` or `array.moveRange` over `array.removeAt` + `array.insertAt`).

Once data has been removed from the tree (e.g. replaced via assignment, or removed from an array), that data cannot be re-inserted into the tree - instead, it must be deep cloned and recreated.

When constructing new objects, you should wrap them in the appropriate builder function rather than simply making a javascript object.
The builders are available on the "create" property on the first argument of the `editTree` function and are named according to the type that they create.
For example:
		
```javascript
function editTree({ root, create }) {
	// This creates a new Users object:
	const users = create.Users({ /* ...properties... */ });
	// Don't do this:
	// const users = { /* ...properties... */ };
}
```

Finally, double check that the edits would accomplish the user's request (if it is possible).

## User Query

Please add two new users to this database: Taylor Williams and Chewy Dog. Then, add one more user for Ryan's little brother. His name is Timmy, and he has the same email as Ryan.

## Response 1



### Editing Tool Invoked

#### Generated Code

```javascript
function editTree({ root, create }) {
  // Use the current timestamp for the creation date
  const now = new Date().toISOString();

  // Add Taylor Williams
  root.set(
    "tawilliams",
    create.User({
      name: "Taylor Williams",
      created: now
    })
  );

  // Add Chewy Dog
  root.set(
    "chdog",
    create.User({
      name: "Chewy Dog",
      created: now
    })
  );

  // Add Timmy Magani with the same email as Ryan
  const ryan = root.get("rymagani");
  const ryanEmail = ryan?.email;
  root.set(
    "timagani",
    create.User({
      name: "Timmy Magani",
      created: now,
      email: ryanEmail
    })
  );
}
```

#### New Tree State

```JSON
{
  // Note: This is a map that has been serialized to JSON. It is not a key-value object/record but is being printed as such.,
  "alpardes": {
    "name": "Alex Pardes",
    "created": "2024-01-01T00:00:00.000Z",
    "email": "pardesio@gmail.com"
  },
  "rymagani": {
    "name": "Ryan Magani",
    "created": "2024-02-01T00:00:00.000Z",
    "email": "ringom@gmail.com"
  },
  "tawilliams": {
    "name": "Taylor Williams",
    "created": "2025-09-15T22:15:46.221Z"
  },
  "chdog": {
    "name": "Chewy Dog",
    "created": "2025-09-15T22:15:46.221Z"
  },
  "timagani": {
    "name": "Timmy Magani",
    "created": "2025-09-15T22:15:46.221Z",
    "email": "ringom@gmail.com"
  }
}
```

## Response 2

I’ve added Taylor Williams, Chewy Dog, and Timmy Magani (Ryan’s little brother, with the same email as Ryan). Let me know if you need any further edits!
