### PR TITLE
Smoke test tree CJS

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -130,7 +130,7 @@
 		"test:customBenchmarks:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:customBenchmarks",
 		"test:memory": "mocha --perfMode --config ./src/test/memory/.mocharc.cjs",
 		"test:memory-profiling:report": "mocha --config ./src/test/memory/.mocharc.cjs",
-		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
+		"test:mocha": "npm run test:mocha:esm && echo skipping non-smoke cjs to avoid overhead && npm run test:mocha:cjs -- --fgrep @Smoke",
 		"test:mocha:cjs": "cross-env MOCHA_SPEC=dist/test mocha",
 		"test:mocha:esm": "mocha",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -130,7 +130,7 @@
 		"test:customBenchmarks:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:customBenchmarks",
 		"test:memory": "mocha --perfMode --config ./src/test/memory/.mocharc.cjs",
 		"test:memory-profiling:report": "mocha --config ./src/test/memory/.mocharc.cjs",
-		"test:mocha": "npm run test:mocha:esm && echo skipping non-smoke cjs to avoid overhead && npm run test:mocha:cjs -- --fgrep @Smoke",
+		"test:mocha": "echo skipping non-smoke cjs to avoid overhead && npm run test:mocha:cjs -- --fgrep @Smoke && npm run test:mocha:esm",
 		"test:mocha:cjs": "cross-env MOCHA_SPEC=dist/test mocha",
 		"test:mocha:esm": "mocha",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",

--- a/packages/dds/tree/src/test/README.md
+++ b/packages/dds/tree/src/test/README.md
@@ -25,6 +25,17 @@ Note that the fact that this approach is always possible does not make it the be
 
 Any other kinds of test files should be documented when created by adding them to this list.
 
+## Test Tagging
+
+Tests can be [tagged](https://mochajs.org/next/explainers/tagging/).
+
+This currently has a few uses:
+
+- The `@fluid-tools/benchmark` uses tags to identify its benchmarks.
+- `@Smoke` is used to identify a small number of cheap to run tests which can be included in [smoke tests](https://en.wikipedia.org/wiki/Smoke_testing_(software)) and run when its not worth running all the tests.
+Currently this is applied to the CJS tests to ensure that the CJS build functions at all while avoiding running the full mostly redundant suite for it.
+This may be applied to other configuration in the future.
+
 ## Document Status
 
 This is written aspirationalally: much of our current test suite only roughly approximates the patterns described above.

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -164,7 +164,7 @@ describe("SharedTree", () => {
 	});
 
 	describe("viewWith", () => {
-		it("initialize tree", () => {
+		it("@Smoke initialize tree", () => {
 			const tree = treeTestFactory();
 			assert.deepEqual(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 


### PR DESCRIPTION
## Description

Introduce the idea of smoke tests in tree, and use it to enable a single test to run on CI for the CJS built (instead of none).

As appropriate tests are found, more can be opted in.

Including startup, running this smoke test suite takes under 2 seconds, so it should not significantly regress CI time.

This pattern is planned to also support prod mode added in https://github.com/microsoft/FluidFramework/pull/24013 so it can have at least some minimal coverage on CI as well.

This will guard again having test configs which are full broken (like happened with experimental/tree's ESM build recently) as well as help detect if the package itself has major issues in the smoke tested config.

Note that due to the fact that the CI test results viewer does not fails to handle multiple tests runs from a single package, resulting in the test results clobbering each other, this removes the 12594 test results from tree, and replaces them with the single results from the cjs run. This is a known and preexisting issues which also impacts other packages.

All the tests still ran however, and if they were failing should show up in the log and fail the CI run, just not the test browser GUI.

I can confirm however that the code coverage from both runs is getting merged as it did not regress and instead covered the same lines, but found a few new branches (which were covered), likely due to some oddities of how the branch coverage is implemented and/or how CJS was compiled (for example one of the changes was binding two branches in a line which was just a function declaration, and another was in an index.ts file.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
