### PR TITLE
Add odsp support to external-views

### DIFF
--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -52,11 +52,9 @@
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/local-driver": "workspace:~",
 		"@fluidframework/map": "workspace:~",
-		"@fluidframework/routerlicious-driver": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/server-local-server": "^7.0.0",
-		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"uuid": "^11.1.0"

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -28,7 +28,10 @@
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"prepack": "npm run webpack",
-		"start": "webpack serve",
+		"start": "npm run start:t9s",
+		"start:local": "webpack serve --env service=local",
+		"start:odsp": "webpack serve --env service=odsp",
+		"start:t9s": "webpack serve --env service=t9s",
 		"start:test": "webpack serve --config webpack.test.cjs",
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
@@ -37,6 +40,7 @@
 		"webpack:dev": "webpack --env development"
 	},
 	"dependencies": {
+		"@fluid-example/example-driver": "workspace:~",
 		"@fluid-internal/client-utils": "workspace:~",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
@@ -59,6 +63,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
+		"@fluid-example/example-webpack-integration": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",

--- a/examples/view-integration/external-views/src/app.ts
+++ b/examples/view-integration/external-views/src/app.ts
@@ -3,6 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import {
+	createExampleDriver,
+	getSpecifiedServiceFromWebpack,
+} from "@fluid-example/example-driver";
 import type {
 	ICodeDetailsLoader,
 	IContainer,
@@ -13,12 +17,6 @@ import {
 	createDetachedContainer,
 	loadExistingContainer,
 } from "@fluidframework/container-loader/legacy";
-import { createRouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver/legacy";
-import {
-	createInsecureTinyliciousTestTokenProvider,
-	createInsecureTinyliciousTestUrlResolver,
-	createTinyliciousTestCreateNewRequest,
-} from "@fluidframework/tinylicious-driver/test-utils";
 import { createElement } from "react";
 // eslint-disable-next-line import/no-internal-modules
 import { createRoot } from "react-dom/client";
@@ -26,9 +24,14 @@ import { createRoot } from "react-dom/client";
 import { DiceRollerContainerRuntimeFactory, type IDiceRoller } from "./container/index.js";
 import { DiceRollerView } from "./view.js";
 
-const urlResolver = createInsecureTinyliciousTestUrlResolver();
-const tokenProvider = createInsecureTinyliciousTestTokenProvider();
-const documentServiceFactory = createRouterliciousDocumentServiceFactory(tokenProvider);
+const service = getSpecifiedServiceFromWebpack();
+const {
+	urlResolver,
+	documentServiceFactory,
+	createCreateNewRequest,
+	createLoadExistingRequest,
+} = await createExampleDriver(service);
+
 const codeLoader: ICodeDetailsLoader = {
 	load: async (details: IFluidCodeDetails): Promise<IFluidModuleWithDetails> => {
 		return {
@@ -42,21 +45,31 @@ let id: string;
 let container: IContainer;
 
 if (location.hash.length === 0) {
+	// Some services support or require specifying the container id at attach time (local, odsp). For
+	// services that do not (t9s), the passed id will be ignored.
+	id = Date.now().toString();
+	const createNewRequest = createCreateNewRequest(id);
 	container = await createDetachedContainer({
 		codeDetails: { package: "1.0" },
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,
 	});
-	await container.attach(createTinyliciousTestCreateNewRequest());
-	if (container.resolvedUrl === undefined) {
-		throw new Error("Resolved Url unexpectedly missing!");
+	await container.attach(createNewRequest);
+	// For most services, the id on the resolvedUrl is the authoritative source for the container id
+	// (regardless of whether the id passed in createCreateNewRequest is respected or not). However,
+	// for odsp the id is a hashed combination of drive and container ID which we can't use. Instead,
+	// we retain the id we generated above.
+	if (service !== "odsp") {
+		if (container.resolvedUrl === undefined) {
+			throw new Error("Resolved Url unexpectedly missing!");
+		}
+		id = container.resolvedUrl.id;
 	}
-	id = container.resolvedUrl.id;
 } else {
 	id = location.hash.substring(1);
 	container = await loadExistingContainer({
-		request: { url: id },
+		request: await createLoadExistingRequest(id),
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,

--- a/examples/view-integration/external-views/webpack.config.cjs
+++ b/examples/view-integration/external-views/webpack.config.cjs
@@ -3,13 +3,17 @@
  * Licensed under the MIT License.
  */
 
+const {
+	createExampleDriverServiceWebpackPlugin,
+	createOdspMiddlewares,
+} = require("@fluid-example/example-webpack-integration");
 const path = require("path");
 const { merge } = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
 
 module.exports = (env) => {
-	const isProduction = env?.production;
+	const { production, service } = env;
 
 	return merge(
 		{
@@ -46,8 +50,17 @@ module.exports = (env) => {
 				new HtmlWebpackPlugin({
 					template: "./src/index.html",
 				}),
+				createExampleDriverServiceWebpackPlugin(service),
 			],
+			devServer: {
+				setupMiddlewares: (middlewares) => {
+					if (service === "odsp") {
+						middlewares.push(...createOdspMiddlewares());
+					}
+					return middlewares;
+				},
+			},
 		},
-		isProduction ? require("./webpack.prod.cjs") : require("./webpack.dev.cjs"),
+		production ? require("./webpack.prod.cjs") : require("./webpack.dev.cjs"),
 	);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6145,9 +6145,6 @@ importers:
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../../packages/dds/map
-      '@fluidframework/routerlicious-driver':
-        specifier: workspace:~
-        version: link:../../../packages/drivers/routerlicious-driver
       '@fluidframework/runtime-definitions':
         specifier: workspace:~
         version: link:../../../packages/runtime/runtime-definitions
@@ -6157,9 +6154,6 @@ importers:
       '@fluidframework/server-local-server':
         specifier: ^7.0.0
         version: 7.0.0
-      '@fluidframework/tinylicious-driver':
-        specifier: workspace:~
-        version: link:../../../packages/drivers/tinylicious-driver
       react:
         specifier: ^18.3.1
         version: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6109,6 +6109,9 @@ importers:
 
   examples/view-integration/external-views:
     dependencies:
+      '@fluid-example/example-driver':
+        specifier: workspace:~
+        version: link:../../utils/example-driver
       '@fluid-internal/client-utils':
         specifier: workspace:~
         version: link:../../../packages/common/client-utils
@@ -6170,6 +6173,9 @@ importers:
       '@biomejs/biome':
         specifier: ~1.9.3
         version: 1.9.4
+      '@fluid-example/example-webpack-integration':
+        specifier: workspace:~
+        version: link:../../utils/example-webpack-integration
       '@fluid-tools/build-cli':
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)


### PR DESCRIPTION
Building on #25482, this updates the external-views example to support ODSP.  This PR should serve as a good template for Copilot to later do PRs for the other examples (the blobs example was a little bit unique since it supports deferred container attach, which most of our examples don't do).