### PR TITLE
refactor(api-markdown-documenter): Reorganize utility modules 

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
@@ -28,13 +28,13 @@ import type { ApiDocument } from "../ApiDocument.js";
 import type { Section } from "../mdast/index.js";
 import { getApiItemKind } from "../utilities/index.js";
 
-import {
-	doesItemRequireOwnDocument,
-	shouldItemBeIncluded,
-} from "./ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 import { createBreadcrumbParagraph } from "./helpers/index.js";
-import { createDocument } from "./utilities/index.js";
+import {
+	createDocument,
+	doesItemRequireOwnDocument,
+	shouldItemBeIncluded,
+} from "./utilities/index.js";
 
 /**
  * Creates a {@link ApiDocument} for the specified `apiItem`.

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
@@ -32,9 +32,9 @@ import {
 	doesItemRequireOwnDocument,
 	shouldItemBeIncluded,
 } from "./ApiItemTransformUtilities.js";
-import { createDocument } from "./Utilities.js";
 import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 import { createBreadcrumbParagraph } from "./helpers/index.js";
+import { createDocument } from "./utilities/index.js";
 
 /**
  * Creates a {@link ApiDocument} for the specified `apiItem`.

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -14,10 +14,6 @@ import {
 import type { ApiDocument } from "../ApiDocument.js";
 import type { Section } from "../mdast/index.js";
 
-import {
-	doesItemRequireOwnDocument,
-	shouldItemBeIncluded,
-} from "./ApiItemTransformUtilities.js";
 import { apiItemToDocument, apiItemToSections } from "./TransformApiItem.js";
 import {
 	type ApiItemTransformationConfiguration,
@@ -25,7 +21,12 @@ import {
 	getApiItemTransformationConfigurationWithDefaults,
 } from "./configuration/index.js";
 import { createBreadcrumbParagraph, createEntryPointList } from "./helpers/index.js";
-import { checkForDuplicateDocumentPaths, createDocument } from "./utilities/index.js";
+import {
+	checkForDuplicateDocumentPaths,
+	createDocument,
+	doesItemRequireOwnDocument,
+	shouldItemBeIncluded,
+} from "./utilities/index.js";
 
 /**
  * Renders the provided model and its contents to a series of {@link ApiDocument}s.

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -19,13 +19,13 @@ import {
 	shouldItemBeIncluded,
 } from "./ApiItemTransformUtilities.js";
 import { apiItemToDocument, apiItemToSections } from "./TransformApiItem.js";
-import { checkForDuplicateDocumentPaths, createDocument } from "./Utilities.js";
 import {
 	type ApiItemTransformationConfiguration,
 	type ApiItemTransformationOptions,
 	getApiItemTransformationConfigurationWithDefaults,
 } from "./configuration/index.js";
 import { createBreadcrumbParagraph, createEntryPointList } from "./helpers/index.js";
+import { checkForDuplicateDocumentPaths, createDocument } from "./utilities/index.js";
 
 /**
  * Renders the provided model and its contents to a series of {@link ApiDocument}s.

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -34,8 +34,8 @@ import type {
 
 import type { LoggingConfiguration } from "../LoggingConfiguration.js";
 
-import { resolveSymbolicLink } from "./Utilities.js";
 import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
+import { resolveSymbolicLink } from "./utilities/index.js";
 
 /**
  * Library of transformations from {@link https://github.com/microsoft/tsdoc/blob/main/tsdoc/src/nodes/DocNode.ts| DocNode}s

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Hierarchy.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Hierarchy.ts
@@ -10,7 +10,7 @@ import {
 	getUnscopedPackageName,
 	type ValidApiItemKind,
 } from "../../utilities/index.js";
-import { createQualifiedDocumentNameForApiItem } from "../ApiItemTransformUtilities.js";
+import { createQualifiedDocumentNameForApiItem } from "../utilities/index.js";
 
 /**
  * Kind of documentation suite hierarchy.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/CreateSectionForApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/CreateSectionForApiItem.ts
@@ -7,10 +7,6 @@ import { type ApiItem, ReleaseTag } from "@microsoft/api-extractor-model";
 
 import type { Section } from "../../mdast/index.js";
 import { getEffectiveReleaseLevel } from "../../utilities/index.js";
-import {
-	doesItemRequireOwnDocument,
-	getHeadingForApiItem,
-} from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import {
 	alphaWarningSpan,
@@ -23,6 +19,7 @@ import {
 	createSummarySection,
 	createThrowsSection,
 } from "../helpers/index.js";
+import { doesItemRequireOwnDocument, getHeadingForApiItem } from "../utilities/index.js";
 
 /**
  * Default {@link ApiItemTransformationConfiguration.defaultSectionLayout} implementation.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -12,9 +12,9 @@ import {
 
 import type { Section, SectionContent } from "../../mdast/index.js";
 import { getApiItemKind, getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
-import { getFilteredMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createMemberTables } from "../helpers/index.js";
+import { getFilteredMembers } from "../utilities/index.js";
 
 /**
  * Default documentation transform for `Enum` items.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -18,9 +18,9 @@ import {
 import type { Section } from "../../mdast/index.js";
 import type { ApiModuleLike } from "../../utilities/index.js";
 import { getApiItemKind, getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
-import { filterItems } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
+import { filterItems } from "../utilities/index.js";
 
 /**
  * Default documentation transform for module-like API items (packages, namespaces).

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiTypeLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiTypeLike.ts
@@ -21,9 +21,9 @@ import {
 	isStatic,
 	type ApiTypeLike,
 } from "../../utilities/index.js";
-import { getFilteredMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
+import { getFilteredMembers } from "../utilities/index.js";
 
 /**
  * Default documentation transform for {@link ApiTypeLike | type-like} API items.

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -54,15 +54,12 @@ import {
 	type ValidApiItemKind,
 	getFilteredParent,
 } from "../../utilities/index.js";
-import {
-	doesItemKindRequireOwnDocument,
-	getLinkForApiItem,
-} from "../ApiItemTransformUtilities.js";
 import { transformTsdoc } from "../TsdocNodeTransforms.js";
 import {
 	HierarchyKind,
 	type ApiItemTransformationConfiguration,
 } from "../configuration/index.js";
+import { doesItemKindRequireOwnDocument, getLinkForApiItem } from "../utilities/index.js";
 
 import {
 	createParametersSummaryTable,

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -28,9 +28,9 @@ import {
 	getModifiers,
 	injectSeparator,
 } from "../../utilities/index.js";
-import { getLinkForApiItem } from "../ApiItemTransformUtilities.js";
 import { transformTsdoc } from "../TsdocNodeTransforms.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+import { getLinkForApiItem } from "../utilities/index.js";
 
 import { createExcerptSpanWithHyperlinks } from "./Helpers.js";
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/index.ts
@@ -15,7 +15,7 @@ export {
 	getHeadingForApiItem,
 	getLinkForApiItem,
 	shouldItemBeIncluded,
-} from "./ApiItemTransformUtilities.js";
+} from "./utilities/index.js";
 export {
 	type ApiItemTransformationConfiguration,
 	type ApiItemTransformationConfigurationBase,

--- a/tools/api-markdown-documenter/src/api-item-transforms/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/index.ts
@@ -53,4 +53,4 @@ export {
 export { transformTsdoc } from "./TsdocNodeTransforms.js";
 export { apiItemToDocument, apiItemToSections } from "./TransformApiItem.js";
 export { transformApiModel } from "./TransformApiModel.js";
-export { checkForDuplicateDocumentPaths } from "./Utilities.js";
+export { checkForDuplicateDocumentPaths } from "./utilities/index.js";

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/ApiItemTransformUtilities.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/ApiItemTransformUtilities.test.ts
@@ -7,7 +7,7 @@ import type { ApiItem } from "@microsoft/api-extractor-model";
 import { expect } from "chai";
 
 import type { ApiItemTransformationConfiguration } from "../../api-item-transforms/index.js";
-import { isItemOrAncestorExcluded } from "../ApiItemTransformUtilities.js";
+import { isItemOrAncestorExcluded } from "../utilities/index.js";
 
 describe("ApiItemTransformUtilities", () => {
 	describe("isItemOrAncestorExcluded", () => {

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
@@ -8,15 +8,14 @@ import { strict as assert } from "node:assert";
 import { type ApiItem, ApiItemKind } from "@microsoft/api-extractor-model";
 import type { Link } from "mdast";
 
-import type { SectionHeading } from "../mdast/index.js";
+import type { SectionHeading } from "../../mdast/index.js";
 import {
 	getApiItemKind,
 	getFilteredParent,
 	getFileSafeNameForApiItem,
 	type ValidApiItemKind,
 	getEffectiveReleaseLevel,
-} from "../utilities/index.js";
-
+} from "../../utilities/index.js";
 import {
 	FolderDocumentPlacement,
 	HierarchyKind,
@@ -25,7 +24,7 @@ import {
 	type FolderHierarchyConfiguration,
 	type DocumentationHierarchyConfiguration,
 	type HierarchyConfiguration,
-} from "./configuration/index.js";
+} from "../configuration/index.js";
 
 /**
  * This module contains `ApiItem`-related utilities for use in transformation logic.

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/DocumentUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/DocumentUtilities.ts
@@ -4,20 +4,11 @@
  */
 
 import type { ApiItem } from "@microsoft/api-extractor-model";
