### PR TITLE
stringToBuffer: Use ArrayBuffer as return type for compatiblity with ISnapshot

### DIFF
--- a/packages/common/client-utils/src/bufferBrowser.ts
+++ b/packages/common/client-utils/src/bufferBrowser.ts
@@ -45,7 +45,7 @@ export function Uint8ArrayToString(
  *
  * @internal
  */
-export const stringToBuffer = (input: string, encoding: string): ArrayBufferLike =>
+export const stringToBuffer = (input: string, encoding: string): ArrayBuffer =>
 	IsoBuffer.from(input, encoding).buffer;
 
 /**

--- a/packages/common/client-utils/src/bufferNode.ts
+++ b/packages/common/client-utils/src/bufferNode.ts
@@ -63,7 +63,7 @@ export function Uint8ArrayToString(
  *
  * @internal
  */
-export function stringToBuffer(input: string, encoding: string): ArrayBufferLike {
+export function stringToBuffer(input: string, encoding: string): ArrayBuffer {
 	const iso = IsoBuffer.from(input, encoding);
 	// In a Node environment, IsoBuffer may be a Node.js Buffer.  Node.js will
 	// pool multiple small Buffer instances into a single ArrayBuffer, in which


### PR DESCRIPTION
The [ISnapshot interface]( https://github.com/microsoft/FluidFramework/blob/19c35668c47741946c64eb78d48827b0d75454c1/packages/common/driver-definitions/src/storage.ts#L482) defines its blobs as ArrayBuffers, which are a subset of ArrayBufferLike. This change unifies on ArrayBuffer for better interoperability between snapshot and our buffer functions. Narrowing the return type of these function to match their actual returned type shouldn't cause issues for any existing consumers.