### PR TITLE
test(client-azure-end-to-end-tests): debug support

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -58,6 +58,7 @@ interface ChildProcess extends AnyChildProcess {
  * @returns A collection of child processes and a promise that rejects on the first child error.
  */
 export async function forkChildProcesses(
+	testLabel: string,
 	numProcesses: number,
 	cleanUpAccumulator: (() => void)[],
 ): Promise<{
@@ -72,6 +73,7 @@ export async function forkChildProcesses(
 	const childErrorPromises: Promise<never>[] = [];
 	for (let i = 0; i < numProcesses; i++) {
 		const child = fork("./lib/test/multiprocess/childClient.tool.js", [
+			testLabel,
 			`child ${i}` /* identifier passed to child process */,
 			childLoggingVerbosity /* console logging verbosity */,
 		]);
@@ -348,6 +350,10 @@ export async function connectAndListenForAttendees(
 		readyTimeoutMs: childConnectTimeoutMs,
 	});
 
+	// These actions are not awaited. They are here to provide additional logging.
+	// It is up to the caller to await attendeeIdPromises if desired. This can mean
+	// An "error" message is output, but the caller does not care about attendee
+	// ids and proceeds.
 	Promise.all(connectResult.attendeeIdPromises)
 		.then(() => console.log("All attendees connected."))
 		.catch((error) => {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -131,11 +131,12 @@ describe(`Presence with AzureClient`, () => {
 			const allAttendeesFullyJoinedTimeoutMs = (2000 + 300 * numClients) * timeoutMultiplier;
 
 			for (const writeClients of [numClients, 1]) {
-				it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function () {
+				it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
 					setTestTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
 
 					// Setup
 					const { children, childErrorPromise } = await forkChildProcesses(
+						this.test?.title ?? "",
 						numClients,
 						afterCleanUp,
 					);
@@ -153,7 +154,7 @@ describe(`Presence with AzureClient`, () => {
 					);
 				});
 
-				it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function () {
+				it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
 					if (useAzure && numClients > 50) {
 						// Even with increased timeouts, more than 50 clients can be too large for AFR.
 						// This may be due to slow responses/inactivity from the clients that are
@@ -173,6 +174,7 @@ describe(`Presence with AzureClient`, () => {
 
 					// Setup
 					const { children, childErrorPromise } = await forkChildProcesses(
+						this.test?.title ?? "",
 						numClients,
 						afterCleanUp,
 					);
@@ -345,8 +347,9 @@ describe(`Presence with AzureClient`, () => {
 				const testValue = "testValue";
 				const workspaceId = "presenceTestWorkspace";
 
-				beforeEach(async () => {
+				beforeEach(async function usingLatestStateObject_beforeEach(): Promise<void> {
 					({ children, childErrorPromise } = await forkChildProcesses(
+						this.currentTest?.title ?? "",
 						numClients,
 						afterCleanUp,
 					));
@@ -432,8 +435,9 @@ describe(`Presence with AzureClient`, () => {
 				const value1 = { name: "Alice", score: 100 };
 				const value2 = { name: "Bob", score: 200 };
 
-				beforeEach(async () => {
+				beforeEach(async function usingLatestMapStateObject_beforeEach(): Promise<void> {
 					({ children, childErrorPromise } = await forkChildProcesses(
+						this.currentTest?.title ?? "",
 						numClients,
 						afterCleanUp,
 					));


### PR DESCRIPTION
- Add additional child logging prefix for distinction under CI where output appears jumbled
- Exclude non-interactive connection telemetry from logs
- On unexpect ClientJoin send additional details