-import type { DocDeclarationReference } from "@microsoft/tsdoc";
-import type { Link } from "mdast";
 
-import type { ApiDocument } from "../ApiDocument.js";
-import type { Section } from "../mdast/index.js";
-import { normalizeDocumentContents } from "../mdast/index.js";
-import { resolveSymbolicReference } from "../utilities/index.js";
-
-import {
-	getDocumentPathForApiItem,
-	getLinkForApiItem,
-	shouldItemBeIncluded,
-} from "./ApiItemTransformUtilities.js";
-import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
+import type { ApiDocument } from "../../ApiDocument.js";
+import { normalizeDocumentContents, type Section } from "../../mdast/index.js";
+import { getDocumentPathForApiItem } from "../ApiItemTransformUtilities.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 
 /**
  * Creates a {@link ApiDocument} representing the provided API item.
@@ -58,37 +49,6 @@ export function createDocument(
 		contents: normalizedContents,
 		documentPath: getDocumentPathForApiItem(documentItem, config.hierarchy),
 	};
-}
-
-/**
- * Resolves a symbolic link and creates a URL to the target.
- *
- * @param contextApiItem - See {@link TsdocNodeTransformOptions.contextApiItem}.
- * @param codeDestination - The link reference target.
- * @param config - See {@link ApiItemTransformationConfiguration}.
- */
-export function resolveSymbolicLink(
-	contextApiItem: ApiItem,
-	codeDestination: DocDeclarationReference,
-	config: ApiItemTransformationConfiguration,
-): Link | undefined {
-	const { apiModel, logger } = config;
-
-	let resolvedReference: ApiItem;
-	try {
-		resolvedReference = resolveSymbolicReference(contextApiItem, codeDestination, apiModel);
-	} catch (error: unknown) {
-		logger.warning((error as Error).message);
-		return undefined;
-	}
-
-	// Return undefined if the resolved API item should be excluded based on release tags
-	if (!shouldItemBeIncluded(resolvedReference, config)) {
-		logger.verbose("Excluding link to item based on release tags");
-		return undefined;
-	}
-
-	return getLinkForApiItem(resolvedReference, config);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/DocumentUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/DocumentUtilities.ts
@@ -7,8 +7,9 @@ import type { ApiItem } from "@microsoft/api-extractor-model";
 
 import type { ApiDocument } from "../../ApiDocument.js";
 import { normalizeDocumentContents, type Section } from "../../mdast/index.js";
-import { getDocumentPathForApiItem } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
+import { getDocumentPathForApiItem } from "./ApiItemTransformUtilities.js";
 
 /**
  * Creates a {@link ApiDocument} representing the provided API item.

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/ReferenceUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/ReferenceUtilities.ts
@@ -8,8 +8,9 @@ import type { DocDeclarationReference } from "@microsoft/tsdoc";
 import type { Link } from "mdast";
 
 import { resolveSymbolicReference } from "../../utilities/index.js";
-import { getLinkForApiItem, shouldItemBeIncluded } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
+import { getLinkForApiItem, shouldItemBeIncluded } from "./ApiItemTransformUtilities.js";
 
 /**
  * Resolves a symbolic link and creates a URL to the target.

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/ReferenceUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/ReferenceUtilities.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ApiItem } from "@microsoft/api-extractor-model";
+import type { DocDeclarationReference } from "@microsoft/tsdoc";
+import type { Link } from "mdast";
+
+import { resolveSymbolicReference } from "../../utilities/index.js";
+import { getLinkForApiItem, shouldItemBeIncluded } from "../ApiItemTransformUtilities.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
+/**
+ * Resolves a symbolic link and creates a URL to the target.
+ *
+ * @param contextApiItem - See {@link TsdocNodeTransformOptions.contextApiItem}.
+ * @param codeDestination - The link reference target.
+ * @param config - See {@link ApiItemTransformationConfiguration}.
+ */
+export function resolveSymbolicLink(
+	contextApiItem: ApiItem,
+	codeDestination: DocDeclarationReference,
+	config: ApiItemTransformationConfiguration,
+): Link | undefined {
+	const { apiModel, logger } = config;
+
+	let resolvedReference: ApiItem;
+	try {
+		resolvedReference = resolveSymbolicReference(contextApiItem, codeDestination, apiModel);
+	} catch (error: unknown) {
+		logger.warning((error as Error).message);
+		return undefined;
+	}
+
+	// Return undefined if the resolved API item should be excluded based on release tags
+	if (!shouldItemBeIncluded(resolvedReference, config)) {
+		logger.verbose("Excluding link to item based on release tags");
+		return undefined;
+	}
+
+	return getLinkForApiItem(resolvedReference, config);
+}

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/index.ts
@@ -3,5 +3,16 @@
  * Licensed under the MIT License.
  */
 
+export {
+	createQualifiedDocumentNameForApiItem,
+	doesItemRequireOwnDocument,
+	doesItemKindRequireOwnDocument,
+	filterItems,
+	getFilteredMembers,
+	getHeadingForApiItem,
+	getLinkForApiItem,
+	isItemOrAncestorExcluded,
+	shouldItemBeIncluded,
+} from "./ApiItemTransformUtilities.js";
 export { createDocument, checkForDuplicateDocumentPaths } from "./DocumentUtilities.js";
 export { resolveSymbolicLink } from "./ReferenceUtilities.js";

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { createDocument, checkForDuplicateDocumentPaths } from "./DocumentUtilities.js";
+export { resolveSymbolicLink } from "./ReferenceUtilities.js";

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/test/ApiItemTransformUtilities.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/test/ApiItemTransformUtilities.test.ts
@@ -6,8 +6,8 @@
 import type { ApiItem } from "@microsoft/api-extractor-model";
 import { expect } from "chai";
 
-import type { ApiItemTransformationConfiguration } from "../../api-item-transforms/index.js";
-import { isItemOrAncestorExcluded } from "../utilities/index.js";
+import type { ApiItemTransformationConfiguration } from "../../index.js";
+import { isItemOrAncestorExcluded } from "../index.js";
 
 describe("ApiItemTransformUtilities", () => {
 	describe("isItemOrAncestorExcluded", () => {

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/test/DocumentUtilities.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/test/DocumentUtilities.test.ts
@@ -5,10 +5,10 @@
 
 import { expect } from "chai";
 
-import type { ApiDocument } from "../../ApiDocument.js";
-import { checkForDuplicateDocumentPaths } from "../Utilities.js";
+import type { ApiDocument } from "../../../ApiDocument.js";
+import { checkForDuplicateDocumentPaths } from "../index.js";
 
-describe("ApiItem to Documentation transformation utilities tests", () => {
+describe("DocumentUtilities tests", () => {
 	describe("checkForDuplicateDocumentPaths", () => {
 		it("Empty list", () => {
 			expect(() => checkForDuplicateDocumentPaths([])).to.not.throw();


### PR DESCRIPTION
Move various "utilities" modules into a "utilities" directory.