### PR TITLE
improvement(tree): Add index-based get method overloads to TableSchema APIs

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1214,8 +1214,8 @@ export namespace System_Unsafe {
 // @alpha
 export namespace TableSchema {
     export interface CellKey<TColumn extends ImplicitAllowedTypes, TRow extends ImplicitAllowedTypes> {
-        readonly column: string | TreeNodeFromImplicitAllowedTypes<TColumn>;
-        readonly row: string | TreeNodeFromImplicitAllowedTypes<TRow>;
+        readonly column: string | number | TreeNodeFromImplicitAllowedTypes<TColumn>;
+        readonly row: string | number | TreeNodeFromImplicitAllowedTypes<TRow>;
     }
     // @sealed
     export interface Column<TCell extends ImplicitAllowedTypes, TProps extends ImplicitFieldSchema = ImplicitFieldSchema> {

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1268,7 +1268,9 @@ export namespace TableSchema {
         readonly columns: TreeArrayNode<TColumn>;
         getCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
         getColumn(id: string): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
+        getColumn(index: number): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
         getRow(id: string): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
+        getRow(index: number): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
         insertColumns(params: InsertColumnsParameters<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         insertRows(params: InsertRowsParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1555,12 +1555,14 @@ export namespace TableSchema {
 		// TODO: by index
 		/**
 		 * Gets a table column by its {@link TableSchema.Column.id}.
+		 * @returns The column, if it exists. Otherwise, `undefined`.
 		 */
 		getColumn(id: string): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
 
 		// TODO: by index
 		/**
 		 * Gets a table row by its {@link TableSchema.Row.id}.
+		 * @returns The row, if it exists. Otherwise, `undefined`.
 		 */
 		getRow(id: string): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
 

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -959,9 +959,15 @@ export namespace System_TableSchema {
 					throw new UsageError(`No column exists at index ${columnOrIdOrIndex}.`);
 				}
 
-				const columnId =
-					typeof columnOrIdOrIndex === "string" ? columnOrIdOrIndex : columnOrIdOrIndex.id;
-				throw new UsageError(`No column with ID "${columnId}" exists in the table.`);
+				if (typeof columnOrIdOrIndex === "string") {
+					throw new UsageError(
+						`No column with ID "${columnOrIdOrIndex}" exists in the table.`,
+					);
+				}
+
+				throw new UsageError(
+					`The specified column node with ID "${columnOrIdOrIndex.id}" does not exist in the table.`,
+				);
 			}
 
 			/**
@@ -1021,8 +1027,13 @@ export namespace System_TableSchema {
 					throw new UsageError(`No row exists at index ${rowOrIdOrIndex}.`);
 				}
 
-				const rowId = typeof rowOrIdOrIndex === "string" ? rowOrIdOrIndex : rowOrIdOrIndex.id;
-				throw new UsageError(`No row with ID "${rowId}" exists in the table.`);
+				if (typeof rowOrIdOrIndex === "string") {
+					throw new UsageError(`No row with ID "${rowOrIdOrIndex}" exists in the table.`);
+				}
+
+				throw new UsageError(
+					`The specified row node with ID "${rowOrIdOrIndex.id}" does not exist in the table.`,
+				);
 			}
 
 			private static _removeRange<TNodeSchema extends ImplicitAllowedTypes>(
@@ -1263,7 +1274,7 @@ export namespace TableSchema {
 
 		/**
 		 * Gets all of the populated cells in the column, keyed by their associated row IDs.
-		 * @throws Throws an error if the column is not in a table.
+		 * @throws Throws an error if the  column is not in a table.
 		 */
 		getCells(): readonly {
 			rowId: string;

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -1391,6 +1391,69 @@ describe("TableFactory unit tests", () => {
 	});
 
 	describeHydration("Reading values", (initializeTree) => {
+		it("Get cell", () => {
+			const cell00 = new Cell({ value: "0-0" });
+			const cell01 = new Cell({ value: "0-1" });
+			const cell10 = new Cell({ value: "1-0" });
+			const cell11 = new Cell({ value: "1-1" });
+			const column0 = new Column({ id: "column-0", props: {} });
+			const column1 = new Column({ id: "column-1", props: {} });
+			const row0 = new Row({
+				id: "row-0",
+				cells: {
+					"column-0": cell00,
+					"column-1": cell01,
+				},
+				props: {},
+			});
+			const row1 = new Row({
+				id: "row-1",
+				cells: { "column-0": cell10, "column-1": cell11 },
+				props: {},
+			});
+
+			const table = initializeTree(Table, {
+				columns: [column0, column1],
+				rows: [row0, row1],
+			});
+
+			// Get cell (by indices)
+			const getByIndices = table.getCell({ row: 1, column: 0 });
+			assert(getByIndices !== undefined);
+			assertEqualTrees(getByIndices, {
+				value: "1-0",
+			});
+
+			// Get cell (by IDs)
+			const getByIds = table.getCell({ row: "row-0", column: "column-0" });
+			assert(getByIds !== undefined);
+			assertEqualTrees(getByIds, {
+				value: "0-0",
+			});
+
+			// Get cell (by nodes)
+			const getByNodes = table.getCell({ row: row1, column: column1 });
+			assert(getByNodes !== undefined);
+			assertEqualTrees(getByNodes, {
+				value: "1-1",
+			});
+
+			// Get cell (index out of bounds)
+			assert(table.getCell({ row: 5, column: 0 }) === undefined);
+
+			// Get cell (nonexistent IDs)
+			assert(table.getCell({ row: "row-0", column: "foo" }) === undefined);
+
+			// Get cell (nodes that aren't in the table)
+			assert(
+				table.getCell({
+					row: new Row({ id: "row-2", cells: {}, props: {} }),
+					column: column0,
+				}) === undefined,
+			);
+		});
+
+		// TODO: replace with column/row/cell specific tests
 		it("Gets proper table elements with getter methods", () => {
 			const cell0 = new Cell({ value: "Hello World!" });
 			const column0 = new Column({ id: "column-0", props: {} });

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -1391,7 +1391,7 @@ describe("TableFactory unit tests", () => {
 	});
 
 	describeHydration("Reading values", (initializeTree) => {
-		it("Get cell", () => {
+		it("getCell", () => {
 			const cell00 = new Cell({ value: "0-0" });
 			const cell01 = new Cell({ value: "0-1" });
 			const cell10 = new Cell({ value: "1-0" });
@@ -1441,36 +1441,123 @@ describe("TableFactory unit tests", () => {
 			// Get cell (index out of bounds)
 			assert(table.getCell({ row: 5, column: 0 }) === undefined);
 
-			// Get cell (nonexistent IDs)
+			// Get cell (nonexistent ID)
 			assert(table.getCell({ row: "row-0", column: "foo" }) === undefined);
 
-			// Get cell (nodes that aren't in the table)
+			// Get cell (node that isn't in the table)
 			assert(
 				table.getCell({
-					row: new Row({ id: "row-2", cells: {}, props: {} }),
+					// Note, while a row with this ID exists in the table, this *node* does not.
+					row: new Row({ id: "row-1", cells: {}, props: {} }),
 					column: column0,
 				}) === undefined,
 			);
 		});
 
-		// TODO: replace with column/row/cell specific tests
-		it("Gets proper table elements with getter methods", () => {
-			const cell0 = new Cell({ value: "Hello World!" });
+		it("getRow", () => {
+			const cell00 = new Cell({ value: "0-0" });
+			const cell01 = new Cell({ value: "0-1" });
+			const cell10 = new Cell({ value: "1-0" });
+			const cell11 = new Cell({ value: "1-1" });
 			const column0 = new Column({ id: "column-0", props: {} });
-			const row0 = new Row({ id: "row-0", cells: { "column-0": cell0 }, props: {} });
-
-			const table = initializeTree(Table, {
-				columns: [column0],
-				rows: [row0],
+			const column1 = new Column({ id: "column-1", props: {} });
+			const row0 = new Row({
+				id: "row-0",
+				cells: {
+					"column-0": cell00,
+					"column-1": cell01,
+				},
+				props: {},
+			});
+			const row1 = new Row({
+				id: "row-1",
+				cells: { "column-0": cell10, "column-1": cell11 },
+				props: {},
 			});
 
-			const cell = table.getCell({ column: "column-0", row: "row-0" });
-			const column = table.getColumn("column-0");
-			const row = table.getRow("row-0");
+			const table = initializeTree(Table, {
+				columns: [column0, column1],
+				rows: [row0, row1],
+			});
 
-			assert.equal(cell, cell0);
-			assert.equal(row, row0);
-			assert.equal(column, column0);
+			// Get row (by index)
+			const getByIndex = table.getRow(1);
+			assert(getByIndex !== undefined);
+			assertEqualTrees(getByIndex, {
+				id: "row-1",
+				cells: {
+					"column-0": { value: "1-0" },
+					"column-1": { value: "1-1" },
+				},
+				props: {},
+			});
+
+			// Get row (by ID)
+			const getByIds = table.getRow("row-0");
+			assert(getByIds !== undefined);
+			assertEqualTrees(getByIds, {
+				id: "row-0",
+				cells: {
+					"column-0": { value: "0-0" },
+					"column-1": { value: "0-1" },
+				},
+				props: {},
+			});
+
+			// Get row (index out of bounds)
+			assert(table.getRow(5) === undefined);
+
+			// Get row (nonexistent ID)
+			assert(table.getRow("foo") === undefined);
+		});
+
+		it("getRow", () => {
+			const cell00 = new Cell({ value: "0-0" });
+			const cell01 = new Cell({ value: "0-1" });
+			const cell10 = new Cell({ value: "1-0" });
+			const cell11 = new Cell({ value: "1-1" });
+			const column0 = new Column({ id: "column-0", props: {} });
+			const column1 = new Column({ id: "column-1", props: {} });
+			const row0 = new Row({
+				id: "row-0",
+				cells: {
+					"column-0": cell00,
+					"column-1": cell01,
+				},
+				props: {},
+			});
+			const row1 = new Row({
+				id: "row-1",
+				cells: { "column-0": cell10, "column-1": cell11 },
+				props: {},
+			});
+
+			const table = initializeTree(Table, {
+				columns: [column0, column1],
+				rows: [row0, row1],
+			});
+
+			// Get column (by index)
+			const getByIndex = table.getColumn(1);
+			assert(getByIndex !== undefined);
+			assertEqualTrees(getByIndex, {
+				id: "column-1",
+				props: {},
+			});
+
+			// Get column (by ID)
+			const getByIds = table.getColumn("column-0");
+			assert(getByIds !== undefined);
+			assertEqualTrees(getByIds, {
+				id: "column-0",
+				props: {},
+			});
+
+			// Get column (index out of bounds)
+			assert(table.getColumn(5) === undefined);
+
+			// Get column (nonexistent ID)
+			assert(table.getColumn("foo") === undefined);
 		});
 	});
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -943,7 +943,9 @@ describe("TableFactory unit tests", () => {
 
 			assert.throws(
 				() => table.removeColumns([new Column({ id: "column-0", props: {} })]),
-				validateUsageError(/No column with ID "column-0" exists in the table./),
+				validateUsageError(
+					/The specified column node with ID "column-0" does not exist in the table./,
+				),
 			);
 		});
 
@@ -956,7 +958,9 @@ describe("TableFactory unit tests", () => {
 
 			assert.throws(
 				() => table.removeColumns([column0, new Column({ id: "column-1", props: {} })]),
-				validateUsageError(/No column with ID "column-1" exists in the table./),
+				validateUsageError(
+					/The specified column node with ID "column-1" does not exist in the table./,
+				),
 			);
 
 			// Additionally, `column-0` should not have been removed.
@@ -1086,7 +1090,9 @@ describe("TableFactory unit tests", () => {
 
 			assert.throws(
 				() => table.removeRows([new Row({ id: "row-0", cells: {}, props: {} })]),
-				validateUsageError(/No row with ID "row-0" exists in the table./),
+				validateUsageError(
+					/The specified row node with ID "row-0" does not exist in the table./,
+				),
 			);
 		});
 
@@ -1099,7 +1105,9 @@ describe("TableFactory unit tests", () => {
 
 			assert.throws(
 				() => table.removeRows([row0, new Row({ id: "row-1", cells: {}, props: {} })]),
-				validateUsageError(/No row with ID "row-1" exists in the table./),
+				validateUsageError(
+					/The specified row node with ID "row-1" does not exist in the table./,
+				),
 			);
 
 			// Additionally, `row-0` should not have been removed.

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1592,8 +1592,8 @@ export namespace System_Unsafe {
 // @alpha
 export namespace TableSchema {
     export interface CellKey<TColumn extends ImplicitAllowedTypes, TRow extends ImplicitAllowedTypes> {
-        readonly column: string | TreeNodeFromImplicitAllowedTypes<TColumn>;
-        readonly row: string | TreeNodeFromImplicitAllowedTypes<TRow>;
+        readonly column: string | number | TreeNodeFromImplicitAllowedTypes<TColumn>;
+        readonly row: string | number | TreeNodeFromImplicitAllowedTypes<TRow>;
     }
     // @sealed
     export interface Column<TCell extends ImplicitAllowedTypes, TProps extends ImplicitFieldSchema = ImplicitFieldSchema> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1646,7 +1646,9 @@ export namespace TableSchema {
         readonly columns: TreeArrayNode<TColumn>;
         getCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
         getColumn(id: string): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
+        getColumn(index: number): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
         getRow(id: string): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
+        getRow(index: number): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
         insertColumns(params: InsertColumnsParameters<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         insertRows(params: InsertRowsParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;


### PR DESCRIPTION
Adds support for index parameters to the following methods on `Table` schema:
- `getColumn`
- `getRow`
- `getCell`
- `setCell`

Also fixes a bug where column/row nodes provided to these (and other) table methods would succeed if the node's ID matched that of a node in the table. These cases will now fail if the node object is not the same.