### PR TITLE
Cleanup tree-agent

### DIFF
--- a/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
+++ b/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
@@ -21,20 +21,13 @@ export function buildFunc<const Return extends z.ZodTypeAny, const Args extends 
 }, ...args: Args): FunctionDef<Args, Return, Rest>;
 
 // @alpha
-export function createSemanticAgent<TSchema extends ImplicitFieldSchema>(client: BaseChatModel, treeView: TreeView<TSchema>, options?: {
-    readonly domainHints?: string;
-    readonly treeToString?: (root: ReadableField<TSchema>) => string;
-    readonly validator?: (js: string) => boolean;
-    readonly log?: Log;
-}): SharedTreeSemanticAgent;
+export function createSemanticAgent<TSchema extends ImplicitFieldSchema>(client: BaseChatModel, treeView: TreeView<TSchema>, options?: Readonly<SemanticAgentOptions<ReadableField<TSchema>>>): SharedTreeSemanticAgent;
 
 // @alpha
-export function createSemanticAgent<T extends TreeNode>(client: BaseChatModel, node: T, options?: {
-    readonly domainHints?: string;
-    readonly treeToString?: (root: T) => string;
-    readonly validator?: (js: string) => boolean;
-    readonly log?: Log;
-}): SharedTreeSemanticAgent;
+export function createSemanticAgent<T extends TreeNode>(client: BaseChatModel, node: T, options?: Readonly<SemanticAgentOptions<T>>): SharedTreeSemanticAgent;
+
+// @alpha
+export function createSemanticAgent<TSchema extends ImplicitFieldSchema>(client: BaseChatModel, treeView: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), options?: Readonly<SemanticAgentOptions<ReadableField<TSchema>>>): SharedTreeSemanticAgent;
 
 // @alpha
 export type Ctor<T = any> = new (...args: any[]) => T;
@@ -75,13 +68,27 @@ export type Infer<T> = T extends FunctionDef<infer Args, infer Return, infer Res
 // @alpha
 export const llmDefault: unique symbol;
 
-// @alpha (undocumented)
-export type Log = (message: string) => void;
+// @alpha
+export interface Logger<TTree extends ReadableField<ImplicitFieldSchema> = ReadableField<ImplicitFieldSchema>> {
+    log(message: string): void;
+    treeToString?(tree: TTree): string;
+}
 
 // @alpha
 export type MethodKeys<T> = {
     [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
 };
+
+// @alpha
+export interface SemanticAgentOptions<TSchema extends ReadableField<ImplicitFieldSchema>> {
+    // (undocumented)
+    domainHints?: string;
+    // (undocumented)
+    logger?: Logger<TSchema>;
+    maximumSequentialEdits?: number;
+    // (undocumented)
+    validator?: (js: string) => boolean;
+}
 
 // @alpha (undocumented)
 export interface SharedTreeSemanticAgent {

--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 export { createSemanticAgent } from "./agent.js";
-export type { Log, SharedTreeSemanticAgent } from "./agent.js";
+export type { Logger, SemanticAgentOptions, SharedTreeSemanticAgent } from "./agent.js";
 export { type TreeView, llmDefault } from "./utils.js";
 export {
 	buildFunc,


### PR DESCRIPTION
* Remove stateful branch member in favor of functional patterns
* Simplify branching flow. Branching now happens at the start of each query, and once again for each edit within the query. Previously, branching happened upon the creation of the agent, and in a couple of places during the query/edit process, and required more rebasing to stay in sync.
* Various cleanups to code and LLM messaging flow - e.g. we no longer throw an error if we exceed the maximum number of edits, but instead return a message with instructions for the user.
* Moved `treeToString` inside of logger object
* Properly set the outer branch dirty bit