### PR TITLE
Fix two tree input handling bugs which could result in asserts 0xb3f and 0xbb1

### DIFF
--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -650,9 +650,8 @@ function assertUniqueKeys<
 }
 
 /**
- * {@link TreeNodeSchemaInitializedData.toFlexContent} for Map nodes.
+ * {@link TreeNodeSchemaInitializedData.toFlexContent} for object nodes.
  *
- * Transforms data under an Object schema.
  * @param data - The tree data to be transformed. Must be a Record-like object.
  * @param schema - The schema to comply with.
  */

--- a/packages/dds/tree/src/test/simple-tree/unhydratedFlexTreeFromInsertable.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedFlexTreeFromInsertable.spec.ts
@@ -42,8 +42,15 @@ import {
 	type FlexTreeHydratedContextMinimal,
 } from "../../feature-libraries/index.js";
 import { validateUsageError } from "../utils.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { contentSchemaSymbol, UnhydratedFlexTreeNode } from "../../simple-tree/core/index.js";
+import {
+	CompatibilityLevel,
+	contentSchemaSymbol,
+	privateDataSymbol,
+	UnhydratedFlexTreeNode,
+	type TreeNodeSchemaInitializedData,
+	type TreeNodeSchemaPrivateData,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../simple-tree/core/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { getUnhydratedContext } from "../../simple-tree/createContext.js";
 // eslint-disable-next-line import-x/no-internal-modules
@@ -1460,7 +1467,7 @@ describe("unhydratedFlexTreeFromInsertable", () => {
 			);
 		});
 
-		it("with contentSchemaSymbol", () => {
+		describe("with contentSchemaSymbol", () => {
 			const f = new SchemaFactory("test");
 			class A extends f.object("A", {
 				value: f.string,
@@ -1468,19 +1475,75 @@ describe("unhydratedFlexTreeFromInsertable", () => {
 			class B extends f.object("B", {
 				value: f.string,
 			}) {}
-			// Type symbol specified when there is only one valid option
-			const content = { [contentSchemaSymbol]: "test.A", value: "hello" };
-			assert.deepEqual(getPossibleTypes(new Set([A]), content), [A]);
 
-			// Type symbol specified when there are multiple valid options
-			const ambiguousContent = { [contentSchemaSymbol]: "test.B", value: "hello" };
-			// Only B, even though A is also valid based on properties
-			assert.deepEqual(getPossibleTypes(new Set([A, B]), ambiguousContent), [B]);
+			it("Type symbol specified when there is only one valid option", () => {
+				// Type symbol specified when there is only one valid option
+				const content = { [contentSchemaSymbol]: "test.A", value: "hello" };
+				assert.deepEqual(getPossibleTypes(new Set([A]), content), [A]);
+			});
 
-			// Type symbol specified that does not match any options
-			const invalidContent = { [contentSchemaSymbol]: "test.C", value: "hello" };
-			// Should report no valid types
-			assert.deepEqual(getPossibleTypes(new Set([]), invalidContent), []);
+			it("Type symbol specified when there are multiple valid options", () => {
+				// Type symbol specified when there are multiple valid options
+				const ambiguousContent = { [contentSchemaSymbol]: "test.B", value: "hello" };
+				// Only B, even though A is also valid based on properties
+				assert.deepEqual(getPossibleTypes(new Set([A, B]), ambiguousContent), [B]);
+			});
+
+			it("Type symbol specified that does not match any options", () => {
+				// Type symbol specified that does not match any options
+				const invalidContent = { [contentSchemaSymbol]: "test.B", value: "hello" };
+				// Should report no valid types
+				assert.deepEqual(getPossibleTypes(new Set([]), invalidContent), []);
+				assert.deepEqual(getPossibleTypes(new Set([A]), invalidContent), []);
+			});
+
+			it("Type symbol with invalid content that passes shallowCompatibilityTest", () => {
+				const invalidContent = { [contentSchemaSymbol]: "test.A", value: 42 };
+				assert.deepEqual(getPossibleTypes(new Set([A]), invalidContent), [A]);
+
+				assert.deepEqual(getPossibleTypes(new Set([A]), { value: 42 }), [A]);
+			});
+
+			it("Type symbol with invalid content - missing field", () => {
+				const invalidContent = { [contentSchemaSymbol]: "test.A", wrong: 42 };
+				assert.deepEqual(getPossibleTypes(new Set([A]), invalidContent), []);
+			});
+
+			it("Respects shallowCompatibilityTest even when contentSchemaSymbol is provided", () => {
+				const tagged = { [contentSchemaSymbol]: "test.A" };
+				const log: string[] = [];
+				let level = CompatibilityLevel.None;
+				const inner: TreeNodeSchemaInitializedData = {
+					shallowCompatibilityTest: () => {
+						log.push("called");
+						return level;
+					},
+				} satisfies Pick<
+					TreeNodeSchemaInitializedData,
+					"shallowCompatibilityTest"
+				> as unknown as TreeNodeSchemaInitializedData;
+
+				const dummySchema = {
+					[privateDataSymbol]: {
+						idempotentInitialize: () => inner,
+					} satisfies Pick<TreeNodeSchemaPrivateData, "idempotentInitialize">,
+					identifier: "test.A",
+				};
+
+				assert.deepEqual(
+					getPossibleTypes(new Set([dummySchema as unknown as typeof A]), tagged),
+					[],
+				);
+				assert.deepEqual(log, ["called"]);
+				log.length = 0;
+
+				level = CompatibilityLevel.Low;
+				assert.deepEqual(
+					getPossibleTypes(new Set([dummySchema as unknown as typeof A]), tagged),
+					[dummySchema],
+				);
+				assert.deepEqual(log, ["called"]);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Description

This fixes two bugs:
1. type fallbacks from NaN to null at the top level in a tree could construct a context from the wrong schema and hit 0xb3f 
2. Tagging input with contentSchemaSymbol skipped shallowCompatibilityTest, violating the invariant documented on toFlexContent causing object nodes to be able to hit 0xbb1 for missing field content (and possible other similar errors for other cases). Since tagContentSchema is strongly typed, hitting this bug with type safe code is hard, but can be done easily un unsafe typed cases.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

