### PR TITLE
feat(tree) alpha API for retrieving IDs of shared branches

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -428,6 +428,7 @@ export interface ITreeAlpha extends ITree {
     createSharedBranch(): string;
     exportSimpleSchema(): SimpleTreeSchema;
     exportVerbose(): VerboseTree | undefined;
+    getSharedBranchIds(): string[];
     viewSharedBranchWith<TRoot extends ImplicitFieldSchema>(branchId: string, config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -463,6 +463,10 @@ export class EditManager<
 		);
 	}
 
+	public getSharedBranchIds(): BranchId[] {
+		return Array.from(this.sharedBranches.keys());
+	}
+
 	public removeBranch(branchId: BranchId): void {
 		assert(branchId !== "main", "Cannot remove main branch");
 		const hadBranch = this.sharedBranches.delete(branchId);

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -7,7 +7,11 @@ import type { IFluidLoadable, ITelemetryBaseLogger } from "@fluidframework/core-
 import { assert, fail, unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
-import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
+import type {
+	IIdCompressor,
+	SessionId,
+	SessionSpaceCompressedId,
+} from "@fluidframework/id-compressor";
 import type {
 	IExperimentalIncrementalSummaryContext,
 	IRuntimeMessageCollection,
@@ -455,6 +459,12 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		return this.editManager.getLocalBranch("main");
 	}
 
+	public getSharedBranchIds(): string[] {
+		return this.editManager
+			.getSharedBranchIds()
+			.filter((id): id is SessionSpaceCompressedId => id !== "main")
+			.map((id) => this.idCompressor.decompress(id));
+	}
 	public createSharedBranch(): string {
 		const branchId = this.idCompressor.generateCompressedId();
 		this.addBranch(branchId);

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -350,6 +350,7 @@ export class SharedTreeKernel
 			viewWith: this.viewWith.bind(this),
 			viewSharedBranchWith: this.viewBranchWith.bind(this),
 			createSharedBranch: this.createSharedBranch.bind(this),
+			getSharedBranchIds: this.getSharedBranchIds.bind(this),
 			kernel: this,
 		};
 	}

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -107,6 +107,12 @@ export interface ITreeAlpha extends ITree {
 	createSharedBranch(): string;
 
 	/**
+	 * Returns a list of all shared branches that currently exist on this tree.
+	 * Any one of them can be checked out using {@link ITreeAlpha.viewSharedBranchWith}.
+	 */
+	getSharedBranchIds(): string[];
+
+	/**
 	 * Returns a view of the tree on the specified shared branch, using the provided schema.
 	 * See {@link ViewableTree.viewWith}.
 	 */

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -771,6 +771,7 @@ export interface ITreeAlpha extends ITree {
     createSharedBranch(): string;
     exportSimpleSchema(): SimpleTreeSchema;
     exportVerbose(): VerboseTree | undefined;
+    getSharedBranchIds(): string[];
     viewSharedBranchWith<TRoot extends ImplicitFieldSchema>(branchId: string, config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 


### PR DESCRIPTION
## Description

Adds an alpha API for retrieving IDs of shared branches.
This is needed for fuzz testing but is generally useful since it's hard to know when shared branch creation op that were submitted by peers have been processed by the local client.

## Breaking Changes

None