### PR TITLE
RuntimeDefinitions: Add and use asAlpha

### DIFF
--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -7,6 +7,9 @@
 // @beta @legacy
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
+// @alpha @sealed @legacy
+export function asAlpha(base: IContainerRuntimeBase): ContainerRuntimeBaseAlpha;
+
 // @beta @legacy
 export interface AttributionInfo {
     timestamp: number;

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -83,10 +83,11 @@ export {
 } from "./summary.js";
 export type { MinimumVersionForCollab } from "./compatibilityDefinitions.js";
 
-export type {
-	ContainerRuntimeBaseAlpha,
-	StageControlsAlpha,
-	CommitStagedChangesOptionsExperimental,
-	IContainerRuntimeBaseExperimental,
-	StageControlsExperimental,
+export {
+	type ContainerRuntimeBaseAlpha,
+	type StageControlsAlpha,
+	type CommitStagedChangesOptionsExperimental,
+	type IContainerRuntimeBaseExperimental,
+	type StageControlsExperimental,
+	asAlpha,
 } from "./stagingMode.js";

--- a/packages/runtime/runtime-definitions/src/stagingMode.ts
+++ b/packages/runtime/runtime-definitions/src/stagingMode.ts
@@ -116,3 +116,12 @@ export interface ContainerRuntimeBaseAlpha extends IContainerRuntimeBase {
 	 */
 	readonly inStagingMode: boolean;
 }
+
+/**
+ * Converts types to their alpha counterparts to expose alpha functionality.
+ * @legacy @alpha
+ * @sealed
+ */
+export function asAlpha(base: IContainerRuntimeBase): ContainerRuntimeBaseAlpha {
+	return base as ContainerRuntimeBaseAlpha;
+}

--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -31,9 +31,9 @@ import type {
 // eslint-disable-next-line import/no-internal-modules
 import { modifyClusterSize } from "@fluidframework/id-compressor/internal/test-utils";
 import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
-import type {
-	ContainerRuntimeBaseAlpha,
-	StageControlsAlpha,
+import {
+	asAlpha,
+	type StageControlsAlpha,
 } from "@fluidframework/runtime-definitions/internal";
 import { RuntimeHeaders, toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import { timeoutAwait } from "@fluidframework/test-utils/internal";
@@ -304,8 +304,7 @@ export class DefaultStressDataObject extends StressDataObject {
 	}
 
 	private stageControls: StageControlsAlpha | undefined;
-	private readonly containerRuntimeExp = this.context
-		.containerRuntime as ContainerRuntimeBaseAlpha;
+	private readonly containerRuntimeExp = asAlpha(this.context.containerRuntime);
 	public enterStagingMode() {
 		assert(
 			this.containerRuntimeExp.enterStagingMode !== undefined,

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -18,7 +18,7 @@ import {
 	LocalResolver,
 } from "@fluidframework/local-driver/internal";
 import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
-import type { ContainerRuntimeBaseAlpha } from "@fluidframework/runtime-definitions/internal";
+import { asAlpha } from "@fluidframework/runtime-definitions/internal";
 import {
 	ILocalDeltaConnectionServer,
 	LocalDeltaConnectionServer,
@@ -299,9 +299,7 @@ describe("Document Dirty", () => {
 				// Submit a non-dirtyable op
 				containerRuntime.submit(nonDirtyableOp);
 
-				const stageControls = (
-					containerRuntime as unknown as ContainerRuntimeBaseAlpha
-				).enterStagingMode();
+				const stageControls = asAlpha(containerRuntime).enterStagingMode();
 
 				// Submit an op in staging mode - we will discard it later
 				sharedMap.set("key", "value");

--- a/packages/test/local-server-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/stagingMode.spec.ts
@@ -28,9 +28,9 @@ import {
 } from "@fluidframework/core-interfaces/internal";
 import type { SessionSpaceCompressedId } from "@fluidframework/id-compressor/internal";
 import { SharedMap } from "@fluidframework/map/internal";
-import type {
-	ContainerRuntimeBaseAlpha,
-	StageControlsExperimental,
+import {
+	asAlpha,
+	type StageControlsExperimental,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	encodeHandleForSerialization,
@@ -58,8 +58,7 @@ class DataObjectWithStagingMode extends DataObject {
 			? -1
 			: DataObjectWithStagingMode.instanceCount++;
 
-	private readonly containerRuntimeExp = this.context
-		.containerRuntime as ContainerRuntimeBaseAlpha;
+	private readonly containerRuntimeExp = asAlpha(this.context.containerRuntime);
 	get DataObjectWithStagingMode() {
 		return this;
 	}

--- a/packages/test/test-end-to-end-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stagingMode.spec.ts
@@ -9,11 +9,11 @@ import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-
 import { DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
-import type {
-	ContainerRuntimeBaseAlpha,
-	IFluidDataStoreChannel,
-	IFluidDataStoreContext,
-	IFluidDataStorePolicies,
+import {
+	asAlpha,
+	type IFluidDataStoreChannel,
+	type IFluidDataStoreContext,
+	type IFluidDataStorePolicies,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	getContainerEntryPointBackCompat,
@@ -74,7 +74,7 @@ describeCompat(
 			const { _context, _runtime, _root } =
 				await getContainerEntryPointBackCompat<ITestDataObject>(container);
 
-			const containerRuntime = _context.containerRuntime as ContainerRuntimeBaseAlpha;
+			const containerRuntime = asAlpha(_context.containerRuntime);
 			return {
 				container,
 				containerRuntime,


### PR DESCRIPTION
This pull request introduces a new utility function, `asAlpha`, to safely cast `IContainerRuntimeBase` to `ContainerRuntimeBaseAlpha` and exposes it throughout the codebase. This change simplifies and standardizes how alpha functionality is accessed in both production and test code, replacing direct type assertions with the new function. Several test files are updated to use `asAlpha`, improving type safety and clarity.
