### PR TITLE
Shared Tree: Updated generateSchemaFromSimpleSchema to build schemas with staging information for allowed types

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
@@ -91,7 +91,7 @@ function generateAllowedTypes(
 ): AllowedTypesFull {
 	const types = Array.from(allowed.entries(), ([id, attributes]) => {
 		const schema = context.get(id) ?? fail(0xb5a /* Missing schema */);
-		return attributes.isStaged ? factory.staged(schema) : schema;
+		return (attributes.isStaged ?? false) ? factory.staged(schema) : schema;
 	});
 	// TODO: AB#53315: `AllowedTypesFullFromMixed` does not correctly handle the `(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]` case.
 	// We have to cast here in order to produce an allowed types list that can be used in tree node factory methods (e.g., `SchemaFactoryAlpha.objectAlpha`).

--- a/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
@@ -91,7 +91,7 @@ function generateAllowedTypes(
 ): AllowedTypesFull {
 	const types = Array.from(allowed.entries(), ([id, attributes]) => {
 		const schema = context.get(id) ?? fail(0xb5a /* Missing schema */);
-		return (attributes.isStaged ?? false) ? factory.staged(schema) : schema;
+		return attributes.isStaged ? factory.staged(schema) : schema;
 	});
 	// TODO: AB#53315: `AllowedTypesFullFromMixed` does not correctly handle the `(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]` case.
 	// We have to cast here in order to produce an allowed types list that can be used in tree node factory methods (e.g., `SchemaFactoryAlpha.objectAlpha`).

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -249,9 +249,7 @@ const schema = new SchemaFactory("com.example");
 		}
 		// Can assign to ImplicitAllowedTypes
 		{
-			type A = UnannotateAllowedTypesList<
-				(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]
-			>;
+			type A = UnannotateAllowedTypesList<(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]>;
 			// @ts-expect-error TODO: AB#53315
 			type _check1 = requireAssignableTo<A, ImplicitAllowedTypes>;
 		}
@@ -261,9 +259,7 @@ const schema = new SchemaFactory("com.example");
 	{
 		// Can assign to ImplicitAllowedTypes
 		{
-			type A = AllowedTypesFullFromMixed<
-				(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]
-			>;
+			type A = AllowedTypesFullFromMixed<(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]>;
 			// @ts-expect-error TODO: AB#53315
 			type _check1 = requireAssignableTo<A, ImplicitAllowedTypes>;
 		}

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -247,6 +247,26 @@ const schema = new SchemaFactory("com.example");
 
 			type _check4 = requireAssignableTo<UnannotateAllowedTypesList<[A]>, [A]>;
 		}
+		// Can assign to ImplicitAllowedTypes
+		{
+			type A = UnannotateAllowedTypesList<
+				(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]
+			>;
+			// @ts-expect-error TODO: AB#53315
+			type _check1 = requireAssignableTo<A, ImplicitAllowedTypes>;
+		}
+	}
+
+	// AllowedTypesFullFromMixed
+	{
+		// Can assign to ImplicitAllowedTypes
+		{
+			type A = AllowedTypesFullFromMixed<
+				(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]
+			>;
+			// @ts-expect-error TODO: AB#53315
+			type _check1 = requireAssignableTo<A, ImplicitAllowedTypes>;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

- Support for building staged allowed types based on `SimpleAllowedTypeAttributes`.
- Tests for `allowUnknownOptionalFields` and `isStaged`.
- Type tests for an issue encountered with the allowed types parameters in schema factories.