### PR TITLE
refactor(api-markdown-documenter): Remove unneeded `getFilteredMembers` helper

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
@@ -268,7 +268,7 @@ export namespace DocumentWriter {
 }
 
 // @public
-function filterItems(apiItems: readonly ApiItem[], config: ApiItemTransformationConfiguration): ApiItem[];
+function filterItems<TApiItem extends ApiItem>(apiItems: readonly TApiItem[], config: ApiItemTransformationConfiguration): TApiItem[];
 
 // @public
 export enum FolderDocumentPlacement {

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -14,7 +14,7 @@ import type { Section, SectionContent } from "../../mdast/index.js";
 import { getApiItemKind, getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createMemberTables } from "../helpers/index.js";
-import { getFilteredMembers } from "../utilities/index.js";
+import { filterItems } from "../utilities/index.js";
 
 /**
  * Default documentation transform for `Enum` items.
@@ -26,7 +26,7 @@ export function transformApiEnum(
 ): Section[] {
 	const sections: Section[] = [];
 
-	const filteredChildren = getFilteredMembers(apiEnum, config);
+	const filteredChildren = filterItems(apiEnum.members, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
 		const flags: ApiEnumMember[] = [];
@@ -34,7 +34,7 @@ export function transformApiEnum(
 			const childKind = getApiItemKind(child);
 			switch (childKind) {
 				case ApiItemKind.EnumMember: {
-					flags.push(child as ApiEnumMember);
+					flags.push(child);
 					break;
 				}
 				default: {

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiTypeLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiTypeLike.ts
@@ -23,7 +23,7 @@ import {
 } from "../../utilities/index.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
-import { getFilteredMembers } from "../utilities/index.js";
+import { filterItems } from "../utilities/index.js";
 
 /**
  * Default documentation transform for {@link ApiTypeLike | type-like} API items.
@@ -71,7 +71,7 @@ export function transformApiTypeLike(
 ): Section[] {
 	const sections: Section[] = [];
 
-	const filteredChildren = getFilteredMembers(apiItem, config);
+	const filteredChildren = filterItems(apiItem.members, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
 		const constructors: ApiConstructor[] = [];

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
@@ -454,23 +454,9 @@ export function shouldItemBeIncluded(
  *
  * @public
  */
-export function filterItems(
-	apiItems: readonly ApiItem[],
+export function filterItems<TApiItem extends ApiItem>(
+	apiItems: readonly TApiItem[],
 	config: ApiItemTransformationConfiguration,
-): ApiItem[] {
+): TApiItem[] {
 	return apiItems.filter((member) => shouldItemBeIncluded(member, config));
-}
-
-/**
- * Filters and returns the child members of the provided `apiItem` to include only those desired by the user configuration.
- * Accounts for {@link DocumentationSuiteConfiguration.minimumReleaseLevel} and {@link DocumentationSuiteConfiguration.exclude}.
- *
- * @param apiItem - The API item being queried.
- * @param config - See {@link ApiItemTransformationConfiguration}.
- */
-export function getFilteredMembers(
-	apiItem: ApiItem,
-	config: ApiItemTransformationConfiguration,
-): ApiItem[] {
-	return filterItems(apiItem.members, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/index.ts
@@ -8,7 +8,6 @@ export {
 	doesItemRequireOwnDocument,
 	doesItemKindRequireOwnDocument,
 	filterItems,
-	getFilteredMembers,
 	getHeadingForApiItem,
 	getLinkForApiItem,
 	isItemOrAncestorExcluded,


### PR DESCRIPTION
Replaces usages with `filterItems`. Also improves the typing of `filterItems`.