### PR TITLE
(compat) Incremenent layer compat generation for Fluid layers

### DIFF
--- a/packages/drivers/local-driver/src/localLayerCompatState.ts
+++ b/packages/drivers/local-driver/src/localLayerCompatState.ts
@@ -19,7 +19,7 @@ export const localDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	/**
 	 * The current generation of the Local Driver layer.
 	 */
-	generation: 1,
+	generation: 2,
 	/**
 	 * The features supported by the Local Driver layer across the Driver / Loader boundary.
 	 */

--- a/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
+++ b/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
@@ -19,7 +19,7 @@ export const odspDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	/**
 	 * The current generation of the ODSP Driver layer.
 	 */
-	generation: 1,
+	generation: 2,
 	/**
 	 * The features supported by the ODSP Driver layer across the Driver / Loader boundary.
 	 */

--- a/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
@@ -19,7 +19,7 @@ export const r11sDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	/**
 	 * The current generation of the Routerlicious Driver layer.
 	 */
-	generation: 1,
+	generation: 2,
 	/**
 	 * The features supported by the Routerlicious Driver layer across the Driver / Loader boundary.
 	 */

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -27,7 +27,7 @@ export const loaderCoreCompatDetails = {
 	/**
 	 * The current generation of the Loader layer.
 	 */
-	generation: 1,
+	generation: 2,
 };
 
 /**

--- a/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
+++ b/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
@@ -31,7 +31,7 @@ export const runtimeCoreCompatDetails = {
 	/**
 	 * The current generation of the Runtime layer.
 	 */
-	generation: 1,
+	generation: 2,
 } as const;
 
 /**

--- a/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
+++ b/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
@@ -26,7 +26,7 @@ export const dataStoreCoreCompatDetails = {
 	/**
 	 * The current generation of the Runtime layer.
 	 */
-	generation: 1,
+	generation: 2,
 };
 
 /**


### PR DESCRIPTION
This change updates the `generation` for the Fluid layerss. The generation should be incremented every month and should automatically happen during a minor or major release. That work is in progress, so until then, manually updating the generation. It has been 3+ months since the last generation (1) so incrementing it to 2.