### PR TITLE
docs: Fix broken links and improve contents

### DIFF
--- a/docs/docs/build/packages.mdx
+++ b/docs/docs/build/packages.mdx
@@ -3,29 +3,42 @@ title: Packages
 sidebar_position: 9
 ---
 
-The Fluid Framework is a multi-layered system consisting of dozens of individual npm packages. Most developers will only
-need two or three of these packages for typical Fluid development: The `fluid-framework` package, which contains the
-public API for the Fluid Framework, and a service-specific client package, such as the
-`@fluidframework/tinylicious-client` package.
+The Fluid Framework is a multi-layered system consisting of dozens of individual npm packages.
+Most developers will only need two or three of these packages for typical Fluid development:
+- The [fluid-framework][] package, which contains the public API for the Fluid Framework
+- A service-specific client package, such as the [@fluidframework/azure-client](../api/azure-client/index.md).
 
 ## Primary API: fluid-framework
 
-The `fluid-framework` package consists primarily of two portions: the [FluidContainer][] object and a selection of
+The [fluid-framework][] package consists primarily of two portions: the [FluidContainer][] object and a selection of
 distributed data structures (DDSes).
 
 ### FluidContainer
 
-The [FluidContainer][] object is the one of the object types returned by calls to `createContainer()` and
-`getContainer()` on the service clients such as [AzureClient][]. It includes functionality to retrieve the Fluid data
-contained within itself, as well as to inspect the state of the collaboration session connection.
+The [FluidContainer][] object is the one of the object types returned by calls to `createContainer()` and `getContainer()` on the [service clients](../deployment/service-options.mdx) such as [AzureClient](../deployment/azure-fluid-relay.mdx).
+It includes functionality to retrieve the Fluid data contained within itself, as well as to inspect the state of the collaboration session connection.
 
-### Shared object packages
+### Distributed Data Structures (DDSes)
 
-You'll use one or more shared objects in your container to model your collaborative data. The `fluid-framework` package includes
-three data structures that cover a broad range of scenarios:
+You'll use one or more DDSes in your container to model your collaborative data.
+The [fluid-framework][] package includes a few such data structures that cover a broad range of scenarios:
 
