### PR TITLE
refactor(api-markdown-documenter): Add `ApiConstructorLike` type alias

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
@@ -41,6 +41,9 @@ import { TypeParameter } from '@microsoft/api-extractor-model';
 // @public
 function ancestryHasModifierTag(apiItem: ApiItem, tagName: string): boolean;
 
+// @public
+export type ApiConstructorLike = ApiConstructor | ApiConstructSignature;
+
 // @public @sealed
 export interface ApiDocument {
     readonly apiItem: ApiItem;
@@ -49,7 +52,7 @@ export interface ApiDocument {
 }
 
 // @public
-export type ApiFunctionLike = ApiConstructSignature | ApiConstructor | ApiFunction | ApiMethod | ApiMethodSignature;
+export type ApiFunctionLike = ApiConstructorLike | ApiFunction | ApiMethod | ApiMethodSignature;
 
 export { ApiItem }
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiTypeLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiTypeLike.ts
@@ -5,7 +5,6 @@
 
 import {
 	type ApiCallSignature,
-	type ApiConstructor,
 	type ApiIndexSignature,
 	type ApiItem,
 	ApiItemKind,
@@ -19,6 +18,7 @@ import {
 	getApiItemKind,
 	getScopedMemberNameForDiagnostics,
 	isStatic,
+	type ApiConstructorLike,
 	type ApiTypeLike,
 } from "../../utilities/index.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
@@ -74,7 +74,7 @@ export function transformApiTypeLike(
 	const filteredChildren = getFilteredMembers(apiItem, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
-		const constructors: ApiConstructor[] = [];
+		const constructors: ApiConstructorLike[] = [];
 		const allProperties: ApiPropertyItem[] = [];
 		const callSignatures: ApiCallSignature[] = [];
 		const indexSignatures: ApiIndexSignature[] = [];
@@ -84,7 +84,7 @@ export function transformApiTypeLike(
 			switch (childKind) {
 				case ApiItemKind.Constructor:
 				case ApiItemKind.ConstructSignature: {
-					constructors.push(child as ApiConstructor);
+					constructors.push(child as ApiConstructorLike);
 					break;
 				}
 				case ApiItemKind.Property:

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -65,6 +65,7 @@ export {
 	verboseConsoleLogger,
 } from "./Logging.js";
 export type {
+	ApiConstructorLike,
 	ApiFunctionLike,
 	ApiMemberKind,
 	ApiModifier,

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -90,13 +90,19 @@ export type ApiMemberKind = Exclude<
 >;
 
 /**
+ * `ApiItem` union type representing constructor-like API kinds.
+ *
+ * @public
+ */
+export type ApiConstructorLike = ApiConstructor | ApiConstructSignature;
+
+/**
  * `ApiItem` union type representing function-like API kinds.
  *
  * @public
  */
 export type ApiFunctionLike =
-	| ApiConstructSignature
-	| ApiConstructor
+	| ApiConstructorLike
 	| ApiFunction
 	| ApiMethod
 	| ApiMethodSignature;


### PR DESCRIPTION
Also updates code to use it, fixing an incorrect typing bug in `TransformApiTypeLike`.