### PR TITLE
Container: Remove blocking work from offline load path

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1668,14 +1668,10 @@ export class Container
 		timings.phase2 = performanceNow();
 
 		// Fetch specified snapshot.
-		const { baseSnapshot, version } =
+		const { baseSnapshot, version, attributes } =
 			await this.serializedStateManager.fetchSnapshot(specifiedVersion);
 		const baseSnapshotTree: ISnapshotTree | undefined = getSnapshotTree(baseSnapshot);
 		this._loadedFromVersion = version;
-		const attributes: IDocumentAttributes = await getDocumentAttributes(
-			this.storageAdapter,
-			baseSnapshotTree,
-		);
 
 		// If we saved ops, we will replay them and don't need DeltaManager to fetch them
 		const lastProcessedSequenceNumber =

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -148,7 +148,7 @@ class RefreshPromiseTracker {
 			throw new Error("Cannot set promise while promise exists");
 		}
 		this.#promise = p;
-		p.catch(this.catchHandler).finally((this.#promise = undefined));
+		p.catch(this.catchHandler).finally(() => { this.#promise = undefined; });
 	}
 }
 

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -148,7 +148,9 @@ class RefreshPromiseTracker {
 			throw new Error("Cannot set promise while promise exists");
 		}
 		this.#promise = p;
-		p.catch(this.catchHandler).finally(() => { this.#promise = undefined; });
+		p.catch(this.catchHandler).finally(() => {
+			this.#promise = undefined;
+		});
 	}
 }
 

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -147,10 +147,10 @@ class RefreshPromiseTracker {
 		if (this.hasPromise) {
 			throw new Error("Cannot set promise while promise exists");
 		}
-		this.#promise = p;
-		p.catch(this.catchHandler).finally(() => {
+		this.#promise = p.finally(() => {
 			this.#promise = undefined;
 		});
+		p.catch(this.catchHandler);
 	}
 }
 
@@ -227,7 +227,7 @@ export class SerializedStateManager {
 	 * only intended to be used for testing purposes.
 	 * @returns The snapshot sequence number associated with the latest fetched snapshot
 	 */
-	public get refreshSnapshotP(): Promise<number> | undefined {
+	public get refreshSnapshotP(): Promise<number | undefined> | undefined {
 		return this.refreshTracker.Promise;
 	}
 

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -267,6 +267,8 @@ export class SerializedStateManager {
 			const attributes = await getDocumentAttributes(this.storageAdapter, baseSnapshotTree);
 			// non-interactive clients will not have any pending state we want to save
 			if (this.offlineLoadEnabled) {
+				// we defer getting the blobs to not impact the container load flow
+				// only getPendingState depends on the resolution of this promise
 				this.refreshTracker.setPromise(
 					getBlobContentsFromTree(baseSnapshot, this.storageAdapter).then((snapshotBlobs) => {
 						this.snapshot = {
@@ -461,6 +463,10 @@ export class SerializedStateManager {
 					throw new UsageError("Can't get pending local state unless offline load is enabled");
 				}
 				if (this.snapshot === undefined && this.refreshTracker.hasPromise) {
+					// we deferred the initial download of the snapshot to not block
+					// the container load flow, so if it is not resolved
+					// and we don't have a snapshot, we will wait for the download
+					// to finish.
 					await this.refreshTracker.Promise;
 				}
 

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -1118,6 +1118,10 @@ describe("serializedStateManager", () => {
 				);
 
 				await serializedStateManager.fetchSnapshot(undefined);
+				// the snapshot load is deferred, so need to wait for that to
+				// finish before we can track refresh
+				await serializedStateManager.refreshSnapshotP;
+
 				const lastProcessedOpSequenceNumber = 20;
 				let seq = 1;
 				while (seq <= lastProcessedOpSequenceNumber) {
@@ -1182,6 +1186,10 @@ describe("serializedStateManager", () => {
 				);
 
 				await serializedStateManager.fetchSnapshot(undefined);
+				// the snapshot load is deferred, so need to wait for that to
+				// finish before we can track refresh
+				await serializedStateManager.refreshSnapshotP;
+
 				const lastProcessedOpSequenceNumber = 20;
 				let seq = 1;
 				while (seq <= lastProcessedOpSequenceNumber) {


### PR DESCRIPTION
The previous code introduced a new blocking call into the container load path which could impact load performance, specifically retrieval of all the snapshot blobs via `getBlobContentsFromTree`. This change moves that call to the background, and integrates it with the exist snapshot refresh code, so they don't conflict. Lasty, I unified calls to get the container attributes, so it is only called one per load, and reused rather than both retrieving for pending state, and for container load