### PR TITLE
feat(ordered-collection): Enable rollback for ConsensusOrderedCollection

### DIFF
--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
@@ -29,6 +29,8 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensus
     protected release(acquireId: string): void;
     // (undocumented)
     protected releaseCore(acquireId: string): void;
+    // @sealed
+    protected rollback(content: unknown, localOpMetadata: unknown): void;
     // (undocumented)
     protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
     waitAndAcquire(callback: ConsensusCallback<T>): Promise<void>;

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -431,8 +431,9 @@ export class ConsensusOrderedCollection<T = any>
 	 */
 	protected rollback(content: unknown, localOpMetadata: unknown): void {
 		assert(typeof localOpMetadata === "function", "localOpMetadata should be a function");
-		// A resolve function is passed into the localOpMetadata on this.submitLocalMessage().
+		// A resolve function is passed as the localOpMetadata on this.submitLocalMessage().
 		// On rollback we resolve with undefined and the promises will handle it appropriately.
-		localOpMetadata(undefined);
+		const resolve = localOpMetadata as PendingResolve<T>;
+		resolve(undefined);
 	}
 }

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -424,4 +424,15 @@ export class ConsensusOrderedCollection<T = any>
 	protected applyStashedOp(): void {
 		throw new Error("not implemented");
 	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.rollback}
+	 * @sealed
+	 */
+	protected rollback(content: unknown, localOpMetadata: unknown): void {
+		assert(typeof localOpMetadata === "function", "localOpMetadata should be a function");
+		// A resolve function is passed into the localOpMetadata on this.submitLocalMessage().
+		// On rollback we resolve with undefined and the promises will handle it appropriately.
+		localOpMetadata(undefined);
+	}
 }

