### PR TITLE
(op bunching) Removed deprecated property processCore from SharedObject

### DIFF
--- a/.changeset/silver-cobras-jam.md
+++ b/.changeset/silver-cobras-jam.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/ordered-collection": minor
+"@fluidframework/register-collection": minor
+"@fluidframework/shared-object-base": minor
+"__section": breaking
+---
+Deprecated property processCore has been removed from SharedObject
+
+The deprecated property `processCore` has been removed from `SharedObject`.
+
+Please see [this github issue](https://github.com/microsoft/FluidFramework/issues/25176) for more details.

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -363,18 +363,6 @@ export class SharedPropertyTree extends SharedObject {
 		this._root._reportDirtinessToView();
 	}
 
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(message, {
-			contents: message.contents,
-			localOpMetadata,
-			clientSequenceNumber: message.clientSequenceNumber,
-		});
-	}
-
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}
 	 */

--- a/experimental/dds/ot/ot/src/ot.ts
+++ b/experimental/dds/ot/ot/src/ot.ts
@@ -10,7 +10,6 @@ import {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	ISummaryTreeWithStats,
 	type IRuntimeMessageCollection,
@@ -107,22 +106,6 @@ export abstract class SharedOT<TState, TOp> extends SharedObject {
 	}
 
 	protected onDisconnect() {}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
-	}
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}

--- a/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
@@ -668,7 +668,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     get logViewer(): LogViewer;
     mergeEditsFrom(other: SharedTree, edits: Iterable<Edit<InternalizedChange>>, stableIdRemapper?: (id: StableNodeId) => StableNodeId): EditId[];
     protected onDisconnect(): void;
-    protected processCore(message: unknown, local: boolean): void;
     protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void;
     protected registerCore(): void;
     // (undocumented)

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -14,7 +14,6 @@ import {
 	IChannelServices,
 	IChannelStorageService,
 } from '@fluidframework/datastore-definitions/internal';
-import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -997,14 +996,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 			summaryLoadPerformanceEvent.cancel({ eventName: 'SummaryLoadFailure' }, error);
 			throw error;
 		}
-	}
-
-	/**
-	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processCore}
-	 */
-	protected processCore(message: unknown, local: boolean): void {
-		const typedMessage = message as ISequencedDocumentMessage;
-		this.processMessage(typedMessage, typedMessage.contents);
 	}
 
 	/**

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -10,10 +10,7 @@ import type {
 	Serializable,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -243,22 +240,6 @@ export class SharedCell<T = any>
 				throw new Error("Unknown operation");
 			}
 		}
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -9,10 +9,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -125,22 +122,6 @@ export class SharedCounter
 	 * Called when the object has disconnected from the delta stream.
 	 */
 	protected onDisconnect(): void {}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
-	}
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}

--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -8,10 +8,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -210,25 +207,6 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
 	protected async loadCore(storage: IChannelStorageService): Promise<void> {
 		const content = await readAndParse<ISerializableInk>(storage, snapshotFileName);
 		this.inkData = new InkData(content);
-	}
-
-	/**
-	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processCore}
-	 */
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/legacy-dds/src/array/sharedArray.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArray.ts
@@ -11,10 +11,7 @@ import type {
 	IChannelFactory,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import type {
-	ISequencedDocumentMessage,
-	ITree,
-} from "@fluidframework/driver-definitions/internal";
+import type { ITree } from "@fluidframework/driver-definitions/internal";
 import { FileMode, MessageType, TreeEntry } from "@fluidframework/driver-definitions/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -561,22 +558,6 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 
 	private getEntryForId(entryId: string): SharedArrayEntry<T> {
 		return this.idToEntryMap.get(entryId) as SharedArrayEntry<T>;
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/legacy-dds/src/signal/sharedSignal.ts
+++ b/packages/dds/legacy-dds/src/signal/sharedSignal.ts
@@ -12,10 +12,7 @@ import type {
 	IChannelFactory,
 } from "@fluidframework/datastore-definitions/internal";
 import { FileMode, MessageType, TreeEntry } from "@fluidframework/driver-definitions/internal";
-import type {
-	ISequencedDocumentMessage,
-	ITree,
-} from "@fluidframework/driver-definitions/internal";
+import type { ITree } from "@fluidframework/driver-definitions/internal";
 import type {
 	ISummaryTreeWithStats,
 	IRuntimeMessageCollection,
@@ -134,22 +131,6 @@ export class SharedSignalClass<T extends SerializableTypeForSharedSignal = any>
 	 * Callback on disconnect
 	 */
 	protected onDisconnect(): void {}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
-	}
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -10,10 +10,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -787,22 +784,6 @@ export class SharedDirectory
 				}
 			}
 		}
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -9,10 +9,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -286,22 +283,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 */
 	protected applyStashedOp(content: unknown): void {
 		this.kernel.tryApplyStashedOp(content as IMapOperation);
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -1001,22 +1001,6 @@ export class SharedMatrix<T = any>
 		);
 	}
 
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
-	}
-
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}
 	 */

