### PR TITLE
Migrate off of process global and openStdin

### DIFF
--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 import * as fs from "node:fs";
 import { EOL as newline } from "node:os";
 import * as path from "node:path";
+import process from "node:process";
 import { Flags } from "@oclif/core";
 
 import {
@@ -378,12 +379,12 @@ async function runFinalHandlers(
 
 async function readStdin(): Promise<string> {
 	return new Promise((resolve) => {
-		const stdin = process.openStdin();
+		const { stdin } = process;
 		stdin.setEncoding("utf8");
 
 		let data = "";
 		stdin.on("data", (chunk) => {
-			data += chunk;
+			data += chunk.toString("utf8");
 		});
 
 		stdin.on("end", () => {


### PR DESCRIPTION
## Description

Based on https://stackoverflow.com/questions/33831978/unknown-method-process-openstdin#comment126485133_33832075 appears we do not need to resume the stream unless using "old" streams mode (from back in NodeJS 0.10), and can just use process.stdin instead of openStdin which was [as done in Node 0.3.3 back in 2011](https://github.com/nodejs/node/blob/43e4efdf210adb2cc3ba26518fd4588f9e0152ff/doc/changelogs/CHANGELOG_ARCHIVE.md#20110102-version-033-unstable).

CheckPolicy's `--stdin` flag is the older user of this code, and was manually tested to work. As far as I can tell nothing uses this feature.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
