### PR TITLE
Container: Reuse buffers created from saved state

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -153,7 +153,6 @@ import {
 	SerializedStateManager,
 } from "./serializedStateManager.js";
 import {
-	type ISnapshotTreeWithBlobContents,
 	combineAppAndProtocolSummary,
 	combineSnapshotTreeAndSnapshotBlobs,
 	getDetachedContainerStateFromSerializedContainer,
@@ -162,6 +161,7 @@ import {
 	getISnapshotFromSerializedContainer,
 	runSingle,
 	convertISnapshotToSnapshotWithBlobs,
+	convertSnapshotInfoToSnapshot,
 } from "./utils.js";
 
 const detachedContainerRefSeqNumber = 0;
@@ -1013,7 +1013,6 @@ export class Container
 		this.storageAdapter = new ContainerStorageAdapter(
 			this.detachedBlobStorage,
 			this.mc.logger,
-			pendingLocalState?.snapshotBlobs,
 			pendingLocalState?.loadedGroupIdSnapshots,
 			addProtocolSummaryIfMissing,
 			enableSummarizeProtocolTree,
@@ -1848,18 +1847,20 @@ export class Container
 				0x250 /* "serialized container with attachment blobs must be rehydrated with detached blob storage" */,
 			);
 		}
-		const snapshotTreeWithBlobContents: ISnapshotTreeWithBlobContents =
-			combineSnapshotTreeAndSnapshotBlobs(baseSnapshot, snapshotBlobs);
-		this.storageAdapter.loadSnapshotFromSnapshotBlobs(snapshotBlobs);
-		const attributes = await getDocumentAttributes(
-			this.storageAdapter,
-			snapshotTreeWithBlobContents,
-		);
+
+		const snapshot = convertSnapshotInfoToSnapshot({
+			baseSnapshot,
+			snapshotBlobs,
+			snapshotSequenceNumber: 0,
+		});
+
+		this.storageAdapter.cacheSnapshotBlobs(snapshot.blobContents);
+		const attributes = await getDocumentAttributes(this.storageAdapter, snapshot.snapshotTree);
 
 		await this.attachDeltaManagerOpHandler(attributes);
 
 		// Initialize the protocol handler
-		const baseTree = getProtocolSnapshotTree(snapshotTreeWithBlobContents);
+		const baseTree = getProtocolSnapshotTree(snapshot.snapshotTree);
 		const qValues = await readAndParse<[string, ICommittedProposal][]>(
 			this.storageAdapter,
 			baseTree.blobs.quorumValues,
@@ -1876,8 +1877,9 @@ export class Container
 
 		await this.instantiateRuntime(
 			codeDetails,
-			snapshotTreeWithBlobContents,
+			combineSnapshotTreeAndSnapshotBlobs(snapshot),
 			pendingRuntimeState,
+			snapshot,
 		);
 
 		this.setLoaded();

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -72,7 +72,7 @@ export class ContainerStorageAdapter
 	}
 
 	/**
-	 * ArrayBufferLikes or utf8 encoded strings, containing blobs from a snapshot
+	 * ArrayBufferLikes  containing blobs from a snapshot
 	 */
 	private readonly blobContents: { [id: string]: ArrayBufferLike } = {};
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
+import { bufferToString } from "@fluid-internal/client-utils";
 import type {
 	ISnapshotTreeWithBlobContents,
 	IContainerStorageService,
@@ -72,6 +72,11 @@ export class ContainerStorageAdapter
 	}
 
 	/**
+	 * ArrayBufferLikes or utf8 encoded strings, containing blobs from a snapshot
+	 */
+	private readonly blobContents: { [id: string]: ArrayBufferLike } = {};
+
+	/**
 	 * An adapter that ensures we're using detachedBlobStorage up until we connect to a real service, and then
 	 * after connecting to a real service augments it with retry and combined summary tree enforcement.
 	 * @param detachedBlobStorage - The detached blob storage to use up until we connect to a real service
@@ -84,10 +89,7 @@ export class ContainerStorageAdapter
 	public constructor(
 		detachedBlobStorage: MemoryDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLoggerExt,
-		/**
-		 * ArrayBufferLikes or utf8 encoded strings, containing blobs from a snapshot
-		 */
-		private readonly blobContents: { [id: string]: ArrayBufferLike | string } = {},
+
 		private loadingGroupIdSnapshotsFromPendingState:
 			| Record<string, SerializedSnapshotInfo>
 			| undefined,
@@ -143,9 +145,9 @@ export class ContainerStorageAdapter
 		);
 	}
 
