### PR TITLE
tree: Fix bug with loading shared branches from summary

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -473,7 +473,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 	}
 
 	protected addBranch(branchId: BranchId): void {
-		this.editManager.addBranch(branchId);
+		this.editManager.addNewBranch(branchId);
 	}
 
 	public getSharedBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChange> {
@@ -575,7 +575,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				break;
 			}
 			case "branch": {
-				this.editManager.addBranch(message.branchId);
+				this.editManager.addNewBranch(message.branchId);
 				break;
 			}
 			default:


### PR DESCRIPTION
## Description

This fixes a bug where when loading from a summary, each shared branch was registered with the EditManager before the branch had finished loading.