### PR TITLE
Allow tree-agent editors to be bound to trees

### DIFF
--- a/packages/framework/tree-agent-ses/src/executor.ts
+++ b/packages/framework/tree-agent-ses/src/executor.ts
@@ -6,7 +6,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import "ses";
 
-import type { SemanticAgentOptions } from "@fluidframework/tree-agent/alpha";
+import type { AsynchronousEditor } from "@fluidframework/tree-agent/alpha";
 
 /**
  * Used to track whether the SES `lockdown` function has already been called by this module.
@@ -24,7 +24,7 @@ const lockdownSymbol = Symbol.for("tree-agent.ses.locked");
 export function createSesEditExecutor(options?: {
 	compartmentOptions?: { globals?: Map<string, unknown>; [key: string]: unknown };
 	lockdownOptions?: Record<string, unknown>;
-}): SemanticAgentOptions["executeEdit"] {
+}): AsynchronousEditor {
 	const optionsGlobals: Map<string, unknown> =
 		options?.compartmentOptions?.globals ?? new Map<string, unknown>();
 

--- a/packages/framework/tree-agent-ses/src/test/ses.spec.ts
+++ b/packages/framework/tree-agent-ses/src/test/ses.spec.ts
@@ -39,7 +39,7 @@ describe.skip("SES edit executor", () => {
 	it("passes globals to the compartment", async () => {
 		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
 		view.initialize("Initial");
-		const executeEdit = createSesEditExecutor({
+		const editor = createSesEditExecutor({
 			lockdownOptions,
 			compartmentOptions: {
 				globals: new Map([["extraGlobal", "globalValue"]]),
@@ -54,7 +54,7 @@ describe.skip("SES edit executor", () => {
 			},
 		};
 
-		const agent = new SharedTreeSemanticAgent(model, view, { executeEdit });
+		const agent = new SharedTreeSemanticAgent(model, view, { editor });
 		await agent.query("");
 		assert.equal(view.root, "globalValue");
 	});
@@ -62,7 +62,7 @@ describe.skip("SES edit executor", () => {
 	it("returns a code error when SES blocks the generated code", async () => {
 		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
 		view.initialize("Initial");
-		const executeEdit = createSesEditExecutor({ lockdownOptions });
+		const editor = createSesEditExecutor({ lockdownOptions });
 		const model: SharedTreeChatModel = {
 			editToolName: "EditTreeTool",
 			async query({ edit }) {
@@ -72,7 +72,7 @@ describe.skip("SES edit executor", () => {
 			},
 		};
 
-		const agent = new SharedTreeSemanticAgent(model, view, { executeEdit });
+		const agent = new SharedTreeSemanticAgent(model, view, { editor });
 		const response = await agent.query("Attempt forbidden edit");
 		assert.match(response, /is not extensible/i);
 		assert.equal(view.root, "Initial", "Tree should not change after SES rejection");

--- a/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
+++ b/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
@@ -11,7 +11,19 @@ export type Arg<T extends z.ZodTypeAny = z.ZodTypeAny> = readonly [name: string,
 export type ArgsTuple<T extends readonly Arg[]> = T extends readonly [infer Single extends Arg] ? [Single[1]] : T extends readonly [infer Head extends Arg, ...infer Tail extends readonly Arg[]] ? [Head[1], ...ArgsTuple<Tail>] : never;
 
 // @alpha
+export type AsynchronousEditor = (context: Record<string, unknown>, code: string) => Promise<void>;
+
+// @alpha
 export type BindableSchema = TreeNodeSchema<string, NodeKind.Object> | TreeNodeSchema<string, NodeKind.Record> | TreeNodeSchema<string, NodeKind.Array> | TreeNodeSchema<string, NodeKind.Map>;
+
+// @alpha
+export const bindEditor: typeof bindEditorImpl;
+
+// @alpha
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), editor: SynchronousEditor): (code: string) => void;
+
+// @alpha
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), editor: AsynchronousEditor): (code: string) => Promise<void>;
 
 // @alpha
 export function buildFunc<const Return extends z.ZodTypeAny, const Args extends readonly Arg[], const Rest extends z.ZodTypeAny | null = null>(def: {
@@ -24,9 +36,12 @@ export function buildFunc<const Return extends z.ZodTypeAny, const Args extends 
 export type Ctor<T = any> = new (...args: any[]) => T;
 
 // @alpha
+export const defaultEditor: AsynchronousEditor;
+
+// @alpha
 export interface EditResult {
     message: string;
-    type: "success" | "disabledError" | "validationError" | "executionError" | "tooManyEditsError" | "expiredError";
+    type: "success" | "disabledError" | "editingError" | "tooManyEditsError" | "expiredError";
 }
 
 // @alpha
@@ -78,10 +93,9 @@ export type MethodKeys<T> = {
 // @alpha
 export interface SemanticAgentOptions {
     domainHints?: string;
-    executeEdit?: (context: Record<string, unknown>, code: string) => void | Promise<void>;
+    editor?: SynchronousEditor | AsynchronousEditor;
     logger?: Logger;
     maximumSequentialEdits?: number;
-    validateEdit?: (code: string) => void | Promise<void>;
 }
 
 // @alpha
@@ -103,6 +117,9 @@ export class SharedTreeSemanticAgent<TSchema extends ImplicitFieldSchema> {
     constructor(client: SharedTreeChatModel, tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), options?: Readonly<SemanticAgentOptions> | undefined);
     query(userPrompt: string): Promise<string>;
 }
+
+// @alpha
+export type SynchronousEditor = (context: Record<string, unknown>, code: string) => void;
 
 // @alpha
 export type TreeView<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema> = Pick<TreeViewAlpha<TRoot>, "root" | "fork" | "merge" | "rebaseOnto" | "schema" | "events"> & TreeBranch;

--- a/packages/framework/tree-agent/src/agent.ts
+++ b/packages/framework/tree-agent/src/agent.ts
@@ -17,7 +17,14 @@ import type {
 } from "@fluidframework/tree/alpha";
 import { ObjectNodeSchema, Tree } from "@fluidframework/tree/alpha";
 
-import type { SharedTreeChatModel, EditResult, SemanticAgentOptions, Logger } from "./api.js";
+import type {
+	SharedTreeChatModel,
+	EditResult,
+	SemanticAgentOptions,
+	Logger,
+	SynchronousEditor,
+	AsynchronousEditor,
+} from "./api.js";
 import { getPrompt, stringifyTree } from "./prompt.js";
 import { Subtree } from "./subtree.js";
 import {
@@ -137,8 +144,7 @@ export class SharedTreeSemanticAgent<TSchema extends ImplicitFieldSchema> {
 			const editResult = await applyTreeFunction(
 				queryTree,
 				editCode,
-				this.options?.validateEdit ?? defaultValidateEdit,
-				this.options?.executeEdit ?? defaultExecuteEdit,
+				this.options?.editor ?? defaultEditor,
 				this.options?.logger,
 			);
 
@@ -199,51 +205,23 @@ function constructTreeNode(schema: TreeNodeSchema, value: FactoryContentObject):
 async function applyTreeFunction<TSchema extends ImplicitFieldSchema>(
 	tree: Subtree<TSchema>,
 	editCode: string,
-	validateEdit: Required<SemanticAgentOptions>["validateEdit"],
-	executeEdit: Required<SemanticAgentOptions>["executeEdit"],
+	editor: Required<SemanticAgentOptions>["editor"],
 	logger: Logger | undefined,
 ): Promise<EditResult> {
 	logger?.log(`### Editing Tool Invoked\n\n`);
 	logger?.log(`#### Generated Code\n\n\`\`\`javascript\n${editCode}\n\`\`\`\n\n`);
 
-	try {
-		await validateEdit(editCode);
-	} catch (error: unknown) {
-		logger?.log(`#### Code Validation Failed\n\n`);
-		logger?.log(`\`\`\`JSON\n${toErrorString(error)}\n\`\`\`\n\n`);
-		return {
-			type: "validationError",
-			message: `The generated code did not pass validation: ${toErrorString(error)}`,
-		};
-	}
-
-	// Stick the tree schema constructors on an object passed to the function so that the LLM can create new nodes.
-	const create: Record<string, (input: FactoryContentObject) => TreeNode> = {};
-	for (const schema of findNamedSchemas(tree.schema)) {
-		const name = getFriendlyName(schema);
-		create[name] = (input: FactoryContentObject) => constructTreeNode(schema, input);
-	}
-
 	// Fork a branch to edit. If the edit fails or produces an error, we discard this branch, otherwise we merge it.
 	const editTree = tree.fork();
-	const context = {
-		get root(): ReadableField<TSchema> {
-			return editTree.field;
-		},
-		set root(value: TreeFieldFromImplicitField<ReadSchema<TSchema>>) {
-			editTree.field = value;
-		},
-		create,
-	};
-
+	const boundEditor = bindEditorToSubtree(editTree, editor);
 	try {
-		await executeEdit(context, editCode);
+		await boundEditor(editCode);
 	} catch (error: unknown) {
 		logger?.log(`#### Error\n\n`);
 		logger?.log(`\`\`\`JSON\n${toErrorString(error)}\n\`\`\`\n\n`);
 		editTree.branch.dispose();
 		return {
-			type: "executionError",
+			type: "editingError",
 			message: `Running the generated code produced an error. The state of the tree will be reset to its previous state as it was before the code ran. Please try again. Here is the error: ${toErrorString(error)}`,
 		};
 	}
@@ -257,13 +235,82 @@ async function applyTreeFunction<TSchema extends ImplicitFieldSchema>(
 	};
 }
 
-const defaultValidateEdit: Required<SemanticAgentOptions>["validateEdit"] = () => {};
-
-const defaultExecuteEdit: Required<SemanticAgentOptions>["executeEdit"] = async (
-	context,
-	code,
-) => {
+/**
+ * The default {@link AsynchronousEditor | editor} implementation that simply uses `new Function` to run the provided code.
+ * @remarks This editor allows both synchronous and asynchronous code (i.e. the provided code may return a Promise).
+ * @example `await new Function("context", code)(context);`
+ * @alpha
+ */
+export const defaultEditor: AsynchronousEditor = async (context, code) => {
 	// eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
 	const fn = new Function("context", code);
 	await fn(context);
 };
