### PR TITLE
Replace tree-agent editor binding with direct context creation

### DIFF
--- a/packages/framework/tree-agent-ses/src/executor.ts
+++ b/packages/framework/tree-agent-ses/src/executor.ts
@@ -6,7 +6,12 @@
 // eslint-disable-next-line import-x/no-unassigned-import
 import "ses";
 
-import type { AsynchronousEditor } from "@fluidframework/tree-agent/alpha";
+import type { ImplicitFieldSchema } from "@fluidframework/tree";
+import {
+	createContext,
+	type AsynchronousEditor,
+	type ViewOrTree,
+} from "@fluidframework/tree-agent/alpha";
 
 /**
  * Used to track whether the SES `lockdown` function has already been called by this module.
@@ -21,10 +26,10 @@ const lockdownSymbol = Symbol.for("tree-agent.ses.locked");
  * @remarks This function will call the SES `lockdown` API the first time it is invoked. For best performance, create the executor once during application initialization.
  * @alpha
  */
-export function createSesEditExecutor(options?: {
+export function createSesEditExecutor<TSchema extends ImplicitFieldSchema>(options?: {
 	compartmentOptions?: { globals?: Map<string, unknown>; [key: string]: unknown };
 	lockdownOptions?: Record<string, unknown>;
-}): AsynchronousEditor {
+}): AsynchronousEditor<TSchema> {
 	const optionsGlobals: Map<string, unknown> =
 		options?.compartmentOptions?.globals ?? new Map<string, unknown>();
 
@@ -57,12 +62,12 @@ export function createSesEditExecutor(options?: {
 		}
 	}
 
-	return async (context: Record<string, unknown>, code: string) => {
+	return async (tree: ViewOrTree<TSchema>, code: string) => {
 		const compartmentOptions = {
 			...options?.compartmentOptions,
 			globals: {
 				...Object.fromEntries(optionsGlobals),
-				context,
+				context: createContext(tree),
 			},
 		};
 

--- a/packages/framework/tree-agent-ses/src/test/ses.spec.ts
+++ b/packages/framework/tree-agent-ses/src/test/ses.spec.ts
@@ -67,7 +67,7 @@ describe.skip("SES edit executor", () => {
 			editToolName: "EditTreeTool",
 			async query({ edit }) {
 				const editResult = await edit("Object.prototype.polluted = 'hacked!';");
-				assert.equal(editResult.type, "executionError", editResult.message);
+				assert.equal(editResult.type, "editingError", editResult.message);
 				return editResult.message;
 			},
 		};

--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -11,9 +11,7 @@
 
 export {
 	SharedTreeSemanticAgent,
-	bindEditor,
-	bindEditorImpl,
-	defaultEditor,
+	createContext,
 } from "./agent.js";
 export type {
 	EditResult,
@@ -23,8 +21,11 @@ export type {
 	SemanticAgentOptions,
 	SynchronousEditor,
 	AsynchronousEditor,
+	TreeView,
+	ViewOrTree,
+	Context,
 } from "./api.js";
-export { type TreeView, llmDefault } from "./utils.js";
+export { llmDefault } from "./utils.js";
 export {
 	buildFunc,
 	exposeMethodsSymbol,

--- a/packages/framework/tree-agent/src/prompt.ts
+++ b/packages/framework/tree-agent/src/prompt.ts
@@ -25,8 +25,8 @@ import {
 /**
  * Produces a "system" prompt for the tree agent, based on the provided subtree.
  */
-export function getPrompt<TRoot extends ImplicitFieldSchema>(args: {
-	subtree: Subtree<TRoot>;
+export function getPrompt(args: {
+	subtree: Pick<Subtree<ImplicitFieldSchema>, "schema" | "field">;
 	editToolName: string | undefined;
 	domainHints?: string;
 }): string {

--- a/packages/framework/tree-agent/src/test/prompt.spec.ts
+++ b/packages/framework/tree-agent/src/test/prompt.spec.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import { buildFunc, exposeMethodsSymbol, type ExposedMethods } from "../methodBinding.js";
 import { getPrompt } from "../prompt.js";
 import { Subtree } from "../subtree.js";
-import type { TreeView } from "../utils.js";
+import type { TreeView } from "../api.js";
 
 const sf = new SchemaFactory("test");
 

--- a/packages/framework/tree-agent/src/utils.ts
+++ b/packages/framework/tree-agent/src/utils.ts
@@ -12,10 +12,8 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import type { ImplicitFieldSchema, TreeNodeSchemaClass } from "@fluidframework/tree";
 import type {
 	InsertableContent,
-	TreeBranchAlpha,
 	TreeNode,
 	TreeNodeSchema,
-	TreeViewAlpha,
 	UnsafeUnknownSchema,
 } from "@fluidframework/tree/alpha";
 import {
@@ -85,17 +83,6 @@ export function getOrCreate<K, V>(
 	}
 	return value;
 }
-
-/**
- * TODO
- * @alpha
- * @privateRemarks This is a subset of the TreeViewAlpha functionality because if take it wholesale, it causes problems with invariance of the generic parameters.
- */
-export type TreeView<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema> = Pick<
-	TreeViewAlpha<TRoot>,
-	"root" | "fork" | "merge" | "rebaseOnto" | "schema" | "events"
-> &
-	TreeBranchAlpha;
 
 /**
  * TODO


### PR DESCRIPTION
Editors now receive trees as input rather than context. The implementation of the editor is expected to call a (newly exposed) `createContext(tree)` function to get the context for the executing code. This change makes the input to an editor fully serializable - both the tree state and the code string are serializable. This was not the case before since the context object was not serializable. Having editor inputs be serializable allows them to be run in a different process than the process owning the `SharedTreeSemanticAgent`, which enables additional scenarios for sandboxing (e.g. running tree-agent in process A but actually executing the generated code in sandboxed process B).

Additionally:
* Exposed the Context type
* Parameterized various types (e.g. the editors) over a TSchema
* Removed `UnsafeUnknownSchema` from type signatures
* Exposed `viewOrTree` on `Subtree` so that we can go back to a `ViewOrTree` from a `Subtree`
* Narrowed input type of the prompt function so it is no longer invariant over TSchema (and can't have anything passed in without a cast)
* Unexposed the default editor
* Added ViewOrTree type since the "view or tree" pattern is now in multiple places in the user-facing API surface.
* Replaced binding unit tests with unit tests using custom editors.
* Various cleanup to docs and code
* Fixed bad string in tree-agent-ses test.