### PR TITLE
Add configuredSharedTreeBeta

### DIFF
--- a/.changeset/mean-gifts-know.md
+++ b/.changeset/mean-gifts-know.md
@@ -12,7 +12,7 @@ import {
 	configuredSharedTreeBeta,
 	ForestTypeExpensiveDebug,
 } from "fluid-framework/beta";
-const SharedTree = configuredSharedTree({
+const SharedTree = configuredSharedTreeBeta({
 	forest: ForestTypeExpensiveDebug,
 });
 ```

--- a/.changeset/mean-gifts-know.md
+++ b/.changeset/mean-gifts-know.md
@@ -1,0 +1,18 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+Add configuredSharedTreeBeta
+
+A limited subset of the options from the existing `@alpha` [`configuredSharedTree`](https://fluidframework.com/docs/api/fluid-framework#configuredsharedtree-function) API have been stabilized to `@beta` in the form of `configuredSharedTreeBeta`.
+
+```typescript
+import {
+	configuredSharedTreeBeta,
+	ForestTypeExpensiveDebug,
+} from "fluid-framework/beta";
+const SharedTree = configuredSharedTree({
+	forest: ForestTypeExpensiveDebug,
+});
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -124,6 +124,9 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
     [key: string]: ConciseTree<THandle>;
 };
 
+// @beta
+export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
+
 // @alpha
 export function createIdentifierIndex<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): IdentifierIndex;
 
