### PR TITLE
test(api-markdown-documenter): Expand test suite

### DIFF
--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
@@ -4,5 +4,5 @@
 
 | Package | Description |
 | - | - |
-| [test-suite-a](/test-suite-a/) | Test package |
+| [test-suite-a](/test-suite-a/) | Test package Contains a suite of test cases for validation API documentation generation. |
 | [test-suite-b](/test-suite-b/) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/functionwithoverloads-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/functionwithoverloads-function.md
@@ -1,0 +1,23 @@
+# functionWithOverloads
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [functionWithOverloads(value)](/test-suite-a/functionwithoverloads-function)
+
+Takes a number and returns a string.
+
+<h2 id="functionwithoverloads-signature">Signature</h2>
+
+```typescript
+export declare function functionWithOverloads(value: number): string;
+```
+
+<h2 id="functionwithoverloads-parameters">Parameters</h2>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | number | A number. |
+
+<h2 id="functionwithoverloads-returns">Returns</h2>
+
+A string.
+
+**Return type**: string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/functionwithoverloads_1-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/functionwithoverloads_1-function.md
@@ -1,0 +1,23 @@
+# functionWithOverloads
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [functionWithOverloads(value)](/test-suite-a/functionwithoverloads_1-function)
+
+Takes a string and returns a boolean.
+
+<h2 id="functionwithoverloads_1-signature">Signature</h2>
+
+```typescript
+export declare function functionWithOverloads(value: string): boolean;
+```
+
+<h2 id="functionwithoverloads_1-parameters">Parameters</h2>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | string | A string. |
+
+<h2 id="functionwithoverloads_1-returns">Returns</h2>
+
+A boolean.
+
+**Return type**: boolean

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/functionwithoverloads_2-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/functionwithoverloads_2-function.md
@@ -1,0 +1,23 @@
+# functionWithOverloads
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [functionWithOverloads(value)](/test-suite-a/functionwithoverloads_2-function)
+
+Takes a boolean and returns a number.
+
+<h2 id="functionwithoverloads_2-signature">Signature</h2>
+
+```typescript
+export declare function functionWithOverloads(value: boolean): number;
+```
+
+<h2 id="functionwithoverloads_2-parameters">Parameters</h2>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | boolean | A boolean. |
+
+<h2 id="functionwithoverloads_2-returns">Returns</h2>
+
+A number.
+
+**Return type**: number

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -39,6 +39,7 @@ const foo = bar;
 | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) | An empty interface |
 | [TestInterface](/test-suite-a/testinterface-interface/) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) | Test interface that extends other interfaces |
+| [TestInterfaceWithCallSignature](/test-suite-a/testinterfacewithcallsignature-interface/) | An interface with a complex call signature. |
 | [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) | An interface with an index signature. |
 | [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) | Test interface with generic type parameter |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -2,7 +2,7 @@
 
 [Packages](/) > [test-suite-a](/test-suite-a/)
 
-Test package
+Test package Contains a suite of test cases for validation API documentation generation.
 
 <h2 id="test-suite-a-remarks">Remarks</h2>
 
@@ -59,13 +59,20 @@ const foo = bar;
 
 | TypeAlias | Description |
 | - | - |
+| [IntersectionType](/test-suite-a/intersectiontype-typealias/) | An intersection type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias/) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias/). |
 | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/) |
 | [TypeAlias](/test-suite-a/typealias-typealias/) | Test Type-Alias |
