### PR TITLE
fix(test-drivers): use valid URL for hostUrl in docker config

### DIFF
--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -31,8 +31,7 @@ interface IServiceEndpoint {
 const dockerConfig = (driverPolicies?: IRouterliciousDriverPolicies) => ({
 	serviceEndpoint: {
 		deltaStreamUrl: "http://localhost:3002",
-		// The 'hostUrl' value doesn't seem to matter for this driver.
-		hostUrl: "this value is unused",
+		hostUrl: "http://localhost:3003",
 		ordererUrl: "http://localhost:3003",
 		deltaStorageUrl: "http://localhost:3001",
 	},


### PR DESCRIPTION
## Description

In PR #25610, the `hostUrl` in the docker config was set to `'this value is unused'` with a comment indicating it didn't seem to matter. However, it turns out that the URL does need to be a valid URL.

This PR fixes the issue by setting `hostUrl` to `http://localhost:3003`, which matches the alfred service URL (same as `ordererUrl`). Alfred is the main service endpoint in the docker setup, accessible via the nginx proxy on port 3003.

## Changes
- Updated `hostUrl` from `'this value is unused'` to `http://localhost:3003` in the docker config
- Removed the misleading comment about the value being unused