### PR TITLE
refactor(tree) branded format version types

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -152,6 +152,7 @@ export {
 	Multiplicity,
 	type SchemaPolicy,
 	SchemaVersion,
+	type SchemaFormatVersion,
 } from "./schema-stored/index.js";
 
 export {

--- a/packages/dds/tree/src/core/schema-stored/index.ts
+++ b/packages/dds/tree/src/core/schema-stored/index.ts
@@ -24,6 +24,7 @@ export {
 	type SchemaAndPolicy,
 	type SchemaPolicy,
 	SchemaVersion,
+	type SchemaFormatVersion,
 } from "./schema.js";
 export {
 	type TreeStoredSchemaSubscription,

--- a/packages/dds/tree/src/core/schema-stored/schema.ts
+++ b/packages/dds/tree/src/core/schema-stored/schema.ts
@@ -7,6 +7,7 @@ import { fail } from "@fluidframework/core-utils/internal";
 
 import { DiscriminatedUnionDispatcher } from "../../codec/index.js";
 import {
+	type Brand,
 	type JsonCompatibleReadOnlyObject,
 	type MakeNominal,
 	brand,
@@ -39,6 +40,7 @@ export enum SchemaVersion {
 	 */
 	v2 = 2,
 }
+export type SchemaFormatVersion = Brand<SchemaVersion, "SchemaFormatVersion">;
 
 type FieldSchemaFormat = FieldSchemaFormatV1 | FieldSchemaFormatV2;
 

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
@@ -21,6 +21,7 @@ import { version2 } from "./detachedFieldIndexFormatV2.js";
 import { makeDetachedNodeToFieldCodecV1 } from "./detachedFieldIndexCodecV1.js";
 import { makeDetachedNodeToFieldCodecV2 } from "./detachedFieldIndexCodecV2.js";
 import type { DetachedFieldSummaryData } from "./detachedFieldIndexTypes.js";
+import type { Brand } from "../../util/index.js";
 
 export function makeDetachedFieldIndexCodec(
 	revisionTagCodec: RevisionTagCodec,
@@ -44,7 +45,7 @@ export function makeDetachedFieldIndexCodecFamily(
 	]);
 }
 
-export type DetachedFieldIndexFormatVersion = 1 | 2;
+export type DetachedFieldIndexFormatVersion = Brand<1 | 2, "DetachedFieldIndexFormatVersion">;
 export function getCodecTreeForDetachedFieldIndexFormat(
 	version: DetachedFieldIndexFormatVersion,
 ): CodecTree {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format.ts
@@ -13,9 +13,10 @@ import {
 	IdentifierOrIndex,
 	ShapeIndex,
 } from "./formatGeneric.js";
+import type { Brand } from "../../../util/index.js";
 
 export const version = 1;
-export type FieldBatchFormatVersion = 1;
+export type FieldBatchFormatVersion = Brand<1, "FieldBatchFormatVersion">;
 
 // Compatible versions used for format/version validation.
 // TODO: A proper version update policy will need to be documented.

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -33,6 +33,7 @@ import { sequenceFieldChangeHandler } from "../sequence-field/index.js";
 
 import { noChangeCodecFamily } from "./noChangeCodecs.js";
 import type { CodecTree } from "../../codec/index.js";
+import { brand, type Brand } from "../../util/index.js";
 
 /**
  * ChangeHandler that only handles no-op / identity changes.
@@ -211,7 +212,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 	FieldKindConfiguration
 > = new Map([
 	[
-		1,
+		brand(1),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 1 }],
@@ -222,7 +223,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 		]),
 	],
 	[
-		2,
+		brand(2),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 2 }],
@@ -233,7 +234,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 		]),
 	],
 	[
-		3,
+		brand(3),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 2 }],
@@ -244,7 +245,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 		]),
 	],
 	[
-		4,
+		brand(4),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 2 }],
@@ -256,7 +257,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 	],
 ]);
 
-export type ModularChangeFormatVersion = 1 | 2 | 3 | 4;
+export type ModularChangeFormatVersion = Brand<1 | 2 | 3 | 4, "ModularChangeFormatVersion">;
 export function getCodecTreeForModularChangeFormat(
 	version: ModularChangeFormatVersion,
 ): CodecTree {

--- a/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
@@ -15,6 +15,7 @@ import type { FieldKey, ITreeCursorSynchronous } from "../../core/index.js";
 import type { FieldBatchCodec, FieldBatchEncodingContext } from "../chunked-forest/index.js";
 
 import { Format } from "./format.js";
+import type { Brand } from "../../util/index.js";
 
 /**
  * Uses field cursors
@@ -52,7 +53,7 @@ export function makeForestSummarizerCodec(
 	});
 }
 
-export type ForestFormatVersion = 1;
+export type ForestFormatVersion = Brand<1, "ForestFormatVersion">;
 export function getCodecTreeForForestFormat(version: ForestFormatVersion): CodecTree {
 	return { name: "Forest", version };
 }

--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
@@ -19,6 +19,7 @@ import { getCodecTreeForSchemaFormat, makeSchemaCodec } from "../schema-index/in
 import { EncodedSchemaChange } from "./schemaChangeFormat.js";
 import type { SchemaChange } from "./schemaChangeTypes.js";
 import { SchemaVersion } from "../../core/index.js";
+import type { Brand } from "../../util/index.js";
 
 /**
  * Create a family of schema change codecs.
@@ -32,7 +33,10 @@ export function makeSchemaChangeCodecs(options: ICodecOptions): ICodecFamily<Sch
 	]);
 }
 
-export type SchemaChangeFormatVersion = SchemaVersion.v1 | SchemaVersion.v2;
+export type SchemaChangeFormatVersion = Brand<
+	SchemaVersion.v1 | SchemaVersion.v2,
+	"SchemaChangeFormatVersion"
+>;
 export function getCodecTreeForSchemaChangeFormat(
 	version: SchemaChangeFormatVersion,
 ): CodecTree {

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -22,7 +22,7 @@ import type {
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
+import { brand, type Brand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { SummaryData } from "./editManager.js";
 import { makeV1CodecWithVersion } from "./editManagerCodecsV1toV4.js";
@@ -101,9 +101,13 @@ export function makeEditManagerCodecs<TChangeset>(
 	return makeCodecFamily(registry);
 }
 
-export type EditManagerFormatVersion = 1 | 2 | 3 | 4 | 5;
+export type EditManagerFormatVersion = Brand<1 | 2 | 3 | 4 | 5, "EditManagerFormatVersion">;
 export const editManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> = new Set([
-	1, 2, 3, 4, 5,
+	brand(1),
+	brand(2),
+	brand(3),
+	brand(4),
+	brand(5),
 ]);
 
 export function getCodecTreeForEditManagerFormatWithChange(

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -20,7 +20,7 @@ import type {
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
+import { brand, type Brand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { DecodedMessage } from "./messageTypes.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
@@ -42,7 +42,7 @@ export function makeMessageCodec<TChangeset>(
 		ChangeEncodingContext
 	>,
 	options: ICodecOptions,
-	writeVersion: MessageFormatVersion = 1,
+	writeVersion: MessageFormatVersion = brand(1),
 ): IJsonCodec<
 	DecodedMessage<TChangeset>,
 	JsonCompatibleReadOnly,
@@ -106,14 +106,17 @@ export function makeMessageCodecs<TChangeset>(
 	return makeCodecFamily(registry);
 }
 
-export type MessageFormatVersion = undefined | 1 | 2 | 3 | 4 | 5;
+export type MessageFormatVersion = Brand<
+	undefined | 1 | 2 | 3 | 4 | 5,
+	"MessageFormatVersion"
+>;
 export const messageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set([
-	undefined,
-	1,
-	2,
-	3,
-	4,
-	5,
+	brand(undefined),
+	brand(1),
+	brand(2),
+	brand(3),
+	brand(4),
+	brand(5),
 ]);
 
 export function getCodecTreeForMessageFormatWithChange(

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -35,6 +35,7 @@ import {
 	MapNodeStoredSchema,
 	ObjectNodeStoredSchema,
 	RevisionTagCodec,
+	type SchemaFormatVersion,
 	SchemaVersion,
 	type TreeFieldStoredSchema,
 	type TreeNodeSchemaIdentifier,
@@ -105,6 +106,7 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { type TreeCheckout, type BranchableTree, createTreeCheckout } from "./treeCheckout.js";
 import {
+	brand,
 	type Breakable,
 	breakingClass,
 	type JsonCompatible,
@@ -179,7 +181,7 @@ export interface ITreePrivate extends ITreeInternal {
  */
 interface ExplicitCodecVersions extends ExplicitCoreCodecVersions {
 	forest: ForestFormatVersion;
-	schema: SchemaVersion;
+	schema: SchemaFormatVersion;
 	detachedFieldIndex: DetachedFieldIndexFormatVersion;
 	fieldBatch: FieldBatchFormatVersion;
 }
@@ -187,27 +189,69 @@ interface ExplicitCodecVersions extends ExplicitCoreCodecVersions {
 const formatVersionToTopLevelCodecVersions = new Map<number, ExplicitCodecVersions>([
 	[
 		1,
-		{ forest: 1, schema: 1, detachedFieldIndex: 1, editManager: 1, message: 1, fieldBatch: 1 },
+		{
+			forest: brand(1),
+			schema: brand(1),
+			detachedFieldIndex: brand(1),
+			editManager: brand(1),
+			message: brand(1),
+			fieldBatch: brand(1),
+		},
 	],
 	[
 		2,
-		{ forest: 1, schema: 1, detachedFieldIndex: 1, editManager: 2, message: 2, fieldBatch: 1 },
+		{
+			forest: brand(1),
+			schema: brand(1),
+			detachedFieldIndex: brand(1),
+			editManager: brand(2),
+			message: brand(2),
+			fieldBatch: brand(1),
+		},
 	],
 	[
 		3,
-		{ forest: 1, schema: 1, detachedFieldIndex: 1, editManager: 3, message: 3, fieldBatch: 1 },
+		{
+			forest: brand(1),
+			schema: brand(1),
+			detachedFieldIndex: brand(1),
+			editManager: brand(3),
+			message: brand(3),
+			fieldBatch: brand(1),
+		},
 	],
 	[
 		4,
-		{ forest: 1, schema: 1, detachedFieldIndex: 1, editManager: 4, message: 4, fieldBatch: 1 },
+		{
+			forest: brand(1),
+			schema: brand(1),
+			detachedFieldIndex: brand(1),
+			editManager: brand(4),
+			message: brand(4),
+			fieldBatch: brand(1),
+		},
 	],
 	[
 		5,
-		{ forest: 1, schema: 2, detachedFieldIndex: 1, editManager: 4, message: 4, fieldBatch: 1 },
+		{
+			forest: brand(1),
+			schema: brand(2),
+			detachedFieldIndex: brand(1),
+			editManager: brand(4),
+			message: brand(4),
+			fieldBatch: brand(1),
+		},
 	],
 	[
 		100, // SharedTreeFormatVersion.vSharedBranches
-		{ forest: 1, schema: 2, detachedFieldIndex: 1, editManager: 5, message: 5, fieldBatch: 1 },
+		{
+			forest: brand(1),
+			schema: brand(2),
+			detachedFieldIndex: brand(1),
+			editManager: brand(5),
+			message: brand(5),
+			fieldBatch: brand(1),
+		},
 	],
 ]);
 
@@ -660,16 +704,12 @@ export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
  * Once an entry is defined and used in production, it cannot be changed.
  * This is because the format for SharedTree changes are not explicitly versioned.
  */
-export const changeFormatVersionForEditManager: DependentFormatVersion<
-	EditManagerFormatVersion,
-	SharedTreeChangeFormatVersion
-> = DependentFormatVersion.fromPairs([
-	// [EditManagerFormatVersion, SharedTreeChangeFormatVersion]
-	[1, 1],
-	[2, 2],
-	[3, 3],
-	[4, 4],
-	[5, 4],
+export const changeFormatVersionForEditManager = DependentFormatVersion.fromPairs([
+	[brand<EditManagerFormatVersion>(1), brand<SharedTreeChangeFormatVersion>(1)],
+	[brand<EditManagerFormatVersion>(2), brand<SharedTreeChangeFormatVersion>(2)],
+	[brand<EditManagerFormatVersion>(3), brand<SharedTreeChangeFormatVersion>(3)],
+	[brand<EditManagerFormatVersion>(4), brand<SharedTreeChangeFormatVersion>(4)],
+	[brand<EditManagerFormatVersion>(5), brand<SharedTreeChangeFormatVersion>(4)],
 ]);
 
 /**
@@ -678,16 +718,13 @@ export const changeFormatVersionForEditManager: DependentFormatVersion<
  * Once an entry is defined and used in production, it cannot be changed.
  * This is because the format for SharedTree changes are not explicitly versioned.
  */
-export const changeFormatVersionForMessage: DependentFormatVersion<
-	MessageFormatVersion,
-	SharedTreeChangeFormatVersion
-> = DependentFormatVersion.fromPairs([
-	[undefined, 1],
-	[1, 1],
-	[2, 2],
-	[3, 3],
-	[4, 4],
-	[5, 4],
+export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs([
+	[brand<MessageFormatVersion>(undefined), brand<SharedTreeChangeFormatVersion>(1)],
+	[brand<MessageFormatVersion>(1), brand<SharedTreeChangeFormatVersion>(1)],
+	[brand<MessageFormatVersion>(2), brand<SharedTreeChangeFormatVersion>(2)],
+	[brand<MessageFormatVersion>(3), brand<SharedTreeChangeFormatVersion>(3)],
+	[brand<MessageFormatVersion>(4), brand<SharedTreeChangeFormatVersion>(4)],
+	[brand<MessageFormatVersion>(5), brand<SharedTreeChangeFormatVersion>(4)],
 ]);
 
 function getCodecTreeForEditManagerFormat(version: EditManagerFormatVersion): CodecTree {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -25,7 +25,12 @@ import {
 	getCodecTreeForSchemaChangeFormat,
 	makeSchemaChangeCodecs,
 } from "../feature-libraries/index.js";
-import type { JsonCompatibleReadOnly, Mutable } from "../util/index.js";
+import {
+	brand,
+	type Brand,
+	type JsonCompatibleReadOnly,
+	type Mutable,
+} from "../util/index.js";
 
 import {
 	EncodedSharedTreeChange,
@@ -64,7 +69,10 @@ interface ChangeFormatDependencies {
 	readonly schemaChange: SchemaChangeFormatVersion;
 }
 
-export type SharedTreeChangeFormatVersion = 1 | 2 | 3 | 4;
+export type SharedTreeChangeFormatVersion = Brand<
+	1 | 2 | 3 | 4,
+	"SharedTreeChangeFormatVersion"
+>;
 
 /**
  * Defines for each SharedTree change format the corresponding dependent formats to use.
@@ -76,10 +84,10 @@ export const dependenciesForChangeFormat: Map<
 	SharedTreeChangeFormatVersion,
 	ChangeFormatDependencies
 > = new Map([
-	[1, { modularChange: 1, schemaChange: 1 }],
-	[2, { modularChange: 2, schemaChange: 1 }],
-	[3, { modularChange: 3, schemaChange: 1 }],
-	[4, { modularChange: 4, schemaChange: 1 }],
+	[brand(1), { modularChange: brand(1), schemaChange: brand(1) }],
+	[brand(2), { modularChange: brand(2), schemaChange: brand(1) }],
+	[brand(3), { modularChange: brand(3), schemaChange: brand(1) }],
+	[brand(4), { modularChange: brand(4), schemaChange: brand(1) }],
 ]);
 
 export function getCodecTreeForChangeFormat(

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -153,7 +153,6 @@ describe("message codec", () => {
 	makeEncodingTestSuite(family, testCases);
 
 	describe("dispatching codec", () => {
-		const version = 1;
 		const codec = makeMessageCodec(
 			TestChange.codecs,
 			DependentFormatVersion.fromUnique(1),
@@ -161,7 +160,6 @@ describe("message codec", () => {
 			{
 				jsonValidator: FormatValidatorBasic,
 			},
-			version,
 		);
 
 		const sessionId: SessionId = "sessionId" as SessionId;

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -74,7 +74,7 @@ import type {
 	IFluidLoadable,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { Breakable } from "../../util/index.js";
+import { brand, Breakable } from "../../util/index.js";
 import { mockSerializer } from "../mockSerializer.js";
 import { TestChange } from "../testChange.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -89,9 +89,9 @@ const codecOptions: ICodecOptions = {
 	jsonValidator: FormatValidatorBasic,
 };
 const formatVersions: ExplicitCoreCodecVersions & { fieldBatch: FieldBatchFormatVersion } = {
-	editManager: 1,
-	message: 1,
-	fieldBatch: 1,
+	editManager: brand(1),
+	message: brand(1),
+	fieldBatch: brand(1),
 };
 
 class MockSharedObjectHandle extends MockHandle<ISharedObject> implements ISharedObjectHandle {

--- a/packages/dds/tree/src/util/brand.ts
+++ b/packages/dds/tree/src/util/brand.ts
@@ -17,7 +17,7 @@ import type { Covariant } from "./typeCheck.js";
  * mismatched branded types will be:
  * `Type 'Name1' is not assignable to type 'Name2'.`
  *
- * These branded types are not opaque: A `Brand<A, B>` can still be used as a `B`.
+ * These branded types are not opaque: A `Brand<A, B>` can still be used as a `A`.
  */
 export type Brand<ValueType, Name> = ValueType & BrandedType<ValueType, Name>;
 


### PR DESCRIPTION
## Description

This PR adds branding to the types that describe format versions. This prevents assigning a version from one format to another.
This is a follow-up to https://github.com/microsoft/FluidFramework/pull/25619.

## Breaking Changes

None
