### PR TITLE
(compat) Fix incorrect usages of storage service at Runtime and Loader layer

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -32,6 +32,7 @@ import type {
 	ReadOnlyInfo,
 	ILoader,
 	ILoaderOptions,
+	IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { isFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import {
@@ -54,7 +55,6 @@ import {
 import {
 	type IDocumentService,
 	type IDocumentServiceFactory,
-	type IDocumentStorageService,
 	type IResolvedUrl,
 	type ISnapshot,
 	type IThrottlingWarning,
@@ -1887,7 +1887,7 @@ export class Container
 
 	private async initializeProtocolStateFromSnapshot(
 		attributes: IDocumentAttributes,
-		storage: IDocumentStorageService,
+		storage: IContainerStorageService,
 		snapshot: ISnapshotTree | undefined,
 	): Promise<void> {
 		const quorumSnapshot: IQuorumSnapshot = {

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -18,6 +18,7 @@ import {
 	ContainerErrorTypes,
 	type IContainerContext,
 	type IBatchMessage,
+	type IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type {
@@ -58,7 +59,6 @@ import {
 	type IEnvelope,
 	type ITelemetryContext,
 	type ISummarizeInternalResult,
-	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import { defaultMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 import {
@@ -242,7 +242,7 @@ describe("Runtime", () => {
 	const mockClientId = "mockClientId";
 
 	// Mock the storage layer so "submitSummary" works.
-	const defaultMockStorage: Partial<IRuntimeStorageService> = {
+	const defaultMockStorage: Partial<IContainerStorageService> = {
 		uploadSummaryWithContext: async (summary: ISummaryTree, context: ISummaryContext) => {
 			return "fakeHandle";
 		},
@@ -251,7 +251,7 @@ describe("Runtime", () => {
 		params: {
 			settings?: Record<string, ConfigTypes>;
 			logger?: ITelemetryBaseLogger;
-			mockStorage?: Partial<IRuntimeStorageService>;
+			mockStorage?: Partial<IContainerStorageService>;
 			loadedFromVersion?: IVersion;
 			baseSnapshot?: ISnapshotTree;
 			connected?: boolean;
@@ -298,7 +298,7 @@ describe("Runtime", () => {
 			},
 			clientId,
 			connected,
-			storage: mockStorage as IRuntimeStorageService,
+			storage: mockStorage as IContainerStorageService,
 			baseSnapshot,
 		} satisfies Partial<IContainerContext>;
 
@@ -2119,7 +2119,7 @@ describe("Runtime", () => {
 					summaryRefSeq: 100,
 					summaryLogger: createChildLogger({}),
 				};
-				class MockStorageService implements Partial<IRuntimeStorageService> {
+				class MockStorageService implements Partial<IContainerStorageService> {
 					/**
 					 * This always returns the same snapshot. Basically, when container runtime receives an ack for the
 					 * deleted snapshot and tries to fetch the latest snapshot, return the latest snapshot.

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -531,43 +531,6 @@ describeCompat(
 				assert.strictEqual(sparseMatrix.id, sparseMatrixId, "Sparse matrix should exist!!");
 			});
 
-			it("Storage in detached container", async () => {
-				const { container } = await createDetachedContainerAndGetEntryPoint();
-
-				const snapshotTree = container.serialize();
-				const defaultDataStore =
-					await getContainerEntryPointBackCompat<TestFluidObject>(container);
-				assert(
-					defaultDataStore.context.storage !== undefined,
-					"Storage should be present in detached data store",
-				);
-				let success1: boolean | undefined;
-				await defaultDataStore.context.storage.getSnapshotTree(undefined).catch((err) => {
-					success1 = false;
-				});
-				assert(
-					success1 === false,
-					"Snapshot fetch should not be allowed in detached data store",
-				);
-
-				const container2: IContainer =
-					await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
-				const defaultDataStore2 =
-					await getContainerEntryPointBackCompat<TestFluidObject>(container2);
-				assert(
-					defaultDataStore2.context.storage !== undefined,
-					"Storage should be present in rehydrated data store",
-				);
-				let success2: boolean | undefined;
-				await defaultDataStore2.context.storage.getSnapshotTree(undefined).catch((err) => {
-					success2 = false;
-				});
-				assert(
-					success2 === false,
-					"Snapshot fetch should not be allowed in rehydrated data store",
-				);
-			});
-
 			it("Change contents of dds, then rehydrate and then check summary", async () => {
 				const { container } = await createDetachedContainerAndGetEntryPoint();
 


### PR DESCRIPTION
There are a couple of incorrect usages of the storage service at the Runtime and Loader layer after `IContainerStorageService` and `IRuntimeStorageService` were added by https://github.com/microsoft/FluidFramework/pull/25057. This PR fixes them.

Also, removed a test that was ensuring `getSnapshotTree` cannot be accessed from data store context. With https://github.com/microsoft/FluidFramework/pull/25057, `getSnapshotTree` is not accesible from data store context's storage anymore so this test is not needed.