### PR TITLE
Add asAlpha to tree package

### DIFF
--- a/.changeset/lazy-comics-cheat.md
+++ b/.changeset/lazy-comics-cheat.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/azure-end-to-end-tests": minor
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"@fluidframework/tree-agent": minor
+"__section": breaking
+---
+`asTreeViewAlpha` has been deprecated in favor of `asAlpha`.
+
+Please replace usages with of `asTreeViewAlpha` with `asAlpha` - the function signature remains the same.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -79,6 +79,9 @@ export const ArrayNodeSchema: {
 };
 
 // @alpha
+export function asAlpha<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewAlpha<TSchema>;
+
+// @alpha @deprecated
 export function asTreeViewAlpha<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewAlpha<TSchema>;
 
 // @alpha @sealed

--- a/packages/dds/tree/src/api.ts
+++ b/packages/dds/tree/src/api.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	type TreeView,
+	type TreeViewAlpha,
+	type ImplicitFieldSchema,
+	// eslint-disable-next-line import/no-deprecated
+	asTreeViewAlpha,
+} from "./simple-tree/index.js";
+
+/**
+ * Module entry points for retrieving alternate (alpha/beta) versions of tree APIs.
+ * For each API (usually a class) that has an alpha/beta version, add overloads to the function(s) below.
+ * In the future, `asBeta` may be added here too.
+ * These functions should only be used by external consumers, not referenced internally within the tree package, to avoid circular import dependencies.
+ */
+
+/**
+ * Retrieve the {@link TreeViewAlpha | alpha API} for a {@link TreeView}.
+ * @alpha
+ */
+export function asAlpha<TSchema extends ImplicitFieldSchema>(
+	view: TreeView<TSchema>,
+): TreeViewAlpha<TSchema> {
+	// eslint-disable-next-line import/no-deprecated
+	return asTreeViewAlpha(view);
+}

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -332,3 +332,4 @@ export type { MapNodeInsertableData } from "./simple-tree/index.js";
 export { JsonAsTree } from "./jsonDomainSchema.js";
 export { FluidSerializableAsTree } from "./serializableDomainSchema.js";
 export { TableSchema, type System_TableSchema } from "./tableSchema.js";
