### PR TITLE
BaseContainerRuntimeFactoryProps input

### DIFF
--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.beta.api.md
@@ -15,7 +15,7 @@ export class BaseContainerRuntimeFactory extends RuntimeFactoryHelper implements
     preInitialize(context: IContainerContext, existing: boolean): Promise<IContainerRuntime & IRuntime>;
 }
 
-// @beta @legacy
+// @beta @legacy @input
 export interface BaseContainerRuntimeFactoryProps {
     // @deprecated (undocumented)
     dependencyContainer?: IFluidDependencySynthesizer;

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -35,6 +35,7 @@ import {
 
 /**
  * {@link BaseContainerRuntimeFactory} construction properties.
+ * @input
  * @legacy
  * @beta
  */


### PR DESCRIPTION
## Description

Mark BaseContainerRuntimeFactoryProps as input to properly capture its intended use and therefore explicitly allow future optional items to be added (as was done with minVersionForCollab).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
