### PR TITLE
Use TRIPS for odspdf stress runs

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -29,7 +29,7 @@ parameters:
   default: $(Agent.TempDirectory)
 
 steps:
-- checkout: git://internal/ff_pipeline_host
+- checkout: PipelineHost
 
 - task: Bash@3
   displayName: Print parameter/variable values for troubleshooting

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -29,7 +29,7 @@ parameters:
   default: $(Agent.TempDirectory)
 
 steps:
-- checkout: PipelineHost
+- checkout: ff_pipeline_host
 
 - task: Bash@3
   displayName: Print parameter/variable values for troubleshooting

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -401,9 +401,8 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ each envVar in parameters.env }}:
-              ${{ each pair in envVar }}:
-                ${{ pair.name }}: ${{ pair.value }}
+            ${{ each pair in parameters.env }}:
+              ${{ pair.name }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -109,10 +109,22 @@ parameters:
   type: boolean
   default: false
 
+# If tests need to run against an ODSP tenant, specify the type of tenant here. Steps will be injected to lease one for the duration of the test.
+- name: odspTenantType
+  type: string
+  default: ''
+  values: ['', 'prod', 'dogfood']
+
+# lockBehavior of the stage (if any).
+- name: lockBehavior
+  type: string
+  default: ''
+  values: ['', 'sequential']
+
 stages:
 - stage: ${{ parameters.stageId}}
-  ${{ if in(parameters.stageId, 'e2e_routerlicious', 'e2e_frs', 'stress_tests_odspdf', 'stress_tests_frs', 'stress_tests_frs_canary') }}:
-    lockBehavior: sequential
+  ${{ if ne(parameters.lockBehavior, '') }}:
+    lockBehavior: ${{ parameters.lockBehavior }}
   condition: ${{ parameters.condition }}
   displayName: ${{ parameters.stageDisplayName }}
   dependsOn: ${{ parameters.stageDependencies }}
@@ -351,7 +363,7 @@ stages:
               path: $(compatVersionInstallsPath)
 
         # Only check out tenants from the tenant pool if we are running tests against ODSP
-        - ${{ if or(eq(parameters.stageId, 'e2e_odsp'), eq(parameters.stageId, 'stress_tests_odsp')) }}:
+        - ${{ if ne(parameters.odspTenantType, '') }}:
           # Retrieve a tenant from the tenant pool
           - task: AzureCLI@2
             displayName: 'Log in to retrieve tenant credentials'
@@ -376,7 +388,7 @@ stages:
                 set -eu -o pipefail
 
                 # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
-                pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN
+                pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --odspEndpoint=${{ parameters.odspTenantType }}
                 echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"
 
         # run the test
@@ -384,11 +396,19 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ if and(ne(parameters.stageId, 'e2e_odsp'), ne(parameters.stageId, 'stress_tests_odsp')) }}:
-              ${{ parameters.env }}
-            ${{ else }}:
-              login__odsp__test__tenants: $(tenantCreds)
+            ${{ each envVar in parameters.env }}:
+              - ${{ each pair in envVar }}:
+                - name: ${{ pair.name }}
+                  value: ${{ pair.value }}
+            # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
+            # The e2e test workload references the keys (login__*).
+            ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
               login__microsoft__clientId: $(appClientId)
+              login__odspdf__test__tenants: $(tenantCreds)
+            ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
+              login__microsoft__clientId: $(appClientId)
+              login__odsp__test__tenants: $(tenantCreds)
+
           inputs:
             command: 'custom'
             workingDir: $(Build.SourcesDirectory)/node_modules/${{ parameters.testPackage }}
@@ -439,8 +459,8 @@ stages:
             condition: always()
             continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
-        # Only release tenants that were checked out from the tenant pool for ODSP tests
-        - ${{ if or(eq(parameters.stageId, 'e2e_odsp'), eq(parameters.stageId, 'stress_tests_odsp')) }}:
+        # Only release tenants that were checked out from the tenant pool for ODSP/ODSPDF tests
+        - ${{ if ne(parameters.odspTenantType, '') }}:
           # Login to release tenant credentials
           # Currently, some of the compat tests run for longer than 60 minutes and exceed the average token lifetime:
           # https://learn.microsoft.com/en-us/entra/identity-platform/configurable-token-lifetimes#access-tokens
@@ -464,7 +484,7 @@ stages:
               targetType: 'inline'
               script: |
                 set -eu -o pipefail
