### PR TITLE
Container: move pendingState to fetchSnashot so it can be GC'd

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1025,7 +1025,6 @@ export class Container
 				this.mc.config.getBoolean("Fluid.Container.enableOfflineFull") ??
 				options.enableOfflineLoad === true);
 		this.serializedStateManager = new SerializedStateManager(
-			pendingLocalState,
 			this.subLogger,
 			this.storageAdapter,
 			offlineLoadEnabled,
@@ -1668,7 +1667,7 @@ export class Container
 
 		// Fetch specified snapshot.
 		const { baseSnapshot, version, attributes } =
-			await this.serializedStateManager.fetchSnapshot(specifiedVersion);
+			await this.serializedStateManager.fetchSnapshot(specifiedVersion, pendingLocalState);
 		const baseSnapshotTree: ISnapshotTree | undefined = getSnapshotTree(baseSnapshot);
 		this._loadedFromVersion = version;
 

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -217,7 +217,6 @@ export class SerializedStateManager implements IDisposable {
 		this.refreshTimer = this.#snapshotRefreshEnabled
 			? new Timer(this.snapshotRefreshTimeoutMs, () => this.tryRefreshSnapshot())
 			: undefined;
-
 		containerEvent.on("saved", () => this.updateSnapshotAndProcessedOpsMaybe());
 	}
 	public get disposed(): boolean {

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -180,12 +180,11 @@ export class SerializedStateManager {
 				error,
 			),
 	);
-	private readonly lastSavedOpSequenceNumber: number = 0;
+	private lastSavedOpSequenceNumber: number = 0;
 	private readonly refreshTimer: Timer;
 	private readonly snapshotRefreshTimeoutMs: number = 60 * 60 * 24 * 1000;
 
 	/**
-	 * @param pendingLocalState - The pendingLocalState being rehydrated, if any (undefined when loading directly from storage)
 	 * @param subLogger - Container's logger to use as parent for our logger
 	 * @param storageAdapter - Storage adapter for fetching snapshots
 	 * @param _offlineLoadEnabled - Is serializing/rehydrating containers allowed?
@@ -193,7 +192,6 @@ export class SerializedStateManager {
 	 * @param containerDirty - Is the container "dirty"? That's the opposite of "saved" - there is pending state that may not have been received yet by the service.
 	 */
 	constructor(
-		private readonly pendingLocalState: IPendingContainerState | undefined,
 		subLogger: ITelemetryBaseLogger,
 		private readonly storageAdapter: ISerializedStateManagerDocumentStorageService,
 		private readonly _offlineLoadEnabled: boolean,
@@ -211,14 +209,6 @@ export class SerializedStateManager {
 		this.refreshTimer = new Timer(this.snapshotRefreshTimeoutMs, () =>
 			this.tryRefreshSnapshot(),
 		);
-		// special case handle. Obtaining the last saved op seq num to avoid
-		// refreshing the snapshot before we have processed it. It could cause
-		// a subsequent stashing to have a newer snapshot than allowed.
-		if (pendingLocalState && pendingLocalState.savedOps.length > 0) {
-			const savedOpsSize = pendingLocalState.savedOps.length;
-			this.lastSavedOpSequenceNumber =
-				pendingLocalState.savedOps[savedOpsSize - 1].sequenceNumber;
-		}
 		containerEvent.on("saved", () => this.updateSnapshotAndProcessedOpsMaybe());
 	}
 
@@ -252,15 +242,18 @@ export class SerializedStateManager {
 	 * Otherwise, fetch it from storage (according to specifiedVersion if provided).
 	 *
 	 * @param specifiedVersion - If a version is specified and we don't have pendingLocalState, fetch this version from storage.
-	 * @param supportGetSnapshotApi - a boolean indicating whether to use the fetchISnapshot or fetchISnapshotTree.
+	 * @param pendingLocalState - The pendingLocalState being rehydrated, if any (undefined when loading directly from storage)
 	 * @returns The snapshot to boot the container from
 	 */
-	public async fetchSnapshot(specifiedVersion: string | undefined): Promise<{
+	public async fetchSnapshot(
+		specifiedVersion: string | undefined,
+		pendingLocalState: IPendingContainerState | undefined,
+	): Promise<{
 		baseSnapshot: ISnapshot | ISnapshotTree;
 		version: IVersion | undefined;
 		attributes: IDocumentAttributes;
 	}> {
-		if (this.pendingLocalState === undefined) {
+		if (pendingLocalState === undefined) {
 			const { baseSnapshot, version } = await getSnapshot(
 				this.mc,
 				this.storageAdapter,
@@ -287,7 +280,16 @@ export class SerializedStateManager {
 			}
 			return { baseSnapshot, version, attributes };
 		} else {
-			const { baseSnapshot, snapshotBlobs } = this.pendingLocalState;
+			const { baseSnapshot, snapshotBlobs, savedOps } = pendingLocalState;
+
+			// special case handle. Obtaining the last saved op seq num to avoid
+			// refreshing the snapshot before we have processed it. It could cause
+			// a subsequent stashing to have a newer snapshot than allowed.
+			if (savedOps.length > 0) {
+				const savedOpsSize = savedOps.length;
+				this.lastSavedOpSequenceNumber = savedOps[savedOpsSize - 1].sequenceNumber;
+			}
+
 			const attributes = await getDocumentAttributes(this.storageAdapter, baseSnapshot);
 			this.snapshot = {
 				baseSnapshot,


### PR DESCRIPTION
This pull request refactors how `pendingLocalState` is handled in the `SerializedStateManager` and its related usage in the `Container` class and associated tests. The main change is moving the management of `pendingLocalState` from being a member of `SerializedStateManager` to being passed explicitly as a parameter when fetching snapshots. This simplifies the state management and improves clarity around the flow of local state during container loading and snapshot operations. Additionally, by not storing a reference to`pendingLocalState` it will allow it to be garbage collected. This is important, as the blobs as strings are not used after fetch snapshot, as they are turned into buffers.

### Refactoring of pending local state handling

* Removed `pendingLocalState` as a member variable from `SerializedStateManager`, and updated its constructor and related logic to no longer store it internally. 
* Changed the signature of `fetchSnapshot` in `SerializedStateManager` to require `pendingLocalState` as an explicit parameter, and updated its internal logic to use this parameter instead of the member variable
* Updated usage in `Container` to pass `pendingLocalState` to `fetchSnapshot`, and removed passing it to the `SerializedStateManager` constructor. 

### Test updates for new pending local state flow

* Refactored all relevant test cases to remove `pendingLocalState` from the `SerializedStateManager` constructor and instead pass it to `fetchSnapshot` as needed.

### Improved snapshot and op sequence handling

* Moved logic for updating `lastSavedOpSequenceNumber` from the constructor to the `fetchSnapshot` method, ensuring it is only set when rehydrating from `pendingLocalState`.