--- a/packages/dds/ordered-collection/src/index.ts
+++ b/packages/dds/ordered-collection/src/index.ts
@@ -15,4 +15,9 @@ export {
 export { ConsensusQueueFactory, ConsensusQueue } from "./consensusOrderedCollectionFactory.js";
 export { ConsensusOrderedCollection } from "./consensusOrderedCollection.js";
 export { ConsensusQueueClass } from "./consensusQueue.js";
-export { acquireAndComplete, waitAcquireAndComplete } from "./testUtils.js";
+export {
+	acquireAndComplete,
+	waitAcquireAndComplete,
+	acquireAndRelease,
+	waitAcquireAndRelease,
+} from "./testUtils.js";

--- a/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -22,7 +22,11 @@ import {
 	type ConsensusQueue,
 } from "../consensusOrderedCollectionFactory.js";
 import { ConsensusResult, type IConsensusOrderedCollection } from "../interfaces.js";
-import { acquireAndComplete, waitAcquireAndComplete } from "../testUtils.js";
+import {
+	acquireAndComplete,
+	acquireAndRelease,
+	waitAcquireAndComplete,
+} from "../testUtils.js";
 
 function createConnectedCollection(
 	id: string,
@@ -460,5 +464,277 @@ describe("ConsensusOrderedCollection", () => {
 		}
 
 		runGCTests(GCOrderedCollectionProvider);
+	});
+
+	describe.only("Rollback", () => {
+		let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+
+		let testCollection1: IConsensusOrderedCollection;
+		let containerRuntime1: MockContainerRuntimeForReconnection;
+
+		let testCollection2: IConsensusOrderedCollection;
+		let containerRuntime2: MockContainerRuntimeForReconnection;
+
+		const processAcquireMessages = (): void => {
+			// acquire() will first send an acquire op. After that is processed it will also send a complete op.
+			// To account for this, we need to flush/process the acquire op, then immediately flush/process the complete op to process everything.
+			containerRuntime1.flush();
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+			setImmediate(() => {
+				containerRuntime1.flush();
+				containerRuntime2.flush();
+				containerRuntimeFactory.processAllMessages();
+			});
+		};
+
+		beforeEach(async () => {
+			containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection({
+				flushMode: 1, // turn based
+			});
+
+			const response1 = createCollectionForReconnection(
+				"collection1",
+				containerRuntimeFactory,
+			);
+			testCollection1 = response1.collection;
+			containerRuntime1 = response1.containerRuntime;
+
+			const response2 = createCollectionForReconnection(
+				"collection2",
+				containerRuntimeFactory,
+			);
+			testCollection2 = response2.collection;
+			containerRuntime2 = response2.containerRuntime;
+		});
+
+		it("can rollback add op", async () => {
+			let addFired = false;
+			testCollection1.on("add", () => {
+				addFired = true;
+			});
+
+			const addP = testCollection1.add("value");
+
+			containerRuntime1.rollback?.();
+
+			containerRuntime1.flush();
+			containerRuntimeFactory.processAllMessages();
+			await addP;
+
+			assert.equal(addFired, false, "Add event should not fire");
+
+			const acquiredP = acquireAndComplete(testCollection1);
+			processAcquireMessages();
+			const acquiredVal = (await acquiredP) as unknown;
+			assert.equal(acquiredVal, undefined, "Should not have added value post rollback");
+		});
+
+		it("can rollback acquire/complete ops", async () => {
+			let acquireFired = false;
+			let completeFired = false;
+			testCollection1.on("acquire", () => {
+				acquireFired = true;
+			});
+			testCollection1.on("complete", () => {
+				completeFired = true;
+			});
+
+			const addP = testCollection1.add("value");
+			containerRuntime1.flush();
+			containerRuntimeFactory.processAllMessages();
+			await addP;
+
+			const acquiredP1 = acquireAndComplete(testCollection1);
+			containerRuntime1.rollback?.();
+
+			processAcquireMessages();
+			const acquiredVal1 = (await acquiredP1) as unknown;
+			assert.equal(acquiredVal1, undefined, "Should not have acquired value post rollback");
+			assert.equal(acquireFired, false, "Acquire event should not fire");
+			assert.equal(completeFired, false, "Complete event should not fire");
+
+			const acquiredP2 = acquireAndComplete(testCollection1);
+			processAcquireMessages();
+			const acquiredVal2 = (await acquiredP2) as unknown;
+			assert.equal(acquiredVal2, "value", "Should be able to acquire value post rollback");
+			assert.equal(acquireFired, true, "acquire event should fire post rollback");
+			assert.equal(completeFired, true, "complete event should fire post rollback");
+		});
+
+		it("can rollback acquire/release ops", async () => {
+			let acquireFired = false;
+			let releaseFired = false;
+			testCollection1.on("acquire", () => {
+				acquireFired = true;
+			});
+			testCollection1.on("localRelease", () => {
+				releaseFired = true;
+			});
+
+			const addP = testCollection1.add("value");
+			containerRuntime1.flush();
+			containerRuntimeFactory.processAllMessages();
+			await addP;
+
+			const acquiredP1 = acquireAndRelease(testCollection1);
+			containerRuntime1.rollback?.();
+
+			processAcquireMessages();
+			const acquiredVal1 = (await acquiredP1) as unknown;
+			assert.equal(acquiredVal1, undefined, "Should not have acquired value post rollback");
+			assert.equal(acquireFired, false, "acquire event should not fire");
+			assert.equal(releaseFired, false, "release event should not fire");
+
+			const acquiredP2 = acquireAndRelease(testCollection1);
+			processAcquireMessages();
+			const acquiredVal2 = (await acquiredP2) as unknown;
+			assert.equal(acquiredVal2, "value", "Should be able to acquire value post rollback");
+			assert.equal(acquireFired, true, "acquire event should fire post rollback");
+			assert.equal(releaseFired, true, "release event should fire post rollback");
+		});
+
+		describe("Rollback across remote ops", () => {
+			it("can rollback add across remote ops", async () => {
+				let addFiredCount1 = 0;
+				let addFiredCount2 = 0;
+				testCollection1.on("add", () => {
+					addFiredCount1++;
+				});
+				testCollection2.on("add", () => {
+					addFiredCount2++;
+				});
+
+				const addP1 = testCollection1.add("value1");
+				const addP2 = testCollection2.add("value2");
+
+				containerRuntime1.rollback?.();
+
+				containerRuntime1.flush();
+				containerRuntime2.flush();
+				containerRuntimeFactory.processAllMessages();
+				await Promise.all([addP1, addP2]);
+
+				assert.deepEqual(
+					[addFiredCount1, addFiredCount2],
+					[1, 1],
+					"Add event should only fire once for each client",
+				);
+
+				const acquiredP1 = acquireAndComplete(testCollection1);
+				processAcquireMessages();
+				const acquiredVal1 = (await acquiredP1) as unknown;
+				assert.equal(acquiredVal1, "value2", "value2 should be the first value acquired");
+
+				const acquiredP2 = acquireAndComplete(testCollection1);
+				processAcquireMessages();
+				const acquiredVal2 = (await acquiredP2) as unknown;
+				assert.equal(
+					acquiredVal2,
+					undefined,
+					"There should have only been one value to acquire",
+				);
+			});
+
+			it("can rollback acquire/complete across remote ops", async () => {
+				let acquireFiredCount1 = 0;
+				let completeFiredCount1 = 0;
+				let acquireFiredCount2 = 0;
+				let completeFiredCount2 = 0;
+				testCollection1.on("acquire", () => {
+					acquireFiredCount1++;
+				});
+				testCollection1.on("complete", () => {
+					completeFiredCount1++;
+				});
+				testCollection2.on("acquire", () => {
+					acquireFiredCount2++;
+				});
+				testCollection2.on("complete", () => {
+					completeFiredCount2++;
+				});
+
+				const addP = testCollection1.add("value");
+				containerRuntime1.flush();
+				containerRuntimeFactory.processAllMessages();
+				await addP;
+
+				const acquiredP1 = acquireAndComplete(testCollection1);
+				const acquiredP2 = acquireAndComplete(testCollection2);
+				containerRuntime1.rollback?.();
+
+				processAcquireMessages();
+
+				const [acquiredVal1, acquiredVal2] = (await Promise.all([acquiredP1, acquiredP2])) as [
+					unknown,
+					unknown,
+				];
+				assert.deepEqual(
+					[acquiredVal1, acquiredVal2],
+					[undefined, "value"],
+					"Client 1 should not have acquired value post rollback, value 2 should have",
+				);
+				assert.deepEqual(
+					[acquireFiredCount1, completeFiredCount1, acquireFiredCount2, completeFiredCount2],
+					[1, 1, 1, 1],
+					"Both clients should have fired each event once",
+				);
+
+				const acquiredP3 = acquireAndComplete(testCollection1);
+				processAcquireMessages();
+				const acquiredVal3 = (await acquiredP3) as unknown;
+				assert.equal(acquiredVal3, undefined, "There should be no more values to acquire");
+			});
+
+			it("can rollback acquire/release across remote ops", async () => {
+				let acquireFiredCount1 = 0;
+				let releaseFiredCount1 = 0;
+				let acquireFiredCount2 = 0;
+				let releaseFiredCount2 = 0;
+				testCollection1.on("acquire", () => {
+					acquireFiredCount1++;
+				});
+				testCollection1.on("localRelease", () => {
+					releaseFiredCount1++;
+				});
+				testCollection2.on("acquire", () => {
+					acquireFiredCount2++;
+				});
+				testCollection2.on("localRelease", () => {
+					releaseFiredCount2++;
+				});
+
+				const addP = testCollection1.add("value");
+				containerRuntime1.flush();
+				containerRuntimeFactory.processAllMessages();
+				await addP;
+
+				const acquiredP1 = acquireAndRelease(testCollection1);
+				const acquiredP2 = acquireAndRelease(testCollection2);
+				containerRuntime1.rollback?.();
+
+				processAcquireMessages();
+
+				const [acquiredVal1, acquiredVal2] = (await Promise.all([acquiredP1, acquiredP2])) as [
+					unknown,
+					unknown,
+				];
+				assert.deepEqual(
+					[acquiredVal1, acquiredVal2],
+					[undefined, "value"],
+					"Client 1 should not have acquired value post rollback, value 2 should have",
+				);
+				assert.deepEqual(
+					[acquireFiredCount1, releaseFiredCount1, acquireFiredCount2, releaseFiredCount2],
+					[1, 0, 1, 1],
+					"Only client 2 should have local release event fired",
+				);
+
+				const acquiredP3 = acquireAndRelease(testCollection1);
+				processAcquireMessages();
+				const acquiredVal3 = (await acquiredP3) as unknown;
+				assert.equal(acquiredVal3, undefined, "There should be no more values to acquire");
+			});
+		});
 	});
 });

