### PR TITLE
feat(client): Container Extensions operation during CatchingUp

### DIFF
--- a/packages/runtime/container-runtime-definitions/src/containerExtension.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerExtension.ts
@@ -282,7 +282,7 @@ export interface ExtensionHost<TRuntimeProperties extends ExtensionRuntimeProper
 	 * @remarks
 	 * Status changes are signaled through :
 	 * - {@link ExtensionHostEvents.disconnected}: Transitioning to Disconnected state
-	 * - {@link ExtensionHostEvents.joined}: Transition to Connected state (either for reading or writing)
+	 * - {@link ExtensionHostEvents.joined}: Transition to CatchingUp or Connected state (either for reading or writing)
 	 * - {@link ExtensionHostEvents.operabilityChanged}: When operability has changed (e.g., write to read)
 	 */
 	readonly getJoinedStatus: () => JoinedStatus;
@@ -313,6 +313,13 @@ export interface ExtensionHost<TRuntimeProperties extends ExtensionRuntimeProper
 	 */
 	getQuorum: () => IQuorumClients;
 
+	/**
+	 * The collection of all clients as enumerated by the service.
+	 *
+	 * @remarks This may include/exclude those found within the quorum.
+	 * It produces results faster than {@link ExtensionHost.getQuorum}, but
+	 * will be inaccurate if any signals are lost.
+	 */
 	getAudience: () => IAudience;
 }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1569,6 +1569,7 @@ export class ContainerRuntime
 			deltaManager,
 			quorum,
 			audience,
+			signalAudience,
 			pendingLocalState,
 			supportedFeatures,
 			snapshotWithContents,
@@ -1723,7 +1724,8 @@ export class ContainerRuntime
 		// Later updates come through calls to setConnectionState/Status.
 		this.canSendOps = connected;
 		this.canSendSignals = this.getConnectionState
-			? this.getConnectionState() === ConnectionState.Connected
+			? this.getConnectionState() === ConnectionState.Connected ||
+				this.getConnectionState() === ConnectionState.CatchingUp
 			: undefined;
 
 		this.mc.logger.sendTelemetryEvent({
@@ -2038,6 +2040,8 @@ export class ContainerRuntime
 				oldClientId = clientId;
 			});
 		}