-	public loadSnapshotFromSnapshotBlobs(snapshotBlobs: ISerializableBlobContents): void {
-		for (const [id, value] of Object.entries(snapshotBlobs)) {
-			this.blobContents[id] = value;
+	public cacheSnapshotBlobs(snapshotBlobs: Map<string, ArrayBuffer>): void {
+		for (const [id, value] of snapshotBlobs.entries()) {
+			this.blobContents[id] ??= value;
 		}
 	}
 
@@ -220,10 +222,6 @@ export class ContainerStorageAdapter
 	public async readBlob(id: string): Promise<ArrayBufferLike> {
 		const maybeBlob = this.blobContents[id];
 		if (maybeBlob !== undefined) {
-			if (typeof maybeBlob === "string") {
-				const blob = stringToBuffer(maybeBlob, "utf8");
-				return blob;
-			}
 			return maybeBlob;
 		}
 		return this._storageService.readBlob(id);

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -89,7 +89,6 @@ export class ContainerStorageAdapter
 	public constructor(
 		detachedBlobStorage: MemoryDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLoggerExt,
-
 		private loadingGroupIdSnapshotsFromPendingState:
 			| Record<string, SerializedSnapshotInfo>
 			| undefined,

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -93,6 +93,11 @@ class MockStorageAdapter implements ISerializedStateManagerDocumentStorageServic
 			this.blobs.set(id, stringToBuffer(blob, "utf8"));
 		}
 	}
+	public cacheSnapshotBlobs(snapshotBlobs: Map<string, ArrayBuffer>): void {
+		for (const [key, value] of snapshotBlobs.entries()) {
+			this.blobs.set(key, value);
+		}
+	}
 
 	public async updateGroupIdSnapshots(): Promise<void> {}
 	public get loadedGroupIdSnapshots(): Record<string, ISnapshot> {

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -274,33 +274,34 @@ export function getProtocolSnapshotTree(snapshot: ISnapshotTree): ISnapshotTree 
 	return ".protocol" in snapshot.trees ? snapshot.trees[".protocol"] : snapshot;
 }
 
-export const combineSnapshotTreeAndSnapshotBlobs = (
-	baseSnapshot: ISnapshotTree,
-	snapshotBlobs: ISerializableBlobContents,
-): ISnapshotTreeWithBlobContents => {
-	const blobsContents: { [path: string]: ArrayBufferLike } = {};
+export const combineSnapshotTreeAndSnapshotBlobs = ({
+	snapshotTree,
+	blobContents,
+}: Pick<ISnapshot, "blobContents" | "snapshotTree">): ISnapshotTreeWithBlobContents => {
+	const currentTreeBlobs: { [path: string]: ArrayBufferLike } = {};
 
 	// Process blobs in the current level
-	for (const [, id] of Object.entries(baseSnapshot.blobs)) {
-		if (snapshotBlobs[id] !== undefined) {
-			blobsContents[id] = stringToBuffer(snapshotBlobs[id], "utf8");
+	for (const [, id] of Object.entries(snapshotTree.blobs)) {
+		const blob = blobContents.get(id);
+		if (blob !== undefined) {
+			currentTreeBlobs[id] = blob;
 		}
 	}
 
 	// Recursively process trees in the current level
 	const trees: { [path: string]: ISnapshotTreeWithBlobContents } = {};
-	for (const [path, tree] of Object.entries(baseSnapshot.trees)) {
-		trees[path] = combineSnapshotTreeAndSnapshotBlobs(tree, snapshotBlobs);
+	for (const [path, tree] of Object.entries(snapshotTree.trees)) {
+		trees[path] = combineSnapshotTreeAndSnapshotBlobs({ snapshotTree: tree, blobContents });
 	}
 
 	// Create a new snapshot tree with blob contents and processed trees
-	const snapshotTreeWithBlobContents: ISnapshotTreeWithBlobContents = {
-		...baseSnapshot,
-		blobsContents,
+	const snapshot: ISnapshotTreeWithBlobContents = {
+		...snapshotTree,
+		blobsContents: currentTreeBlobs,
 		trees,
 	};
 
-	return snapshotTreeWithBlobContents;
+	return snapshot;
 };
 
 export function isDeltaStreamConnectionForbiddenError(

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -275,8 +275,8 @@ export function getProtocolSnapshotTree(snapshot: ISnapshotTree): ISnapshotTree 
 }
 
 export const combineSnapshotTreeAndSnapshotBlobs = ({
-	snapshotTree,
 	blobContents,
+	snapshotTree,
 }: Pick<ISnapshot, "blobContents" | "snapshotTree">): ISnapshotTreeWithBlobContents => {
 	const currentTreeBlobs: { [path: string]: ArrayBufferLike } = {};
 


### PR DESCRIPTION
This pull request refactors how snapshot blobs are managed and accessed within the container loader, improving consistency and removing legacy string encoding logic. The main changes revolve around using `ArrayBuffer` for blob contents, updating interfaces and adapters to support this, and simplifying how snapshots are combined and cached. This continues to goal of ensuring we only call string to buffer once for each serialized blob, and reuse that buffer everywhere, to prevent multiple instances which wastes memory.

**Snapshot Blob Management and Refactoring:**

* Updated `ContainerStorageAdapter` to store blob contents as `ArrayBufferLike` only, removed legacy support for utf8-encoded string blobs, and replaced the `loadSnapshotFromSnapshotBlobs` method with `cacheSnapshotBlobs`, which now accepts a `Map<string, ArrayBuffer>`. 
* Changed all code paths in `container.ts` and `serializedStateManager.ts` to use the new `cacheSnapshotBlobs` method and ensure blobs are always stored as `ArrayBuffer`. 
* Updated the interface for `ISerializedStateManagerDocumentStorageService` to include the new `cacheSnapshotBlobs` method, reflecting the changes in storage adapter capabilities.

**Snapshot Combination and Utilities:**

* Refactored `combineSnapshotTreeAndSnapshotBlobs` to accept an object containing both `snapshotTree` and `blobContents` as a `Map`, updating recursive logic to work with this new structure and removing string-to-buffer conversion.
* Updated usage of snapshot combination and conversion utilities in `container.ts` to match the new signatures and flow, including introducing `convertSnapshotInfoToSnapshot`.

**Testing and Type Updates:**

* Updated mock implementations and imports in tests and related files to support the new blob caching method and type changes.

These changes streamline snapshot blob handling, improve type safety, and remove legacy string encoding logic, making blob management more robust and easier to maintain.