### PR TITLE
BUG/ [Routerlicious-Driver]Add undefined value handling in restWrapper

### DIFF
--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -47,10 +47,10 @@ const buildRequestUrl = (requestConfig: AxiosRequestConfig) =>
 const axiosBuildRequestInitConfig = (requestConfig: AxiosRequestConfig): RequestInit => {
 	const requestInit: RequestInit = {
 		method: requestConfig.method,
-		// NOTE: I believe that although the Axios type permits non-string values in the header, here we are
-		// guaranteed the requestConfig only has string values in its header.
-		headers: requestConfig.headers as Record<string, string>,
-		body: requestConfig.data,
+		// Only set headers if they exist to avoid passing undefined
+		...(requestConfig.headers && { headers: requestConfig.headers as Record<string, string> }),
+		// Only set body if it exists to avoid passing undefined
+		...(requestConfig.data !== undefined && { body: requestConfig.data }),
 	};
 	return requestInit;
 };


### PR DESCRIPTION
## Description

This PR fixes an issue in the @fluidframework/routerlicious-driver package, specifically in restWrapper.ts, where the function axiosBuildRequestInitConfig was directly accessing requestConfig.headers without checking if it was undefined.

When headers is undefined, the code fails during request initialization, causing runtime errors.

Root Cause

The existing implementation assumed that requestConfig.headers would always be defined:

headers: requestConfig.headers as Record<string, string>,


However, in some cases, the Axios request configuration does not include headers, leading to failures when attempting to spread or cast an undefined value.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

## Breaking Changes

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
> If there are no breaking changes, delete this section.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