--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
@@ -23,8 +23,6 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensus
     protected loadCore(storage: IChannelStorageService): Promise<void>;
     // (undocumented)
     protected onDisconnect(): void;
-    // (undocumented)
-    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void;
     // (undocumented)
     protected release(acquireId: string): void;

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -10,10 +10,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import type {
 	ISummaryTreeWithStats,
 	IRuntimeMessageCollection,
@@ -305,22 +302,6 @@ export class ConsensusOrderedCollection<T = any>
 				this.emit("localRelease", value, false /* intentional */);
 			}
 		}
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/pact-map/src/pactMap.ts
+++ b/packages/dds/pact-map/src/pactMap.ts
@@ -10,10 +10,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -390,22 +387,6 @@ export class PactMapClass<T = unknown>
 
 		// Otherwise we can resubmit
 		this.submitLocalMessage(pactMapOp, localOpMetadata);
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/register-collection/api-report/register-collection.legacy.beta.api.md
+++ b/packages/dds/register-collection/api-report/register-collection.legacy.beta.api.md
@@ -20,8 +20,6 @@ export class ConsensusRegisterCollectionClass<T> extends SharedObject<IConsensus
     protected loadCore(storage: IChannelStorageService): Promise<void>;
     // (undocumented)
     protected onDisconnect(): void;
-    // (undocumented)
-    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void;
     read(key: string, readPolicy?: ReadPolicy): T | undefined;
     // (undocumented)

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -10,10 +10,7 @@ import {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import {
 	ISummaryTreeWithStats,
 	IRuntimeMessageCollection,
@@ -276,22 +273,6 @@ export class ConsensusRegisterCollection<T>
 	}
 
 	protected onDisconnect() {}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
-	}
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -864,22 +864,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 		}
 	}
 
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
-	}
-
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}
 	 */

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.beta.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.beta.api.md
@@ -80,9 +80,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: unknown) => void) => void): Promise<T>;
     protected onConnect(): void;
     protected abstract onDisconnect(): void;
-    // @deprecated
-    protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    protected processMessagesCore?(messagesCollection: IRuntimeMessageCollection): void;
+    protected abstract processMessagesCore(messagesCollection: IRuntimeMessageCollection): void;
     protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
     protected reSubmitSquashed(content: unknown, localOpMetadata: unknown): void;
     protected rollback(content: unknown, localOpMetadata: unknown): void;

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -178,20 +178,6 @@ export abstract class SharedObjectCore<
 		const { opProcessingHelper, callbacksHelper } = this.setUpSampledTelemetryHelpers();
 		this.opProcessingHelper = opProcessingHelper;
 		this.callbacksHelper = callbacksHelper;
