### PR TITLE
test(build-tools): remove eslint-config-fluid from tests

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -165,6 +165,13 @@
 				"type-fest",
 				"typescript"
 			]
-		}
+		},
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"core-js",
+			"es5-ext",
+			"sharp",
+			"unrs-resolver"
+		]
 	}
 }

--- a/build-tools/packages/build-cli/src/test/filter.test.ts
+++ b/build-tools/packages/build-cli/src/test/filter.test.ts
@@ -183,7 +183,8 @@ describe("selectAndFilterPackages", () => {
 		const names = selected.map((p) => p.name);
 		expect(names).to.be.containingAllOf([
 			"@fluidframework/build-common",
-			"@fluidframework/eslint-config-fluid",
+			// TODO: Re-enable once eslint-config-fluid is no longer in the client release group
+			// "@fluidframework/eslint-config-fluid",
 			"@fluid-internal/eslint-plugin-fluid",
 			"@fluidframework/protocol-definitions",
 			"@fluid-tools/api-markdown-documenter",


### PR DESCRIPTION
Remove eslint-config-fluid from the test in build-tools. Can be added back once eslint-config-fluid is out of the client release group.

Also opportunistically approves some dep postinstalls.