### PR TITLE
Revert "Avoid reading ops from cache when a versioned document is opened"

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -225,11 +225,10 @@ export class OdspDocumentService
 			async (from, to, telemetryProps, fetchReason) =>
 				service.get(from, to, telemetryProps, fetchReason),
 			// Get cachedOps Callback.
-			// TODO AB#47218: This condition will be removed when file version can be read from the cache entry for an op.
-			this.odspResolvedUrl.fileVersion === undefined
-				? async (from, to) =>
-						((await this.opsCache?.get(from, to)) as ISequencedDocumentMessage[]) ?? []
-				: async () => [],
+			async (from, to) => {
+				const res = await this.opsCache?.get(from, to);
+				return (res as ISequencedDocumentMessage[]) ?? [];
+			},
 			// Ops requestFromSocket Callback.
 			(from, to) => {
 				const currentConnection = this.odspDelayLoadedDeltaStream?.currentDeltaConnection;


### PR DESCRIPTION
Reverts microsoft/FluidFramework#25314 since #25337 is merged and adds file version information to op cache entries. 