-
-		const processMessagesCore = this.processMessagesCore?.bind(this);
-		this.processMessagesHelper =
-			processMessagesCore === undefined
-				? (messagesCollection: IRuntimeMessageCollection) =>
-						processHelper(messagesCollection, this.process.bind(this))
-				: (messagesCollection: IRuntimeMessageCollection) => {
-						processMessagesCoreHelper(
-							messagesCollection,
-							this.opProcessingHelper,
-							this.emitInternal.bind(this),
-							processMessagesCore,
-						);
-					};
 	}
 
 	/**
@@ -409,25 +395,10 @@ export abstract class SharedObjectCore<
 		return;
 	}
 
-	/**
-	 * Derived classes must override this to do custom processing on a remote message.
-	 * @param message - The message to process
-	 * @param local - True if the shared object is local
-	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
-	 * For messages from a remote client, this will be undefined.
-	 *
-	 * @deprecated Replaced by {@link SharedObjectCore.processMessagesCore}.
-	 */
-	protected abstract processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void;
-
 	/* eslint-disable jsdoc/check-indentation */
 	/**
+	 * Derived classes must override this to do custom processing on a bunch of remote messages.
 	 * Process a 'bunch' of messages for this shared object.
-	 *
 	 * @remarks
 	 * A 'bunch' is a group of messages that have the following properties:
 	 * - They are all part of the same grouped batch, which entails:
@@ -441,16 +412,7 @@ export abstract class SharedObjectCore<
 	 *
 	 */
 	/* eslint-enable jsdoc/check-indentation */
