### PR TITLE
test(client-core-interfaces): json* test case parity

### DIFF
--- a/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
@@ -18,6 +18,7 @@ import type {
 	ObjectWithOptionalRecursion,
 	ObjectWithSymbolOrRecursion,
 } from "./testValues.js";
+// This import list should be kept mostly in-sync with jsonDeserialized.spec.ts. Deltas should be commented.
 import {
 	boolean,
 	number,
@@ -79,6 +80,8 @@ import {
 	objectWithUndefined,
 	objectWithUnknown,
 	objectWithOptionalUnknown,
+	// See tests in jsonSerializable.exactOptionalPropertyTypes.(true|false).spec.ts
+	// objectWithOptionalUndefined,
 	objectWithOptionalSymbol,
 	objectWithOptionalBigint,
 	objectWithNumberKey,
@@ -1433,6 +1436,30 @@ describe("JsonSerializable", () => {
 						{ boolean },
 					);
 					assertIdenticalTypes(filteredIn, createInstanceOf<Record<string, boolean>>());
+				});
+				it("object with exactly `unknown`", () => {
+					const { filteredIn } = passThru(
+						// @ts-expect-error not assignable to type '{ "error required property may not allow `unknown` value": never; }'
+						objectWithUnknown,
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<{
+							unknown: { "error required property may not allow `unknown` value": never };
+						}>(),
+					);
+				});
+				it("object with optional `unknown`", () => {
+					const { filteredIn } = passThru(
+						// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<never> | OpaqueJsonSerializable<unknown>`)
+						objectWithOptionalUnknown,
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<{
+							optUnknown?: JsonTypeWith<never> | OpaqueJsonSerializable<unknown>;
+						}>(),
+					);
 				});
 
 				it("object with array of `bigint`s", () => {


### PR DESCRIPTION
Note the relationship of import lists and add test cases to keep cleaner parity even if somewhat redundant with other cases.