### PR TITLE
Container:  Connect as read even with pending state

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1641,10 +1641,9 @@ export class Container
 		const timings: Record<string, number> = { phase1: performanceNow() };
 		this.service = await this.createDocumentService(resolvedUrl, { mode: "load" });
 
-		// Except in cases where it has stashed ops or requested by feature gate, the container will connect in "read" mode
+		// Except in cases where its requested by feature gate, the container will connect in "read" mode
 		const mode =
-			this.mc.config.getBoolean("Fluid.Container.ForceWriteConnection") === true ||
-			(pendingLocalState?.savedOps.length ?? 0) > 0
+			this.mc.config.getBoolean("Fluid.Container.ForceWriteConnection") === true
 				? "write"
 				: "read";
 		const connectionArgs: IConnectionArgs = {

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -42,6 +42,7 @@ describe("Local Server Stress", () => {
 		// Use skip, replay, and only properties to control which seeds run.
 		skip: [
 			124, // directory 0xc38
+			105, // Task-manger hides dirty state AB#49649
 		],
 	});
 });


### PR DESCRIPTION
This code wasn't correct, and probably isn't the behavior we want. Specifically, savedOps does not mean there are local changes. savedOps actually contains all remote ops, and local changes only exist within the runtimes state. 

We want to incorporate staging mode with offline in the near future, and in that case we may never send local ops if they do exist and user chooses to disgard them. In that case the user may not expect to edit the document at all, which is what connecting as write will do. 

I think this was an attempt at an optimization, nothing requires write connect this early, it was just assuming we would edit later, so it tries to skip the read write transition. As i call out above, this optimization is based on some false assumptions.