### PR TITLE
Reference new tenant management documentation in getkeys README

### DIFF
--- a/tools/getkeys/README.md
+++ b/tools/getkeys/README.md
@@ -15,7 +15,7 @@ prague-secrets or WAC Bohemia security group.
 You should restart the console/shell after running the script (or for bash/zsh run `source ~/.bashrc` or `source ~/.zshrc`)
 for the exported environment variables to become available.
 
-> Note: The getkeys tool is no longer used for ODSP tenant credential management. Please refer to the [ff_internal documentation](https://dev.azure.com/fluidframework/internal/_git/ff_internal?path=/packages/trips-setup/README.md) for the updated process.
+> Note: The getkeys tool is no longer used for ODSP tenant credential management. Please refer to the tenant setup documentation in ff_internal for the updated process.
 
 ## TO-DO
 

--- a/tools/getkeys/README.md
+++ b/tools/getkeys/README.md
@@ -15,6 +15,8 @@ prague-secrets or WAC Bohemia security group.
 You should restart the console/shell after running the script (or for bash/zsh run `source ~/.bashrc` or `source ~/.zshrc`)
 for the exported environment variables to become available.
 
+> Note: The getkeys tool is no longer used for ODSP tenant credential management. Please refer to the [ff_internal documentation](https://dev.azure.com/fluidframework/internal/_git/ff_internal?path=/packages/trips-setup/README.md) for the updated process.
+
 ## TO-DO
 
 This tool had a fallback mechanism using REST to access Azure Keyvault if the Azure CLI wasn't installed, but it got


### PR DESCRIPTION
Since getkeys is no longer used for storing test tenant credential information, update the documentation to reflect this and point to the correct docs. 

[AB#48374](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/48374)