### PR TITLE
Bump client packages to 2.71.1 and update typetests

### DIFF
--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-local-service",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Local implementation of the Azure Fluid Relay service for testing/development use",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -95,7 +95,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.3",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.70.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.71.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-service-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Helper service-side utilities for connecting to Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/ai-collab",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example app that showcases the experimental package for AI collaboration in Fluid-based applications.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/blobs",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example of using blobs in Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/collaborative-textarea",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "A minimal example using the react collaborative-textarea",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/contact-collection",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example of using a Fluid Object as a collection of items",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/data-object-grid",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Data object grid creates child data objects from a registry and lays them out in a grid.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/presence-tracker",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example application that tracks page focus and mouse position using the Fluid Framework presence features.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/staging",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Using the experimental staging feature.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/task-selection",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example demonstrating selecting a unique task amongst connected Fluid clients",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-cli-app/package.json
+++ b/examples/apps/tree-cli-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-cli-app",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "SharedTree CLI app demo",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-comparison",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Comparing API usage in legacy SharedTree and new SharedTree.",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-baseline",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-common",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/experimental-tree/package.json
+++ b/examples/benchmarks/bubblebench/experimental-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-experimental-tree",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-ot",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/shared-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-shared-tree",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/odspsnapshotfetch-perftestapp",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Benchmark binary vs. json download",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/tablebench",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Table focused benchmarks",
 	"homepage": "https://fluidframework.com",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-insights-logger",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Provides a simple Fluid application with a UI view written in React to test the Fluid App Insights telemetry logger that will route typical Fluid telemetry to configured Azure App Insights",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/canvas",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Fluid ink canvas",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/clicker",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal Fluid component sample to implement a collaborative counter.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/codemirror",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/diceroller",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Object sample to implement a collaborative dice roller.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/inventory-app",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal sample of SharedTree/React integration.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/monaco",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Monaco code editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-model",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Constellation model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-view",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-container",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Container for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-model",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Coordinate model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-interface",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Interface for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-plot-coordinate-view",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-slider-coordinate-view",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-triangle-view",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/prosemirror",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "ProseMirror",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/smde",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-document",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Chaincode component containing a table's data",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/examples/data-objects/table-tree/package.json
+++ b/examples/data-objects/table-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-tree",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Simple table example app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/todo",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Simple todo canvas.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webflow",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Collaborative markdown editor.",
 	"homepage": "https://fluidframework.com",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-data",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Integrating an external data source with Fluid data.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-controller",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/todo-list/package.json
+++ b/examples/service-clients/azure-client/todo-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/azure-client-todo-list",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal Fluid Container sample demonstrating the use of SharedTree and nested DDSs via a simple to-do list application.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/shared-tree-demo",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "A shared tree demo using react and odsp client",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bundle-size-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "A package for understanding the bundle size of Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-driver/package.json
+++ b/examples/utils/example-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Simplified drivers used by examples in the FluidFramework repo.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Shared utilities used by examples.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-webpack-integration/package.json
+++ b/examples/utils/example-webpack-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-webpack-integration",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Webpack configuration used by examples in the FluidFramework repo.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/import-testing",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "import-testing",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/migration-tools",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Tools for migrating data",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webpack-fluid-loader",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Fluid object loader for webpack-dev-server",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-live-schema-upgrade",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example application that demonstrates how to add a data object to a live container.",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-same-container",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in the same container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-separate-container",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in a new container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-shim",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Migrating from legacy SharedTree to new SharedTree using a tree shim.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-container-views",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal Fluid Container & data store sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-views",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/view-framework-sampler",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Example of integrating a Fluid data object with a variety of view frameworks.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-changeset",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "property changeset definitions and related functionalities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-common",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "common functions used in properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/platform-dependent",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Helper package that separates code for browser and server.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-dds",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "definition of the property distributed data store",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-properties",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "definitions of properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ot",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/src/packageVersion.ts
+++ b/experimental/dds/ot/ot/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ot";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sharejs-json1",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
+++ b/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sharejs-json1";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sequence-deprecated",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Deprecated distributed sequences",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/sequence-deprecated/src/packageVersion.ts
+++ b/experimental/dds/sequence-deprecated/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sequence-deprecated";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/tree",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-objects",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A collection of ready to use Fluid Data Objects",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/last-edited",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Tracks the last edited information in the Container.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "client-release-group-root",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -143,7 +143,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.70.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.71.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/client-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Not intended for use outside the Fluid Framework.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.70.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"concurrently": "^8.2.1",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid container definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -125,7 +125,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.70.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-interfaces",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid object interfaces",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.70.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Not intended for use outside the Fluid client repo.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.70.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"concurrently": "^8.2.1",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid driver definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.70.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.71.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/cell",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed data structure for a single value",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/src/packageVersion.ts
+++ b/packages/dds/cell/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/cell";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.70.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/counter",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Counter DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/counter/src/packageVersion.ts
+++ b/packages/dds/counter/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/counter";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ink",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Ink DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ink/src/packageVersion.ts
+++ b/packages/dds/ink/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ink";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/legacy-dds/package.json
+++ b/packages/dds/legacy-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/legacy-dds",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Legacy DDSs for the Fluid Framework. These are not intended for use in new code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/legacy-dds/src/packageVersion.ts
+++ b/packages/dds/legacy-dds/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/legacy-dds";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.70.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/map",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed map",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/map/src/packageVersion.ts
+++ b/packages/dds/map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/map";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -161,7 +161,7 @@
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.70.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/matrix",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed matrix",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/matrix/src/packageVersion.ts
+++ b/packages/dds/matrix/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/matrix";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -154,7 +154,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.70.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/merge-tree",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Merge tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.70.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ordered-collection",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Consensus Collection",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/src/packageVersion.ts
+++ b/packages/dds/ordered-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/ordered-collection";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/pact-map",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed data structure for key-value pairs using pact consensus",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/pact-map/src/packageVersion.ts
+++ b/packages/dds/pact-map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/pact-map";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.70.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/register-collection",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Consensus Register",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/register-collection/src/packageVersion.ts
+++ b/packages/dds/register-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/register-collection";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -170,7 +170,7 @@
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.70.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/sequence",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed sequence",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/sequence/src/packageVersion.ts
+++ b/packages/dds/sequence/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/sequence";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.70.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-object-base",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid base class for shared distributed data structures",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-object-base/src/packageVersion.ts
+++ b/packages/dds/shared-object-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-object-base";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.70.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-summary-block",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A DDS that does not generate ops but is part of summary",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-summary-block/src/packageVersion.ts
+++ b/packages/dds/shared-summary-block/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-summary-block";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -148,7 +148,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.70.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.71.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/task-manager",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed data structure for queueing exclusive tasks",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/task-manager/src/packageVersion.ts
+++ b/packages/dds/task-manager/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/task-manager";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-dds-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid DDS test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -199,7 +199,7 @@
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.70.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/src/packageVersion.ts
+++ b/packages/dds/tree/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tree";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -94,7 +94,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.70.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/debugger",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid Debugger - a tool to play through history of a file",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -111,7 +111,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.70.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-base",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Shared driver code for Fluid driver implementations",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/src/packageVersion.ts
+++ b/packages/drivers/driver-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-base";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -102,7 +102,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.70.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-web-cache",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Implementation of the driver caching API for a web browser",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-web-cache/src/packageVersion.ts
+++ b/packages/drivers/driver-web-cache/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-web-cache";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.70.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/file-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A driver that reads/write from/to local file storage.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -141,7 +141,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.70.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/local-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid local driver",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/src/packageVersion.ts
+++ b/packages/drivers/local-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/local-driver";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.70.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.70.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/src/packageVersion.ts
+++ b/packages/drivers/odsp-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-driver";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.70.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-urlresolver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Url Resolver for odsp urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.70.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/replay-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Document replay version of Socket.IO implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.70.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Socket.IO + Git implementation of Fluid service API",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-driver/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-driver";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.70.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-urlresolver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Url Resolver for routerlicious urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -99,7 +99,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.70.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-driver",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Driver for tinylicious",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -103,7 +103,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.3",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.70.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.71.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/agent-scheduler",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Built in runtime object for distributing agents across instances of a container",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/ai-collab/package.json
+++ b/packages/framework/ai-collab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ai-collab",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Experimental package to simplify integrating AI into Fluid-based applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.3",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.70.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.71.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/aqueduct",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A set of implementations for Fluid Framework interfaces.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/attributor",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Operation attributor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -93,7 +93,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.58.3",
-		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.70.0",
+		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.71.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@microsoft/api-extractor": "7.52.11",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/app-insights-logger",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Contains a Fluid logging client that sends telemetry events to Azure App Insights",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-telemetry",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Customer facing Fluid telemetry types and classes for both producing and consuming said telemetry",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-object-base",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Data object base for synchronously and lazily loaded object scenarios",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/dds-interceptions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Distributed Data Structures that support an interception callback",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluid-framework",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "The main entry point into Fluid Framework public packages",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -139,7 +139,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.70.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.71.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-static",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A tool to enable consumption of Fluid Data Objects without requiring custom container code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/oldest-client-observer",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Data object to determine if the local client is the oldest amongst connected clients",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/presence",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A component for lightweight data sharing within a single session",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence/src/packageVersion.ts
+++ b/packages/framework/presence/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/presence";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/react",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Utilities for integrating content powered by the Fluid Framework into React applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.70.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/request-handler",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A simple request handling library for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.70.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/synthesize",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A library for synthesizing scope objects.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent-langchain/package.json
+++ b/packages/framework/tree-agent-langchain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent-langchain",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "LangChain integration helpers for @fluidframework/tree-agent",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent-ses/package.json
+++ b/packages/framework/tree-agent-ses/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent-ses",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "SES integration helpers for @fluidframework/tree-agent",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent/package.json
+++ b/packages/framework/tree-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Experimental package to simplify integrating AI into Fluid-based applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.70.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/undo-redo",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Undo Redo",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -202,7 +202,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.70.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-loader",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid container loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/container-loader/src/packageVersion.ts
+++ b/packages/loader/container-loader/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-loader";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -131,7 +131,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.70.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Collection of utility functions for Fluid drivers",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/driver-utils/src/packageVersion.ts
+++ b/packages/loader/driver-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-utils";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-loader-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Mocks and other test utilities for the Fluid Framework Loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.70.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -197,7 +197,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.70.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid container runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/src/packageVersion.ts
+++ b/packages/runtime/container-runtime/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-runtime";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -101,7 +101,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.70.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid data store definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -137,7 +137,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.70.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.11",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid data store implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore/src/packageVersion.ts
+++ b/packages/runtime/datastore/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/datastore";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.70.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/id-compressor",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "ID compressor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/id-compressor/src/packageVersion.ts
+++ b/packages/runtime/id-compressor/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/id-compressor";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.70.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.70.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Collection of utility functions for Fluid Runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-utils/src/packageVersion.ts
+++ b/packages/runtime/runtime-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/runtime-utils";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.70.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-runtime-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid runtime test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.3",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.70.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.71.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-client",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-end-to-end-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Azure client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/odsp-end-to-end-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Odsp client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-client",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the ODSP service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -109,7 +109,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.70.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-client",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Tinylicious service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/functional-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Functional tests",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-stress-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Stress tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/mocha-test-setup",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/mocha-test-setup/src/packageVersion.ts
+++ b/packages/test/mocha-test-setup/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/mocha-test-setup";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-snapshots",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Comprehensive test of snapshot logic.",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/snapshots/src/packageVersion.ts
+++ b/packages/test/snapshots/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-snapshots";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/stochastic-test-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Utilities for stochastic tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-driver-definitions",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-drivers",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/src/packageVersion.ts
+++ b/packages/test/test-drivers/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-drivers";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-end-to-end-tests",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-end-to-end-tests";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-pairwise-generator",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-service-load",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Service load tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/src/packageVersion.ts
+++ b/packages/test/test-service-load/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-service-load";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.70.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-utils/src/packageVersion.ts
+++ b/packages/test/test-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-utils";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-version-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-version-utils/src/packageVersion.ts
+++ b/packages/test/test-version-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-version-utils";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/test/types_jest-environment-puppeteer/package.json
+++ b/packages/test/types_jest-environment-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types/jest-environment-puppeteer",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "TypeScript `globals` definitions fix-up for jest-environment-puppeteer",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/changelog-generator-wrapper/package.json
+++ b/packages/tools/changelog-generator-wrapper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/changelog-generator-wrapper",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-browser-extension",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "A browser extension for visualizing Fluid Framework stats and operations",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -151,7 +151,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.70.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools-core",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid Framework developer tools core functionality",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-core/src/packageVersion.ts
+++ b/packages/tools/devtools/devtools-core/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/devtools-core";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/tools/devtools/devtools-test-app/package.json
+++ b/packages/tools/devtools/devtools-test-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/devtools-test-app",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "An example application demonstrating how Fluid's devtools can be integrated into an application",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-view",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Contains a visualization suite for use alongside the Fluid Devtools",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -127,7 +127,7 @@
 		"@fluid-tools/build-cli": "^0.58.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.70.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.71.0",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Fluid Framework developer tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.58.3",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.70.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.71.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/fetch-tool",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Console tool to fetch Fluid data from relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.70.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-runner",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Utility for running various functionality inside a Fluid Framework environment",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/replay-tool",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "A tool that lets the user to replay ops.",
 	"homepage": "https://fluidframework.com",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.70.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/isomorphic-fetch": "^0.0.39",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-doclib-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "ODSP utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/odsp-doclib-utils/src/packageVersion.ts