-	protected processMessagesCore?(messagesCollection: IRuntimeMessageCollection): void;
-
-	/**
-	 * Calls {@link SharedObjectCore.processCore} or {@link SharedObjectCore.processMessagesCore} depending on whether
-	 * processMessagesCore is defined. This helper is used to keep the code cleaner while we have to support both these
-	 * function.
-	 */
-	private readonly processMessagesHelper: (
-		messagesCollection: IRuntimeMessageCollection,
-	) => void;
+	protected abstract processMessagesCore(messagesCollection: IRuntimeMessageCollection): void;
 
 	/**
 	 * Called when the object has disconnected from the delta stream.
@@ -628,39 +590,6 @@ export abstract class SharedObjectCore<
 		}
 	}
 
-	/**
-	 * Handles a message being received from the remote delta server.
-	 * @param message - The message to process
-	 * @param local - Whether the message originated from the local client
-	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
-	 * For messages from a remote client, this will be undefined.
-	 *
-	 * @deprecated Replaced by {@link SharedObjectCore.processMessages}.
-	 */
-	private process(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.verifyNotClosed(); // This will result in container closure.
-		this.emitInternal("pre-op", message, local, this);
-
-		this.opProcessingHelper.measure(
-			(): ICustomData<ProcessTelemetryProperties> => {
-				this.processCore(message, local, localOpMetadata);
-				const telemetryProperties: ProcessTelemetryProperties = {
-					sequenceDifference: message.sequenceNumber - message.referenceSequenceNumber,
-				};
-				return {
-					customData: telemetryProperties,
-				};
-			},
-			local ? "local" : "remote",
-		);
-
-		this.emitInternal("op", message, local, this);
-	}
-
 	/* eslint-disable jsdoc/check-indentation */
 	/**
 	 * Process a bunch of messages for this shared object. A bunch is group of messages that have the following properties:
@@ -677,13 +606,11 @@ export abstract class SharedObjectCore<
 	private processMessages(messagesCollection: IRuntimeMessageCollection): void {
 		this.verifyNotClosed(); // This will result in container closure.
 
+		const { envelope, local, messagesContent } = messagesCollection;
+
 		// Decode any handles in the contents before processing the messages.
 		const decodedMessagesContent: IRuntimeMessagesContent[] = [];
-		for (const {
-			contents,
-			localOpMetadata,
-			clientSequenceNumber,
-		} of messagesCollection.messagesContent) {
+		for (const { contents, localOpMetadata, clientSequenceNumber } of messagesContent) {
 			const decodedMessageContent: IRuntimeMessagesContent = {
 				contents: parseHandles(contents, this.serializer),
 				localOpMetadata,
@@ -692,11 +619,36 @@ export abstract class SharedObjectCore<
 			decodedMessagesContent.push(decodedMessageContent);
 		}
 
-		const decodedMessagesCollection: IRuntimeMessageCollection = {
-			...messagesCollection,
-			messagesContent: decodedMessagesContent,
+		const emitEvents = (event: "pre-op" | "op"): void => {
+			for (const { contents, clientSequenceNumber } of decodedMessagesContent) {
+				const message: ISequencedDocumentMessage = {
+					...envelope,
+					contents,
+					clientSequenceNumber,
+				};
+				this.emitInternal(event, message, local);
+			}
 		};
-		this.processMessagesHelper(decodedMessagesCollection);
+
+		emitEvents("pre-op");
+		this.opProcessingHelper.measure(
+			(): ICustomData<ProcessTelemetryProperties> => {
+				const decodedMessagesCollection: IRuntimeMessageCollection = {
+					envelope,
+					local,
+					messagesContent: decodedMessagesContent,
+				};
+				this.processMessagesCore(decodedMessagesCollection);
+				const telemetryProperties: ProcessTelemetryProperties = {
+					sequenceDifference: envelope.sequenceNumber - envelope.referenceSequenceNumber,
+				};
+				return {
+					customData: telemetryProperties,
+				};
+			},
+			local ? "local" : "remote",
+		);
+		emitEvents("op");
 	}
 
 	/**
@@ -1069,76 +1021,4 @@ export function createSharedObjectKind<TSharedObject>(
 function isChannel(loadable: IFluidLoadable): loadable is IChannel {
 	// This assumes no other IFluidLoadable has an `attributes` field, and thus may not be fully robust.
 	return (loadable as IChannel).attributes !== undefined;
-}
-
-/**
- * Utility that processes the given messages in the message collection together by calling `processMessagesCore`.
- * This will be called when {@link SharedObjectCore.processMessagesCore} is defined.
- */
-function processMessagesCoreHelper(
-	messagesCollection: IRuntimeMessageCollection,
-	opProcessingHelper: SampledTelemetryHelper<void, ProcessTelemetryProperties>,
-	emitInternal: (
-		event: "pre-op" | "op",
-		op: ISequencedDocumentMessage,
-		local: boolean,
-	) => void,
-	processMessagesCore: (messagesCollection: IRuntimeMessageCollection) => void,
-): void {
-	const { envelope, local, messagesContent } = messagesCollection;
-
-	const emitEvents = (
-		event: "pre-op" | "op",
-		messagesContentForEvent: readonly IRuntimeMessagesContent[],
-	): void => {
-		for (const { contents, clientSequenceNumber } of messagesContentForEvent) {
-			const message: ISequencedDocumentMessage = {
-				...envelope,
-				contents,
-				clientSequenceNumber,
-			};
-			emitInternal(event, message, local);
-		}
-	};
-
-	emitEvents("pre-op", messagesContent);
-	opProcessingHelper.measure(
-		(): ICustomData<ProcessTelemetryProperties> => {
-			processMessagesCore(messagesCollection);
-			const telemetryProperties: ProcessTelemetryProperties = {
-				sequenceDifference: envelope.sequenceNumber - envelope.referenceSequenceNumber,
-			};
-			return {
-				customData: telemetryProperties,
-			};
-		},
-		local ? "local" : "remote",
-	);
-	emitEvents("op", messagesContent);
-}
-
-/**
- * Utility that processes the given messages in the message collection one by one by calling `process`. This will
- * be called when {@link SharedObjectCore.processMessagesCore} is not defined.
- */
-function processHelper(
-	messagesCollection: IRuntimeMessageCollection,
-	process: (
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	) => void,
-): void {
-	const { envelope, local, messagesContent } = messagesCollection;
-	for (const { contents, localOpMetadata, clientSequenceNumber } of messagesContent) {
-		process(
-			{
-				...envelope,
-				contents,
-				clientSequenceNumber,
-			},
-			local,
-			localOpMetadata,
-		);
-	}
 }

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -397,8 +397,7 @@ export abstract class SharedObjectCore<
 
 	/* eslint-disable jsdoc/check-indentation */
 	/**
-	 * Derived classes must override this to do custom processing on a bunch of remote messages.
-	 * Process a 'bunch' of messages for this shared object.
+	 * Derived classes must override this to do custom processing on a 'bunch' of remote messages.
 	 * @remarks
 	 * A 'bunch' is a group of messages that have the following properties:
 	 * - They are all part of the same grouped batch, which entails:

--- a/packages/dds/shared-object-base/src/sharedObjectKernel.ts
+++ b/packages/dds/shared-object-base/src/sharedObjectKernel.ts
@@ -203,10 +203,6 @@ class SharedObjectFromKernel<
 		this.#kernel.applyStashedOp(content);
 	}
 
-	protected override processCore(): void {
-		fail("processCore should not be called");
-	}
-
 	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
 		this.#kernel.processMessagesCore(messagesCollection);
 	}

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -16,7 +16,6 @@ import type {
 	IChannelStorageService,
 	IDeltaConnection,
 } from "@fluidframework/datastore-definitions/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
@@ -30,7 +29,7 @@ import { SharedObject } from "../sharedObject.js";
 
 /* eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-unsafe-function-type --
 	Trying to use specific function signatures here instead of Function makes it so some of the properties of
-	OverridableType below (summarizeCore, loadCore, processCore) end up not typed correctly */
+	OverridableType below (summarizeCore, loadCore, processMessagesCore) end up not typed correctly */
 type Overridable<T> = T extends Function | string | number | undefined | []
 	? T
 	: {
@@ -65,12 +64,6 @@ type OverridableType = Overridable<{
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
 	) => ISummaryTreeWithStats;
 	loadCore: (this: SharedObject, services: IChannelStorageService) => Promise<void>;
-	processCore: (
-		this: SharedObject,
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	) => void;
 	processMessagesCore: (
 		this: SharedObject,
 		messagesCollection: IRuntimeMessageCollection,
@@ -87,7 +80,6 @@ function createTestSharedObject(overrides: OverridableType): {
 	class TestSharedObject extends SharedObject {
 		protected summarizeCore = overrides?.summarizeCore?.bind(this);
 		protected loadCore = overrides?.loadCore?.bind(this);
-		protected processCore = overrides?.processCore?.bind(this);
 		protected processMessagesCore = overrides?.processMessagesCore?.bind(this);
 		protected onDisconnect = overrides?.onDisconnect?.bind(this);
 		protected applyStashedOp = overrides?.applyStashedOp?.bind(this);

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -13,7 +13,6 @@ import type {
 	IChannelStorageService,
 	IFluidDataStoreRuntimeInternalConfig,
 } from "@fluidframework/datastore-definitions/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	IGarbageCollectionData,
 	ISummaryTreeWithStats,
@@ -45,13 +44,6 @@ class MySharedObject extends SharedObject {
 		throw new Error("Method not implemented.");
 	}
 	protected async loadCore(services: IChannelStorageService): Promise<void> {
-		throw new Error("Method not implemented.");
-	}
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
 		throw new Error("Method not implemented.");
 	}
 	protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
@@ -107,13 +99,6 @@ class MySharedObjectCore extends SharedObjectCore {
 		throw new Error("Method not implemented.");
 	}
 	protected async loadCore(services: IChannelStorageService): Promise<void> {
-		throw new Error("Method not implemented.");
-	}
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
 		throw new Error("Method not implemented.");
 	}
 	protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -9,7 +9,6 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -100,13 +99,6 @@ export class SharedSummaryBlockClass extends SharedObject implements ISharedSumm
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.onDisconnect}
 	 */
 	protected onDisconnect(): void {}
-
-	/**
-	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processCore}
-	 */
-	protected processCore(message: ISequencedDocumentMessage, local: boolean): void {
-		throw new Error("shared summary block should not generate any ops.");
-	}
 
 	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processMessagesCore}

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -14,10 +14,7 @@ import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type {
 	ISummaryTreeWithStats,
@@ -96,7 +93,7 @@ export class TaskManagerClass
 	 */
 	private readonly taskQueues = new Map<string, string[]>();
 
-	// opWatcher emits for every op on this data store.  This is just a repackaging of processCore into events.
+	// opWatcher emits for every op on this data store.  This is just a repackaging of processMessagesCore into events.
 	private readonly opWatcher: EventEmitter = new EventEmitter();
 	// queueWatcher emits an event whenever the consensus state of the task queues changes
 	private readonly queueWatcher: EventEmitter = new EventEmitter();
@@ -696,22 +693,6 @@ export class TaskManagerClass
 		if (pendingOps.length === 0) {
 			this.latestPendingOps.delete(content.taskId);
 		}
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessage(
-			message,
-			{
-				contents: message.contents,
-				localOpMetadata,
-				clientSequenceNumber: message.clientSequenceNumber,
-			},
-			local,
-		);
 	}
 
 	/**

--- a/packages/dds/test-dds-utils/src/test/sharedNothing.ts
+++ b/packages/dds/test-dds-utils/src/test/sharedNothing.ts
@@ -51,9 +51,6 @@ class SharedNothing extends SharedObject {
 		this.applyStashedOpCalls++;
 		this.methodCalls.push("applyStashedOp");
 	}
-	protected processCore(): void {
-		throw new Error("processCore should not be called on SharedNothing");
-	}
 	protected processMessagesCore(): void {
 		this.processMessagesCoreCalls++;
 		this.methodCalls.push("processMessagesCore");

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -58,7 +58,6 @@ import {
 	type ISharedObject,
 	type ISharedObjectHandle,
 } from "@fluidframework/shared-object-base/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	ISummaryTreeWithStats,
 	IExperimentalIncrementalSummaryContext,
@@ -339,14 +338,6 @@ export class TestSharedTreeCore extends SharedObject {
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats {
 		return this.kernel.summarizeCore(serializer, telemetryContext, incrementalSummaryContext);
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		fail("processCore should not be called on SharedTree");
 	}
 
 	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
@@ -16,10 +16,7 @@ import {
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
 import { SummaryObject, SummaryType } from "@fluidframework/driver-definitions";
-import {
-	MessageType,
-	type ISequencedDocumentMessage,
-} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import {
 	IExperimentalIncrementalSummaryContext,
@@ -154,23 +151,6 @@ class TestIncrementalSummaryBlobDDS extends SharedObject {
 			const blobContent = await readAndParse<IBlob>(storage, blob);
 			this.blobMap.set(blob, blobContent);
 		}
-	}
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessagesCore({
-			envelope: message,
-			local,
-			messagesContent: [
-				{
-					contents: message.contents,
-					localOpMetadata,
-					clientSequenceNumber: message.clientSequenceNumber,
-				},
-			],
-		});
 	}
 	protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
 		const { envelope, messagesContent } = messagesCollection;
@@ -389,24 +369,6 @@ class TestIncrementalSummaryTreeDDSClass extends SharedObject {
 			node.children.push(childNode);
 		}
 		return node;
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessagesCore({
-			envelope: message,
-			local,
-			messagesContent: [
-				{
-					contents: message.contents,
-					localOpMetadata,
-					clientSequenceNumber: message.clientSequenceNumber,
-				},
-			],
-		});
 	}
 
 	protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {


### PR DESCRIPTION
## Description
Removed deprecated property `processCore` from `SharedObject` and all its implementations.

## Breaking Changes
This is a breaking change. The deprecations were announced in release [2.22.0](https://github.com/microsoft/FluidFramework/releases/tag/client_v2.22.0).