### PR TITLE
docs(container-definitions): Reserve some keys in IFluidCodeDetailsConfig for framework use

### DIFF
--- a/.changeset/forty-snakes-swim.md
+++ b/.changeset/forty-snakes-swim.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/container-definitions": minor
+"__section": legacy
+---
+Some keys in IFluidCodeDetailsConfig are now reserved for Fluid Framework use
+
+The keys of [`IFluidCodeDetailsConfig`](https://fluidframework.com/docs/api/container-definitions/ifluidcodedetailsconfig-interface)
+(the [type of the `config` property on `IFluidCodeDetails`](https://fluidframework.com/docs/api/container-definitions/ifluidcodedetails-interface#config-propertysignature))
+used to be entirely free for consumer use.
+Going forward, keys with the `"FluidFramework."` prefix are reserved for Fluid Framework's internal use.
+
+We do not expect this to affect any consumers.

--- a/packages/common/container-definitions/src/fluidPackage.ts
+++ b/packages/common/container-definitions/src/fluidPackage.ts
@@ -100,10 +100,10 @@ export interface IFluidCodeDetails {
 	 * Configuration details and additional information about the Fluid document.
 	 *
 	 * @remarks
-	 * This is mainly consumer-defined data.
+	 * This is mainly consumer-defined data (e.g. links to a package manager and base CDNs).
 	 * Its contents and semantics (including whether or not this data is present) are completely up to the consumer,
-	 * except for keys starting with "FluidFramework." (e.g. "FluidFramework.CustomSetting1")
-	 * which are reserved by Fluid and should not be used by consumers.
+	 * _except_ for keys starting with "FluidFramework." (e.g. "FluidFramework.CustomSetting1")
+	 * which are reserved by the framework and should not be used by consumers.
 	 * Outside of those reserved keys, Fluid does not interpret this data in any way.
 	 */
 	readonly config?: IFluidCodeDetailsConfig;

--- a/packages/common/container-definitions/src/fluidPackage.ts
+++ b/packages/common/container-definitions/src/fluidPackage.ts
@@ -72,7 +72,13 @@ export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
 	typeof (pkg as Partial<IFluidPackage>)?.fluid === "object";
 
 /**
- * Package manager configuration. Provides a key value mapping of config values
+ * A key-value mapping of config values.
+ *
+ * @remarks
+ * Can be used by consumers for things like providing additional configuration for their package manager.
+ *
+ * @see {@link IFluidCodeDetails.config}
+ *
  * @legacy @beta
  */
 export interface IFluidCodeDetailsConfig {
@@ -85,16 +91,20 @@ export interface IFluidCodeDetailsConfig {
  */
 export interface IFluidCodeDetails {
 	/**
-	 * The code package to be used on the Fluid document. This is either the package name which will be loaded
-	 * from a package manager. Or the expanded Fluid package.
+	 * The code package to be used on the Fluid document.
+	 * This is either the package name which will be loaded from a package manager, or the expanded Fluid package.
 	 */
 	readonly package: string | Readonly<IFluidPackage>;
 
 	/**
-	 * Configuration details. This includes links to the package manager and base CDNs.
+	 * Configuration details and additional information about the Fluid document.
 	 *
-	 * @remarks This is strictly consumer-defined data.
-	 * Its contents and semantics (including whether or not this data is present) are completely up to the consumer.
+	 * @remarks
+	 * This is mainly consumer-defined data.
+	 * Its contents and semantics (including whether or not this data is present) are completely up to the consumer,
+	 * except for keys starting with "FluidFramework." (e.g. "FluidFramework.CustomSetting1")
+	 * which are reserved by Fluid and should not be used by consumers.
+	 * Outside of those reserved keys, Fluid does not interpret this data in any way.
 	 */
 	readonly config?: IFluidCodeDetailsConfig;
 }


### PR DESCRIPTION
## Description

Updates the documentation on `IFluidCodeDetails` and `IFluidCodeDetailsConfig` to make some string keys in the latter reserved for Fluid Framework use.

## Breaking Changes

While it could theoretically cause breaking changes, I could not find evidence of our partners using keys like the ones this PR now makes reserved; the chances seem pretty low IMO. Furthermore, the scenario for which we intend to use reserved keys does not apply to existing Fluid documents, so even if some partner was using keys like these, their Fluid files would not go through the code that will care about the new reserved keys (at least not the code we already know of today).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