@@ -936,7 +939,10 @@ export const SharedTreeFormatVersion: {
 export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
 
 // @alpha @input
-export type SharedTreeOptions = Partial<CodecWriteOptions> & Partial<SharedTreeFormatOptions> & ForestOptions;
+export type SharedTreeOptions = Partial<CodecWriteOptions> & Partial<SharedTreeFormatOptions> & SharedTreeOptionsBeta;
+
+// @beta @input
+export type SharedTreeOptionsBeta = ForestOptions;
 
 // @alpha @sealed
 export interface SimpleArrayNodeSchema<out TCustomMetadata = unknown> extends SimpleNodeSchemaBaseAlpha<NodeKind.Array, TCustomMetadata> {

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -278,13 +278,13 @@ export interface ForestOptions {
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
-// @alpha
+// @beta
 export const ForestTypeExpensiveDebug: ForestType;
 
-// @alpha
+// @beta
 export const ForestTypeOptimized: ForestType;
 
-// @alpha
+// @beta
 export const ForestTypeReference: ForestType;
 
 // @alpha @sealed

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -43,6 +43,9 @@ export interface CommitMetadata {
     readonly kind: CommitKind;
 }
 
+// @beta
+export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
+
 // @public @sealed @system
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
@@ -394,6 +397,9 @@ export interface SchemaStatics {
 
 // @public @system
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
+
+// @beta @input
+export type SharedTreeOptionsBeta = ForestOptions;
 
 // @public @sealed @system
 export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCustomMetadata = unknown> {

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -124,6 +124,15 @@ export interface ForestOptions {
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
+// @beta
+export const ForestTypeExpensiveDebug: ForestType;
+
+// @beta
+export const ForestTypeOptimized: ForestType;
+
+// @beta
+export const ForestTypeReference: ForestType;
+
 // @public
 export type ImplicitAllowedTypes = AllowedTypes | TreeNodeSchema;
 

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -127,6 +127,15 @@ export interface ForestOptions {
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
+// @beta
+export const ForestTypeExpensiveDebug: ForestType;
+
+// @beta
+export const ForestTypeOptimized: ForestType;
+
+// @beta
+export const ForestTypeReference: ForestType;
+
 // @public
 export type ImplicitAllowedTypes = AllowedTypes | TreeNodeSchema;
 

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -43,6 +43,12 @@ export interface CommitMetadata {
     readonly kind: CommitKind;
 }
 
+// @beta
+export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
+
+// @beta @legacy
+export function configuredSharedTreeBetaLegacy(options: SharedTreeOptionsBeta): ISharedObjectKind<ITree> & SharedObjectKind<ITree>;
+
 // @public @sealed @system
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
@@ -403,6 +409,9 @@ export const SharedTreeAttributes: IChannelAttributes;
 
 // @beta @legacy
 export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
+
+// @beta @input
+export type SharedTreeOptionsBeta = ForestOptions;
 
 // @public @sealed @system
 export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCustomMetadata = unknown> {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -57,6 +57,7 @@ export {
 export {
 	type ITreeInternal,
 	type SharedTreeOptions,
+	type SharedTreeOptionsBeta,
 	type ForestType,
 	type SharedTreeFormatOptions,
 	SharedTreeFormatVersion,
@@ -275,6 +276,8 @@ export {
 export {
 	SharedTree,
 	configuredSharedTree,
+	configuredSharedTreeBeta,
+	configuredSharedTreeBetaLegacy,
 } from "./treeFactory.js";
 export { SharedTreeAttributes, SharedTreeFactoryType } from "./sharedTreeAttributes.js";
 export { persistedToSimpleSchema } from "./shared-tree/index.js";

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -7,6 +7,7 @@ export {
 	type ITreePrivate,
 	type SharedTreeOptionsInternal,
 	type SharedTreeOptions,
+	type SharedTreeOptionsBeta,
 	SharedTreeKernel,
 	getBranch,
 	type ForestType,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -636,11 +636,17 @@ export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
 
 /**
  * Configuration options for SharedTree.
+ * @beta @input
+ */
+export type SharedTreeOptionsBeta = ForestOptions;
+
+/**
+ * Configuration options for SharedTree.
  * @alpha @input
  */
 export type SharedTreeOptions = Partial<CodecWriteOptions> &
 	Partial<SharedTreeFormatOptions> &
-	ForestOptions;
+	SharedTreeOptionsBeta;
 
 export interface SharedTreeOptionsInternal
 	extends Omit<SharedTreeOptions, "treeEncodeType">,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -724,7 +724,7 @@ export interface ForestType extends ErasedType<"ForestType"> {}
  * A simple implementation with minimal complexity and moderate debuggability, validation and performance.
  * @privateRemarks
  * The "ObjectForest" forest type.
- * @alpha
+ * @beta
  */
 export const ForestTypeReference = toForestType(
 	(breaker: Breakable, schema: TreeStoredSchemaSubscription, idCompressor: IIdCompressor) =>
@@ -738,7 +738,7 @@ export const ForestTypeReference = toForestType(
  * Uses an internal representation optimized for size designed to scale to larger datasets with reduced overhead.
  * @privateRemarks
  * The "ChunkedForest" forest type.
- * @alpha
+ * @beta
  */
 export const ForestTypeOptimized = toForestType(
 	(breaker: Breakable, schema: TreeStoredSchemaSubscription, idCompressor: IIdCompressor) =>
@@ -752,7 +752,7 @@ export const ForestTypeOptimized = toForestType(
  * May be asymptotically slower than {@link ForestTypeReference}, and may perform very badly with larger data sizes.
  * @privateRemarks
  * The "ObjectForest" forest type with expensive asserts for debugging.
- * @alpha
+ * @beta
  */
 export const ForestTypeExpensiveDebug = toForestType(
 	(breaker: Breakable, schema: TreeStoredSchemaSubscription) =>

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -20,6 +20,7 @@ import {
 	SharedTreeKernel,
 	type ITreePrivate,
 	type SharedTreeOptions,
+	type SharedTreeOptionsBeta,
 	type SharedTreeOptionsInternal,
 	type SharedTreeKernelView,
 } from "./shared-tree/index.js";
@@ -91,26 +92,65 @@ export const SharedTree = configuredSharedTree({});
 /**
  * {@link SharedTree} but allowing a non-default configuration.
  * @remarks
- * This is useful for debugging and testing to opt into extra validation or see if opting out of some optimizations fixes an issue.
+ * This is useful for debugging and testing.
+ * For example it can be used to opt into extra validation or see if opting out of some optimizations fixes an issue.
+ *
+ * With great care, and knowledge of the support and stability of the options exposed here,
+ * this can also be used to opt into some features early or for performance tuning.
+ *
  * @example
  * ```typescript
  * import {
- * 	ForestType,
- * 	TreeCompressionStrategy,
- * 	configuredSharedTree,
- * 	typeboxValidator,
+ * 	configuredSharedTreeBeta,
+ * 	ForestTypeReference,
  * } from "@fluidframework/tree/internal";
  * const SharedTree = configuredSharedTree({
  * 	forest: ForestTypeReference,
- * 	jsonValidator: typeboxValidator,
+ * });
+ * ```
+ * @privateRemarks
+ * The Legacy `ISharedObjectKind<ITree>` type is omitted here for simplicity.
+ * @beta
+ */
+export function configuredSharedTreeBeta(
+	options: SharedTreeOptionsBeta,
+): SharedObjectKind<ITree> {
+	return configuredSharedTree(options);
+}
+
+/**
+ * {@link configuredSharedTreeBeta} including the legacy `ISharedObjectKind` type.
+ * @privateRemarks
+ * This is given a different export name (with legacy appended) to avoid the need to do the special reexport with different types from the fluid-framework package.
+ * @legacy @beta
+ */
+export function configuredSharedTreeBetaLegacy(
+	options: SharedTreeOptionsBeta,
+): ISharedObjectKind<ITree> & SharedObjectKind<ITree> {
+	return configuredSharedTree(options);
+}
+
+/**
+ * {@link configuredSharedTreeBetaLegacy} but including `@alpha` options.
+ *
+ * @example
+ * ```typescript
+ * import {
+ * 	TreeCompressionStrategy,
+ * 	configuredSharedTree,
+ * 	FormatValidatorBasic,
+ * 	ForestTypeReference,
+ * } from "@fluidframework/tree/internal";
+ * const SharedTree = configuredSharedTree({
+ * 	forest: ForestTypeReference,
+ * 	jsonValidator: FormatValidatorBasic,
  * 	treeEncodeType: TreeCompressionStrategy.Uncompressed,
  * });
  * ```
  * @privateRemarks
- * This should be legacy, but has to be internal due to limitations of API tagging preventing it from being both alpha and alpha+legacy.
- * TODO:
- * Expose Ajv validator for better error message quality somehow.
- * Maybe as part of a test utils or dev-tool package?
+ * This should be legacy, but has to be internal due to no alpha+legacy being setup yet.
+ *
+ * This should be renamed to `configuredSharedTreeAlpha` to avoid colliding with the eventual public version which will have less options.
  * @internal
  */
 export function configuredSharedTree(

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -103,7 +103,7 @@ export const SharedTree = configuredSharedTree({});
  * import {
  * 	configuredSharedTreeBeta,
  * 	ForestTypeReference,
- * } from "@fluidframework/tree/internal";
+ * } from "fluid-framework/beta";
  * const SharedTree = configuredSharedTree({
  * 	forest: ForestTypeReference,
  * });

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -134,6 +134,9 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
 // @alpha
 export function configuredSharedTree(options: SharedTreeOptions): SharedObjectKind<ITree>;
 
+// @beta
+export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
+
 // @public
 export enum ConnectionState {
     CatchingUp = 1,
@@ -1308,7 +1311,10 @@ export const SharedTreeFormatVersion: {
 export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
 
 // @alpha @input
-export type SharedTreeOptions = Partial<CodecWriteOptions> & Partial<SharedTreeFormatOptions> & ForestOptions;
+export type SharedTreeOptions = Partial<CodecWriteOptions> & Partial<SharedTreeFormatOptions> & SharedTreeOptionsBeta;
+
+// @beta @input
+export type SharedTreeOptionsBeta = ForestOptions;
 
 // @alpha @sealed
 export interface SimpleArrayNodeSchema<out TCustomMetadata = unknown> extends SimpleNodeSchemaBaseAlpha<NodeKind.Array, TCustomMetadata> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -334,13 +334,13 @@ export interface ForestOptions {
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
-// @alpha
+// @beta
 export const ForestTypeExpensiveDebug: ForestType;
 
-// @alpha
+// @beta
 export const ForestTypeOptimized: ForestType;
 
-// @alpha
+// @beta
 export const ForestTypeReference: ForestType;
 
 // @alpha @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -177,6 +177,15 @@ export interface ForestOptions {
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
+// @beta
+export const ForestTypeExpensiveDebug: ForestType;
+
+// @beta
+export const ForestTypeOptimized: ForestType;
+
+// @beta
+export const ForestTypeReference: ForestType;
+
 // @public
 export interface IConnection {
     readonly id: string;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -50,6 +50,9 @@ export interface CommitMetadata {
     readonly kind: CommitKind;
 }
 
+// @beta
+export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
+
 // @public
 export enum ConnectionState {
     CatchingUp = 1,
@@ -760,6 +763,9 @@ export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedTyp
 
 // @public
 export const SharedTree: SharedObjectKind<ITree>;
+
+// @beta @input
+export type SharedTreeOptionsBeta = ForestOptions;
 
 // @public @sealed @system
 export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCustomMetadata = unknown> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -180,6 +180,15 @@ export interface ForestOptions {
 export interface ForestType extends ErasedType<"ForestType"> {
 }
 
+// @beta
+export const ForestTypeExpensiveDebug: ForestType;
+
+// @beta
+export const ForestTypeOptimized: ForestType;
+
+// @beta
+export const ForestTypeReference: ForestType;
+
 // @beta @legacy
 export interface IBranchOrigin {
     id: string;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -50,6 +50,9 @@ export interface CommitMetadata {
     readonly kind: CommitKind;
 }
 
+// @beta
+export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
+
 // @public
 export enum ConnectionState {
     CatchingUp = 1,
@@ -1116,6 +1119,9 @@ export type SharedStringSegment = TextSegment | Marker;
 
 // @public
 export const SharedTree: SharedObjectKind<ITree>;
+
+// @beta @input
+export type SharedTreeOptionsBeta = ForestOptions;
 
 export { Side }
 

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -104,18 +104,23 @@ export const SharedTree: SharedObjectKind<ITree> = OriginalSharedTree;
 /**
  * {@link SharedTree} but allowing a non-default configuration.
  * @remarks
- * This is useful for debugging and testing to opt into extra validation or see if opting out of some optimizations fixes an issue.
+ * This is useful for debugging and testing.
+ * For example it can be used to opt into extra validation or see if opting out of some optimizations fixes an issue.
+ *
+ * With great care, and knowledge of the support and stability of the options exposed here,
+ * this can also be used to opt into some features early or for performance tuning.
+ *
  * @example
  * ```typescript
  * import {
- * 	ForestType,
  * 	TreeCompressionStrategy,
  * 	configuredSharedTree,
- * 	typeboxValidator,
- * } from "@fluid-framework/alpha";
+ * 	FormatValidatorBasic,
+ * 	ForestTypeReference,
+ * } from "fluid-framework/alpha";
  * const SharedTree = configuredSharedTree({
  * 	forest: ForestTypeReference,
- * 	jsonValidator: typeboxValidator,
+ * 	jsonValidator: FormatValidatorBasic,
  * 	treeEncodeType: TreeCompressionStrategy.Uncompressed,
  * });
  * ```

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -105,7 +105,7 @@ export const SharedTree: SharedObjectKind<ITree> = OriginalSharedTree;
  * {@link SharedTree} but allowing a non-default configuration.
  * @remarks
  * This is useful for debugging and testing.
- * For example it can be used to opt into extra validation or see if opting out of some optimizations fixes an issue.
+ * For example, it can be used to opt into extra validation or see if opting out of some optimizations fixes an issue.
  *
  * With great care, and knowledge of the support and stability of the options exposed here,
  * this can also be used to opt into some features early or for performance tuning.


### PR DESCRIPTION
## Description

Add beta version of configuredSharedTreeBeta and the options for ForestType.

This will allow beta API users to select chunked forest (a prerequisite for incremental summary), as well as the debug forest. It also sets up the needed types to stabilize more options.

The alpha versions of these should eventually get renamed, but this does not do so to reduce the risk of breaks.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


