### PR TITLE
pwd when installing in pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -182,6 +182,8 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
               set -eu -o pipefail
+              # Ensure its easy to tell which workspace this is running in by inspecting the logs
+              pwd
               pnpm i --frozen-lockfile
 
         - task: Npm@1

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -182,8 +182,6 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
               set -eu -o pipefail
-              # Ensure it's easy to tell which workspace this is running in by inspecting the logs
-              pwd
               pnpm i --frozen-lockfile
 
         - task: Npm@1
@@ -308,6 +306,8 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
               set -eu -o pipefail
+              # Ensure it's easy to tell which workspace this is running in by inspecting the logs
+              pwd
               pnpm i --frozen-lockfile
 
         - task: Npm@1

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -182,7 +182,7 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
               set -eu -o pipefail
-              # Ensure its easy to tell which workspace this is running in by inspecting the logs
+              # Ensure it's easy to tell which workspace this is running in by inspecting the logs
               pwd
               pnpm i --frozen-lockfile
 

--- a/tools/pipelines/deploy-website.yml
+++ b/tools/pipelines/deploy-website.yml
@@ -126,6 +126,8 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
               set -eu -o pipefail
+              # Ensure it's easy to tell which workspace this is running in by inspecting the logs
+              pwd
               pnpm i --frozen-lockfile
 
         - task: Npm@1
@@ -261,6 +263,8 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
               set -eu -o pipefail
+              # Ensure it's easy to tell which workspace this is running in by inspecting the logs
+              pwd
               pnpm i --frozen-lockfile
 
         - task: Npm@1


### PR DESCRIPTION
## Description

I wanted to check which workspace was producing the unapporved scripts warning in https://dev.azure.com/fluidframework/internal/_build/results?buildId=363790&view=logs&j=336c0fe9-169e-5c8f-4859-d4f7d822aab8&t=fad73df2-95c8-584a-7f9a-32136d7dfe26 but its unclear. This changes adds `pwd` to that script which should allow figuring out which directory is being installed in and thus which workspace it is from the log.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
