### PR TITLE
docs: Fix broken website link

### DIFF
--- a/docs/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
@@ -36,7 +36,7 @@ class Note extends factory.object("Note", {
 }) {}
 ```
 
-To ensure [forwards compatibility](./index.mdx#understanding-compatibility), use [`allowUnknownOptionalFields`](../../../api/fluid-framework/schemafactoryobjectoptions-interface#allowunknownoptionalfields-propertysignature) to handle new optional fields added by newer clients.
+To ensure [forwards compatibility](./index.mdx#understanding-compatibility), use [`allowUnknownOptionalFields`](../../../api/fluid-framework/objectschemaoptions-interface.md#allowunknownoptionalfields-propertysignature) to handle new optional fields added by newer clients.
 Note that this needs to already be set on the old clients before the field is added.
 If it's not already set, then this degenerates into an un-forwards compatible change and requires a [staged rollout](./index.mdx#staged-rollouts) - because the app has to stage the enabling of allowUnknownOptionalFields.
 


### PR DESCRIPTION
`SchemaFactoryObjectOptions` was renamed to `ObjectSchemaOptions` in the most recent v2 release. The website contained an explicit link to the former API item, which caused the website build to begin failing as soon as the most recent release's doc model was published.

This PR fixes the broken link.