### PR TITLE
Improve 'copy devDependencies' step of include-test-real-service.yml

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -309,6 +309,8 @@ stages:
                 tar --extract --verbose --file $TAR_PATH ./dist/test
                 tar --extract --verbose --file $TAR_PATH ./src/test
 
+          # The test workload we are running frequently depends on devDependencies of the package being installed.
+          # To make sure these are available, copy them to the root package.json and reinstall.
           - task: Bash@3
             displayName: Copy devDependencies
             inputs:
@@ -321,7 +323,26 @@ stages:
                 node -e "
                   const { devDependencies } = require('$testPkgJsonPath');
                   const pkg = require('$pkgJsonPath');
-                  pkg.devDependencies=devDependencies;
+                  if (!pkg.devDependencies) {
+                    pkg.devDependencies = {};
+                  }
+                  // Avoid copying some common dev dependencies that should only be required at build time.
+                  // Keeping the dependency tree small helps reduce job time and likelihood of install failures, since
+                  // dependencies added as part of this step won't be reproducible via pnpm-lock.
+                  const avoidCopying = new Set([
+                    '@types/node',
+                    'typescript',
+                    '@microsoft/api-extractor',
+                    '@fluid-tools/build-cli',
+                    '@fluidframework/build-common',
+                    '@fluidframework/build-tools'
+                  ]);
+                  for (const [k, v] of Object.entries(devDependencies)) {
+                    if (!pkg.devDependencies[k] && !avoidCopying.has(k)) {
+                      console.log(`Adding devDependency ${k}@${v}`);
+                      pkg.devDependencies[k] = v;
+                    }
+                  }
                   require('fs').writeFileSync('$pkgJsonPath', JSON.stringify(pkg));
                 "
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -339,7 +339,8 @@ stages:
                   ]);
                   for (const [k, v] of Object.entries(devDependencies)) {
                     if (!pkg.devDependencies[k] && !avoidCopying.has(k)) {
-                      console.log(`Adding devDependency ${k}@${v}`);
+                      // Note that if you use string interpolation, bash interpreting the dollar sign takes precedence.
+                      console.log('Adding devDependency ' + k + '@' + v);
                       pkg.devDependencies[k] = v;
                     }
                   }


### PR DESCRIPTION
## Description

Follow-up to #25535: in line with using a "host repository" that has package-lock'd internal dependencies, tighten the "copy devDependency" script that we use to get devDependencies necessary at workload runtime to exclude some common dependencies that are only used at build time.

This is motivated by still seeing some DDS fuzz harness pipeline failures due to recently published transitive dependencies of build-tools.

Test run: [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=357194&view=logs&j=bbaafa3d-c204-5f81-4508-786dc29a3642&t=f302f968-fb15-5cb8-d0fb-0d951f384806)
