### PR TITLE
Automatically sharePendingBlobs

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -924,7 +924,6 @@ export class BlobManager {
 	public readonly sharePendingBlobs = async (): Promise<void> => {
 		const localIdsToUpload = [...this.pendingOnlyLocalIds];
 		this.pendingOnlyLocalIds.clear();
-		// TODO: Determine if Promise.all is ergonomic at the callsite. Would Promise.allSettled be better?
 		await Promise.all<void>(
 			localIdsToUpload.map(async (localId) => this.uploadAndAttach(localId)),
 		);


### PR DESCRIPTION
[AB#51053](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/51053)

Invokes sharePendingBlobs() automatically as soon as it is safe after the ContainerRuntime loads.  Expectation is that scenarios that don't want to write (frozen container) will remain readonly and/or !connected, and so the share will never be invoked.

Also beefs up the corresponding e2e tests a bit, including verification from a third client so we can be sure we aren't cheating the results by being the original uploader (client1) or having the pending state available (client2).