### PR TITLE
Add ff_pipeline_host resource to service client tests

### DIFF
--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -20,6 +20,10 @@ resources:
       - main
       - next
       - lts
+  repositories:
+    - repository: ff_pipeline_host
+      type: git
+      name: ff_pipeline_host
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self


### PR DESCRIPTION
## Description

#25599 updated the include-test-real-service template to use a repository reference rather than an explicit checkout. This reference needs to exist on all pipelines that use it, but this one was missed.