### PR TITLE
fix(api-markdown-documenter): Don't clobber required extensions with user-provided ones

### DIFF
--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/Render.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/Render.ts
@@ -56,16 +56,18 @@ export function renderDocument(
  * @param config - Markdown transformation configuration.
  */
 function renderMarkdown(tree: MdastTree, config: RenderMarkdownConfiguration): string {
+	const extensions = [
+		gfmToMarkdown({
+			tablePipeAlign: false,
+		}),
+		...(config.mdastToMarkdownOptions?.extensions ?? []),
+	];
 	const options: MdastToMarkdownOptions = {
 		emphasis: "_",
 		bullet: "-",
 		incrementListMarker: false,
-		extensions: [
-			gfmToMarkdown({
-				tablePipeAlign: false,
-			}),
-		],
 		...config.mdastToMarkdownOptions,
+		extensions,
 	};
 	return toMarkdownString(tree, options);
 }


### PR DESCRIPTION
The Markdown render was incorrectly allowing user-provided extensions to clobber the system-required `gfm` extension. This caused rendering to fail to correctly handle `gfm` content (e.g. tables) unless the user specified the extension. The code has been updated to merge the sets of extensions, rather than overriding.