### PR TITLE
tree: Remove EditManager.getLocalChanges

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -419,10 +419,6 @@ export class EditManager<
 		return getPathFromBase(this.getTrunkHead(branchId), this.trunkBase);
 	}
 
-	public getLocalChanges(branchId: BranchId): readonly TChangeset[] {
-		return this.getLocalCommits(branchId).map((c) => c.change);
-	}
-
 	public getLocalCommits(branchId: BranchId): readonly GraphCommit<TChangeset>[] {
 		const branch = this.getSharedBranch(branchId);
 		return branch.getLocalCommits();

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -459,7 +459,9 @@ export function checkChangeList(manager: TestEditManager, intentions: number[]):
 }
 
 export function getAllChanges(manager: TestEditManager): RecursiveReadonly<TestChange>[] {
-	return manager.getTrunkChanges("main").concat(manager.getLocalChanges("main"));
+	return manager
+		.getTrunkChanges("main")
+		.concat(manager.getLocalCommits("main").map((c) => c.change));
 }
 
 /** Adds a sequenced change to an `EditManager` and returns the delta that was caused by the change */


### PR DESCRIPTION
## Description

This removes the public function `getLocalChanges` from `EditManager`, as it was only used by tests. The logic is now inlined into a test helper.