+
+		this.signalAudience = signalAudience;
 
 		const closeSummarizerDelayOverride = this.mc.config.getNumber(
 			"Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs",
@@ -2948,7 +2952,7 @@ export class ContainerRuntime
 	 * Emits service connection events based on connection state changes.
 	 *
 	 * @remarks
-	 * "connectedToService" is emitted when container connection state transitions to 'Connected' regardless of connection mode.
+	 * "connectedToService" is emitted when container connection state transitions to 'CatchingUp' or 'Connected' regardless of connection mode.
 	 * "disconnectedFromService" excludes false "disconnected" events that happen when readonly client transitions to 'Connected'.
 	 */
 	private emitServiceConnectionEvents(
@@ -2960,16 +2964,20 @@ export class ContainerRuntime
 			return;
 		}
 
-		const canSendSignals = this.getConnectionState() === ConnectionState.Connected;
+		const connectionState = this.getConnectionState();
+		const canSendSignals =
+			connectionState === ConnectionState.Connected ||
+			connectionState === ConnectionState.CatchingUp;
 		const canSendSignalsChanged = this.canSendSignals !== canSendSignals;
 		this.canSendSignals = canSendSignals;
 		if (canSendSignalsChanged) {
-			// If canSendSignals changed, we either transitioned from Connected to Disconnected or CatchingUp to Connected
+			// If canSendSignals changed, we either transitioned from CatchingUp or
+			// Connected to Disconnected or EstablishingConnection to CatchingUp.
 			if (canSendSignals) {
-				// Emit for CatchingUp to Connected transition
+				// Emit for EstablishingConnection to CatchingUp or Connected transition
 				this.emit("connectedToService", clientId, canSendOps);
 			} else {
-				// Emit for Connected to Disconnected transition
+				// Emit for CatchingUp or Connected to Disconnected transition
 				this.emit("disconnectedFromService");
 			}
 		} else if (canSendOpsChanged) {
@@ -3731,6 +3739,14 @@ export class ContainerRuntime
 	public getAudience(): IAudience {
 		return this._audience;
 	}
+
+	/**
+	 * When defined, this {@link @fluidframework/container-definitions#IAudience}
+	 * maintains member list using signals only.
+	 * Thus "write" members may be known earlier than quorum and avoid noise from
+	 * un-summarized quorum history.
+	 */
+	private readonly signalAudience?: IAudience;
 
 	/**
 	 * Returns true of container is dirty, i.e. there are some pending local changes that
@@ -5239,7 +5255,11 @@ export class ContainerRuntime
 		const getConnectionState = this.getConnectionState;
 		if (getConnectionState) {
 			const connectionState = getConnectionState();
-			if (connectionState === ConnectionState.Connected) {
+			if (
+				connectionState === ConnectionState.Connected ||
+				connectionState === ConnectionState.CatchingUp
+			) {
+				// Note: when CatchingUp, canSendOps will always be false.
 				return this.canSendOps ? "joinedForWriting" : "joinedForReading";
 			}
 		} else if (this.canSendOps) {
@@ -5265,9 +5285,10 @@ export class ContainerRuntime
 	): T {
 		let entry = this.extensions.get(id);
 		if (entry === undefined) {
+			const audience = this.signalAudience;
 			const runtime = {
 				getJoinedStatus: this.getJoinedStatus.bind(this),
-				getClientId: () => this.clientId,
+				getClientId: audience ? () => audience.getSelf()?.clientId : () => this.clientId,
 				events: this.lazyEventsForExtensions.value,
 				logger: this.baseLogger,
 				submitAddressedSignal: (
@@ -5277,7 +5298,7 @@ export class ContainerRuntime
 					this.submitExtensionSignal(id, addressChain, message);
 				},
 				getQuorum: this.getQuorum.bind(this),
-				getAudience: this.getAudience.bind(this),
+				getAudience: audience ? () => audience : this.getAudience.bind(this),
 				supportedFeatures: this.ILayerCompatDetails.supportedFeatures,
 			} satisfies ExtensionHost<TRuntimeProperties>;
 			entry = new factory(runtime, ...useContext);

--- a/packages/runtime/container-runtime/src/test/containerRuntime.extensions.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.extensions.spec.ts
@@ -269,8 +269,8 @@ describe("Runtime", () => {
 
 					assert.strictEqual(
 						extension.connectedToService,
-						false,
-						"Extension should be disconnected during CatchingUp state",
+						true,
+						"Extension should be connected during CatchingUp state",
 					);
 				});
 
@@ -379,22 +379,26 @@ describe("Runtime", () => {
 
 					// Transition to CatchingUp
 					updateConnectionState(runtime, context, ConnectionState.CatchingUp, "mockClientId");
+					assert.strictEqual(events.length, 1, "Should have received one joined event");
+					assert.deepStrictEqual(
+						events[0],
+						{ type: "joined", clientId: "mockClientId", canWrite: false },
+						"First event should be joined for reading",
+					);
 					assert.strictEqual(
 						extension.connectedToService,
-						false,
-						"Extension should be disconnected during CatchingUp",
+						true,
+						"Extension should be connected during CatchingUp",
 					);
-					assert.strictEqual(events.length, 0, "Should have no events during CatchingUp");
 
 					// Transition to Connected
 					updateConnectionState(runtime, context, ConnectionState.Connected, "mockClientId");
-					assert.strictEqual(events.length, 1, "Should have received one joined events");
+					assert.strictEqual(events.length, 2, "Should have received two events total");
 					assert.deepStrictEqual(
-						events[0],
-						{ type: "joined", clientId: "mockClientId", canWrite: true },
-						"First event should be joined for writing",
+						events[1],
+						{ type: "operabilityChanged", canWrite: true },
+						"Second event should be operabilityChanged to can write",
 					);
-
 					assert.strictEqual(
 						extension.connectedToService,
 						true,
@@ -403,11 +407,11 @@ describe("Runtime", () => {
 
 					// Transition back to Disconnected
 					updateConnectionState(runtime, context, ConnectionState.Disconnected);
-					assert.strictEqual(events.length, 2, "Should have received two events total");
+					assert.strictEqual(events.length, 3, "Should have received three events total");
 					assert.deepStrictEqual(
-						events[1],
+						events[2],
 						{ type: "disconnected" },
-						"Second event should be disconnected",
+						"Third event should be disconnected",
 					);
 					assert.strictEqual(
 						extension.connectedToService,
@@ -462,21 +466,8 @@ describe("Runtime", () => {
 					);
 					assert.strictEqual(
 						readOnlyExtension.connectedToService,
-						false,
-						"Extension should be disconnected during CatchingUp",
-					);
-					assert.strictEqual(
-						readOnlyEvents.length,
-						0,
-						"Should have no events during CatchingUp",
-					);
-
-					// Transition to Connected
-					updateConnectionState(
-						readOnlyRuntime,
-						readOnlyContext,
-						ConnectionState.Connected,
-						"mockClientId",
+						true,
+						"Extension should be connected during CatchingUp",
 					);
 					assert.strictEqual(
 						readOnlyEvents.length,
@@ -488,6 +479,15 @@ describe("Runtime", () => {
 						{ type: "joined", clientId: "mockClientId", canWrite: false },
 						"Event should be joined for reading",
 					);
+
+					// Transition to Connected
+					updateConnectionState(
+						readOnlyRuntime,
+						readOnlyContext,
+						ConnectionState.Connected,
+						"mockClientId",
+					);
+					assert.strictEqual(readOnlyEvents.length, 1, "Should have received one event total");
 					assert.strictEqual(
 						readOnlyExtension.connectedToService,
 						true,


### PR DESCRIPTION
- "connectedToService" is emitted for CatchingUp (ahead of Connected)
- Signal only Audience will be sent to provide information sooner and allow early activity.

Presence limits quorum use to ordering of fallback Join responses, which are expected to happen later and often when quorum is more complete.