### PR TITLE
fix(api-markdown-documenter): Ensure no line breaks in HTML table cell content

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -5,6 +5,12 @@
 `LayoutUtilities.createTypeParametersSection` now returns `undefined` when the item has no type paramters.
 This aligns the behavior of this function with other section creation helpers.
 
+### 🐞 Bug Fixes
+
+- Fixed an issue where HTML table cell content was generated with line breaks for formatting.
+  This would break Markdown table syntax.
+  Line breaks are now omitted in this context.
+
 ## 0.22.0
 
 ### Documentation Domain has been removed

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -794,7 +794,7 @@ function createTableCellFromTsdocSection(
 		// In some circumstances, `hast-util-to-html` seems to insert newlines presumably for formatting purposes,
 		// though it is unclear exactly what scenarios cause this behavior.
 		// Remove any such newlines here.
-		value: toHtml(node).replace(/\n/g, "" /* omit newlines */),
+		value: toHtml(node).replace(/\r?\n/g, "" /* omit newlines */),
 	}));
 	return {
 		type: "tableCell",

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -790,7 +790,11 @@ function createTableCellFromTsdocSection(
 	const htmlTrees = transformed.map((node) => toHast(node));
 	const htmlNodes: Html[] = htmlTrees.map((node) => ({
 		type: "html",
-		value: toHtml(node),
+		// In order for the Markdown syntax to be correct, the body of the cell must not contain any newlines.
+		// In some circumstances, `hast-util-to-html` seems to insert newlines presumably for formatting purposes,
+		// though it is unclear exactly what scenarios cause this behavior.
+		// Remove any such newlines here.
+		value: toHtml(node).replace(/\n/g, "" /* omit newlines */),
 	}));
 	return {
 		type: "tableCell",


### PR DESCRIPTION
Fixed an issue where HTML table cell content was generated with line breaks for formatting. This would break Markdown table syntax. Line breaks are now omitted in this context.

I have been unable to reproduce this behavior outside of the context of our fluidframework website build (even passing the same problematic content from that build into tests within the documenter library). It isn't clear to me what is causing the line breaking behavior in one setting and not the other. But I have verified that this fixes the behavior for the website build.