### PR TITLE
ci: stop running e2e real service tests on lts

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -28,8 +28,6 @@ resources:
       branches:
       - release/*
       - main
-      - next
-      - lts
   - pipeline: routerlicious
     source: server-routerlicious
     branch: main # Default branch for manual/scheduled triggers if none is selected


### PR DESCRIPTION
Tests have been failing for some time, and we are decommissioning the backing environment. I also disabled it for `next` since we haven't used that branch in a long time, and if we bring it back, we'd want to control the enabling of pipelines like this anyway.