### PR TITLE
test(local-server-stress-tests): Remove ordered-collection from local server stress tests

### DIFF
--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -79,7 +79,6 @@
 		"@fluidframework/local-driver": "workspace:~",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/matrix": "workspace:~",
-		"@fluidframework/ordered-collection": "workspace:~",
 		"@fluidframework/register-collection": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
@@ -116,7 +115,6 @@
 				"@fluidframework/tree#build:test",
 				"@fluidframework/task-manager#build:test",
 				"@fluidframework/legacy-dds#build:test",
-				"@fluidframework/ordered-collection#build:test",
 				"@fluidframework/task-manager#build:test",
 				"@fluidframework/counter#build:test",
 				"@fluidframework/register-collection#build:test"

--- a/packages/test/local-server-stress-tests/src/ddsModels.ts
+++ b/packages/test/local-server-stress-tests/src/ddsModels.ts
@@ -11,7 +11,6 @@ import type { IChannelFactory } from "@fluidframework/datastore-definitions/inte
 import { baseSharedArrayModel } from "@fluidframework/legacy-dds/internal/test";
 import { baseMapModel, baseDirModel } from "@fluidframework/map/internal/test";
 import { baseSharedMatrixModel } from "@fluidframework/matrix/internal/test";
-import { baseConsensusOrderedCollectionModel } from "@fluidframework/ordered-collection/internal/test";
 import {
 	baseSharedStringModel,
 	baseIntervalModel,
@@ -77,5 +76,4 @@ export const ddsModelMap = generateSubModelMap(
 	baseTaskManagerModel,
 	baseCounterModel,
 	baseRegisterCollectionModel,
-	baseConsensusOrderedCollectionModel,
 );

--- a/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
@@ -913,20 +913,8 @@ async function synchronizeClients(connectedClients: Client[]) {
 							connectedClients[0].container.deltaManager.lastSequenceNumber,
 				)
 			) {
-				// There are some cases where more ops are generated as a result of processing ops.
-				// For example, for ConsensusOrderedCollection, a `complete`/`release` op will be generated
-				// when processing an `acquire` op.
-				// If that type of op is the last op before a final sync, then we will miss it by waiting
-				// for the initial saved event. To ensure we process all ops we wait for two JS turns.
-				// The first allows any ops generated during the processing of ops to be submitted.
-				// The second allows for the processing of those ops.
-				// TODO: AB#53704: Support async reducers in DDS Fuzz models to avoid this workaround.
-				setTimeout(() => {
-					setTimeout(() => {
-						resolve();
-						off();
-					}, 0);
-				}, 0);
+				resolve();
+				off();
 			}
 		};
 		// if you hit timeout issues in the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14059,9 +14059,6 @@ importers:
       '@fluidframework/matrix':
         specifier: workspace:~
         version: link:../../dds/matrix
-      '@fluidframework/ordered-collection':
-        specifier: workspace:~
-        version: link:../../dds/ordered-collection
       '@fluidframework/register-collection':
         specifier: workspace:~
         version: link:../../dds/register-collection


### PR DESCRIPTION
## Description

This PR removes `ConsensusOrderedCollection` from the local server stress test suite. The `setTimeout` workaround seems to not prevent the issue of the container being left in a dirty state, and CI is failing non-deterministically. For now we can remove `ConsensusOrderedCollection` from the local server stress test suite.