### PR TITLE
Allow build scripts already in use by client

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,6 +400,19 @@
 		},
 		"patchedDependencies": {
 			"@microsoft/api-extractor@7.52.11": "patches/@microsoft__api-extractor@7.52.11.patch"
-		}
+		},
+		"onlyBuiltDependencies": [
+			"@azure/msal-node-extensions",
+			"@azure/msal-node-runtime",
+			"@biomejs/biome",
+			"@parcel/watcher",
+			"@vvago/vale",
+			"classic-level",
+			"core-js",
+			"keytar",
+			"msgpackr-extract",
+			"puppeteer",
+			"unrs-resolver"
+		]
 	}
 }


### PR DESCRIPTION
## Description

With CI passing without these, I thought we were fine, but it seems like linting depends on at least one of them.

As we used to run when we were on pnpm 9 automatically, enabling them on pnpm 10 is not much of a regression, but the set we do run should be audited and trimmed down to what's required in the future.

If getting strange errors when linting locally, removing your `./node_modules` files and running `pnpm i` after this change may help.

List generated using `pnpm approve-builds` and selecting all.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
