### PR TITLE
RuntimeDefinitions: Rename asAlpha to asLegacyAlpha

### DIFF
--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -8,7 +8,7 @@
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
 // @alpha @sealed @legacy
-export function asAlpha(base: IContainerRuntimeBase): ContainerRuntimeBaseAlpha;
+export function asLegacyAlpha(base: IContainerRuntimeBase): ContainerRuntimeBaseAlpha;
 
 // @beta @legacy
 export interface AttributionInfo {

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -89,5 +89,5 @@ export {
 	type CommitStagedChangesOptionsExperimental,
 	type IContainerRuntimeBaseExperimental,
 	type StageControlsExperimental,
-	asAlpha,
+	asLegacyAlpha,
 } from "./stagingMode.js";

--- a/packages/runtime/runtime-definitions/src/stagingMode.ts
+++ b/packages/runtime/runtime-definitions/src/stagingMode.ts
@@ -122,6 +122,6 @@ export interface ContainerRuntimeBaseAlpha extends IContainerRuntimeBase {
  * @legacy @alpha
  * @sealed
  */
-export function asAlpha(base: IContainerRuntimeBase): ContainerRuntimeBaseAlpha {
+export function asLegacyAlpha(base: IContainerRuntimeBase): ContainerRuntimeBaseAlpha {
 	return base as ContainerRuntimeBaseAlpha;
 }

--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -32,7 +32,7 @@ import type {
 import { modifyClusterSize } from "@fluidframework/id-compressor/internal/test-utils";
 import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import {
-	asAlpha,
+	asLegacyAlpha,
 	type StageControlsAlpha,
 } from "@fluidframework/runtime-definitions/internal";
 import { RuntimeHeaders, toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
@@ -304,7 +304,7 @@ export class DefaultStressDataObject extends StressDataObject {
 	}
 
 	private stageControls: StageControlsAlpha | undefined;
-	private readonly containerRuntimeExp = asAlpha(this.context.containerRuntime);
+	private readonly containerRuntimeExp = asLegacyAlpha(this.context.containerRuntime);
 	public enterStagingMode() {
 		assert(
 			this.containerRuntimeExp.enterStagingMode !== undefined,

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -18,7 +18,7 @@ import {
 	LocalResolver,
 } from "@fluidframework/local-driver/internal";
 import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
-import { asAlpha } from "@fluidframework/runtime-definitions/internal";
+import { asLegacyAlpha } from "@fluidframework/runtime-definitions/internal";
 import {
 	ILocalDeltaConnectionServer,
 	LocalDeltaConnectionServer,
@@ -299,7 +299,7 @@ describe("Document Dirty", () => {
 				// Submit a non-dirtyable op
 				containerRuntime.submit(nonDirtyableOp);
 
-				const stageControls = asAlpha(containerRuntime).enterStagingMode();
+				const stageControls = asLegacyAlpha(containerRuntime).enterStagingMode();
 
 				// Submit an op in staging mode - we will discard it later
 				sharedMap.set("key", "value");

--- a/packages/test/local-server-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/stagingMode.spec.ts
@@ -29,7 +29,7 @@ import {
 import type { SessionSpaceCompressedId } from "@fluidframework/id-compressor/internal";
 import { SharedMap } from "@fluidframework/map/internal";
 import {
-	asAlpha,
+	asLegacyAlpha,
 	type StageControlsExperimental,
 } from "@fluidframework/runtime-definitions/internal";
 import {
@@ -58,7 +58,7 @@ class DataObjectWithStagingMode extends DataObject {
 			? -1
 			: DataObjectWithStagingMode.instanceCount++;
 
-	private readonly containerRuntimeExp = asAlpha(this.context.containerRuntime);
+	private readonly containerRuntimeExp = asLegacyAlpha(this.context.containerRuntime);
 	get DataObjectWithStagingMode() {
 		return this;
 	}

--- a/packages/test/test-end-to-end-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stagingMode.spec.ts
@@ -10,7 +10,7 @@ import { DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
 import {
-	asAlpha,
+	asLegacyAlpha,
 	type IFluidDataStoreChannel,
 	type IFluidDataStoreContext,
 	type IFluidDataStorePolicies,
@@ -74,7 +74,7 @@ describeCompat(
 			const { _context, _runtime, _root } =
 				await getContainerEntryPointBackCompat<ITestDataObject>(container);
 
-			const containerRuntime = asAlpha(_context.containerRuntime);
+			const containerRuntime = asLegacyAlpha(_context.containerRuntime);
 			return {
 				container,
 				containerRuntime,


### PR DESCRIPTION
This pull request updates the naming of the function used to cast a container runtime to its alpha interface, changing it from `asAlpha` to `asLegacyAlpha`. This change is applied throughout the codebase to improve clarity and consistency, especially in preparation for future API changes. All imports, exports, and usages of this function are updated accordingly in both runtime and test files.