### PR TITLE
FrozenContainer: Support read blob

### DIFF
--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -101,16 +101,8 @@ export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProp
 }
 
 // @alpha @legacy
-export interface ILoadFrozenContainerFromPendingStateProps {
-    readonly clientDetailsOverride?: IClientDetails | undefined;
-    readonly codeLoader: ICodeDetailsLoader_2;
-    readonly configProvider?: IConfigProviderBase | undefined;
-    readonly logger?: ITelemetryBaseLogger | undefined;
-    readonly options?: IContainerPolicies | undefined;
+export interface ILoadFrozenContainerFromPendingStateProps extends ILoadExistingContainerProps {
     readonly pendingLocalState: string;
-    readonly request: IRequest;
-    readonly scope?: FluidObject | undefined;
-    readonly urlResolver: IUrlResolver;
 }
 
 // @beta @legacy

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -179,51 +179,12 @@ export async function loadExistingContainer(
  * Properties required to load a frozen container from pending state.
  * @legacy @alpha
  */
-export interface ILoadFrozenContainerFromPendingStateProps {
-	/**
-	 * The code loader handles loading the necessary code for running a container once it is loaded.
-	 */
-	readonly codeLoader: ICodeDetailsLoader;
-
-	/**
-	 * The url resolver used by the loader for resolving external urls into Fluid urls.
-	 */
-	readonly urlResolver: IUrlResolver;
-
-	/**
-	 * The request to resolve the container.
-	 */
-	readonly request: IRequest;
-
+export interface ILoadFrozenContainerFromPendingStateProps
+	extends ILoadExistingContainerProps {
 	/**
 	 * Pending local state to be applied to the container.
 	 */
 	readonly pendingLocalState: string;
-
-	/**
-	 * A property bag of options/policies used by various layers to control features.
-	 */
-	readonly options?: IContainerPolicies | undefined;
-
-	/**
-	 * Scope is provided to all container and is a set of shared services for container's to integrate with their host environment.
-	 */
-	readonly scope?: FluidObject | undefined;
-
-	/**
-	 * The logger that all telemetry should be pushed to.
-	 */
-	readonly logger?: ITelemetryBaseLogger | undefined;
-
-	/**
-	 * The configuration provider which may be used to control features.
-	 */
-	readonly configProvider?: IConfigProviderBase | undefined;
-
-	/**
-	 * Client details provided in the override will be merged over the default client.
-	 */
-	readonly clientDetailsOverride?: IClientDetails | undefined;
 }
 
 /**
@@ -236,6 +197,6 @@ export async function loadFrozenContainerFromPendingState(
 ): Promise<IContainer> {
 	return loadExistingContainer({
 		...props,
-		documentServiceFactory: new FrozenDocumentServiceFactory(),
+		documentServiceFactory: new FrozenDocumentServiceFactory(props.documentServiceFactory),
 	});
 }

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -29,8 +29,13 @@ import {
 import type { IConnectionStateChangeReason } from "./contracts.js";
 
 export class FrozenDocumentServiceFactory implements IDocumentServiceFactory {
+	constructor(private readonly documentServiceFactory?: IDocumentServiceFactory) {}
+
 	async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
-		return new FrozenDocumentService(resolvedUrl);
+		return new FrozenDocumentService(
+			resolvedUrl,
+			await this.documentServiceFactory?.createDocumentService(resolvedUrl),
+		);
 	}
 	async createContainer(): Promise<IDocumentService> {
 		throw new Error("The FrozenDocumentServiceFactory cannot be used to create containers.");
@@ -41,7 +46,10 @@ class FrozenDocumentService
 	extends TypedEventEmitter<IDocumentServiceEvents>
 	implements IDocumentService
 {
-	constructor(public readonly resolvedUrl: IResolvedUrl) {
+	constructor(
+		public readonly resolvedUrl: IResolvedUrl,
+		private readonly documentService?: IDocumentService,
+	) {
 		super();
 	}
 
@@ -49,7 +57,7 @@ class FrozenDocumentService
 		storageOnly: true,
 	};
 	async connectToStorage(): Promise<IDocumentStorageService> {
-		return frozenDocumentStorageService;
+		return new FrozenDocumentStorageService(await this.documentService?.connectToStorage());
 	}
 	async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {
 		return frozenDocumentDeltaStorageService;
@@ -63,15 +71,19 @@ class FrozenDocumentService
 const frozenDocumentStorageServiceHandler = (): never => {
 	throw new Error("Operations are not supported on the FrozenDocumentStorageService.");
 };
-const frozenDocumentStorageService: IDocumentStorageService = {
-	getSnapshotTree: frozenDocumentStorageServiceHandler,
-	getSnapshot: frozenDocumentStorageServiceHandler,
-	getVersions: frozenDocumentStorageServiceHandler,
-	createBlob: frozenDocumentStorageServiceHandler,
-	readBlob: frozenDocumentStorageServiceHandler,
-	uploadSummaryWithContext: frozenDocumentStorageServiceHandler,
-	downloadSummary: frozenDocumentStorageServiceHandler,
-};
+class FrozenDocumentStorageService implements IDocumentStorageService {
+	constructor(private readonly documentStorageService?: IDocumentStorageService) {}
+
+	getSnapshotTree = frozenDocumentStorageServiceHandler;
+	getSnapshot = frozenDocumentStorageServiceHandler;
+	getVersions = frozenDocumentStorageServiceHandler;
+	createBlob = frozenDocumentStorageServiceHandler;
+	readBlob =
+		this.documentStorageService?.readBlob.bind(this.documentStorageService) ??
+		frozenDocumentStorageServiceHandler;
+	uploadSummaryWithContext = frozenDocumentStorageServiceHandler;
+	downloadSummary = frozenDocumentStorageServiceHandler;
+}
 
 const frozenDocumentDeltaStorageService: IDocumentDeltaStorageService = {
 	fetchMessages: () => ({

--- a/packages/test/local-server-tests/src/test/loadFrozenContainerFromPendingState.spec.ts
+++ b/packages/test/local-server-tests/src/test/loadFrozenContainerFromPendingState.spec.ts
@@ -28,9 +28,10 @@ describe("loadFrozenContainerFromPendingState", () => {
 	it("loadFrozenContainerFromPendingState", async () => {
 		const deltaConnectionServer = LocalDeltaConnectionServer.create();
 
-		const { urlResolver, codeDetails, codeLoader, loaderProps } = createLoader({
-			deltaConnectionServer,
-		});
+		const { urlResolver, codeDetails, codeLoader, loaderProps, documentServiceFactory } =
+			createLoader({
+				deltaConnectionServer,
+			});
 		const container = asLegacyAlpha(
 			await createDetachedContainer({
 				codeDetails,
@@ -77,6 +78,7 @@ describe("loadFrozenContainerFromPendingState", () => {
 
 		const frozenContainer = await loadFrozenContainerFromPendingState({
 			codeLoader,
+			documentServiceFactory,
 			urlResolver,
 			request: {
 				url,


### PR DESCRIPTION
Pending local state does not currently capture blobs, so we need to support reading blobs from the network. This will prevent usages in full offline situations, but works for current scenarios when we capture and rehydrate state while online