### PR TITLE
test-drivers: Remove unnecessary axios dep

### DIFF
--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -68,7 +68,6 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"@fluidframework/tool-utils": "workspace:~",
 		"agentkeepalive": "^4.5.0",
-		"axios": "^1.8.4",
 		"semver": "^7.7.1",
 		"uuid": "^11.1.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14488,9 +14488,6 @@ importers:
       agentkeepalive:
         specifier: ^4.5.0
         version: 4.6.0
-      axios:
-        specifier: ^1.8.4
-        version: 1.12.2(debug@4.4.3)
       semver:
         specifier: ^7.7.1
         version: 7.7.3


### PR DESCRIPTION
## Description

Remove unused dep on axios in the test-drivers package.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).