### PR TITLE
semantic-editing: Fix references in methods

### DIFF
--- a/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
+++ b/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
@@ -11,7 +11,7 @@ export type Arg<T extends z.ZodTypeAny = z.ZodTypeAny> = readonly [name: string,
 export type ArgsTuple<T extends readonly Arg[]> = T extends readonly [infer Single extends Arg] ? [Single[1]] : T extends readonly [infer Head extends Arg, ...infer Tail extends readonly Arg[]] ? [Head[1], ...ArgsTuple<Tail>] : never;
 
 // @alpha
-export type BindableSchema = TreeNodeSchema<string, NodeKind.Object | NodeKind.Array | NodeKind.Map | NodeKind.Record>;
+export type BindableSchema = TreeNodeSchema<string, NodeKind.Object> | TreeNodeSchema<string, NodeKind.Record> | TreeNodeSchema<string, NodeKind.Array> | TreeNodeSchema<string, NodeKind.Map>;
 
 // @alpha
 export function buildFunc<const Return extends z.ZodTypeAny, const Args extends readonly Arg[], const Rest extends z.ZodTypeAny | null = null>(def: {
@@ -45,6 +45,7 @@ export interface ExposedMethods {
     expose<const K extends string & keyof MethodKeys<InstanceType<S>>, S extends BindableSchema & Ctor<{
         [P in K]: Infer<Z>;
     }> & IExposedMethods, Z extends FunctionDef<any, any, any>>(schema: S, methodName: K, zodFunction: Z): void;
+    instanceOf<T extends TreeNodeSchemaClass>(schema: T): z.ZodType<InstanceType<T>, z.ZodTypeDef, InstanceType<T>>;
 }
 
 // @alpha
@@ -70,9 +71,6 @@ export interface IExposedMethods {
 
 // @alpha
 export type Infer<T> = T extends FunctionDef<infer Args, infer Return, infer Rest> ? z.infer<z.ZodFunction<z.ZodTuple<ArgsTuple<Args>, Rest>, Return>> : never;
-
-// @alpha
-export function instanceOf<T extends TreeNodeSchemaClass>(schema: T): z.ZodType<InstanceType<T>, z.ZodTypeDef, InstanceType<T>>;
 
 // @alpha
 export const llmDefault: unique symbol;

--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -11,7 +11,7 @@
 
 export { createSemanticAgent } from "./agent.js";
 export type { Log, SharedTreeSemanticAgent } from "./agent.js";
-export type { TreeView, llmDefault, instanceOf } from "./utils.js";
+export { type TreeView, llmDefault } from "./utils.js";
 export {
 	buildFunc,
 	exposeMethodsSymbol,

--- a/packages/framework/tree-agent/src/methodBinding.ts
+++ b/packages/framework/tree-agent/src/methodBinding.ts
@@ -4,8 +4,10 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { NodeKind, TreeNodeSchema } from "@fluidframework/tree";
+import type { NodeKind, TreeNodeSchema, TreeNodeSchemaClass } from "@fluidframework/tree";
 import type { z } from "zod";
+
+import { instanceOf } from "./utils.js";
 
 /**
  * A utility type that extracts the method keys from a given type.
@@ -25,19 +27,21 @@ export type Ctor<T = any> = new (...args: any[]) => T;
  * A type that represents an object schema class.
  * @alpha
  */
-export type BindableSchema = TreeNodeSchema<
-	string,
-	NodeKind.Object | NodeKind.Array | NodeKind.Map | NodeKind.Record
->;
+export type BindableSchema =
+	| TreeNodeSchema<string, NodeKind.Object>
+	| TreeNodeSchema<string, NodeKind.Record>
+	| TreeNodeSchema<string, NodeKind.Array>
+	| TreeNodeSchema<string, NodeKind.Map>;
 
 /**
  * Get the exposed methods of a schema class.
  * @param schemaClass - The schema class to extract methods from.
  * @returns A record of method names and their corresponding Zod types.
  */
-export function getExposedMethods(
-	schemaClass: BindableSchema,
-): Record<string, FunctionWrapper> {
+export function getExposedMethods(schemaClass: BindableSchema): {
+	methods: Record<string, FunctionWrapper>;
+	referencedTypes: Set<TreeNodeSchema>;
+} {
 	return ExposedMethodsI.getExposedMethods(schemaClass);
 }
 
@@ -126,6 +130,13 @@ export interface ExposedMethods {
 		S extends BindableSchema & Ctor<{ [P in K]: Infer<Z> }> & IExposedMethods,
 		Z extends FunctionDef<any, any, any>,
 	>(schema: S, methodName: K, zodFunction: Z): void;
+
+	/**
+	 * Create a Zod schema for a SharedTree schema class.
+	 */
+	instanceOf<T extends TreeNodeSchemaClass>(
+		schema: T,
+	): z.ZodType<InstanceType<T>, z.ZodTypeDef, InstanceType<T>>;
 }
 
 /**
@@ -154,6 +165,7 @@ export interface IExposedMethods {
 
 class ExposedMethodsI implements ExposedMethods {
 	private readonly methods: Record<string, FunctionWrapper> = {};
+	private readonly referencedTypes = new Set<TreeNodeSchema>();
 
 	public constructor(private readonly schemaClass: BindableSchema) {}
 
@@ -175,14 +187,25 @@ class ExposedMethodsI implements ExposedMethods {
 		);
 	}
 
-	public static getExposedMethods(
-		schemaClass: BindableSchema,
-	): Record<string, FunctionWrapper> {
+	public instanceOf<T extends TreeNodeSchemaClass>(
+		schema: T,
+	): z.ZodType<InstanceType<T>, z.ZodTypeDef, InstanceType<T>> {
+		this.referencedTypes.add(schema);
+		return instanceOf(schema);
+	}
+
+	public static getExposedMethods(schemaClass: BindableSchema): {
+		methods: Record<string, FunctionWrapper>;
+		referencedTypes: Set<TreeNodeSchema>;
+	} {
 		const exposedMethods = new ExposedMethodsI(schemaClass);
 		const extractable = schemaClass as unknown as IExposedMethods;
 		if (extractable[exposeMethodsSymbol] !== undefined) {
 			extractable[exposeMethodsSymbol](exposedMethods);
 		}
-		return exposedMethods.methods;
+		return {
+			methods: exposedMethods.methods,
+			referencedTypes: exposedMethods.referencedTypes,
+		};
 	}
 }

--- a/packages/framework/tree-agent/src/methodBinding.ts
+++ b/packages/framework/tree-agent/src/methodBinding.ts
@@ -133,6 +133,8 @@ export interface ExposedMethods {
 
 	/**
 	 * Create a Zod schema for a SharedTree schema class.
+	 * @remarks
+	 * Use it to "wrap" schema types that are referenced as arguments or return types when exposing methods (with {@link ExposedMethods.expose}).	 
 	 */
 	instanceOf<T extends TreeNodeSchemaClass>(
 		schema: T,

--- a/packages/framework/tree-agent/src/methodBinding.ts
+++ b/packages/framework/tree-agent/src/methodBinding.ts
@@ -134,7 +134,7 @@ export interface ExposedMethods {
 	/**
 	 * Create a Zod schema for a SharedTree schema class.
 	 * @remarks
-	 * Use it to "wrap" schema types that are referenced as arguments or return types when exposing methods (with {@link ExposedMethods.expose}).	 
+	 * Use it to "wrap" schema types that are referenced as arguments or return types when exposing methods (with {@link ExposedMethods.expose}).
 	 */
 	instanceOf<T extends TreeNodeSchemaClass>(
 		schema: T,

--- a/packages/framework/tree-agent/src/test/systemPrompt.spec.ts
+++ b/packages/framework/tree-agent/src/test/systemPrompt.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+import type { ImplicitFieldSchema } from "@fluidframework/tree";
 import {
 	getSimpleSchema,
 	SchemaFactory,
@@ -17,7 +18,7 @@ import { z } from "zod";
 
 import { buildFunc, exposeMethodsSymbol, type ExposedMethods } from "../methodBinding.js";
 import { generateEditTypesForPrompt } from "../typeGeneration.js";
-import { getFriendlySchemaName, getZodSchemaAsTypeScript, instanceOf } from "../utils.js";
+import { getFriendlySchemaName, getZodSchemaAsTypeScript } from "../utils.js";
 
 const factory = SharedTree.getFactory();
 const sf = new SchemaFactory("test");
@@ -54,7 +55,7 @@ class TestTodoAppSchema extends sf.object("TestTodoAppSchema", {
 		methods.expose(
 			TestTodoAppSchema,
 			"addTodo",
-			buildFunc({ returns: instanceOf(Todo) }, ["todo", instanceOf(Todo)]),
+			buildFunc({ returns: methods.instanceOf(Todo) }, ["todo", methods.instanceOf(Todo)]),
 		);
 	}
 
@@ -80,6 +81,34 @@ const initialAppState = {
 };
 
 describe("System prompt", () => {
+	const getDomainSchemaString = <TSchema extends ImplicitFieldSchema>(
+		schemaClass: TSchema,
+		initialValue: unknown,
+	): string => {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: schemaClass }));
+		view.initialize(initialValue as never);
+		const schema = getSimpleSchema(view.schema);
+		const { domainTypes } = generateEditTypesForPrompt(view.schema, schema);
+		for (const [key, value] of Object.entries(domainTypes)) {
+			const friendlyKey = getFriendlySchemaName(key);
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete domainTypes[key];
+			if (
+				friendlyKey !== undefined &&
+				friendlyKey !== "string" &&
+				friendlyKey !== "number" &&
+				friendlyKey !== "boolean"
+			) {
+				domainTypes[friendlyKey] = value;
+			}
+		}
+		return getZodSchemaAsTypeScript(domainTypes);
+	};
+
 	it("doesNodeContainArraySchema should return true if the node contains an array schema property", () => {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
@@ -124,33 +153,9 @@ describe("System prompt", () => {
 			}
 		}
 
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(new TreeViewConfiguration({ schema: ArrayWithMethod }));
-		view.initialize(["test"]);
-
-		const schema = getSimpleSchema(view.schema);
-
-		const { domainTypes } = generateEditTypesForPrompt(view.schema, schema);
-		for (const [key, value] of Object.entries(domainTypes)) {
-			const friendlyKey = getFriendlySchemaName(key);
-			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-			delete domainTypes[key];
-			if (
-				friendlyKey !== undefined &&
-				friendlyKey !== "string" &&
-				friendlyKey !== "number" &&
-				friendlyKey !== "boolean"
-			) {
-				domainTypes[friendlyKey] = value;
-			}
-		}
-
-		const domainSchemaString = getZodSchemaAsTypeScript(domainTypes);
+		const arrayDomainSchemaString = getDomainSchemaString(ArrayWithMethod, ["test"]);
 		assert.deepEqual(
-			domainSchemaString,
+			arrayDomainSchemaString,
 			`// Note: this array has custom user-defined methods directly on it.
 type Todo = string[] & {
     M2(n: string): boolean;
@@ -174,37 +179,44 @@ type Todo = string[] & {
 			}
 		}
 
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(new TreeViewConfiguration({ schema: MapWithMethod }));
-		view.initialize(new Map());
-
-		const schema = getSimpleSchema(view.schema);
-
-		const { domainTypes } = generateEditTypesForPrompt(view.schema, schema);
-		for (const [key, value] of Object.entries(domainTypes)) {
-			const friendlyKey = getFriendlySchemaName(key);
-			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-			delete domainTypes[key];
-			if (
-				friendlyKey !== undefined &&
-				friendlyKey !== "string" &&
-				friendlyKey !== "number" &&
-				friendlyKey !== "boolean"
-			) {
-				domainTypes[friendlyKey] = value;
-			}
-		}
-
-		const domainSchemaString = getZodSchemaAsTypeScript(domainTypes);
+		const mapDomainSchemaString = getDomainSchemaString(MapWithMethod, new Map());
 		assert.deepEqual(
-			domainSchemaString,
+			mapDomainSchemaString,
 			`// Note: this map has custom user-defined methods directly on it.
 type Todo = Map<string, string> & {
     M2(n: string): boolean;
 };
+`,
+		);
+	});
+
+	it("method binding works on for node return types", () => {
+		class Obj extends sf.object("Obj", {}) {}
+
+		class MapWithMethod extends sf.map("Todo", sf.string) {
+			public M2(n: string): Obj {
+				return new Obj({});
+			}
+
+			public static [exposeMethodsSymbol](methods: ExposedMethods): void {
+				methods.expose(
+					MapWithMethod,
+					"M2",
+					buildFunc({ returns: methods.instanceOf(Obj) }, ["n", z.string()]),
+				);
+			}
+		}
+
+		const mapDomainSchemaString = getDomainSchemaString(MapWithMethod, new Map());
+		assert.deepEqual(
+			mapDomainSchemaString,
+			`// Note: this map has custom user-defined methods directly on it.
+type Todo = Map<string, string> & {
+    M2(n: string): Obj;
+};
+
+interface Obj {
+}
 `,
 		);
 	});

--- a/packages/framework/tree-agent/src/typeGeneration.ts
+++ b/packages/framework/tree-agent/src/typeGeneration.ts
@@ -6,14 +6,17 @@
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import {
+	ArrayNodeSchema,
 	FieldKind,
+	getSimpleSchema,
+	MapNodeSchema,
 	NodeKind,
+	ObjectNodeSchema,
 	ValueSchema,
 	walkFieldSchema,
 } from "@fluidframework/tree/internal";
 import type {
 	ImplicitFieldSchema,
-	SchemaVisitor,
 	SimpleFieldSchema,
 	SimpleNodeSchema,
 	SimpleTreeSchema,
@@ -62,19 +65,39 @@ export function generateEditTypesForPrompt(
 	domainTypes: Record<string, ZodTypeAny>;
 } {
 	return getOrCreate(promptSchemaCache, schema, () => {
-		const treeNodeSchemas = new Set<TreeNodeSchema>();
-		walkFieldSchema(rootSchema, {} satisfies SchemaVisitor, treeNodeSchemas);
-		const nodeSchemas = [...treeNodeSchemas.values()].filter(
-			(treeNodeSchema) =>
-				treeNodeSchema.kind === NodeKind.Object ||
-				treeNodeSchema.kind === NodeKind.Array ||
-				treeNodeSchema.kind === NodeKind.Map ||
-				treeNodeSchema.kind === NodeKind.Record,
-		) as BindableSchema[];
+		const allSchemas = new Set<TreeNodeSchema>();
+		const objectTypeSchemas = new Set<TreeNodeSchema>();
+		walkFieldSchema(
+			rootSchema,
+			{
+				node: (n) => {
+					allSchemas.add(n);
+					if (
+						n instanceof ObjectNodeSchema ||
+						n instanceof MapNodeSchema ||
+						n instanceof ArrayNodeSchema ||
+						n instanceof MapNodeSchema
+					) {
+						objectTypeSchemas.add(n);
+						const exposedMethods = getExposedMethods(n);
+						for (const t of exposedMethods.referencedTypes) {
+							allSchemas.add(t);
+							objectTypeSchemas.add(t);
+						}
+					}
+				},
+			},
+			new Set<TreeNodeSchema>(),
+		);
+		const nodeSchemas = [...objectTypeSchemas.values()] as BindableSchema[];
 		const bindableSchemas = new Map<string, BindableSchema>(
 			nodeSchemas.map((nodeSchema) => [nodeSchema.identifier, nodeSchema]),
 		);
-		return generateEditTypes(schema, new Map(), bindableSchemas);
+		return generateEditTypes(
+			[...allSchemas.values()].map((s) => getSimpleSchema(s)),
+			new Map(),
+			bindableSchemas,
+		);
 	});
 }
 
@@ -87,20 +110,22 @@ export function generateEditTypesForPrompt(
  * @remarks The return type of this function is designed to work with Typechat's createZodJsonValidator as well as be used as the JSON schema for OpenAi's structured output response format.
  */
 function generateEditTypes(
-	schema: SimpleTreeSchema,
+	schemas: Iterable<SimpleTreeSchema>,
 	objectCache: MapGetSet<SimpleNodeSchema, ZodTypeAny>,
 	bindableSchemas: Map<string, BindableSchema>,
 ): {
 	domainTypes: Record<string, ZodTypeAny>;
 } {
 	const domainTypes: Record<string, ZodTypeAny> = {};
-	for (const name of schema.definitions.keys()) {
-		domainTypes[name] = getOrCreateType(
-			schema.definitions,
-			name,
-			objectCache,
-			bindableSchemas,
-		);
+	for (const schema of schemas) {
+		for (const name of schema.definitions.keys()) {
+			domainTypes[name] = getOrCreateType(
+				schema.definitions,
+				name,
+				objectCache,
+				bindableSchemas,
+			);
+		}
 	}
 
 	return {
@@ -108,20 +133,27 @@ function generateEditTypes(
 	};
 }
 
-function getBoundMethods(
-	definition: string,
-	bindableSchemas: Map<string, BindableSchema>,
-): [string, ZodTypeAny][] {
+function getBoundMethodsForBindable(bindableSchema: BindableSchema): {
+	referencedTypes: Set<TreeNodeSchema>;
+	methods: [string, ZodTypeAny][];
+} {
 	const methodTypes: [string, ZodTypeAny][] = [];
-	const bindableSchema = bindableSchemas.get(definition) ?? fail("Unknown definition");
 	const methods = getExposedMethods(bindableSchema);
-	for (const [name, method] of Object.entries(methods)) {
+	for (const [name, method] of Object.entries(methods.methods)) {
 		const zodFunction = z.instanceof(FunctionWrapper);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
 		(zodFunction as any).method = method;
 		methodTypes.push([name, zodFunction]);
 	}
-	return methodTypes;
+	return { methods: methodTypes, referencedTypes: methods.referencedTypes };
+}
+
+function getBoundMethods(
+	definition: string,
+	bindableSchemas: Map<string, BindableSchema>,
+): [string, ZodTypeAny][] {
+	const bindableSchema = bindableSchemas.get(definition) ?? fail("Unknown definition");
+	return getBoundMethodsForBindable(bindableSchema).methods;
 }
 
 function addBindingIntersectionIfNeeded(

--- a/packages/framework/tree-agent/src/typeGeneration.ts
+++ b/packages/framework/tree-agent/src/typeGeneration.ts
@@ -12,6 +12,7 @@ import {
 	MapNodeSchema,
 	NodeKind,
 	ObjectNodeSchema,
+	RecordNodeSchema,
 	ValueSchema,
 	walkFieldSchema,
 } from "@fluidframework/tree/internal";
@@ -76,7 +77,7 @@ export function generateEditTypesForPrompt(
 						n instanceof ObjectNodeSchema ||
 						n instanceof MapNodeSchema ||
 						n instanceof ArrayNodeSchema ||
-						n instanceof MapNodeSchema
+						n instanceof RecordNodeSchema
 					) {
 						objectTypeSchemas.add(n);
 						const exposedMethods = getExposedMethods(n);

--- a/packages/framework/tree-agent/src/typeGeneration.ts
+++ b/packages/framework/tree-agent/src/typeGeneration.ts
@@ -68,28 +68,24 @@ export function generateEditTypesForPrompt(
 	return getOrCreate(promptSchemaCache, schema, () => {
 		const allSchemas = new Set<TreeNodeSchema>();
 		const objectTypeSchemas = new Set<TreeNodeSchema>();
-		walkFieldSchema(
-			rootSchema,
-			{
-				node: (n) => {
-					allSchemas.add(n);
-					if (
-						n instanceof ObjectNodeSchema ||
-						n instanceof MapNodeSchema ||
-						n instanceof ArrayNodeSchema ||
-						n instanceof RecordNodeSchema
-					) {
-						objectTypeSchemas.add(n);
-						const exposedMethods = getExposedMethods(n);
-						for (const t of exposedMethods.referencedTypes) {
-							allSchemas.add(t);
-							objectTypeSchemas.add(t);
-						}
+		walkFieldSchema(rootSchema, {
+			node: (n) => {
+				allSchemas.add(n);
+				if (
+					n instanceof ObjectNodeSchema ||
+					n instanceof MapNodeSchema ||
+					n instanceof ArrayNodeSchema ||
+					n instanceof RecordNodeSchema
+				) {
+					objectTypeSchemas.add(n);
+					const exposedMethods = getExposedMethods(n);
+					for (const t of exposedMethods.referencedTypes) {
+						allSchemas.add(t);
+						objectTypeSchemas.add(t);
 					}
-				},
+				}
 			},
-			new Set<TreeNodeSchema>(),
-		);
+		});
 		const nodeSchemas = [...objectTypeSchemas.values()] as BindableSchema[];
 		const bindableSchemas = new Map<string, BindableSchema>(
 			nodeSchemas.map((nodeSchema) => [nodeSchema.identifier, nodeSchema]),
@@ -120,6 +116,7 @@ function generateEditTypes(
 	const domainTypes: Record<string, ZodTypeAny> = {};
 	for (const schema of schemas) {
 		for (const name of schema.definitions.keys()) {
+			// If this does overwrite anything in domainTypes, it is guaranteed to be overwritten with an identical value due to the getOrCreate
 			domainTypes[name] = getOrCreateType(
 				schema.definitions,
 				name,

--- a/packages/framework/tree-agent/src/utils.ts
+++ b/packages/framework/tree-agent/src/utils.ts
@@ -544,18 +544,12 @@ function getTypePrecendece(type: z.ZodType): TypePrecedence {
 export function instanceOf<T extends TreeNodeSchemaClass>(
 	schema: T,
 ): z.ZodType<InstanceType<T>, z.ZodTypeDef, InstanceType<T>> {
-	const existing = instanceZods.get(schema.identifier);
-	if (existing !== undefined) {
-		return existing as z.ZodType<InstanceType<T>, z.ZodTypeDef, InstanceType<T>>;
-	}
 	if (!(schema instanceof ObjectNodeSchema)) {
 		throw new UsageError(`${schema.identifier} must be an instance of ObjectNodeSchema.`);
 	}
 	const effect = z.instanceof(schema);
-	instanceZods.set(schema.identifier, effect);
 	instanceOfs.set(effect, schema);
 	return effect;
 }
 
 const instanceOfs = new WeakMap<z.ZodTypeAny, ObjectNodeSchema>();
-const instanceZods = new Map<string, z.ZodTypeAny>();

--- a/packages/framework/tree-agent/src/utils.ts
+++ b/packages/framework/tree-agent/src/utils.ts
@@ -346,7 +346,7 @@ export function getZodSchemaAsTypeScript(schema: Record<string, z.ZodType>): str
 					return append(name);
 				}
 				throw new Error(
-					"Unsupporteded zod effects type. Did you use z.instanceOf? Use ExposedMethods.instanceOf function to reference schema classes in methods.",
+					"Unsupported zod effects type. Did you use z.instanceOf? Use ExposedMethods.instanceOf function to reference schema classes in methods.",
 				);
 			}
 			case z.ZodFirstPartyTypeKind.ZodVoid: {

--- a/packages/framework/tree-agent/src/utils.ts
+++ b/packages/framework/tree-agent/src/utils.ts
@@ -345,6 +345,9 @@ export function getZodSchemaAsTypeScript(schema: Record<string, z.ZodType>): str
 
 					return append(name);
 				}
+				throw new Error(
+					"Unsupporteded zod effects type. Did you use z.instanceOf? Use ExposedMethods.instanceOf function to reference schema classes in methods.",
+				);
 			}
 			case z.ZodFirstPartyTypeKind.ZodVoid: {
 				return append("void");


### PR DESCRIPTION
## Description

This PR fixes a bug in which references to schema types in exposed methods would be converted to void in the types shown to the agent. It also cleans up some code and removes some unnecessary optimizations in the type string generation.