### PR TITLE
test(client): multiclient improvements

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -214,7 +214,7 @@ const WorkspaceSchema: WorkspaceSchema = {};
 
 class MessageHandler {
 	private readonly log: EventEntry[] = [];
-	private msgQueue: undefined | MessageFromParent[];
+	private msgQueue: undefined | Exclude<MessageFromParent, { command: "ping" | "connect" }>[];
 	private container: IFluidContainer | undefined;
 	private presence: Presence | undefined;
 	private readonly workspaces = new Map<string, StatesWorkspace<WorkspaceSchema>>();
@@ -484,7 +484,7 @@ class MessageHandler {
 
 		// Process any queued messages received while connecting
 		for (const queuedMsg of this.msgQueue) {
-			await this.onMessage(queuedMsg);
+			this.processMessage(queuedMsg);
 		}
 		this.msgQueue = undefined;
 	}

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -227,7 +227,7 @@ class MessageHandler {
 			eventName: msg.event,
 			details:
 				msg.event === "debugReportComplete" && msg.log
-					? `{"logLength":${msg.log.length}}`
+					? JSON.stringify({ logLength: msg.log.length })
 					: JSON.stringify(msg),
 		});
 		send(msg);

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -473,7 +473,7 @@ class MessageHandler {
 		// Send existing attendees excluding self to parent/orchestrator
 		const self = presence.attendees.getMyself();
 		for (const attendee of presence.attendees.getAttendees()) {
-			if (attendee !== self) {
+			if (attendee !== self && attendee.getConnectionStatus() === "Connected") {
 				this.sendAttendeeConnected(attendee);
 			}
 		}

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -67,7 +67,13 @@ export interface ConnectCommand {
  */
 interface DebugReportCommand {
 	command: "debugReport";
+	/**
+	 * Send event log entries.
+	 */
 	sendEventLog?: true;
+	/**
+	 * Send basic attendee statistics (like count of connected).
+	 */
 	reportAttendees?: true;
 }
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -13,11 +13,20 @@ export interface UserIdAndName {
 	name: string;
 }
 
+export interface EventEntry {
+	timestamp: number;
+	agentId: string;
+	eventCategory: string;
+	eventName: string;
+	details?: string;
+}
+
 /**
  * Message types sent from the orchestrator to the child processes
  */
 export type MessageToChild =
 	| ConnectCommand
+	| DebugReportCommand
 	| DisconnectSelfCommand
 	| RegisterWorkspaceCommand
 	| GetLatestValueCommand
@@ -48,6 +57,18 @@ export interface ConnectCommand {
 	 * If not provided, a new Fluid container will be created.
 	 */
 	containerId?: string;
+}
+
+/**
+ * Instructs a child process to report debug information.
+ *
+ * @privateRemarks
+ * This can be expanded over time to include more options.
+ */
+interface DebugReportCommand {
+	command: "debugReport";
+	sendEventLog?: true;
+	reportAttendees?: true;
 }
 
 /**
@@ -127,6 +148,7 @@ export type MessageFromChild =
 	| AttendeeConnectedEvent
 	| AttendeeDisconnectedEvent
 	| ConnectedEvent
+	| DebugReportCompleteEvent
 	| DisconnectedSelfEvent
 	| ErrorEvent
 	| LatestMapValueGetResponseEvent
@@ -165,6 +187,14 @@ interface ConnectedEvent {
 	event: "connected";
 	containerId: string;
 	attendeeId: AttendeeId;
+}
+
+/**
+ * Sent from the child processes to the orchestrator in response to a {@link DebugReportCommand}.
+ */
+interface DebugReportCompleteEvent {
+	event: "debugReportComplete";
+	log?: EventEntry[];
 }
 
 /**

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -108,6 +108,11 @@ export async function forkChildProcesses(
 	return { children, childErrorPromise };
 }
 
+/**
+ * Instructs all listed child processes to send debug reports and then the
+ * collection is output sorted by timestamp. Report content is up to the child
+ * processes, but typically includes messages sent and some telemetry events.
+ */
 export async function executeDebugReports(
 	childrenRequestedToReport: ChildProcess[],
 ): Promise<void> {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -109,10 +109,10 @@ export async function forkChildProcesses(
 }
 
 export async function executeDebugReports(
-	childrenNotFullyJoined: ChildProcess[],
+	childrenRequestedToReport: ChildProcess[],
 ): Promise<void> {
 	const debugReportPromises: Promise<EventEntry[]>[] = [];
-	for (const child of childrenNotFullyJoined) {
+	for (const child of childrenRequestedToReport) {
 		const debugReportPromise = new Promise<EventEntry[]>((resolve) => {
 			const handler = (msg: MessageFromChild): void => {
 				if (msg.event === "debugReportComplete") {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -144,11 +144,9 @@ describe(`Presence with AzureClient`, () => {
 				);
 			});
 
-			it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function () {
-				// AB#48866: Fix intermittently failing presence tests
-				if (useAzure) {
-					this.skip();
-				}
+			// Once test waits for all clients to fully join, reliability degrades.
+			// Improved join will resolve reliability issue.
+			it.skip(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function () {
 				// TODO: AB#45620: "Presence: perf: update Join pattern for scale" can handle
 				// larger counts of read-only attendees. Without protocol changes tests with
 				// 20+ attendees exceed current limits.

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -47,7 +47,7 @@ const timeoutMultiplier = debuggerAttached ? 1000 : useAzure ? 3 : 1;
  * @param context - The Mocha test context.
  * @param duration - The duration in milliseconds to set the timeout to. Zero disables the timeout.
  */
-function setTimeout(context: Mocha.Context, duration: number): void {
+function setTestTimeout(context: Mocha.Context, duration: number): void {
 	const currentTimeout = context.timeout();
 	const newTimeout =
 		debuggerAttached || currentTimeout === 0 || duration === 0
@@ -123,7 +123,7 @@ describe(`Presence with AzureClient`, () => {
 					this.skip();
 				}
 
-				setTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
+				setTestTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
 
 				// Setup
 				const { children, childErrorPromise } = await forkChildProcesses(
@@ -162,7 +162,7 @@ describe(`Presence with AzureClient`, () => {
 
 				const childDisconnectTimeoutMs = 10_000 * timeoutMultiplier;
 
-				setTimeout(
+				setTestTimeout(
 					this,
 					childConnectTimeoutMs +
 						allAttendeesFullyJoinedTimeoutMs +
@@ -241,7 +241,7 @@ describe(`Presence with AzureClient`, () => {
 					// Gather and report debug info from children
 					// If there are less than 10 children, get all reports.
 					// Otherwise, just child 0 and those not fully joined.
-					setTimeout(this, 0); // Disable test timeout. Will throw within 20s below.
+					setTestTimeout(this, 0); // Disable test timeout. Will throw within 20s below.
 					const childrenRequestedToReport =
 						children.length <= 10
 							? children


### PR DESCRIPTION
1. update timeout for disconnected after full join with additional debugging output if full join fails
    - Keep skipping 100+ client scale for azure.
    - Remove stale comment
2. cleanup
    - use standard container declaration pattern (strong typing)
    - separate presence instantiation from container create/load helper
    - cleanup `Message*` type imports
3. early out on disconnect
4. atomically set MessageHandler state on connect
5. misc improvements
    - reject on "error"/unexpected responses during "connect"
    - type corrections
    - event cleanup
    - detect more early error cases
6. queue child commands while connecting
7. child logging for failure reports
    - Capture child activity of interest and log on testing failure to facilitate debugging.
    - Only attendeeDisconnected setup has enhanced debug reports when one or more children fail to connect.
8. disable disconnected test