+export { asAlpha } from "./api.js";

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -517,6 +517,7 @@ export interface TreeViewEvents {
 /**
  * Retrieve the {@link TreeViewAlpha | alpha API} for a {@link TreeView}.
  * @alpha
+ * @deprecated Use {@link asAlpha} instead.
  */
 export function asTreeViewAlpha<TSchema extends ImplicitFieldSchema>(
 	view: TreeView<TSchema>,

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -518,6 +518,7 @@ export interface TreeViewEvents {
  * Retrieve the {@link TreeViewAlpha | alpha API} for a {@link TreeView}.
  * @alpha
  * @deprecated Use {@link asAlpha} instead.
+ * @privateRemarks Despite being deprecated, this function should be used within the tree package (outside of tests) rather than `asAlpha` in order to avoid circular import dependencies.
  */
 export function asTreeViewAlpha<TSchema extends ImplicitFieldSchema>(
 	view: TreeView<TSchema>,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -58,7 +58,7 @@ import {
 } from "./operationTypes.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { SchematizingSimpleTreeView } from "../../../shared-tree/schematizingTreeView.js";
-import { asTreeViewAlpha, getOrCreateInnerNode } from "../../../simple-tree/index.js";
+import { getOrCreateInnerNode } from "../../../simple-tree/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
@@ -67,6 +67,7 @@ import {
 } from "../../../simple-tree/index.js";
 import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
 import type { ISharedTree } from "../../../treeFactory.js";
+import { asAlpha } from "../../../api.js";
 
 export type FuzzView = SchematizingSimpleTreeView<typeof fuzzFieldSchema> & {
 	/**
@@ -148,7 +149,7 @@ export function viewFromState(
 				schema: treeSchema,
 			});
 
-			const treeView = asTreeViewAlpha(tree.viewWith(config));
+			const treeView = asAlpha(tree.viewWith(config));
 			treeView.events.on("schemaChanged", () => {
 				if (!treeView.compatibility.canView) {
 					treeView.dispose();

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -68,7 +68,6 @@ import {
 	type TreeViewAlpha,
 	TreeViewConfiguration,
 	type ValidateRecursiveSchema,
-	asTreeViewAlpha,
 	SchemaFactoryAlpha,
 	type ITree,
 	toInitialSchema,
@@ -118,6 +117,7 @@ import { simpleTreeNodeSlot } from "../../simple-tree/core/treeNodeKernel.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { TreeSimpleContent } from "../feature-libraries/flex-tree/utils.js";
 import { FluidClientVersion } from "../../codec/index.js";
+import { asAlpha } from "../../api.js";
 
 const enableSchemaValidation = true;
 
@@ -1648,7 +1648,7 @@ describe("SharedTree", () => {
 			// This test ensures that the feature works across peers as opposed to solely across branches.
 			const provider = new TestTreeProviderLite(2);
 			const config = new TreeViewConfiguration({ schema: JsonAsTree.JsonObject });
-			const viewA = asTreeViewAlpha(provider.trees[0].viewWith(config));
+			const viewA = asAlpha(provider.trees[0].viewWith(config));
 			const viewB = provider.trees[1].viewWith(config);
 			viewA.initialize(
 				new JsonAsTree.JsonObject({ child: new JsonAsTree.JsonObject({ id: "A" }) }),
@@ -2392,9 +2392,7 @@ describe("SharedTree", () => {
 		const tree = DefaultTestSharedTreeKind.getFactory().create(runtime, "tree");
 		const runtimeFactory = new MockContainerRuntimeFactory();
 		runtimeFactory.createContainerRuntime(runtime);
-		const view = asTreeViewAlpha(
-			tree.viewWith(new TreeViewConfiguration({ schema: StringArray })),
-		);
+		const view = asAlpha(tree.viewWith(new TreeViewConfiguration({ schema: StringArray })));
 		view.initialize([]);
 		assert.throws(
 			() => {
@@ -2419,9 +2417,7 @@ describe("SharedTree", () => {
 		const tree = sharedObject.getFactory().create(runtime, "tree");
 		const runtimeFactory = new MockContainerRuntimeFactory();
 		runtimeFactory.createContainerRuntime(runtime);
-		const view = asTreeViewAlpha(
-			tree.viewWith(new TreeViewConfiguration({ schema: StringArray })),
-		);
+		const view = asAlpha(tree.viewWith(new TreeViewConfiguration({ schema: StringArray })));
 		view.initialize(["A"]);
 		view.root.removeAt(0);
 		// The fork prevents the trimming of the commit that removes "A"

--- a/packages/dds/tree/src/test/shared-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/tree.spec.ts
@@ -15,7 +15,6 @@ import {
 	type InsertableTypedNode,
 	type TreeNodeSchema,
 	type NodeFromSchema,
-	asTreeViewAlpha,
 	type TreeViewAlpha,
 	type TransactionConstraint,
 	type rollback,
@@ -36,6 +35,7 @@ import { runTransaction, Tree } from "../../shared-tree/tree.js";
 // Including tests for TreeAlpha here so they don't have to move if/when stabilized
 // eslint-disable-next-line import/no-internal-modules
 import { TreeAlpha } from "../../shared-tree/treeAlpha.js";
+import { asAlpha } from "../../api.js";
 
 describe("treeApi", () => {
 	describe("runTransaction", () => {
@@ -426,9 +426,6 @@ describe("treeApi", () => {
 			new TreeViewConfiguration({ schema: schemaFactory.null, enableSchemaValidation: true }),
 		);
 		view.initialize(null);
-		assert.equal(
-			asTreeViewAlpha(view) satisfies TreeViewAlpha<typeof schemaFactory.null>,
-			view,
-		);
+		assert.equal(asAlpha(view) satisfies TreeViewAlpha<typeof schemaFactory.null>, view);
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -48,7 +48,6 @@ import { brand } from "../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { SchematizingSimpleTreeView } from "../../shared-tree/schematizingTreeView.js";
 import {
-	asTreeViewAlpha,
 	getOrCreateInnerNode,
 	SchemaFactory,
 	toUpgradeSchema,
@@ -60,6 +59,7 @@ import {
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { stringSchema } from "../../simple-tree/leafNodeSchema.js";
+import { asAlpha } from "../../api.js";
 
 const rootField: NormalizedFieldUpPath = {
 	parent: undefined,
@@ -1195,7 +1195,7 @@ describe("sharedTreeView", () => {
 
 		itView("disposing of a view also disposes of its revertibles", ({ view, tree }) => {
 			const treeBranch = tree.branch();
-			const viewBranch = asTreeViewAlpha(treeBranch.viewWith(view.config));
+			const viewBranch = asAlpha(treeBranch.viewWith(view.config));
 			const revertiblesCreated: Revertible[] = [];
 			const unsubscribe = viewBranch.events.on("changed", (_, getRevertible) => {
 				assert(getRevertible !== undefined, "commit should be revertible");
@@ -1226,7 +1226,7 @@ describe("sharedTreeView", () => {
 
 		itView("can be reverted after rebasing", ({ view, tree }) => {
 			const treeBranch = tree.branch();
-			const viewBranch = asTreeViewAlpha(treeBranch.viewWith(view.config));
+			const viewBranch = asAlpha(treeBranch.viewWith(view.config));
 			viewBranch.root.insertAtStart("A");
 
 			const stacks = createTestUndoRedoStacks(viewBranch.events);

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -31,14 +31,11 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 import { strict as assert } from "node:assert";
-import {
-	asTreeViewAlpha,
-	SchemaFactory,
-	TreeViewConfiguration,
-} from "../../simple-tree/index.js";
+import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { initialize } from "../../shared-tree/schematizeTree.js";
 import { FieldKinds } from "../../feature-libraries/index.js";
+import { asAlpha } from "../../api.js";
 
 const rootPath: NormalizedUpPath = {
 	detachedNodeId: undefined,
@@ -190,7 +187,7 @@ function createInitializedView() {
 		child: factory.optional(ChildNodeSchema),
 	}) {}
 	const provider = new TestTreeProviderLite();
-	const view = asTreeViewAlpha(
+	const view = asAlpha(
 		provider.trees[0].viewWith(
 			new TreeViewConfiguration({
 				schema: RootNodeSchema,
@@ -493,7 +490,7 @@ describe("Undo and redo", () => {
 		class Schema extends sf.object("Object", { foo: sf.number }) {}
 		const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
 		const tree = DefaultTestSharedTreeKind.getFactory().create(runtime, "tree");
-		const view = asTreeViewAlpha(tree.viewWith(new TreeViewConfiguration({ schema: Schema })));
+		const view = asAlpha(tree.viewWith(new TreeViewConfiguration({ schema: Schema })));
 		view.initialize({ foo: 1 });
 		assert.equal(tree.isAttached(), false);
 		let revertible: Revertible | undefined;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -79,6 +79,9 @@ export const ArrayNodeSchema: {
 };
 
 // @alpha
+export function asAlpha<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewAlpha<TSchema>;
+
+// @alpha @deprecated
 export function asTreeViewAlpha<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewAlpha<TSchema>;
 
 // @public

--- a/packages/framework/tree-agent/src/test/systemPrompt.spec.ts
+++ b/packages/framework/tree-agent/src/test/systemPrompt.spec.ts
@@ -9,7 +9,7 @@ import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 import type { ImplicitFieldSchema } from "@fluidframework/tree";
 import {
-	asTreeViewAlpha,
+	asAlpha,
 	getSimpleSchema,
 	SchemaFactory,
 	SharedTree,
@@ -167,7 +167,7 @@ describe("System prompt", () => {
 			responses: ["pong", "second", "third"],
 		});
 
-		const agent = createSemanticAgent(chat, asTreeViewAlpha(view)) as FunctioningSemanticAgent<
+		const agent = createSemanticAgent(chat, asAlpha(view)) as FunctioningSemanticAgent<
 			typeof ArrayWithMethod
 		>;
 

--- a/packages/framework/tree-agent/src/test/utils.ts
+++ b/packages/framework/tree-agent/src/test/utils.ts
@@ -15,7 +15,7 @@ import { type ImplicitFieldSchema, TreeViewConfiguration } from "@fluidframework
 import {
 	SharedTree,
 	TreeAlpha,
-	asTreeViewAlpha,
+	asAlpha,
 	type InsertableField,
 	type InsertableTreeFieldFromImplicitField,
 	type ReadableField,
@@ -133,7 +133,7 @@ async function queryDomain<TSchema extends ImplicitFieldSchema, T = ReadableFiel
 	view.initialize(initialTree);
 	const client = createLlmClient(provider);
 	await (options?.subtree === undefined
-		? createSemanticAgent(client, asTreeViewAlpha(view), {
+		? createSemanticAgent(client, asAlpha(view), {
 				log: options?.log,
 				domainHints: options?.domainHints,
 				treeToString: options?.treeToString as (root: ReadableField<TSchema>) => string,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
@@ -11,7 +11,7 @@ import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-sta
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import type { Revertible, TreeView, ValidateRecursiveSchema } from "@fluidframework/tree";
 import { SchemaFactory, Tree, TreeStatus, TreeViewConfiguration } from "@fluidframework/tree";
-import { allowUnused, asTreeViewAlpha } from "@fluidframework/tree/alpha";
+import { allowUnused, asAlpha } from "@fluidframework/tree/alpha";
 import { SharedTree } from "@fluidframework/tree/legacy";
 import type { AxiosResponse } from "axios";
 
@@ -216,7 +216,7 @@ for (const testOpts of testMatrix) {
 				it("can handle undo/redo and transactions", async () => {
 					const { container } = await client.createContainer(schema, "2");
 					await container.attach();
-					const view = asTreeViewAlpha(
+					const view = asAlpha(
 						container.initialObjects.tree1.viewWith(
 							new TreeViewConfiguration({ schema: User, enableSchemaValidation: true }),
 						),


### PR DESCRIPTION
This will allow future APIs that follow the same pattern to share the same common `asAlpha` API.
This also aligns the tree API with the [recently introduced container-runtime API](https://github.com/microsoft/FluidFramework/pull/25509).