+++ b/packages/utils/odsp-doclib-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-doclib-utils";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.70.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/telemetry-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Collection of telemetry relates utilities for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -113,7 +113,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.58.3",
 		"@fluidframework/eslint-config-fluid": "^7.0.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.70.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.71.0",
 		"@microsoft/api-extractor": "7.52.11",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tool-utils",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"description": "Common utilities for Fluid tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/src/packageVersion.ts
+++ b/packages/utils/tool-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tool-utils";
-export const pkgVersion = "2.71.0";
+export const pkgVersion = "2.71.1";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
-        version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
+        version: 7.0.0(eslint@8.57.1)(typescript@5.9.2)
       eslint:
         specifier: ~8.57.1
         version: 8.57.1
@@ -159,8 +159,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@2.70.0
-        version: '@fluidframework/azure-service-utils@2.70.0'
+        specifier: npm:@fluidframework/azure-service-utils@2.71.0
+        version: 'link:'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -7403,8 +7403,8 @@ importers:
         specifier: ~1.9.3
         version: 1.9.4
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@2.70.0
-        version: '@fluid-internal/client-utils@2.70.0'
+        specifier: npm:@fluid-internal/client-utils@2.71.0
+        version: 'link:'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7530,8 +7530,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@2.70.0
-        version: '@fluidframework/container-definitions@2.70.0'
+        specifier: npm:@fluidframework/container-definitions@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7572,8 +7572,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@2.70.0
-        version: '@fluidframework/core-interfaces@2.70.0'
+        specifier: npm:@fluidframework/core-interfaces@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7638,8 +7638,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@2.70.0
-        version: '@fluidframework/core-utils@2.70.0'
+        specifier: npm:@fluidframework/core-utils@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7711,8 +7711,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@2.70.0
-        version: '@fluidframework/driver-definitions@2.70.0'
+        specifier: npm:@fluidframework/driver-definitions@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7781,8 +7781,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@2.70.0
-        version: '@fluidframework/cell@2.70.0'
+        specifier: npm:@fluidframework/cell@2.71.0
+        version: 'link:'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7881,8 +7881,8 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@2.70.0
-        version: '@fluidframework/counter@2.70.0'
+        specifier: npm:@fluidframework/counter@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -8190,8 +8190,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@2.70.0
-        version: '@fluidframework/map@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/map@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8314,8 +8314,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@2.70.0
-        version: '@fluidframework/matrix@2.70.0'
+        specifier: npm:@fluidframework/matrix@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8435,8 +8435,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@2.70.0
-        version: '@fluidframework/merge-tree@2.70.0'
+        specifier: npm:@fluidframework/merge-tree@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8541,8 +8541,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@2.70.0
-        version: '@fluidframework/ordered-collection@2.70.0'
+        specifier: npm:@fluidframework/ordered-collection@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8726,8 +8726,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@2.70.0
-        version: '@fluidframework/register-collection@2.70.0'
+        specifier: npm:@fluidframework/register-collection@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8841,8 +8841,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@2.70.0
-        version: '@fluidframework/sequence@2.70.0'
+        specifier: npm:@fluidframework/sequence@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8959,8 +8959,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@2.70.0
-        version: '@fluidframework/shared-object-base@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/shared-object-base@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9062,8 +9062,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@2.70.0
-        version: '@fluidframework/shared-summary-block@2.70.0'
+        specifier: npm:@fluidframework/shared-summary-block@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9171,8 +9171,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@2.70.0
-        version: '@fluidframework/task-manager@2.70.0'
+        specifier: npm:@fluidframework/task-manager@2.71.0
+        version: 'link:'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9416,8 +9416,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@2.70.0
-        version: '@fluidframework/tree@2.70.0'
+        specifier: npm:@fluidframework/tree@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -9513,8 +9513,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@2.70.0
-        version: '@fluidframework/debugger@2.70.0'
+        specifier: npm:@fluidframework/debugger@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -9580,8 +9580,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@2.70.0
-        version: '@fluidframework/driver-base@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/driver-base@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -9662,8 +9662,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@2.70.0
-        version: '@fluidframework/driver-web-cache@2.70.0'
+        specifier: npm:@fluidframework/driver-web-cache@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -9738,8 +9738,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@2.70.0
-        version: '@fluidframework/file-driver@2.70.0'
+        specifier: npm:@fluidframework/file-driver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -9832,8 +9832,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@2.70.0
-        version: '@fluidframework/local-driver@2.70.0(debug@4.4.3)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/local-driver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -9935,8 +9935,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@2.70.0
-        version: '@fluidframework/odsp-driver@2.70.0(debug@4.4.3)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-driver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10005,8 +10005,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@2.70.0
-        version: '@fluidframework/odsp-driver-definitions@2.70.0'
+        specifier: npm:@fluidframework/odsp-driver-definitions@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10072,8 +10072,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@2.70.0
-        version: '@fluidframework/odsp-urlresolver@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-urlresolver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10148,8 +10148,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@2.70.0
-        version: '@fluidframework/replay-driver@2.70.0'
+        specifier: npm:@fluidframework/replay-driver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10239,8 +10239,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@2.70.0
-        version: '@fluidframework/routerlicious-driver@2.70.0(debug@4.4.3)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/routerlicious-driver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10330,8 +10330,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@2.70.0
-        version: '@fluidframework/routerlicious-urlresolver@2.70.0'
+        specifier: npm:@fluidframework/routerlicious-urlresolver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10415,8 +10415,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@2.70.0
-        version: '@fluidframework/tinylicious-driver@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-driver@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10500,8 +10500,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@2.70.0
-        version: '@fluidframework/agent-scheduler@2.70.0'
+        specifier: npm:@fluidframework/agent-scheduler@2.71.0
+        version: 'link:'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10694,8 +10694,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@2.70.0
-        version: '@fluidframework/aqueduct@2.70.0'
+        specifier: npm:@fluidframework/aqueduct@2.71.0
+        version: 'link:'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10879,8 +10879,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
-        specifier: npm:@fluidframework/app-insights-logger@2.70.0
-        version: '@fluidframework/app-insights-logger@2.70.0(tslib@1.14.1)'
+        specifier: npm:@fluidframework/app-insights-logger@2.71.0
+        version: 'link:'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11346,8 +11346,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@2.70.0
-        version: '@fluidframework/fluid-static@2.70.0'
+        specifier: npm:@fluidframework/fluid-static@2.71.0
+        version: 'link:'
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11710,8 +11710,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@2.70.0
-        version: '@fluidframework/request-handler@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/request-handler@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -11792,8 +11792,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@2.70.0
-        version: '@fluidframework/synthesize@2.70.0'
+        specifier: npm:@fluidframework/synthesize@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -12159,8 +12159,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@2.70.0
-        version: '@fluidframework/undo-redo@2.70.0'
+        specifier: npm:@fluidframework/undo-redo@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -12268,8 +12268,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@2.70.0
-        version: '@fluidframework/container-loader@2.70.0'
+        specifier: npm:@fluidframework/container-loader@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12371,8 +12371,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@2.70.0
-        version: '@fluidframework/driver-utils@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/driver-utils@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12553,8 +12553,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@2.70.0
-        version: '@fluidframework/container-runtime@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/container-runtime@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12644,8 +12644,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@2.70.0
-        version: '@fluidframework/container-runtime-definitions@2.70.0'
+        specifier: npm:@fluidframework/container-runtime-definitions@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12726,8 +12726,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@2.70.0
-        version: '@fluidframework/datastore@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/datastore@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12814,8 +12814,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@2.70.0
-        version: '@fluidframework/datastore-definitions@2.70.0'
+        specifier: npm:@fluidframework/datastore-definitions@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12887,8 +12887,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@2.70.0
-        version: '@fluidframework/id-compressor@2.70.0'
+        specifier: npm:@fluidframework/id-compressor@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -12966,8 +12966,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@2.70.0
-        version: '@fluidframework/runtime-definitions@2.70.0'
+        specifier: npm:@fluidframework/runtime-definitions@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -13045,8 +13045,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@2.70.0
-        version: '@fluidframework/runtime-utils@2.70.0(debug@4.4.3)'
+        specifier: npm:@fluidframework/runtime-utils@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -13163,8 +13163,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@2.70.0
-        version: '@fluidframework/test-runtime-utils@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-runtime-utils@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -13242,8 +13242,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@2.70.0
-        version: '@fluidframework/azure-client@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/azure-client@2.71.0
+        version: 'link:'
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13720,8 +13720,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@2.70.0
-        version: '@fluidframework/tinylicious-client@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-client@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -15053,8 +15053,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@2.70.0
-        version: '@fluidframework/test-utils@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-utils@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -15356,8 +15356,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@2.70.0
-        version: '@fluidframework/devtools@2.70.0'
+        specifier: npm:@fluidframework/devtools@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -15679,8 +15679,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@2.70.0
-        version: '@fluidframework/devtools-core@2.70.0'
+        specifier: npm:@fluidframework/devtools-core@2.71.0
+        version: 'link:'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -16168,8 +16168,8 @@ importers:
         specifier: ^0.58.3
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@2.70.0
-        version: '@fluid-tools/fetch-tool@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluid-tools/fetch-tool@2.71.0
+        version: 'link:'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -16250,8 +16250,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@2.70.0
-        version: '@fluidframework/fluid-runner@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/fluid-runner@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -16462,8 +16462,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@2.70.0
-        version: '@fluidframework/odsp-doclib-utils@2.70.0(debug@4.4.3)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-doclib-utils@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -16547,8 +16547,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@2.70.0
-        version: '@fluidframework/telemetry-utils@2.70.0'
+        specifier: npm:@fluidframework/telemetry-utils@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -16641,8 +16641,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@2.70.0
-        version: '@fluidframework/tool-utils@2.70.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tool-utils@2.71.0
+        version: 'link:'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -17794,14 +17794,8 @@ packages:
       '@types/react': '>=16.8.0 <19.0.0'
       react: '>=16.8.0 <19.0.0'
 
-  '@fluid-internal/client-utils@2.70.0':
-    resolution: {integrity: sha512-gxnv2/UjIu0fAEpyjkfWHodjQDGJ0EvjzmvQK8UFGAn49P29CKedktt+juGxmCh0ImMMrICeszHvKCvV4s7qlA==}
-
   '@fluid-internal/eslint-plugin-fluid@0.3.1':
     resolution: {integrity: sha512-7ifjbVEJcSEqTinmhg9LgrkVeh/JQdWa5FzvmWRgD9vgFjxPBpNw0/zBFpyDr1rUd6dnT853oO8y/hnmyH1rtw==}
-
-  '@fluid-internal/test-driver-definitions@2.70.0':
-    resolution: {integrity: sha512-jmMLgNqjzsDlXXb9W5SDdY18r3EaB03v0M7fb/1U6VRKCQB1t0rgmC0KXYy3bknROujisH9x66VZKc+mszuURw==}
 
   '@fluid-tools/benchmark@0.51.0':
     resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
@@ -17815,35 +17809,16 @@ packages:
     resolution: {integrity: sha512-WL7R9haO0as6TuNLXVD4bAWUiyuO6n0dbvntZIn3GfMOogoDAVOzNsU/NTRdZvtlGcsUiiW6MrCkmNjncPaeJQ==}
     hasBin: true
 
-  '@fluid-tools/fetch-tool@2.70.0':
-    resolution: {integrity: sha512-pzxZTjnR1XEyuXRwUmo8OR63B7UF+egXspgspzut5cSa1IgGQcRvZIfW/bFiNUCtnrwjHlDkJ98LFCm4T46HCw==}
-    hasBin: true
-
   '@fluid-tools/version-tools@0.58.3':
     resolution: {integrity: sha512-qRsjnm6L+7i3wHsWmnR7CaQuD4LIUp7aIM04a9qqjC3uf+sXA36PKOrKS8I0Ty/r1mIiVCEQywT+eMnGP7KzLQ==}
     engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/agent-scheduler@2.70.0':
-    resolution: {integrity: sha512-+76rblqwHTOx2MZZivh7LGHzn0k3XIeRiQsDJwkPd6nIQ6X9L8NgnvBg77Ek4042QSMe+Cz4cq22/bithA4HBQ==}
-
-  '@fluidframework/app-insights-logger@2.70.0':
-    resolution: {integrity: sha512-crmGhbHv0RXaF/eCS4QffnDny96KzaVAHM8NVI524XoaxO1k4MiNkVJqETHGqcUhupyLOE62CBR9Hx4uPbTn5g==}
-
   '@fluidframework/aqueduct@1.4.0':
     resolution: {integrity: sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==}
 
