### PR TITLE
test(client-odsp-end-to-end-tests): correct script setup

### DIFF
--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -25,11 +25,11 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"test": "npm run test:realsvc:odsp:run",
+		"test": "npm run test:realsvc:odsp",
 		"test:coverage": "c8 npm test",
-		"test:realsvc:odsp": "cross-env npm run test:realsvc:odsp:run -- --driver=odsp --odspEndpointName=odsp",
+		"test:realsvc:odsp": "npm run test:realsvc:odsp:run -- --driver=odsp --odspEndpointName=odsp",
 		"test:realsvc:odsp:run": "mocha --exit --timeout 20000 --config src/test/.mocharc.cjs",
-		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
+		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc:odsp"
 	},
 	"c8": {
 		"all": true,

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 # test-service-clients pipeline
+# pipeline: https://dev.azure.com/fluidframework/internal/_build?definitionId=80
 
 name: $(Build.BuildId)
 
@@ -82,7 +83,7 @@ stages:
       poolBuild: Small-eastus2
       testPackage: ${{ variables.testOdspPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
-      testCommand: test:realsvc:odsp:run
+      testCommand: test:realsvc:odsp
       artifactBuildId: $(resources.pipeline.client.runID)
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:


### PR DESCRIPTION
Use `test:realsvc:odsp` instead of `test:realsvc:odsp:run` so that `driver` and `odspEndpointName` specifications are used. This brings configuration into alignment with `@fluidframework/azure-end-to-end-tests`.

Additional changes:
- drop the unused `cross-env` in `test:realsvc:odsp`
- `test:realsvc:verbose` calls `test:realsvc:odsp` instead of non-existent `test:realsvc`
- add convenience URL to top of pipeline yml file