--- a/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -466,7 +466,7 @@ describe("ConsensusOrderedCollection", () => {
 		runGCTests(GCOrderedCollectionProvider);
 	});
 
-	describe.only("Rollback", () => {
+	describe("Rollback", () => {
 		let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
 
 		let testCollection1: IConsensusOrderedCollection;

--- a/packages/dds/ordered-collection/src/testUtils.ts
+++ b/packages/dds/ordered-collection/src/testUtils.ts
@@ -36,3 +36,35 @@ export async function waitAcquireAndComplete<T>(
 	});
 	return res as T;
 }
+
+/**
+ * Helper method to acquire and release an item
+ * Should be used in test code only
+ * @internal
+ */
+export async function acquireAndRelease<T>(
+	collection: IConsensusOrderedCollection<T>,
+): Promise<T | undefined> {
+	let res: T | undefined;
+	await collection.acquire(async (value: T) => {
+		res = value;
+		return ConsensusResult.Release;
+	});
+	return res;
+}
+
+/**
+ * Helper method to acquire and release an item
+ * Should be used in test code only
+ * @internal
+ */
+export async function waitAcquireAndRelease<T>(
+	collection: IConsensusOrderedCollection<T>,
+): Promise<T> {
+	let res: T | undefined;
+	await collection.waitAndAcquire(async (value: T) => {
+		res = value;
+		return ConsensusResult.Release;
+	});
+	return res as T;
+}


### PR DESCRIPTION
## Description

This PR enables rollback for the `ConsensusOrderedCollection` DDS. 

Since it's a consensus-based DDS, we don't actually modify any data until an op is ack'd. The only requirement for rollback is to resolve open promises for local ops that are usually resolved in `processCore()`. The promises are already setup to "do nothing" when resolved with `undefined`, so we simply call the resolve function in the `localOpMetadata` with `undefined`.

## Misc
[AB#47480](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47480)