### PR TITLE
test(e2e): skip "on-demand summary succeeds while normal summary is inflight"

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarization/onDemandSummarizerApi.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/onDemandSummarizerApi.spec.ts
@@ -186,7 +186,11 @@ describeCompat("on-demand summarizer api", "NoCompat", (getTestObjectProvider, a
 		assert(summaryResults.summarySubmitted, "on-demand summary not submitted");
 		assert(summaryResults.summaryOpBroadcasted, "on-demand summary op not broadcasted");
 	});
-
+	/**
+	 * Disabled: overlapping summaries occasionally exceed Mocha's 5s default timeout.
+	 * Risk: `loadSummarizerContainerAndMakeSummary` is still an unused API but we temporarily lose coverage of the concurrent-summary scenario.
+	 * Planned work: {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/50613}
+	 */
 	it.skip("on-demand summary succeeds while normal summary is inflight", async () => {
 		const enabledSummarizerConfig: ITestContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/onDemandSummarizerApi.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/onDemandSummarizerApi.spec.ts
@@ -187,7 +187,7 @@ describeCompat("on-demand summarizer api", "NoCompat", (getTestObjectProvider, a
 		assert(summaryResults.summaryOpBroadcasted, "on-demand summary op not broadcasted");
 	});
 
-	it("on-demand summary succeeds while normal summary is inflight", async () => {
+	it.skip("on-demand summary succeeds while normal summary is inflight", async () => {
 		const enabledSummarizerConfig: ITestContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
 		};


### PR DESCRIPTION
## Description
This test is timing out non-deterministically. Will investigate further but disabling for now to limit noise on PRs.