### PR TITLE
[Archive] Try out "alter props" approach to composing in behaviors on top of PureDataObjectFactory

### DIFF
--- a/examples/apps/data-object-grid/src/dataObjectGrid.ts
+++ b/examples/apps/data-object-grid/src/dataObjectGrid.ts
@@ -4,7 +4,15 @@
  */
 
 import type { EventEmitter } from "@fluid-example/example-utils";
-import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
+import type {
+	// eslint-disable-next-line import/no-deprecated
+	DataObjectFactory,
+} from "@fluidframework/aqueduct/legacy";
+import {
+	DataObject,
+	getAlteredPropsSupportingDataObject,
+	PureDataObjectFactory,
+} from "@fluidframework/aqueduct/legacy";
 import type { Serializable } from "@fluidframework/datastore-definitions/legacy";
 import type React from "react";
 import type { Layout } from "react-grid-layout";
@@ -78,11 +86,13 @@ export interface IDataObjectGridItem<T = unknown> {
 export class DataObjectGrid extends DataObject implements IDataObjectGrid<ISingleHandleItem> {
 	public static readonly ComponentName = "@fluid-example/data-object-grid";
 
-	private static readonly factory = new DataObjectFactory({
-		type: DataObjectGrid.ComponentName,
-		ctor: DataObjectGrid,
-		registryEntries: [...registryEntries],
-	});
+	private static readonly factory = new PureDataObjectFactory(
+		getAlteredPropsSupportingDataObject({
+			type: DataObjectGrid.ComponentName,
+			ctor: DataObjectGrid,
+			registryEntries: [...registryEntries],
+		}),
+	);
 
 	public static getFactory(): DataObjectFactory<DataObjectGrid> {
 		return DataObjectGrid.factory;

--- a/packages/framework/aqueduct/api-report/aqueduct.beta.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.beta.api.md
@@ -4,4 +4,7 @@
 
 ```ts
 
+// @public
+export function getAlteredPropsSupportingDataObject<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes>(props: DataObjectFactoryProps<TObj, I>): DataObjectFactoryProps<TObj, I>;
+
 ```

--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
@@ -57,7 +57,7 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
     protected get root(): ISharedDirectory;
 }
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes> extends PureDataObjectFactory<TObj, I> {
     constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects?: readonly IChannelFactory[], optionalProviders?: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
     constructor(props: DataObjectFactoryProps<TObj, I>);
@@ -80,6 +80,9 @@ export interface DataObjectTypes {
     InitialState?: any;
     OptionalProviders?: FluidObject;
 }
+
+// @public
+export function getAlteredPropsSupportingDataObject<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes>(props: DataObjectFactoryProps<TObj, I>): DataObjectFactoryProps<TObj, I>;
 
 // @beta @legacy (undocumented)
 export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {

--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.public.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.public.api.md
@@ -4,4 +4,7 @@
 
 ```ts
 
+// @public
+export function getAlteredPropsSupportingDataObject<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes>(props: DataObjectFactoryProps<TObj, I>): DataObjectFactoryProps<TObj, I>;
+
 ```

--- a/packages/framework/aqueduct/api-report/aqueduct.public.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.public.api.md
@@ -4,4 +4,7 @@
 
 ```ts
 
+// @public
+export function getAlteredPropsSupportingDataObject<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes>(props: DataObjectFactoryProps<TObj, I>): DataObjectFactoryProps<TObj, I>;
+
 ```

--- a/packages/framework/aqueduct/src/data-object-factories/index.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/index.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export { DataObjectFactory } from "./dataObjectFactory.js";
+export {
+	DataObjectFactory,
+	getAlteredPropsSupportingDataObject,
+} from "./dataObjectFactory.js";
 export {
 	type DataObjectFactoryProps,
 	PureDataObjectFactory,

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -23,6 +23,7 @@ export {
 	type DataObjectFactoryProps,
 	PureDataObjectFactory,
 	TreeDataObjectFactory,
+	getAlteredPropsSupportingDataObject,
 } from "./data-object-factories/index.js";
 export {
 	DataObject,


### PR DESCRIPTION
## Description

This was an exploration around how to have more composable patterns for DataStore Factory behaviors, compared to the current strategy of class-based inheritance.  Down-side of inheritance is it's one-way, and so when a downstream dependency wants to add more behavior, they have to pick which subclass to use, rather than letting callers compose in the various behaviors irrespective of where in the dependency tree the corresponding code lives.

Not moving forward with this in particular. The specific behavior here (adding DDS factories) should just be handled by callers themselves.

On a related notes, someday perhaps we'll decompose `PureDataObjectFactory` into composable bits all up.
