### PR TITLE
Table Readonly ID

### DIFF
--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -295,6 +295,28 @@ describe("TableFactory unit tests", () => {
 				rows: [{ id: "row-0", props: { label: "Row 0" }, cells: {} }],
 			});
 		});
+
+		// Tables manage to make ids readonly at the type level:
+		// this is a bit surprising since thats not currently implemented for identifiers in general,
+		// but works in this case due to how interfaces are used.
+		it("Readonly IDs", () => {
+			const column = new Column({ props: {} });
+			// Read
+			const _columnId = column.id;
+			assert.throws(() => {
+				// Write
+				// @ts-expect-error id is readonly
+				column.id = "column-1";
+			});
+			const row = new Row({ cells: {} });
+			// Read
+			const _rowId = row.id;
+			assert.throws(() => {
+				// Write
+				// @ts-expect-error id is readonly
+				row.id = "row-1";
+			});
+		});
 	});
 
 	describeHydration("Initialization", (initializeTree) => {

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -297,7 +297,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// Tables manage to make ids readonly at the type level:
-		// this is a bit surprising since thats not currently implemented for identifiers in general,
+		// this is a bit surprising since that's not currently implemented for identifiers in general,
 		// but works in this case due to how interfaces are used.
 		it("Readonly IDs", () => {
 			const column = new Column({ props: {} });


### PR DESCRIPTION
## Description

Ids in tables are currently readonly. This is a bit surprising, but this test ensure it keeps its current behavior, or at least detects if it changes.

These were split out from work which tried to add schema based readonly only to find that tables already had the readonlyness.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

