### PR TITLE
fix(eslint): update import-x order config to use simple grouping

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @fluidframework/eslint-config-fluid Changelog
 
-## [8.1.0]
+## [8.1.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v8.1.0)
 
 ### import-x/order rule simplified
 
@@ -14,7 +14,7 @@ The TypeScript resolver configuration has been updated to work correctly with th
 
 The `@fluid-internal/fluid/no-hyphen-after-jsdoc-tag` rule has been temporarily disabled pending resolution of ADO work item 29535.
 
-## [8.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v8.0_0)
+## [8.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v8.0.0)
 
 ### eslint-plugin-import replaced by eslint-plugin-import-x
 

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [8.1.0]
+
+### import-x/order rule simplified
+
+The `import-x/order` rule configuration has been simplified to use basic grouping without alphabetization or newlines-between settings. This provides more flexibility in import ordering while still maintaining consistent grouping of import types.
+
+### Resolver configuration updated
+
+The TypeScript resolver configuration has been updated to work correctly with the repository's build setup. The resolver no longer requires explicit name and options wrapping, and uses the resolver directly.
+
+### no-hyphen-after-jsdoc-tag rule disabled
+
+The `@fluid-internal/fluid/no-hyphen-after-jsdoc-tag` rule has been temporarily disabled pending resolution of ADO work item 29535.
+
 ## [8.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v8.0_0)
 
 ### eslint-plugin-import replaced by eslint-plugin-import-x

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -51,8 +51,9 @@ module.exports = {
 
 		/**
 		 * Disallow `-` immediately following a JSDoc/TSDoc tag (e.g. `@deprecated - foo`).
+		 * FIXME: https://dev.azure.com/fluidframework/internal/_workitems/edit/29535
 		 */
-		"@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": "error",
+		"@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": "off",
 
 		/**
 		 * Disallow file path based links in JSDoc/TSDoc comments.

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-const tsResolver = require("eslint-import-resolver-typescript");
-
 /**
  * Base configuration from which all of our exported configs extends.
  */
@@ -186,15 +184,8 @@ module.exports = {
 		"import-x/order": [
 			"error",
 			{
-				"newlines-between": "always",
-				"alphabetize": {
-					order: "asc",
-					// Sorting is case-sensitive by default, which is the same as Biome. To avoid
-					// another huge set of changes to order things case-insensitively, we'll just
-					// use the rule with this config for now. This decision should be considered
-					// pragmatic and not a statement of preference, and we should revisit this.
-					caseInsensitive: false,
-				},
+				"newlines-between": "ignore",
+				"groups": [["builtin", "external", "internal", "parent", "sibling", "index"]],
 			},
 		],
 
@@ -370,6 +361,7 @@ module.exports = {
 			files: ["**/types/*validate*Previous*.ts"],
 			rules: {
 				"@typescript-eslint/comma-spacing": "off",
+				"import-x/order": "off",
 			},
 		},
 	],
@@ -379,40 +371,36 @@ module.exports = {
 			"@typescript-eslint/parser": [".ts", ".tsx", ".d.ts", ".cts", ".mts"],
 		},
 		"import-x/resolver": {
-			name: "tsResolver",
-			options: {
-				typescript: {
-					extensions: [
-						// `.mts`, `.cts`, `.d.mts`, `.d.cts`, `.mjs`, `.cjs` are not included because `.cjs` and `.mjs` must be used
-						// explicitly in imports
-						".ts",
-						".tsx",
-						".d.ts",
-						".js",
-						".jsx",
-					],
-					conditionNames: [
-						// This supports the test-only conditional export pattern used in merge-tree and id-compressor.
-						"allow-ff-test-exports",
+			typescript: {
+				extensions: [
+					// `.mts`, `.cts`, `.d.mts`, `.d.cts`, `.mjs`, `.cjs` are not included because `.cjs` and `.mjs` must be used
+					// explicitly in imports
+					".ts",
+					".tsx",
+					".d.ts",
+					".js",
+					".jsx",
+				],
+				conditionNames: [
+					// This supports the test-only conditional export pattern used in merge-tree and id-compressor.
+					"allow-ff-test-exports",
 
-						// Default condition names below, see https://github.com/import-js/eslint-import-resolver-typescript#conditionnames
-						"types",
-						"import",
+					// Default condition names below, see https://github.com/import-js/eslint-import-resolver-typescript#conditionnames
+					"types",
+					"import",
 
-						// APF: https://angular.io/guide/angular-package-format
-						"esm2020",
-						"es2020",
-						"es2015",
+					// APF: https://angular.io/guide/angular-package-format
+					"esm2020",
+					"es2020",
+					"es2015",
 
-						"require",
-						"node",
-						"node-addons",
-						"browser",
-						"default",
-					],
-				},
+					"require",
+					"node",
+					"node-addons",
+					"browser",
+					"default",
+				],
 			},
-			resolver: tsResolver, // required
 		},
 	},
 };

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "8.0.0",
+	"version": "8.1.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -45,7 +45,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1217,12 +1217,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2340,49 +2345,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2393,74 +2365,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -45,7 +45,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1198,12 +1198,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2010,49 +2015,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2063,74 +2035,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -47,7 +47,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1219,12 +1219,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2414,49 +2419,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2467,74 +2439,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -45,7 +45,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1217,12 +1217,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2340,49 +2345,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2393,74 +2365,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -48,7 +48,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1296,12 +1296,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2655,49 +2660,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2708,74 +2680,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -45,7 +45,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1227,12 +1227,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2379,49 +2384,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2432,74 +2404,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -45,7 +45,7 @@
             "error"
         ],
         "@fluid-internal/fluid/no-hyphen-after-jsdoc-tag": [
-            "error"
+            "off"
         ],
         "@fluid-internal/fluid/no-markdown-links-in-jsdoc": [
             "error"
@@ -1213,12 +1213,17 @@
         "import-x/order": [
             "error",
             {
-                "newlines-between": "always",
-                "alphabetize": {
-                    "order": "asc",
-                    "caseInsensitive": false,
-                    "orderImportKind": "ignore"
-                },
+                "newlines-between": "ignore",
+                "groups": [
+                    [
+                        "builtin",
+                        "external",
+                        "internal",
+                        "parent",
+                        "sibling",
+                        "index"
+                    ]
+                ],
                 "distinctGroup": true,
                 "sortTypesGroup": false,
                 "named": false,
@@ -2336,49 +2341,16 @@
             ]
         },
         "import-x/resolver": {
-            "name": "tsResolver",
-            "options": {
-                "typescript": {
-                    "extensions": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js",
-                        ".jsx"
-                    ],
-                    "conditionNames": [
-                        "allow-ff-test-exports",
-                        "types",
-                        "import",
-                        "esm2020",
-                        "es2020",
-                        "es2015",
-                        "require",
-                        "node",
-                        "node-addons",
-                        "browser",
-                        "default"
-                    ]
-                }
-            },
-            "resolver": {
-                "DEFAULT_CONFIGS": [
-                    "tsconfig.json",
-                    "jsconfig.json"
+            "typescript": {
+                "extensions": [
+                    ".ts",
+                    ".tsx",
+                    ".d.ts",
+                    ".js",
+                    ".jsx"
                 ],
-                "DEFAULT_IGNORE": "**/node_modules/**",
-                "DEFAULT_JSCONFIG": "jsconfig.json",
-                "DEFAULT_TRY_PATHS": [
-                    "",
-                    "tsconfig.json",
-                    "jsconfig.json"
-                ],
-                "DEFAULT_TSCONFIG": "tsconfig.json",
-                "IMPORT_RESOLVER_NAME": "eslint-import-resolver-typescript",
-                "JS_EXT_PATTERN": {},
-                "MATCH_ALL": "**",
-                "TSCONFIG_NOT_FOUND_REGEXP": {},
-                "defaultConditionNames": [
+                "conditionNames": [
+                    "allow-ff-test-exports",
                     "types",
                     "import",
                     "esm2020",
@@ -2389,74 +2361,8 @@
                     "node-addons",
                     "browser",
                     "default"
-                ],
-                "defaultExtensionAlias": {
-                    ".js": [
-                        ".ts",
-                        ".tsx",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".ts": [
-                        ".ts",
-                        ".d.ts",
-                        ".js"
-                    ],
-                    ".jsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx"
-                    ],
-                    ".tsx": [
-                        ".tsx",
-                        ".d.ts",
-                        ".jsx",
-                        ".js"
-                    ],
-                    ".cjs": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".cts": [
-                        ".cts",
-                        ".d.cts",
-                        ".cjs"
-                    ],
-                    ".mjs": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ],
-                    ".mts": [
-                        ".mts",
-                        ".d.mts",
-                        ".mjs"
-                    ]
-                },
-                "defaultExtensions": [
-                    ".ts",
-                    ".tsx",
-                    ".d.ts",
-                    ".js",
-                    ".jsx",
-                    ".json",
-                    ".node"
-                ],
-                "defaultMainFields": [
-                    "types",
-                    "typings",
-                    "fesm2020",
-                    "fesm2015",
-                    "esm2020",
-                    "es2020",
-                    "module",
-                    "jsnext:main",
-                    "main"
-                ],
-                "interfaceVersion": 2
-            },
-            "typescript": true
+                ]
+            }
         },
         "jsdoc": {
             "mode": "typescript",


### PR DESCRIPTION
This PR updates the @fluidframework/eslint-config-fluid package (v8.0.0 -> v8.1.0) with the following changes:

## Changes

### import-x/order rule simplified
The `import-x/order` rule configuration has been simplified so that it enforces some ordering but doesn't require a lot of formatting changes in our source. Once we are fully migrated to Eslint 9 we can revisit the ordering we want.

### Resolver configuration updated
The TypeScript resolver configuration has been updated to work correctly with the repository's build setup.

### no-hyphen-after-jsdoc-tag rule disabled
The `@fluid-internal/fluid/no-hyphen-after-jsdoc-tag` rule has been temporarily disabled pending resolution of AB#29535.