### PR TITLE
Get test tenants in same step as test workload in pipelines

### DIFF
--- a/packages/test/test-drivers/src/index.ts
+++ b/packages/test/test-drivers/src/index.ts
@@ -17,7 +17,13 @@ export {
 	OdspDriverApi,
 	OdspDriverApiType,
 } from "./odspDriverApi.js";
-export { assertOdspEndpoint, getOdspCredentials, OdspTestDriver } from "./odspTestDriver.js";
+export {
+	assertOdspEndpoint,
+	getOdspCredentials,
+	OdspTestDriver,
+	TenantSetupResult,
+	UserPassCredentials,
+} from "./odspTestDriver.js";
 export {
 	RouterliciousDriverApi,
 	RouterliciousDriverApiType,

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -102,8 +102,8 @@ export function getOdspCredentials(
 	const creds: { username: string; password: string }[] = [];
 	const loginTenants =
 		odspEndpointName === "odsp"
-			? process.env.login__odsp__test__tenants
-			: process.env.login__odspdf__test__tenants;
+			? JSON.stringify(process.env.login__odsp__test__tenants)
+			: JSON.stringify(process.env.login__odspdf__test__tenants);
 
 	if (loginTenants !== undefined) {
 		/**

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -120,6 +120,11 @@ export function getOdspCredentials(
 			for (const account of output) {
 				const username = account.UserPrincipalName;
 				const password = account.Password;
+				if (username === undefined || password === undefined) {
+					throw new Error(
+						`username or password should not be undefined when getting odsp credentials - user: ${username}, pass: ${password}`,
+					);
+				}
 				if (requestedUserName === undefined || requestedUserName === username) {
 					creds.push({ username, password });
 				}

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -102,8 +102,8 @@ export function getOdspCredentials(
 	const creds: { username: string; password: string }[] = [];
 	const loginTenants =
 		odspEndpointName === "odsp"
-			? JSON.stringify(process.env.login__odsp__test__tenants)
-			: JSON.stringify(process.env.login__odspdf__test__tenants);
+			? process.env.login__odsp__test__tenants
+			: process.env.login__odspdf__test__tenants;
 
 	if (loginTenants !== undefined) {
 		/**

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -53,23 +53,24 @@ interface IOdspTestDriverConfig extends TokenConfig {
 	options: HostStoragePolicy | undefined;
 }
 
-// specific a range of user name from <prefix><start> to <prefix><start + count - 1> all having the same password
-interface LoginTenantRange {
-	prefix: string;
-	start: number;
-	count: number;
-	password: string;
-}
+// // specific a range of user name from <prefix><start> to <prefix><start + count - 1> all having the same password
+// interface LoginTenantRange {
+// 	prefix: string;
+// 	start: number;
+// 	count: number;
+// 	password: string;
+// }
 
-interface LoginTenants {
-	[tenant: string]: {
-		range: LoginTenantRange;
-		// add different format here
-	};
-}
+// interface LoginTenants {
+// 	[tenant: string]: {
+// 		range: LoginTenantRange;
+// 		// add different format here
+// 	};
+// }
 
 /**
  * A simplified version of the credentials returned by the tenant pool containing only username and password values.
+ * @internal
  */
 export interface UserPassCredentials {
 	username: string;
@@ -88,7 +89,10 @@ export function assertOdspEndpoint(
 	throw new TypeError("Not a odsp endpoint");
 }
 
-interface TenantSetupResult {
+/**
+ * @internal
+ */
+export interface TenantSetupResult {
 	userPass: UserPassCredentials[];
 	reservationId: string;
 	appClientId: string;
@@ -127,11 +131,6 @@ export async function getOdspCredentials(
 	requestedUserName?: string,
 ): Promise<TenantSetupResult> {
 	const creds: UserPassCredentials[] = [];
-
-	/**
-	 * call trips here to populate username, password, and app client id
-	 * save reservation id somewhere to clean up in the refresh case
-	 */
 	const odspEndpoint = odspEndpointName === "odsp" ? "prod" : "dogfood";
 
 	const result = await importTenantSetupPackage({

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -231,26 +231,6 @@ export interface UserPassCredentials {
 	password: string;
 }
 
-interface CleanupArgs {
-	reservationId?: string;
-	odspEndpoint?: "prod" | "dogfood" | "df";
-}
-
-const importTenantCleanupPackage = async (args: CleanupArgs): Promise<void> => {
-	if (process.env.FLUID_TENANT_SETUP_PKG_SPECIFIER !== undefined) {
-		// We expect that the specified package provides a releaseTenants function.
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const { releaseTenants } = await import(process.env.FLUID_TENANT_SETUP_PKG_SPECIFIER);
-		assert(
-			typeof releaseTenants === "function",
-			"A releaseTenants function was not provided from the specified package",
-		);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-		return releaseTenants(args);
-	}
-	return undefined;
-};
-
 /**
  * Fetch fresh tokens.
  * @param server - The server to auth against
@@ -271,11 +251,6 @@ export async function refreshTokens(
 	const refresh_token = tokens.refreshToken;
 	assert(refresh_token.length > 0, 0x1ec /* "No refresh token provided." */);
 
-	await importTenantCleanupPackage({
-		reservationId: clientConfig.reservationId,
-		odspEndpoint: clientConfig.endpointName === "odsp" ? "prod" : "dogfood",
-	});
-	// might also need to setup again?????
 	const credentials: TokenRequestCredentials = {
 		grant_type: "refresh_token",
 		refresh_token,

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -171,7 +171,7 @@ export async function fetchTokens(
 		try {
 			throwOdspNetworkError(
 				// pre-0.58 error message: unableToGetAccessToken
-				`Unable to get access token. user: ${credentials.grant_type === "password" ? credentials.username : "n/a"}`,
+				`Unable to get access token. response: ${JSON.stringify(parsedResponse)}`,
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				parsedResponse.error === "invalid_grant" ? 401 : response.status,
 				response,

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -171,7 +171,7 @@ export async function fetchTokens(
 		try {
 			throwOdspNetworkError(
 				// pre-0.58 error message: unableToGetAccessToken
-				"Unable to get access token.",
+				`Unable to get access token. user: ${credentials.grant_type === "password" ? credentials.username : "n/a"}`,
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				parsedResponse.error === "invalid_grant" ? 401 : response.status,
 				response,

--- a/packages/utils/odsp-doclib-utils/tsconfig.json
+++ b/packages/utils/odsp-doclib-utils/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		"types": ["node"],
 		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},

--- a/packages/utils/odsp-doclib-utils/tsconfig.json
+++ b/packages/utils/odsp-doclib-utils/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"types": ["node"],
 		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -441,11 +441,14 @@ stages:
                 # Parse the JSON output and set environment variables
                 export tenant__reservationId=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId')
                 if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then
-                  export login__odspdf__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
+                  export login__odspdf__test__tenants=$(echo "$SETUP_OUTPUT" | jq -c '.userPass')
                 elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
-                  export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
+                  export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -c '.userPass')
                 fi
               fi
+
+              echo "Leased tenant with reservation ID: $tenant__reservationId"
+              echo "ODSP tenant credentials: $login__odsp__test__tenants"
 
               pnpm run ${{ parameters.testCommand }} -- ${{ variant.flags }}
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -418,7 +418,7 @@ stages:
             script: |
               set -eu -o pipefail
 
-              ${{ if ne(parameters.odspTenantType, 'none') }}:
+              if [[ "${{ parameters.odspTenantType }}" != "none" ]]; then
                 SETUP_OUTPUT=$(node -e "
                   (async () => {
                     try {
@@ -438,13 +438,14 @@ stages:
                   })();
                 ")
 
-              # Parse the JSON output and set environment variables
-              export tenant__reservationId=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId')
-              ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
-                export login__odspdf__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
-              ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
-                export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
-
+                # Parse the JSON output and set environment variables
+                export tenant__reservationId=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId')
+                if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then
+                  export login__odspdf__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
+                elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
+                  export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
+                fi
+              fi
 
               pnpm exec ${{ parameters.testCommand }} -- ${{ variant.flags }}
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -436,22 +436,45 @@ stages:
                       process.exit(1);
                     }
                   })();
-                ")
+                " 2>/dev/null)  # Redirect stderr to avoid mixing error messages with JSON
 
-                # DEBUG
-                echo "$SETUP_OUTPUT" | jq -r '.reservationId'
-                echo "$SETUP_OUTPUT" | jq -c '.userPass'
+                # DEBUG - Check what we actually got
+                echo "Raw SETUP_OUTPUT length: ${#SETUP_OUTPUT}"
+                echo "Raw SETUP_OUTPUT content: '$SETUP_OUTPUT'"
 
-                # Parse the JSON output and set environment variables
-                export tenant__reservationId=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId')
-                if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then
-                  export login__odspdf__test__tenants=$(echo "$SETUP_OUTPUT" | jq -c '.userPass')
-                elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
-                  export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -c '.userPass')
+                # Validate JSON before processing
+                if ! echo "$SETUP_OUTPUT" | jq . > /dev/null 2>&1; then
+                  echo "ERROR: SETUP_OUTPUT is not valid JSON!"
+                  echo "First 200 characters: ${SETUP_OUTPUT:0:200}"
+                  exit 1
                 fi
-                echo "$SETUP_OUTPUT"
-                echo "Leased tenant with reservation ID: $tenant__reservationId"
-                echo "ODSP tenant credentials: $login__odsp__test__tenants"
+
+                # Now safely parse the JSON
+                RESERVATION_ID=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId // "null"')
+                USER_PASS=$(echo "$SETUP_OUTPUT" | jq -c '.userPass // "null"')
+
+                echo "Parsed reservationId: '$RESERVATION_ID'"
+                echo "Parsed userPass: '$USER_PASS'"
+
+                # Only set variables if parsing succeeded
+                if [[ "$RESERVATION_ID" != "null" && "$RESERVATION_ID" != "" ]]; then
+                  export tenant__reservationId="$RESERVATION_ID"
+
+                  # Set Azure DevOps variables for cleanup task
+                  echo "##vso[task.setvariable variable=stringBearerToken]$RESERVATION_ID"
+                  echo "##vso[task.setvariable variable=tenantCreds]$USER_PASS"
+
+                  if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then
+                    export login__odspdf__test__tenants="$USER_PASS"
+                  elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
+                    export login__odsp__test__tenants="$USER_PASS"
+                  fi
+
+                  echo "Successfully set up tenant with reservation ID: $tenant__reservationId"
+                else
+                  echo "ERROR: Failed to parse reservationId from setup output"
+                  exit 1
+                fi
               fi
 
               pnpm run ${{ parameters.testCommand }} -- ${{ variant.flags }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -383,18 +383,18 @@ stages:
 
                 az login --service-principal -u $servicePrincipalId -p $idToken --tenant $tenantId
 
-          - task: Bash@3
-            displayName: 'Run tenant setup script'
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-            inputs:
-              targetType: 'inline'
-              script: |
-                set -eu -o pipefail
+          # - task: Bash@3
+          #   displayName: 'Run tenant setup script'
+          #   env:
+          #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          #   inputs:
+          #     targetType: 'inline'
+          #     script: |
+          #       set -eu -o pipefail
 
-                # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
-                pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --odspEndpoint=${{ parameters.odspTenantType }}
-                echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"
+          #       # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
+          #       pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --odspEndpoint=${{ parameters.odspTenantType }}
+          #       echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"
 
         # run the test
         - task: Bash@3
@@ -423,8 +423,8 @@ stages:
                   (async () => {
                     try {
                       const tenantSetupPackage = '${{ parameters.tenantSetupPackage }}';
-                      const { getOrRefreshCredentials } = await import(tenantSetupPackage);
-                      const result = await getOrRefreshCredentials({
+                      const { setupTenants } = await import(tenantSetupPackage);
+                      const result = await setupTenants({
                         waitTime: 3600,
                         accessToken: process.env.SYSTEM_ACCESSTOKEN,
                         odspEndpoint: '${{ parameters.odspTenantType }}'

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -430,7 +430,7 @@ stages:
                         odspEndpoint: '${{ parameters.odspTenantType }}'
                       });
                       fs.writeFileSync('/tmp/setup_result.json', result);
-                    catch (e) {
+                    } catch (e) {
                       console.error('Error during tenant setup: ', e);
                       fs.unlinkSync('/tmp/setup_result.json');
                       process.exit(1);

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -438,6 +438,10 @@ stages:
                   })();
                 ")
 
+                # DEBUG
+                echo "$SETUP_OUTPUT" | jq -r '.reservationId'
+                echo "$SETUP_OUTPUT" | jq -c '.userPass'
+
                 # Parse the JSON output and set environment variables
                 export tenant__reservationId=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId')
                 if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -447,7 +447,7 @@ stages:
                 fi
               fi
 
-              pnpm exec ${{ parameters.testCommand }} -- ${{ variant.flags }}
+              pnpm run ${{ parameters.testCommand }} -- ${{ variant.flags }}
 
 
         - ${{ if eq(parameters.skipTestResultPublishing, false) }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -441,15 +441,9 @@ stages:
                 # Read JSON from temp file
                 JSON_OUTPUT=$(cat /tmp/setup_result.json)
 
-                echo "JSON result:"
-                echo "$JSON_OUTPUT"
-
                 # Now safely parse the JSON
                 RESERVATION_ID=$(echo "$JSON_OUTPUT" | jq -r '.reservationId // "null"')
                 USER_PASS=$(echo "$JSON_OUTPUT" | jq '.userPass // "null"')
-
-                echo "Parsed reservationId: '$RESERVATION_ID'"
-                echo "Parsed userPass: '$USER_PASS'"
 
                 # Only set variables if parsing succeeded
                 if [[ "$RESERVATION_ID" != "null" && "$RESERVATION_ID" != "" ]]; then
@@ -465,9 +459,9 @@ stages:
                     export login__odsp__test__tenants="$USER_PASS"
                   fi
 
-                  echo "Successfully set up tenant with reservation ID: $tenant__reservationId"
+                  echo "Successfully set up tenant with reservation ID: "
                   printenv tenant__reservationId
-                  echo "successfully set up credentials: $login__odsp__test__tenants"
+                  echo "successfully set up credentials: "
                   printenv login__odsp__test__tenants
                 else
                   echo "ERROR: Failed to parse reservationId from setup output"

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -406,7 +406,7 @@ stages:
               ${{ pair.key }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
-            login__microsoft__clientId: $(appClientId)
+            # login__microsoft__clientId: $(appClientId)
             # ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
             #   login__odspdf__test__tenants: $(tenantCreds)
             # ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
@@ -418,54 +418,54 @@ stages:
             script: |
               set -eu -o pipefail
 
-              if [[ "${{ parameters.odspTenantType }}" != "none" ]]; then
-                SETUP_OUTPUT=$(node -e "
-                  (async () => {
-                    try {
-                      const tenantSetupPackage = '${{ parameters.tenantSetupPackage }}';
-                      const { setupTenants } = await import(tenantSetupPackage);
-                      const result = await setupTenants({
-                        waitTime: 3600,
-                        accessToken: process.env.SYSTEM_ACCESSTOKEN,
-                        odspEndpoint: '${{ parameters.odspTenantType }}'
-                      });
-                      fs.writeFileSync('/tmp/setup_result.json', result);
-                    } catch (e) {
-                      console.error('Error during tenant setup: ', e);
-                      fs.unlinkSync('/tmp/setup_result.json');
-                      process.exit(1);
-                    }
-                  })();
-                ")
+              # if [[ "${{ parameters.odspTenantType }}" != "none" ]]; then
+              #   SETUP_OUTPUT=$(node -e "
+              #     (async () => {
+              #       try {
+              #         const tenantSetupPackage = '${{ parameters.tenantSetupPackage }}';
+              #         const { setupTenants } = await import(tenantSetupPackage);
+              #         const result = await setupTenants({
+              #           waitTime: 3600,
+              #           accessToken: process.env.SYSTEM_ACCESSTOKEN,
+              #           odspEndpoint: '${{ parameters.odspTenantType }}'
+              #         });
+              #         fs.writeFileSync('/tmp/setup_result.json', result);
+              #       } catch (e) {
+              #         console.error('Error during tenant setup: ', e);
+              #         fs.unlinkSync('/tmp/setup_result.json');
+              #         process.exit(1);
+              #       }
+              #     })();
+              #   ")
 
-                # Read JSON from temp file
-                JSON_OUTPUT=$(cat /tmp/setup_result.json)
+              #   # Read JSON from temp file
+              #   JSON_OUTPUT=$(cat /tmp/setup_result.json)
 
-                # Now safely parse the JSON
-                RESERVATION_ID=$(echo "$JSON_OUTPUT" | jq -r '.reservationId // "null"')
-                USER_PASS=$(echo "$JSON_OUTPUT" | jq '.userPass // "null"')
+              #   # Now safely parse the JSON
+              #   RESERVATION_ID=$(echo "$JSON_OUTPUT" | jq -r '.reservationId // "null"')
+              #   USER_PASS=$(echo "$JSON_OUTPUT" | jq '.userPass // "null"')
 
-                # Only set variables if parsing succeeded
-                if [[ "$RESERVATION_ID" != "null" && "$RESERVATION_ID" != "" ]]; then
-                  export tenant__reservationId="$RESERVATION_ID"
+              #   # Only set variables if parsing succeeded
+              #   if [[ "$RESERVATION_ID" != "null" && "$RESERVATION_ID" != "" ]]; then
+              #     export tenant__reservationId="$RESERVATION_ID"
 
-                  # Set Azure DevOps variables for cleanup task
-                  echo "##vso[task.setvariable variable=stringBearerToken]$RESERVATION_ID"
-                  echo "##vso[task.setvariable variable=tenantCreds]$USER_PASS"
+              #     # Set Azure DevOps variables for cleanup task
+              #     echo "##vso[task.setvariable variable=stringBearerToken]$RESERVATION_ID"
+              #     echo "##vso[task.setvariable variable=tenantCreds]$USER_PASS"
 
-                  if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then
-                    export login__odspdf__test__tenants="$USER_PASS"
-                  elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
-                    export login__odsp__test__tenants="$USER_PASS"
-                  fi
+              #     if [[ "${{ parameters.odspTenantType }}" == "dogfood" ]]; then
+              #       export login__odspdf__test__tenants="$USER_PASS"
+              #     elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
+              #       export login__odsp__test__tenants="$USER_PASS"
+              #     fi
 
-                else
-                  echo "ERROR: Failed to parse reservationId from setup output"
-                  exit 1
-                fi
-                # Clean up temp file
-                rm -f /tmp/setup_result.json
-              fi
+              #   else
+              #     echo "ERROR: Failed to parse reservationId from setup output"
+              #     exit 1
+              #   fi
+              #   # Clean up temp file
+              #   rm -f /tmp/setup_result.json
+              # fi
 
               pnpm run ${{ parameters.testCommand }} -- ${{ variant.flags }}
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -397,10 +397,11 @@ stages:
                 echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"
 
         # run the test
-        - task: Npm@1
+        - task: Bash@3
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
           continueOnError: ${{ parameters.continueOnError }}
           env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             ${{ each pair in parameters.env }}:
               ${{ pair.key }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
@@ -412,9 +413,41 @@ stages:
               login__microsoft__clientId: $(appClientId)
               login__odsp__test__tenants: $(tenantCreds)
           inputs:
-            command: 'custom'
-            workingDir: $(Build.SourcesDirectory)/node_modules/${{ parameters.testPackage }}
-            customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
+            targetType: 'inline'
+            workingDirectory: $(Build.SourcesDirectory)/node_modules/${{ parameters.testPackage }}
+            script: |
+              set -eu -o pipefail
+
+              ${{ if ne(parameters.odspTenantType, 'none') }}:
+                SETUP_OUTPUT=$(node -e "
+                  (async () => {
+                    try {
+                      const tenantSetupPackage = '${{ parameters.tenantSetupPackage }}';
+                      const { getOrRefreshCredentials } = await import(tenantSetupPackage);
+                      const result = await getOrRefreshCredentials({
+                        waitTime: 3600,
+                        accessToken: process.env.SYSTEM_ACCESSTOKEN,
+                        odspEndpoint: '${{ parameters.odspTenantType }}'
+                      });
+                      console.log(JSON.stringify(result));
+                    }
+                    catch (e) {
+                      console.error('Error during tenant setup: ', e);
+                      process.exit(1);
+                    }
+                  })();
+                ")
+
+              # Parse the JSON output and set environment variables
+              export tenant__reservationId=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId')
+              ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
+                export login__odspdf__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
+              ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
+                export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -r '.userPass')
+
+
+              pnpm exec ${{ parameters.testCommand }} -- ${{ variant.flags }}
+
 
         - ${{ if eq(parameters.skipTestResultPublishing, false) }}:
           # filter report

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -436,22 +436,17 @@ stages:
                       process.exit(1);
                     }
                   })();
-                " 2>/dev/null)  # Redirect stderr to avoid mixing error messages with JSON
+                ")
 
-                # DEBUG - Check what we actually got
-                echo "Raw SETUP_OUTPUT length: ${#SETUP_OUTPUT}"
-                echo "Raw SETUP_OUTPUT content: '$SETUP_OUTPUT'"
+                # Extract just the JSON line (the last line should be the JSON)
+                JSON_OUTPUT=$(echo "$SETUP_OUTPUT" | tail -n 1)
 
-                # Validate JSON before processing
-                if ! echo "$SETUP_OUTPUT" | jq . > /dev/null 2>&1; then
-                  echo "ERROR: SETUP_OUTPUT is not valid JSON!"
-                  echo "First 200 characters: ${SETUP_OUTPUT:0:200}"
-                  exit 1
-                fi
+                echo "JSON result:"
+                echo "$JSON_OUTPUT"
 
                 # Now safely parse the JSON
-                RESERVATION_ID=$(echo "$SETUP_OUTPUT" | jq -r '.reservationId // "null"')
-                USER_PASS=$(echo "$SETUP_OUTPUT" | jq -c '.userPass // "null"')
+                RESERVATION_ID=$(echo "$JSON_OUTPUT" | jq -r '.reservationId // "null"')
+                USER_PASS=$(echo "$JSON_OUTPUT" | jq -c '.userPass // "null"')
 
                 echo "Parsed reservationId: '$RESERVATION_ID'"
                 echo "Parsed userPass: '$USER_PASS'"

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -406,12 +406,12 @@ stages:
               ${{ pair.key }}: ${{ pair.value }}
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
-            ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
-              login__microsoft__clientId: $(appClientId)
-              login__odspdf__test__tenants: $(tenantCreds)
-            ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
-              login__microsoft__clientId: $(appClientId)
-              login__odsp__test__tenants: $(tenantCreds)
+            login__microsoft__clientId: $(appClientId)
+            # ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
+            #   login__odspdf__test__tenants: $(tenantCreds)
+            # ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
+            #   login__microsoft__clientId: $(appClientId)
+            #   login__odsp__test__tenants: $(tenantCreds)
           inputs:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/node_modules/${{ parameters.testPackage }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -446,7 +446,7 @@ stages:
 
                 # Now safely parse the JSON
                 RESERVATION_ID=$(echo "$JSON_OUTPUT" | jq -r '.reservationId // "null"')
-                USER_PASS=$(echo "$JSON_OUTPUT" | jq -c '.userPass // "null"')
+                USER_PASS=$(echo "$JSON_OUTPUT" | jq '.userPass // "null"')
 
                 echo "Parsed reservationId: '$RESERVATION_ID'"
                 echo "Parsed userPass: '$USER_PASS'"

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -429,17 +429,17 @@ stages:
                         accessToken: process.env.SYSTEM_ACCESSTOKEN,
                         odspEndpoint: '${{ parameters.odspTenantType }}'
                       });
-                      console.log(JSON.stringify(result));
-                    }
+                      fs.writeFileSync('/tmp/setup_result.json', result);
                     catch (e) {
                       console.error('Error during tenant setup: ', e);
+                      fs.unlinkSync('/tmp/setup_result.json');
                       process.exit(1);
                     }
                   })();
                 ")
 
-                # Extract just the JSON line (the last line should be the JSON)
-                JSON_OUTPUT=$(echo "$SETUP_OUTPUT" | tail -n 1)
+                # Read JSON from temp file
+                JSON_OUTPUT=$(cat /tmp/setup_result.json)
 
                 echo "JSON result:"
                 echo "$JSON_OUTPUT"
@@ -470,6 +470,8 @@ stages:
                   echo "ERROR: Failed to parse reservationId from setup output"
                   exit 1
                 fi
+                # Clean up temp file
+                rm -f /tmp/setup_result.json
               fi
 
               pnpm run ${{ parameters.testCommand }} -- ${{ variant.flags }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -466,6 +466,9 @@ stages:
                   fi
 
                   echo "Successfully set up tenant with reservation ID: $tenant__reservationId"
+                  printenv tenant__reservationId
+                  echo "successfully set up credentials: $login__odsp__test__tenants"
+                  printenv login__odsp__test__tenants
                 else
                   echo "ERROR: Failed to parse reservationId from setup output"
                   exit 1

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -459,10 +459,6 @@ stages:
                     export login__odsp__test__tenants="$USER_PASS"
                   fi
 
-                  echo "Successfully set up tenant with reservation ID: "
-                  printenv tenant__reservationId
-                  echo "successfully set up credentials: "
-                  printenv login__odsp__test__tenants
                 else
                   echo "ERROR: Failed to parse reservationId from setup output"
                   exit 1

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -445,10 +445,10 @@ stages:
                 elif [[ "${{ parameters.odspTenantType }}" == "prod" ]]; then
                   export login__odsp__test__tenants=$(echo "$SETUP_OUTPUT" | jq -c '.userPass')
                 fi
+                echo "$SETUP_OUTPUT"
+                echo "Leased tenant with reservation ID: $tenant__reservationId"
+                echo "ODSP tenant credentials: $login__odsp__test__tenants"
               fi
-
-              echo "Leased tenant with reservation ID: $tenant__reservationId"
-              echo "ODSP tenant credentials: $login__odsp__test__tenants"
 
               pnpm run ${{ parameters.testCommand }} -- ${{ variant.flags }}
 

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -192,3 +192,4 @@ stages:
       env:
         FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains createTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
+        FLUID_TENANT_SETUP_PKG_SPECIFIER: '@ff-internal/trips-setup'


### PR DESCRIPTION
Update the pipeline template to set up the tenant credentials and start the test workload in the same task. 

[AB#51458](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/51458)