-                pnpm exec trips-cleanup --reservationId=$(stringBearerToken)
+                pnpm exec trips-cleanup --reservationId=$(stringBearerToken) --odspEndpoint=${{ parameters.odspTenantType }}
             condition: eq(variables['tenantSetupSuccess'], 'true')
 
         # Log Test Failures

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -401,7 +401,7 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ if ne(length(parameters.env)), 0 }}:
+            ${{ if ne(length(parameters.env), 0) }}:
               ${{ each pair in parameters.env }}:
                 ${{ pair.name }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -402,9 +402,9 @@ stages:
           continueOnError: ${{ parameters.continueOnError }}
           env:
             ${{ each envVar in parameters.env }}:
-              - ${{ each pair in envVar }}:
-                - name: ${{ pair.name }}
-                  value: ${{ pair.value }}
+              ${{ each pair in envVar }}:
+                ${{ pair.name }}: ${{ pair.value }}
+
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -167,7 +167,7 @@ stages:
 
         steps:
         # Setup
-        - checkout: git://internal/ff_pipeline_host
+        - checkout: PipelineHost
           clean: true
 
         # Install self-signed cert for R11s deployment in local cert store

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -404,7 +404,6 @@ stages:
             ${{ each envVar in parameters.env }}:
               ${{ each pair in envVar }}:
                 ${{ pair.name }}: ${{ pair.value }}
-
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
@@ -413,7 +412,6 @@ stages:
             ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
               login__microsoft__clientId: $(appClientId)
               login__odsp__test__tenants: $(tenantCreds)
-
           inputs:
             command: 'custom'
             workingDir: $(Build.SourcesDirectory)/node_modules/${{ parameters.testPackage }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -401,7 +401,9 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ parameters.env }}
