### PR TITLE
fix(server): lockdown ioredis-mock dependency 

### DIFF
--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -101,7 +101,7 @@
 		"c8": "^10.1.3",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.57.0",
-		"ioredis-mock": "^8.9.0",
+		"ioredis-mock": "8.9.0",
 		"lorem-ipsum": "^1.0.6",
 		"mocha": "^10.8.2",
 		"rimraf": "^3.0.2",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -341,7 +341,7 @@ importers:
         specifier: ~8.57.0
         version: 8.57.1
       ioredis-mock:
-        specifier: ^8.9.0
+        specifier: 8.9.0
         version: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1))(ioredis@5.6.1)
       lorem-ipsum:
         specifier: ^1.0.6

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -69,7 +69,7 @@
 		"debug": "^4.3.4",
 		"express": "^4.21.2",
 		"ioredis": "^5.6.1",
-		"ioredis-mock": "^8.9.0",
+		"ioredis-mock": "8.9.0",
 		"json-stringify-safe": "5.0.1",
 		"jsonwebtoken": "^9.0.0",
 		"nconf": "^0.11.4",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
         specifier: ^5.6.1
         version: 5.6.1
       ioredis-mock:
-        specifier: ^8.9.0
+        specifier: 8.9.0
         version: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1))(ioredis@5.6.1)
       json-stringify-safe:
         specifier: 5.0.1

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -63,7 +63,7 @@
 		"debug": "^4.3.4",
 		"events": "^3.1.0",
 		"ioredis": "^5.6.1",
-		"ioredis-mock": "^8.9.0",
+		"ioredis-mock": "8.9.0",
 		"lodash": "^4.17.21",
 		"string-hash": "^1.1.3",
 		"uuid": "^11.1.0"

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1883,7 +1883,7 @@ importers:
         specifier: ^5.6.1
         version: 5.6.1
       ioredis-mock:
-        specifier: ^8.9.0
+        specifier: 8.9.0
         version: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1))(ioredis@5.6.1)
       lodash:
         specifier: ^4.17.21


### PR DESCRIPTION
## Description
During FF to Pages bump, we noticed this dependency would be bumped to 8.13.0 and this new version causes build error in Pages. We plan on investigating this further but for now we should lock down this dependency to version 8.9.0 to mitigate problems during bump. 