### PR TITLE
fix(eslint-plugin-fluid): Indexing fixes

### DIFF
--- a/common/build/eslint-plugin-fluid/CHANGELOG.md
+++ b/common/build/eslint-plugin-fluid/CHANGELOG.md
@@ -1,6 +1,14 @@
 # @fluidframework/eslint-plugin-fluid Changelog
 
-## [0.3.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.2.0)
+## [0.3.1](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.3.1)
+
+Fixes indexing issues in the following rules, which would cause incorrect notification ranges and could cause malformed code fixes:
+
+- `@fluid-internal/fluid/no-file-path-links-in-jsdoc`
+- `@fluid-internal/fluid/no-hyphen-after-jsdoc-tag`
+- `@fluid-internal/fluid/no-markdown-links-in-jsdoc`
+
+## [0.3.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.3.0)
 
 New rules added:
 

--- a/common/build/eslint-plugin-fluid/package.json
+++ b/common/build/eslint-plugin-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/eslint-plugin-fluid",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Custom ESLint rules for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
@@ -40,7 +40,10 @@ module.exports = {
 					// Find links where the `target` component is a file path (starts with `/`, `./`, or `../`)
 					const matches = comment.value.matchAll(/{@link\s+(\/|\.\/|\.\.\/).*}/g);
 					for (const match of matches) {
-						const startIndex = comment.range[0] + match.index;
+						// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+						const commentStartIndex = comment.range[0] + 2;
+
+						const startIndex = commentStartIndex + match.index;
 						const endIndex = startIndex + match[0].length;
 
 						context.report({

--- a/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
@@ -36,7 +36,7 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
-					// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+					// +2 for the leading "/*", which is omitted by `comment.value`, but included in `comment.range`.
 					const commentStartIndex = comment.range[0] + 2;
 
 					// JSDoc/TSDoc link syntax: {@link target|text} or {@link target}

--- a/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
@@ -36,13 +36,13 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
+					// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+					const commentStartIndex = comment.range[0] + 2;
+
 					// JSDoc/TSDoc link syntax: {@link target|text} or {@link target}
 					// Find links where the `target` component is a file path (starts with `/`, `./`, or `../`)
 					const matches = comment.value.matchAll(/{@link\s+(\/|\.\/|\.\.\/).*}/g);
 					for (const match of matches) {
-						// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
-						const commentStartIndex = comment.range[0] + 2;
-
 						const startIndex = commentStartIndex + match.index;
 						const endIndex = startIndex + match[0].length;
 

--- a/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
@@ -33,11 +33,14 @@ module.exports = {
 
 				for (const comment of comments) {
 					// Find any JSDoc/TSDoc tags followed by a hyphen
-					const matches = comment.value.matchAll(/(@[a-zA-Z0-9]+)\s*?-(.*)/g);
+					const matches = comment.value.matchAll(/(@[a-zA-Z0-9]+)\s*?-\s*?(.*)/g);
 					for (const match of matches) {
 						const [fullMatch, tag, body] = match;
 
-						const startIndex = comment.range[0] + match.index;
+						// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+						const commentStartIndex = comment.range[0] + 2;
+
+						const startIndex = commentStartIndex + match.index;
 						const endIndex = startIndex + fullMatch.length;
 
 						context.report({

--- a/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
@@ -32,13 +32,13 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
+					// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+					const commentStartIndex = comment.range[0] + 2;
+
 					// Find any JSDoc/TSDoc tags followed by a hyphen
 					const matches = comment.value.matchAll(/(@[a-zA-Z0-9]+)\s*?-\s*?(.*)/g);
 					for (const match of matches) {
 						const [fullMatch, tag, body] = match;
-
-						// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
-						const commentStartIndex = comment.range[0] + 2;
 
 						const startIndex = commentStartIndex + match.index;
 						const endIndex = startIndex + fullMatch.length;

--- a/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
@@ -32,7 +32,7 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
-					// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+					// +2 for the leading "/*", which is omitted by `comment.value`, but included in `comment.range`.
 					const commentStartIndex = comment.range[0] + 2;
 
 					// Find any JSDoc/TSDoc tags followed by a hyphen

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -35,7 +35,10 @@ module.exports = {
 					const matches = comment.value.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);
 					for (const match of matches) {
 						const [fullMatch, text, url] = match;
-						const startIndex = comment.range[0] + match.index;
+						// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+						const commentStartIndex = comment.range[0] + 2;
+
+						const startIndex = commentStartIndex + match.index;
 						const endIndex = startIndex + fullMatch.length;
 
 						context.report({

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -32,7 +32,7 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
-					// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+					// +2 for the leading "/*", which is omitted by `comment.value`, but included in `comment.range`.
 					const commentStartIndex = comment.range[0] + 2;
 
 					const matches = comment.value.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -32,11 +32,12 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
+					// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
+					const commentStartIndex = comment.range[0] + 2;
+
 					const matches = comment.value.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);
 					for (const match of matches) {
 						const [fullMatch, text, url] = match;
-						// +2 for the leading "/*", which is ommitted by `comment.value`, but included in `comment.range`.
-						const commentStartIndex = comment.range[0] + 2;
 
 						const startIndex = commentStartIndex + match.index;
 						const endIndex = startIndex + fullMatch.length;

--- a/common/build/eslint-plugin-fluid/src/test/enforce-no-file-path-links-in-jsdoc/enforce-no-file-path-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/enforce-no-file-path-links-in-jsdoc/enforce-no-file-path-links-in-jsdoc.test.js
@@ -36,19 +36,31 @@ describe("Do not allow file path links in JSDoc/TSDoc comments", function () {
 		assert.strictEqual(result.errorCount, 4);
 
 		// Error 1
-		assert.strictEqual(result.messages[0].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[0].line, 10);
+		const error1 = result.messages[0];
+		assert.strictEqual(error1.message, expectedErrorMessage);
+		assert.strictEqual(error1.line, 10);
+		assert.strictEqual(error1.column, 56); // 1-based, inclusive
+		assert.strictEqual(error1.endColumn, 84); // 1-based, exclusive
 
 		// Error 2
-		assert.strictEqual(result.messages[1].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[1].line, 11);
+		const error2 = result.messages[1];
+		assert.strictEqual(error2.message, expectedErrorMessage);
+		assert.strictEqual(error2.line, 11);
+		assert.strictEqual(error2.column, 17); // 1-based, inclusive
+		assert.strictEqual(error2.endColumn, 41); // 1-based, exclusive
 
 		// Error 3
-		assert.strictEqual(result.messages[2].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[2].line, 16);
+		const error3 = result.messages[2];
+		assert.strictEqual(error3.message, expectedErrorMessage);
+		assert.strictEqual(error3.line, 16);
+		assert.strictEqual(error3.column, 57); // 1-based, inclusive
+		assert.strictEqual(error3.endColumn, 84); // 1-based, exclusive
 
 		// Error 4
-		assert.strictEqual(result.messages[3].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[3].line, 17);
+		const error4 = result.messages[3];
+		assert.strictEqual(error4.message, expectedErrorMessage);
+		assert.strictEqual(error4.line, 17);
+		assert.strictEqual(error4.column, 17); // 1-based, inclusive
+		assert.strictEqual(error4.endColumn, 40); // 1-based, exclusive
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/enforce-no-hyphen-after-jsdoc-tag/enforce-no-hyphen-after-jsdoc-tag.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/enforce-no-hyphen-after-jsdoc-tag/enforce-no-hyphen-after-jsdoc-tag.test.js
@@ -41,21 +41,36 @@ describe("Do not allow `-` following JSDoc/TSDoc tags", function () {
 		assert.strictEqual(result.errorCount, 3);
 
 		// Error 1
-		assert.strictEqual(result.messages[0].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[0].line, 8);
-		assert.strictEqual(result.messages[0].fix?.text, "@remarks Here are some remarks.");
+		const error1 = result.messages[0];
+		assert.strictEqual(error1.message, expectedErrorMessage);
+		assert.strictEqual(error1.line, 8);
+		assert.strictEqual(error1.column, 4); // 1-based, inclusive
+		assert.strictEqual(error1.endColumn, 37); // 1-based, exclusive
+		assert(error1.fix !== undefined);
+		assert.strictEqual(error1.fix.text, "@remarks Here are some remarks.");
+		assert.deepEqual(error1.fix.range, [226, 259]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
 
 		// Error 2
-		assert.strictEqual(result.messages[1].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[1].line, 9);
+		const error2 = result.messages[1];
+		assert.strictEqual(error2.message, expectedErrorMessage);
+		assert.strictEqual(error2.line, 9);
+		assert.strictEqual(error2.column, 4); // 1-based, inclusive
+		assert.strictEqual(error2.endColumn, 65); // 1-based, exclusive
+		assert(error2.fix !== undefined);
 		assert.strictEqual(
-			result.messages[1].fix?.text,
+			error2.fix.text,
 			"@deprecated This function is deprecated, use something else.",
 		);
+		assert.deepEqual(error2.fix.range, [263, 324]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
 
 		// Error 3
-		assert.strictEqual(result.messages[2].message, expectedErrorMessage);
-		assert.strictEqual(result.messages[2].line, 10);
-		assert.strictEqual(result.messages[2].fix?.text, "@returns The concatenated string.");
+		const error3 = result.messages[2];
+		assert.strictEqual(error3.message, expectedErrorMessage);
+		assert.strictEqual(error3.line, 10);
+		assert.strictEqual(error3.column, 4); // 1-based, inclusive
+		assert.strictEqual(error3.endColumn, 39); // 1-based, exclusive
+		assert(error3.fix !== undefined);
+		assert.strictEqual(error3.fix.text, "@returns The concatenated string.");
+		assert.deepEqual(error3.fix.range, [328, 363]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/enforce-no-markdown-links-in-jsdoc/enforce-no-markdown-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/enforce-no-markdown-links-in-jsdoc/enforce-no-markdown-links-in-jsdoc.test.js
@@ -31,14 +31,22 @@ describe("Do not allow Markdown links in JSDoc/TSDoc comments", function () {
 	it("Should report errors for Markdown links in block comments", async function () {
 		const result = await lintFile("test.ts");
 		assert.strictEqual(result.errorCount, 1);
+
+		const error = result.messages[0];
 		assert.strictEqual(
-			result.messages[0].message,
+			error.message,
 			"Markdown link syntax (`[text](url)`) is not allowed in JSDoc/TSDoc comments. Use `{@link url|text}` syntax instead.",
 		);
-		assert.strictEqual(result.messages[0].line, 10);
+		assert.strictEqual(error.line, 10);
+		// Note: columns are 1-based
+		assert.strictEqual(error.column, 51); // inclusive
+		assert.strictEqual(error.endColumn, 75); // exclusive
 
 		// Test auto-fix
-		assert.notEqual(result.messages[0].fix, undefined);
-		assert.deepEqual(result.messages[0].fix.text, "{@link https://bing.com | bing}");
+		assert.notEqual(error.fix, undefined);
+		// Note: range is 0-based global character index in the file.
+		// The start is inclusive, and the end is exclusive.
+		assert.deepEqual(error.fix.range, [259, 283]);
+		assert.deepEqual(error.fix.text, "{@link https://bing.com | bing}");
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/enforce-no-markdown-links-in-jsdoc/enforce-no-markdown-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/enforce-no-markdown-links-in-jsdoc/enforce-no-markdown-links-in-jsdoc.test.js
@@ -38,15 +38,12 @@ describe("Do not allow Markdown links in JSDoc/TSDoc comments", function () {
 			"Markdown link syntax (`[text](url)`) is not allowed in JSDoc/TSDoc comments. Use `{@link url|text}` syntax instead.",
 		);
 		assert.strictEqual(error.line, 10);
-		// Note: columns are 1-based
-		assert.strictEqual(error.column, 51); // inclusive
-		assert.strictEqual(error.endColumn, 75); // exclusive
+		assert.strictEqual(error.column, 51); // 1-based, inclusive
+		assert.strictEqual(error.endColumn, 75); // 1-based, exclusive
 
 		// Test auto-fix
 		assert.notEqual(error.fix, undefined);
-		// Note: range is 0-based global character index in the file.
-		// The start is inclusive, and the end is exclusive.
-		assert.deepEqual(error.fix.range, [259, 283]);
+		assert.deepEqual(error.fix.range, [259, 283]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
 		assert.deepEqual(error.fix.text, "{@link https://bing.com | bing}");
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/example/no-hyphen-after-jsdoc-tag/test.ts
+++ b/common/build/eslint-plugin-fluid/src/test/example/no-hyphen-after-jsdoc-tag/test.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * I am a test function with pretty standard docs, but all of my tags have hyphens after them ☹️.
+ * I am a test function with pretty standard docs, but all of my tags have hyphens after them :(
  * @remarks - Here are some remarks.
  * @deprecated- This function is deprecated, use something else.
  * @returns - The concatenated string.
@@ -14,7 +14,7 @@ function invalid<T>(param1: string, param2: T): string {
 }
 
 /**
- * I am a test function with pretty standard docs, and none of my tags have hyphens after them 🙂.
+ * I am a test function with pretty standard docs, and none of my tags have hyphens after them :)
  * @remarks Here are some remarks.
  * @deprecated This function is deprecated, use something else.
  * @returns The concatenated string.


### PR DESCRIPTION
Fixed indexing issues in the following rules, which would cause incorrect notification ranges and could cause malformed code fixes:

- `@fluid-internal/fluid/no-file-path-links-in-jsdoc`
- `@fluid-internal/fluid/no-hyphen-after-jsdoc-tag`
- `@fluid-internal/fluid/no-markdown-links-in-jsdoc`