### PR TITLE
test(client-container-loader): respect exactOptionalPropertyTypes

### DIFF
--- a/packages/loader/container-loader/src/test/attachment.spec.ts
+++ b/packages/loader/container-loader/src/test/attachment.spec.ts
@@ -87,7 +87,11 @@ const createProxyWithFailDefault = <T extends Record<string, any>>(
 	return new Proxy(partial, {
 		get: (t, p, r): unknown => {
 			if (p in t) {
-				return Reflect.get(t, p, r);
+				const value = Reflect.get(t, p, r);
+				if (value === AbsentProperty) {
+					return undefined;
+				}
+				return value;
 			}
 
 			return new Proxy(

--- a/packages/loader/container-loader/src/test/attachment.spec.ts
+++ b/packages/loader/container-loader/src/test/attachment.spec.ts
@@ -25,6 +25,9 @@ import {
 } from "../attachment.js";
 import { combineAppAndProtocolSummary } from "../utils.js";
 
+import type { PartialOrAbsent } from "./failProxy.js";
+import { AbsentProperty } from "./failProxy.js";
+
 const emptySummary = combineAppAndProtocolSummary(
 	{ tree: {}, type: SummaryType.Tree },
 	{ tree: {}, type: SummaryType.Tree },
@@ -78,8 +81,8 @@ const createDetachStorage = (
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createProxyWithFailDefault = <T extends Record<string, any> | undefined>(
-	partial: Partial<T> = {},
+const createProxyWithFailDefault = <T extends Record<string, any>>(
+	partial: PartialOrAbsent<T> = {},
 ): T => {
 	return new Proxy(partial, {
 		get: (t, p, r): unknown => {
@@ -202,7 +205,7 @@ describe("runRetriableAttachProcess", () => {
 				// we have blobs storage, but it is empty,
 				// so it should be treat like there are no blobs
 				detachedBlobStorage: createProxyWithFailDefault<
-					AttachProcessProps["detachedBlobStorage"]
+					Required<AttachProcessProps>["detachedBlobStorage"]
 				>({ size: 0 }),
 			});
 
@@ -221,7 +224,7 @@ describe("runRetriableAttachProcess", () => {
 				await runRetriableAttachProcess(
 					createProxyWithFailDefault<AttachProcessProps>({
 						initialAttachmentData: initial,
-						detachedBlobStorage: undefined,
+						detachedBlobStorage: AbsentProperty,
 						createAttachmentSummary: () => {
 							throw error;
 						},
@@ -251,7 +254,7 @@ describe("runRetriableAttachProcess", () => {
 						initialAttachmentData: initial,
 						setAttachmentData: (data) => (attachmentData = data),
 						createAttachmentSummary: () => emptySummary,
-						detachedBlobStorage: undefined,
+						detachedBlobStorage: AbsentProperty,
 						createOrGetStorageService: () => {
 							throw error;
 						},

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -47,14 +47,14 @@ class MockContainer
 		IDocumentMessage
 	>;
 	resolvedUrl?: IResolvedUrl | undefined;
-	attachState?: AttachState | undefined;
-	closed?: boolean | undefined = false;
-	isDirty?: boolean | undefined;
-	connectionState?: ConnectionState | undefined;
+	attachState?: AttachState;
+	closed?: boolean = false;
+	isDirty?: boolean;
+	connectionState?: ConnectionState;
 	connected?: boolean | undefined;
-	audience?: IAudience | undefined;
+	audience?: IAudience;
 	clientId?: string | undefined;
-	readOnlyInfo?: ReadOnlyInfo | undefined;
+	readOnlyInfo?: ReadOnlyInfo;
 
 	get mockDeltaManager(): MockDeltaManager {
 		return this.deltaManager as unknown as MockDeltaManager;

--- a/packages/loader/container-loader/src/test/failProxy.ts
+++ b/packages/loader/container-loader/src/test/failProxy.ts
@@ -31,16 +31,17 @@ export const failSometimeProxy = <T extends object>(handler: PartialOrAbsent<T>)
 				return undefined;
 			}
 			if (p in handler) {
-				if (handler[p] === AbsentProperty) {
+				const value = Reflect.get(t, p, r);
+				if (value === AbsentProperty) {
 					return undefined;
 				}
-				return Reflect.get(t, p, r);
+				return value;
 			}
 			throw new Error(`${p.toString()} not implemented`);
 		},
 		has: (t, p): boolean => {
 			if (p in handler) {
-				return handler[p] !== AbsentProperty;
+				return Reflect.get(t, p) !== AbsentProperty;
 			}
 			throw new Error(`${p.toString()} not implemented or declared as absent`);
 		},

--- a/packages/loader/container-loader/src/test/failProxy.ts
+++ b/packages/loader/container-loader/src/test/failProxy.ts
@@ -15,16 +15,34 @@ export const failProxy = <T extends object>(): T => {
 	return proxy;
 };
 
-export const failSometimeProxy = <T extends object>(handler: Partial<T>): T => {
+export const AbsentProperty = Symbol("AbsentProperty");
+
+// Allow properties to be explicitly absent to make it easier to create
+// partial handlers where proxy won't throw for missing properties, but
+// still appear `undefined` when accessed.
+export type PartialOrAbsent<T> = {
+	[P in keyof T]?: T[P] | typeof AbsentProperty;
+};
+
+export const failSometimeProxy = <T extends object>(handler: PartialOrAbsent<T>): T => {
 	const proxy = new Proxy<T>(handler as T, {
 		get: (t, p, r): unknown => {
 			if (p === "then") {
 				return undefined;
 			}
 			if (p in handler) {
+				if (handler[p] === AbsentProperty) {
+					return undefined;
+				}
 				return Reflect.get(t, p, r);
 			}
 			throw new Error(`${p.toString()} not implemented`);
+		},
+		has: (t, p): boolean => {
+			if (p in handler) {
+				return handler[p] !== AbsentProperty;
+			}
+			throw new Error(`${p.toString()} not implemented or declared as absent`);
 		},
 	});
 	return proxy;

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -26,7 +26,7 @@ import { Container } from "../container.js";
 import { Loader } from "../loader.js";
 import type { IPendingDetachedContainerState } from "../serializedStateManager.js";
 
-import { failProxy, failSometimeProxy } from "./failProxy.js";
+import { AbsentProperty, failProxy, failSometimeProxy } from "./failProxy.js";
 import {
 	createTestCodeLoaderProxy,
 	createTestDocumentServiceFactoryProxy,
@@ -35,7 +35,7 @@ import {
 const documentServiceFactoryFailProxy = failSometimeProxy<
 	IDocumentServiceFactory & IProvideLayerCompatDetails
 >({
-	ILayerCompatDetails: undefined,
+	ILayerCompatDetails: AbsentProperty,
 });
 
 describe("loader unit test", () => {

--- a/packages/loader/container-loader/src/test/testProxies.ts
+++ b/packages/loader/container-loader/src/test/testProxies.ts
@@ -22,7 +22,7 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { v4 as uuid } from "uuid";
 
-import { failSometimeProxy } from "./failProxy.js";
+import { AbsentProperty, failSometimeProxy } from "./failProxy.js";
 
 export function createTestDocumentServiceFactoryProxy(
 	resolvedUrl: IResolvedUrl,
@@ -38,7 +38,7 @@ export function createTestDocumentServiceFactoryProxy(
 						createBlob: async () => ({ id: uuid() }),
 					}),
 			}),
-		ILayerCompatDetails: compatibilityDetails,
+		ILayerCompatDetails: compatibilityDetails ?? AbsentProperty,
 	});
 }
 
@@ -74,7 +74,7 @@ export function createTestCodeLoaderProxy(props?: {
 									}),
 									disposed: false,
 									setConnectionState: () => {},
-									ILayerCompatDetails: props?.layerCompatDetails,
+									ILayerCompatDetails: props?.layerCompatDetails ?? AbsentProperty,
 								});
 							},
 						},

--- a/packages/loader/container-loader/src/test/tsconfig.json
+++ b/packages/loader/container-loader/src/test/tsconfig.json
@@ -5,7 +5,6 @@
 		"outDir": "../../lib/test",
 		"types": ["mocha", "node"],
 		"noUncheckedIndexedAccess": false,
-		"exactOptionalPropertyTypes": false,
 	},
 	"include": ["./**/*"],
 	"references": [


### PR DESCRIPTION
Use `AbsentProperty` token to mark absent properties under Proxy rather than `undefined` to support exactOptionalPropertyTypes=true builds. Additionally add `has` checks within `failSometimeProxy` to detect new properties whose existence is checked that way.

Remove unused `undefined` unions in `MockContainer` that violate `IContainer` specification under exactOptionalPropertyTypes=true.