### PR TITLE
improvement(client-datastore): BREAKING CHANGE: remove FluidDataStoreRuntime.submitMessage

### DIFF
--- a/.changeset/odd-loops-flash.md
+++ b/.changeset/odd-loops-flash.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/datastore": minor
+"@fluidframework/test-runtime-utils": minor
+"__section": breaking
+---
+Remove submitMessage from FluidDataStoreRuntime and MockFluidDataStoreRuntime
+
+As needed, access `submitMessage` via `IFluidDataStoreContext`/`IFluidParentContext`. See https://github.com/microsoft/FluidFramework/issues/24406 for details.

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -155,6 +155,9 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"Interface_DataObjectFactoryProps": {
+				"backCompat": false
+			},
 			"Interface_IDataObjectProps": {
 				"backCompat": false
 			}

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -283,6 +283,7 @@ declare type old_as_current_for_Interface_DataObjectFactoryProps = requireAssign
  * typeValidation.broken:
  * "Interface_DataObjectFactoryProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_DataObjectFactoryProps = requireAssignableTo<TypeOnly<current.DataObjectFactoryProps<never>>, TypeOnly<old.DataObjectFactoryProps<never>>>
 
 /*

--- a/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
@@ -93,8 +93,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
-    // @deprecated
-    submitMessage(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
     submitSignal(type: string, content: unknown, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -157,7 +157,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_FluidDataStoreRuntime": {
+				"backCompat": false
+			},
+			"ClassStatics_FluidDataStoreRuntime": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1171,21 +1171,6 @@ export class FluidDataStoreRuntime
 	}
 
 	/**
-	 * Do not use.
-	 * @deprecated Use `IFluidDataStoreContext.submitMessage` instead.
-	 * @see https://github.com/microsoft/FluidFramework/issues/24406
-	 */
-	public submitMessage(
-		type: DataStoreMessageType,
-		// TODO: use something other than `any` here (breaking change)
-		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-		content: any,
-		localOpMetadata: unknown,
-	): void {
-		this.submit(type, content, localOpMetadata);
-	}
-
-	/**
 	 * Submits the signal to be sent to other clients.
 	 * @param type - Type of the signal.
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -31,6 +31,7 @@ declare type old_as_current_for_Class_FluidDataStoreRuntime = requireAssignableT
  * typeValidation.broken:
  * "Class_FluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.FluidDataStoreRuntime>, TypeOnly<old.FluidDataStoreRuntime>>
 
 /*
@@ -58,6 +59,7 @@ declare type current_as_old_for_Class_FluidObjectHandle = requireAssignableTo<Ty
  * typeValidation.broken:
  * "ClassStatics_FluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<typeof current.FluidDataStoreRuntime>, TypeOnly<typeof old.FluidDataStoreRuntime>>
 
 /*

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
@@ -501,8 +501,6 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
-    // @deprecated (undocumented)
-    submitMessage(type: MessageType, content: any): null;
     // (undocumented)
     submitSignal(type: string, content: any): null;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -157,7 +157,13 @@
 			"Class_MockFluidDataStoreContext": {
 				"backCompat": false
 			},
+			"Class_MockFluidDataStoreRuntime": {
+				"backCompat": false
+			},
 			"ClassStatics_MockFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"ClassStatics_MockFluidDataStoreRuntime": {
 				"backCompat": false
 			},
 			"Class_MockObjectStorageService": {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -1044,14 +1044,6 @@ export class MockFluidDataStoreRuntime
 		return null;
 	}
 
-	/**
-	 * @deprecated Use `IFluidDataStoreContext.submitMessage` instead.
-	 * @see https://github.com/microsoft/FluidFramework/issues/24406
-	 */
-	public submitMessage(type: MessageType, content: any) {
-		return null;
-	}
-
 	private submitMessageInternal(messageContent: any, localOpMetadata: unknown): number {
 		assert(
 			this.containerRuntime !== undefined,

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -194,6 +194,7 @@ declare type old_as_current_for_Class_MockFluidDataStoreRuntime = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.MockFluidDataStoreRuntime>, TypeOnly<old.MockFluidDataStoreRuntime>>
 
 /*
@@ -377,6 +378,7 @@ declare type current_as_old_for_ClassStatics_MockFluidDataStoreContext = require
  * typeValidation.broken:
  * "ClassStatics_MockFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<typeof current.MockFluidDataStoreRuntime>, TypeOnly<typeof old.MockFluidDataStoreRuntime>>
 
 /*


### PR DESCRIPTION
remove FluidDataStoreRuntime.submitMessage and MockFluidDataStoreRuntime.submitMessage
