### PR TITLE
Make TreeViewConfiguration create TreeViewConfigurationAlpha instances

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -117,6 +117,9 @@ export const ArrayNodeSchema: {
 // @alpha
 export function asAlpha<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewAlpha<TSchema>;
 
+// @alpha
+export function asAlpha<TSchema extends ImplicitFieldSchema>(view: TreeViewConfiguration<TSchema>): TreeViewConfigurationAlpha<TSchema>;
+
 // @beta
 export function asBeta<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewBeta<TSchema>;
 

--- a/packages/dds/tree/src/api.ts
+++ b/packages/dds/tree/src/api.ts
@@ -3,19 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type TreeView,
-	type TreeViewAlpha,
-	type TreeViewBeta,
-	type ImplicitFieldSchema,
-	// eslint-disable-next-line import-x/no-deprecated
-	asTreeViewAlpha,
+import type {
+	TreeView,
+	TreeViewAlpha,
+	TreeViewBeta,
+	ImplicitFieldSchema,
+	TreeViewConfiguration,
+	TreeViewConfigurationAlpha,
 } from "./simple-tree/index.js";
 
 /**
  * Module entry points for retrieving alternate (alpha/beta) versions of tree APIs.
  * For each API (usually a class) that has an alpha/beta version, add overloads to the function(s) below.
- * In the future, `asBeta` may be added here too.
  * These functions should only be used by external consumers, not referenced internally within the tree package, to avoid circular import dependencies.
  */
 
@@ -25,9 +24,21 @@ import {
  */
 export function asAlpha<TSchema extends ImplicitFieldSchema>(
 	view: TreeView<TSchema>,
-): TreeViewAlpha<TSchema> {
-	// eslint-disable-next-line import-x/no-deprecated
-	return asTreeViewAlpha(view);
+): TreeViewAlpha<TSchema>;
+
+/**
+ * Retrieve the {@link TreeViewConfigurationAlpha | alpha API} for a {@link TreeViewConfiguration}.
+ * @alpha
+ */
+export function asAlpha<TSchema extends ImplicitFieldSchema>(
+	view: TreeViewConfiguration<TSchema>,
+): TreeViewConfigurationAlpha<TSchema>;
+
+/**
+ * Implementation of overloads for {@link asAlpha}.
+ */
+export function asAlpha(view: unknown): unknown {
+	return view;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/configuration.ts
+++ b/packages/dds/tree/src/simple-tree/api/configuration.ts
@@ -207,8 +207,15 @@ export class TreeViewConfiguration<
 	 */
 	public constructor(props: ITreeViewConfiguration<TSchema>) {
 		if (this.constructor === TreeViewConfiguration) {
+			// Ensure all TreeViewConfiguration instances are actually TreeViewConfigurationAlpha, allowing `asAlpha` to work correctly.
+			// If everything in TreeViewConfigurationAlpha is stabilized and this is removed, the `!` on the properties above should be removed to restore better type safety.
 			return new TreeViewConfigurationAlpha(props);
 		}
+		assert(
+			// The type cast here is needed to avoid this assert narrowing "this" to never, breaking the code below.
+			(this.constructor as unknown) === TreeViewConfigurationAlpha,
+			"Invalid configuration class constructed.",
+		);
 
 		const config = { ...defaultTreeConfigurationOptions, ...props };
 		this.schema = config.schema;
@@ -256,6 +263,8 @@ export class TreeViewConfiguration<
 
 /**
  * {@link TreeViewConfiguration} extended with some alpha APIs.
+ * @remarks
+ * See {@link (asAlpha:2)} for an API to downcast from {@link TreeViewConfiguration} to this type.
  * @sealed @alpha
  */
 export class TreeViewConfigurationAlpha<

--- a/packages/dds/tree/src/simple-tree/api/configuration.ts
+++ b/packages/dds/tree/src/simple-tree/api/configuration.ts
@@ -175,22 +175,22 @@ export class TreeViewConfiguration<
 	/**
 	 * {@inheritDoc ITreeViewConfiguration.schema}
 	 */
-	public readonly schema: TSchema;
+	public readonly schema!: TSchema;
 
 	/**
 	 * {@inheritDoc ITreeConfigurationOptions.enableSchemaValidation}
 	 */
-	public readonly enableSchemaValidation: boolean;
+	public readonly enableSchemaValidation!: boolean;
 
 	/**
 	 * {@inheritDoc ITreeConfigurationOptions.preventAmbiguity}
 	 */
-	public readonly preventAmbiguity: boolean;
+	public readonly preventAmbiguity!: boolean;
 
 	/**
 	 * {@link TreeSchema.definitions} but with public types.
 	 */
-	protected readonly definitionsInternal: ReadonlyMap<string, TreeNodeSchema>;
+	protected readonly definitionsInternal!: ReadonlyMap<string, TreeNodeSchema>;
 
 	/**
 	 * Construct a new {@link TreeViewConfiguration}.
@@ -206,6 +206,10 @@ export class TreeViewConfiguration<
 	 * since this would be a cyclic dependency that will cause an error when constructing this configuration.
 	 */
 	public constructor(props: ITreeViewConfiguration<TSchema>) {
+		if (this.constructor === TreeViewConfiguration) {
+			return new TreeViewConfigurationAlpha(props);
+		}
+
 		const config = { ...defaultTreeConfigurationOptions, ...props };
 		this.schema = config.schema;
 		this.enableSchemaValidation = config.enableSchemaValidation;

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -577,7 +577,7 @@ export interface TreeViewEvents {
 /**
  * Retrieve the {@link TreeViewAlpha | alpha API} for a {@link TreeView}.
  * @alpha
- * @deprecated Use {@link asAlpha} instead.
+ * @deprecated Use {@link (asAlpha:1)} instead.
  * @privateRemarks Despite being deprecated, this function should be used within the tree package (outside of tests) rather than `asAlpha` in order to avoid circular import dependencies.
  */
 export function asTreeViewAlpha<TSchema extends ImplicitFieldSchema>(

--- a/packages/dds/tree/src/test/simple-tree/api/configuration.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/configuration.spec.ts
@@ -17,6 +17,7 @@ import { independentView } from "../../../shared-tree/index.js";
 
 import {
 	TreeViewConfiguration,
+	TreeViewConfigurationAlpha,
 	checkUnion,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../simple-tree/api/configuration.js";
@@ -256,5 +257,10 @@ describe("simple-tree configuration", () => {
 				],
 			);
 		});
+	});
+
+	it("creates TreeViewConfigurationAlpha", () => {
+		const config = new TreeViewConfiguration({ schema: [] });
+		assert(config instanceof TreeViewConfigurationAlpha);
 	});
 });

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -117,6 +117,9 @@ export const ArrayNodeSchema: {
 // @alpha
 export function asAlpha<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewAlpha<TSchema>;
 
+// @alpha
+export function asAlpha<TSchema extends ImplicitFieldSchema>(view: TreeViewConfiguration<TSchema>): TreeViewConfigurationAlpha<TSchema>;
+
 // @beta
 export function asBeta<TSchema extends ImplicitFieldSchema>(view: TreeView<TSchema>): TreeViewBeta<TSchema>;
 


### PR DESCRIPTION
## Description

Make TreeViewConfiguration create TreeViewConfigurationAlpha instances.

This makes it safe to down cast TreeViewConfiguration to TreeViewConfigurationAlpha

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I'm not convinced this is a good idea: strange JS tricks have a complexity cost, and this behavior might be more surprising than it is useful.