### PR TITLE
Tweaks to ErasedTypeImplementation

### DIFF
--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -144,24 +144,34 @@ export abstract class ErasedTypeImplementation<
 	}
 
 	/**
-	 * Allows narrowing from TInterface to the internal implementation type via `instanceof`.
+	 * {@link https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates|Type predicate} for narrowing the internal implementation type via `instanceof`.
 	 */
-	public static [Symbol.hasInstance]<
-		TThis extends abstract new (
-			...args: unknown[]
-		) => object,
-	>(this: TThis, value: ErasedBaseType | InstanceType<TThis>): value is InstanceType<TThis> {
-		return Object.prototype.isPrototypeOf.call(this.prototype, value);
+	public static [Symbol.hasInstance]<TThis extends { prototype: object }>(
+		this: TThis,
+		value: unknown,
+	): value is InstanceTypeRelaxed<TThis> {
+		return (
+			typeof value === "object" &&
+			value !== null &&
+			Object.prototype.isPrototypeOf.call(this.prototype, value)
+		);
 	}
 
 	/**
-	 * Narrows from TInterface to the internal implementation type, throwing if the value is not of the correct type.
+	 * {@link https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions|Type assertion} which narrows from ErasedBaseType to the internal implementation type.
+	 * @remarks
+	 * This does a checked conversion, throwing a `TypeError` if invalid.
+	 *
+	 * If would be safer if this narrowed from `TInterface`, but that is not possible since type parameters can not be accessed in static methods.
+	 * Replacing `ErasedTypeImplementation` with a generic function which returns a non-generic class could be used to work around this limitation if desired.
+	 *
+	 * Derived classes can provide their own customized narrowing function with a more specific types if desired.
 	 */
-	public static narrow<TThis extends abstract new (...args: unknown[]) => object>(
+	public static narrow<TThis extends { prototype: object }>(
 		this: TThis,
-		value: ErasedBaseType | InstanceType<TThis>,
-	): asserts value is InstanceType<TThis> {
-		if (!Object.prototype.isPrototypeOf.call(this.prototype, value)) {
+		value: ErasedBaseType | InstanceTypeRelaxed<TThis>,
+	): asserts value is InstanceTypeRelaxed<TThis> {
+		if (!ErasedTypeImplementation[Symbol.hasInstance].call(this, value as object)) {
 			throw new TypeError("Invalid ErasedBaseType instance");
 		}
 	}
@@ -169,9 +179,17 @@ export abstract class ErasedTypeImplementation<
 	/**
 	 * Upcasts the instance to the erased interface type.
 	 * @remarks
-	 * This is mainly useful when inferring interface type is required.
+	 * This is mainly useful when inferring the interface type is required.
 	 */
 	public upCast<TThis extends TInterface>(this: TThis): TInterface {
 		return this;
 	}
 }
+
+/**
+ * The same as the built-in InstanceType, but works on classes with private constructors.
+ * @privateRemarks
+ * This is based on the trick in {@link https://stackoverflow.com/a/74657881}.
+ * @internal
+ */
+export type InstanceTypeRelaxed<TClass> = InstanceType<(new () => never) & TClass>;

--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -162,7 +162,7 @@ export abstract class ErasedTypeImplementation<
 	 * @remarks
 	 * This does a checked conversion, throwing a `TypeError` if invalid.
 	 *
-	 * If would be safer if this narrowed from `TInterface`, but that is not possible since type parameters can not be accessed in static methods.
+	 * It would be safer if this narrowed from `TInterface`, but that is not possible since type parameters can not be accessed in static methods.
 	 * Replacing `ErasedTypeImplementation` with a generic function which returns a non-generic class could be used to work around this limitation if desired.
 	 *
 	 * Derived classes can provide their own customized narrowing function with a more specific types if desired.

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -55,7 +55,7 @@ export { LogLevel } from "./logger.js";
 export type { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./provider.js";
 export type { ConfigTypes, IConfigProviderBase } from "./config.js";
 export type { ISignalEnvelope, TypedMessage } from "./messages.js";
-export type { ErasedType, ErasedBaseType } from "./erasedType.js";
+export type { ErasedType, ErasedBaseType, InstanceTypeRelaxed } from "./erasedType.js";
 export { ErasedTypeImplementation } from "./erasedType.js";
 
 export type {

--- a/packages/common/core-interfaces/src/test/erasedType.spec.ts
+++ b/packages/common/core-interfaces/src/test/erasedType.spec.ts
@@ -15,9 +15,7 @@ describe("erasedType", () => {
 
 		class FooInternal extends ErasedTypeImplementation<Foo> implements Foo {
 			public readonly bar: number = 5;
-
 			public readonly secret: string = "x";
-
 			public constructor() {
 				super();
 			}
@@ -40,6 +38,106 @@ describe("erasedType", () => {
 
 		assert.equal(foo, f);
 		assert.equal(secret, "x");
+		assert.equal(secret2, "x");
+	});
+
+	it("ErasedBaseType with constructor arguments", () => {
+		interface Foo extends ErasedBaseType<"x"> {
+			bar: number;
+		}
+
+		class FooInternal extends ErasedTypeImplementation<Foo> implements Foo {
+			public readonly bar: number = 5;
+			public readonly secret: string = "x";
+			public constructor(x: number) {
+				super();
+			}
+		}
+
+		const f: Foo = new FooInternal(5);
+
+		FooInternal.narrow(f);
+
+		// f is now typed as FooInternal, which exposes access to "secret":
+		const secret = f.secret;
+
+		// Convert back to Foo:
+		const foo = f.upCast();
+
+		assert(foo instanceof FooInternal);
+
+		// foo is now typed as FooInternal, which exposes access to "secret":
+		const secret2 = foo.secret;
+
+		assert.equal(foo, f);
+		assert.equal(secret, "x");
+		assert.equal(secret2, "x");
+	});
+
+	it("ErasedBaseType generic: covariant", () => {
+		interface Foo<T> extends ErasedBaseType<["x", T]> {
+			bar: number;
+		}
+
+		class FooInternal<T> extends ErasedTypeImplementation<Foo<T>> implements Foo<T> {
+			public readonly bar: number = 5;
+			public constructor(public readonly secret: T) {
+				super();
+			}
+		}
+
+		const f: Foo<string> = new FooInternal("x");
+
+		FooInternal.narrow(f);
+
+		// f is now typed as FooInternal, which exposes access to "secret":
+		const secretX = f.secret;
+
+		// Convert back to Foo:
+		const foo = f.upCast();
+
+		assert(foo instanceof FooInternal);
+
+		// foo is now typed as FooInternal, which exposes access to "secret":
+		const secret2 = foo.secret;
+
+		assert.equal(foo, f);
+		assert.equal(secretX, "x");
+		assert.equal(secret2, "x");
+	});
+
+	it("ErasedBaseType private constructor", () => {
+		interface Foo<T> extends ErasedBaseType<["x", T]> {
+			bar: number;
+		}
+
+		class FooInternal<T> extends ErasedTypeImplementation<Foo<T>> implements Foo<T> {
+			public readonly bar: number = 5;
+			private constructor(public readonly secret: T) {
+				super();
+			}
+			public static create<T>(secret: T): FooInternal<T> {
+				return new FooInternal(secret);
+			}
+		}
+
+		const f: Foo<string> = FooInternal.create("x");
+
+		FooInternal.narrow(f);
+
+		// f is now typed as FooInternal, which exposes access to "secret":
+		const secretX = f.secret;
+
+		// Convert back to Foo:
+		const foo = f.upCast();
+
+		assert(foo instanceof FooInternal);
+
+		// foo is now typed as FooInternal, which exposes access to "secret":
+		const secret2 = foo.secret;
+
+		assert.equal(foo, f);
+		assert.equal(secretX, "x");
 		assert.equal(secret2, "x");
 	});
 });

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -253,32 +253,20 @@ export class AnnotatedAllowedTypesInternal<
 		return this.lazyEvaluate.value.identifiers;
 	}
 
-	public static override [Symbol.hasInstance]<
-		TThis extends
-			| (abstract new (
-					...args: unknown[]
-			  ) => object)
-			| typeof AnnotatedAllowedTypesInternal,
-	>(
+	public static override [Symbol.hasInstance]<TThis extends { prototype: object }>(
 		this: TThis,
-		value: ErasedBaseType | InstanceTypeRelaxed<TThis> | ImplicitAllowedTypes,
+		value: unknown,
 	): value is InstanceTypeRelaxed<TThis> & AnnotatedAllowedTypesInternal & AllowedTypesFull {
-		return Object.prototype.isPrototypeOf.call(this.prototype, value);
+		return ErasedTypeImplementation[Symbol.hasInstance].call(this, value);
 	}
 
-	public static override narrow<
-		TThis extends
-			| (abstract new (
-					...args: unknown[]
-			  ) => object)
-			| typeof AnnotatedAllowedTypesInternal,
-	>(
+	public static override narrow<TThis extends { prototype: object }>(
 		this: TThis,
 		value: ErasedBaseType | InstanceTypeRelaxed<TThis> | ImplicitAllowedTypes,
 	): asserts value is InstanceTypeRelaxed<TThis> &
 		AnnotatedAllowedTypesInternal &
 		AllowedTypesFull {
-		if (!Object.prototype.isPrototypeOf.call(this.prototype, value)) {
+		if (!ErasedTypeImplementation[Symbol.hasInstance].call(this, value)) {
 			throw new TypeError("Invalid AnnotatedAllowedTypes instance");
 		}
 	}


### PR DESCRIPTION
## Description

Improve typing and docs on ErasedTypeImplementation.

These changes are split out (and refined) from https://github.com/microsoft/FluidFramework/pull/25422 which used ErasedTypeImplementation and hit some limitations.

This only impacts the internal aspects, not public typing.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
