### PR TITLE
test(client): fix tests to setup fully knowledgeable Presence

### DIFF
--- a/packages/framework/presence/src/test/batching.spec.ts
+++ b/packages/framework/presence/src/test/batching.spec.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "node:assert";
+
 import { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal";
 import { describe, it, after, afterEach, before, beforeEach } from "mocha";
 import { useFakeTimers, type SinonFakeTimers } from "sinon";
@@ -23,7 +25,8 @@ describe("Presence", () => {
 	describe("batching", () => {
 		let runtime: MockEphemeralRuntime;
 		let logger: EventAndErrorTrackingLogger;
-		const initialTime = 1000;
+		const initialTime = 500;
+		const testStartTime = 1010;
 		let clock: SinonFakeTimers;
 		let presence: PresenceWithNotifications;
 
@@ -35,8 +38,6 @@ describe("Presence", () => {
 			logger = new EventAndErrorTrackingLogger();
 			runtime = new MockEphemeralRuntime(logger);
 
-			// Note that while the initialTime is set to 1000, the prepareConnectedPresence call advances
-			// it to 1010 so all tests start at that time.
 			clock.setSystemTime(initialTime);
 
 			// Set up the presence connection.
@@ -47,6 +48,12 @@ describe("Presence", () => {
 				clock,
 				logger,
 			).presence;
+
+			// Note that while the initialTime was set to 500, the prepareConnectedPresence call advances
+			// it. Set a consistent start time for all tests.
+			const deltaToStart = testStartTime - clock.now;
+			assert(deltaToStart >= 0);
+			clock.tick(deltaToStart);
 		});
 
 		afterEach(() => {
@@ -72,7 +79,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -99,7 +110,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -126,7 +141,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -168,7 +187,7 @@ describe("Presence", () => {
 				assertFinalExpectations(runtime, logger);
 			});
 
-			it("sets timer for default allowableUpdateLatency", async () => {
+			it("sets timer for default allowableUpdateLatencyMs", async () => {
 				runtime.signalsExpected.push([
 					{
 						type: "Pres:DatastoreUpdate",
@@ -180,7 +199,7 @@ describe("Presence", () => {
 									"clientToSessionId": {
 										[connectionId2]: {
 											"rev": 0,
-											"timestamp": 1000,
+											"timestamp": initialTime,
 											"value": attendeeId2,
 										},
 									},
@@ -215,7 +234,7 @@ describe("Presence", () => {
 				clock.tick(100); // Time is now 1110
 			});
 
-			it("batches signals sent within default allowableUpdateLatency", async () => {
+			it("batches signals sent within default allowableUpdateLatencyMs", async () => {
 				runtime.signalsExpected.push(
 					[
 						{
@@ -226,7 +245,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -253,7 +276,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -315,7 +342,7 @@ describe("Presence", () => {
 				clock.tick(30); // Time is now 1180
 			});
 
-			it("batches signals sent within a specified allowableUpdateLatency", async () => {
+			it("batches signals sent within a specified allowableUpdateLatencyMs", async () => {
 				runtime.signalsExpected.push(
 					[
 						{
@@ -326,7 +353,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -353,7 +384,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -424,7 +459,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -460,7 +499,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -530,7 +573,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -566,7 +613,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -632,7 +683,7 @@ describe("Presence", () => {
 									"clientToSessionId": {
 										[connectionId2]: {
 											"rev": 0,
-											"timestamp": 1000,
+											"timestamp": initialTime,
 											"value": attendeeId2,
 										},
 									},
@@ -713,7 +764,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"n:name:testNotificationWorkspace": {
@@ -739,7 +794,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"n:name:testNotificationWorkspace": {
@@ -801,7 +860,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"s:name:testStateWorkspace": {
@@ -841,7 +904,11 @@ describe("Presence", () => {
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
-											[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+											[connectionId2]: {
+												"rev": 0,
+												"timestamp": initialTime,
+												"value": attendeeId2,
+											},
 										},
 									},
 									"n:name:testNotificationWorkspace": {

--- a/packages/framework/presence/src/test/notificationsManager.spec.ts
+++ b/packages/framework/presence/src/test/notificationsManager.spec.ts
@@ -137,12 +137,16 @@ describe("Presence", () => {
 				{
 					type: "Pres:DatastoreUpdate",
 					content: {
-						"sendTimestamp": 1020,
+						"sendTimestamp": clock.now,
 						"avgLatency": 10,
 						"data": {
 							"system:presence": {
 								"clientToSessionId": {
-									[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+									[connectionId2]: {
+										"rev": 0,
+										"timestamp": initialTime,
+										"value": attendeeId2,
+									},
 								},
 							},
 							"n:name:testNotificationWorkspace": {
@@ -190,12 +194,16 @@ describe("Presence", () => {
 				{
 					type: "Pres:DatastoreUpdate",
 					content: {
-						"sendTimestamp": 1020,
+						"sendTimestamp": clock.now,
 						"avgLatency": 10,
 						"data": {
 							"system:presence": {
 								"clientToSessionId": {
-									[connectionId2]: { "rev": 0, "timestamp": 1000, "value": attendeeId2 },
+									[connectionId2]: {
+										"rev": 0,
+										"timestamp": initialTime,
+										"value": attendeeId2,
+									},
 								},
 							},
 							"n:name:testNotificationWorkspace": {

--- a/packages/framework/presence/src/test/schemaValidation/valueManagers.spec.ts
+++ b/packages/framework/presence/src/test/schemaValidation/valueManagers.spec.ts
@@ -565,14 +565,14 @@ describe("Presence", () => {
 					{
 						"type": "Pres:DatastoreUpdate",
 						"content": {
-							"sendTimestamp": 1030,
+							"sendTimestamp": clock.now,
 							"avgLatency": 10,
 							"data": {
 								"system:presence": {
 									"clientToSessionId": {
 										[connectionId2]: {
 											"rev": 0,
-											"timestamp": 1000,
+											"timestamp": initialTime,
 											"value": attendeeId2,
 										},
 									},
@@ -584,12 +584,12 @@ describe("Presence", () => {
 											"items": {
 												"key1": {
 													"rev": 0,
-													"timestamp": 1030,
+													"timestamp": clock.now,
 													"value": toOpaqueJson({ "x": 0, "y": 0, "z": 0 }),
 												},
 												"key2": {
 													"rev": 0,
-													"timestamp": 1030,
+													"timestamp": clock.now,
 													"value": toOpaqueJson({ "x": 0, "y": 0, "z": 0 }),
 												},
 											},
@@ -650,14 +650,14 @@ describe("Presence", () => {
 						{
 							"type": "Pres:DatastoreUpdate",
 							"content": {
-								"sendTimestamp": 1030,
+								"sendTimestamp": clock.now,
 								"avgLatency": 10,
 								"data": {
 									"system:presence": {
 										"clientToSessionId": {
 											[connectionId2]: {
 												"rev": 0,
-												"timestamp": 1000,
+												"timestamp": initialTime,
 												"value": attendeeId2,
 											},
 										},
@@ -669,7 +669,7 @@ describe("Presence", () => {
 												"items": {
 													"key1": {
 														"rev": 1,
-														"timestamp": 1030,
+														"timestamp": clock.now,
 														"value": toOpaqueJson({ "x": 0, "y": 1, "z": 2 }),
 													},
 												},

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -708,7 +708,10 @@ export class MockQuorumClients implements IQuorumClients, EventEmitter {
 	}
 
 	getMembers(): Map<string, ISequencedClient> {
-		return this.members;
+		// Implementation always generates a new Map.
+		// Mock should as well in case any callers rely on being able to modify
+		// the returned Map.
+		return new Map(this.members);
 	}
 	getMember(clientId: string): ISequencedClient | undefined {
 		return this.getMembers().get(clientId);


### PR DESCRIPTION
+ add/improve join tests including coverage of protocol update hole
+ fix MockQuorum to return a copy during getMembers call
+ adjust test clock times to be relative to other times that may vary as tests or test setup changes
+ introduce `broadcastJoinResponseDelaysMs` that captures some current implementation behavior (will be updated to come from implementation soon)