### PR TITLE
Fix Bohemia integration pipeline: use console.log instead of console.warn or console.error

### DIFF
--- a/packages/common/core-utils/src/assert.ts
+++ b/packages/common/core-utils/src/assert.ts
@@ -63,7 +63,8 @@ export function fail(message: string | number, debugMessageBuilder?: () => strin
 		if (debugMessageBuilder !== undefined) {
 			messageString = `${messageString}\nDebug Message: ${debugMessageBuilder()}`;
 		}
-		console.error(`Bug in Fluid Framework: Failed Assertion: ${messageString}`);
+		// Using console.warn instead of console.error since the latter currently breaks Loop/Pages integration.
+		console.warn(`Bug in Fluid Framework: Failed Assertion: ${messageString}`);
 	});
 	const error = new Error(messageString);
 	onAssertionError(error);

--- a/packages/common/core-utils/src/assert.ts
+++ b/packages/common/core-utils/src/assert.ts
@@ -63,8 +63,8 @@ export function fail(message: string | number, debugMessageBuilder?: () => strin
 		if (debugMessageBuilder !== undefined) {
 			messageString = `${messageString}\nDebug Message: ${debugMessageBuilder()}`;
 		}
-		// Using console.warn instead of console.error since the latter currently breaks Loop/Pages integration.
-		console.warn(`Bug in Fluid Framework: Failed Assertion: ${messageString}`);
+		// Using console.log instead of console.error or console.warn since the latter two currently break Loop/Pages integration.
+		console.log(`Bug in Fluid Framework: Failed Assertion: ${messageString}`);
 	});
 	const error = new Error(messageString);
 	onAssertionError(error);


### PR DESCRIPTION
## Description

This PR fixes the build integration pipeline error encountered [here](https://dev.azure.com/office/OC/_build/results?buildId=40951759&view=logs&j=eab3c21e-49a7-54ab-c48b-81ebf3d510d7&t=36b7ade7-774e-5518-5236-7db22ec61d1b&l=21111).

The Bohemia repo uses our `assert` function and takes a dependency on its current implementation (specifically, the fact that it does not call `console.error/warn`). This is not something we want to support. The `assert` function is legacy beta since we haven't gone through the process of making it internal, but no FF consumer should not be using it.

## Breaking Changes

None
