### PR TITLE
Expose creation of a frozen document service factory.

### DIFF
--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -23,6 +23,9 @@ export interface ContainerAlpha extends IContainer {
 // @beta @legacy
 export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
 
+// @alpha @legacy
+export function createFrozenDocumentServiceFactory(documentServiceFactory: IDocumentServiceFactory): IDocumentServiceFactory;
+
 // @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -24,7 +24,7 @@ export interface ContainerAlpha extends IContainer {
 export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
 
 // @alpha @legacy
-export function createFrozenDocumentServiceFactory(documentServiceFactory: IDocumentServiceFactory): IDocumentServiceFactory;
+export function createFrozenDocumentServiceFactory(factory?: IDocumentServiceFactory | Promise<IDocumentServiceFactory>): IDocumentServiceFactory;
 
 // @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -21,7 +21,7 @@ import type {
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 
-import { FrozenDocumentServiceFactory } from "./frozenServices.js";
+import { createFrozenDocumentServiceFactory } from "./frozenServices.js";
 import { Loader } from "./loader.js";
 import type { ProtocolHandlerBuilder } from "./protocol.js";
 
@@ -197,6 +197,6 @@ export async function loadFrozenContainerFromPendingState(
 ): Promise<IContainer> {
 	return loadExistingContainer({
 		...props,
-		documentServiceFactory: new FrozenDocumentServiceFactory(props.documentServiceFactory),
+		documentServiceFactory: createFrozenDocumentServiceFactory(props.documentServiceFactory),
 	});
 }

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -197,6 +197,8 @@ export async function loadFrozenContainerFromPendingState(
 ): Promise<IContainer> {
 	return loadExistingContainer({
 		...props,
-		documentServiceFactory: createFrozenDocumentServiceFactory(props.documentServiceFactory),
+		documentServiceFactory: await createFrozenDocumentServiceFactory(
+			props.documentServiceFactory,
+		),
 	});
 }

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -197,8 +197,6 @@ export async function loadFrozenContainerFromPendingState(
 ): Promise<IContainer> {
 	return loadExistingContainer({
 		...props,
-		documentServiceFactory: await createFrozenDocumentServiceFactory(
-			props.documentServiceFactory,
-		),
+		documentServiceFactory: createFrozenDocumentServiceFactory(props.documentServiceFactory),
 	});
 }

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -28,6 +28,17 @@ import {
 
 import type { IConnectionStateChangeReason } from "./contracts.js";
 
+/**
+ * A connection to a delta stream which does not support submitting or receiving ops.
+ * Used in storage-only mode and in frozen loads.
+ * @returns A FrozenDocumentServiceFactory
+ * @legacy @alpha
+ */
+export function createFrozenDocumentServiceFactory(
+	documentServiceFactory: IDocumentServiceFactory,
+): IDocumentServiceFactory {
+	return new FrozenDocumentServiceFactory(documentServiceFactory);
+}
 export class FrozenDocumentServiceFactory implements IDocumentServiceFactory {
 	constructor(private readonly documentServiceFactory?: IDocumentServiceFactory) {}
 

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -5,6 +5,7 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IDisposable } from "@fluidframework/core-interfaces";
+import { isPromiseLike } from "@fluidframework/core-utils/internal";
 import {
 	ScopeType,
 	type ConnectionMode,
@@ -27,7 +28,6 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 
 import type { IConnectionStateChangeReason } from "./contracts.js";
-import { isPromiseLike } from "@fluidframework/core-utils/internal";
 
 /**
  * Creation of a FrozenDocumentServiceFactory which wraps an existing

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -29,8 +29,10 @@ import {
 import type { IConnectionStateChangeReason } from "./contracts.js";
 
 /**
- * A connection to a delta stream which does not support submitting or receiving ops.
- * Used in storage-only mode and in frozen loads.
+ * Creation of a FrozenDocumentServiceFactory which wraps an existing
+ * DocumentServiceFactory to provide a storage-only document service.
+ *
+ * @param documentServiceFactory - The underlying DocumentServiceFactory to wrap.
  * @returns A FrozenDocumentServiceFactory
  * @legacy @alpha
  */

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -5,6 +5,7 @@
 
 export { ConnectionState } from "./connectionState.js";
 export { type ContainerAlpha, waitContainerToCatchUp, asLegacyAlpha } from "./container.js";
+export { createFrozenDocumentServiceFactory } from "./frozenServices.js";
 export {
 	createDetachedContainer,
 	loadExistingContainer,


### PR DESCRIPTION
Exposing creation of a frozen document service factory via standalone function. Given Pages container load flow, this is the step of less friction where we can enforce storage only in containers that were loaded with pending local state. 