### PR TITLE
Add tests which build code using Fluid Framework with libCheck and different compiler versions and configurations

### DIFF
--- a/common/build/build-common/tsconfig.base.json
+++ b/common/build/build-common/tsconfig.base.json
@@ -7,13 +7,14 @@
 		"incremental": true,
 		"inlineSources": true,
 		"jsx": "react",
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		// "lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"noImplicitAny": false,
 		"noUnusedLocals": true,
 		"pretty": true,
 		"sourceMap": true,
 		"strict": true,
 		"target": "ES2021",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"types": [],
 		// Enabling these compiler flags is necessary for typechecking compliance with semver as per https://www.semver-ts.org/
 		// See specifically https://www.semver-ts.org/formal-spec/5-compiler-considerations.html#strictness.

--- a/common/build/build-common/tsconfig.base.json
+++ b/common/build/build-common/tsconfig.base.json
@@ -7,14 +7,13 @@
 		"incremental": true,
 		"inlineSources": true,
 		"jsx": "react",
-		// "lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"noImplicitAny": false,
 		"noUnusedLocals": true,
 		"pretty": true,
 		"sourceMap": true,
 		"strict": true,
 		"target": "ES2021",
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"types": [],
 		// Enabling these compiler flags is necessary for typechecking compliance with semver as per https://www.semver-ts.org/
 		// See specifically https://www.semver-ts.org/formal-spec/5-compiler-considerations.html#strictness.

--- a/examples/utils/import-testing/.mocharc.cjs
+++ b/examples/utils/import-testing/.mocharc.cjs
@@ -8,4 +8,5 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
+config.timeout = 6000;
 module.exports = config;

