### PR TITLE
Migrate most use of validateAssertionError to validateAssertionError2

### DIFF
--- a/packages/common/client-utils/src/test/mocha/events.spec.ts
+++ b/packages/common/client-utils/src/test/mocha/events.spec.ts
@@ -362,7 +362,7 @@ export class MyExposingClass {
  *
  * @remarks
  * This does not work for asserts that get "tagging" see {@link @fluidframework/test-runtime-utils#validateAssertionError} for that.
- * This avoids a dependency on `@fluidframework/test-runtime-utils` since this package cannot use it.
+ * This function exists here to avoid a dependency on `@fluidframework/test-runtime-utils` since this package cannot use it.
  */
 function validateError(expectedErrorMsg: string | RegExp): (error: Error) => true {
 	return (error: Error) => {

--- a/packages/common/client-utils/src/test/mocha/events.spec.ts
+++ b/packages/common/client-utils/src/test/mocha/events.spec.ts
@@ -258,10 +258,7 @@ describe("CustomEventEmitter", () => {
 		let count = 0;
 		const listener = (): number => (count += 1);
 		emitter.on("open", listener);
-		assert.throws(
-			() => emitter.on("open", listener),
-			(e: Error) => validateAssertionError(e, /register.*twice.*open/),
-		);
+		assert.throws(() => emitter.on("open", listener), validateError(/register.*twice.*open/));
 		// If error is caught, the listener should still fire once for the first registration
 		emitter.emit("open");
 		assert.strictEqual(count, 1);
@@ -276,7 +273,7 @@ describe("CustomEventEmitter", () => {
 		emitter.emit(eventSymbol);
 		assert.throws(
 			() => emitter.on(eventSymbol, listener),
-			(e: Error) => validateAssertionError(e, /register.*twice.*TestEvent/),
+			validateError(/register.*twice.*TestEvent/),
 		);
 	});
 });
@@ -358,29 +355,28 @@ export class MyExposingClass {
 }
 
 /**
- * Validates that an error thrown by assert() function has the expected message.
+ * Validates that an error has the expected message.
  *
- * @param error - The error object thrown by `assert()` function.
  * @param expectedErrorMessage - The message that the error object should match.
- * @returns `true` if the message in the error object that was passed in matches the expected
- * message. Otherwise it throws an error.
+ * @returns an error validation function suitable for use with NodeJS's `assert.throws()`.
  *
  * @remarks
- * Similar to {@link @fluidframework/test-runtime-utils#validateAssertionError}.
- *
- * @internal
+ * This does not work for asserts which get "tagging" see {@link @fluidframework/test-runtime-utils#validateAssertionError} for that.
+ * This avoids a dependency on `@fluidframework/test-runtime-utils` since this package cannot use it.
  */
-function validateAssertionError(error: Error, expectedErrorMsg: string | RegExp): boolean {
-	const actualMsg = error.message;
-	if (
-		typeof expectedErrorMsg === "string"
-			? actualMsg !== expectedErrorMsg
-			: !expectedErrorMsg.test(actualMsg)
-	) {
-		// This throws an Error instead of an AssertionError because AssertionError would require a dependency on the
-		// node assert library, which we don't want to do for this library because it's used in the browser.
-		const message = `Unexpected assertion thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`;
-		throw new Error(message);
-	}
-	return true;
+function validateError(expectedErrorMsg: string | RegExp): (error: Error) => true {
+	return (error: Error) => {
+		const actualMsg = error.message;
+		if (
+			typeof expectedErrorMsg === "string"
+				? actualMsg !== expectedErrorMsg
+				: !expectedErrorMsg.test(actualMsg)
+		) {
+			// This throws an Error instead of an AssertionError because AssertionError would require a dependency on the
+			// node assert library, which we don't want to do for this library because it's used in the browser.
+			const message = `Unexpected assertion thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`;
+			throw new Error(message);
+		}
+		return true;
+	};
 }

--- a/packages/common/client-utils/src/test/mocha/events.spec.ts
+++ b/packages/common/client-utils/src/test/mocha/events.spec.ts
@@ -361,7 +361,7 @@ export class MyExposingClass {
  * @returns an error validation function suitable for use with NodeJS's `assert.throws()`.
  *
  * @remarks
- * This does not work for asserts which get "tagging" see {@link @fluidframework/test-runtime-utils#validateAssertionError} for that.
+ * This does not work for asserts that get "tagging" see {@link @fluidframework/test-runtime-utils#validateAssertionError} for that.
  * This avoids a dependency on `@fluidframework/test-runtime-utils` since this package cannot use it.
  */
 function validateError(expectedErrorMsg: string | RegExp): (error: Error) => true {

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -27,7 +27,7 @@ import {
 	MockEmptyDeltaConnection,
 	MockFluidDataStoreRuntime,
 	MockStorage,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { SharedStringFactory, type SharedString } from "../sequenceFactory.js";
@@ -253,8 +253,7 @@ describe("SharedString", () => {
 				() => {
 					sharedString.annotateMarker(simpleMarker, newIdProps);
 				},
-				(e: Error) =>
-					validateAssertionError(e, "Cannot change the markerId of an existing marker"),
+				validateAssertionError("Cannot change the markerId of an existing marker"),
 				"Error from attempting to update marker was not thrown or was not the expected error",
 			);
 		});
@@ -273,8 +272,7 @@ describe("SharedString", () => {
 				() => {
 					sharedString.annotateMarker(simpleMarker, newIdProps);
 				},
-				(e: Error) =>
-					validateAssertionError(e, "Cannot change the markerId of an existing marker"),
+				validateAssertionError("Cannot change the markerId of an existing marker"),
 				"Error from attempting to update marker was not thrown or was not the expected error",
 			);
 		});
@@ -293,8 +291,7 @@ describe("SharedString", () => {
 				() => {
 					sharedString.annotateMarker(simpleMarker, newIdProps);
 				},
-				(e: Error) =>
-					validateAssertionError(e, "Cannot change the markerId of an existing marker"),
+				validateAssertionError("Cannot change the markerId of an existing marker"),
 				"Error from attempting to update marker was not thrown or was not the expected error",
 			);
 		});

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -128,9 +128,7 @@ describe("SharedObject", () => {
 	it("rejects slashes in id", () => {
 		const invalidId = "beforeSlash/afterSlash";
 		const codeBlock = (): SharedObject => new MySharedObject(invalidId);
-		assert.throws(codeBlock, (e: Error) =>
-			validateAssertionError("Id cannot contain slashes"),
-		);
+		assert.throws(codeBlock, validateAssertionError("Id cannot contain slashes"));
 	});
 });
 
@@ -138,9 +136,7 @@ describe("SharedObjectCore", () => {
 	it("rejects slashes in id", () => {
 		const invalidId = "beforeSlash/afterSlash";
 		const codeBlock = (): SharedObjectCore => new MySharedObjectCore({ id: invalidId });
-		assert.throws(codeBlock, (e: Error) =>
-			validateAssertionError("Id cannot contain slashes"),
-		);
+		assert.throws(codeBlock, validateAssertionError("Id cannot contain slashes"));
 	});
 
 	describe("handle encoding in submitLocalMessage", () => {

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -22,7 +22,7 @@ import { isSerializedHandle } from "@fluidframework/runtime-utils/internal";
 import {
 	MockFluidDataStoreRuntime,
 	MockHandle,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 import sinon from "sinon";
 
@@ -129,7 +129,7 @@ describe("SharedObject", () => {
 		const invalidId = "beforeSlash/afterSlash";
 		const codeBlock = (): SharedObject => new MySharedObject(invalidId);
 		assert.throws(codeBlock, (e: Error) =>
-			validateAssertionError(e, "Id cannot contain slashes"),
+			validateAssertionError("Id cannot contain slashes"),
 		);
 	});
 });
@@ -139,7 +139,7 @@ describe("SharedObjectCore", () => {
 		const invalidId = "beforeSlash/afterSlash";
 		const codeBlock = (): SharedObjectCore => new MySharedObjectCore({ id: invalidId });
 		assert.throws(codeBlock, (e: Error) =>
-			validateAssertionError(e, "Id cannot contain slashes"),
+			validateAssertionError("Id cannot contain slashes"),
 		);
 	});
 

--- a/packages/dds/tree/src/test/codec/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/codec.spec.ts
@@ -9,7 +9,7 @@ import { Type } from "@sinclair/typebox";
 
 import { type IJsonCodec, withSchemaValidation } from "../../codec/index.js";
 import { FormatValidatorBasic } from "../../external-utilities/index.js";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 describe("Codec APIs", () => {
 	describe("withSchemaValidation", () => {
@@ -22,14 +22,14 @@ describe("Codec APIs", () => {
 			it("on encode", () => {
 				assert.throws(
 					() => codec.encode("bad data" as unknown as number),
-					(error: Error) => validateAssertionError(error, /Encoded schema should validate/),
+					validateAssertionError(/Encoded schema should validate/),
 				);
 			});
 
 			it("on decode", () => {
 				assert.throws(
 					() => codec.decode("bad data" as unknown as number),
-					(error: Error) => validateAssertionError(error, /Encoded schema should validate/),
+					validateAssertionError(/Encoded schema should validate/),
 				);
 			});
 		});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { compareArrays } from "@fluidframework/core-utils/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 // eslint-disable-next-line import-x/no-internal-modules
 import { BasicChunk } from "../../../../feature-libraries/chunked-forest/basicChunk.js";
@@ -564,11 +564,9 @@ describe("chunkDecoding", () => {
 
 			assert.throws(
 				() => decoder.decode([], stream),
-				(error: Error) =>
-					validateAssertionError(
-						error,
-						"incremental decoder not available for incremental field decoding",
-					),
+				validateAssertionError(
+					"incremental decoder not available for incremental field decoding",
+				),
 			);
 		});
 
@@ -590,7 +588,7 @@ describe("chunkDecoding", () => {
 
 			assert.throws(
 				() => decoder.decode([], stream),
-				(error: Error) => validateAssertionError(error, /Unsupported FieldBatchFormatVersion/),
+				validateAssertionError(/Unsupported FieldBatchFormatVersion/),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/codecs.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/codecs.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import {
 	makeFieldBatchCodec,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -96,7 +96,7 @@ describe("makeFieldBatchCodec", () => {
 
 			assert.throws(
 				() => codec.encode([input], context),
-				(error: Error) => validateAssertionError(error, /Unsupported FieldBatchFormatVersion/),
+				validateAssertionError(/Unsupported FieldBatchFormatVersion/),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert, fail } from "node:assert";
 import { compareArrays } from "@fluidframework/core-utils/internal";
 import {
 	MockHandle,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 
 import {
@@ -498,16 +498,11 @@ describe("compressedEncode", () => {
 				fieldBatchVersion,
 			);
 
-			assert.throws(
-				() => {
-					checkFieldEncode(incrementalFieldEncoder, context, [{ type: brand("foo") }]);
-				},
-				(error: Error) =>
-					validateAssertionError(
-						error,
-						"incremental encoder must be defined to use incrementalFieldEncoder",
-					),
-			);
+			assert.throws(() => {
+				checkFieldEncode(incrementalFieldEncoder, context, [{ type: brand("foo") }]);
+			}, validateAssertionError(
+				"incremental encoder must be defined to use incrementalFieldEncoder",
+			));
 		});
 
 		it("has correct shape", () => {
@@ -527,7 +522,7 @@ describe("compressedEncode", () => {
 
 			assert.throws(
 				() => checkFieldEncode(incrementalFieldEncoder, context, []),
-				(error: Error) => validateAssertionError(error, /Unsupported FieldBatchFormatVersion/),
+				validateAssertionError(/Unsupported FieldBatchFormatVersion/),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -7,7 +7,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
 	type FieldAnchor,
@@ -93,13 +93,11 @@ describe("LazyField", () => {
 		cursor.free();
 		assert.throws(
 			() => optionalField.editor.set(undefined, optionalField.length === undefined),
-			(e: Error) =>
-				validateAssertionError(e, /only allowed on fields with TreeStatus.InDocument status/),
+			validateAssertionError(/only allowed on fields with TreeStatus.InDocument status/),
 		);
 		assert.throws(
 			() => valueField.editor.set(mapTreeFromCursor(singleJsonCursor({}))),
-			(e: Error) =>
-				validateAssertionError(e, /only allowed on fields with TreeStatus.InDocument status/),
+			validateAssertionError(/only allowed on fields with TreeStatus.InDocument status/),
 		);
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import {
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 
@@ -159,7 +159,7 @@ describe("ForestSummarizerCodec", () => {
 						} as unknown as Format,
 						context,
 					),
-				(e: Error) => validateAssertionError(e, "Encoded schema should validate"),
+				validateAssertionError("Encoded schema should validate"),
 			);
 		});
 
@@ -175,7 +175,7 @@ describe("ForestSummarizerCodec", () => {
 						} as unknown as Format,
 						context,
 					),
-				(e: Error) => validateAssertionError(e, "Encoded schema should validate"),
+				validateAssertionError("Encoded schema should validate"),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/incrementalSummaryBuilder.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/incrementalSummaryBuilder.spec.ts
@@ -9,7 +9,7 @@ import { stringToBuffer } from "@fluid-internal/client-utils";
 import type { IExperimentalIncrementalSummaryContext } from "@fluidframework/runtime-definitions/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import { SummaryType, type ISnapshotTree } from "@fluidframework/driver-definitions/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
 	ForestIncrementalSummaryBehavior,
@@ -159,7 +159,7 @@ describe("ForestIncrementalSummaryBuilder", () => {
 						incrementalSummaryContext,
 						stringify,
 					}),
-				(error: Error) => validateAssertionError(error, /Already tracking/),
+				validateAssertionError(/Already tracking/),
 			);
 			assert.equal(builder.forestSummaryState, ForestSummaryTrackingState.Tracking);
 		});
@@ -225,7 +225,7 @@ describe("ForestIncrementalSummaryBuilder", () => {
 						incrementalSummaryContext: localIncrementalSummaryContext,
 						forestSummaryContent: mockForestSummaryContent,
 					}),
-				(error: Error) => validateAssertionError(error, /Not tracking/),
+				validateAssertionError(/Not tracking/),
 			);
 			assert.equal(builder.forestSummaryState, ForestSummaryTrackingState.ReadyToTrack);
 		});
@@ -350,7 +350,7 @@ describe("ForestIncrementalSummaryBuilder", () => {
 			const builder = createIncrementalSummaryBuilder();
 			assert.throws(
 				() => builder.encodeIncrementalField(testCursor, () => mockEncodedChunk),
-				(error: Error) => validateAssertionError(error, /Not tracking/),
+				validateAssertionError(/Not tracking/),
 			);
 		});
 
@@ -570,7 +570,7 @@ describe("ForestIncrementalSummaryBuilder", () => {
 					builder.decodeIncrementalChunk(999 as ChunkReferenceId, (encoded) => {
 						return getMockChunk();
 					}),
-				(error: Error) => validateAssertionError(error, "Encoded incremental chunk not found"),
+				validateAssertionError("Encoded incremental chunk not found"),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
 	type FieldKey,
@@ -61,11 +61,7 @@ describe("object-forest", () => {
 			visitor.enterField(rootFieldKey);
 			assert.throws(
 				() => visitor.attach(rootFieldKey, 1, 0),
-				(e: Error) =>
-					validateAssertionError(
-						e,
-						/Attach source field must be different from current field/,
-					),
+				validateAssertionError(/Attach source field must be different from current field/),
 			);
 			visitor.exitField(rootFieldKey);
 			visitor.free();
@@ -83,11 +79,9 @@ describe("object-forest", () => {
 			visitor.enterField(rootFieldKey);
 			assert.throws(
 				() => visitor.detach({ start: 0, end: 1 }, rootFieldKey, dummyDetachedNodeId, false),
-				(e: Error) =>
-					validateAssertionError(
-						e,
-						/Detach destination field must be different from current field/,
-					),
+				validateAssertionError(
+					/Detach destination field must be different from current field/,
+				),
 			);
 			visitor.exitField(rootFieldKey);
 			visitor.free();
@@ -126,11 +120,9 @@ describe("object-forest", () => {
 		visitor.enterField(rootFieldKey);
 		assert.throws(
 			() => visitor.destroy(detachedFieldKey, 1),
-			(error: Error) =>
-				validateAssertionError(
-					error,
-					`Found unexpected cursors when editing with the following annotations: ["named","fork: named","namedFork",null,"fork: undefined"]`,
-				),
+			validateAssertionError(
+				`Found unexpected cursors when editing with the following annotations: ["named","fork: named","namedFork",null,"fork: undefined"]`,
+			),
 		);
 		visitor.exitField(rootFieldKey);
 		visitor.free();

--- a/packages/dds/tree/src/test/rebase/rebaseBranch.spec.ts
+++ b/packages/dds/tree/src/test/rebase/rebaseBranch.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert, fail } from "node:assert";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 // Allow importing from these specific files which are being tested:
 import {
@@ -85,12 +85,12 @@ describe("rebaseBranch", () => {
 
 		assert.throws(
 			() => rebaseBranch(mintRevisionTag, new TestChangeRebaser(), n3, n2),
-			(e: Error) => validateAssertionError(e, "branches must be related"),
+			validateAssertionError("branches must be related"),
 		);
 
 		assert.throws(
 			() => rebaseBranch(mintRevisionTag, new TestChangeRebaser(), n2, n3, n1),
-			(e: Error) => validateAssertionError(e, "target commit is not in target branch"),
+			validateAssertionError("target commit is not in target branch"),
 		);
 	});
 

--- a/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
 	type GraphCommit,
@@ -421,10 +421,10 @@ describe("Branches", () => {
 	}
 
 	function assertDisposed(fn: () => void): void {
-		assert.throws(fn, (e: Error) => validateAssertionError(e, "Branch is disposed"));
+		assert.throws(fn, validateAssertionError("Branch is disposed"));
 	}
 
 	function assertNotDisposed(fn: () => void): void {
-		assert.doesNotThrow(fn, (e: Error) => validateAssertionError(e, /\*/));
+		assert.doesNotThrow(fn, validateAssertionError(/\*/));
 	}
 });

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -10,7 +10,7 @@ import {
 	TransactionStack,
 	type OnPop,
 } from "../../shared-tree-core/index.js";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import {
 	DefaultChangeFamily,
 	type DefaultChangeset,
@@ -118,7 +118,7 @@ describe("TransactionStacks", () => {
 		const transaction = new TransactionStack();
 		assert.throws(
 			() => transaction.commit(),
-			(e: Error) => validateAssertionError(e, "No transaction to commit"),
+			validateAssertionError("No transaction to commit"),
 		);
 	});
 
@@ -126,7 +126,7 @@ describe("TransactionStacks", () => {
 		const transaction = new TransactionStack();
 		assert.throws(
 			() => transaction.abort(),
-			(e: Error) => validateAssertionError(e, "No transaction to abort"),
+			validateAssertionError("No transaction to abort"),
 		);
 	});
 
@@ -137,23 +137,17 @@ describe("TransactionStacks", () => {
 		assert.equal(transaction.disposed, true);
 		assert.throws(
 			() => transaction.isInProgress(),
-			(e: Error) => validateAssertionError(e, "Transactor is disposed"),
+			validateAssertionError("Transactor is disposed"),
 		);
-		assert.throws(
-			() => transaction.start(),
-			(e: Error) => validateAssertionError(e, "Transactor is disposed"),
-		);
+		assert.throws(() => transaction.start(), validateAssertionError("Transactor is disposed"));
 		assert.throws(
 			() => transaction.commit(),
-			(e: Error) => validateAssertionError(e, "Transactor is disposed"),
+			validateAssertionError("Transactor is disposed"),
 		);
-		assert.throws(
-			() => transaction.abort(),
-			(e: Error) => validateAssertionError(e, "Transactor is disposed"),
-		);
+		assert.throws(() => transaction.abort(), validateAssertionError("Transactor is disposed"));
 		assert.throws(
 			() => transaction.dispose(),
-			(e: Error) => validateAssertionError(e, "Transactor is disposed"),
+			validateAssertionError("Transactor is disposed"),
 		);
 	});
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -10,7 +10,7 @@ import {
 	createMockLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 import {
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 
@@ -662,19 +662,14 @@ describe("sharedTreeView", () => {
 			const viewBranch = treeBranch.viewWith(view.config);
 			viewBranch.root.insertAtEnd("42");
 
-			assert.throws(
-				() => {
-					Tree.runTransaction(view, () => {
-						view.root.insertAtEnd("43");
-						tree.merge(treeBranch, true);
-					});
-				},
-				(e: Error) =>
-					validateAssertionError(
-						e,
-						"Views cannot be merged into a view while it has a pending transaction",
-					),
-			);
+			assert.throws(() => {
+				Tree.runTransaction(view, () => {
+					view.root.insertAtEnd("43");
+					tree.merge(treeBranch, true);
+				});
+			}, validateAssertionError(
+				"Views cannot be merged into a view while it has a pending transaction",
+			));
 		});
 
 		itView("rejects rebases while a transaction is in progress", ({ view, tree }) => {
@@ -686,11 +681,9 @@ describe("sharedTreeView", () => {
 				viewBranch.root.insertAtEnd("43");
 				assert.throws(
 					() => treeBranch.rebaseOnto(tree),
-					(e: Error) =>
-						validateAssertionError(
-							e,
-							"A view cannot be rebased while it has a pending transaction",
-						),
+					validateAssertionError(
+						"A view cannot be rebased while it has a pending transaction",
+					),
 				);
 			});
 			assert.equal(viewBranch.root[0], "43");
@@ -716,7 +709,7 @@ describe("sharedTreeView", () => {
 			view.root.insertAtEnd("A");
 			assert.throws(
 				() => viewBranch.checkout.transaction.commit(),
-				(e: Error) => validateAssertionError(e, "No transaction to commit"),
+				validateAssertionError("No transaction to commit"),
 			);
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 import {
 	MockHandle,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 import { isStableId } from "@fluidframework/id-compressor/internal";
@@ -1550,11 +1550,7 @@ describe("treeNodeApi", () => {
 			});
 			assert.throws(
 				() => Tree.shortId(view.root),
-				(error: Error) =>
-					validateAssertionError(
-						error,
-						/may not be called on a node with more than one identifier/,
-					),
+				validateAssertionError(/may not be called on a node with more than one identifier/),
 			);
 		});
 
@@ -1661,11 +1657,7 @@ describe("treeNodeApi", () => {
 			});
 			assert.throws(
 				() => TreeAlpha.identifier(view.root),
-				(error: Error) =>
-					validateAssertionError(
-						error,
-						/may not be called on a node with more than one identifier/,
-					),
+				validateAssertionError(/may not be called on a node with more than one identifier/),
 			);
 		});
 
@@ -1762,11 +1754,7 @@ describe("treeNodeApi", () => {
 				});
 				assert.throws(
 					() => TreeAlpha.identifier.getShort(view.root),
-					(error: Error) =>
-						validateAssertionError(
-							error,
-							/may not be called on a node with more than one identifier/,
-						),
+					validateAssertionError(/may not be called on a node with more than one identifier/),
 				);
 			});
 

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
 	allowUnused,
@@ -397,14 +397,14 @@ describe("allowedTypes", () => {
 		it("in an array", () => {
 			assert.throws(
 				() => normalizeAllowedTypes([Foo, Bar]),
-				(error: Error) => validateAssertionError(error, /Encountered an undefined schema/),
+				validateAssertionError(/Encountered an undefined schema/),
 			);
 		});
 
 		it("directly", () => {
 			assert.throws(
 				() => normalizeAllowedTypes(Bar),
-				(error: Error) => validateAssertionError(error, /Encountered an undefined schema/),
+				validateAssertionError(/Encountered an undefined schema/),
 			);
 		});
 
@@ -412,7 +412,7 @@ describe("allowedTypes", () => {
 			const normalized = normalizeAllowedTypes([() => Bar]);
 			assert.throws(
 				() => normalized.evaluate(),
-				(error: Error) => validateAssertionError(error, /Encountered an undefined schema/),
+				validateAssertionError(/Encountered an undefined schema/),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 import {
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 import { describeHydration, hydrate } from "../utils.js";
@@ -770,8 +770,7 @@ describe("ArrayNode", () => {
 
 				assert.throws(
 					() => init(Array, [0, 1, 2]),
-					(error: Error) =>
-						validateAssertionError(error, /Shadowing of array indices is not permitted/),
+					validateAssertionError(/Shadowing of array indices is not permitted/),
 				);
 			});
 
@@ -786,8 +785,7 @@ describe("ArrayNode", () => {
 
 				assert.throws(
 					() => init(Array, [0, 1, 2]),
-					(error: Error) =>
-						validateAssertionError(error, /Shadowing of array indices is not permitted/),
+					validateAssertionError(/Shadowing of array indices is not permitted/),
 				);
 			});
 
@@ -805,8 +803,7 @@ describe("ArrayNode", () => {
 
 				assert.throws(
 					() => init(Array, [0, 1, 2]),
-					(error: Error) =>
-						validateAssertionError(error, /Shadowing of array indices is not permitted/),
+					validateAssertionError(/Shadowing of array indices is not permitted/),
 				);
 			});
 		},
@@ -827,8 +824,7 @@ describe("ArrayNode", () => {
 					// False positive
 					// eslint-disable-next-line @typescript-eslint/no-array-constructor
 					() => new Array([0, 1, 2], 42),
-					(error: Error) =>
-						validateAssertionError(error, /Shadowing of array indices is not permitted/),
+					validateAssertionError(/Shadowing of array indices is not permitted/),
 				);
 			});
 		},

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import { isStableId } from "@fluidframework/id-compressor/internal";
 
 import {
@@ -719,7 +719,7 @@ describeHydration(
 
 				assert.throws(
 					() => new Schema({ foo: undefined }),
-					(e: Error) => validateAssertionError(e, /this shadowing will not work/),
+					validateAssertionError(/this shadowing will not work/),
 				);
 			});
 		});

--- a/packages/dds/tree/src/test/simple-tree/treeContext.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeContext.spec.ts
@@ -15,7 +15,7 @@ import {
 import { getView } from "../utils.js";
 import { TreeAlpha } from "../../shared-tree/index.js";
 import type { requireAssignableTo } from "../../util/index.js";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 describe("TreeBranch", () => {
 	const schemaFactory = new SchemaFactory(undefined);
@@ -115,7 +115,7 @@ describe("TreeBranch", () => {
 			assert.deepEqual([...branchBranch.root], ["y"]);
 			assert.throws(
 				() => view.rebaseOnto(branch),
-				(e: Error) => validateAssertionError(e, /cannot be rebased onto another branch./),
+				validateAssertionError(/cannot be rebased onto another branch./),
 			);
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert, fail } from "node:assert";
 import {
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 
@@ -153,15 +153,9 @@ describe("TreeNodeValid", () => {
 			}
 		}
 
-		assert.throws(
-			() => new Subclass(),
-			(error: Error) => validateAssertionError(error, /invalid schema class/),
-		);
+		assert.throws(() => new Subclass(), validateAssertionError(/invalid schema class/));
 		// Ensure oneTimeSetup doesn't prevent error from rethrowing
-		assert.throws(
-			() => new Subclass(),
-			(error: Error) => validateAssertionError(error, /invalid schema class/),
-		);
+		assert.throws(() => new Subclass(), validateAssertionError(/invalid schema class/));
 	});
 
 	it("multiple subclass valid", () => {

--- a/packages/dds/tree/src/test/simple-tree/unhydratedFlexTreeFromInsertable.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedFlexTreeFromInsertable.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "node:assert";
 
 import {
 	MockHandle,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 
@@ -172,7 +172,7 @@ describe("unhydratedFlexTreeFromInsertable", () => {
 
 		assert.throws(
 			() => unhydratedFlexTreeFromInsertable(tree, Foo),
-			(error: Error) => validateAssertionError(error, /Encountered an undefined schema/),
+			validateAssertionError(/Encountered an undefined schema/),
 		);
 	});
 
@@ -181,11 +181,9 @@ describe("unhydratedFlexTreeFromInsertable", () => {
 
 		assert.throws(
 			() => unhydratedFlexTreeFromInsertable("Hello world", [schemaFactory.number]),
-			(error: Error) =>
-				validateAssertionError(
-					error,
-					/The provided data is incompatible with all of the types allowed by the schema/,
-				),
+			validateAssertionError(
+				/The provided data is incompatible with all of the types allowed by the schema/,
+			),
 		);
 	});
 

--- a/packages/framework/presence/src/test/presenceDatastoreManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceDatastoreManager.spec.ts
@@ -10,7 +10,7 @@ import type {
 	RawInboundExtensionMessage,
 } from "@fluidframework/container-runtime-definitions/internal";
 import type { JsonSerializable, TypedMessage } from "@fluidframework/core-interfaces/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal";
 import type { SinonFakeTimers } from "sinon";
 import { useFakeTimers, spy } from "sinon";
@@ -783,8 +783,7 @@ describe("Presence", () => {
 				// Act & Verify
 				assert.throws(
 					() => processUnrecognizedMessage({ optional: false }),
-					(e: Error) =>
-						validateAssertionError(e, /Unrecognized message type in critical message/),
+					validateAssertionError(/Unrecognized message type in critical message/),
 				);
 
 				// Verify

--- a/packages/runtime/container-runtime/src/test/batching.spec.ts
+++ b/packages/runtime/container-runtime/src/test/batching.spec.ts
@@ -24,7 +24,7 @@ import {
 	MockAudience,
 	MockDeltaManager,
 	MockQuorumClients,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 import { type SinonFakeTimers, createSandbox, useFakeTimers } from "sinon";
 
@@ -204,7 +204,7 @@ describe("Runtime batching", () => {
 
 			assert.throws(
 				() => processBatch(batch, containerRuntime),
-				(e: Error) => validateAssertionError(e, "batch presence was validated above"),
+				validateAssertionError("batch presence was validated above"),
 				"Batch end without batch start should fail",
 			);
 		});
@@ -216,7 +216,7 @@ describe("Runtime batching", () => {
 
 			assert.throws(
 				() => processBatch(batch, containerRuntime),
-				(e: Error) => validateAssertionError(e, "there can't be active batch"),
+				validateAssertionError("there can't be active batch"),
 				"Batch with multiple batch starts should fail",
 			);
 		});
@@ -356,7 +356,7 @@ describe("Runtime batching", () => {
 			} as unknown as ISequencedDocumentMessage;
 			assert.throws(
 				() => containerRuntime.process(modernRuntimeMessage, false /* local */),
-				(e: Error) => validateAssertionError(e, "Failed processing op in test"),
+				validateAssertionError("Failed processing op in test"),
 				"Message processing should have failed",
 			);
 
@@ -402,7 +402,7 @@ describe("Runtime batching", () => {
 
 			assert.throws(
 				() => containerRuntime.process(legacyMessage, false /* local */),
-				(e: Error) => validateAssertionError(e, "Failed processing op in test"),
+				validateAssertionError("Failed processing op in test"),
 				"Message processing should have failed",
 			);
 
@@ -446,7 +446,7 @@ describe("Runtime batching", () => {
 
 			assert.throws(
 				() => containerRuntime.process(nonRuntimeMessage, false /* local */),
-				(e: Error) => validateAssertionError(e, "Failed processing op in test"),
+				validateAssertionError("Failed processing op in test"),
 				"Message processing should have failed",
 			);
 

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -111,9 +111,7 @@ describe("Data Store Context Tests", () => {
 						snapshotTree: undefined,
 					});
 
-				assert.throws(codeBlock, (e: Error) =>
-					validateAssertionError("Data store ID contains slash"),
-				);
+				assert.throws(codeBlock, validateAssertionError("Data store ID contains slash"));
 			});
 
 			it("Errors thrown during realize are wrapped as DataProcessingError", async () => {
@@ -669,9 +667,7 @@ describe("Data Store Context Tests", () => {
 						snapshot: undefined,
 					});
 
-				assert.throws(codeBlock, (e: Error) =>
-					validateAssertionError("Data store ID contains slash"),
-				);
+				assert.throws(codeBlock, validateAssertionError("Data store ID contains slash"));
 			});
 			describe("writing with isolated channels enabled", () =>
 				testGenerateAttributes({
@@ -1070,9 +1066,7 @@ describe("Data Store Context Tests", () => {
 						channelToDataStoreFn,
 					});
 
-				assert.throws(codeBlock, (e: Error) =>
-					validateAssertionError("Data store ID contains slash"),
-				);
+				assert.throws(codeBlock, validateAssertionError("Data store ID contains slash"));
 			});
 
 			describe("should error on attach if data store cannot be constructed/initialized", () => {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -48,7 +48,7 @@ import {
 import {
 	MockDeltaManager,
 	MockFluidDataStoreRuntime,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 
 import {
@@ -112,7 +112,7 @@ describe("Data Store Context Tests", () => {
 					});
 
 				assert.throws(codeBlock, (e: Error) =>
-					validateAssertionError(e, "Data store ID contains slash"),
+					validateAssertionError("Data store ID contains slash"),
 				);
 			});
 
@@ -670,7 +670,7 @@ describe("Data Store Context Tests", () => {
 					});
 
 				assert.throws(codeBlock, (e: Error) =>
-					validateAssertionError(e, "Data store ID contains slash"),
+					validateAssertionError("Data store ID contains slash"),
 				);
 			});
 			describe("writing with isolated channels enabled", () =>
@@ -1071,7 +1071,7 @@ describe("Data Store Context Tests", () => {
 					});
 
 				assert.throws(codeBlock, (e: Error) =>
-					validateAssertionError(e, "Data store ID contains slash"),
+					validateAssertionError("Data store ID contains slash"),
 				);
 			});
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "node:assert";
 
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import { ContainerMessageType } from "../../index.js";
 import {
@@ -141,17 +141,14 @@ describe("OpGroupingManager", () => {
 				contentSizeInBytes: 0,
 				referenceSequenceNumber: 0,
 			};
-			assert.throws(
-				() => {
-					new OpGroupingManager(
-						{
-							groupedBatchingEnabled: true,
-						},
-						mockLogger,
-					).groupBatch(emptyBatch);
-				},
-				(e: Error) => validateAssertionError(e, "Unexpected attempt to group an empty batch"),
-			);
+			assert.throws(() => {
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: true,
+					},
+					mockLogger,
+				).groupBatch(emptyBatch);
+			}, validateAssertionError("Unexpected attempt to group an empty batch"));
 		});
 
 		it("singleton batch is returned as-is", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import { ContainerMessageType } from "../../index.js";
 import {
@@ -81,13 +81,9 @@ describe("OpCompressor", () => {
 					() => {
 						compressor.compressBatch(batch as OutboundSingletonBatch); // The need to cast indicates this is not going to work
 					},
-					(error: Error) => {
-						validateAssertionError(
-							error,
-							"Batch should not be empty and should contain a single message",
-						); // 0x5a4
-						return true;
-					},
+					validateAssertionError(
+						"Batch should not be empty and should contain a single message", // 0x5a4
+					),
 					"Expected error was not thrown",
 				);
 			});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -17,7 +17,7 @@ import type {
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import type { ICompressionRuntimeOptions } from "../../compressionDefinitions.js";
 import { CompressionAlgorithms } from "../../compressionDefinitions.js";
@@ -1131,12 +1131,9 @@ describe("Outbox", () => {
 
 			assert.throws(
 				() => outbox.flush(),
-				(error: Error) => {
-					return validateAssertionError(
-						error,
-						"Flushing must not happen while incoming changes are being processed",
-					);
-				},
+				validateAssertionError(
+					"Flushing must not happen while incoming changes are being processed",
+				),
 				"Should assert when flushing non-empty batches while reentrant",
 			);
 

--- a/packages/runtime/container-runtime/src/test/runCounter.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runCounter.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import type { BatchResubmitInfo } from "../opLifecycle/index.js";
 import { BatchRunCounter, RunCounter } from "../runCounter.js";
@@ -95,17 +95,14 @@ describe("BatchRunCounter", () => {
 
 		it("should not allow reentrancy if outer call sets resubmitInfo", () => {
 			const batchRunCounter = new BatchRunCounter();
-			assert.throws(
-				() => {
-					batchRunCounter.run(
-						() => {
-							batchRunCounter.run(() => {});
-						},
-						{ batchId: "foo", staged: true },
-					);
-				},
-				(e) => validateAssertionError(e as Error, "Reentrancy not allowed in BatchRunCounter"),
-			);
+			assert.throws(() => {
+				batchRunCounter.run(
+					() => {
+						batchRunCounter.run(() => {});
+					},
+					{ batchId: "foo", staged: true },
+				);
+			}, validateAssertionError("Reentrancy not allowed in BatchRunCounter"));
 		});
 	});
 });

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -98,7 +98,8 @@ describe("FluidDataStoreRuntime Tests", () => {
 					throw new Error("This shouldn't be called during the test");
 				},
 			);
-		assert.throws(codeBlock, (e: Error) =>
+		assert.throws(
+			codeBlock,
 			validateAssertionError(
 				"Id cannot contain slashes. DataStoreContext should have validated this.",
 			),

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -24,7 +24,7 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	MockFluidDataStoreContext,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 import sinon from "sinon";
 
@@ -100,7 +100,6 @@ describe("FluidDataStoreRuntime Tests", () => {
 			);
 		assert.throws(codeBlock, (e: Error) =>
 			validateAssertionError(
-				e,
 				"Id cannot contain slashes. DataStoreContext should have validated this.",
 			),
 		);

--- a/packages/runtime/datastore/src/test/localChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/localChannelContext.spec.ts
@@ -10,7 +10,7 @@ import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal"
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import {
 	MockFluidDataStoreContext,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { FluidDataStoreRuntime, type ISharedObjectRegistry } from "../dataStoreRuntime.js";
@@ -56,7 +56,7 @@ describe("LocalChannelContext Tests", () => {
 			);
 		assert.throws(
 			codeBlock,
-			(e: Error) => validateAssertionError(e, "Channel context ID cannot contain slashes"),
+			validateAssertionError("Channel context ID cannot contain slashes"),
 			"Expected exception was not thrown",
 		);
 	});
@@ -78,7 +78,7 @@ describe("LocalChannelContext Tests", () => {
 			);
 		assert.throws(
 			codeBlock,
-			(e: Error) => validateAssertionError(e, "Channel context ID cannot contain slashes"),
+			validateAssertionError("Channel context ID cannot contain slashes"),
 			"Expected exception was not thrown",
 		);
 	});

--- a/packages/runtime/datastore/src/test/remoteChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/remoteChannelContext.spec.ts
@@ -13,7 +13,7 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	MockFluidDataStoreContext,
-	validateAssertionError,
+	validateAssertionError2 as validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { FluidDataStoreRuntime, type ISharedObjectRegistry } from "../dataStoreRuntime.js";
@@ -61,7 +61,7 @@ describe("RemoteChannelContext Tests", () => {
 			);
 		assert.throws(
 			codeBlock,
-			(e: Error) => validateAssertionError(e, "Channel context ID cannot contain slashes"),
+			validateAssertionError("Channel context ID cannot contain slashes"),
 			"Expected exception was not thrown",
 		);
 	});

--- a/packages/runtime/test-runtime-utils/src/index.ts
+++ b/packages/runtime/test-runtime-utils/src/index.ts
@@ -29,7 +29,6 @@ export {
 } from "./mocksForReconnection.js";
 export { MockStorage } from "./mockStorage.js";
 export {
-	validateAssertionError,
 	validateAssertionError2,
 	validateUsageError,
 	validateTypeError,

--- a/packages/runtime/test-runtime-utils/src/test/validateAssertionError.spec.ts
+++ b/packages/runtime/test-runtime-utils/src/test/validateAssertionError.spec.ts
@@ -8,34 +8,22 @@ import { strict } from "assert";
 import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import { shortCodeMap } from "../assertionShortCodesMap.js";
-import { validateAssertionError } from "../validateAssertionError.js";
+import { validateAssertionError2 as validateAssertionError } from "../validateAssertionError.js";
 
-describe("validateAssertionError", () => {
+describe("validateAssertionError(", () => {
 	it("untagged", () => {
-		strict.throws(
-			() => {
-				assert(false, "X");
-			},
-			(e: Error) => validateAssertionError(e, "X"),
-		);
-		strict.throws(
-			() => {
-				fail("X");
-			},
-			(e: Error) => validateAssertionError(e, "X"),
-		);
-		strict.throws(
-			() => {
-				assert(false, "X", () => "Extra");
-			},
-			(e: Error) => validateAssertionError(e, "X\nDebug Message: Extra"),
-		);
-		strict.throws(
-			() => {
-				fail("X", () => "Extra");
-			},
-			(e: Error) => validateAssertionError(e, "X\nDebug Message: Extra"),
-		);
+		strict.throws(() => {
+			assert(false, "X");
+		}, validateAssertionError("X"));
+		strict.throws(() => {
+			fail("X");
+		}, validateAssertionError("X"));
+		strict.throws(() => {
+			assert(false, "X", () => "Extra");
+		}, validateAssertionError("X\nDebug Message: Extra"));
+		strict.throws(() => {
+			fail("X", () => "Extra");
+		}, validateAssertionError("X\nDebug Message: Extra"));
 	});
 
 	it("tagged", () => {
@@ -44,29 +32,23 @@ describe("validateAssertionError", () => {
 
 		const [tag, expanded] = Object.entries(shortCodeMap)[0] ?? strict.fail();
 
-		strict.throws(
-			() => {
-				assert(false, tag);
-			},
-			(e: Error) => validateAssertionError(e, expanded),
-		);
-		strict.throws(
-			() => {
-				fail(tag);
-			},
-			(e: Error) => validateAssertionError(e, expanded),
-		);
+		strict.throws(() => {
+			assert(false, tag);
+		}, validateAssertionError(expanded));
+		strict.throws(() => {
+			fail(tag);
+		}, validateAssertionError(expanded));
 		strict.throws(
 			() => {
 				assert(false, tag, () => "Extra");
 			},
-			(e: Error) => validateAssertionError(e, `${expanded}\nDebug Message: Extra`),
+			validateAssertionError(`${expanded}\nDebug Message: Extra`),
 		);
 		strict.throws(
 			() => {
 				fail(tag, () => "Extra");
 			},
-			(e: Error) => validateAssertionError(e, `${expanded}\nDebug Message: Extra`),
+			validateAssertionError(`${expanded}\nDebug Message: Extra`),
 		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -37,7 +37,7 @@ import {
 import { responseToException } from "@fluidframework/runtime-utils/internal";
 import { FluidSerializer, parseHandles } from "@fluidframework/shared-object-base/internal";
 import { MockLogger, TelemetryDataTag } from "@fluidframework/telemetry-utils/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import {
 	ITestContainerConfig,
 	ITestObjectProvider,
@@ -1541,8 +1541,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				() => getGCStateFromSummary(summary2.summaryTree),
 				// Assertion error message text changed in Node 20.18.1 to append the failed comparison info.
 				// This validation can be made more strict again once the repo requires Node >= 20.18.1
-				(e: Error) =>
-					validateAssertionError(e, /^getGCStateFromSummary: GC state is not a blob/),
+				validateAssertionError(/^getGCStateFromSummary: GC state is not a blob/),
 			);
 			const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
 			assert(
@@ -1556,11 +1555,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				() => getGCTombstoneStateFromSummary(summary3.summaryTree),
 				// Assertion error message text changed in Node 20.18.1 to append the failed comparison info.
 				// This validation can be made more strict again once the repo requires Node >= 20.18.1
-				(e: Error) =>
-					validateAssertionError(
-						e,
-						/^getGCTombstoneStateFromSummary: GC data should be a tree/,
-					),
+				validateAssertionError(/^getGCTombstoneStateFromSummary: GC data should be a tree/),
 			);
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -17,7 +17,7 @@ import type {
 	SequenceDeltaEvent,
 	SharedString,
 } from "@fluidframework/sequence/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { validateAssertionError2 as validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import {
 	ChannelFactoryRegistry,
 	DataObjectFactoryType,
@@ -176,7 +176,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 		async () => {
 			sharedMap.set("key", "BEFORE");
 
-			try {
+			assert.throws(() => {
 				containerRuntime.orderSequentially(() => {
 					sharedMap.set("key", "SHOULD BE ROLLED BACK");
 
@@ -185,12 +185,8 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 						type: "rejoin",
 					});
 				});
-			} catch (err) {
-				error = err as Error;
-			}
+			}, validateAssertionError("Unexpected message type submitted in Staging Mode"));
 
-			assert(error !== undefined, "No error");
-			validateAssertionError(error, "Unexpected message type submitted in Staging Mode");
 			assert.equal(
 				changedEventData.length,
 				3,


### PR DESCRIPTION
## Description

Part of removing the old validateAssertionError.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