-  '@fluidframework/aqueduct@2.70.0':
-    resolution: {integrity: sha512-fx+s2ormvYAdh8N4TE8RtzIp/5xQ6mlnHVnwVxLYv+nw0vln6fi9SDDiOFksDONAsK64cojCtjTfOZcEqfWIrQ==}
-
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
-
-  '@fluidframework/azure-client@2.70.0':
-    resolution: {integrity: sha512-px2j87O7ppvDifGuspEF3CiMe/jRG3Wq1+TY+89eKemP1LMQoEViSnftVC1ZD5+2qeDwd/YBorwGc5QoK7MgiQ==}
-
-  '@fluidframework/azure-service-utils@2.70.0':
-    resolution: {integrity: sha512-NyhX9wvY2dSrZSPncrfkFst0xp6DPPiDvKWIItrdg3hlVI+xbeS/DJ/5393qDvYWa2v0TCJaCrxYRtq5Y/tumQ==}
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
@@ -17859,9 +17834,6 @@ packages:
 
   '@fluidframework/bundle-size-tools@0.58.3':
     resolution: {integrity: sha512-hIfJyHS+ia0dTmCXPm06LsM0omliRvf5NhL+YbYWEesW5QBWpEuaSJH8v/4HAWDAwAsFo2+YQFO/ZNzMLWpyyw==}
