### PR TITLE
StagingMode: Change default to non-readonly

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -282,7 +282,7 @@ export abstract class FluidDataStoreContext
 
 	private isStagingMode: boolean = false;
 	public isReadOnly = (): boolean =>
-		(this.isStagingMode && this.channel?.policies?.readonlyInStagingMode !== false) ||
+		(this.isStagingMode && this.channel?.policies?.readonlyInStagingMode === true) ||
 		this.parentContext.isReadOnly();
 
 	public get connected(): boolean {


### PR DESCRIPTION
Defaulting to readonly has proved challenging for prototyping, as it requires quite a bit more setup to use the feature. Given this is an alpha feature, which isn't currently in use, changing the default should present no issues, and should make further feature exploration easier.  