### PR TITLE
TreeNodeSchemaPrivateData.childAnnotatedAllowedTypes -> childAllowedTypes

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -10,7 +10,7 @@ import type { SimpleNodeSchemaBase } from "./simpleNodeSchemaBase.js";
 import type { TreeNode } from "./treeNode.js";
 import type { InternalTreeNode, Unhydrated } from "./types.js";
 import type { UnionToIntersection } from "../../util/index.js";
-import type { ImplicitAllowedTypes, AllowedTypesFullEvaluated } from "./allowedTypes.js";
+import type { AllowedTypesFullEvaluated, AllowedTypesFull } from "./allowedTypes.js";
 import type { Context } from "./context.js";
 import type { FieldKey, NodeData, TreeNodeStoredSchema } from "../../core/index.js";
 import type { UnhydratedFlexTreeField } from "./unhydratedFlexTree.js";
@@ -379,16 +379,11 @@ export interface TreeNodeSchemaPrivateData {
 	 * In this case "field" includes anything that is a field in the internal (flex-tree) abstraction layer.
 	 * This includes the content field for arrays, and all the fields for map nodes.
 	 * If this node does not have fields (and thus is a leaf), the array will be empty.
-	 *
-	 * This set cannot be used before the schema in it have been defined:
-	 * more specifically, when using lazy schema references (for example to make foreword references to schema which have not yet been defined),
-	 * users must wait until after the schema are defined to access this array.
-	 *
 	 * @privateRemarks
 	 * If this is stabilized, it will live alongside the childTypes property on {@link TreeNodeSchemaCore}.
 	 * @system
 	 */
-	readonly childAnnotatedAllowedTypes: readonly ImplicitAllowedTypes[];
+	readonly childAllowedTypes: readonly AllowedTypesFull[];
 
 	/**
 	 * Idempotent initialization function that pre-caches data and can dereference lazy schema references.

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -417,7 +417,7 @@ export interface TreeNodeSchemaInitializedData {
 	 * If this is stabilized, it will live alongside the childTypes property on {@link TreeNodeSchemaCore}.
 	 * @system
 	 */
-	readonly childAnnotatedAllowedTypes: readonly AllowedTypesFullEvaluated[];
+	readonly childAllowedTypes: readonly AllowedTypesFullEvaluated[];
 
 	/**
 	 * A {@link Context} which can be used for unhydrated nodes of this schema.

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -259,7 +259,7 @@ export function isClassBasedSchema(
  */
 export function createTreeNodeSchemaPrivateData(
 	schema: TreeNodeSchemaCore<string, NodeKind, boolean>,
-	childAnnotatedAllowedTypes: readonly AllowedTypesFull[],
+	childAllowedTypes: readonly AllowedTypesFull[],
 	toStored: TreeNodeSchemaPrivateData["toStored"],
 ): TreeNodeSchemaPrivateData {
 	const schemaValid = schemaAsTreeNodeValid(schema);
@@ -269,7 +269,7 @@ export function createTreeNodeSchemaPrivateData(
 
 	return {
 		idempotentInitialize: () => schemaValid.oneTimeInitialize().oneTimeInitialized,
-		childAllowedTypes: childAnnotatedAllowedTypes,
+		childAllowedTypes,
 		toStored,
 	};
 }

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -25,7 +25,7 @@ import {
 } from "./treeNodeKernel.js";
 import type { InternalTreeNode } from "./types.js";
 import { typeSchemaSymbol } from "./withType.js";
-import type { ImplicitAllowedTypes } from "./allowedTypes.js";
+import type { AllowedTypesFull } from "./allowedTypes.js";
 import type { SimpleNodeSchemaBase } from "./simpleNodeSchemaBase.js";
 
 /**
@@ -259,7 +259,7 @@ export function isClassBasedSchema(
  */
 export function createTreeNodeSchemaPrivateData(
 	schema: TreeNodeSchemaCore<string, NodeKind, boolean>,
-	childAnnotatedAllowedTypes: readonly ImplicitAllowedTypes[],
+	childAnnotatedAllowedTypes: readonly AllowedTypesFull[],
 	toStored: TreeNodeSchemaPrivateData["toStored"],
 ): TreeNodeSchemaPrivateData {
 	const schemaValid = schemaAsTreeNodeValid(schema);
@@ -269,7 +269,7 @@ export function createTreeNodeSchemaPrivateData(
 
 	return {
 		idempotentInitialize: () => schemaValid.oneTimeInitialize().oneTimeInitialized,
-		childAnnotatedAllowedTypes,
+		childAllowedTypes: childAnnotatedAllowedTypes,
 		toStored,
 	};
 }

--- a/packages/dds/tree/src/simple-tree/core/walkSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/walkSchema.ts
@@ -28,8 +28,7 @@ export function walkNodeSchema(
 	// Since walkNodeSchema is used in the implementation of TreeNodeSchemaPrivateData.idempotentInitialize,
 	// Avoid depending on it here to avoid circular dependencies for recursive schema.
 	// Instead normalize/evaluate the allowed types as needed.
-	const annotatedAllowedTypes =
-		getTreeNodeSchemaPrivateData(schema).childAnnotatedAllowedTypes;
+	const annotatedAllowedTypes = getTreeNodeSchemaPrivateData(schema).childAllowedTypes;
 
 	for (const fieldAllowedTypes of annotatedAllowedTypes) {
 		walkAllowedTypes(

--- a/packages/dds/tree/src/simple-tree/createContext.ts
+++ b/packages/dds/tree/src/simple-tree/createContext.ts
@@ -49,6 +49,6 @@ export function getTreeNodeSchemaInitializedData(
 	return {
 		...handler,
 		context: getUnhydratedContext(schema),
-		childAnnotatedAllowedTypes: data.childAllowedTypes.map((t) => t.evaluate()),
+		childAllowedTypes: data.childAllowedTypes.map((t) => t.evaluate()),
 	};
 }

--- a/packages/dds/tree/src/simple-tree/createContext.ts
+++ b/packages/dds/tree/src/simple-tree/createContext.ts
@@ -9,7 +9,6 @@ import { getOrCreate } from "../util/index.js";
 import {
 	Context,
 	getTreeNodeSchemaPrivateData,
-	normalizeAndEvaluateAnnotatedAllowedTypes,
 	UnhydratedContext,
 	type TreeNodeSchema,
 	type TreeNodeSchemaInitializedData,
@@ -50,8 +49,6 @@ export function getTreeNodeSchemaInitializedData(
 	return {
 		...handler,
 		context: getUnhydratedContext(schema),
-		childAnnotatedAllowedTypes: data.childAnnotatedAllowedTypes.map(
-			normalizeAndEvaluateAnnotatedAllowedTypes,
-		),
+		childAnnotatedAllowedTypes: data.childAllowedTypes.map((t) => t.evaluate()),
 	};
 }

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -63,7 +63,7 @@ export class LeafNodeSchema<Name extends string, const T extends ValueSchema>
 					allowedTypes: ReadonlySet<TreeNodeSchema>,
 				): FlexContent => leafToFlexContent(data, this, allowedTypes),
 			})),
-		childAnnotatedAllowedTypes: [],
+		childAllowedTypes: [],
 		toStored: () => new LeafNodeStoredSchema(this.leafKind),
 	};
 	#initializedData: TreeNodeSchemaInitializedData | undefined;

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -1273,8 +1273,11 @@ export function arraySchema<
 		}
 
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-			return (privateData ??= createTreeNodeSchemaPrivateData(this, [info], (storedOptions) =>
-				arrayNodeStoredSchema(convertAllowedTypes(info, storedOptions), persistedMetadata),
+			return (privateData ??= createTreeNodeSchemaPrivateData(
+				this,
+				[normalizedTypes],
+				(storedOptions) =>
+					arrayNodeStoredSchema(convertAllowedTypes(info, storedOptions), persistedMetadata),
 			));
 		}
 	}

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -336,7 +336,7 @@ export function mapSchema<
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
 			return (privateData ??= createTreeNodeSchemaPrivateData(
 				this,
-				[info],
+				[normalizedTypes],
 				(storedOptions) =>
 					new MapNodeStoredSchema(
 						{

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -577,10 +577,7 @@ export function objectSchema<
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
 			return (privateData ??= createTreeNodeSchemaPrivateData(
 				this,
-				Array.from(
-					flexKeyMap.values(),
-					({ schema }) => normalizeFieldSchema(schema).allowedTypes,
-				),
+				Array.from(CustomObjectNode.fields.values(), (schema) => schema.allowedTypesFull),
 				(storedOptions) => {
 					const fields: Map<FieldKey, TreeFieldStoredSchema> = new Map();
 					for (const fieldSchema of flexKeyMap.values()) {

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -381,7 +381,7 @@ export function recordSchema<
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
 			return (privateData ??= createTreeNodeSchemaPrivateData(
 				this,
-				[info],
+				[normalizedTypes],
 				(storedOptions) =>
 					new MapNodeStoredSchema(
 						{

--- a/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
@@ -93,7 +93,6 @@ describe("TreeNodeValid", () => {
 			}
 
 			public static readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
-			public static readonly childAnnotatedAllowedTypes = [];
 
 			public override get [typeNameSymbol](): string {
 				throw new Error("Method not implemented.");
@@ -174,7 +173,6 @@ describe("TreeNodeValid", () => {
 			public static readonly info = numberSchema;
 			public static readonly implicitlyConstructable: false;
 			public static readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
-			public static readonly childAnnotatedAllowedTypes = [];
 
 			public static override buildRawNode<T2>(
 				this: typeof TreeNodeValid<T2>,
@@ -240,7 +238,6 @@ describe("TreeNodeValid", () => {
 			public static readonly info = numberSchema;
 			public static readonly implicitlyConstructable: false;
 			public static readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
-			public static readonly childAnnotatedAllowedTypes = [];
 
 			public static override buildRawNode<T2>(
 				this: typeof TreeNodeValid<T2>,


### PR DESCRIPTION
## Description

Fix TreeNodeSchemaPrivateData.childAnnotatedAllowedTypes to have a better type, and rename it to  childAllowedTypes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