+
+/**
+ * Binds the given {@link SynchronousEditor | editor} to the given view or tree.
+ * @returns A function that takes a string of JavaScript code and executes it on the given view or tree using the given editor function.
+ * @remarks This is useful for testing/debugging code execution without needing to set up a full {@link SharedTreeSemanticAgent | agent}.
+ * @alpha
+ */
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(
+	tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode),
+	editor: SynchronousEditor,
+): (code: string) => void;
+/**
+ * Binds the given {@link AsynchronousEditor | editor} to the given view or tree.
+ * @returns A function that takes a string of JavaScript code and executes it on the given view or tree using the given editor function.
+ * @remarks This is useful for testing/debugging code execution without needing to set up a full {@link SharedTreeSemanticAgent | agent}.
+ * @alpha
+ */
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(
+	tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode),
+	editor: AsynchronousEditor,
+): (code: string) => Promise<void>;
+/**
+ * Binds the given {@link SynchronousEditor | editor} or {@link AsynchronousEditor | editor} to the given view or tree.
+ * @returns A function that takes a string of JavaScript code and executes it on the given view or tree using the given editor function.
+ * @remarks This is useful for testing/debugging code execution without needing to set up a full {@link SharedTreeSemanticAgent | agent}.
+ * @alpha
+ */
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(
+	tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode),
+	editor: SynchronousEditor | AsynchronousEditor,
+): ((code: string) => void) | ((code: string) => Promise<void>) {
+	const subtree = new Subtree(tree);
+	return bindEditorToSubtree(subtree, editor);
+}
+
+/**
+ * Binds the given {@link SynchronousEditor | synchronous} or {@link AsynchronousEditor | asynchronous} editor to the given view or tree.
+ * @returns A function that takes a string of JavaScript code and executes it on the given view or tree using the given editor.
+ * @remarks This is useful for testing/debugging code execution without needing to set up a full {@link SharedTreeSemanticAgent | agent}.
+ * @alpha
+ * @privateRemarks This exists (as opposed to just exporting bindEditorImpl directly) so that API documentation links work correctly.
+ */
+export const bindEditor = bindEditorImpl;
+
+function bindEditorToSubtree<TSchema extends ImplicitFieldSchema>(
+	tree: Subtree<TSchema>,
+	executeEdit: SynchronousEditor | AsynchronousEditor,
+): (code: string) => void | Promise<void> {
+	// Stick the tree schema constructors on an object passed to the function so that the LLM can create new nodes.
+	const create: Record<string, (input: FactoryContentObject) => TreeNode> = {};
+	for (const schema of findNamedSchemas(tree.schema)) {
+		const name = getFriendlyName(schema);
+		create[name] = (input: FactoryContentObject) => constructTreeNode(schema, input);
+	}
+
+	const context = {
+		get root(): ReadableField<TSchema> {
+			return tree.field;
+		},
+		set root(value: TreeFieldFromImplicitField<ReadSchema<TSchema>>) {
+			tree.field = value;
+		},
+		create,
+	};
+
+	// eslint-disable-next-line @typescript-eslint/promise-function-async
+	return (code: string) => executeEdit(context, code);
+}

--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -9,13 +9,20 @@
  * @packageDocumentation
  */
 
-export { SharedTreeSemanticAgent } from "./agent.js";
+export {
+	SharedTreeSemanticAgent,
+	bindEditor,
+	bindEditorImpl,
+	defaultEditor,
+} from "./agent.js";
 export type {
 	EditResult,
 	SharedTreeChatModel,
 	SharedTreeChatQuery,
 	Logger,
 	SemanticAgentOptions,
+	SynchronousEditor,
+	AsynchronousEditor,
 } from "./api.js";
 export { type TreeView, llmDefault } from "./utils.js";
 export {


### PR DESCRIPTION
* `editExecutor` is now called an "Editor" and has named types
* The default editor implementation has been exposed
* A `bindEditor` function has been exposed which allows users to apply their (potentially custom) editor to a tree (e.g. for debugging or testing).
* `editValidator` has been removed since validation can simply be done by the editor
* `executionError` has been renamed to `editingError` for consistency