-
-  '@fluidframework/cell@2.70.0':
-    resolution: {integrity: sha512-KwwjN+z/Adg6jbqlh6HM0qrmjv9PS22zkT96InC8H8aTIZb94Aj9cLBw0Z3E/pBhiEy0MWsg2P/tsANivKrakw==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -17881,26 +17853,14 @@ packages:
   '@fluidframework/container-definitions@1.4.0':
     resolution: {integrity: sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==}
 
-  '@fluidframework/container-definitions@2.70.0':
-    resolution: {integrity: sha512-yc4ChlkJplXD1rrq9uOXb+OfYRX5kSyLRlRIyibqyn7XO6vIg6OvzKkHuaxi3aF0+UWIZaFsuXhs4AbT7lR/Nw==}
-
   '@fluidframework/container-loader@1.4.0':
     resolution: {integrity: sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==}
-
-  '@fluidframework/container-loader@2.70.0':
-    resolution: {integrity: sha512-FznSbQGasboswIQkAshEUY41AaV/5oJOps90FQFJ67Cdml/av0SZFFYhqq6xIjxZCfWgws9VRUSL/Diwt7rtwg==}
 
   '@fluidframework/container-runtime-definitions@1.4.0':
     resolution: {integrity: sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==}
 
-  '@fluidframework/container-runtime-definitions@2.70.0':
-    resolution: {integrity: sha512-FQDHJq9mqQIJ7ZE0mD/Q0kVSgRdgqngrVoe/NC0WY+Q23+FBrAtSmYwIhM8OIX5cFCMkEsFSjTSos4oeBAWW9A==}
-
   '@fluidframework/container-runtime@1.4.0':
     resolution: {integrity: sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==}
-
-  '@fluidframework/container-runtime@2.70.0':
-    resolution: {integrity: sha512-7baiLbGaF+Q5os9+CNfc8imVS4+vLfioPbo0wbW8PRQy6inlQdkc+fWoLdmGHttncBQQ1ZRKsUF32zpb0oM3VA==}
 
   '@fluidframework/container-utils@1.4.0':
     resolution: {integrity: sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==}
@@ -17908,72 +17868,26 @@ packages:
   '@fluidframework/core-interfaces@1.4.0':
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
 
-  '@fluidframework/core-interfaces@2.70.0':
-    resolution: {integrity: sha512-Yc1Lidf5SMWR8edRZWa30Kc2Okp8J2HPSRFJ2GoZarpeefmo+fdJUfAgsd26shIY8neSAa0P52MJuHRpvODGpg==}
-
-  '@fluidframework/core-utils@2.70.0':
-    resolution: {integrity: sha512-k1dHkGJQwYJ/UJJY9FQ4C5i1HMTjaO8QVGdbF6I90+K6lyuy4gPSzRVnRrPomyBFYNcS4KcXtoo4gQHe1K15bQ==}
-
-  '@fluidframework/counter@2.70.0':
-    resolution: {integrity: sha512-DwL3BMvvVVqh4oYQ+164Lt0JLNrH8hn7zLIR4M+Dl/omq83ddKGKOB6eO623vu5DTLvJTChWNPhQ0H93nilPKA==}
-
   '@fluidframework/datastore-definitions@1.4.0':
     resolution: {integrity: sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==}
-
-  '@fluidframework/datastore-definitions@2.70.0':
-    resolution: {integrity: sha512-hPdS9V1lUImqO9hV45LvCP9ZtqAV60QewbQeFeRYQytz9JLviaeKXdV+48fV0javxnWFTuwHW6JLlt4W5A1YcQ==}
 
   '@fluidframework/datastore@1.4.0':
     resolution: {integrity: sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==}
 
-  '@fluidframework/datastore@2.70.0':
-    resolution: {integrity: sha512-XhBUpK+GBZGgf5NzXlpqBTBNJK+3KXHD1hnEREgancZitso6PNQTNZuJDWxFyDjl8r4Lgehm1/2wV0w5GlAOWA==}
-
-  '@fluidframework/debugger@2.70.0':
-    resolution: {integrity: sha512-93hheEvlorT0BK2q/woIoqEkskitivHGwQ1D4nIyREjos7M9lW9DYG+1PrfYwWkRiQ2kwLvGvh403qwc3rpMmg==}
-
-  '@fluidframework/devtools-core@2.70.0':
-    resolution: {integrity: sha512-19VCYtANkHKkFhavA2RPyMD6woEde+KQw/h928GJXs9nN+e/zGSZ27G0x+9EYA4CGrktvA3bRfzo+OPrqD31Hg==}
-
-  '@fluidframework/devtools@2.70.0':
-    resolution: {integrity: sha512-JLt7rVFD2TuCUwG1Min2AyC97vNluyTOXVlSOhi7jqyx8TtvaOsimYfONF4Y6nxWGOH0dYjkEr6KfN4E+pcv3w==}
-
   '@fluidframework/driver-base@1.4.0':
     resolution: {integrity: sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==}
-
-  '@fluidframework/driver-base@2.70.0':
-    resolution: {integrity: sha512-iF1eKfxybqokJlzzd3r2BCAl17TbqG6a5YUXaXOAje0xcZ+rOWPx8RwjOtBBwcyjmbMikzcM5SmNK4fwpc2vFg==}
 
   '@fluidframework/driver-definitions@1.4.0':
     resolution: {integrity: sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==}
 
-  '@fluidframework/driver-definitions@2.70.0':
-    resolution: {integrity: sha512-a9PXvkV1RPovjmE2jsWdZFrrFsKDjCIwF0vmAOFdTXI34KRbxHHkEj1WMRh/bQGSywnXPxSjcilzmwBx8s4QJw==}
-
   '@fluidframework/driver-utils@1.4.0':
     resolution: {integrity: sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==}
-
-  '@fluidframework/driver-utils@2.70.0':
-    resolution: {integrity: sha512-rBSrl3BtulB37Em25T5XmThc3lAnC1AXsuGYv0l6HA2fLcJt7T2XMe5/RoEeXVqK5sM1kSzJ9g0YpawVeq59ww==}
-
-  '@fluidframework/driver-web-cache@2.70.0':
-    resolution: {integrity: sha512-+wAhl5b1wOZsnbNcQuKRzTEgEIDTc55LT/qB1ZcqXvouLGwRSsSjF7Dr+VX0MW+ij5Cjg26Z8vOgVHO0T3vlNQ==}
 
   '@fluidframework/eslint-config-fluid@7.0.0':
     resolution: {integrity: sha512-f05GXfPE4bfynw3Pu9TOfZo+K6OV8rihls8bqDhRMpTIzzilBjdG0fbnRfcAjT46CQJVluFuiJU3rY+f6BPXkA==}
 
-  '@fluidframework/file-driver@2.70.0':
-    resolution: {integrity: sha512-1IOz6iQ1okvzHlvVfqAuYQ4XH3MBAaqYeV5ZXg8KOeWoXIkcUiHYqM9U9C+yFilNimDCWbdOHQ2SeULPiiSSAQ==}
-
-  '@fluidframework/fluid-runner@2.70.0':
-    resolution: {integrity: sha512-24+BvUPYOXQ3xWvnbqFur25+dyNNgKfeZg0liqxeR7zZ2lgKOs+oOsBU8UP0yYIvE0F7iKiHQK43HIHtwrzYkQ==}
-    hasBin: true
-
   '@fluidframework/fluid-static@1.4.0':
     resolution: {integrity: sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==}
-
-  '@fluidframework/fluid-static@2.70.0':
-    resolution: {integrity: sha512-pFbF5SZuuAXKMTVS85TdgFnGNX4B9YJppuWFpp3c2ze5vqfYoJS8Rkmt86Lvrw3NneSvZbc1+p0RarKz1C6lLQ==}
 
   '@fluidframework/garbage-collector@1.4.0':
     resolution: {integrity: sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==}
@@ -17984,38 +17898,8 @@ packages:
   '@fluidframework/gitresources@7.0.0':
     resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
 
-  '@fluidframework/id-compressor@2.70.0':
-    resolution: {integrity: sha512-OzaR1mnH2NTfEieo7B6dbvuWle9JWGQW8sCvpeE1MS1yYlGgOfjWzaDqiq7477Qreqdc7EXZ2NI12k3dwMitjw==}
-
-  '@fluidframework/local-driver@2.70.0':
-    resolution: {integrity: sha512-TbTVwRDcXvExxrZSZl9mJP/UTkmLLmwEsp9q/EKVPURpbo+zpMqjRG6CN0oxFV00kNjggUnA0OWCs8jIRZD3pA==}
-
   '@fluidframework/map@1.4.0':
     resolution: {integrity: sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==}
-
-  '@fluidframework/map@2.70.0':
-    resolution: {integrity: sha512-52vhZYLOzWfTtEWwoecABYVy0BgQhzm0yG5rP1Oqk2FjvLjT2hkUAXxhcNgUhSLW3MLsig6i+kfpBlnPFar/Ew==}
-
-  '@fluidframework/matrix@2.70.0':
-    resolution: {integrity: sha512-moXv9wqq6cGWlBTcc3UrUG6KDrochDHR+Ep7eIe18Cc6Ruc12Emrgz0HUcT6Wh9fU0fqpG10npuIJHNBWcu1iw==}
-
-  '@fluidframework/merge-tree@2.70.0':
-    resolution: {integrity: sha512-WM5xy0rr5uZ/c5ON4fbzyJGdIM/zDf50Petfwjw9ueMW1dI/qtnaas1NHG7PFOBHvGE78QxQwN8C55RyfJEiAQ==}
-
-  '@fluidframework/odsp-doclib-utils@2.70.0':
-    resolution: {integrity: sha512-CLS4EPYGM8aabqfUxmDUP+eqocwWYDoraz1bHfiyKIo4vpofAYO9/HAoJ0kjo4OFZp/TdmacrhTsZ9Mvt4GH6g==}
-
-  '@fluidframework/odsp-driver-definitions@2.70.0':
-    resolution: {integrity: sha512-aagailL00KcQN81Gv9Z0hHHBykV0B3p9iXBNTxJE2rz4A3y6FfWc9filmNi9j8tWJf/+Ok68jjIf39pJ0qhBsA==}
-
-  '@fluidframework/odsp-driver@2.70.0':
-    resolution: {integrity: sha512-nFqOJ3hcPei2OZhRyx/H+xMIV500bEr9MCkgZAEnbvP/r7XF4ZpKXVpuxbamLSaLW6QHP+LAWg3QpL8OIEv/yw==}
-
-  '@fluidframework/odsp-urlresolver@2.70.0':
-    resolution: {integrity: sha512-KxlNANbYea6MgV85YzGjuXJpv8q1286qKfG++MglNv/ta1ox5z8vaQB4oXo+7J9hnL3/pOB2DyzjMqOcg7kYgA==}
-
-  '@fluidframework/ordered-collection@2.70.0':
-    resolution: {integrity: sha512-DF6tsoofU9p+eUYw2YF85bv1JpyOlOOcGnZnkLi2pIwCCHuvIX0QYCo900+4tH1ZdIO7P1C7Gbt+68NADxnNjA==}
 
   '@fluidframework/protocol-base@0.1036.5002':
     resolution: {integrity: sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==}
@@ -18032,41 +17916,17 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  '@fluidframework/register-collection@2.70.0':
-    resolution: {integrity: sha512-plZXXkzpwL7nmA3lUd/xPgHjRR2TDj6GYPGyK3b1ouqf8nIQJplqDRFmILhVJokoj+i+x5ElnUgelZVE6SdFCQ==}
-
-  '@fluidframework/replay-driver@2.70.0':
-    resolution: {integrity: sha512-L84IY6QBoaapaJH2IY5VLuMtWlaeAK9TU7udQ9yDCfw9lwnQ0bZ4catT7oQNyNmQ83MSzH9ntVg1lK3oDn3UpA==}
-
   '@fluidframework/request-handler@1.4.0':
     resolution: {integrity: sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==}
-
-  '@fluidframework/request-handler@2.70.0':
-    resolution: {integrity: sha512-DCp8Lh5VhjN2ZFGVQitON/3dZ3VRCWGgZ7YKPwAGTpjq/IBgcEa7oCcV0CU1RCmZNMw69RBwHM5Te46e18ANnw==}
 
   '@fluidframework/routerlicious-driver@1.4.0':
     resolution: {integrity: sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==}
 
-  '@fluidframework/routerlicious-driver@2.70.0':
-    resolution: {integrity: sha512-zLsflqODyrFF11GozR87yAHK68Mmbdw1FvBxRlavEbrkOuqzZD0gJp8yL/8VFX0Pn5sAhhQ8IwS8k3ST0PtMlQ==}
-
-  '@fluidframework/routerlicious-urlresolver@2.70.0':
-    resolution: {integrity: sha512-/r4NUf/j05JJttqBU8qhm9fXb1fyyUIp9YHKaaUQPYKmcfNTqdnKCSaXBsxSjdMocqmiNVk5INpqlmV1K6H5hQ==}
-
   '@fluidframework/runtime-definitions@1.4.0':
     resolution: {integrity: sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==}
 
-  '@fluidframework/runtime-definitions@2.70.0':
-    resolution: {integrity: sha512-RE7hJDOpZo6//N+vnV6Qp3da6Fh6Xna0KW8nJALJ8DZaVCKkKzOnm8AcgouXakDtDKPb1CYnho3Z2iOw4UEPDA==}
-
   '@fluidframework/runtime-utils@1.4.0':
     resolution: {integrity: sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==}
-
-  '@fluidframework/runtime-utils@2.70.0':
-    resolution: {integrity: sha512-3uoyO2fifkMgCxflfX+T4NEx8rIpofaOMfBDd8zn409bOaNmbJNN8Exd+MCxyQOGcnUb7zCWsj1w5ogYAHnZBA==}
-
-  '@fluidframework/sequence@2.70.0':
-    resolution: {integrity: sha512-JmS/g99E2S3DQA4DdlLdgZIe1L3EEtm3VxbntQT2Vjrv9Gv6nGkOr+JMX/X2VRqaZG6FG0EFNrWwHyegyWeJHA==}
 
   '@fluidframework/server-lambdas-driver@7.0.0':
     resolution: {integrity: sha512-HNXeXUWYIR+jjGMAB61gCWsryuwqysA2o7/bwvdZuM4avqfm75dJUheB6N04uG5GfRfvesMHU68452YHIf6FYQ==}
@@ -18104,51 +17964,15 @@ packages:
   '@fluidframework/shared-object-base@1.4.0':
     resolution: {integrity: sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==}
 
-  '@fluidframework/shared-object-base@2.70.0':
-    resolution: {integrity: sha512-3/Jt6Tx5QSsqSzmTuHD/5/CWlG1HShTprEa2zfu5t8e3K0d035qgGi3SJ7jXq7u+h47sP4yg6QI/rPLg64ArTQ==}
-
-  '@fluidframework/shared-summary-block@2.70.0':
-    resolution: {integrity: sha512-rgSeE7Gvkl8Nsy8qFH917w+w19kLKCoBPrFdCQjEwNfbcz9WT0EsP0cej0iwzWDa1WQpWvdmASy8VR9bGkCLvg==}
-
   '@fluidframework/synthesize@1.4.0':
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
-
-  '@fluidframework/synthesize@2.70.0':
-    resolution: {integrity: sha512-KWb+l1KMEAVg1myYTRKNuGYok97rSS3HjKJFvSdmJMSFDnxXsh9usQ9g9NtfjQOe9y6RuJUQbbsFxS6WlrOFRA==}
-
-  '@fluidframework/task-manager@2.70.0':
-    resolution: {integrity: sha512-d2VzWLGZGTidvo+4AZvCVXA0xd5Eb0jTjDUPGTGr+yqp5fbrUkOaAhlzbpLFNhnPpFeofKLGZRg54WUBy9D9/w==}
 
   '@fluidframework/telemetry-utils@1.4.0':
     resolution: {integrity: sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==}
 
-  '@fluidframework/telemetry-utils@2.70.0':
-    resolution: {integrity: sha512-Q0ta3bx43Y3VZTPymJbKq03Cgomp7o6AvB7nkPmrVuOmQjFlN16hyXYuNafw3I0gQzxdNh6EyqYY7A6Dv6hzKA==}
-
-  '@fluidframework/test-runtime-utils@2.70.0':
-    resolution: {integrity: sha512-jI2HLzPLvq1rQz2xFeF+15n45tfTJj/TgZoptOAOn6APD4KIdB+vQmsEzXoYjf5ahEfle8AQDjkoc1rkKO0eaw==}
-
   '@fluidframework/test-tools@1.0.195075':
     resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
-
-  '@fluidframework/test-utils@2.70.0':
-    resolution: {integrity: sha512-3cvOJRLx7XmiQEUwmKUCJj1DXMhyzSOaqJy5apO+GlciwEjlpgLDSbqJZW6E4CLZbrzBlJungcXS0Rmc7u2RVA==}
-
-  '@fluidframework/tinylicious-client@2.70.0':
-    resolution: {integrity: sha512-wGBPEtod9TJDrDglrAUSZfivDTVvbYW/rg1dUaCU/3fGx4zs7qLPNz0MdYTQ4RcAWn4AUMi15vx0s6lMJqF2VQ==}
-
-  '@fluidframework/tinylicious-driver@2.70.0':
-    resolution: {integrity: sha512-5r1AKjylWQrfFxdYi6StXOl1fIr4NaDD7JReW+g3uvOGcpAKUovzxSxBzeRza8gpZKIMnRuHJMr6hB18C6DaNQ==}
-
-  '@fluidframework/tool-utils@2.70.0':
-    resolution: {integrity: sha512-yXlb0AxPC49Dqq9eU31eX4AHLvoqWH7KdWqzQD8KQ2nUUGZRyz79ldItlolHhgeVSXEuYOH301U66XHVSkG9WA==}
-
-  '@fluidframework/tree@2.70.0':
-    resolution: {integrity: sha512-E1EWSweOH6MUHYvuHkNpFjV/8YUdTH7P11YGzG0qISA5cObYzPC4qHjBvO0cGAddOk3AE56IASaKyMKKJt+5VQ==}
-
-  '@fluidframework/undo-redo@2.70.0':
-    resolution: {integrity: sha512-AUWKyL/Cyix2MnXHwdMn0qp7DzdIiAN0iA3O+6QGFi34yxHezWAFiWZsdLjl8A+U5Vr0JEarOOh/rKNTh0I20w==}
 
   '@fluidframework/view-interfaces@1.4.0':
     resolution: {integrity: sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==}
@@ -30029,16 +29853,6 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluid-internal/client-utils@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@types/events_pkg': '@types/events@3.0.3'
-      base64-js: 1.5.1
-      buffer: 6.0.3
-      events_pkg: events@3.3.0
-      sha.js: 2.4.12
-
   '@fluid-internal/eslint-plugin-fluid@0.3.1(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
@@ -30049,10 +29863,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-internal/test-driver-definitions@2.70.0':
+  '@fluid-internal/eslint-plugin-fluid@0.3.1(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
+      '@microsoft/tsdoc': 0.15.1
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      ts-morph: 22.0.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
 
   '@fluid-tools/benchmark@0.51.0':
     dependencies:
@@ -30168,31 +29987,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/fetch-tool@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@azure/identity': 4.5.0
-      '@azure/identity-cache-persistence': 1.1.1
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-runtime': 2.70.0(debug@4.4.3)
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore': 2.70.0(debug@4.4.3)
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/odsp-doclib-utils': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/odsp-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.70.0
-      '@fluidframework/odsp-urlresolver': 2.70.0(encoding@0.1.13)
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/routerlicious-urlresolver': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/tool-utils': 2.70.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@fluid-tools/version-tools@0.58.3(@types/node@18.19.86)':
     dependencies:
       '@oclif/core': 4.0.36
@@ -30208,32 +30002,6 @@ snapshots:
       - react-devtools-core
       - supports-color
       - utf-8-validate
-
-  '@fluidframework/agent-scheduler@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore': 2.70.0(debug@4.4.3)
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/map': 2.70.0(debug@4.4.3)
-      '@fluidframework/register-collection': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/app-insights-logger@2.70.0(tslib@1.14.1)':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@microsoft/applicationinsights-web': 2.8.18(tslib@1.14.1)
-      '@ungap/structured-clone': 1.2.1
-    transitivePeerDependencies:
-      - tslib
 
   '@fluidframework/aqueduct@1.4.0':
     dependencies:
@@ -30253,28 +30021,6 @@ snapshots:
       '@fluidframework/synthesize': 1.4.0
       '@fluidframework/view-interfaces': 1.4.0
       uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/aqueduct@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-runtime': 2.70.0(debug@4.4.3)
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore': 2.70.0(debug@4.4.3)
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/map': 2.70.0(debug@4.4.3)
-      '@fluidframework/request-handler': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/synthesize': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@fluidframework/tree': 2.70.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30302,29 +30048,6 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
-
-  '@fluidframework/azure-client@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-loader': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/fluid-static': 2.70.0
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/telemetry-utils': 2.70.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/azure-service-utils@2.70.0':
-    dependencies:
-      '@fluidframework/driver-definitions': 2.70.0
-      jsrsasign: 11.1.0
-      uuid: 11.1.0
 
   '@fluidframework/build-common@2.0.3': {}
 
@@ -30390,19 +30113,6 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/cell@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/common-definitions@0.20.1': {}
 
   '@fluidframework/common-definitions@1.1.0': {}
@@ -30445,11 +30155,6 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       events: 3.3.0
 
-  '@fluidframework/container-definitions@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-
   '@fluidframework/container-loader@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30472,24 +30177,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-loader@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@types/events_pkg': '@types/events@3.0.3'
-      '@ungap/structured-clone': 1.2.1
-      debug: 4.4.3(supports-color@8.1.1)
-      double-ended-queue: 2.1.0-0
-      events_pkg: events@3.3.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@fluidframework/container-runtime-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30498,16 +30185,6 @@ snapshots:
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
-
-  '@fluidframework/container-runtime-definitions@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@fluidframework/container-runtime@1.4.0':
     dependencies:
@@ -30533,29 +30210,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-runtime@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore': 2.70.0(debug@4.4.3)
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@tylerbu/sorted-btree-es6': 1.8.0
-      double-ended-queue: 2.1.0-0
-      lz4js: 0.2.0
-      semver-ts: 1.0.3
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/container-utils@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30568,23 +30222,6 @@ snapshots:
 
   '@fluidframework/core-interfaces@1.4.0': {}
 
-  '@fluidframework/core-interfaces@2.70.0': {}
-
-  '@fluidframework/core-utils@2.70.0': {}
-
-  '@fluidframework/counter@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/datastore-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30593,16 +30230,6 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
-
-  '@fluidframework/datastore-definitions@2.70.0':
-    dependencies:
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@fluidframework/datastore@1.4.0':
     dependencies:
@@ -30626,70 +30253,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/datastore@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/debugger@2.70.0':
-    dependencies:
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/replay-driver': 2.70.0
-      jsonschema: 1.4.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/devtools-core@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/aqueduct': 2.70.0
-      '@fluidframework/cell': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-loader': 2.70.0
-      '@fluidframework/container-runtime': 2.70.0(debug@4.4.3)
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/counter': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/map': 2.70.0(debug@4.4.3)
-      '@fluidframework/matrix': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/sequence': 2.70.0
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@fluidframework/tree': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/devtools@2.70.0':
-    dependencies:
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/devtools-core': 2.70.0
-      '@fluidframework/fluid-static': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/driver-base@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30702,27 +30265,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-base@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/driver-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
-
-  '@fluidframework/driver-definitions@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
 
   '@fluidframework/driver-utils@1.4.0':
     dependencies:
@@ -30736,32 +30283,6 @@ snapshots:
       '@fluidframework/telemetry-utils': 1.4.0
       axios: 0.30.2(debug@4.4.3)
       uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/driver-utils@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      axios: 1.12.2(debug@4.4.3)
-      lz4js: 0.2.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/driver-web-cache@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      idb: 6.1.5
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30793,36 +30314,32 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/file-driver@2.70.0':
+  '@fluidframework/eslint-config-fluid@7.0.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/replay-driver': 2.70.0
+      '@fluid-internal/eslint-plugin-fluid': 0.3.1(eslint@8.57.1)(typescript@5.9.2)
+      '@rushstack/eslint-patch': 1.12.0
+      '@rushstack/eslint-plugin': 0.19.0(eslint@8.57.1)(typescript@5.9.2)
+      '@rushstack/eslint-plugin-security': 0.11.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      eslint-config-biome: 2.1.3
+      eslint-config-prettier: 10.1.8(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-i@2.29.1)(eslint@8.57.1)
+      eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-jsdoc: 55.0.5(eslint@8.57.1)
+      eslint-plugin-promise: 7.2.1(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
+      eslint-plugin-tsdoc: 0.4.0
+      eslint-plugin-unicorn: 48.0.1(eslint@8.57.1)
+      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
     transitivePeerDependencies:
-      - debug
+      - eslint
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
       - supports-color
-
-  '@fluidframework/fluid-runner@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluidframework/aqueduct': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-loader': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/odsp-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@json2csv/plainjs': 7.0.6
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
+      - typescript
 
   '@fluidframework/fluid-static@1.4.0':
     dependencies:
@@ -30842,28 +30359,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-static@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/aqueduct': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-loader': 2.70.0
-      '@fluidframework/container-runtime': 2.70.0(debug@4.4.3)
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/request-handler': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@fluidframework/tree': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/garbage-collector@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30873,41 +30368,6 @@ snapshots:
   '@fluidframework/gitresources@0.1036.5002': {}
 
   '@fluidframework/gitresources@7.0.0': {}
-
-  '@fluidframework/id-compressor@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@tylerbu/sorted-btree-es6': 1.8.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/local-driver@2.70.0(debug@4.4.3)(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/protocol-base': 7.0.0
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/server-local-server': 7.0.0
-      '@fluidframework/server-services-client': 7.0.0
-      '@fluidframework/server-services-core': 7.0.0
-      '@fluidframework/server-test-utils': 7.0.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      jsrsasign: 11.1.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
 
   '@fluidframework/map@1.4.0':
     dependencies:
@@ -30922,129 +30382,6 @@ snapshots:
       '@fluidframework/runtime-utils': 1.4.0
       '@fluidframework/shared-object-base': 1.4.0
       path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/map@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/matrix@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/merge-tree': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@tiny-calc/nano': 0.0.0-alpha.5
-      double-ended-queue: 2.1.0-0
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/merge-tree@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/odsp-doclib-utils@2.70.0(debug@4.4.3)(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/odsp-driver-definitions': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      isomorphic-fetch: 3.0.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
-
-  '@fluidframework/odsp-driver-definitions@2.70.0':
-    dependencies:
-      '@fluidframework/driver-definitions': 2.70.0
-
-  '@fluidframework/odsp-driver@2.70.0(debug@4.4.3)(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/odsp-doclib-utils': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      socket.io-client: 4.7.5
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/odsp-urlresolver@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/odsp-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.70.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/ordered-collection@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -31073,32 +30410,6 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
-  '@fluidframework/register-collection@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/replay-driver@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/request-handler@1.4.0':
     dependencies:
       '@fluidframework/common-utils': 0.32.2
@@ -31107,17 +30418,6 @@ snapshots:
       '@fluidframework/runtime-definitions': 1.4.0
       '@fluidframework/runtime-utils': 1.4.0
     transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/request-handler@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
       - supports-color
 
   '@fluidframework/routerlicious-driver@1.4.0(encoding@0.1.13)':
@@ -31145,34 +30445,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-driver@2.70.0(debug@4.4.3)(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/server-services-client': 7.0.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      cross-fetch: 3.1.8(encoding@0.1.13)
-      json-stringify-safe: 5.0.1
-      socket.io-client: 4.7.5
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/routerlicious-urlresolver@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      nconf: 0.12.1
-
   '@fluidframework/runtime-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -31181,16 +30453,6 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
-
-  '@fluidframework/runtime-definitions@2.70.0':
-    dependencies:
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@fluidframework/runtime-utils@1.4.0':
     dependencies:
@@ -31206,41 +30468,6 @@ snapshots:
       '@fluidframework/runtime-definitions': 1.4.0
       '@fluidframework/telemetry-utils': 1.4.0
     transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/runtime-utils@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/telemetry-utils': 2.70.0
-      semver-ts: 1.0.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/sequence@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/merge-tree': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      double-ended-queue: 2.1.0-0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
       - supports-color
 
   '@fluidframework/server-lambdas-driver@7.0.0':
@@ -31485,57 +30712,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/shared-object-base@2.70.0(debug@4.4.3)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore': 2.70.0(debug@4.4.3)
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/shared-summary-block@2.70.0':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/synthesize@1.4.0': {}
-
-  '@fluidframework/synthesize@2.70.0':
-    dependencies:
-      '@fluidframework/core-utils': 2.70.0
-
-  '@fluidframework/task-manager@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   '@fluidframework/telemetry-utils@1.4.0':
     dependencies:
@@ -31547,157 +30724,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/telemetry-utils@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      debug: 4.4.3(supports-color@8.1.1)
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/test-runtime-utils@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      jsrsasign: 11.1.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@fluidframework/test-tools@1.0.195075': {}
-
-  '@fluidframework/test-utils@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluid-internal/test-driver-definitions': 2.70.0
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-loader': 2.70.0
-      '@fluidframework/container-runtime': 2.70.0(debug@4.4.3)
-      '@fluidframework/container-runtime-definitions': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore': 2.70.0(debug@4.4.3)
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/local-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/map': 2.70.0(debug@4.4.3)
-      '@fluidframework/odsp-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/request-handler': 2.70.0(debug@4.4.3)
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      best-random: 1.0.3
-      debug: 4.4.3(supports-color@8.1.1)
-      mocha: 10.8.2
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/tinylicious-client@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluidframework/container-definitions': 2.70.0
-      '@fluidframework/container-loader': 2.70.0
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/fluid-static': 2.70.0
-      '@fluidframework/map': 2.70.0(debug@4.4.3)
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@fluidframework/tinylicious-driver': 2.70.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/tinylicious-driver@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/routerlicious-driver': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      jsrsasign: 11.1.0
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/tool-utils@2.70.0(encoding@0.1.13)':
-    dependencies:
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/driver-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/odsp-doclib-utils': 2.70.0(debug@4.4.3)(encoding@0.1.13)
-      async-mutex: 0.3.2
-      debug: 4.4.3(supports-color@8.1.1)
-      proper-lockfile: 4.1.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@fluidframework/tree@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/container-runtime': 2.70.0(debug@4.4.3)
-      '@fluidframework/core-interfaces': 2.70.0
-      '@fluidframework/core-utils': 2.70.0
-      '@fluidframework/datastore-definitions': 2.70.0
-      '@fluidframework/driver-definitions': 2.70.0
-      '@fluidframework/id-compressor': 2.70.0
-      '@fluidframework/runtime-definitions': 2.70.0
-      '@fluidframework/runtime-utils': 2.70.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.70.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.70.0
-      '@sinclair/typebox': 0.34.13
-      '@tylerbu/sorted-btree-es6': 1.8.0
-      '@types/ungap__structured-clone': 1.2.0
-      '@ungap/structured-clone': 1.2.1
-      semver-ts: 1.0.3
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/undo-redo@2.70.0':
-    dependencies:
-      '@fluid-internal/client-utils': 2.70.0
-      '@fluidframework/map': 2.70.0(debug@4.4.3)
-      '@fluidframework/matrix': 2.70.0
-      '@fluidframework/merge-tree': 2.70.0
-      '@fluidframework/sequence': 2.70.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   '@fluidframework/view-interfaces@1.4.0':
     dependencies:
@@ -33059,10 +32086,28 @@ snapshots:
       - supports-color
       - typescript
 
+  '@rushstack/eslint-plugin-security@0.11.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 8.31.1(eslint@8.57.1)(typescript@5.9.2)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@rushstack/eslint-plugin@0.19.0(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
       '@typescript-eslint/utils': 8.31.1(eslint@8.57.1)(typescript@5.4.5)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@rushstack/eslint-plugin@0.19.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 8.31.1(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -33830,6 +32875,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 7.18.0
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -33840,6 +32903,19 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 7.18.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -33867,6 +32943,18 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -33907,6 +32995,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/visitor-keys': 7.18.0
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.31.1(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.31.1
@@ -33918,6 +33021,20 @@ snapshots:
       semver: 7.7.3
       ts-api-utils: 2.1.0(typescript@5.4.5)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.31.1(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.31.1
+      '@typescript-eslint/visitor-keys': 8.31.1
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -33947,6 +33064,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@8.31.1(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
@@ -33955,6 +33083,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.31.1(typescript@5.4.5)
       eslint: 8.57.1
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.31.1(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.31.1
+      '@typescript-eslint/types': 8.31.1
+      '@typescript-eslint/typescript-estree': 8.31.1(typescript@5.9.2)
+      eslint: 8.57.1
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -36255,7 +35394,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -36264,6 +35403,17 @@ snapshots:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.4.5)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-i@2.29.1)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-i@2.29.1)(eslint@8.57.1)
@@ -36287,6 +35437,23 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      get-tsconfig: 4.12.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      doctrine: 3.0.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       get-tsconfig: 4.12.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -36408,6 +35575,12 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.4.5))(eslint@8.57.1)(typescript@5.4.5)
+
+  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -42807,9 +41980,17 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
+  ts-api-utils@1.4.3(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+
   ts-api-utils@2.1.0(typescript@5.4.5):
     dependencies:
       typescript: 5.4.5
+
+  ts-api-utils@2.1.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
 
   ts-deepmerge@7.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
         specifier: npm:@fluidframework/azure-service-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/azure-service-utils@2.71.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -7404,7 +7404,7 @@ importers:
         version: 1.9.4
       '@fluid-internal/client-utils-previous':
         specifier: npm:@fluid-internal/client-utils@2.71.0
-        version: 'link:'
+        version: '@fluid-internal/client-utils@2.71.0'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7531,7 +7531,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-definitions-previous':
         specifier: npm:@fluidframework/container-definitions@2.71.0
-        version: 'link:'
+        version: '@fluidframework/container-definitions@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7573,7 +7573,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/core-interfaces-previous':
         specifier: npm:@fluidframework/core-interfaces@2.71.0
-        version: 'link:'
+        version: '@fluidframework/core-interfaces@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7639,7 +7639,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/core-utils-previous':
         specifier: npm:@fluidframework/core-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/core-utils@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7712,7 +7712,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-definitions-previous':
         specifier: npm:@fluidframework/driver-definitions@2.71.0
-        version: 'link:'
+        version: '@fluidframework/driver-definitions@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -7782,7 +7782,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/cell-previous':
         specifier: npm:@fluidframework/cell@2.71.0
-        version: 'link:'
+        version: '@fluidframework/cell@2.71.0'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7882,7 +7882,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
         specifier: npm:@fluidframework/counter@2.71.0
-        version: 'link:'
+        version: '@fluidframework/counter@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -8191,7 +8191,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/map-previous':
         specifier: npm:@fluidframework/map@2.71.0
-        version: 'link:'
+        version: '@fluidframework/map@2.71.0(debug@4.4.3)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8315,7 +8315,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
         specifier: npm:@fluidframework/matrix@2.71.0
-        version: 'link:'
+        version: '@fluidframework/matrix@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8436,7 +8436,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
         specifier: npm:@fluidframework/merge-tree@2.71.0
-        version: 'link:'
+        version: '@fluidframework/merge-tree@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8542,7 +8542,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
         specifier: npm:@fluidframework/ordered-collection@2.71.0
-        version: 'link:'
+        version: '@fluidframework/ordered-collection@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8727,7 +8727,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
         specifier: npm:@fluidframework/register-collection@2.71.0
-        version: 'link:'
+        version: '@fluidframework/register-collection@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8842,7 +8842,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
         specifier: npm:@fluidframework/sequence@2.71.0
-        version: 'link:'
+        version: '@fluidframework/sequence@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8960,7 +8960,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
         specifier: npm:@fluidframework/shared-object-base@2.71.0
-        version: 'link:'
+        version: '@fluidframework/shared-object-base@2.71.0(debug@4.4.3)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9063,7 +9063,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
         specifier: npm:@fluidframework/shared-summary-block@2.71.0
-        version: 'link:'
+        version: '@fluidframework/shared-summary-block@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9172,7 +9172,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
         specifier: npm:@fluidframework/task-manager@2.71.0
-        version: 'link:'
+        version: '@fluidframework/task-manager@2.71.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9417,7 +9417,7 @@ importers:
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
         specifier: npm:@fluidframework/tree@2.71.0
-        version: 'link:'
+        version: '@fluidframework/tree@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -9514,7 +9514,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/debugger-previous':
         specifier: npm:@fluidframework/debugger@2.71.0
-        version: 'link:'
+        version: '@fluidframework/debugger@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -9581,7 +9581,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-base-previous':
         specifier: npm:@fluidframework/driver-base@2.71.0
-        version: 'link:'
+        version: '@fluidframework/driver-base@2.71.0(debug@4.4.3)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -9663,7 +9663,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-web-cache-previous':
         specifier: npm:@fluidframework/driver-web-cache@2.71.0
-        version: 'link:'
+        version: '@fluidframework/driver-web-cache@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -9739,7 +9739,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
         specifier: npm:@fluidframework/file-driver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/file-driver@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -9833,7 +9833,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
         specifier: npm:@fluidframework/local-driver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/local-driver@2.71.0(debug@4.4.3)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -9936,7 +9936,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
         specifier: npm:@fluidframework/odsp-driver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/odsp-driver@2.71.0(debug@4.4.3)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10006,7 +10006,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
         specifier: npm:@fluidframework/odsp-driver-definitions@2.71.0
-        version: 'link:'
+        version: '@fluidframework/odsp-driver-definitions@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10073,7 +10073,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
         specifier: npm:@fluidframework/odsp-urlresolver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/odsp-urlresolver@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10149,7 +10149,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
         specifier: npm:@fluidframework/replay-driver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/replay-driver@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10240,7 +10240,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
         specifier: npm:@fluidframework/routerlicious-driver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/routerlicious-driver@2.71.0(debug@4.4.3)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10331,7 +10331,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
         specifier: npm:@fluidframework/routerlicious-urlresolver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/routerlicious-urlresolver@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10416,7 +10416,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
         specifier: npm:@fluidframework/tinylicious-driver@2.71.0
-        version: 'link:'
+        version: '@fluidframework/tinylicious-driver@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -10501,7 +10501,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
         specifier: npm:@fluidframework/agent-scheduler@2.71.0
-        version: 'link:'
+        version: '@fluidframework/agent-scheduler@2.71.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10695,7 +10695,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
         specifier: npm:@fluidframework/aqueduct@2.71.0
-        version: 'link:'
+        version: '@fluidframework/aqueduct@2.71.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10880,7 +10880,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
         specifier: npm:@fluidframework/app-insights-logger@2.71.0
-        version: 'link:'
+        version: '@fluidframework/app-insights-logger@2.71.0(tslib@1.14.1)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11347,7 +11347,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
         specifier: npm:@fluidframework/fluid-static@2.71.0
-        version: 'link:'
+        version: '@fluidframework/fluid-static@2.71.0'
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11711,7 +11711,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
         specifier: npm:@fluidframework/request-handler@2.71.0
-        version: 'link:'
+        version: '@fluidframework/request-handler@2.71.0(debug@4.4.3)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -11793,7 +11793,7 @@ importers:
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
         specifier: npm:@fluidframework/synthesize@2.71.0
-        version: 'link:'
+        version: '@fluidframework/synthesize@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -12160,7 +12160,7 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
         specifier: npm:@fluidframework/undo-redo@2.71.0
-        version: 'link:'
+        version: '@fluidframework/undo-redo@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -12269,7 +12269,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-loader-previous':
         specifier: npm:@fluidframework/container-loader@2.71.0
-        version: 'link:'
+        version: '@fluidframework/container-loader@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12372,7 +12372,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/driver-utils-previous':
         specifier: npm:@fluidframework/driver-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/driver-utils@2.71.0(debug@4.4.3)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12554,7 +12554,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-runtime-previous':
         specifier: npm:@fluidframework/container-runtime@2.71.0
-        version: 'link:'
+        version: '@fluidframework/container-runtime@2.71.0(debug@4.4.3)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12645,7 +12645,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/container-runtime-definitions-previous':
         specifier: npm:@fluidframework/container-runtime-definitions@2.71.0
-        version: 'link:'
+        version: '@fluidframework/container-runtime-definitions@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12727,7 +12727,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/datastore-previous':
         specifier: npm:@fluidframework/datastore@2.71.0
-        version: 'link:'
+        version: '@fluidframework/datastore@2.71.0(debug@4.4.3)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12815,7 +12815,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/datastore-definitions-previous':
         specifier: npm:@fluidframework/datastore-definitions@2.71.0
-        version: 'link:'
+        version: '@fluidframework/datastore-definitions@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -12888,7 +12888,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
         specifier: npm:@fluidframework/id-compressor@2.71.0
-        version: 'link:'
+        version: '@fluidframework/id-compressor@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -12967,7 +12967,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
         specifier: npm:@fluidframework/runtime-definitions@2.71.0
-        version: 'link:'
+        version: '@fluidframework/runtime-definitions@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -13046,7 +13046,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
         specifier: npm:@fluidframework/runtime-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/runtime-utils@2.71.0(debug@4.4.3)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -13164,7 +13164,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
         specifier: npm:@fluidframework/test-runtime-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/test-runtime-utils@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -13243,7 +13243,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
         specifier: npm:@fluidframework/azure-client@2.71.0
-        version: 'link:'
+        version: '@fluidframework/azure-client@2.71.0(encoding@0.1.13)'
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13721,7 +13721,7 @@ importers:
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
         specifier: npm:@fluidframework/tinylicious-client@2.71.0
-        version: 'link:'
+        version: '@fluidframework/tinylicious-client@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -15054,7 +15054,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
         specifier: npm:@fluidframework/test-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/test-utils@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -15357,7 +15357,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/devtools-previous':
         specifier: npm:@fluidframework/devtools@2.71.0
-        version: 'link:'
+        version: '@fluidframework/devtools@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -15680,7 +15680,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)
       '@fluidframework/devtools-core-previous':
         specifier: npm:@fluidframework/devtools-core@2.71.0
-        version: 'link:'
+        version: '@fluidframework/devtools-core@2.71.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^7.0.0
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
@@ -16169,7 +16169,7 @@ importers:
         version: 0.58.3(@types/node@18.19.86)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
         specifier: npm:@fluid-tools/fetch-tool@2.71.0
-        version: 'link:'
+        version: '@fluid-tools/fetch-tool@2.71.0(encoding@0.1.13)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -16251,7 +16251,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
         specifier: npm:@fluidframework/fluid-runner@2.71.0
-        version: 'link:'
+        version: '@fluidframework/fluid-runner@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -16463,7 +16463,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
         specifier: npm:@fluidframework/odsp-doclib-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/odsp-doclib-utils@2.71.0(debug@4.4.3)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -16548,7 +16548,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
         specifier: npm:@fluidframework/telemetry-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/telemetry-utils@2.71.0'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -16642,7 +16642,7 @@ importers:
         version: 7.0.0(eslint@8.57.1)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
         specifier: npm:@fluidframework/tool-utils@2.71.0
-        version: 'link:'
+        version: '@fluidframework/tool-utils@2.71.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@18.19.86)
@@ -17794,8 +17794,14 @@ packages:
       '@types/react': '>=16.8.0 <19.0.0'
       react: '>=16.8.0 <19.0.0'
 
+  '@fluid-internal/client-utils@2.71.0':
+    resolution: {integrity: sha512-0hiJx2P7IUtUmAK96iIOerkolU+iT9nMgHA4sF+Lu5GgBih74CTXMZpmP7687QOR5RhSx4ceSmuhFOceEI8uUQ==}
+
   '@fluid-internal/eslint-plugin-fluid@0.3.1':
     resolution: {integrity: sha512-7ifjbVEJcSEqTinmhg9LgrkVeh/JQdWa5FzvmWRgD9vgFjxPBpNw0/zBFpyDr1rUd6dnT853oO8y/hnmyH1rtw==}
+
+  '@fluid-internal/test-driver-definitions@2.71.0':
+    resolution: {integrity: sha512-2gsDlapTWZ2MgZd18A3YRgHDtQJpplS8Tvat4mGeJMXJ0AOu5a4XBqzrfPndNn4OHxstLMk1G79UPR0VTsNWjg==}
 
   '@fluid-tools/benchmark@0.51.0':
     resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
@@ -17809,16 +17815,35 @@ packages:
     resolution: {integrity: sha512-WL7R9haO0as6TuNLXVD4bAWUiyuO6n0dbvntZIn3GfMOogoDAVOzNsU/NTRdZvtlGcsUiiW6MrCkmNjncPaeJQ==}
     hasBin: true
 
+  '@fluid-tools/fetch-tool@2.71.0':
+    resolution: {integrity: sha512-LA1mh1L1/lPKnJte/N1iP21cXH2ZtlpxlUcLLGnc7i4PcDVp1zoQWAEZlzmvjc7ouSvCcHLTyYGnBpETdcfbJQ==}
+    hasBin: true
+
   '@fluid-tools/version-tools@0.58.3':
     resolution: {integrity: sha512-qRsjnm6L+7i3wHsWmnR7CaQuD4LIUp7aIM04a9qqjC3uf+sXA36PKOrKS8I0Ty/r1mIiVCEQywT+eMnGP7KzLQ==}
     engines: {node: '>=20.15.1'}
     hasBin: true
 
+  '@fluidframework/agent-scheduler@2.71.0':
+    resolution: {integrity: sha512-YKbpDmQRqCGKmz7RIoXX+LVWTj4+59xluovAXn+FP1TdWczWPy/N6/jRmhGz72VAorxmZymHYVa+2DEaq5YehQ==}
+
+  '@fluidframework/app-insights-logger@2.71.0':
+    resolution: {integrity: sha512-T5r4NBZLrgevTz3NtTvwT7oC/0InrB/wDCGdEVesxG8TzAJ2zyv58267viQ57vekhbBajlpRwecwqTGI1DhFXA==}
+
   '@fluidframework/aqueduct@1.4.0':
     resolution: {integrity: sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==}
 
+  '@fluidframework/aqueduct@2.71.0':
+    resolution: {integrity: sha512-AIWn4u6S0TezGfsSG06Y9wjYAFv5tZQFAW1zQf54WRfJvPYugCQB87oh1V2psVSVeE2YYredAN69shFllDOrXw==}
+
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
+
+  '@fluidframework/azure-client@2.71.0':
+    resolution: {integrity: sha512-PbLySWrsQkztZqv8mRb318Cf5rURp95AihVb8W0IhYnYejtCyAZykpr0QHz7q6xXHBujvvrKBoQVuTFD05AdoA==}
+
+  '@fluidframework/azure-service-utils@2.71.0':
+    resolution: {integrity: sha512-ygR8G2eRRaA81LThpboKArT/Vrm/Nk6Nvn2SpadS/2YvOfZgb5XybRjJZn6w+46If0Ywy+m6FSIL8+BCau8wOQ==}
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
@@ -17834,6 +17859,9 @@ packages:
 
   '@fluidframework/bundle-size-tools@0.58.3':
     resolution: {integrity: sha512-hIfJyHS+ia0dTmCXPm06LsM0omliRvf5NhL+YbYWEesW5QBWpEuaSJH8v/4HAWDAwAsFo2+YQFO/ZNzMLWpyyw==}
+
+  '@fluidframework/cell@2.71.0':
+    resolution: {integrity: sha512-OftoIsT6RhX+rZ9ei7zDEQM2oGi2Es0xlHjKkcD2Zzt+X2IZZsM9WMGsg3cJyxWrbcHEboTUD3OrGbLzfohVGA==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -17853,14 +17881,26 @@ packages:
   '@fluidframework/container-definitions@1.4.0':
     resolution: {integrity: sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==}
 
+  '@fluidframework/container-definitions@2.71.0':
+    resolution: {integrity: sha512-Glmxtck1S1rEovJJWHo2CV7GYrXN+JsFLro8Jgc4hhlamD80XNb4uxBaBVno+9pcEt/wa2gz9iOvsjRO46YHDw==}
+
   '@fluidframework/container-loader@1.4.0':
     resolution: {integrity: sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==}
+
+  '@fluidframework/container-loader@2.71.0':
+    resolution: {integrity: sha512-G6QqlM5rqmkJsqZoCqSvEH3rEYtETgoBk4AK5PTIne9tA7X4QQKPcz00e49kAYb9SFB4LUpdp5pzFBK9h1AhPQ==}
 
   '@fluidframework/container-runtime-definitions@1.4.0':
     resolution: {integrity: sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==}
 
+  '@fluidframework/container-runtime-definitions@2.71.0':
+    resolution: {integrity: sha512-9y5qQj5lsTZBccJkHxfF5wPnHjOLbRJ1kdgrh2G2O6tC3lPim3yGavSLk2z5+3cYqanWKC0y7nAZZfl4Je5XYg==}
+
   '@fluidframework/container-runtime@1.4.0':
     resolution: {integrity: sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==}
+
+  '@fluidframework/container-runtime@2.71.0':
+    resolution: {integrity: sha512-gtovhPREwO3jp4OJaiNRvImtWwJRo3iFqp2+m89x3eQ1Ba2bgPoTPAVjVRCoGgiTuGWtkUJDfg2ets0FoJ7YRg==}
 
   '@fluidframework/container-utils@1.4.0':
     resolution: {integrity: sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==}
@@ -17868,26 +17908,72 @@ packages:
   '@fluidframework/core-interfaces@1.4.0':
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
 
+  '@fluidframework/core-interfaces@2.71.0':
+    resolution: {integrity: sha512-EMsT7FgITfBciDWiZ27avvRhBAH2vmDbnuahJ8pei6AHJwgK+bTopzrVO47sRgwYBclkIkZunpNsTFSMot49jQ==}
+
+  '@fluidframework/core-utils@2.71.0':
+    resolution: {integrity: sha512-oYXM+mwAtyoPsGojqkh4WH6TBckaYcFAJ0m2eO6x/lVv0H2Xy81D/ae8u+2sX4KnSFp7jSNBThb3Ec5UXQB4tw==}
+
+  '@fluidframework/counter@2.71.0':
+    resolution: {integrity: sha512-dYrDHr8Bt7en/MrN4qvUaQmkN4lojEcJmzk9maLCB65uofkEjggGmDBAOzejZG2SiN/eL4hu4ScGdeB5mE3LjA==}
+
   '@fluidframework/datastore-definitions@1.4.0':
     resolution: {integrity: sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==}
+
+  '@fluidframework/datastore-definitions@2.71.0':
+    resolution: {integrity: sha512-cdTDadMGcEuncDPeZo2aSTQBKZXK5tp51pCRKovl622rkXA6ogL0AJ1/xhO0kYbSnEpPjirKqoj8jsiXJowUwA==}
 
   '@fluidframework/datastore@1.4.0':
     resolution: {integrity: sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==}
 
+  '@fluidframework/datastore@2.71.0':
+    resolution: {integrity: sha512-XhJpa7tAoUzFwFoe5zXFMcI4lDprNMOwOrebDj5XTxcpQd2WsYtEO4DxBr1qi1VFqGhLakVh4cd0hU+UD7u+3A==}
+
+  '@fluidframework/debugger@2.71.0':
+    resolution: {integrity: sha512-9xfuf4DESVokyZ11Y775Gq9saexHnL6LgpzY5x9m8adluhdkq7u1x2+v0Y9Wx8PQkCztTYDEK1PrJMZlJSbOWw==}
+
+  '@fluidframework/devtools-core@2.71.0':
+    resolution: {integrity: sha512-ZYN0Oi4rnvh9CSxms4jiJaATDx6ojPSIUZgA75Zipe902mPv3zMZCnP40xabFkw3jSxAB72E9Rk929uyWh1DFA==}
+
+  '@fluidframework/devtools@2.71.0':
+    resolution: {integrity: sha512-0xwLXa2YwTatFuEVbsHuLD6BCnKAmSzRd4oNoSLm3biBdvZCCTn4rVx7mFzPyx5yDOJO/TKUukNsItN57JcjqA==}
+
   '@fluidframework/driver-base@1.4.0':
     resolution: {integrity: sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==}
+
+  '@fluidframework/driver-base@2.71.0':
+    resolution: {integrity: sha512-J62ISpenDDnoVAwZK8WVTzLxG55QCSCw7D1vpdb9gHiJGxiKxfWTQr6YDTJQNMk8FtMzGFGfrXl6Vh3IPzYBCg==}
 
   '@fluidframework/driver-definitions@1.4.0':
     resolution: {integrity: sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==}
 
+  '@fluidframework/driver-definitions@2.71.0':
+    resolution: {integrity: sha512-OFR7zu5K5AfJ4SnYaJjfmFfYxQz5GPzdZytX+RhVT3LCIheMBLzfBpfCnV92P0/AEaTM2qJqDOc2K1uVtL1/Hw==}
+
   '@fluidframework/driver-utils@1.4.0':
     resolution: {integrity: sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==}
+
+  '@fluidframework/driver-utils@2.71.0':
+    resolution: {integrity: sha512-TO4LDDb57Jn36VNhbSKzPgudTyVDIysfGZhRfI+pJmty9wm3884Z+AksRjdbJsfc7S+GpJ6IikXaXedxZ5h1Ug==}
+
+  '@fluidframework/driver-web-cache@2.71.0':
+    resolution: {integrity: sha512-zbOjoLbe04S+AAbbED6aLbEDlRNMZ9re1NOeCba++a0OCP6boOkNLpqp+TosBrbKigBISGrNGqQ1Dli5oAe8sg==}
 
   '@fluidframework/eslint-config-fluid@7.0.0':
     resolution: {integrity: sha512-f05GXfPE4bfynw3Pu9TOfZo+K6OV8rihls8bqDhRMpTIzzilBjdG0fbnRfcAjT46CQJVluFuiJU3rY+f6BPXkA==}
 
+  '@fluidframework/file-driver@2.71.0':
+    resolution: {integrity: sha512-RGW6TCpTyD0luiMe29qbxto20tvCDE2RqHQZXa11+CEjssuDA4RlnIre/TJGs4P1zzPC2Ya05nZBT6kedz1Z0g==}
+
+  '@fluidframework/fluid-runner@2.71.0':
+    resolution: {integrity: sha512-OKIvALtCHTUqsKtw1jRUs7UIn9oOv2hCTdrEfDECS2gbLodWdMQ4bv6Ldr7HEM254bdVTQpo3/9aZkhpHCCzOA==}
+    hasBin: true
+
   '@fluidframework/fluid-static@1.4.0':
     resolution: {integrity: sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==}
+
+  '@fluidframework/fluid-static@2.71.0':
+    resolution: {integrity: sha512-JT1jjaIxpWidOTKH9Jc9SzeNwxuyTcqg7Y9PXWWFlCTlf3FriZhQg3GmGf5HR6BgZKJu9wTHqoShdnaMYi3A/g==}
 
   '@fluidframework/garbage-collector@1.4.0':
     resolution: {integrity: sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==}
@@ -17898,8 +17984,38 @@ packages:
   '@fluidframework/gitresources@7.0.0':
     resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
 
+  '@fluidframework/id-compressor@2.71.0':
+    resolution: {integrity: sha512-qVK5GTc+jcF6cocKW/ChW304yRthWnQfnvanwrRm8234kqd+GVgCoIUpArFPx56Z+VOlu8QX3hezxCiIczLXOQ==}
+
+  '@fluidframework/local-driver@2.71.0':
+    resolution: {integrity: sha512-9vzjDa4qGJQpWvBv1Jl2udSUH/7hsp6TvS4XILPpF4SBYLQdQ/Z2c/Vyyme8rsGoyZPNzxYVOzTIcV+Bn4HMSQ==}
+
   '@fluidframework/map@1.4.0':
     resolution: {integrity: sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==}
+
+  '@fluidframework/map@2.71.0':
+    resolution: {integrity: sha512-MrAlKvZpG0gYBKnFeOncbjlIZQA1gaNzoZeu4w8YEy4w+w4jI8jvhKzh/fybV0XWtg6wZcY4DbkMyGKIkIzhtA==}
+
+  '@fluidframework/matrix@2.71.0':
+    resolution: {integrity: sha512-+/ASmRQVQ3FnY2YjnTKbQs4EggE/9yOwt6NPtn2dltdYs/jYWT8mZ3pQmHDSeKM1uYlHVLNNLqhM/cVTb6eJgA==}
+
+  '@fluidframework/merge-tree@2.71.0':
+    resolution: {integrity: sha512-VhS6LLqWxu2ZoD0rEGFzvR9XnOk6CkuJ5aJ68rSHUj6dAoE7cfIXyqexfgHPM+ev7PGRnJ5HzOsipPMCUzkpTw==}
+
+  '@fluidframework/odsp-doclib-utils@2.71.0':
+    resolution: {integrity: sha512-CWFzUizj2GAaSBrIKyoR9g5I8JDz402zTYRUj6eeWO+wbizsaOV27JVFJQW1rTTOS48H0ajsjjWCAyZj8Qllig==}
+
+  '@fluidframework/odsp-driver-definitions@2.71.0':
+    resolution: {integrity: sha512-vzXSwy0Mr5uNwS3KtLhIma7yXW+DnzRurttunGSXdEEhWPWfi+ZI7mAWTnH/auQ6QoWsCCQUuEe0y/9l+roC7g==}
+
+  '@fluidframework/odsp-driver@2.71.0':
+    resolution: {integrity: sha512-KKen+XhCAsYu5RFWpzzZJyZ2P4OgTXa46QDIU7ppb8cM9i157I4a5Axapiz6gL/V+ZfKSlXRkX1ecC3BMeGY5g==}
+
+  '@fluidframework/odsp-urlresolver@2.71.0':
+    resolution: {integrity: sha512-zhtBXHBXZ7GeG6i+ERNbBkEho3CvIT4DUugJ1OKap/16ptxcB2mQISgGWsGpC2ZCOq18yY2MqTujkYV/JYHV2A==}
+
+  '@fluidframework/ordered-collection@2.71.0':
+    resolution: {integrity: sha512-Rfk67OVwtEYxWKER390Ir8nzhzpMGDhFmtUPhTqRBr6ysixrkL+a+UrcoykxEzcWcndKebsWwhbxJP67b5GYVg==}
 
   '@fluidframework/protocol-base@0.1036.5002':
     resolution: {integrity: sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==}
@@ -17916,17 +18032,41 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
+  '@fluidframework/register-collection@2.71.0':
+    resolution: {integrity: sha512-1UOF43UfEmt/AVGi4PioMqFDw64Tr5BNt4+29tNe2Tnev55BUuRA+HHbu8VGGFWNHEEOFXfVCVoQzcXYuNtg1Q==}
+
+  '@fluidframework/replay-driver@2.71.0':
+    resolution: {integrity: sha512-rdns8Pgdn4DJPw/0DRrrvI7td3k+oDjjkQsS5ANAYkEMa6Bw4Rpl1Q/tfckLVqOOnTbZRq2q9MMFzF3S/br7rw==}
+
   '@fluidframework/request-handler@1.4.0':
     resolution: {integrity: sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==}
+
+  '@fluidframework/request-handler@2.71.0':
+    resolution: {integrity: sha512-gnapjVGNXEAd8gulwb0Qfz6ZdiL6EwC+Qx57V9JtzwHVxHSTGkhuN64tXgpLGW8G7AZUocqcOh/FWnZbeiAObA==}
 
   '@fluidframework/routerlicious-driver@1.4.0':
     resolution: {integrity: sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==}
 
+  '@fluidframework/routerlicious-driver@2.71.0':
+    resolution: {integrity: sha512-+2eZG99s1KohaykQD+7IBBsoSm/2JBDgjLRuFpCWZBHFJic+u/xsg8FbMazCoOdQERmGg8eNVfgkS96IxW1kQQ==}
+
+  '@fluidframework/routerlicious-urlresolver@2.71.0':
+    resolution: {integrity: sha512-0D3J6DQMzdLv2BGfQpV/3yz6mfL7h0QTSlSUk3mZqM46hWJCoL1cabTUIgKLKXHcyq7GQ0CLretqXmmhOg9hsw==}
+
   '@fluidframework/runtime-definitions@1.4.0':
     resolution: {integrity: sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==}
 
+  '@fluidframework/runtime-definitions@2.71.0':
+    resolution: {integrity: sha512-7IW9u8tGTjcl9SkrhYiXRSj1FIoKiUCOzAWpdp/bQlJxN7a+VMQZGkVrxsLPUxokeAaMcQ19zfYMbrET7uHkcw==}
+
   '@fluidframework/runtime-utils@1.4.0':
     resolution: {integrity: sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==}
+
+  '@fluidframework/runtime-utils@2.71.0':
+    resolution: {integrity: sha512-OAOl45v7J2ft2q6Pb25JOUVuXDd9PsdDGd4/NvuTK+YLtLn3QaSmhf9VODb3S9AR/J1uzFWwBHa4qki5ndYM8A==}
+
+  '@fluidframework/sequence@2.71.0':
+    resolution: {integrity: sha512-f8VqVn1hsaQ1SJw1Bm+t2TjqZOoYfdLNudBucNJ2gOxeyCQW5+j0VVLPbPa9SAHVJ2FsdTyDEu+yNvFou7dvqA==}
 
   '@fluidframework/server-lambdas-driver@7.0.0':
     resolution: {integrity: sha512-HNXeXUWYIR+jjGMAB61gCWsryuwqysA2o7/bwvdZuM4avqfm75dJUheB6N04uG5GfRfvesMHU68452YHIf6FYQ==}
@@ -17964,15 +18104,51 @@ packages:
   '@fluidframework/shared-object-base@1.4.0':
     resolution: {integrity: sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==}
 
+  '@fluidframework/shared-object-base@2.71.0':
+    resolution: {integrity: sha512-fZUuNqeL+is+7u9tFoPHdsHDMVDtj3df2ykquHeoOmYZDGZV5mfnSZy/Aj50Jh8vOMlCwp8hJfPj8KxPE2aoGw==}
+
+  '@fluidframework/shared-summary-block@2.71.0':
+    resolution: {integrity: sha512-kKHPJycy1qC0s/YKGhy49E96NVGh5BDJIcTwX1ik+ePoPMgJ7YtN9Xf06a1EGGHdxFuAApG4UGBBmYVQMaLYpA==}
+
   '@fluidframework/synthesize@1.4.0':
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
+
+  '@fluidframework/synthesize@2.71.0':
+    resolution: {integrity: sha512-RZDqCQYx2VdbWiEndmdPSz2H55tRNgw1j3fDLG6wyUX5ZErA/lWIMRSSPL+GgnLmv5LVHl6sremVSLMIGNr95w==}
+
+  '@fluidframework/task-manager@2.71.0':
+    resolution: {integrity: sha512-pi7pJkBG9f96vWfywrW4qoyL8MG7fFJCceKamhwa0NR8tPTUdPpNOZyc9fmIZxZPL5HX4OuTjf4/QWN5HWdW9A==}
 
   '@fluidframework/telemetry-utils@1.4.0':
     resolution: {integrity: sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==}
 
+  '@fluidframework/telemetry-utils@2.71.0':
+    resolution: {integrity: sha512-XExTmXBMyPfSp/GghA8l3lUdFDkbm+HUF1cq8vsVnrKpIkKlpHy7jiA4gBEdGqodfNdLptPMHrivC402gK2uxw==}
+
+  '@fluidframework/test-runtime-utils@2.71.0':
+    resolution: {integrity: sha512-Y9mvwCrbgzMfVdSsEgmPcrd5mZGmtDwJt8ZiN4rv3MmOJl7seSPpIU43vRLVgRijKXu+TwdQZ14cSkNN3UySMw==}
+
   '@fluidframework/test-tools@1.0.195075':
     resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
+
+  '@fluidframework/test-utils@2.71.0':
+    resolution: {integrity: sha512-wzctfq5jHNftIaS0aG8KukzKop41hgDSq2QFq7u1KoHvdfDO8GwToablDBfieyCnQihvT35PF6htb6EBeo1zQA==}
+
+  '@fluidframework/tinylicious-client@2.71.0':
+    resolution: {integrity: sha512-pM3kn3Ltj8ZiEYb8wLeco+PNoTf7RI5U3f8naCsp2tHDS9kFjapQEEzVd796mSmGZFUiMIkEgQBZPyVyC6sxpQ==}
+
+  '@fluidframework/tinylicious-driver@2.71.0':
+    resolution: {integrity: sha512-S/PchLMKAr1et1kN/L4uCfLcC2CMNFbXBsWvoLnl/xJmrL1Mez0UnBZpD3GkWSMmF7igop1LrnrAge5AzhDv+Q==}
+
+  '@fluidframework/tool-utils@2.71.0':
+    resolution: {integrity: sha512-lh6tUN4f86UWs145F8ljeC3W5T/2seMIUzbN1kuyP1AMOD09ABVnTGVSUoKTzqCgrLwAB6BJUTw29DqdAM8rAA==}
+
+  '@fluidframework/tree@2.71.0':
+    resolution: {integrity: sha512-ZwmkqB45IUToAja7bcHmqFb/xVWh9qSepAsQMCZfL4IK7o1Y+nk+D/NvvVQFcasWaeZwzt+M6ub0RIhYezKIKQ==}
+
+  '@fluidframework/undo-redo@2.71.0':
+    resolution: {integrity: sha512-LCQm4keKoWW3T13lSRljox1VAOfbEgvMIpLSDTupzycCkdjlIYyU2ASH1JVjC/UlrtOyeBtBGCpkChFFTK9JhA==}
 
   '@fluidframework/view-interfaces@1.4.0':
     resolution: {integrity: sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==}
@@ -29853,6 +30029,16 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
+  '@fluid-internal/client-utils@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@types/events_pkg': '@types/events@3.0.3'
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      events_pkg: events@3.3.0
+      sha.js: 2.4.12
+
   '@fluid-internal/eslint-plugin-fluid@0.3.1(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
@@ -29872,6 +30058,11 @@ snapshots:
       - eslint
       - supports-color
       - typescript
+
+  '@fluid-internal/test-driver-definitions@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
 
   '@fluid-tools/benchmark@0.51.0':
     dependencies:
@@ -29987,6 +30178,31 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@fluid-tools/fetch-tool@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@azure/identity': 4.5.0
+      '@azure/identity-cache-persistence': 1.1.1
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-runtime': 2.71.0(debug@4.4.3)
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore': 2.71.0(debug@4.4.3)
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/odsp-doclib-utils': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/odsp-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.71.0
+      '@fluidframework/odsp-urlresolver': 2.71.0(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/routerlicious-urlresolver': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/tool-utils': 2.71.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@fluid-tools/version-tools@0.58.3(@types/node@18.19.86)':
     dependencies:
       '@oclif/core': 4.0.36
@@ -30002,6 +30218,32 @@ snapshots:
       - react-devtools-core
       - supports-color
       - utf-8-validate
+
+  '@fluidframework/agent-scheduler@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore': 2.71.0(debug@4.4.3)
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/map': 2.71.0(debug@4.4.3)
+      '@fluidframework/register-collection': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/app-insights-logger@2.71.0(tslib@1.14.1)':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@microsoft/applicationinsights-web': 2.8.18(tslib@1.14.1)
+      '@ungap/structured-clone': 1.2.1
+    transitivePeerDependencies:
+      - tslib
 
   '@fluidframework/aqueduct@1.4.0':
     dependencies:
@@ -30021,6 +30263,28 @@ snapshots:
       '@fluidframework/synthesize': 1.4.0
       '@fluidframework/view-interfaces': 1.4.0
       uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/aqueduct@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-runtime': 2.71.0(debug@4.4.3)
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore': 2.71.0(debug@4.4.3)
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/map': 2.71.0(debug@4.4.3)
+      '@fluidframework/request-handler': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/synthesize': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@fluidframework/tree': 2.71.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30048,6 +30312,29 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  '@fluidframework/azure-client@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-loader': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/fluid-static': 2.71.0
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/telemetry-utils': 2.71.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/azure-service-utils@2.71.0':
+    dependencies:
+      '@fluidframework/driver-definitions': 2.71.0
+      jsrsasign: 11.1.0
+      uuid: 11.1.0
 
   '@fluidframework/build-common@2.0.3': {}
 
@@ -30113,6 +30400,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@fluidframework/cell@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/common-definitions@0.20.1': {}
 
   '@fluidframework/common-definitions@1.1.0': {}
@@ -30155,6 +30455,11 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       events: 3.3.0
 
+  '@fluidframework/container-definitions@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+
   '@fluidframework/container-loader@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30177,6 +30482,24 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/container-loader@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@types/events_pkg': '@types/events@3.0.3'
+      '@ungap/structured-clone': 1.2.1
+      debug: 4.4.3(supports-color@8.1.1)
+      double-ended-queue: 2.1.0-0
+      events_pkg: events@3.3.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@fluidframework/container-runtime-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30185,6 +30508,16 @@ snapshots:
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
+
+  '@fluidframework/container-runtime-definitions@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/container-runtime@1.4.0':
     dependencies:
@@ -30210,6 +30543,29 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/container-runtime@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore': 2.71.0(debug@4.4.3)
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@tylerbu/sorted-btree-es6': 1.8.0
+      double-ended-queue: 2.1.0-0
+      lz4js: 0.2.0
+      semver-ts: 1.0.3
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/container-utils@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30222,6 +30578,23 @@ snapshots:
 
   '@fluidframework/core-interfaces@1.4.0': {}
 
+  '@fluidframework/core-interfaces@2.71.0': {}
+
+  '@fluidframework/core-utils@2.71.0': {}
+
+  '@fluidframework/counter@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/datastore-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30230,6 +30603,16 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
+
+  '@fluidframework/datastore-definitions@2.71.0':
+    dependencies:
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/datastore@1.4.0':
     dependencies:
@@ -30253,6 +30636,70 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/datastore@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/debugger@2.71.0':
+    dependencies:
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/replay-driver': 2.71.0
+      jsonschema: 1.4.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/devtools-core@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/aqueduct': 2.71.0
+      '@fluidframework/cell': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-loader': 2.71.0
+      '@fluidframework/container-runtime': 2.71.0(debug@4.4.3)
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/counter': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/map': 2.71.0(debug@4.4.3)
+      '@fluidframework/matrix': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/sequence': 2.71.0
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@fluidframework/tree': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/devtools@2.71.0':
+    dependencies:
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/devtools-core': 2.71.0
+      '@fluidframework/fluid-static': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/driver-base@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30265,11 +30712,27 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/driver-base@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/driver-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
+
+  '@fluidframework/driver-definitions@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
 
   '@fluidframework/driver-utils@1.4.0':
     dependencies:
@@ -30283,6 +30746,32 @@ snapshots:
       '@fluidframework/telemetry-utils': 1.4.0
       axios: 0.30.2(debug@4.4.3)
       uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/driver-utils@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      axios: 1.12.2(debug@4.4.3)
+      lz4js: 0.2.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/driver-web-cache@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      idb: 6.1.5
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30341,6 +30830,37 @@ snapshots:
       - supports-color
       - typescript
 
+  '@fluidframework/file-driver@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/replay-driver': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/fluid-runner@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluidframework/aqueduct': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-loader': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/odsp-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@json2csv/plainjs': 7.0.6
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@fluidframework/fluid-static@1.4.0':
     dependencies:
       '@fluidframework/aqueduct': 1.4.0
@@ -30359,6 +30879,28 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/fluid-static@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/aqueduct': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-loader': 2.71.0
+      '@fluidframework/container-runtime': 2.71.0(debug@4.4.3)
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/request-handler': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@fluidframework/tree': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/garbage-collector@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30368,6 +30910,41 @@ snapshots:
   '@fluidframework/gitresources@0.1036.5002': {}
 
   '@fluidframework/gitresources@7.0.0': {}
+
+  '@fluidframework/id-compressor@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@tylerbu/sorted-btree-es6': 1.8.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/local-driver@2.71.0(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/protocol-base': 7.0.0
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/server-local-server': 7.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-test-utils': 7.0.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      jsrsasign: 11.1.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@fluidframework/map@1.4.0':
     dependencies:
@@ -30382,6 +30959,129 @@ snapshots:
       '@fluidframework/runtime-utils': 1.4.0
       '@fluidframework/shared-object-base': 1.4.0
       path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/map@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/matrix@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/merge-tree': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@tiny-calc/nano': 0.0.0-alpha.5
+      double-ended-queue: 2.1.0-0
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/merge-tree@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/odsp-doclib-utils@2.71.0(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/odsp-driver-definitions': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      isomorphic-fetch: 3.0.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+
+  '@fluidframework/odsp-driver-definitions@2.71.0':
+    dependencies:
+      '@fluidframework/driver-definitions': 2.71.0
+
+  '@fluidframework/odsp-driver@2.71.0(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/odsp-doclib-utils': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      socket.io-client: 4.7.5
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/odsp-urlresolver@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/odsp-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.71.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/ordered-collection@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30410,6 +31110,32 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
+  '@fluidframework/register-collection@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/replay-driver@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/request-handler@1.4.0':
     dependencies:
       '@fluidframework/common-utils': 0.32.2
@@ -30418,6 +31144,17 @@ snapshots:
       '@fluidframework/runtime-definitions': 1.4.0
       '@fluidframework/runtime-utils': 1.4.0
     transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/request-handler@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   '@fluidframework/routerlicious-driver@1.4.0(encoding@0.1.13)':
@@ -30445,6 +31182,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@fluidframework/routerlicious-driver@2.71.0(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      cross-fetch: 3.1.8(encoding@0.1.13)
+      json-stringify-safe: 5.0.1
+      socket.io-client: 4.7.5
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/routerlicious-urlresolver@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      nconf: 0.12.1
+
   '@fluidframework/runtime-definitions@1.4.0':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
@@ -30453,6 +31218,17 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
+
+  '@fluidframework/runtime-definitions@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/runtime-utils@1.4.0':
     dependencies:
@@ -30468,6 +31244,41 @@ snapshots:
       '@fluidframework/runtime-definitions': 1.4.0
       '@fluidframework/telemetry-utils': 1.4.0
     transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/runtime-utils@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/telemetry-utils': 2.71.0
+      semver-ts: 1.0.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/sequence@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/merge-tree': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      double-ended-queue: 2.1.0-0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   '@fluidframework/server-lambdas-driver@7.0.0':
@@ -30712,7 +31523,57 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/shared-object-base@2.71.0(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore': 2.71.0(debug@4.4.3)
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/shared-summary-block@2.71.0':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/synthesize@1.4.0': {}
+
+  '@fluidframework/synthesize@2.71.0':
+    dependencies:
+      '@fluidframework/core-utils': 2.71.0
+
+  '@fluidframework/task-manager@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@fluidframework/telemetry-utils@1.4.0':
     dependencies:
@@ -30724,7 +31585,157 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@fluidframework/telemetry-utils@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      debug: 4.4.3(supports-color@8.1.1)
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/test-runtime-utils@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      jsrsasign: 11.1.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@fluidframework/test-tools@1.0.195075': {}
+
+  '@fluidframework/test-utils@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/test-driver-definitions': 2.71.0
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-loader': 2.71.0
+      '@fluidframework/container-runtime': 2.71.0(debug@4.4.3)
+      '@fluidframework/container-runtime-definitions': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore': 2.71.0(debug@4.4.3)
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/local-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/map': 2.71.0(debug@4.4.3)
+      '@fluidframework/odsp-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/request-handler': 2.71.0(debug@4.4.3)
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      best-random: 1.0.3
+      debug: 4.4.3(supports-color@8.1.1)
+      mocha: 10.8.2
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/tinylicious-client@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluidframework/container-definitions': 2.71.0
+      '@fluidframework/container-loader': 2.71.0
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/fluid-static': 2.71.0
+      '@fluidframework/map': 2.71.0(debug@4.4.3)
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@fluidframework/tinylicious-driver': 2.71.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/tinylicious-driver@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/routerlicious-driver': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      jsrsasign: 11.1.0
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@fluidframework/tool-utils@2.71.0(encoding@0.1.13)':
+    dependencies:
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/driver-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/odsp-doclib-utils': 2.71.0(debug@4.4.3)(encoding@0.1.13)
+      async-mutex: 0.3.2
+      debug: 4.4.3(supports-color@8.1.1)
+      proper-lockfile: 4.1.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@fluidframework/tree@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/container-runtime': 2.71.0(debug@4.4.3)
+      '@fluidframework/core-interfaces': 2.71.0
+      '@fluidframework/core-utils': 2.71.0
+      '@fluidframework/datastore-definitions': 2.71.0
+      '@fluidframework/driver-definitions': 2.71.0
+      '@fluidframework/id-compressor': 2.71.0
+      '@fluidframework/runtime-definitions': 2.71.0
+      '@fluidframework/runtime-utils': 2.71.0(debug@4.4.3)
+      '@fluidframework/shared-object-base': 2.71.0(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.71.0
+      '@sinclair/typebox': 0.34.13
+      '@tylerbu/sorted-btree-es6': 1.8.0
+      '@types/ungap__structured-clone': 1.2.0
+      '@ungap/structured-clone': 1.2.1
+      semver-ts: 1.0.3
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/undo-redo@2.71.0':
+    dependencies:
+      '@fluid-internal/client-utils': 2.71.0
+      '@fluidframework/map': 2.71.0(debug@4.4.3)
+      '@fluidframework/matrix': 2.71.0
+      '@fluidframework/merge-tree': 2.71.0
+      '@fluidframework/sequence': 2.71.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@fluidframework/view-interfaces@1.4.0':
     dependencies:

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/markdown-magic",
-	"version": "2.71.0",
+	"version": "2.71.1",
 	"private": true,
 	"description": "Contains shared utilities for Markdown content generation and embedding using markdown-magic.",
 	"homepage": "https://fluidframework.com",


### PR DESCRIPTION
This PR bumps client packages to 2.71.1 following the 2.71.0 release and updates typetests. Changes were generated withe the following commands:

Bump
```
pnpm exec flub bump client --bumpType patch
```

Typetests
```
pnpm exec flub typetests -g client --reset --normalize --previous
pnpm install --no-frozen-lockfile
pnpm run typetests:gen
```