### PR TITLE
in docs, pnpm approve-builds

### DIFF
--- a/docs/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/index.mdx
@@ -86,7 +86,7 @@ To prevent this, the application can employ a [staged rollout](./index.mdx#stage
 **Examples:**
 - Adding an optional field when compatibility flag is enabled
 
-#### 🌶️ Spicy
+#### 🌶 Spicy
 | Backwards Compatible | Forwards Compatible | Rollout Process |
 |-----------------------|----------------------|-----------------|
 | ✅                    | ❌                   | ⚠️ Staged       |

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -8,10 +8,4 @@ packages:
   - .
 
 onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - core-js
-  - core-js-pure
-  - keytar
   - linkcheck-bin
-  - typesense-instantsearch-adapter
-  - unrs-resolver

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -5,4 +5,13 @@
 # Because we have the client release group at the root of the repo, there's a pnpm-workspace.yaml file in the hierarchy
 # for our independent packages as well. This file makes pnpm treat the project as a one-package workspace.
 packages:
-  - "."
+  - .
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - core-js
+  - core-js-pure
+  - keytar
+  - linkcheck-bin
+  - typesense-instantsearch-adapter
+  - unrs-resolver


### PR DESCRIPTION
## Description

Two fixes:
1. in docs, pnpm approve-builds for "linkcheck-bin"
2. Work around bug in lint checker where it cannot handle the generated link to itself for a markdown section `#### 🌶️ Spicy`. Removing the  `FE0F` ( `VARIATION SELECTOR-16` ) from 🌶️to work around bug (giving 🌶) seems to fix it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
