### PR TITLE
tree: Fix bug where commits to a branch could be submitted twice

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -115,11 +115,14 @@ export class EditManager<
 	/**
 	 * @param changeFamily - the change family of changes on the trunk and local branch
 	 * @param localSessionId - the id of the local session that will be used for local commits
+	 * @param mintRevisionTag - a function which generates globally unique revision tags
+	 * @param onSharedBranchCreated - called when a new shared branch is created. This is not called for the main branch.
 	 */
 	public constructor(
 		public readonly changeFamily: TChangeFamily,
 		public readonly localSessionId: SessionId,
 		private readonly mintRevisionTag: () => RevisionTag,
+		private readonly onSharedBranchCreated?: (branchId: BranchId) => void,
 		logger?: ITelemetryLoggerExt,
 	) {
 		this.trunkBase = {
@@ -146,12 +149,7 @@ export class EditManager<
 			this.telemetryEventBatcher,
 		);
 
-		const mainBranch = this.createSharedBranch("main", undefined, undefined, mainTrunk);
-
-		// Track all forks of the local branch for purposes of trunk eviction. Unlike the local branch, they have
-		// an unknown lifetime and rebase frequency, so we can not make any assumptions about which trunk commits
-		// they require and therefore we monitor them explicitly.
-		onForkTransitive(mainBranch.localBranch, (fork) => this.registerBranch(fork));
+		this.createSharedBranch("main", undefined, undefined, mainTrunk);
 	}
 
 	public getLocalBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChangeset> {
@@ -456,10 +454,7 @@ export class EditManager<
 
 		const mainBranch = this.getSharedBranch("main");
 		const branchTrunk = mainBranch.rebasePeer(sessionId, referenceSequenceNumber).fork();
-
-		const sharedBranch = this.createSharedBranch(branchId, sessionId, mainBranch, branchTrunk);
-		this.registerBranch(sharedBranch.localBranch);
-		onForkTransitive(sharedBranch.localBranch, (fork) => this.registerBranch(fork));
+		this.createSharedBranch(branchId, sessionId, mainBranch, branchTrunk);
 	}
 
 	public addBranch(branchId: BranchId): void {
@@ -498,6 +493,17 @@ export class EditManager<
 
 		assert(!this.sharedBranches.has(branchId), "A branch with this ID already exists");
 		this.sharedBranches.set(branchId, sharedBranch);
+
+		// Track all forks of the local branch for purposes of trunk eviction. Unlike the local branch, they have
+		// an unknown lifetime and rebase frequency, so we can not make any assumptions about which trunk commits
+		// they require and therefore we monitor them explicitly.
+		onForkTransitive(sharedBranch.localBranch, (fork) => this.registerBranch(fork));
+
+		if (branchId !== "main") {
+			this.registerBranch(sharedBranch.localBranch);
+			this.onSharedBranchCreated?.(branchId);
+		}
+
 		return sharedBranch;
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -150,6 +150,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			changeFamily,
 			localSessionId,
 			this.mintRevisionTag,
+			(branchId) => this.registerSharedBranch(branchId),
 			rebaseLogger,
 		);
 
@@ -413,8 +414,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 						brand(envelope.referenceSequenceNumber),
 						message.branchId,
 					);
-
-					this.registerSharedBranch(message.branchId);
 					break;
 				}
 				default:
@@ -464,7 +463,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 
 	protected addBranch(branchId: BranchId): void {
 		this.editManager.addBranch(branchId);
-		this.registerSharedBranch(branchId);
 	}
 
 	public getSharedBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChange> {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2545,6 +2545,7 @@ describe("SharedTree", () => {
 				mainView1.root.insertAtEnd("A");
 				const branchId = tree1.createSharedBranch();
 				mainView1.root.insertAtEnd("B");
+				await provider.ensureSynchronized();
 
 				const branchView1 = tree1.viewSharedBranchWith(branchId, config);
 				branchView1.root.insertAtEnd("X");


### PR DESCRIPTION
## Description

This fixes a bug where `SharedTreeCore.submitCommit` was called twice when editing a shared branch. An event handler was being registered both when creating the branch and also when the branch creation was sequenced. This change adds a callback to `EditManager` which is fired when a new branch is added, and `SharedTreeCore`'s event handler for submitting commits is registered as part of that callback.