### PR TITLE
feat(client-loader): breakout `readonly` explicitly on ConnectionStatus

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
@@ -70,6 +70,7 @@ export interface ConnectionStatusTemplate {
     canSendOps: boolean;
     // (undocumented)
     connectionState: ConnectionState;
+    readonly: boolean;
 }
 
 // @beta @legacy

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -69,6 +69,10 @@ export interface ConnectionStatusTemplate {
 	 * True if the runtime is currently allowed to send ops.
 	 */
 	canSendOps: boolean;
+	/**
+	 * True if the container is in readonly mode.
+	 */
+	readonly: boolean;
 }
 
 /**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2558,6 +2558,7 @@ export class Container
 						setConnectionStatus({
 							connectionState,
 							canSendOps: false,
+							readonly,
 						});
 
 						break;
@@ -2570,6 +2571,7 @@ export class Container
 							connectionState,
 							pendingClientConnectionId,
 							canSendOps: false,
+							readonly,
 						});
 
 						break;
@@ -2587,6 +2589,7 @@ export class Container
 							connectionState,
 							clientConnectionId,
 							canSendOps: !readonly,
+							readonly,
 						});
 
 						break;
@@ -2597,6 +2600,7 @@ export class Container
 							priorPendingClientConnectionId: pendingClientConnectionId,
 							priorConnectedClientConnectionId: this.clientId,
 							canSendOps: false,
+							readonly,
 						});
 
 						break;

--- a/packages/runtime/container-runtime/src/test/containerRuntime.extensions.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.extensions.spec.ts
@@ -173,6 +173,7 @@ function updateConnectionState(
 			runtime.setConnectionStatus({
 				connectionState,
 				canSendOps: false,
+				readonly: context.isReadonly,
 			});
 
 			break;
@@ -183,6 +184,7 @@ function updateConnectionState(
 				connectionState,
 				pendingClientConnectionId: clientId,
 				canSendOps: false,
+				readonly: context.isReadonly,
 			});
 
 			break;
@@ -193,6 +195,7 @@ function updateConnectionState(
 				connectionState,
 				clientConnectionId: clientId,
 				canSendOps: !context.isReadonly,
+				readonly: context.isReadonly,
 			});
 
 			break;
@@ -201,6 +204,7 @@ function updateConnectionState(
 			runtime.setConnectionStatus({
 				connectionState,
 				canSendOps: false,
+				readonly: context.isReadonly,
 				priorPendingClientConnectionId: context.signalAudience?.getSelf()?.clientId,
 				priorConnectedClientConnectionId: context.clientId,
 			});


### PR DESCRIPTION
to add clarity apart from canSendOps