+| [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias/) | A test type with a construct signature. |
+| [TypeWithProperties](/test-suite-a/typewithproperties-typealias/) | A test type with properties. |
+| [UnionType](/test-suite-a/uniontype-typealias/) | A union type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias/) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias/). |
 
 ## Functions
 
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
+| [functionWithOverloads(value)](/test-suite-a/functionwithoverloads-function) | | string | Takes a number and returns a string. |
+| [functionWithOverloads(value)](/test-suite-a/functionwithoverloads_1-function) | | boolean | Takes a string and returns a boolean. |
+| [functionWithOverloads(value)](/test-suite-a/functionwithoverloads_2-function) | | number | Takes a boolean and returns a number. |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function) | `Alpha` | TTypeParameter | Test function |
 | [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) & [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number> | Test function that returns an inline type |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/intersectiontype-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/intersectiontype-typealias/index.md
@@ -1,0 +1,11 @@
+# IntersectionType
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [IntersectionType](/test-suite-a/intersectiontype-typealias/)
+
+An intersection type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias/) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias/).
+
+<h2 id="intersectiontype-signature">Signature</h2>
+
+```typescript
+export type IntersectionType = TypeWithProperties & TypeWithConstructSignature;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
@@ -4,6 +4,8 @@
 
 A test abstract getter property.
 
+@escapedTag
+
 <h2 id="abstractpropertygetter-signature">Signature</h2>
 
 ```typescript

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
@@ -51,7 +51,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
+| [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -6,7 +6,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-This is a test deprecation notice. Here is a [link](/test-suite-a/testfunctionreturninguniontype-function) to something else!
+This is a test deprecation notice. Here is a [link](/test-suite-a/testfunctionreturninguniontype-function) to something else! And here is a malformed link to nothing: _{@link }_.
 
 <h2 id="testfunctionreturningintersectiontype-signature">Signature</h2>
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithcallsignature-interface/_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithcallsignature-interface/_call_-callsignature.md
@@ -1,0 +1,17 @@
+# \<T extends string>(foo: T): number & T
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithCallSignature](/test-suite-a/testinterfacewithcallsignature-interface/) > [\<T extends string>(foo: T): number & T](/test-suite-a/testinterfacewithcallsignature-interface/_call_-callsignature)
+
+Test call signature.
+
+<h2 id="_call_-signature">Signature</h2>
+
+```typescript
+<T extends string>(foo: T): number & T;
+```
+
+### Type Parameters
+
+| Parameter | Constraint | Description |
+| - | - | - |
+| T | string | A type parameter |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithcallsignature-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithcallsignature-interface/index.md
@@ -1,0 +1,17 @@
+# TestInterfaceWithCallSignature
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithCallSignature](/test-suite-a/testinterfacewithcallsignature-interface/)
+
+An interface with a complex call signature.
+
+<h2 id="testinterfacewithcallsignature-signature">Signature</h2>
+
+```typescript
+export interface TestInterfaceWithCallSignature
+```
+
+## Call Signatures
+
+| Call Signature | Return Type | Description |
+| - | - | - |
+| [\<T extends string>(foo: T): number & T](/test-suite-a/testinterfacewithcallsignature-interface/_call_-callsignature) | number & T | Test call signature. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typewithconstructsignature-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typewithconstructsignature-typealias/index.md
@@ -1,0 +1,13 @@
+# TypeWithConstructSignature
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias/)
+
+A test type with a construct signature.
+
+<h2 id="typewithconstructsignature-signature">Signature</h2>
+
+```typescript
+export type TypeWithConstructSignature = {
+    new (input: string): TypeWithConstructSignature;
+};
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typewithproperties-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typewithproperties-typealias/index.md
@@ -1,0 +1,15 @@
+# TypeWithProperties
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TypeWithProperties](/test-suite-a/typewithproperties-typealias/)
+
+A test type with properties.
+
+<h2 id="typewithproperties-signature">Signature</h2>
+
+```typescript
+export type TypeWithProperties = {
+    foo: string;
+    readonly bar: number;
+    readonly baz?: boolean;
+};
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/uniontype-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/uniontype-typealias/index.md
@@ -1,0 +1,11 @@
+# UnionType
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [UnionType](/test-suite-a/uniontype-typealias/)
+
+A union type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias/) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias/).
+
+<h2 id="uniontype-signature">Signature</h2>
+
+```typescript
+export type UnionType = TypeWithProperties | TypeWithConstructSignature;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
@@ -4,5 +4,5 @@
 
 | Package | Description |
 | - | - |
-| [test-suite-a](/test-suite-a/) | Test package |
+| [test-suite-a](/test-suite-a/) | Test package Contains a suite of test cases for validation API documentation generation. |
 | [test-suite-b](/test-suite-b/) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -39,6 +39,7 @@ const foo = bar;
 | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) | An empty interface |
 | [TestInterface](/test-suite-a/testinterface-interface) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
+| [TestInterfaceWithCallSignature](/test-suite-a/testinterfacewithcallsignature-interface) | An interface with a complex call signature. |
 | [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface) | An interface with an index signature. |
 | [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface) | Test interface with generic type parameter |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -2,7 +2,7 @@
 
 [Packages](/) > [test-suite-a](/test-suite-a/)
 
-Test package
+Test package Contains a suite of test cases for validation API documentation generation.
 
 <h2 id="test-suite-a-remarks">Remarks</h2>
 
@@ -59,13 +59,20 @@ const foo = bar;
 
 | TypeAlias | Description |
 | - | - |
+| [IntersectionType](/test-suite-a/intersectiontype-typealias) | An intersection type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias). |
 | [TestMappedType](/test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum) |
 | [TypeAlias](/test-suite-a/typealias-typealias) | Test Type-Alias |
+| [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias) | A test type with a construct signature. |
+| [TypeWithProperties](/test-suite-a/typewithproperties-typealias) | A test type with properties. |
+| [UnionType](/test-suite-a/uniontype-typealias) | A union type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias). |
 
 ## Functions
 
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
+| [functionWithOverloads(value)](/test-suite-a/#functionwithoverloads-function) | | string | Takes a number and returns a string. |
+| [functionWithOverloads(value)](/test-suite-a/#functionwithoverloads_1-function) | | boolean | Takes a string and returns a boolean. |
+| [functionWithOverloads(value)](/test-suite-a/#functionwithoverloads_2-function) | | number | Takes a boolean and returns a number. |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/#testfunction-function) | `Alpha` | TTypeParameter | Test function |
 | [testFunctionReturningInlineType()](/test-suite-a/#testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](/test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) & [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number> | Test function that returns an inline type |
@@ -87,6 +94,72 @@ const foo = bar;
 | [TestNamespace](/test-suite-a/testnamespace-namespace/) | | Test Namespace |
 
 ## Function Details
+
+<h3 id="functionwithoverloads-function">functionWithOverloads</h3>
+
+Takes a number and returns a string.
+
+<h4 id="functionwithoverloads-signature">Signature</h4>
+
+```typescript
+export declare function functionWithOverloads(value: number): string;
+```
+
+<h4 id="functionwithoverloads-parameters">Parameters</h4>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | number | A number. |
+
+<h4 id="functionwithoverloads-returns">Returns</h4>
+
+A string.
+
+**Return type**: string
+
+<h3 id="functionwithoverloads_1-function">functionWithOverloads</h3>
+
+Takes a string and returns a boolean.
+
+<h4 id="functionwithoverloads_1-signature">Signature</h4>
+
+```typescript
+export declare function functionWithOverloads(value: string): boolean;
+```
+
+<h4 id="functionwithoverloads_1-parameters">Parameters</h4>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | string | A string. |
+
+<h4 id="functionwithoverloads_1-returns">Returns</h4>
+
+A boolean.
+
+**Return type**: boolean
+
+<h3 id="functionwithoverloads_2-function">functionWithOverloads</h3>
+
+Takes a boolean and returns a number.
+
+<h4 id="functionwithoverloads_2-signature">Signature</h4>
+
+```typescript
+export declare function functionWithOverloads(value: boolean): number;
+```
+
+<h4 id="functionwithoverloads_2-parameters">Parameters</h4>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | boolean | A boolean. |
+
+<h4 id="functionwithoverloads_2-returns">Returns</h4>
+
+A number.
+
+**Return type**: number
 
 <h3 id="testfunction-function">testFunction</h3>
 
@@ -152,7 +225,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-This is a test deprecation notice. Here is a [link](/test-suite-a/#testfunctionreturninguniontype-function) to something else!
+This is a test deprecation notice. Here is a [link](/test-suite-a/#testfunctionreturninguniontype-function) to something else! And here is a malformed link to nothing: _{@link }_.
 
 <h4 id="testfunctionreturningintersectiontype-signature">Signature</h4>
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/intersectiontype-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/intersectiontype-typealias.md
@@ -1,0 +1,11 @@
+# IntersectionType
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [IntersectionType](/test-suite-a/intersectiontype-typealias)
+
+An intersection type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias).
+
+<h2 id="intersectiontype-signature">Signature</h2>
+
+```typescript
+export type IntersectionType = TypeWithProperties & TypeWithConstructSignature;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -51,7 +51,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](/test-suite-a/testclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [abstractPropertyGetter](/test-suite-a/testclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [testClassGetterProperty](/test-suite-a/testclass-class#testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
@@ -111,6 +111,8 @@ Here are some remarks about the property
 <h3 id="abstractpropertygetter-property">abstractPropertyGetter</h3>
 
 A test abstract getter property.
+
+@escapedTag
 
 <h4 id="abstractpropertygetter-signature">Signature</h4>
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithcallsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithcallsignature-interface.md
@@ -1,0 +1,35 @@
+# TestInterfaceWithCallSignature
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithCallSignature](/test-suite-a/testinterfacewithcallsignature-interface)
+
+An interface with a complex call signature.
+
+<h2 id="testinterfacewithcallsignature-signature">Signature</h2>
+
+```typescript
+export interface TestInterfaceWithCallSignature
+```
+
+## Call Signatures
+
+| Call Signature | Return Type | Description |
+| - | - | - |
+| [\<T extends string>(foo: T): number & T](/test-suite-a/testinterfacewithcallsignature-interface#_call_-callsignature) | number & T | Test call signature. |
+
+## Call Signature Details
+
+<h3 id="_call_-callsignature"><T extends string>(foo: T): number & T</h3>
+
+Test call signature.
+
+<h4 id="_call_-signature">Signature</h4>
+
+```typescript
+<T extends string>(foo: T): number & T;
+```
+
+##### Type Parameters
+
+| Parameter | Constraint | Description |
+| - | - | - |
+| T | string | A type parameter |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typewithconstructsignature-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typewithconstructsignature-typealias.md
@@ -1,0 +1,13 @@
+# TypeWithConstructSignature
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias)
+
+A test type with a construct signature.
+
+<h2 id="typewithconstructsignature-signature">Signature</h2>
+
+```typescript
+export type TypeWithConstructSignature = {
+    new (input: string): TypeWithConstructSignature;
+};
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typewithproperties-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typewithproperties-typealias.md
@@ -1,0 +1,15 @@
+# TypeWithProperties
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TypeWithProperties](/test-suite-a/typewithproperties-typealias)
+
+A test type with properties.
+
+<h2 id="typewithproperties-signature">Signature</h2>
+
+```typescript
+export type TypeWithProperties = {
+    foo: string;
+    readonly bar: number;
+    readonly baz?: boolean;
+};
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/uniontype-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/uniontype-typealias.md
@@ -1,0 +1,11 @@
+# UnionType
+
+[Packages](/) > [test-suite-a](/test-suite-a/) > [UnionType](/test-suite-a/uniontype-typealias)
+
+A union type combining [TypeWithProperties](/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](/test-suite-a/typewithconstructsignature-typealias).
+
+<h2 id="uniontype-signature">Signature</h2>
+
+```typescript
+export type UnionType = TypeWithProperties | TypeWithConstructSignature;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/index.md
@@ -2,5 +2,5 @@
 
 | Package | Description |
 | - | - |
-| [test-suite-a](docs/test-suite-a) | Test package |
+| [test-suite-a](docs/test-suite-a) | Test package Contains a suite of test cases for validation API documentation generation. |
 | [test-suite-b](docs/test-suite-b) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -37,6 +37,7 @@ const foo = bar;
 | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) | An empty interface |
 | [TestInterface](docs/test-suite-a#testinterface-interface) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](docs/test-suite-a#testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
+| [TestInterfaceWithCallSignature](docs/test-suite-a#testinterfacewithcallsignature-interface) | An interface with a complex call signature. |
 | [TestInterfaceWithIndexSignature](docs/test-suite-a#testinterfacewithindexsignature-interface) | An interface with an index signature. |
 | [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface) | Test interface with generic type parameter |
 
@@ -362,6 +363,40 @@ A number
 - [TestInterface](docs/test-suite-a#testinterface-interface)
 - [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)
 - [TestMappedType](docs/test-suite-a#testmappedtype-typealias)
+
+<h2 id="testinterfacewithcallsignature-interface">TestInterfaceWithCallSignature</h2>
+
+An interface with a complex call signature.
+
+<h3 id="testinterfacewithcallsignature-signature">Signature</h3>
+
+```typescript
+export interface TestInterfaceWithCallSignature
+```
+
+### Call Signatures
+
+| Call Signature | Return Type | Description |
+| - | - | - |
+| [\<T extends string>(foo: T): number & T](docs/test-suite-a#testinterfacewithcallsignature-_call_-callsignature) | number & T | Test call signature. |
+
+### Call Signature Details
+
+<h4 id="testinterfacewithcallsignature-_call_-callsignature"><T extends string>(foo: T): number & T</h4>
+
+Test call signature.
+
+<h5 id="_call_-signature">Signature</h5>
+
+```typescript
+<T extends string>(foo: T): number & T;
+```
+
+###### Type Parameters
+
+| Parameter | Constraint | Description |
+| - | - | - |
+| T | string | A type parameter |
 
 <h2 id="testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</h2>
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -1,6 +1,6 @@
 [Packages](docs/) > [test-suite-a](docs/test-suite-a)
 
-Test package
+Test package Contains a suite of test cases for validation API documentation generation.
 
 <h1 id="test-suite-a-remarks">Remarks</h1>
 
@@ -57,13 +57,20 @@ const foo = bar;
 
 | TypeAlias | Description |
 | - | - |
+| [IntersectionType](docs/test-suite-a#intersectiontype-typealias) | An intersection type combining [TypeWithProperties](docs/test-suite-a#typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a#typewithconstructsignature-typealias). |
 | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | Test Mapped Type, using [TestEnum](docs/test-suite-a#testenum-enum) |
 | [TypeAlias](docs/test-suite-a#typealias-typealias) | Test Type-Alias |
+| [TypeWithConstructSignature](docs/test-suite-a#typewithconstructsignature-typealias) | A test type with a construct signature. |
+| [TypeWithProperties](docs/test-suite-a#typewithproperties-typealias) | A test type with properties. |
+| [UnionType](docs/test-suite-a#uniontype-typealias) | A union type combining [TypeWithProperties](docs/test-suite-a#typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a#typewithconstructsignature-typealias). |
 
 # Functions
 
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
+| [functionWithOverloads(value)](docs/test-suite-a#functionwithoverloads-function) | | string | Takes a number and returns a string. |
+| [functionWithOverloads(value)](docs/test-suite-a#functionwithoverloads_1-function) | | boolean | Takes a string and returns a boolean. |
+| [functionWithOverloads(value)](docs/test-suite-a#functionwithoverloads_2-function) | | number | Takes a boolean and returns a number. |
 | [testFunctionReturningInlineType()](docs/test-suite-a#testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](docs/test-suite-a#testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](docs/test-suite-a#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) & [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number> | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](docs/test-suite-a#testfunctionreturninguniontype-function) | | string \| [TestInterface](docs/test-suite-a#testinterface-interface) | Test function that returns an inline type |
@@ -607,7 +614,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](docs/test-suite-a#testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | A test abstract getter property. |
+| [abstractPropertyGetter](docs/test-suite-a#testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [testClassGetterProperty](docs/test-suite-a#testclass-testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](docs/test-suite-a#testclass-testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
@@ -667,6 +674,8 @@ Here are some remarks about the property
 <h4 id="testclass-abstractpropertygetter-property">abstractPropertyGetter</h4>
 
 A test abstract getter property.
+
+@escapedTag
 
 <h5 id="abstractpropertygetter-signature">Signature</h5>
 
@@ -893,6 +902,16 @@ Here are some remarks about the enum value
 
 # Type Details
 
+<h2 id="intersectiontype-typealias">IntersectionType</h2>
+
+An intersection type combining [TypeWithProperties](docs/test-suite-a#typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a#typewithconstructsignature-typealias).
+
+<h3 id="intersectiontype-signature">Signature</h3>
+
+```typescript
+export type IntersectionType = TypeWithProperties & TypeWithConstructSignature;
+```
+
 <h2 id="testmappedtype-typealias">TestMappedType</h2>
 
 Test Mapped Type, using [TestEnum](docs/test-suite-a#testenum-enum)
@@ -923,7 +942,109 @@ export type TypeAlias = string;
 
 Here are some remarks about the type alias
 
+<h2 id="typewithconstructsignature-typealias">TypeWithConstructSignature</h2>
+
+A test type with a construct signature.
+
+<h3 id="typewithconstructsignature-signature">Signature</h3>
+
+```typescript
+export type TypeWithConstructSignature = {
+    new (input: string): TypeWithConstructSignature;
+};
+```
+
+<h2 id="typewithproperties-typealias">TypeWithProperties</h2>
+
+A test type with properties.
+
+<h3 id="typewithproperties-signature">Signature</h3>
+
+```typescript
+export type TypeWithProperties = {
+    foo: string;
+    readonly bar: number;
+    readonly baz?: boolean;
+};
+```
+
+<h2 id="uniontype-typealias">UnionType</h2>
+
+A union type combining [TypeWithProperties](docs/test-suite-a#typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a#typewithconstructsignature-typealias).
+
+<h3 id="uniontype-signature">Signature</h3>
+
+```typescript
+export type UnionType = TypeWithProperties | TypeWithConstructSignature;
+```
+
 # Function Details
+
+<h2 id="functionwithoverloads-function">functionWithOverloads</h2>
+
+Takes a number and returns a string.
+
+<h3 id="functionwithoverloads-signature">Signature</h3>
+
+```typescript
+export declare function functionWithOverloads(value: number): string;
+```
+
+<h3 id="functionwithoverloads-parameters">Parameters</h3>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | number | A number. |
+
+<h3 id="functionwithoverloads-returns">Returns</h3>
+
+A string.
+
+**Return type**: string
+
+<h2 id="functionwithoverloads_1-function">functionWithOverloads</h2>
+
+Takes a string and returns a boolean.
+
+<h3 id="functionwithoverloads_1-signature">Signature</h3>
+
+```typescript
+export declare function functionWithOverloads(value: string): boolean;
+```
+
+<h3 id="functionwithoverloads_1-parameters">Parameters</h3>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | string | A string. |
+
+<h3 id="functionwithoverloads_1-returns">Returns</h3>
+
+A boolean.
+
+**Return type**: boolean
+
+<h2 id="functionwithoverloads_2-function">functionWithOverloads</h2>
+
+Takes a boolean and returns a number.
+
+<h3 id="functionwithoverloads_2-signature">Signature</h3>
+
+```typescript
+export declare function functionWithOverloads(value: boolean): number;
+```
+
+<h3 id="functionwithoverloads_2-parameters">Parameters</h3>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | boolean | A boolean. |
+
+<h3 id="functionwithoverloads_2-returns">Returns</h3>
+
+A number.
+
+**Return type**: number
 
 <h2 id="testfunctionreturninginlinetype-function">testFunctionReturningInlineType</h2>
 
@@ -950,7 +1071,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-This is a test deprecation notice. Here is a [link](docs/test-suite-a#testfunctionreturninguniontype-function) to something else!
+This is a test deprecation notice. Here is a [link](docs/test-suite-a#testfunctionreturninguniontype-function) to something else! And here is a malformed link to nothing: _{@link }_.
 
 <h3 id="testfunctionreturningintersectiontype-signature">Signature</h3>
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/index.md
@@ -4,4 +4,4 @@
 
 | Package | Description |
 | - | - |
-| [test-suite-a](docs/test-suite-a/) | Test package |
+| [test-suite-a](docs/test-suite-a/) | Test package Contains a suite of test cases for validation API documentation generation. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/functionwithoverloads-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/functionwithoverloads-function.md
@@ -1,0 +1,21 @@
+## functionWithOverloads
+
+Takes a number and returns a string.
+
+<h3 id="functionwithoverloads-signature">Signature</h3>
+
+```typescript
+export declare function functionWithOverloads(value: number): string;
+```
+
+<h3 id="functionwithoverloads-parameters">Parameters</h3>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | number | A number. |
+
+<h3 id="functionwithoverloads-returns">Returns</h3>
+
+A string.
+
+**Return type**: string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/functionwithoverloads_1-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/functionwithoverloads_1-function.md
@@ -1,0 +1,21 @@
+## functionWithOverloads
+
+Takes a string and returns a boolean.
+
+<h3 id="functionwithoverloads_1-signature">Signature</h3>
+
+```typescript
+export declare function functionWithOverloads(value: string): boolean;
+```
+
+<h3 id="functionwithoverloads_1-parameters">Parameters</h3>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | string | A string. |
+
+<h3 id="functionwithoverloads_1-returns">Returns</h3>
+
+A boolean.
+
+**Return type**: boolean

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/functionwithoverloads_2-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/functionwithoverloads_2-function.md
@@ -1,0 +1,21 @@
+## functionWithOverloads
+
+Takes a boolean and returns a number.
+
+<h3 id="functionwithoverloads_2-signature">Signature</h3>
+
+```typescript
+export declare function functionWithOverloads(value: boolean): number;
+```
+
+<h3 id="functionwithoverloads_2-parameters">Parameters</h3>
+
+| Parameter | Type | Description |
+| - | - | - |
+| value | boolean | A boolean. |
+
+<h3 id="functionwithoverloads_2-returns">Returns</h3>
+
+A number.
+
+**Return type**: number

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
@@ -37,6 +37,7 @@ const foo = bar;
 | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) | An empty interface |
 | [TestInterface](docs/test-suite-a/testinterface-interface) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](docs/test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
+| [TestInterfaceWithCallSignature](docs/test-suite-a/testinterfacewithcallsignature-interface) | An interface with a complex call signature. |
 | [TestInterfaceWithIndexSignature](docs/test-suite-a/testinterfacewithindexsignature-interface) | An interface with an index signature. |
 | [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface) | Test interface with generic type parameter |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
@@ -1,6 +1,6 @@
 ## test-suite-a
 
-Test package
+Test package Contains a suite of test cases for validation API documentation generation.
 
 <h3 id="test-suite-a-remarks">Remarks</h3>
 
@@ -57,13 +57,20 @@ const foo = bar;
 
 | TypeAlias | Description |
 | - | - |
+| [IntersectionType](docs/test-suite-a/intersectiontype-typealias) | An intersection type combining [TypeWithProperties](docs/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a/typewithconstructsignature-typealias). |
 | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](docs/test-suite-a/testenum-enum) |
 | [TypeAlias](docs/test-suite-a/typealias-typealias) | Test Type-Alias |
+| [TypeWithConstructSignature](docs/test-suite-a/typewithconstructsignature-typealias) | A test type with a construct signature. |
+| [TypeWithProperties](docs/test-suite-a/typewithproperties-typealias) | A test type with properties. |
+| [UnionType](docs/test-suite-a/uniontype-typealias) | A union type combining [TypeWithProperties](docs/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a/typewithconstructsignature-typealias). |
 
 ### Functions
 
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
+| [functionWithOverloads(value)](docs/test-suite-a/functionwithoverloads-function) | | string | Takes a number and returns a string. |
+| [functionWithOverloads(value)](docs/test-suite-a/functionwithoverloads_1-function) | | boolean | Takes a string and returns a boolean. |
+| [functionWithOverloads(value)](docs/test-suite-a/functionwithoverloads_2-function) | | number | Takes a boolean and returns a number. |
 | [testFunctionReturningInlineType()](docs/test-suite-a/testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](docs/test-suite-a/testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](docs/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) & [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number> | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](docs/test-suite-a/testfunctionreturninguniontype-function) | | string \| [TestInterface](docs/test-suite-a/testinterface-interface) | Test function that returns an inline type |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/intersectiontype-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/intersectiontype-typealias.md
@@ -1,0 +1,9 @@
+## IntersectionType
+
+An intersection type combining [TypeWithProperties](docs/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a/typewithconstructsignature-typealias).
+
+<h3 id="intersectiontype-signature">Signature</h3>
+
+```typescript
+export type IntersectionType = TypeWithProperties & TypeWithConstructSignature;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-abstractpropertygetter-property.md
@@ -2,6 +2,8 @@
 
 A test abstract getter property.
 
+@escapedTag
+
 <h3 id="abstractpropertygetter-signature">Signature</h3>
 
 ```typescript

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
@@ -49,7 +49,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](docs/test-suite-a/testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [abstractPropertyGetter](docs/test-suite-a/testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [testClassGetterProperty](docs/test-suite-a/testclass-testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](docs/test-suite-a/testclass-testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -4,7 +4,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-This is a test deprecation notice. Here is a [link](docs/test-suite-a/testfunctionreturninguniontype-function) to something else!
+This is a test deprecation notice. Here is a [link](docs/test-suite-a/testfunctionreturninguniontype-function) to something else! And here is a malformed link to nothing: _{@link }_.
 
 <h3 id="testfunctionreturningintersectiontype-signature">Signature</h3>
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithcallsignature-_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithcallsignature-_call_-callsignature.md
@@ -1,0 +1,15 @@
+## \<T extends string>(foo: T): number & T
+
+Test call signature.
+
+<h3 id="_call_-signature">Signature</h3>
+
+```typescript
+<T extends string>(foo: T): number & T;
+```
+
+#### Type Parameters
+
+| Parameter | Constraint | Description |
+| - | - | - |
+| T | string | A type parameter |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithcallsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithcallsignature-interface.md
@@ -1,0 +1,15 @@
+## TestInterfaceWithCallSignature
+
+An interface with a complex call signature.
+
+<h3 id="testinterfacewithcallsignature-signature">Signature</h3>
+
+```typescript
+export interface TestInterfaceWithCallSignature
+```
+
+### Call Signatures
+
+| Call Signature | Return Type | Description |
+| - | - | - |
+| [\<T extends string>(foo: T): number & T](docs/test-suite-a/testinterfacewithcallsignature-_call_-callsignature) | number & T | Test call signature. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/typewithconstructsignature-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/typewithconstructsignature-typealias.md
@@ -1,0 +1,11 @@
+## TypeWithConstructSignature
+
+A test type with a construct signature.
+
+<h3 id="typewithconstructsignature-signature">Signature</h3>
+
+```typescript
+export type TypeWithConstructSignature = {
+    new (input: string): TypeWithConstructSignature;
+};
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/typewithproperties-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/typewithproperties-typealias.md
@@ -1,0 +1,13 @@
+## TypeWithProperties
+
+A test type with properties.
+
+<h3 id="typewithproperties-signature">Signature</h3>
+
+```typescript
+export type TypeWithProperties = {
+    foo: string;
+    readonly bar: number;
+    readonly baz?: boolean;
+};
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/uniontype-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/uniontype-typealias.md
@@ -1,0 +1,9 @@
+## UnionType
+
+A union type combining [TypeWithProperties](docs/test-suite-a/typewithproperties-typealias) and [TypeWithConstructSignature](docs/test-suite-a/typewithconstructsignature-typealias).
+
+<h3 id="uniontype-signature">Signature</h3>
+
+```typescript
+export type UnionType = TypeWithProperties | TypeWithConstructSignature;
+```

--- a/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
+++ b/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
@@ -1926,6 +1926,88 @@
 				},
 				{
 					"kind": "Interface",
+					"canonicalReference": "test-suite-a!TestInterfaceWithCallSignature:interface",
+					"docComment": "/**\n * An interface with a complex call signature.\n *\n * @public\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export interface TestInterfaceWithCallSignature "
+						}
+					],
+					"fileUrlPath": "dist/TestInterface.d.ts",
+					"releaseTag": "Public",
+					"name": "TestInterfaceWithCallSignature",
+					"preserveMemberOrder": false,
+					"members": [
+						{
+							"kind": "CallSignature",
+							"canonicalReference": "test-suite-a!TestInterfaceWithCallSignature:call(1)",
+							"docComment": "/**\n * Test call signature.\n *\n * @param foo - A value of type T\n *\n * @typeParam T - A type parameter\n *\n * @returns `foo` branded with a number\n */\n",
+							"excerptTokens": [
+								{
+									"kind": "Content",
+									"text": "<T extends "
+								},
+								{
+									"kind": "Content",
+									"text": "string"
+								},
+								{
+									"kind": "Content",
+									"text": ">(foo: "
+								},
+								{
+									"kind": "Content",
+									"text": "T"
+								},
+								{
+									"kind": "Content",
+									"text": "): "
+								},
+								{
+									"kind": "Content",
+									"text": "number & T"
+								},
+								{
+									"kind": "Content",
+									"text": ";"
+								}
+							],
+							"returnTypeTokenRange": {
+								"startIndex": 5,
+								"endIndex": 6
+							},
+							"releaseTag": "Public",
+							"overloadIndex": 1,
+							"parameters": [
+								{
+									"parameterName": "foo",
+									"parameterTypeTokenRange": {
+										"startIndex": 3,
+										"endIndex": 4
+									},
+									"isOptional": false
+								}
+							],
+							"typeParameters": [
+								{
+									"typeParameterName": "T",
+									"constraintTokenRange": {
+										"startIndex": 1,
+										"endIndex": 2
+									},
+									"defaultTypeTokenRange": {
+										"startIndex": 0,
+										"endIndex": 0
+									}
+								}
+							]
+						}
+					],
+					"extendsTokenRanges": []
+				},
+				{
+					"kind": "Interface",
 					"canonicalReference": "test-suite-a!TestInterfaceWithIndexSignature:interface",
 					"docComment": "/**\n * An interface with an index signature.\n *\n * @public\n */\n",
 					"excerptTokens": [

--- a/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
+++ b/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"toolPackage": "@microsoft/api-extractor",
-		"toolVersion": "7.47.5",
+		"toolVersion": "7.52.13",
 		"schemaVersion": 1011,
 		"oldestForwardsCompatibleVersion": 1001,
 		"tsdocConfig": {
@@ -162,7 +162,7 @@
 	},
 	"kind": "Package",
 	"canonicalReference": "test-suite-a!",
-	"docComment": "/**\n * <b>Test package</b>\n *\n * @remarks\n *\n * This remarks block includes a bulleted list!\n * - Bullet 1\n * - Bullet 2\n *\n * And an ordered list for good measure!\n * 1. List item 1\n * 2. List item 2\n * 3. List item 3\n *\n * Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:\n * - Good link (no alias): {@link TestClass}\n * - Good link (with alias): {@link testFunction | function alias text}\n * - Bad link (no alias): {@link InvalidItem}\n * - Bad link (with alias): {@link InvalidItem | even though I link to an invalid item, I would still like this text to be rendered}\n *\n * @example\n *\n * A test example\n * ```typescript\n * const foo = bar;\n * ```\n *\n * @packageDocumentation\n */\n",
+	"docComment": "/**\n * <b>Test package</b> <p>Contains a suite of test cases for validation API documentation generation.</p>\n *\n * @remarks\n *\n * This remarks block includes a bulleted list!\n * - Bullet 1\n * - Bullet 2\n *\n * And an ordered list for good measure!\n * 1. List item 1\n * 2. List item 2\n * 3. List item 3\n *\n * Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:\n * - Good link (no alias): {@link TestClass}\n * - Good link (with alias): {@link testFunction | function alias text}\n * - Bad link (no alias): {@link InvalidItem}\n * - Bad link (with alias): {@link InvalidItem | even though I link to an invalid item, I would still like this text to be rendered}\n *\n * @example\n *\n * A test example\n * ```typescript\n * const foo = bar;\n * ```\n *\n * @packageDocumentation\n */\n",
 	"name": "test-suite-a",
 	"preserveMemberOrder": false,
 	"members": [
@@ -172,6 +172,177 @@
 			"name": "",
 			"preserveMemberOrder": false,
 			"members": [
+				{
+					"kind": "Function",
+					"canonicalReference": "test-suite-a!functionWithOverloads:function(1)",
+					"docComment": "/**\n * Takes a number and returns a string.\n *\n * @param value - A number.\n *\n * @returns A string.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export declare function functionWithOverloads(value: "
+						},
+						{
+							"kind": "Content",
+							"text": "number"
+						},
+						{
+							"kind": "Content",
+							"text": "): "
+						},
+						{
+							"kind": "Content",
+							"text": "string"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestFunction.d.ts",
+					"returnTypeTokenRange": {
+						"startIndex": 3,
+						"endIndex": 4
+					},
+					"releaseTag": "Public",
+					"overloadIndex": 1,
+					"parameters": [
+						{
+							"parameterName": "value",
+							"parameterTypeTokenRange": {
+								"startIndex": 1,
+								"endIndex": 2
+							},
+							"isOptional": false
+						}
+					],
+					"name": "functionWithOverloads"
+				},
+				{
+					"kind": "Function",
+					"canonicalReference": "test-suite-a!functionWithOverloads:function(2)",
+					"docComment": "/**\n * Takes a string and returns a boolean.\n *\n * @param value - A string.\n *\n * @returns A boolean.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export declare function functionWithOverloads(value: "
+						},
+						{
+							"kind": "Content",
+							"text": "string"
+						},
+						{
+							"kind": "Content",
+							"text": "): "
+						},
+						{
+							"kind": "Content",
+							"text": "boolean"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestFunction.d.ts",
+					"returnTypeTokenRange": {
+						"startIndex": 3,
+						"endIndex": 4
+					},
+					"releaseTag": "Public",
+					"overloadIndex": 2,
+					"parameters": [
+						{
+							"parameterName": "value",
+							"parameterTypeTokenRange": {
+								"startIndex": 1,
+								"endIndex": 2
+							},
+							"isOptional": false
+						}
+					],
+					"name": "functionWithOverloads"
+				},
+				{
+					"kind": "Function",
+					"canonicalReference": "test-suite-a!functionWithOverloads:function(3)",
+					"docComment": "/**\n * Takes a boolean and returns a number.\n *\n * @param value - A boolean.\n *\n * @returns A number.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export declare function functionWithOverloads(value: "
+						},
+						{
+							"kind": "Content",
+							"text": "boolean"
+						},
+						{
+							"kind": "Content",
+							"text": "): "
+						},
+						{
+							"kind": "Content",
+							"text": "number"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestFunction.d.ts",
+					"returnTypeTokenRange": {
+						"startIndex": 3,
+						"endIndex": 4
+					},
+					"releaseTag": "Public",
+					"overloadIndex": 3,
+					"parameters": [
+						{
+							"parameterName": "value",
+							"parameterTypeTokenRange": {
+								"startIndex": 1,
+								"endIndex": 2
+							},
+							"isOptional": false
+						}
+					],
+					"name": "functionWithOverloads"
+				},
+				{
+					"kind": "TypeAlias",
+					"canonicalReference": "test-suite-a!IntersectionType:type",
+					"docComment": "/**\n * An intersection type combining {@link TypeWithProperties} and {@link TypeWithConstructSignature}.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export type IntersectionType = "
+						},
+						{
+							"kind": "Reference",
+							"text": "TypeWithProperties",
+							"canonicalReference": "test-suite-a!TypeWithProperties:type"
+						},
+						{
+							"kind": "Content",
+							"text": " & "
+						},
+						{
+							"kind": "Reference",
+							"text": "TypeWithConstructSignature",
+							"canonicalReference": "test-suite-a!TypeWithConstructSignature:type"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestType.d.ts",
+					"releaseTag": "Public",
+					"name": "IntersectionType",
+					"typeTokenRange": {
+						"startIndex": 1,
+						"endIndex": 4
+					}
+				},
 				{
 					"kind": "Class",
 					"canonicalReference": "test-suite-a!TestAbstractClass:class",
@@ -623,7 +794,7 @@
 						{
 							"kind": "Property",
 							"canonicalReference": "test-suite-a!TestClass#abstractPropertyGetter:member",
-							"docComment": "/**\n * A test abstract getter property.\n */\n",
+							"docComment": "/**\n * A test abstract getter property.\n *\n * \\@escapedTag\n */\n",
 							"excerptTokens": [
 								{
 									"kind": "Content",
@@ -1215,7 +1386,7 @@
 				{
 					"kind": "Function",
 					"canonicalReference": "test-suite-a!testFunctionReturningIntersectionType:function(1)",
-					"docComment": "/**\n * Test function that returns an inline type\n *\n * @deprecated\n *\n * This is a test deprecation notice. Here is a {@link testFunctionReturningUnionType | link} to something else!\n *\n * @returns an intersection type\n *\n * @public\n */\n",
+					"docComment": "/**\n * Test function that returns an inline type\n *\n * @deprecated\n *\n * This is a test deprecation notice. Here is a {@link testFunctionReturningUnionType | link} to something else! And here is a malformed link to nothing: {@link}.\n *\n * @returns an intersection type\n *\n * @public\n */\n",
 					"excerptTokens": [
 						{
 							"kind": "Content",
@@ -2388,6 +2559,103 @@
 					"typeTokenRange": {
 						"startIndex": 1,
 						"endIndex": 2
+					}
+				},
+				{
+					"kind": "TypeAlias",
+					"canonicalReference": "test-suite-a!TypeWithConstructSignature:type",
+					"docComment": "/**\n * A test type with a construct signature.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export type TypeWithConstructSignature = "
+						},
+						{
+							"kind": "Content",
+							"text": "{\n    new (input: string): "
+						},
+						{
+							"kind": "Reference",
+							"text": "TypeWithConstructSignature",
+							"canonicalReference": "test-suite-a!TypeWithConstructSignature:type"
+						},
+						{
+							"kind": "Content",
+							"text": ";\n}"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestType.d.ts",
+					"releaseTag": "Public",
+					"name": "TypeWithConstructSignature",
+					"typeTokenRange": {
+						"startIndex": 1,
+						"endIndex": 4
+					}
+				},
+				{
+					"kind": "TypeAlias",
+					"canonicalReference": "test-suite-a!TypeWithProperties:type",
+					"docComment": "/**\n * A test type with properties.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export type TypeWithProperties = "
+						},
+						{
+							"kind": "Content",
+							"text": "{\n    foo: string;\n    readonly bar: number;\n    readonly baz?: boolean;\n}"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestType.d.ts",
+					"releaseTag": "Public",
+					"name": "TypeWithProperties",
+					"typeTokenRange": {
+						"startIndex": 1,
+						"endIndex": 2
+					}
+				},
+				{
+					"kind": "TypeAlias",
+					"canonicalReference": "test-suite-a!UnionType:type",
+					"docComment": "/**\n * A union type combining {@link TypeWithProperties} and {@link TypeWithConstructSignature}.\n */\n",
+					"excerptTokens": [
+						{
+							"kind": "Content",
+							"text": "export type UnionType = "
+						},
+						{
+							"kind": "Reference",
+							"text": "TypeWithProperties",
+							"canonicalReference": "test-suite-a!TypeWithProperties:type"
+						},
+						{
+							"kind": "Content",
+							"text": " | "
+						},
+						{
+							"kind": "Reference",
+							"text": "TypeWithConstructSignature",
+							"canonicalReference": "test-suite-a!TypeWithConstructSignature:type"
+						},
+						{
+							"kind": "Content",
+							"text": ";"
+						}
+					],
+					"fileUrlPath": "dist/TestType.d.ts",
+					"releaseTag": "Public",
+					"name": "UnionType",
+					"typeTokenRange": {
+						"startIndex": 1,
+						"endIndex": 4
 					}
 				}
 			]


### PR DESCRIPTION
Expands the end-to-end test suite to include additional cases. Specifically:
- More type alias cases
- Functions with overloads
- Call signatures with complex typing