### PR TITLE
LoadingGroups: Remove recursions from function

### DIFF
--- a/packages/runtime/runtime-utils/src/snapshotUtils.ts
+++ b/packages/runtime/runtime-utils/src/snapshotUtils.ts
@@ -16,21 +16,22 @@ export function isSnapshotFetchRequiredForLoadingGroupId(
 	snapshotTree: ISnapshotTree,
 	blobContents: Map<string, ArrayBuffer>,
 ): boolean {
-	for (const [_, id] of Object.entries(snapshotTree.blobs)) {
-		if (!blobContents.has(id)) {
-			return true;
-		}
-	}
-	for (const [_, childTree] of Object.entries(snapshotTree.trees)) {
-		// Only evaluate childTree if it does not have a loading groupId because if the childTree has a loading
-		// groupId then it will be evaluated whether we want to fetch blobs for that childTree or not when
-		// that particular childTree is getting realized. Now we just want to check for blobs which belongs to
-		// tree with current loading groupId. Note: Child with no loading groupId, will fall under parent with
-		// a loading groupId as it does not have its own loading groupId.
-		if (childTree.groupId === undefined) {
-			const value = isSnapshotFetchRequiredForLoadingGroupId(childTree, blobContents);
-			if (value) {
+	const trees = [snapshotTree];
+	let tree: ISnapshotTree | undefined;
+	while ((tree = trees.pop()) !== undefined) {
+		for (const [_, id] of Object.entries(tree.blobs)) {
+			if (!blobContents.has(id)) {
 				return true;
+			}
+		}
+		for (const [_, childTree] of Object.entries(tree.trees)) {
+			// Only evaluate childTree if it does not have a loading groupId because if the childTree has a loading
+			// groupId then it will be evaluated whether we want to fetch blobs for that childTree or not when
+			// that particular childTree is getting realized. Now we just want to check for blobs which belongs to
+			// tree with current loading groupId. Note: Child with no loading groupId, will fall under parent with
+			// a loading groupId as it does not have its own loading groupId.
+			if (childTree.groupId === undefined) {
+				trees.push(childTree);
 			}
 		}
 	}


### PR DESCRIPTION
This pull request refactors the logic in the `isSnapshotFetchRequiredForLoadingGroupId` function to improve its efficiency and readability. Instead of using recursion to traverse the snapshot tree, it now uses an explicit stack-based approach for iterative traversal. This change makes the code easier to follow and can help avoid potential stack overflow issues with deeply nested trees.

Snapshot tree traversal improvements:

* Replaced recursive traversal with an iterative approach using a stack (`trees`) to process each `ISnapshotTree` node, making the function more efficient and readable.
* Ensured that child trees without a `groupId` are pushed onto the stack for further evaluation, maintaining the correct logic for determining if a snapshot fetch is required.