### PR TITLE
Make getCells implementation slightly more type safe

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -216,7 +216,10 @@ export namespace System_TableSchema {
 					throw new UsageError(`Column with ID "${this.id}" is not contained in a table.`);
 				}
 
-				const result = [];
+				const result: {
+					rowId: string;
+					cell: CellValueType;
+				}[] = [];
 				for (const row of tableNode.rows) {
 					const cell = row.getCell(this.id);
 					if (cell !== undefined) {
@@ -226,7 +229,7 @@ export namespace System_TableSchema {
 							);
 						}
 
-						result.push({ rowId: row.id, cell: cell as CellValueType });
+						result.push({ rowId: row.id, cell });
 					}
 				}
 				return result;


### PR DESCRIPTION
## Description

Avoid an empty array initially inferring to any[] before being narrowed by push, and an `as` cast which could silently down cast but is not intended to.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

