### PR TITLE
Freeze AllowedTypes

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -4,7 +4,7 @@
  */
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { assert, Lazy } from "@fluidframework/core-utils/internal";
+import { Lazy } from "@fluidframework/core-utils/internal";
 
 import {
 	type ErasedBaseType,
@@ -332,7 +332,7 @@ export class AnnotatedAllowedTypesInternal<
 	public static create<const T extends readonly AnnotatedAllowedType[]>(
 		types: T,
 		metadata: AllowedTypesMetadata = {},
-	): AnnotatedAllowedTypesInternal<T> & AllowedTypesFull<T> {
+	): AnnotatedAllowedTypesInternal<Readonly<T>> & AllowedTypesFull<Readonly<T>> {
 		const result = new AnnotatedAllowedTypesInternal(types, metadata);
 		return result as typeof result & UnannotateAllowedTypesList<T>;
 	}
@@ -340,7 +340,8 @@ export class AnnotatedAllowedTypesInternal<
 	public static createUnannotated<const T extends AllowedTypes>(
 		types: T,
 		metadata: AllowedTypesMetadata = {},
-	): AnnotatedAllowedTypesInternal & T {
+	): AnnotatedAllowedTypesInternal & Readonly<T> {
+		Object.freeze(types);
 		const annotatedTypes: AnnotatedAllowedType[] = types.map(normalizeToAnnotatedAllowedType);
 		const result = AnnotatedAllowedTypesInternal.create(annotatedTypes, metadata);
 		return result as typeof result & T;
@@ -349,6 +350,7 @@ export class AnnotatedAllowedTypesInternal<
 	public static createMixed<
 		const T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[],
 	>(types: T, metadata: AllowedTypesMetadata = {}): AllowedTypesFullFromMixed<T> {
+		Object.freeze(types);
 		const annotatedTypes: AnnotatedAllowedType[] = types.map(normalizeToAnnotatedAllowedType);
 		const result = AnnotatedAllowedTypesInternal.create(annotatedTypes, metadata);
 		return result as AllowedTypesFullFromMixed<T>;
@@ -524,14 +526,9 @@ export function normalizeAllowedTypesInternal(
 	// Adding this cache improved the performance of the "large recursive union" test (which mostly just constructs a TreeConfiguration) by ~5 times.
 	// This cache is strictly a performance optimization: it is not required for correctness.
 	return getOrCreate(cachedNormalize, type, () => {
-		// Due to more specific internal type, the above does not narrow sufficiently, so more narrowing is needed.
-		// It is possible this will give a false error if a TreeNodeSchema which matches this check is used.
-		assert(
-			!("types" in type && "metadata" in type),
-			0xc7d /* invalid AnnotatedAllowedTypes */,
-		);
-
-		const annotatedTypes: AnnotatedAllowedType[] = (isReadonlyArray(type) ? type : [type]).map(
+		const inputArray = isReadonlyArray(type) ? type : [type];
+		Object.freeze(inputArray);
+		const annotatedTypes: AnnotatedAllowedType[] = inputArray.map(
 			normalizeToAnnotatedAllowedType,
 		);
 
@@ -637,8 +634,8 @@ export type TreeNodeFromImplicitAllowedTypes<
  * This type exists only to be linked from documentation to provide a single linkable place to document some details of
  * "Input" types and how they handle schema.
  *
- * When a schema is used to describe data which is an input into an API, the API is [contravariant](https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)) over the schema.
- * (See also, [TypeScript Variance Annotations](https://www.typescriptlang.org/docs/handbook/2/generics.html#variance-annotations)).
+ * When a schema is used to describe data which is an input into an API, the API is {@link https://en.wikipedia.org/wiki/Type_variance | contravariant}) over the schema.
+ * (See also {@link https://www.typescriptlang.org/docs/handbook/2/generics.html#variance-annotations | TypeScript Variance Annotations}).
  *
  * Since these schema are expressed using TypeScript types, it is possible for the user of the API to provide non-exact values of these types which has implications that depended on the variance.
  *

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -568,4 +568,38 @@ describe("allowedTypes", () => {
 			type X7 = InsertableTreeFieldFromImplicitField<typeof Canvas.info.stuff>;
 		});
 	});
+
+	// If derived data is computed based on a allowed type array, then modifications to that array would cause the derived data to become invalid.
+	// As there is no invalidation mechanism, this would lead to incorrect behavior, and is prevented by freezing the arrays when the derived data is computed.
+	// Note that cases where adding to the array would not produce invalid data are not required to freeze the array: more cases could be made to allow mutations by deriving data at a later point.
+	// If done, these tests may need updates to instead test that modifying the arrays does not expose incorrect derived data.
+	describe("freezes inputs producing derived data", () => {
+		it("AnnotatedAllowedTypesInternal.create", () => {
+			const input = [{ type: stringSchema, metadata: {} }];
+			const result = AnnotatedAllowedTypesInternal.create(input);
+			assert(Object.isFrozen(input));
+			assert.throws(() => {
+				// @ts-expect-error Array should be readonly, so this error is good.
+				result.push(stringSchema);
+			}, "TypeError: result.push is not a function");
+		});
+
+		it("normalizeAllowedTypes", () => {
+			const input = [stringSchema];
+			const _ = normalizeAllowedTypes(input);
+			assert(Object.isFrozen(input));
+		});
+
+		it("AnnotatedAllowedTypesInternal.createUnannotated", () => {
+			const input = [stringSchema];
+			const _ = AnnotatedAllowedTypesInternal.createUnannotated(input);
+			assert(Object.isFrozen(input));
+		});
+
+		it("AnnotatedAllowedTypesInternal.createMixed", () => {
+			const input = [stringSchema];
+			const _ = AnnotatedAllowedTypesInternal.createMixed(input);
+			assert(Object.isFrozen(input));
+		});
+	});
 });

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -569,7 +569,7 @@ describe("allowedTypes", () => {
 		});
 	});
 
-	// If derived data is computed based on a allowed type array, then modifications to that array would cause the derived data to become invalid.
+	// If derived data is computed based on an allowed type array, then modifications to that array would cause the derived data to become invalid.
 	// As there is no invalidation mechanism, this would lead to incorrect behavior, and is prevented by freezing the arrays when the derived data is computed.
 	// Note that cases where adding to the array would not produce invalid data are not required to freeze the array: more cases could be made to allow mutations by deriving data at a later point.
 	// If done, these tests may need updates to instead test that modifying the arrays does not expose incorrect derived data.

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -571,7 +571,9 @@ describe("allowedTypes", () => {
 
 	// If derived data is computed based on an allowed type array, then modifications to that array would cause the derived data to become invalid.
 	// As there is no invalidation mechanism, this would lead to incorrect behavior, and is prevented by freezing the arrays when the derived data is computed.
-	// Note that cases where adding to the array would not produce invalid data are not required to freeze the array: more cases could be made to allow mutations by deriving data at a later point.
+	// These are glass box tests: they are testing that the cases where the code currently derives data from the arrays results in the arrays being frozen.
+	// Future changes could be made to delay both the freezing and the computation of the derived data:
+	// if such changes are made these tests will need to be updated.
 	// If done, these tests may need updates to instead test that modifying the arrays does not expose incorrect derived data.
 	describe("freezes inputs producing derived data", () => {
 		it("AnnotatedAllowedTypesInternal.create", () => {


### PR DESCRIPTION
## Description

The annotated allowed type work reintroduced the possibility of modifying an allowed type array after derived data was computed. This change closes that gap and adds some tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
