### PR TITLE
Remove extra -- from pnpm exec scripts

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -367,7 +367,7 @@ stages:
                 set -eu -o pipefail
 
                 # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
-                pnpm exec trips-setup -- --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN
+                pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN
                 echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"
 
         # run the test
@@ -455,7 +455,7 @@ stages:
               targetType: 'inline'
               script: |
                 set -eu -o pipefail
-                pnpm exec trips-cleanup -- --reservationId=$(stringBearerToken)
+                pnpm exec trips-cleanup --reservationId=$(stringBearerToken)
             condition: eq(variables['tenantSetupSuccess'], 'true')
 
         # Log Test Failures

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -92,7 +92,7 @@ stages:
           echo "Listing files in '$WORK_FOLDER'"
           ls -laR $WORK_FOLDER;
 
-          pnpm exec telemetry-generator -- --handlerModule "$(pathToTelemetryGeneratorHandlersNew)/stageTimingRetriever.js" --dir "$WORK_FOLDER";
+          pnpm exec telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlersNew)/stageTimingRetriever.js" --dir "$WORK_FOLDER";
 
     - ${{ if parameters.uploadTestPassRateTelemetry }}:
       - task: Bash@3
@@ -124,4 +124,4 @@ stages:
             echo "Listing files in '$WORK_FOLDER'"
             ls -laR $WORK_FOLDER;
 
-            pnpm exec telemetry-generator -- --handlerModule "$(pathToTelemetryGeneratorHandlersNew)/testPassRate.js" --dir "$WORK_FOLDER"
+            pnpm exec telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlersNew)/testPassRate.js" --dir "$WORK_FOLDER"


### PR DESCRIPTION
## Description

Follow-up to #25535: this extra syntax is no longer required after moving off `npx` and though they are benign for me locally, they cause parameters to not be plumbed through in pipelines (likely due to shell differences)

Test run: [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=357111&view=results)