### PR TITLE
Remove old tenants from stress tests

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -51,8 +51,6 @@ stages:
       skipTestResultPublishing: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
-        login__microsoft__clientId: $(login-microsoft-clientId)
-        login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
         FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains getTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
 


### PR DESCRIPTION
Follow up to #25437, which mistakenly left the old tenants in the stress pipeline. Remove this and use the new tenants fully. 