### PR TITLE
Remove nodeKey field kind

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -107,8 +107,7 @@ export const required = new FieldKindWithEditor(
 		// Which direction is allowed is a subjective policy choice.
 		(other.kind === sequence.identifier ||
 			other.kind === requiredIdentifier ||
-			other.kind === optional.identifier ||
-			other.kind === nodeKey.identifier) &&
+			other.kind === optional.identifier) &&
 		allowsTreeSchemaIdentifierSuperset(types, other.types),
 	new Set(),
 );
@@ -127,28 +126,6 @@ export const sequence = new FieldKindWithEditor(
 		allowsTreeSchemaIdentifierSuperset(types, other.types),
 	// TODO: add normalizer/importers for handling ops from other kinds.
 	new Set([]),
-);
-
-const nodeKeyIdentifier = "NodeKey";
-
-/**
- * Exactly one identifier.
- *
- * TODO: this is almost the same as identifier, but apparently unused.
- * Confirm if this is truly unused since before the document format was stabilized, and remove if possible.
- * @deprecated Superseded by {@link identifier}.
- */
-export const nodeKey = new FieldKindWithEditor(
-	nodeKeyIdentifier,
-	Multiplicity.Single,
-	noChangeHandler,
-	(types, other) =>
-		(other.kind === sequence.identifier ||
-			other.kind === requiredIdentifier ||
-			other.kind === optional.identifier ||
-			other.kind === nodeKeyIdentifier) &&
-		allowsTreeSchemaIdentifierSuperset(types, other.types),
-	new Set(),
 );
 
 const identifierFieldIdentifier = "Identifier";
@@ -214,7 +191,6 @@ export const fieldKindConfigurations: ReadonlyMap<
 	[
 		brand(1),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
-			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 1 }],
 			[optional.identifier, { kind: optional, formatVersion: 1 }],
 			[sequence.identifier, { kind: sequence, formatVersion: 1 }],
@@ -225,7 +201,6 @@ export const fieldKindConfigurations: ReadonlyMap<
 	[
 		brand(2),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
-			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 2 }],
 			[optional.identifier, { kind: optional, formatVersion: 2 }],
 			[sequence.identifier, { kind: sequence, formatVersion: 1 }],
@@ -236,7 +211,6 @@ export const fieldKindConfigurations: ReadonlyMap<
 	[
 		brand(3),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
-			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 2 }],
 			[optional.identifier, { kind: optional, formatVersion: 2 }],
 			[sequence.identifier, { kind: sequence, formatVersion: 2 }],
@@ -247,7 +221,6 @@ export const fieldKindConfigurations: ReadonlyMap<
 	[
 		brand(4),
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
-			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
 			[required.identifier, { kind: required, formatVersion: 2 }],
 			[optional.identifier, { kind: optional, formatVersion: 2 }],
 			[sequence.identifier, { kind: sequence, formatVersion: 3 }],
@@ -284,7 +257,7 @@ export function getCodecTreeForModularChangeFormat(
  * code which uses this should be audited for compatibility considerations.
  */
 export const fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor> = new Map(
-	[required, optional, sequence, nodeKey, identifier, forbidden].map((s) => [s.identifier, s]),
+	[required, optional, sequence, identifier, forbidden].map((s) => [s.identifier, s]),
 );
 
 // Create named Aliases for nicer intellisense.

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_0.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_0.json
@@ -27,10 +27,6 @@
               "version": 3,
               "children": [
                 {
-                  "name": "FieldKind:NodeKey",
-                  "version": 1
-                },
-                {
                   "name": "FieldKind:Value",
                   "version": 2
                 },
@@ -78,10 +74,6 @@
               "name": "ModularChange",
               "version": 3,
               "children": [
-                {
-                  "name": "FieldKind:NodeKey",
-                  "version": 1
-                },
                 {
                   "name": "FieldKind:Value",
                   "version": 2

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_43.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_43.json
@@ -27,10 +27,6 @@
               "version": 4,
               "children": [
                 {
-                  "name": "FieldKind:NodeKey",
-                  "version": 1
-                },
-                {
                   "name": "FieldKind:Value",
                   "version": 2
                 },
@@ -78,10 +74,6 @@
               "name": "ModularChange",
               "version": 4,
               "children": [
-                {
-                  "name": "FieldKind:NodeKey",
-                  "version": 1
-                },
                 {
                   "name": "FieldKind:Value",
                   "version": 2

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_52.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_52.json
@@ -27,10 +27,6 @@
               "version": 4,
               "children": [
                 {
-                  "name": "FieldKind:NodeKey",
-                  "version": 1
-                },
-                {
                   "name": "FieldKind:Value",
                   "version": 2
                 },
@@ -78,10 +74,6 @@
               "name": "ModularChange",
               "version": 4,
               "children": [
-                {
-                  "name": "FieldKind:NodeKey",
-                  "version": 1
-                },
                 {
                   "name": "FieldKind:Value",
                   "version": 2


### PR DESCRIPTION
## Description

There has never been a way to use the nodeKey field kind since before the simple simple-tree API layer was created. Any document using it is impossible to open with our existing view schema APIs, and would have had to have been created using either internal APIs or before shared-tree was stabilized in FF 2.0.

## Breaking Changes

Removing support for nodeKey could cause a currently impossible to "view" document which uses it from before FF 2.0 to error on load rather than on view.

As such documents are believed to not exist, and if they do exist are impossible to view or edit and never had forwards compat guarantees, erroring on load for them seems like a non-issue.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