+            ${{ if ne(length(parameters.env)), 0 }}:
+              ${{ each pair in parameters.env }}:
+                ${{ pair.name }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -50,7 +50,6 @@ parameters:
 - name: env
   type: object
   default:
-    dummyKey: dummyValue
 
 - name: splitTestVariants
   type: object
@@ -402,9 +401,8 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ if ne(length(parameters.env), 0) }}:
-              ${{ each pair in parameters.env }}:
-                ${{ pair.name }}: ${{ pair.value }}
+            ${{ each pair in parameters.env }}:
+              ${{ pair.key }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -167,7 +167,7 @@ stages:
 
         steps:
         # Setup
-        - checkout: PipelineHost
+        - checkout: ff_pipeline_host
           clean: true
 
         # Install self-signed cert for R11s deployment in local cert store

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -113,13 +113,18 @@ parameters:
 - name: odspTenantType
   type: string
   default: ''
-  values: ['', 'prod', 'dogfood']
+  values:
+    - ''
+    - 'prod'
+    - 'dogfood'
 
 # lockBehavior of the stage (if any).
 - name: lockBehavior
   type: string
   default: ''
-  values: ['', 'sequential']
+  values:
+    - ''
+    - 'sequential'
 
 stages:
 - stage: ${{ parameters.stageId}}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -50,6 +50,7 @@ parameters:
 - name: env
   type: object
   default:
+    dummyKey: dummyValue
 
 - name: splitTestVariants
   type: object

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -401,8 +401,7 @@ stages:
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
-            ${{ each pair in parameters.env }}:
-              ${{ pair.name }}: ${{ pair.value }}
+            ${{ parameters.env }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -112,23 +112,23 @@ parameters:
 # If tests need to run against an ODSP tenant, specify the type of tenant here. Steps will be injected to lease one for the duration of the test.
 - name: odspTenantType
   type: string
-  default: ''
+  default: none
   values:
-    - ''
-    - 'prod'
-    - 'dogfood'
+    - none
+    - prod
+    - dogfood
 
 # lockBehavior of the stage (if any).
 - name: lockBehavior
   type: string
-  default: ''
+  default: none
   values:
-    - ''
-    - 'sequential'
+    - none
+    - sequential
 
 stages:
 - stage: ${{ parameters.stageId}}
-  ${{ if ne(parameters.lockBehavior, '') }}:
+  ${{ if ne(parameters.lockBehavior, 'none') }}:
     lockBehavior: ${{ parameters.lockBehavior }}
   condition: ${{ parameters.condition }}
   displayName: ${{ parameters.stageDisplayName }}
@@ -368,7 +368,7 @@ stages:
               path: $(compatVersionInstallsPath)
 
         # Only check out tenants from the tenant pool if we are running tests against ODSP
-        - ${{ if ne(parameters.odspTenantType, '') }}:
+        - ${{ if ne(parameters.odspTenantType, 'none') }}:
           # Retrieve a tenant from the tenant pool
           - task: AzureCLI@2
             displayName: 'Log in to retrieve tenant credentials'
@@ -465,7 +465,7 @@ stages:
             continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
         # Only release tenants that were checked out from the tenant pool for ODSP/ODSPDF tests
-        - ${{ if ne(parameters.odspTenantType, '') }}:
+        - ${{ if ne(parameters.odspTenantType, 'none') }}:
           # Login to release tenant credentials
           # Currently, some of the compat tests run for longer than 60 minutes and exceed the average token lifetime:
           # https://learn.microsoft.com/en-us/entra/identity-platform/configurable-token-lifetimes#access-tokens

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -42,7 +42,7 @@ stages:
     - group: ado-feeds
 
     steps:
-    - checkout: PipelineHost
+    - checkout: ff_pipeline_host
 
     - template: /tools/pipelines/templates/include-use-node-version.yml@self
 

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -42,7 +42,7 @@ stages:
     - group: ado-feeds
 
     steps:
-    - checkout: git://internal/ff_pipeline_host
+    - checkout: PipelineHost
 
     - template: /tools/pipelines/templates/include-use-node-version.yml@self
 

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -18,6 +18,11 @@ resources:
       - release/*
       - main
       - next
+  repositories:
+  - repository: ff_pipeline_host
+    type: git
+    name: ff_pipeline_host
+
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -21,7 +21,7 @@ resources:
   repositories:
   - repository: ff_pipeline_host
     type: git
-    name: ff_pipeline_host
+    name: PipelineHost
 
 
 variables:

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -21,7 +21,7 @@ resources:
   repositories:
   - repository: ff_pipeline_host
     type: git
-    name: PipelineHost
+    name: ff_pipeline_host
 
 
 variables:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -17,6 +17,11 @@ resources:
       - main
       - next
       - lts
+  repositories:
+  - repository: ff_pipeline_host
+    type: git
+    name: ff_pipeline_host
+
 
 parameters:
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -20,7 +20,7 @@ resources:
   repositories:
   - repository: ff_pipeline_host
     type: git
-    name: PipelineHost
+    name: ff_pipeline_host
 
 
 parameters:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -20,7 +20,7 @@ resources:
   repositories:
   - repository: ff_pipeline_host
     type: git
-    name: ff_pipeline_host
+    name: PipelineHost
 
 
 parameters:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -42,6 +42,7 @@ stages:
     parameters:
       stageId: stress_tests_odsp
       stageDisplayName: Stress tests - Odsp
+      odspTenantType: prod
       poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
@@ -59,6 +60,7 @@ stages:
     parameters:
       stageId: stress_tests_odspdf
       stageDisplayName: Stress tests - Odspdf
+      odspTenantType: dogfood
       poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
@@ -67,11 +69,7 @@ stages:
       testCommand: start:odspdf
       skipTestResultPublishing: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
-      stageVariables:
-        - group: stress-odspdf-lock
       env:
-        login__microsoft__clientId: $(login-microsoft-clientId)
-        login__odspdf__test__tenants: $(automation-stress-login-odspdf-test-tenants)
         FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains getTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
 
@@ -106,6 +104,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       timeoutInMinutes: 120
       testCommand: start:frs
+      lockBehavior: sequential
       skipTestResultPublishing: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       stageVariables:
@@ -126,6 +125,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       timeoutInMinutes: 120
       testCommand: start:frs:canary
+      lockBehavior: sequential
       skipTestResultPublishing: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       stageVariables:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -20,9 +20,9 @@ resources:
       - next
       - lts
   repositories:
-    - repository: ff_pipeline_host
-      type: git
-      name: ff_pipeline_host
+  - repository: ff_pipeline_host
+    type: git
+    name: PipelineHost
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -19,6 +19,10 @@ resources:
       - main
       - next
       - lts
+  repositories:
+    - repository: ff_pipeline_host
+      type: git
+      name: ff_pipeline_host
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -22,7 +22,7 @@ resources:
   repositories:
   - repository: ff_pipeline_host
     type: git
-    name: PipelineHost
+    name: ff_pipeline_host
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -32,7 +32,7 @@ resources:
   repositories:
     - repository: ff_pipeline_host
       type: git
-      name: PipelineHost
+      name: ff_pipeline_host
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -29,6 +29,10 @@ resources:
       - main
       - next
       - lts
+  repositories:
+    - repository: ff_pipeline_host
+      type: git
+      name: ff_pipeline_host
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -96,6 +96,7 @@ stages:
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
       testCommand: test:realsvc:routerlicious:report
+      lockBehavior: sequential
       continueOnError: true
       ${{ if eq(parameters.useR11sPpeEnvironment, true) }}:
         r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
@@ -135,6 +136,7 @@ stages:
       timeoutInMinutes: 360
       continueOnError: true
       testCommand: test:realsvc:frs:report
+      lockBehavior: sequential
       r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
       stageVariables:
         - group: e2e-frs-lock
@@ -160,6 +162,7 @@ stages:
     parameters:
       stageId: e2e_odsp
       stageDisplayName: e2e - odsp
+      odspTenantType: prod
       poolBuild: Small-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -32,7 +32,7 @@ resources:
   repositories:
     - repository: ff_pipeline_host
       type: git
-      name: ff_pipeline_host
+      name: PipelineHost
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self


### PR DESCRIPTION
## Description

Updates `include-test-real-service` to support odspdf TRIPS tenants.

I did some minor refactoring for parameter clarity while in the area.

Test runs:

- e2e tests before trips-setup package update in the host repo [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=358461&view=results) (unaffected, as it should be)
- Stress run using updated trips-setup [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=358690&view=results)