### PR TITLE
Skip @fluidframework/eslint-config-fluid when installing dev deps in perf benchmarks pipeline

### DIFF
--- a/tools/pipelines/templates/include-copy-dev-dependencies.yml
+++ b/tools/pipelines/templates/include-copy-dev-dependencies.yml
@@ -40,7 +40,8 @@ steps:
           '@microsoft/api-extractor',
           '@fluid-tools/build-cli',
           '@fluidframework/build-common',
-          '@fluidframework/build-tools'
+          '@fluidframework/build-tools',
+          '@fluidframework/eslint-config-fluid'
         ]);
         for (const [k, v] of Object.entries(devDependencies)) {
           if (!pkg.devDependencies[k] && !avoidCopying.has(k)) {


### PR DESCRIPTION
## Description

Adds `@fluidframework/eslint-config-fluid` as another package to skip installing when the Performance Benchmarks pipeline has to do its installation of dev-deps. We recently made it part of the client release group (temporarily) but did not allow it to be published, so the pipeline can't find it when it runs.

While the change in this PR could be reverted once we move `@fluidframework/eslint-config-fluid` back out from the client release group, I think it's fine to keep it, since we indeed don't need that package when running tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).