### PR TITLE
improvement(client): remove useless Unverified branding

### DIFF
--- a/packages/runtime/container-runtime-definitions/src/containerExtension.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerExtension.ts
@@ -65,10 +65,25 @@ export type OutboundExtensionMessage<TMessage extends TypedMessage = TypedMessag
  * Brand for value that has not been verified.
  *
  * @remarks
- * Usage:
+ * What element is unverified is left up to the user and should be
+ * coordinated with and documented for associated logic.
  *
- * - Cast any value to `UnverifiedBrand` using `as unknown as UnverifiedBrand<T>`
- * when it is not yet confirmed that value is of type `T`.
+ * One type of unverified data is whether a `string` represents an identifier
+ * known to the system, such as an email address. This unverified email address
+ * could be represented as `string & UnverifiedBrand<EmailAddress>` where
+ * `EmailAddress` is a branded type for email addresses, such as
+ * `string & BrandedType<"EmailAddress">`.
+ *
+ * Another type of unverified data is particular structure of value where little
+ * to no or weak structure is known. An example is data received over the
+ * wire that is expected to be of a certain structure but has not yet been
+ * verified.
+ *
+ * Usage where value (type `U`) is not yet verified to be type `T`:
+ *
+ * - Cast value of type `U` suspected/expected to be `T` but not verified (where
+ * `T extends U`) to `UnverifiedBrand` using `as U & UnverifiedBrand<T>`. An
+ * example base type `U` for an object is `Record<string, unknown>`.
  *
  * - When `T` value is needed, use narrowing type guards to check (preferred)
  * or cast from `UnverifiedBrand` using `as unknown` when "instance" must
@@ -80,25 +95,6 @@ export type OutboundExtensionMessage<TMessage extends TypedMessage = TypedMessag
  *   unverified: Foo | (Record<string, unknown> & UnverifiedBrand<Foo>)
  * ): unverified is Foo {
  *   return unverified.IFooProvider === unverified;
- * }
- * ```
- *
- * @privateRemarks
- * Potential helper to mark expected types as unverified:
- * ```typescript
- * type BaseTypeOf<T> =
- * 	T extends string ? string
- * 	: T extends number ? number
- * 		: T extends boolean ? boolean
- * 			: T extends bigint ? bigint
- * 				: T extends undefined ? undefined
- * 					: T extends object ? Record<keyof any, unknown>
- * 						: never;
- *
- * function markUnverified<const T, TKnown extends BaseTypeOf<T> = BaseTypeOf<T>>(
- * 	value: T,
- * ): TKnown & UnverifiedBrand<T> {
- * 	return value as TKnown & UnverifiedBrand<T>;
  * }
  * ```
  *

--- a/packages/runtime/container-runtime-definitions/src/containerExtension.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerExtension.ts
@@ -83,6 +83,25 @@ export type OutboundExtensionMessage<TMessage extends TypedMessage = TypedMessag
  * }
  * ```
  *
+ * @privateRemarks
+ * Potential helper to mark expected types as unverified:
+ * ```typescript
+ * type BaseTypeOf<T> =
+ * 	T extends string ? string
+ * 	: T extends number ? number
+ * 		: T extends boolean ? boolean
+ * 			: T extends bigint ? bigint
+ * 				: T extends undefined ? undefined
+ * 					: T extends object ? Record<keyof any, unknown>
+ * 						: never;
+ *
+ * function markUnverified<const T, TKnown extends BaseTypeOf<T> = BaseTypeOf<T>>(
+ * 	value: T,
+ * ): TKnown & UnverifiedBrand<T> {
+ * 	return value as TKnown & UnverifiedBrand<T>;
+ * }
+ * ```
+ *
  * @sealed
  * @internal
  */

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -41,7 +41,6 @@ import type {
 	IContainerRuntimeWithResolveHandle_Deprecated,
 	JoinedStatus,
 	OutboundExtensionMessage,
-	UnverifiedBrand,
 } from "@fluidframework/container-runtime-definitions/internal";
 import type {
 	FluidObject,
@@ -708,13 +707,6 @@ export let getSingleUseLegacyLogCallback = (logger: ITelemetryLoggerExt, type: s
  */
 export interface UnknownIncomingTypedMessage extends TypedMessage {
 	content: OpaqueJsonDeserialized<unknown>;
-}
-
-/**
- * Does nothing helper to apply unverified branding to a value.
- */
-function markUnverified<const T>(value: T): T & UnverifiedBrand<T> {
-	return value as T & UnverifiedBrand<T>;
 }
 
 type UnsequencedSignalEnvelope = Omit<ISignalEnvelope, "clientBroadcastSignalSequenceNumber">;
@@ -3321,12 +3313,12 @@ export class ContainerRuntime
 		local: boolean,
 	): void {
 		const envelope = message.content;
-		const transformed = markUnverified({
+		const transformed = {
 			clientId: message.clientId,
 			content: envelope.contents.content,
 			type: envelope.contents.type,
 			targetClientId: message.targetClientId,
-		});
+		};
 
 		// Only collect signal telemetry for broadcast messages sent by the current client.
 		if (message.clientId === this.clientId) {
@@ -3349,8 +3341,7 @@ export class ContainerRuntime
 
 	private routeNonContainerSignal(
 		address: string,
-		signalMessage: IInboundSignalMessage<UnknownIncomingTypedMessage> &
-			UnverifiedBrand<UnknownIncomingTypedMessage>,
+		signalMessage: IInboundSignalMessage<UnknownIncomingTypedMessage>,
 		local: boolean,
 	): void {
 		// channelCollection signals are identified by no starting `/` in address.


### PR DESCRIPTION
where associate type already is clear about unknowns.

And update `UnverifiedBrand` use patterns.