### PR TITLE
fix(client-loader): recognize early local signals

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2417,11 +2417,10 @@ export class Container
 		if (protocolHandlerShouldProcessSignal(message)) {
 			this.protocolHandler.processSignal(message);
 		} else {
-			// Use signalAudience to determine local
 			const local =
 				// Check against signal audience to detect current signals
 				// including very early signals before reaching "Connected".
-				message.clientId === this.signalAudience?.getSelf()?.clientId ||
+				message.clientId === this.signalAudience.getSelf()?.clientId ||
 				// and use "regular" audience to detect signals from past
 				// connection bouncing slowly back from service. This may never
 				// happen, but is kept as it was used historically as the only

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2417,7 +2417,16 @@ export class Container
 		if (protocolHandlerShouldProcessSignal(message)) {
 			this.protocolHandler.processSignal(message);
 		} else {
-			const local = this.clientId === message.clientId;
+			// Use signalAudience to determine local
+			const local =
+				// Check against signal audience to detect current signals
+				// including very early signals before reaching "Connected".
+				message.clientId === this.signalAudience?.getSelf()?.clientId ||
+				// and use "regular" audience to detect signals from past
+				// connection bouncing slowly back from service. This may never
+				// happen, but is kept as it was used historically as the only
+				// check.
+				message.clientId === this.clientId;
 			this.runtime.processSignal(message, local);
 		}
 	}


### PR DESCRIPTION
Use signal audience to correctly classify pre-Connected, local signals as local.