### PR TITLE
improvement(api-markdown-documenter): Better table column naming

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -734,8 +734,17 @@ function createTypeExcerptCell(
  */
 function getTableHeadingTitleForApiKind(itemKind: ApiItemKind): string {
 	switch (itemKind) {
+		case ApiItemKind.CallSignature: {
+			return "Call Signature";
+		}
+		case ApiItemKind.ConstructSignature: {
+			return "Constructor";
+		}
 		case ApiItemKind.EnumMember: {
 			return "Flag";
+		}
+		case ApiItemKind.IndexSignature: {
+			return "Index Signature";
 		}
 		case ApiItemKind.MethodSignature: {
 			return ApiItemKind.Method;

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
@@ -44,7 +44,7 @@ Here are some remarks about the interface
 
 ## Call Signatures
 
-| CallSignature | Return Type | Description |
+| Call Signature | Return Type | Description |
 | - | - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) => void): any](/test-suite-a/testinterface-interface/_call_-callsignature) | any | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](/test-suite-a/testinterface-interface/_call__1-callsignature) | number | Another example call signature |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
@@ -12,6 +12,6 @@ export interface TestInterfaceWithIndexSignature
 
 ## Index Signatures
 
-| IndexSignature | Description |
+| Index Signature | Description |
 | - | - |
 | [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature) | Test index signature. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -44,7 +44,7 @@ Here are some remarks about the interface
 
 ## Call Signatures
 
-| CallSignature | Return Type | Description |
+| Call Signature | Return Type | Description |
 | - | - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) => void): any](/test-suite-a/testinterface-interface#_call_-callsignature) | any | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](/test-suite-a/testinterface-interface#_call__1-callsignature) | number | Another example call signature |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -12,7 +12,7 @@ export interface TestInterfaceWithIndexSignature
 
 ## Index Signatures
 
-| IndexSignature | Description |
+| Index Signature | Description |
 | - | - |
 | [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface#_indexer_-indexsignature) | Test index signature. |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -139,7 +139,7 @@ Here are some remarks about the interface
 
 ### Call Signatures
 
-| CallSignature | Return Type | Description |
+| Call Signature | Return Type | Description |
 | - | - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) => void): any](docs/test-suite-a#testinterface-_call_-callsignature) | any | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](docs/test-suite-a#testinterface-_call__1-callsignature) | number | Another example call signature |
@@ -368,7 +368,7 @@ export interface TestInterfaceWithIndexSignature
 
 ### Index Signatures
 
-| IndexSignature | Description |
+| Index Signature | Description |
 | - | - |
 | [\[foo: number\]: { bar: string; }](docs/test-suite-a#testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
@@ -42,7 +42,7 @@ Here are some remarks about the interface
 
 ### Call Signatures
 
-| CallSignature | Return Type | Description |
+| Call Signature | Return Type | Description |
 | - | - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) => void): any](docs/test-suite-a/testinterface-_call_-callsignature) | any | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](docs/test-suite-a/testinterface-_call__1-callsignature) | number | Another example call signature |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -10,6 +10,6 @@ export interface TestInterfaceWithIndexSignature
 
 ### Index Signatures
 
-| IndexSignature | Description |
+| Index Signature | Description |
 | - | - |
 | [\[foo: number\]: { bar: string; }](docs/test-suite-a/testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |


### PR DESCRIPTION
Space separates titles for API item kinds that are compound words. E.g. `CallSignature` -> `Call Signature`.

See updated test collateral for example impact.