### PR TITLE
test(client-azure-end-to-end): fix Azure connect timeouts

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -57,6 +57,7 @@ export interface ConnectCommand {
 	 * If not provided, a new Fluid container will be created.
 	 */
 	containerId?: string;
+	connectTimeoutMs: number;
 }
 
 /**

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -43,7 +43,7 @@ const debuggerAttached = inspector.url() !== undefined;
 /**
  * Set this to a high number when debugging to avoid timeouts from debugging time.
  */
-const timeoutMultiplier = debuggerAttached ? 1000 : useAzure ? 3 : 1;
+const timeoutMultiplier = debuggerAttached ? 1000 : useAzure ? 5 : 1;
 
 /**
  * Sets the timeout for the given test context.
@@ -338,6 +338,7 @@ describe(`Presence with AzureClient`, () => {
 				 * Timeout for child processes to connect to container ({@link ConnectedEvent})
 				 */
 				const childConnectTimeoutMs = 1000 * numClients * timeoutMultiplier;
+				const testCaseTimeoutMs = childConnectTimeoutMs + 1000;
 
 				let children: ChildProcess[];
 				let childErrorPromise: Promise<never>;
@@ -348,6 +349,8 @@ describe(`Presence with AzureClient`, () => {
 				const workspaceId = "presenceTestWorkspace";
 
 				beforeEach(async function usingLatestStateObject_beforeEach(): Promise<void> {
+					setTestTimeout(this, testCaseTimeoutMs);
+
 					({ children, childErrorPromise } = await forkChildProcesses(
 						this.currentTest?.title ?? "",
 						numClients,
@@ -423,6 +426,7 @@ describe(`Presence with AzureClient`, () => {
 				 * Timeout for child processes to connect to container ({@link ConnectedEvent})
 				 */
 				const childConnectTimeoutMs = 1000 * numClients * timeoutMultiplier;
+				const testCaseTimeoutMs = childConnectTimeoutMs + 1000;
 
 				let children: ChildProcess[];
 				let childErrorPromise: Promise<never>;
@@ -436,6 +440,8 @@ describe(`Presence with AzureClient`, () => {
 				const value2 = { name: "Bob", score: 200 };
 
 				beforeEach(async function usingLatestMapStateObject_beforeEach(): Promise<void> {
+					setTestTimeout(this, testCaseTimeoutMs);
+
 					({ children, childErrorPromise } = await forkChildProcesses(
 						this.currentTest?.title ?? "",
 						numClients,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -337,82 +337,95 @@ describe(`Presence with AzureClient`, () => {
 				/**
 				 * Timeout for child processes to connect to container ({@link ConnectedEvent})
 				 */
-				const childConnectTimeoutMs = 1000 * numClients * timeoutMultiplier;
-				const testCaseTimeoutMs = childConnectTimeoutMs + 1000;
+				const childConnectTimeoutMs = (4000 + 1000 * numClients) * timeoutMultiplier;
+				const testCaseTimeoutMs = 1000;
+				const testSetupAndActTimeoutMs = childConnectTimeoutMs + testCaseTimeoutMs;
 
-				let children: ChildProcess[];
-				let childErrorPromise: Promise<never>;
-				let containerCreatorAttendeeId: AttendeeId;
-				let attendeeIdPromises: Promise<AttendeeId>[];
-				let remoteClients: ChildProcess[];
-				const testValue = "testValue";
-				const workspaceId = "presenceTestWorkspace";
+				// These tests use beforeEach to setup complex state that takes a lot of time
+				// and is dependent on number of clients. Keeping the work in beforeEach
+				// allows time reporting to report the tested scenario apart from the setup time.
+				// So this describe block isolates those beforeEach setups from each distinct
+				// client count. Test cases descriptions also have the client count for clarity.
+				describe(`with ${numClients} clients`, () => {
+					let children: ChildProcess[];
+					let childErrorPromise: Promise<never>;
+					let containerCreatorAttendeeId: AttendeeId;
+					let attendeeIdPromises: Promise<AttendeeId>[];
+					let remoteClients: ChildProcess[];
+					const testValue = "testValue";
+					const workspaceId = "presenceTestWorkspace";
 
-				beforeEach(async function usingLatestStateObject_beforeEach(): Promise<void> {
-					setTestTimeout(this, testCaseTimeoutMs);
+					beforeEach(async function usingLatestStateObject_beforeEach(): Promise<void> {
+						const startTime = performance.now();
+						setTestTimeout(this, testSetupAndActTimeoutMs);
 
-					({ children, childErrorPromise } = await forkChildProcesses(
-						this.currentTest?.title ?? "",
-						numClients,
-						afterCleanUp,
-					));
-					({ containerCreatorAttendeeId, attendeeIdPromises } = await connectChildProcesses(
-						children,
-						{ writeClients: numClients, readyTimeoutMs: childConnectTimeoutMs },
-					));
-					await Promise.all(attendeeIdPromises);
-					remoteClients = children.filter((_, index) => index !== 0);
-					// NOTE: For testing purposes child clients will expect a Latest value of type string (StateFactory.latest<{ value: string }>).
-					await registerWorkspaceOnChildren(children, workspaceId, {
-						latest: true,
-						timeoutMs: workspaceRegisterTimeoutMs,
-					});
-				});
-
-				it(`allows clients to read Latest state from other clients [${numClients} clients]`, async function () {
-					// Setup
-					const updateEventsPromise = waitForLatestValueUpdates(
-						remoteClients,
-						workspaceId,
-						childErrorPromise,
-						stateUpdateTimeoutMs,
-						{ fromAttendeeId: containerCreatorAttendeeId, expectedValue: testValue },
-					);
-
-					// Act - Trigger the update
-					children[0].send({
-						command: "setLatestValue",
-						workspaceId,
-						value: testValue,
-					});
-					const updateEvents = await updateEventsPromise;
-
-					// Verify all events are from the expected attendee
-					for (const updateEvent of updateEvents) {
-						assert.strictEqual(updateEvent.attendeeId, containerCreatorAttendeeId);
-						assert.deepStrictEqual(updateEvent.value, testValue);
-					}
-
-					// Act - Request each remote client to read latest state from container creator
-					for (const child of remoteClients) {
-						child.send({
-							command: "getLatestValue",
-							workspaceId,
-							attendeeId: containerCreatorAttendeeId,
+						({ children, childErrorPromise } = await forkChildProcesses(
+							this.currentTest?.title ?? "",
+							numClients,
+							afterCleanUp,
+						));
+						({ containerCreatorAttendeeId, attendeeIdPromises } = await connectChildProcesses(
+							children,
+							{ writeClients: numClients, readyTimeoutMs: childConnectTimeoutMs },
+						));
+						await Promise.all(attendeeIdPromises);
+						remoteClients = children.filter((_, index) => index !== 0);
+						// NOTE: For testing purposes child clients will expect a Latest value of type string (StateFactory.latest<{ value: string }>).
+						await registerWorkspaceOnChildren(children, workspaceId, {
+							latest: true,
+							timeoutMs: workspaceRegisterTimeoutMs,
 						});
-					}
 
-					const getResponses = await getLatestValueResponses(
-						remoteClients,
-						workspaceId,
-						childErrorPromise,
-						getStateTimeoutMs,
-					);
+						testConsole.log(
+							`  Setup for "${this.currentTest?.title}" completed in ${performance.now() - startTime}ms`,
+						);
+					});
 
-					// Verify - all responses should contain the expected value
-					for (const getResponse of getResponses) {
-						assert.deepStrictEqual(getResponse.value, testValue);
-					}
+					it(`allows clients to read Latest state from other clients [${numClients} clients]`, async function () {
+						// Setup
+						const updateEventsPromise = waitForLatestValueUpdates(
+							remoteClients,
+							workspaceId,
+							childErrorPromise,
+							stateUpdateTimeoutMs,
+							{ fromAttendeeId: containerCreatorAttendeeId, expectedValue: testValue },
+						);
+
+						// Act - Trigger the update
+						children[0].send({
+							command: "setLatestValue",
+							workspaceId,
+							value: testValue,
+						});
+						const updateEvents = await updateEventsPromise;
+
+						// Verify all events are from the expected attendee
+						for (const updateEvent of updateEvents) {
+							assert.strictEqual(updateEvent.attendeeId, containerCreatorAttendeeId);
+							assert.deepStrictEqual(updateEvent.value, testValue);
+						}
+
+						// Act - Request each remote client to read latest state from container creator
+						for (const child of remoteClients) {
+							child.send({
+								command: "getLatestValue",
+								workspaceId,
+								attendeeId: containerCreatorAttendeeId,
+							});
+						}
+
+						const getResponses = await getLatestValueResponses(
+							remoteClients,
+							workspaceId,
+							childErrorPromise,
+							getStateTimeoutMs,
+						);
+
+						// Verify - all responses should contain the expected value
+						for (const getResponse of getResponses) {
+							assert.deepStrictEqual(getResponse.value, testValue);
+						}
+					});
 				});
 			}
 		});
@@ -425,197 +438,211 @@ describe(`Presence with AzureClient`, () => {
 				/**
 				 * Timeout for child processes to connect to container ({@link ConnectedEvent})
 				 */
-				const childConnectTimeoutMs = 1000 * numClients * timeoutMultiplier;
-				const testCaseTimeoutMs = childConnectTimeoutMs + 1000;
+				const childConnectTimeoutMs = (4000 + 1000 * numClients) * timeoutMultiplier;
+				const testCaseTimeoutMs = 1000;
+				const testSetupAndActTimeoutMs = childConnectTimeoutMs + testCaseTimeoutMs;
 
-				let children: ChildProcess[];
-				let childErrorPromise: Promise<never>;
-				let containerCreatorAttendeeId: AttendeeId;
-				let attendeeIdPromises: Promise<AttendeeId>[];
-				let remoteClients: ChildProcess[];
-				const workspaceId = "presenceTestWorkspace";
-				const key1 = "player1";
-				const key2 = "player2";
-				const value1 = { name: "Alice", score: 100 };
-				const value2 = { name: "Bob", score: 200 };
+				// These tests use beforeEach to setup complex state that takes a lot of time
+				// and is dependent on number of clients. Keeping the work in beforeEach
+				// allows time reporting to report the tested scenario apart from the setup time.
+				// So this describe block isolates those beforeEach setups from each distinct
+				// client count. Test cases descriptions also have the client count for clarity.
+				describe(`with ${numClients} clients`, () => {
+					let children: ChildProcess[];
+					let childErrorPromise: Promise<never>;
+					let containerCreatorAttendeeId: AttendeeId;
+					let attendeeIdPromises: Promise<AttendeeId>[];
+					let remoteClients: ChildProcess[];
+					const workspaceId = "presenceTestWorkspace";
+					const key1 = "player1";
+					const key2 = "player2";
+					const value1 = { name: "Alice", score: 100 };
+					const value2 = { name: "Bob", score: 200 };
 
-				beforeEach(async function usingLatestMapStateObject_beforeEach(): Promise<void> {
-					setTestTimeout(this, testCaseTimeoutMs);
+					beforeEach(async function usingLatestMapStateObject_beforeEach(): Promise<void> {
+						const startTime = performance.now();
 
-					({ children, childErrorPromise } = await forkChildProcesses(
-						this.currentTest?.title ?? "",
-						numClients,
-						afterCleanUp,
-					));
-					({ containerCreatorAttendeeId, attendeeIdPromises } = await connectChildProcesses(
-						children,
-						{ writeClients: numClients, readyTimeoutMs: childConnectTimeoutMs },
-					));
-					await Promise.all(attendeeIdPromises);
-					remoteClients = children.filter((_, index) => index !== 0);
-					// NOTE: For testing purposes child clients will expect a LatestMap value of type Record<string, string | number> (StateFactory.latestMap<{ value: Record<string, string | number> }, string>).
-					await registerWorkspaceOnChildren(children, workspaceId, {
-						latestMap: true,
-						timeoutMs: workspaceRegisterTimeoutMs,
+						setTestTimeout(this, testSetupAndActTimeoutMs);
+
+						({ children, childErrorPromise } = await forkChildProcesses(
+							this.currentTest?.title ?? "",
+							numClients,
+							afterCleanUp,
+						));
+						({ containerCreatorAttendeeId, attendeeIdPromises } = await connectChildProcesses(
+							children,
+							{ writeClients: numClients, readyTimeoutMs: childConnectTimeoutMs },
+						));
+						await Promise.all(attendeeIdPromises);
+						remoteClients = children.filter((_, index) => index !== 0);
+						// NOTE: For testing purposes child clients will expect a LatestMap value of type Record<string, string | number> (StateFactory.latestMap<{ value: Record<string, string | number> }, string>).
+						await registerWorkspaceOnChildren(children, workspaceId, {
+							latestMap: true,
+							timeoutMs: workspaceRegisterTimeoutMs,
+						});
+
+						testConsole.log(
+							`  Setup for "${this.currentTest?.title}" completed in ${performance.now() - startTime}ms`,
+						);
 					});
-				});
 
-				it(`allows clients to read LatestMap values from other clients [${numClients} clients]`, async () => {
-					// Setup
-					const testKey = "cursor";
-					const testValue = { x: 150, y: 300 };
-					const updateEventsPromise = waitForLatestMapValueUpdates(
-						remoteClients,
-						workspaceId,
-						testKey,
-						childErrorPromise,
-						stateUpdateTimeoutMs,
-						{ fromAttendeeId: containerCreatorAttendeeId, expectedValue: testValue },
-					);
+					it(`allows clients to read LatestMap values from other clients [${numClients} clients]`, async () => {
+						// Setup
+						const testKey = "cursor";
+						const testValue = { x: 150, y: 300 };
+						const updateEventsPromise = waitForLatestMapValueUpdates(
+							remoteClients,
+							workspaceId,
+							testKey,
+							childErrorPromise,
+							stateUpdateTimeoutMs,
+							{ fromAttendeeId: containerCreatorAttendeeId, expectedValue: testValue },
+						);
 
-					// Act
-					children[0].send({
-						command: "setLatestMapValue",
-						workspaceId,
-						key: testKey,
-						value: testValue,
-					});
-					const updateEvents = await updateEventsPromise;
-
-					// Check all events are from the expected attendee
-					for (const updateEvent of updateEvents) {
-						assert.strictEqual(updateEvent.attendeeId, containerCreatorAttendeeId);
-						assert.strictEqual(updateEvent.key, testKey);
-						assert.deepStrictEqual(updateEvent.value, testValue);
-					}
-
-					for (const child of remoteClients) {
-						child.send({
-							command: "getLatestMapValue",
+						// Act
+						children[0].send({
+							command: "setLatestMapValue",
 							workspaceId,
 							key: testKey,
-							attendeeId: containerCreatorAttendeeId,
+							value: testValue,
 						});
-					}
-					const getResponses = await getLatestMapValueResponses(
-						remoteClients,
-						workspaceId,
-						testKey,
-						childErrorPromise,
-						getStateTimeoutMs,
-					);
+						const updateEvents = await updateEventsPromise;
 
-					// Verify
-					for (const getResponse of getResponses) {
-						assert.deepStrictEqual(getResponse.value, testValue);
-					}
-				});
+						// Check all events are from the expected attendee
+						for (const updateEvent of updateEvents) {
+							assert.strictEqual(updateEvent.attendeeId, containerCreatorAttendeeId);
+							assert.strictEqual(updateEvent.key, testKey);
+							assert.deepStrictEqual(updateEvent.value, testValue);
+						}
 
-				it(`returns per-key values on read [${numClients} clients]`, async function () {
-					// Setup
-					const allAttendeeIds = await Promise.all(attendeeIdPromises);
-					const attendee0Id = containerCreatorAttendeeId;
-					const attendee1Id = allAttendeeIds[1];
+						for (const child of remoteClients) {
+							child.send({
+								command: "getLatestMapValue",
+								workspaceId,
+								key: testKey,
+								attendeeId: containerCreatorAttendeeId,
+							});
+						}
+						const getResponses = await getLatestMapValueResponses(
+							remoteClients,
+							workspaceId,
+							testKey,
+							childErrorPromise,
+							getStateTimeoutMs,
+						);
 
-					const key1Recipients = children.filter((_, index) => index !== 0);
-					const key2Recipients = children.filter((_, index) => index !== 1);
-					const key1UpdateEventsPromise = waitForLatestMapValueUpdates(
-						key1Recipients,
-						workspaceId,
-						key1,
-						childErrorPromise,
-						stateUpdateTimeoutMs,
-						{ fromAttendeeId: attendee0Id, expectedValue: value1 },
-					);
-					const key2UpdateEventsPromise = waitForLatestMapValueUpdates(
-						key2Recipients,
-						workspaceId,
-						key2,
-						childErrorPromise,
-						stateUpdateTimeoutMs,
-						{ fromAttendeeId: attendee1Id, expectedValue: value2 },
-					);
-
-					// Act
-					children[0].send({
-						command: "setLatestMapValue",
-						workspaceId,
-						key: key1,
-						value: value1,
+						// Verify
+						for (const getResponse of getResponses) {
+							assert.deepStrictEqual(getResponse.value, testValue);
+						}
 					});
-					const key1UpdateEvents = await key1UpdateEventsPromise;
-					children[1].send({
-						command: "setLatestMapValue",
-						workspaceId,
-						key: key2,
-						value: value2,
-					});
-					const key2UpdateEvents = await key2UpdateEventsPromise;
 
-					// Verify all events are from the expected attendees
-					for (const updateEvent of key1UpdateEvents) {
-						assert.strictEqual(updateEvent.attendeeId, attendee0Id);
-						assert.strictEqual(updateEvent.key, key1);
-						assert.deepStrictEqual(updateEvent.value, value1);
-					}
-					for (const updateEvent of key2UpdateEvents) {
-						assert.strictEqual(updateEvent.attendeeId, attendee1Id);
-						assert.strictEqual(updateEvent.key, key2);
-						assert.deepStrictEqual(updateEvent.value, value2);
-					}
+					it(`returns per-key values on read [${numClients} clients]`, async function () {
+						// Setup
+						const allAttendeeIds = await Promise.all(attendeeIdPromises);
+						const attendee0Id = containerCreatorAttendeeId;
+						const attendee1Id = allAttendeeIds[1];
 
-					// Read key1 of attendee0 from all children
-					for (const child of children) {
-						child.send({
-							command: "getLatestMapValue",
+						const key1Recipients = children.filter((_, index) => index !== 0);
+						const key2Recipients = children.filter((_, index) => index !== 1);
+						const key1UpdateEventsPromise = waitForLatestMapValueUpdates(
+							key1Recipients,
+							workspaceId,
+							key1,
+							childErrorPromise,
+							stateUpdateTimeoutMs,
+							{ fromAttendeeId: attendee0Id, expectedValue: value1 },
+						);
+						const key2UpdateEventsPromise = waitForLatestMapValueUpdates(
+							key2Recipients,
+							workspaceId,
+							key2,
+							childErrorPromise,
+							stateUpdateTimeoutMs,
+							{ fromAttendeeId: attendee1Id, expectedValue: value2 },
+						);
+
+						// Act
+						children[0].send({
+							command: "setLatestMapValue",
 							workspaceId,
 							key: key1,
-							attendeeId: attendee0Id,
+							value: value1,
 						});
-					}
-					const key1Responses = await getLatestMapValueResponses(
-						children,
-						workspaceId,
-						key1,
-						childErrorPromise,
-						getStateTimeoutMs,
-					);
-
-					// Read key2 of attendee1 from all children
-					for (const child of children) {
-						child.send({
-							command: "getLatestMapValue",
+						const key1UpdateEvents = await key1UpdateEventsPromise;
+						children[1].send({
+							command: "setLatestMapValue",
 							workspaceId,
 							key: key2,
-							attendeeId: attendee1Id,
+							value: value2,
 						});
-					}
-					const key2Responses = await getLatestMapValueResponses(
-						children,
-						workspaceId,
-						key2,
-						childErrorPromise,
-						getStateTimeoutMs,
-					);
+						const key2UpdateEvents = await key2UpdateEventsPromise;
 
-					// Verify
-					assert.strictEqual(
-						key1Responses.length,
-						numClients,
-						"Expected responses from all clients for key1",
-					);
-					assert.strictEqual(
-						key2Responses.length,
-						numClients,
-						"Expected responses from all clients for key2",
-					);
+						// Verify all events are from the expected attendees
+						for (const updateEvent of key1UpdateEvents) {
+							assert.strictEqual(updateEvent.attendeeId, attendee0Id);
+							assert.strictEqual(updateEvent.key, key1);
+							assert.deepStrictEqual(updateEvent.value, value1);
+						}
+						for (const updateEvent of key2UpdateEvents) {
+							assert.strictEqual(updateEvent.attendeeId, attendee1Id);
+							assert.strictEqual(updateEvent.key, key2);
+							assert.deepStrictEqual(updateEvent.value, value2);
+						}
 
-					for (const response of key1Responses) {
-						assert.deepStrictEqual(response.value, value1, "Key1 value should match");
-					}
-					for (const response of key2Responses) {
-						assert.deepStrictEqual(response.value, value2, "Key2 value should match");
-					}
+						// Read key1 of attendee0 from all children
+						for (const child of children) {
+							child.send({
+								command: "getLatestMapValue",
+								workspaceId,
+								key: key1,
+								attendeeId: attendee0Id,
+							});
+						}
+						const key1Responses = await getLatestMapValueResponses(
+							children,
+							workspaceId,
+							key1,
+							childErrorPromise,
+							getStateTimeoutMs,
+						);
+
+						// Read key2 of attendee1 from all children
+						for (const child of children) {
+							child.send({
+								command: "getLatestMapValue",
+								workspaceId,
+								key: key2,
+								attendeeId: attendee1Id,
+							});
+						}
+						const key2Responses = await getLatestMapValueResponses(
+							children,
+							workspaceId,
+							key2,
+							childErrorPromise,
+							getStateTimeoutMs,
+						);
+
+						// Verify
+						assert.strictEqual(
+							key1Responses.length,
+							numClients,
+							"Expected responses from all clients for key1",
+						);
+						assert.strictEqual(
+							key2Responses.length,
+							numClients,
+							"Expected responses from all clients for key2",
+						);
+
+						for (const response of key1Responses) {
+							assert.deepStrictEqual(response.value, value1, "Key1 value should match");
+						}
+						for (const response of key2Responses) {
+							assert.deepStrictEqual(response.value, value2, "Key2 value should match");
+						}
+					});
 				});
 			}
 		});


### PR DESCRIPTION
allow more time for connecting to real AFR service in Presence tests.

Change from a fixed 10s to dynamic time based on number of clients.

Additionally changes:
- fix `beforeEach` cross contamination from different client counts by injected a `describe` block within loop body
- output `beforeEach` completion time (otherwise untracked from mocha output)
- output timestamp under verbose logging
- send along or request and show log if connect times out