--- a/examples/utils/import-testing/.mocharc.cjs
+++ b/examples/utils/import-testing/.mocharc.cjs
@@ -8,5 +8,5 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
-config.timeout = 6000;
+config.timeout = 20000;
 module.exports = config;

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -57,12 +57,12 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5",
-		"typescriptTest1": "npm:typescript@~5.4.5",
-		"typescriptTest2": "npm:typescript@~5.5.4",
-		"typescriptTest3": "npm:typescript@~5.6.3",
-		"typescriptTest4": "npm:typescript@~5.7.3",
-		"typescriptTest5": "npm:typescript@~5.8.3",
-		"typescriptTest6": "npm:typescript@~5.9.2"
+		"typescript-5.4": "npm:typescript@~5.4.5",
+		"typescript-5.5": "npm:typescript@~5.5.4",
+		"typescript-5.6": "npm:typescript@~5.6.3",
+		"typescript-5.7": "npm:typescript@~5.7.3",
+		"typescript-5.8": "npm:typescript@~5.8.3",
+		"typescript-5.9": "npm:typescript@~5.9.2"
 	},
 	"typeValidation": {
 		"disabled": true,

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -56,7 +56,13 @@
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^4.4.0",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"typescriptTest1": "npm:typescript@~5.4.5",
+		"typescriptTest2": "npm:typescript@~5.5.4",
+		"typescriptTest3": "npm:typescript@~5.6.3",
+		"typescriptTest4": "npm:typescript@~5.7.3",
+		"typescriptTest5": "npm:typescript@~5.8.3",
+		"typescriptTest6": "npm:typescript@~5.9.2"
 	},
 	"typeValidation": {
 		"disabled": true,

--- a/examples/utils/import-testing/src/test/build.spec.ts
+++ b/examples/utils/import-testing/src/test/build.spec.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "node:assert";
+// import { strict as assert } from "node:assert";
 import { execFile } from "node:child_process";
 import fs from "node:fs";
+import { env } from "node:process";
 import { promisify } from "node:util";
 
 const packageJson = fs.readFileSync("package.json");
@@ -15,26 +16,58 @@ const packageObj = JSON.parse(packageJson.toString()) as {
 const devDependencies = packageObj.devDependencies;
 
 const typescriptVersions = Object.entries(devDependencies).filter(([name]) =>
-	name.startsWith("typescriptTest"),
+	name.startsWith("typescript-"),
 );
 
 const execFileAsync = promisify(execFile);
 
+// TODO: cases which do not build, but probably should:
+// - Building with `"lib": ["ES2022"]` (missing "DOM"): Error: ../../../packages/utils/telemetry-utils/lib/config.d.ts(37,56): error TS2304: Cannot find name 'Storage'.
+// - Building with `"lib": ["ES2022", "DOM", "esnext.disposable"]` and TS 5.6 or newer
+// - Building with `"exactOptionalPropertyTypes": true`
+
+async function compileTest(tscName: string, args: string[]): Promise<void> {
+	const result = execFileAsync(
+		`./node_modules/${tscName}/bin/tsc`,
+		["--project", "./tsconfig.test.json", "--noEmit", ...args],
+		{},
+	);
+
+	try {
+		await result;
+	} catch (error) {
+		throw new Error((error as Record<string, string>).stdout);
+	}
+}
+
 // Compile this package using several versions of typescript to ensure the type checking in its imports (mainly fluid-framework) passes.
 describe("build tests", () => {
-	for (const [name, version] of typescriptVersions) {
-		it(`can import with ${name} (${version})`, async () => {
-			const result = execFileAsync(
-				`./node_modules/${name}/bin/tsc`,
-				["--project", "./tsconfig.test.json", "--noEmit"],
-				{},
-			);
+	// Skip these tests when using CJS, as this only build for ESM, so running in both modes would be redundant.
+	if (env.FLUID_TEST_MODULE_SYSTEM !== "CJS") {
+		for (const [name, version] of typescriptVersions) {
+			it(`can build with ${name} (${version})`, async () => {
+				await compileTest(name, []);
+			});
+		}
 
-			try {
-				await result;
-			} catch (error) {
-				throw new Error((error as Record<string, string>).stdout);
-			}
-		}).timeout(20000);
+		describe("can build with esnext.disposable", () => {
+			it("typescript-5.5", async () => {
+				await compileTest("typescript-5.5", ["--lib", "ES2022,DOM,esnext.disposable"]);
+			});
+			// Currently fails for typescript 5.6 and newer:
+			it.skip("typescript-5.6", async () => {
+				await compileTest("typescript-5.6", ["--lib", "ES2022,DOM,esnext.disposable"]);
+			});
+		});
+
+		// Error: ../../../packages/utils/telemetry-utils/lib/config.d.ts(37,56): error TS2304: Cannot find name 'Storage'.
+		it.skip("without DOM", async () => {
+			await compileTest("typescript-5.4", ["--lib", "ES2022"]);
+		});
+
+		// Several errors
+		it.skip("exactOptionalPropertyTypes", async () => {
+			await compileTest("typescript-5.4", ["--exactOptionalPropertyTypes"]);
+		});
 	}
 });

--- a/examples/utils/import-testing/src/test/build.spec.ts
+++ b/examples/utils/import-testing/src/test/build.spec.ts
@@ -61,11 +61,13 @@ describe("build tests", () => {
 		});
 
 		// Error: ../../../packages/utils/telemetry-utils/lib/config.d.ts(37,56): error TS2304: Cannot find name 'Storage'.
+		// That code isn't even package exported: might be fixable by fixing how we do roll-ups?
 		it.skip("without DOM", async () => {
 			await compileTest("typescript-5.4", ["--lib", "ES2022"]);
 		});
 
-		// Several errors
+		// Several errors.
+		// Many of the errors are in types with no release tag which are intended to be package private: this might indicate an issue or limitation of how we do roll-ups?
 		it.skip("exactOptionalPropertyTypes", async () => {
 			await compileTest("typescript-5.4", ["--exactOptionalPropertyTypes"]);
 		});

--- a/examples/utils/import-testing/src/test/build.spec.ts
+++ b/examples/utils/import-testing/src/test/build.spec.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { promisify } from "node:util";
+
+const packageJson = fs.readFileSync("package.json");
+const packageObj = JSON.parse(packageJson.toString()) as {
+	devDependencies: Record<string, string>;
+};
+const devDependencies = packageObj.devDependencies;
+
+const typescriptVersions = Object.entries(devDependencies).filter(([name]) =>
+	name.startsWith("typescriptTest"),
+);
+
+const execFileAsync = promisify(execFile);
+
+// Compile this package using several versions of typescript to ensure the type checking in its imports (mainly fluid-framework) passes.
+describe("build tests", () => {
+	for (const [name, version] of typescriptVersions) {
+		it(`can import with ${name} (${version})`, async () => {
+			const result = execFileAsync(
+				`./node_modules/${name}/bin/tsc`,
+				["--project", "./tsconfig.test.json", "--noEmit"],
+				{},
+			);
+
+			try {
+				await result;
+			} catch (error) {
+				throw new Error((error as Record<string, string>).stdout);
+			}
+		}).timeout(20000);
+	}
+});

--- a/examples/utils/import-testing/src/test/build.spec.ts
+++ b/examples/utils/import-testing/src/test/build.spec.ts
@@ -21,11 +21,6 @@ const typescriptVersions = Object.entries(devDependencies).filter(([name]) =>
 
 const execFileAsync = promisify(execFile);
 
-// TODO: cases which do not build, but probably should:
-// - Building with `"lib": ["ES2022"]` (missing "DOM"): Error: ../../../packages/utils/telemetry-utils/lib/config.d.ts(37,56): error TS2304: Cannot find name 'Storage'.
-// - Building with `"lib": ["ES2022", "DOM", "esnext.disposable"]` and TS 5.6 or newer
-// - Building with `"exactOptionalPropertyTypes": true`
-
 async function compileTest(tscName: string, args: string[]): Promise<void> {
 	const result = execFileAsync(
 		`./node_modules/${tscName}/bin/tsc`,

--- a/examples/utils/import-testing/src/test/importer.spec.ts
+++ b/examples/utils/import-testing/src/test/importer.spec.ts
@@ -151,9 +151,11 @@ describe("import tests", () => {
 		type Inner = typeof inner;
 		type Inner2 = typeof inner2;
 		type _check1 = requireAssignableTo<undefined, Inner2>;
+
 		// This undesired assignment is permitted due to schema-aware types being mangled by `any` from d.ts file. See note on BadArraySelf.
 		// Intellisense thinks this is an error because it's not using the d.ts files and instead using the actual source which has correct typing.
-		type _check2 = requireAssignableTo<number, Inner2>;
+		// "build" tests (which compile these tests and the source in this package together) have the same behavior as intellisense, so this is disabled.
+		// type _check2 = requireAssignableTo<number, Inner2>;
 	});
 
 	it("GoodArraySelf", () => {

--- a/examples/utils/import-testing/tsconfig.test.json
+++ b/examples/utils/import-testing/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
+	"compilerOptions": {
+		"target": "es2022",
+		"module": "Node16",
+		"strict": true,
+		"skipLibCheck": false,
+		"incremental": false,
+		"exactOptionalPropertyTypes": true,
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noImplicitThis": true,
+	},
+}

--- a/examples/utils/import-testing/tsconfig.test.json
+++ b/examples/utils/import-testing/tsconfig.test.json
@@ -1,16 +1,17 @@
 {
 	"include": ["src/**/*"],
-	"exclude": ["src/test/**/*"],
+	// "exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"target": "es2022",
 		"module": "Node16",
 		"strict": true,
 		"skipLibCheck": false,
 		"incremental": false,
-		"exactOptionalPropertyTypes": true,
 		"noImplicitAny": true,
 		"noImplicitOverride": true,
 		"noImplicitReturns": true,
 		"noImplicitThis": true,
+		"noUncheckedIndexedAccess": true,
+		"lib": ["ES2022", "DOM"],
 	},
 }

--- a/examples/utils/import-testing/tsconfig.test.json
+++ b/examples/utils/import-testing/tsconfig.test.json
@@ -13,5 +13,8 @@
 		"noImplicitThis": true,
 		"noUncheckedIndexedAccess": true,
 		"lib": ["ES2022", "DOM"],
+
+		// The pretty formatting seems to make it through how we log these errors, so keep it on.
+		"pretty": true,
 	},
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5115,6 +5115,24 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      typescriptTest1:
+        specifier: npm:typescript@~5.4.5
+        version: typescript@5.4.5
+      typescriptTest2:
+        specifier: npm:typescript@~5.5.4
+        version: typescript@5.5.4
+      typescriptTest3:
+        specifier: npm:typescript@~5.6.3
+        version: typescript@5.6.3
+      typescriptTest4:
+        specifier: npm:typescript@~5.7.3
+        version: typescript@5.7.3
+      typescriptTest5:
+        specifier: npm:typescript@~5.8.3
+        version: typescript@5.8.3
+      typescriptTest6:
+        specifier: npm:typescript@~5.9.2
+        version: typescript@5.9.2
 
   examples/utils/migration-tools:
     dependencies:
@@ -15075,7 +15093,7 @@ importers:
         version: 0.58.3(@types/node@22.14.1)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(typescript@5.8.2)
+        version: 10.1.4(typescript@5.9.2)
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -27090,13 +27108,38 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -30607,9 +30650,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -35481,14 +35524,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.5
 
-  cosmiconfig@8.3.6(typescript@5.8.2):
+  cosmiconfig@8.3.6(typescript@5.9.2):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.9.2
 
   cosmiconfig@9.0.0(typescript@5.4.5):
     dependencies:
@@ -36314,33 +36357,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36354,13 +36397,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -38358,10 +38401,10 @@ snapshots:
       - supports-color
       - typescript
 
-  jest-environment-puppeteer@10.1.4(typescript@5.8.2):
+  jest-environment-puppeteer@10.1.4(typescript@5.9.2):
     dependencies:
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.8.2)
+      cosmiconfig: 8.3.6(typescript@5.9.2)
       deepmerge: 4.3.1
       jest-dev-server: 10.1.4
       jest-environment-node: 29.7.0
@@ -43231,9 +43274,19 @@ snapshots:
 
   typescript@5.4.5: {}
 
+  typescript@5.5.4: {}
+
   typescript@5.6.1-rc: {}
 
+  typescript@5.6.3: {}
+
+  typescript@5.7.3: {}
+
   typescript@5.8.2: {}
+
+  typescript@5.8.3: {}
+
+  typescript@5.9.2: {}
 
   typeson-registry@1.0.0-alpha.39:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5115,22 +5115,22 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
-      typescriptTest1:
+      typescript-5.4:
         specifier: npm:typescript@~5.4.5
         version: typescript@5.4.5
-      typescriptTest2:
+      typescript-5.5:
         specifier: npm:typescript@~5.5.4
         version: typescript@5.5.4
-      typescriptTest3:
+      typescript-5.6:
         specifier: npm:typescript@~5.6.3
         version: typescript@5.6.3
-      typescriptTest4:
+      typescript-5.7:
         specifier: npm:typescript@~5.7.3
         version: typescript@5.7.3
-      typescriptTest5:
+      typescript-5.8:
         specifier: npm:typescript@~5.8.3
         version: typescript@5.8.3
-      typescriptTest6:
+      typescript-5.9:
         specifier: npm:typescript@~5.9.2
         version: typescript@5.9.2
 
@@ -30650,9 +30650,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -36357,33 +36357,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36397,13 +36397,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2

--- a/syncpack.config.cjs
+++ b/syncpack.config.cjs
@@ -147,6 +147,15 @@ module.exports = {
 			range: "",
 		},
 
+		// @fluid-example/import-testing typescript versions should use ~
+		{
+			label: "@fluid-example/import-testing typescript versions should use ~",
+			dependencies: ["typescript-*"],
+			dependencyTypes: ["dev"],
+			packages: ["@fluid-example/import-testing"],
+			range: "~",
+		},
+
 		// All deps should use caret ranges unless previously overridden
 		{
 			label: "Dependencies should use caret dependency ranges",


### PR DESCRIPTION
## Description

Multiple users have reported issues where Fluid code gives strange compile errors with their TypeScript configuration.

This adds a suite of tests which test a few configurations.

Several tests are skipped due to the current issues.

This reuses the existing import-testing project, which is setup to confirm using Fluid-Framework works with our default compiler configuration.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

