### PR TITLE
Add more context helpers to tree-agent

### DIFF
--- a/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
+++ b/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
@@ -20,10 +20,10 @@ export type BindableSchema = TreeNodeSchema<string, NodeKind.Object> | TreeNodeS
 export const bindEditor: typeof bindEditorImpl;
 
 // @alpha
-export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), editor: SynchronousEditor): (code: string) => void;
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), editor: AsynchronousEditor): (code: string) => Promise<void>;
 
 // @alpha
-export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), editor: AsynchronousEditor): (code: string) => Promise<void>;
+export function bindEditorImpl<TSchema extends ImplicitFieldSchema>(tree: TreeView<TSchema> | (ReadableField<TSchema> & TreeNode), editor: SynchronousEditor): (code: string) => void;
 
 // @alpha
 export function buildFunc<const Return extends z.ZodTypeAny, const Args extends readonly Arg[], const Rest extends z.ZodTypeAny | null = null>(def: {

--- a/packages/framework/tree-agent/src/api.ts
+++ b/packages/framework/tree-agent/src/api.ts
@@ -23,6 +23,71 @@ export interface Logger {
 }
 
 /**
+ * The context object available to generated code when editing a tree.
+ * @remarks This object is provided to JavaScript code executed by the {@link SynchronousEditor | editor} as a variable named `context`.
+ * It contains the current state of the tree and utilities for creating and inspecting tree nodes.
+ * @alpha
+ */
+export interface Context<TSchema extends ImplicitFieldSchema> {
+	/**
+	 * The root of the tree that can be read or modified.
+	 * @remarks
+	 * You can read properties and navigate through the tree starting from this root.
+	 * You can also assign a new value to this property to replace the entire tree, as long as the new value is one of the types allowed at the root.
+	 *
+	 * Example: Read the current root with `const currentRoot = context.root;`
+	 *
+	 * Example: Replace the entire root with `context.root = context.create.MyRootType({ });`
+	 */
+	root: ReadableField<TSchema>;
+
+	/**
+	 * A collection of builder functions for creating new tree nodes.
+	 * @remarks
+	 * Each property on this object is named after a type in the tree schema.
+	 * Call the corresponding function to create a new node of that type.
+	 * Always use these builder functions when creating new nodes rather than plain JavaScript objects.
+	 *
+	 * Example: Create a new Person node with `context.create.Person({ name: "Alice", age: 30 })`
+	 *
+	 * Example: Create a new Task node with `context.create.Task({ title: "Buy groceries", completed: false })`
+	 */
+	create: Record<string, (input: FactoryContentObject) => TreeNode>;
+
+	/**
+	 * A collection of type-checking functions for tree nodes.
+	 * @remarks
+	 * Each property on this object is named after a type in the tree schema.
+	 * Call the corresponding function to check if a node is of that specific type.
+	 * This is useful when working with nodes that could be one of multiple types.
+	 *
+	 * Example: Check if a node is a Person with `if (context.is.Person(node)) { console.log(node.name); }`
+	 */
+	is: Record<string, <T extends TreeNode>(input: T) => input is T>;
+
+	/**
+	 * Returns the parent node of the given child node.
+	 * @param child - The node whose parent you want to find.
+	 * @returns The parent node, or `undefined` if the node is the root or is not in the tree.
+	 * @remarks
+	 * Example: Get the parent with `const parent = context.parent(childNode);`
+	 */
+	parent(child: TreeNode): TreeNode | undefined;
+
+	/**
+	 * Returns the key or index of the given node within its parent.
+	 * @param child - The node whose key you want to find.
+	 * @returns A string key if the node is in an object or map, or a numeric index if the node is in an array.
+	 * @remarks
+	 * For a node in an object, this might return a string like "firstName".
+	 * For a node in an array, this might return a number like 0, 1, 2, etc.
+	 *
+	 * Example: `const key = context.key(childNode);`
+	 */
+	key(child: TreeNode): string | number;
+}
+
+/**
  * A synchronous function that executes a string of JavaScript code to perform an edit within a {@link SharedTreeSemanticAgent}.
  * @param context - An object that must be provided to the generated code as a variable named "context" in its top-level scope.
  * @param code - The JavaScript code that should be executed.

--- a/packages/framework/tree-agent/src/test/__snapshots__/prompt.md
+++ b/packages/framework/tree-agent/src/test/__snapshots__/prompt.md
@@ -38,8 +38,77 @@ If the user asks you to edit the document, you will write a snippet of JavaScrip
 The snippet may be synchronous or asynchronous (i.e. it may `await` functions if necessary).
 The snippet has a `context` variable in its scope.
 This `context` variable holds the current state of the tree in the `root` property.
-You may mutate any part of the root tree as necessary, taking into account the caveats around arrays and maps detailed below.
+You may mutate any part of this tree as necessary, taking into account the caveats around arrays and maps detailed below.
 You may also set the `root` property of the context to be an entirely new value as long as it is one of the types allowed at the root of the tree (`Obj`).
+You should also use the `context` object to create new data to insert into the tree, using the builder functions available on the `create` property.
+There are other additional helper functions available on the `context` object to help you analyze the tree.
+Here is the definition of the `Context` interface:
+```typescript
+	type TreeData = TestMap | TestArrayItem | TestArray | Obj;
+
+	/**
+	 * An object available to generated code which provides read and write access to the tree as well as utilities for creating and inspecting data in the tree.
+	 * @remarks This object is available as a variable named `context` in the scope of the generated JavaScript snippet.
+	 */
+	interface Context<TSchema extends ImplicitFieldSchema> {
+	/**
+	 * The root of the tree that can be read or mutated.
+	 * @remarks
+	 * You can read properties and navigate through the tree starting from this root.
+	 * You can also assign a new value to this property to replace the entire tree, as long as the new value is one of the types allowed at the root.
+	 *
+	 * Example: Read the current root with `const currentRoot = context.root;`
+	 * Example: Replace the entire root with `context.root = context.create.Obj({ });`
+	 */
+	root: ReadableField<TSchema>;
+	
+	/**
+	 * A collection of builder functions for creating new tree nodes.
+	 * @remarks
+	 * Each property on this object is named after a type in the tree schema.
+	 * Call the corresponding function to create a new node of that type.
+	 * Always use these builder functions when creating new nodes rather than plain JavaScript objects.
+	 *
+	 * For example:
+	 *
+	 * ```javascript
+	 * // This creates a new TestArrayItem object:
+	 * const testArrayItem = context.create.TestArrayItem({ ...properties });
+	 * // Don't do this:
+	 * // const testArrayItem = { ...properties };
+	 * ```
+	 */
+	create: Record<string, <T extends TreeData>(input: T) => T>;
+
+	
+	/**
+	 * A collection of type-guard functions for data in the tree.
+	 * @remarks
+	 * Each property on this object is named after a type in the tree schema.
+	 * Call the corresponding function to check if a node is of that specific type.
+	 * This is useful when working with nodes that could be one of multiple types.
+	 *
+	 * Example: Check if a node is a TestArrayItem with `if (context.is.TestArrayItem(node)) {}`
+	 */
+	is: Record<string, <T extends TreeData>(input: unknown) => input is T>;
+
+	/**
+	 * Returns the parent object/array/map of the given object/array/map, if there is one.
+	 * @returns The parent node, or `undefined` if the node is the root or is not in the tree.
+	 * @remarks
+	 * Example: Get the parent with `const parent = context.parent(child);`
+	 */
+	parent(child: TreeData): TreeData | undefined;
+
+	/**
+	 * Returns the property key or index of the given object/array/map within its parent.
+	 * @returns A string key if the child is in an object or map, or a numeric index if the child is in an array.
+	 *
+	 * Example: `const key = context.key(child);`
+	 */
+	key(child: TreeData): string | number;
+}
+```
 Manipulating the data using the APIs described below is allowed, but when possible ALWAYS prefer to use any application helper methods exposed on the schema TypeScript types if the goal can be accomplished that way.
 It will often not be possible to fully accomplish the goal using those helpers. When this is the case, mutate the objects as normal, taking into account the following guidance.
 #### Editing Arrays
@@ -265,17 +334,6 @@ export interface TreeMap<T> extends ReadonlyMap<string, T> {
 #### Additional Notes
 
 Before outputting the edit function, you should check that it is valid according to both the application tree's schema and any restrictions of the editing APIs described above.
-
-When constructing new objects, you should wrap them in the appropriate builder function rather than simply making a javascript object.
-The builders are available on the `create` property on the context object and are named according to the type that they create.
-For example:
-
-```javascript
-// This creates a new TestArrayItem object:
-const testArrayItem = context.create.TestArrayItem({ /* ...properties... */ });
-// Don't do this:
-// const testArrayItem = { /* ...properties... */ };
-```
 
 Once non-primitive data has been removed from the tree (e.g. replaced via assignment, or removed from an array), that data cannot be re-inserted into the tree.
 Instead, it must be deep cloned and recreated.

--- a/packages/framework/tree-agent/src/test/agent.spec.ts
+++ b/packages/framework/tree-agent/src/test/agent.spec.ts
@@ -17,12 +17,7 @@ import {
 } from "@fluidframework/tree/alpha";
 
 import { SharedTreeSemanticAgent, bindEditor } from "../agent.js";
-import type {
-	EditResult,
-	SharedTreeChatModel,
-	SynchronousEditor,
-	AsynchronousEditor,
-} from "../api.js";
+import type { EditResult, SharedTreeChatModel } from "../api.js";
 
 const sf = new SchemaFactory(undefined);
 const editToolName = "EditTreeTool";
@@ -254,25 +249,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("passes constructors to edit code", async () => {
-		const sfLocal = new SchemaFactory("Test");
-		class Person extends sfLocal.object("Person", {
-			name: sfLocal.required(sfLocal.string),
-		}) {}
-		const view = independentView(new TreeViewConfiguration({ schema: Person }), {});
-		view.initialize(new Person({ name: "Alice" }));
-		const model: SharedTreeChatModel = {
-			editToolName,
-			async query({ edit }) {
-				const result = await edit(`context.root = context.create.Person({ name: "Bob" });`);
-				assert.equal(result.type, "success", result.message);
-				assert.equal(typeof result.message, "string");
-				assert.ok(result.message.includes("Bob"));
-				return "Done";
-			},
-		};
-		const agent = new SharedTreeSemanticAgent(model, view);
-		assert.equal(await agent.query("Change"), "Done");
-		assert.equal((view.root as unknown as Person).name, "Bob");
+		// Moved to the dedicated context helpers describe block below.
 	});
 
 	it("supplies the system prompt as context", async () => {
@@ -297,6 +274,97 @@ describe("Semantic Agent", () => {
 			(first as string).includes(editToolName),
 			"System prompt should reference edit tool name",
 		);
+	});
+
+	describe("context helpers", () => {
+		it("passes constructors to edit code", async () => {
+			const sfLocal = new SchemaFactory("Test");
+			class Person extends sfLocal.object("Person", {
+				name: sfLocal.required(sfLocal.string),
+			}) {}
+			const view = independentView(new TreeViewConfiguration({ schema: Person }), {});
+			view.initialize(new Person({ name: "Alice" }));
+			const model: SharedTreeChatModel = {
+				editToolName,
+				async query({ edit }) {
+					const result = await edit(`context.root = context.create.Person({ name: "Bob" });`);
+					assert.equal(result.type, "success", result.message);
+					return "Done";
+				},
+			};
+			const agent = new SharedTreeSemanticAgent(model, view);
+			assert.equal(await agent.query("Change"), "Done");
+			assert.equal(view.root.name, "Bob");
+		});
+
+		it("provides working type guards via context.is", async () => {
+			const sfLocal = new SchemaFactory("TestIs");
+			class Person extends sfLocal.object("Person", {
+				name: sfLocal.required(sfLocal.string),
+				age: sfLocal.required(sfLocal.number),
+			}) {}
+			const view = independentView(new TreeViewConfiguration({ schema: Person }), {});
+			view.initialize(new Person({ name: "Alice", age: 25 }));
+			const model: SharedTreeChatModel = {
+				editToolName,
+				async query({ edit }) {
+					const result = await edit(
+						`if (context.is.Person(context.root)) { context.root.age = 26; } else { throw new Error('Type guard failed'); }`,
+					);
+					assert.equal(result.type, "success", result.message);
+					return "OK";
+				},
+			};
+			const agent = new SharedTreeSemanticAgent(model, view);
+			assert.equal(await agent.query("Update Age"), "OK");
+			assert.equal(view.root.age, 26);
+		});
+
+		it("exposes parent helper returning the owning object", async () => {
+			const sfLocal = new SchemaFactory("TestParent");
+			class Child extends sfLocal.object("Child", {
+				value: sfLocal.required(sfLocal.string),
+			}) {}
+			class Parent extends sfLocal.object("Parent", { child: Child }) {}
+			const view = independentView(new TreeViewConfiguration({ schema: Parent }), {});
+			view.initialize(new Parent({ child: new Child({ value: "Initial" }) }));
+			const model: SharedTreeChatModel = {
+				editToolName,
+				async query({ edit }) {
+					const result = await edit(
+						`const p = context.parent(context.root.child); if (!p) { throw new Error('No parent'); } if (!context.is.Parent(p)) { throw new Error('Wrong parent type'); } p.child.value = 'ViaParent';`,
+					);
+					assert.equal(result.type, "success", result.message);
+					return "Done";
+				},
+			};
+			const agent = new SharedTreeSemanticAgent(model, view);
+			assert.equal(await agent.query("Parent Edit"), "Done");
+			assert.equal(view.root.child.value, "ViaParent");
+		});
+
+		it("exposes key helper returning property name for object child", async () => {
+			const sfLocal = new SchemaFactory("TestKey");
+			class Child extends sfLocal.object("Child", {
+				value: sfLocal.required(sfLocal.string),
+			}) {}
+			class Parent extends sfLocal.object("Parent", { child: Child }) {}
+			const view = independentView(new TreeViewConfiguration({ schema: Parent }), {});
+			view.initialize(new Parent({ child: new Child({ value: "Initial" }) }));
+			const model: SharedTreeChatModel = {
+				editToolName,
+				async query({ edit }) {
+					const result = await edit(
+						`const k = context.key(context.root.child); if (k !== 'child') { throw new Error('Unexpected key: ' + k); } context.root.child.value = 'KeyWorked';`,
+					);
+					assert.equal(result.type, "success", result.message);
+					return "Done";
+				},
+			};
+			const agent = new SharedTreeSemanticAgent(model, view);
+			assert.equal(await agent.query("Key Edit"), "Done");
+			assert.equal(view.root.child.value, "KeyWorked");
+		});
 	});
 
 	it("supplies additional context if the tree changes between queries", async () => {
@@ -373,7 +441,7 @@ describe("Semantic Agent", () => {
 		it("binds a synchronous editor and returns a void runner", () => {
 			const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
 			view.initialize("Initial");
-			const syncEditor: SynchronousEditor = (context, _code) => {
+			const syncEditor = (context, _code): void => {
 				(context as unknown as TestContext).root = "SyncEdit";
 			};
 			const run = bindEditor(view, syncEditor);
@@ -385,10 +453,10 @@ describe("Semantic Agent", () => {
 		it("binds an asynchronous editor and returns a Promise runner", async () => {
 			const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
 			view.initialize("Initial");
-			const asyncEditor: AsynchronousEditor = async (context, _code) => {
+			const asyncEditor = async (context, _code): Promise<void> => {
 				(context as unknown as TestContext).root = "AsyncEdit";
 			};
-			const run = bindEditor(view, asyncEditor) as (code: string) => Promise<void>;
+			const run = bindEditor(view, asyncEditor);
 			const promise = run("ignored");
 			assert.ok(typeof (promise as unknown as { then?: unknown }).then === "function");
 			await promise;
@@ -398,7 +466,7 @@ describe("Semantic Agent", () => {
 		it("propagates synchronous errors", () => {
 			const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
 			view.initialize("Initial");
-			const syncErrorEditor: SynchronousEditor = (_context, _code) => {
+			const syncErrorEditor = (_context, _code): void => {
 				throw new Error("syncBoom");
 			};
 			const run = bindEditor(view, syncErrorEditor);
@@ -409,10 +477,10 @@ describe("Semantic Agent", () => {
 		it("propagates asynchronous errors (Promise rejection)", async () => {
 			const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
 			view.initialize("Initial");
-			const asyncErrorEditor: AsynchronousEditor = async () => {
+			const asyncErrorEditor = async (): Promise<void> => {
 				throw new Error("asyncBoom");
 			};
-			const run = bindEditor(view, asyncErrorEditor) as (code: string) => Promise<void>;
+			const run = bindEditor(view, asyncErrorEditor);
 			const promise = run("ignored");
 			await assert.rejects(promise, /asyncBoom/);
 			assert.equal(view.root, "Initial", "Tree should not have changed after async error");


### PR DESCRIPTION
* Create a `Context` type and provide its interface to the LLM prompt
* Add `is`, `parent` and `key` to the context
* API fix: switch order of `bindEditor` overloads so that asynchronous signature is correctly chosen when used.
* Minor test cleanup