-1. [SharedMap](../data-structures/map.mdx), a map-like data structure for storing key/value pair data.
-2. [SharedString](../data-structures/string.md), a data structure for string data.
+- [SharedTree](../data-structures/tree/index.mdx): a collaborative tree data structure for building complex, hierarchical data models.
+	:::tip
+	This is the DDS we recommend for most new applications.
+	:::
+- [SharedString](../data-structures/string.md): a data structure for collaborative text data.
+	:::tip
+	This DDS can be used when live, collaborative text editing is required.
+	`SharedTree` supports text content, but does not yet support many rich collaborative text editing features.
+
+	For scenarios where collaborative text editing is required, we recommend using `SharedString` _with_ `SharedTree` via [handles](../data-structures/tree/node-types.mdx#leaf-nodes).
+	:::
+- [SharedMap](../data-structures/map.mdx): a map-like data structure for storing key/value pair data.
+	:::warning
+	We do not recommend this DDS for new applications. `SharedTree` is a more powerful and flexible alternative that can easily model key/value pair data.
+	:::
+
 
 ## Package scopes
 
@@ -36,9 +49,14 @@ Fluid Framework packages are published under one of the following npm scopes:
 -   @fluid-internal
 -   @fluid-tools
 
-In addition to the scoped packages, two unscoped packages are published: the [fluid-framework][] package, described earlier, and the `tinylicious` package, which contains a minimal Fluid server. For more information, see [Tinylicious](../testing/tinylicious.mdx).
+In addition to the scoped packages, two unscoped packages are published: the [fluid-framework][] package, described earlier, and the `tinylicious` package which contains a minimal Fluid server.
+For more information, see [Tinylicious](../testing/tinylicious.mdx).
 
 Unless you are contributing to the Fluid Framework, you should only need the unscoped packages and packages from the **@fluidframework** scope.
 You can [read more about the scopes and their intent][scopes] in the Fluid Framework wiki.
 
+
+{/* Links */}
+[FluidContainer]: ./containers.mdx
+[fluid-framework]: ../api/fluid-framework/index.md
 [scopes]: https://github.com/microsoft/FluidFramework/wiki/npm-package-scopes

--- a/docs/docs/build/packages.mdx
+++ b/docs/docs/build/packages.mdx
@@ -15,7 +15,7 @@ distributed data structures (DDSes).
 
 ### FluidContainer
 
-The [FluidContainer][] object is the one of the object types returned by calls to `createContainer()` and `getContainer()` on the [service clients](../deployment/service-options.mdx) such as [AzureClient](../deployment/azure-fluid-relay.mdx).
+The [FluidContainer][] object is one of the object types returned by calls to `createContainer()` and `getContainer()` on the [service clients](../deployment/service-options.mdx) such as [AzureClient](../deployment/azure-fluid-relay.mdx).
 It includes functionality to retrieve the Fluid data contained within itself, as well as to inspect the state of the collaboration session connection.
 
 ### Distributed Data Structures (DDSes)
@@ -49,7 +49,7 @@ Fluid Framework packages are published under one of the following npm scopes:
 -   @fluid-internal
 -   @fluid-tools
 
-In addition to the scoped packages, two unscoped packages are published: the [fluid-framework][] package, described earlier, and the `tinylicious` package which contains a minimal Fluid server.
+In addition to the scoped packages, two unscoped packages are published: the [fluid-framework][] package, described earlier, and the `tinylicious` package, which contains a minimal Fluid server.
 For more information, see [Tinylicious](../testing/tinylicious.mdx).
 
 Unless you are contributing to the Fluid Framework, you should only need the unscoped packages and packages from the **@fluidframework** scope.

--- a/docs/docs/data-structures/tree/node-types.mdx
+++ b/docs/docs/data-structures/tree/node-types.mdx
@@ -10,11 +10,11 @@ Data on a [SharedTree](./index.mdx) is stored as a [node](./nodes.mdx) of one of
 A [leaf](../../api/fluid-framework/nodekind-enum.md#leaf-enummember) node represents an atomic value, while a [TreeNode](../../api/fluid-framework/treenode-class.md) represents an object or collection.
 The following leaf node types are available:
 
--   [**boolean**](../../api/fluid-framework/schemafactory-class.md#boolean-property): Works identically to a JavaScript boolean.
--   [**number**](../../api/fluid-framework/schemafactory-class.md#number-property): Works identically to a JavaScript number except does not support -0, NaN or Infinity.
--   [**string**](../../api/fluid-framework/schemafactory-class.md#string-property): Works identically to a JavaScript string except for not supporting unpaired UTF-16 surrogate pairs.
--   [**null**](../../api/fluid-framework/schemafactory-class.md#null-property): Works identically to a JavaScript null.
--   [**FluidHandle**](../../api/fluid-framework/schemafactory-class.md#handle-property): A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles](../../concepts/handles.mdx).
+-   [**boolean**](../../api/fluid-framework/schemastatics-interface.md#boolean-propertysignature): Works identically to a JavaScript boolean.
+-   [**number**](../../api/fluid-framework/schemastatics-interface.md#number-propertysignature): Works identically to a JavaScript number except does not support -0, NaN or Infinity.
+-   [**string**](../../api/fluid-framework/schemastatics-interface.md#string-propertysignature): Works identically to a JavaScript string except for not supporting unpaired UTF-16 surrogate pairs.
+-   [**null**](../../api/fluid-framework/schemastatics-interface.md#null-propertysignature): Works identically to a JavaScript null.
+-   [**FluidHandle**](../../api/fluid-framework/schemastatics-interface.md#handle-propertysignature): A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles](../../concepts/handles.mdx).
 
 ## TreeNodes
 
@@ -27,8 +27,8 @@ The object node's fields can be node types.
 A `SharedTree` can have many object nodes at various places in the tree and they do not all have to conform to the same schema.
 Your schema can specify different properties for different object nodes.
 The schema also specifies whether a child property is
-[required](../../api/fluid-framework/schemafactory-class.md#required-property),
-[optional](../../api/fluid-framework/schemafactory-class.md#optional-property)
+[required](../../api/fluid-framework/schemastatics-interface.md#required-propertysignature),
+[optional](../../api/fluid-framework/schemastatics-interface.md#optional-propertysignature)
 or an [identifier](../../api/fluid-framework/schemafactory-class.md#identifier-property),
 as well as what types of nodes are allowed in the field.
 For example, a property could be either number or string.

--- a/docs/docs/data-structures/tree/node-types.mdx
+++ b/docs/docs/data-structures/tree/node-types.mdx
@@ -7,29 +7,29 @@ Data on a [SharedTree](./index.mdx) is stored as a [node](./nodes.mdx) of one of
 
 ## Leaf Nodes
 
-A [leaf](https://fluidframework.com/docs/api/fluid-framework/nodekind-enum#leaf-enummember) node represents an atomic value, while a [TreeNode](https://fluidframework.com/docs/api/fluid-framework/treenode-class) represents an object or collection.
+A [leaf](../../api/fluid-framework/nodekind-enum.md#leaf-enummember) node represents an atomic value, while a [TreeNode](../../api/fluid-framework/treenode-class.md) represents an object or collection.
 The following leaf node types are available:
 
--   [**boolean**](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#boolean-property): Works identically to a JavaScript boolean.
--   [**number**](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#number-property): Works identically to a JavaScript number except does not support -0, NaN or Infinity.
--   [**string**](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#string-property): Works identically to a JavaScript string except for not supporting unpaired UTF-16 surrogate pairs.
--   [**null**](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#null-property): Works identically to a JavaScript null.
--   [**FluidHandle**](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#handle-property): A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles](../../concepts/handles.mdx).
+-   [**boolean**](../../api/fluid-framework/schemafactory-class.md#boolean-property): Works identically to a JavaScript boolean.
+-   [**number**](../../api/fluid-framework/schemafactory-class.md#number-property): Works identically to a JavaScript number except does not support -0, NaN or Infinity.
+-   [**string**](../../api/fluid-framework/schemafactory-class.md#string-property): Works identically to a JavaScript string except for not supporting unpaired UTF-16 surrogate pairs.
+-   [**null**](../../api/fluid-framework/schemafactory-class.md#null-property): Works identically to a JavaScript null.
+-   [**FluidHandle**](../../api/fluid-framework/schemafactory-class.md#handle-property): A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles](../../concepts/handles.mdx).
 
 ## TreeNodes
 
-The following subsections describe the available [TreeNode](https://fluidframework.com/docs/api/fluid-framework/treenode-class) types.
+The following subsections describe the available [TreeNode](../../api/fluid-framework/treenode-class.md) types.
 
 ### Object Nodes
 
-An [object node](https://fluidframework.com/docs/api/fluid-framework/treeobjectnode-typealias) is a JavaScript object like TreeNode with zero or more named child [fields](https://fluidframework.com/docs/api/fluid-framework/fieldschema-class) exposed as properties of the object.
+An [object node](../../api/fluid-framework/treeobjectnode-typealias.md) is a JavaScript object like TreeNode with zero or more named child [fields](../../api/fluid-framework/fieldschema-class.md) exposed as properties of the object.
 The object node's fields can be node types.
 A `SharedTree` can have many object nodes at various places in the tree and they do not all have to conform to the same schema.
 Your schema can specify different properties for different object nodes.
 The schema also specifies whether a child property is
-[required](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#required-property),
-[optional](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#optional-property)
-or an [identifier](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#identifier-property),
+[required](../../api/fluid-framework/schemafactory-class.md#required-property),
+[optional](../../api/fluid-framework/schemafactory-class.md#optional-property)
+or an [identifier](../../api/fluid-framework/schemafactory-class.md#identifier-property),
 as well as what types of nodes are allowed in the field.
 For example, a property could be either number or string.
 


### PR DESCRIPTION
Fixes broken links in `Package.mdx`, and updates guidance to focus on `SharedTree`.

Also fixes API docs links in `node-types.md` and updates them to use relative file paths rather than fully qualified URLs.