### PR TITLE
build(server): upgrade eslint config and add compatibility workarounds

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -344,8 +344,14 @@ module.exports = {
 				"^packages/test/test-utils/package.json",
 				// TODO: AB#7630 uses lint only ts projects for coverage which don't have representative tsc scripts
 				"^packages/tools/fluid-runner/package.json",
+
+				// Server packages need to be cleaned up; excluding as a workaround
+				"^server/routerlicious/packages/.*/package.json",
 			],
-			"fluid-build-tasks-tsc": [],
+			"fluid-build-tasks-tsc": [
+				// Server packages need to be cleaned up; excluding as a workaround
+				"^server/routerlicious/packages/.*/package.json",
+			],
 			"html-copyright-file-header": [
 				// Tests generate HTML "snapshot" artifacts
 				"tools/api-markdown-documenter/src/test/snapshots/.*",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -139,10 +139,12 @@
 	"pnpm": {
 		"commentsOverrides": [
 			"@types/node is overridden to v18 to ensure all packages are building using the v18 types.",
+			"node types >= 22 are bumped down to 20.x to work around issues with packages using different types.",
 			"oclif includes some AWS-related features, but we don't use them, so we override those dependencies with empty packages. This helps reduce lockfile churn since the deps release very frequently."
 		],
 		"overrides": {
 			"@types/node@<18": "^18.19.39",
+			"@types/node@>=22": "^20.0.0",
 			"oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
 			"oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0",
 			"qs": "^6.11.0",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -32,7 +32,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -35,7 +35,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@7.0.0",
 		"@types/node": "^18.19.39",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/lambdas-driver/.eslintrc.cjs
+++ b/server/routerlicious/packages/lambdas-driver/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove these overrides
@@ -20,6 +20,6 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 	},
 };

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -67,7 +67,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas/.eslintrc.cjs
+++ b/server/routerlicious/packages/lambdas/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	rules: {
 		"@rushstack/no-new-null": "off",
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 		"unicorn/no-null": "off",
 
@@ -27,7 +27,7 @@ module.exports = {
 		"@typescript-eslint/prefer-nullish-coalescing": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove this override
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -80,7 +80,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas/src/nexus/index.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/index.ts
@@ -569,9 +569,9 @@ export function configureWebSocketServices(
 			/**
 			 * @param contentBatches - typed as `unknown` array as it comes from wire and has not been validated.
 			 * v1 signals are expected to be an array of strings (Json.stringified `ISignalEnvelope`s from
-			 * [Container.submitSignal](https://github.com/microsoft/FluidFramework/blob/ccb26baf65be1cbe3f708ec0fe6887759c25be6d/packages/loader/container-loader/src/container.ts#L2292-L2294)
+			 * {@link https://github.com/microsoft/FluidFramework/blob/ccb26baf65be1cbe3f708ec0fe6887759c25be6d/packages/loader/container-loader/src/container.ts#L2292-L2294|Container.submitSignal}
 			 * and sent via
-			 * [DocumentDeltaConnection.emitMessages](https://github.com/microsoft/FluidFramework/blob/ccb26baf65be1cbe3f708ec0fe6887759c25be6d/packages/drivers/driver-base/src/documentDeltaConnection.ts#L313C1-L321C4)),
+			 * {@link https://github.com/microsoft/FluidFramework/blob/ccb26baf65be1cbe3f708ec0fe6887759c25be6d/packages/drivers/driver-base/src/documentDeltaConnection.ts#L313C1-L321C4|DocumentDeltaConnection.emitMessages}
 			 * but actual content is passed-thru and not decoded.
 			 *
 			 * v2 signals are expected to be an array of `ISentSignalMessage` objects.

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -584,7 +584,7 @@ export class ScribeLambda implements IPartitionLambda {
 					typeof message.contents === "string" &&
 					message.type !== MessageType.ClientLeave
 				) {
-					// eslint-disable-next-line import/namespace
+					// eslint-disable-next-line import-x/namespace
 					const clonedMessage = _.cloneDeep(message);
 					clonedMessage.contents = JSON.parse(clonedMessage.contents as string);
 					this.protocolHandler.processMessage(clonedMessage, false);

--- a/server/routerlicious/packages/local-server/.eslintrc.cjs
+++ b/server/routerlicious/packages/local-server/.eslintrc.cjs
@@ -20,7 +20,7 @@ module.exports = {
 		{
 			files: ["src/test/**/*.ts"],
 			rules: {
-				"import/no-nodejs-modules": "off",
+				"import-x/no-nodejs-modules": "off",
 			},
 		},
 	],

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/jsrsasign": "^10.5.12",

--- a/server/routerlicious/packages/memory-orderer/.eslintrc.cjs
+++ b/server/routerlicious/packages/memory-orderer/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
 	],
 	rules: {
 		"@typescript-eslint/restrict-template-expressions": "off",
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove these overrides
@@ -18,6 +18,6 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 	},
 };

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -81,7 +81,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@7.0.0",
 		"@types/mocha": "^10.0.1",
 		"c8": "^10.1.3",

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -138,7 +138,7 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
 			null,
 		);
 
-		// eslint-disable-next-line import/namespace
+		// eslint-disable-next-line import-x/namespace
 		const result = _.clone(existing);
 		result.expiration = newExpiration;
 

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererSetup.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererSetup.ts
@@ -87,6 +87,7 @@ export class LocalOrdererSetup implements ILocalOrdererSetup {
 
 		const existingRef = await this.gitManager.getRef(encodeURIComponent(this.documentId));
 		if (!existingRef) {
+			// eslint-disable-next-line @typescript-eslint/return-await -- false positive?
 			return -1;
 		}
 

--- a/server/routerlicious/packages/protocol-base/.eslintrc.cjs
+++ b/server/routerlicious/packages/protocol-base/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove this override
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -68,7 +68,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/routerlicious-base/.eslintrc.cjs
+++ b/server/routerlicious/packages/routerlicious-base/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
 		"prettier",
 	],
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove these overrides
@@ -17,7 +17,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove this override
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -90,7 +90,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/app.ts
@@ -49,9 +49,9 @@ export function create(
 	} else {
 		app.use(alternativeMorganLoggerMiddleware(loggerFormat));
 	}
-	// eslint-disable-next-line import/namespace
+	// eslint-disable-next-line import-x/namespace
 	app.use(bodyParser.json());
-	// eslint-disable-next-line import/namespace
+	// eslint-disable-next-line import-x/namespace
 	app.use(bodyParser.urlencoded({ extended: false }));
 
 	const healthEndpoints = createHealthCheckEndpoints("nexus", startupCheck, readinessCheck);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -61,9 +61,9 @@ export function create(
 	} else {
 		app.use(alternativeMorganLoggerMiddleware(loggerFormat));
 	}
-	// eslint-disable-next-line import/namespace
+	// eslint-disable-next-line import-x/namespace
 	app.use(bodyParser.json());
-	// eslint-disable-next-line import/namespace
+	// eslint-disable-next-line import-x/namespace
 	app.use(bodyParser.urlencoded({ extended: false }));
 
 	app.use(

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -533,7 +533,7 @@ export class TenantManager {
 		);
 
 		const tenant = await this.getTenant(id);
-		// eslint-disable-next-line import/namespace
+		// eslint-disable-next-line import-x/namespace
 		return _.extend(tenant, {
 			key: tenantKeys?.key1,
 			secondaryKey: tenantKeys?.key2,

--- a/server/routerlicious/packages/routerlicious-base/src/utils/params.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/params.ts
@@ -5,7 +5,7 @@
 
 import { getParam } from "@fluidframework/server-services-utils";
 // In this case we want @types/express-serve-static-core, not express-serve-static-core, and so disable the lint rule
-// eslint-disable-next-line import/no-unresolved
+// eslint-disable-next-line import-x/no-unresolved
 import type { Params } from "express-serve-static-core";
 
 const getParamFromRequest = (params: Params, paramName: string) =>

--- a/server/routerlicious/packages/routerlicious/.eslintrc.cjs
+++ b/server/routerlicious/packages/routerlicious/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
 	],
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove this override

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -62,7 +62,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/nconf": "^0.10.2",

--- a/server/routerlicious/packages/services-client/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-client/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove these overrides
@@ -20,7 +20,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove this override
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -77,7 +77,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-core/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-core/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove these overrides
@@ -20,6 +20,6 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 	},
 };

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@7.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/sinon": "^17.0.3",

--- a/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		// This package uses node's events APIs.
 		// This should probably be reconsidered, but until then we will leave an exception for it here.
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove this override

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.cjs
@@ -16,7 +16,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
-		"import/no-nodejs-modules": "off",
+		"import-x/no-deprecated": "warn",
+		"import-x/no-nodejs-modules": "off",
 	},
 };

--- a/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.cjs
@@ -18,5 +18,8 @@ module.exports = {
 		// TODO: remove usages of deprecated APIs and remove this override
 		"import-x/no-deprecated": "warn",
 		"import-x/no-nodejs-modules": "off",
+
+		// TODO: re-enable once eslint is v9+ and @typescript-eslint is upgraded accordingly
+		"@typescript-eslint/no-unsafe-return": "off",
 	},
 };

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -35,7 +35,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-shared/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: enable strict null checks in tsconfig and remove these overrides
@@ -20,7 +20,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove this override
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -82,7 +82,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/body-parser": "^1.19.2",

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -22,7 +22,7 @@ type RequestField = undefined | string | string[];
 interface IRestLessServerOptions {
 	/**
 	 * Request body size limit in number of bytes or as a string to
-	 * be passed to the [bytes](https://www.npmjs.com/package/bytes) library.
+	 * be passed to the {@link https://www.npmjs.com/package/bytes|bytes} library.
 	 * Only verified when parsing request body as a stream.
 	 * Default: 1gb
 	 */

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -136,7 +136,9 @@ export interface ISocketIoServerConfig {
 	 */
 	pingPongLatencyTrackingAggregationThreshold: number;
 	/**
-	 * Whether to enable Socket.io [perMessageDeflate](https://socket.io/docs/v4/server-options/#permessagedeflate) option.
+	 * Whether to enable the Socket.io
+	 * {@link https://socket.io/docs/v4/server-options/#permessagedeflate|perMessageDeflate}
+	 * option.
 	 * Default is `true`.
 	 */
 	perMessageDeflate: boolean;
@@ -156,7 +158,8 @@ class SocketIoServer implements core.IWebSocketServer {
 			/**
 			 * Fluid Socket.io connection URL looks like:
 			 * "<hostname>/socket.io/?documentId=[documentId]&tenantId=[tenantId]&EIO=[3/4]&transport=[websocket/polling]"
-			 * [socket.handshake.query](https://socket.io/docs/v4/server-socket-instance/#sockethandshake) contains parsed query params.
+			 * {@link https://socket.io/docs/v4/server-socket-instance/#sockethandshake|socket.handshake.query} contains
+			 * parsed query params.
 			 * The following properties are used for **telemetry purposes only.**
 			 * These should **not** be used to identify the tenant and document associated with the socket connection
 			 * for real logic and access purposes without validating against the JWT access token.

--- a/server/routerlicious/packages/services-telemetry/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-telemetry/.eslintrc.cjs
@@ -19,6 +19,6 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 	},
 };

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -62,7 +62,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@7.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",

--- a/server/routerlicious/packages/services-utils/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-utils/.eslintrc.cjs
@@ -9,11 +9,11 @@ module.exports = {
 		"prettier",
 	],
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: remove usages of deprecated APIs and remove these overrides
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove these overrides
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -27,7 +27,7 @@ import {
 } from "@fluidframework/server-services-telemetry";
 import type { RequestHandler, Request, Response } from "express";
 // In this case we want @types/express-serve-static-core, not express-serve-static-core, and so disable the lint rule
-// eslint-disable-next-line import/no-unresolved
+// eslint-disable-next-line import-x/no-unresolved
 import type { Params } from "express-serve-static-core";
 import { decode, sign } from "jsonwebtoken";
 import type { Provider } from "nconf";

--- a/server/routerlicious/packages/services/.eslintrc.cjs
+++ b/server/routerlicious/packages/services/.eslintrc.cjs
@@ -9,13 +9,13 @@ module.exports = {
 		"prettier",
 	],
 	rules: {
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
 		// TODO: remove this override and fix violations
 		"@typescript-eslint/strict-boolean-expressions": "warn",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 	},
 };

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -80,7 +80,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/test-utils/.eslintrc.cjs
+++ b/server/routerlicious/packages/test-utils/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
 		"@typescript-eslint/consistent-type-assertions": "off",
 		"@typescript-eslint/no-unsafe-return": "off",
 		"@typescript-eslint/no-use-before-define": "off",
-		"import/no-nodejs-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 		"no-case-declarations": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],
 
@@ -21,7 +21,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 
 		// TODO: fix violations and remove this override
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -72,7 +72,7 @@
 		"@fluid-tools/build-cli": "^0.60.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.60.0",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@7.0.0",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -35,7 +35,7 @@ export class TestCollection implements ICollection<any> {
 		if (!value) {
 			throw new Error("Not found");
 		}
-		// eslint-disable-next-line import/namespace
+		// eslint-disable-next-line import-x/namespace
 		_.extend(value, set);
 	}
 
@@ -45,7 +45,7 @@ export class TestCollection implements ICollection<any> {
 			if (!value) {
 				throw new Error("Not found");
 			}
-			// eslint-disable-next-line import/namespace
+			// eslint-disable-next-line import-x/namespace
 			_.extend(value, set);
 		});
 	}
@@ -56,7 +56,7 @@ export class TestCollection implements ICollection<any> {
 			this.collection.push(set);
 		}
 
-		// eslint-disable-next-line import/namespace
+		// eslint-disable-next-line import-x/namespace
 		_.extend(value, set);
 	}
 

--- a/server/routerlicious/packages/tinylicious/.eslintrc.cjs
+++ b/server/routerlicious/packages/tinylicious/.eslintrc.cjs
@@ -15,13 +15,13 @@ module.exports = {
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/promise-function-async": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"import/no-internal-modules": "off",
-		"import/no-nodejs-modules": "off",
+		"import-x/no-internal-modules": "off",
+		"import-x/no-nodejs-modules": "off",
 
 		// TODO: enable strict null checks in tsconfig and remove this override
 		"@typescript-eslint/prefer-nullish-coalescing": "off",
 
 		// TODO: remove usages of deprecated APIs and remove this override
-		"import/no-deprecated": "warn",
+		"import-x/no-deprecated": "warn",
 	},
 };

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -73,7 +73,7 @@
 	"devDependencies": {
 		"@fluid-internal/mocha-test-setup": "~2.0.5",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/eslint-config-fluid": "^6.1.0",
+		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/compression": "^1.7.2",
 		"@types/cookie-parser": "^1.4.1",

--- a/server/routerlicious/packages/tinylicious/src/app.ts
+++ b/server/routerlicious/packages/tinylicious/src/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import type { TypedEventEmitter } from "@fluidframework/common-utils";
 import type { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import type { IDocumentStorage, MongoManager } from "@fluidframework/server-services-core";
@@ -34,7 +34,7 @@ export function create(
 	config: Provider,
 	storage: IDocumentStorage,
 	mongoManager: MongoManager,
-	// eslint-disable-next-line import/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated
 	collaborationSessionEventEmitter: TypedEventEmitter<ICollaborationSessionEvents> | undefined,
 ) {
 	// Maximum REST request size

--- a/server/routerlicious/packages/tinylicious/src/resources.ts
+++ b/server/routerlicious/packages/tinylicious/src/resources.ts
@@ -4,7 +4,7 @@
  */
 
 // import * as services from "@fluidframework/server-services";
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import type { TypedEventEmitter } from "@fluidframework/common-utils";
 import type { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import type * as core from "@fluidframework/server-services-core";
@@ -19,7 +19,7 @@ export class TinyliciousResources implements core.IResources {
 		public mongoManager: core.MongoManager,
 		public port: any,
 		public webServerFactory: core.IWebServerFactory,
-		// eslint-disable-next-line import/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated
 		public collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
 	) {}
 

--- a/server/routerlicious/packages/tinylicious/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/tinylicious/src/resourcesFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import type { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import { LocalOrdererManager } from "@fluidframework/server-local-server";
@@ -98,7 +98,7 @@ export class TinyliciousResourcesFactory implements IResourcesFactory<Tinyliciou
 		);
 
 		const collaborationSessionEventEmitter =
-			// eslint-disable-next-line import/no-deprecated
+			// eslint-disable-next-line import-x/no-deprecated
 			new TypedEventEmitter<ICollaborationSessionEvents>();
 
 		return new TinyliciousResources(

--- a/server/routerlicious/packages/tinylicious/src/routes/index.ts
+++ b/server/routerlicious/packages/tinylicious/src/routes/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import type { TypedEventEmitter } from "@fluidframework/common-utils";
 import type { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import type { IDocumentStorage, MongoManager } from "@fluidframework/server-services-core";
@@ -22,7 +22,7 @@ export function create(
 	config: Provider,
 	mongoManager: MongoManager,
 	documentStorage: IDocumentStorage,
-	// eslint-disable-next-line import/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated
 	collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
 ) {
 	return {

--- a/server/routerlicious/packages/tinylicious/src/routes/ordering/index.ts
+++ b/server/routerlicious/packages/tinylicious/src/routes/ordering/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import type { TypedEventEmitter } from "@fluidframework/common-utils";
 import type {
 	IBroadcastSignalEventPayload,
@@ -22,7 +22,7 @@ export function create(
 	config: Provider,
 	storage: IDocumentStorage,
 	mongoManager: MongoManager,
-	// eslint-disable-next-line import/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated
 	collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
 ): Router {
 	const router: Router = Router();

--- a/server/routerlicious/packages/tinylicious/src/routes/storage/git/blobs.ts
+++ b/server/routerlicious/packages/tinylicious/src/routes/storage/git/blobs.ts
@@ -7,7 +7,7 @@ import fs from "fs";
 
 import { Uint8ArrayToString } from "@fluidframework/common-utils";
 import type { IBlob, ICreateBlobParams, ICreateBlobResponse } from "@fluidframework/gitresources";
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import { Router } from "express";
 import * as git from "isomorphic-git";
 import type nconf from "nconf";
@@ -52,7 +52,7 @@ export async function getBlob(
 		url: "",
 		sha,
 		size: buffer.length,
-		// eslint-disable-next-line import/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated
 		content: Uint8ArrayToString(buffer, "base64"),
 		encoding: "base64",
 	};

--- a/server/routerlicious/packages/tinylicious/src/runner.ts
+++ b/server/routerlicious/packages/tinylicious/src/runner.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
+// eslint-disable-next-line import-x/no-deprecated
 import { Deferred, type TypedEventEmitter } from "@fluidframework/common-utils";
 import {
 	configureWebSocketServices,
@@ -29,7 +29,7 @@ import * as app from "./app";
 export class TinyliciousRunner implements IRunner {
 	private server?: IWebServer;
 
-	// eslint-disable-next-line import/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated
 	private runningDeferred?: Deferred<void>;
 
 	constructor(
@@ -40,7 +40,7 @@ export class TinyliciousRunner implements IRunner {
 		private readonly tenantManager: ITenantManager,
 		private readonly storage: IDocumentStorage,
 		private readonly mongoManager: MongoManager,
-		// eslint-disable-next-line import/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated
 		private readonly collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
 	) {}
 
@@ -48,7 +48,7 @@ export class TinyliciousRunner implements IRunner {
 		const version = process.env.npm_package_version;
 		winston.info(`Starting tinylicious@${version}`);
 
-		// eslint-disable-next-line import/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated
 		this.runningDeferred = new Deferred<void>();
 
 		// Make sure provided port is unoccupied

--- a/server/routerlicious/packages/tinylicious/src/services/inMemorycollection.ts
+++ b/server/routerlicious/packages/tinylicious/src/services/inMemorycollection.ts
@@ -47,7 +47,7 @@ export class Collection<T> implements ICollection<T> {
 		if (!value) {
 			throw new Error("Not found");
 		}
-		// eslint-disable-next-line import/namespace
+		// eslint-disable-next-line import-x/namespace
 		_.extend(value, set);
 	}
 
@@ -57,7 +57,7 @@ export class Collection<T> implements ICollection<T> {
 			this.collection.push(set);
 		}
 
-		// eslint-disable-next-line import/namespace
+		// eslint-disable-next-line import-x/namespace
 		_.extend(value, set);
 	}
 

--- a/server/routerlicious/packages/tinylicious/src/services/levelDbCollection.ts
+++ b/server/routerlicious/packages/tinylicious/src/services/levelDbCollection.ts
@@ -70,7 +70,7 @@ export class Collection<T> implements ICollection<T> {
 		if (!value) {
 			throw new Error("Not found");
 		} else {
-			// eslint-disable-next-line import/namespace
+			// eslint-disable-next-line import-x/namespace
 			_.extend(value, set);
 			return this.insertOne(value);
 		}
@@ -85,7 +85,7 @@ export class Collection<T> implements ICollection<T> {
 		if (!value) {
 			return this.insertOne(set);
 		} else {
-			// eslint-disable-next-line import/namespace
+			// eslint-disable-next-line import-x/namespace
 			_.extend(value, set);
 			return this.insertOne(value);
 		}

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@types/node@<18': ^18.19.39
+  '@types/node@>=22': ^20.0.0
   oclif>@aws-sdk/client-cloudfront: npm:empty-npm-package@1.0.0
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   qs: ^6.11.0
@@ -28,16 +29,16 @@ importers:
         version: file:../../packages/tools/changelog-generator-wrapper
       '@fluid-tools/build-cli':
         specifier: ^0.60.0
-        version: 0.60.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        version: 0.60.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.60.0
-        version: 0.60.0(@types/node@22.10.7)
+        version: 0.60.0(@types/node@18.19.39)
       '@microsoft/api-extractor':
         specifier: ^7.45.1
-        version: 7.45.1(patch_hash=71d364447818fcf8b1b4ad4d13b8db7eb5a947ada6c7787558db23fa19eb9fc4)(@types/node@22.10.7)
+        version: 7.45.1(patch_hash=71d364447818fcf8b1b4ad4d13b8db7eb5a947ada6c7787558db23fa19eb9fc4)(@types/node@18.19.39)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -70,13 +71,13 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: ^0.60.0
-        version: 0.60.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        version: 0.60.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.60.0
-        version: 0.60.0(@types/node@22.10.7)
+        version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^8.1.0
         version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
@@ -85,7 +86,7 @@ importers:
         version: '@fluidframework/gitresources@7.0.0'
       '@microsoft/api-extractor':
         specifier: ^7.45.1
-        version: 7.45.1(patch_hash=71d364447818fcf8b1b4ad4d13b8db7eb5a947ada6c7787558db23fa19eb9fc4)(@types/node@22.10.7)
+        version: 7.45.1(patch_hash=71d364447818fcf8b1b4ad4d13b8db7eb5a947ada6c7787558db23fa19eb9fc4)(@types/node@18.19.39)
       concurrently:
         specifier: ^8.2.1
         version: 8.2.1
@@ -2552,7 +2553,7 @@ packages:
     resolution: {integrity: sha512-PgP35JfmGjHU0LSXOyRew0zHuA9N6OJwOlos1fZ20b7j8ISeAdib3L+n0jIxBtX958UeEpte6xhG/gxJ5iUqMw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/confirm@3.2.0':
     resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==}
@@ -2562,7 +2563,7 @@ packages:
     resolution: {integrity: sha512-fuF9laMmHoOgWapF9h9hv6opA5WvmGFHsTYGCmuFxcghIhEhb3dN0CdQR4BUMqa2H506NCj8cGX4jwMsE4t6dA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/core@10.1.4':
     resolution: {integrity: sha512-5y4/PUJVnRb4bwWY67KLdebWOhOc7xj5IP2J80oWXa64mVag24rwQ1VAdnj7/eDY/odhguW0zQ1Mp1pj6fO/2w==}
@@ -2576,13 +2577,13 @@ packages:
     resolution: {integrity: sha512-S9KnIOJuTZpb9upeRSBBhoDZv7aSV3pG9TECrBj0f+ZsFwccz886hzKBrChGrXMJwd4NKY+pOA9Vy72uqnd6Eg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/expand@4.0.6':
     resolution: {integrity: sha512-TRTfi1mv1GeIZGyi9PQmvAaH65ZlG4/FACq6wSzs7Vvf1z5dnNWsAAXBjWMHt76l+1hUY8teIqJFrWBk5N6gsg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/figures@1.0.9':
     resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
@@ -2596,37 +2597,37 @@ packages:
     resolution: {integrity: sha512-zeo++6f7hxaEe7OjtMzdGZPHiawsfmCZxWB9X1NpmYgbeoyerIbWemvlBxxl+sQIlHC0WuSAG19ibMq3gbhaqQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/number@3.0.6':
     resolution: {integrity: sha512-xO07lftUHk1rs1gR0KbqB+LJPhkUNkyzV/KhH+937hdkMazmAYHLm1OIrNKpPelppeV1FgWrgFDjdUD8mM+XUg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/password@4.0.6':
     resolution: {integrity: sha512-QLF0HmMpHZPPMp10WGXh6F+ZPvzWE7LX6rNoccdktv/Rov0B+0f+eyXkAcgqy5cH9V+WSpbLxu2lo3ysEVK91w==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/prompts@7.2.3':
     resolution: {integrity: sha512-hzfnm3uOoDySDXfDNOm9usOuYIaQvTgKp/13l1uJoe6UNY+Zpcn2RYt0jXz3yA+yemGHvDOxVzqWl3S5sQq53Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/rawlist@4.0.6':
     resolution: {integrity: sha512-QoE4s1SsIPx27FO4L1b1mUjVcoHm1pWE/oCmm4z/Hl+V1Aw5IXl8FYYzGmfXaBT0l/sWr49XmNSiq7kg3Kd/Lg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/search@3.0.6':
     resolution: {integrity: sha512-eFZ2hiAq0bZcFPuFFBmZEtXU1EarHLigE+ENCtpO+37NHCl4+Yokq1P/d09kUblObaikwfo97w+0FtG/EXl5Ng==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/select@2.5.0':
     resolution: {integrity: sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==}
@@ -2636,7 +2637,7 @@ packages:
     resolution: {integrity: sha512-yANzIiNZ8fhMm4NORm+a74+KFYHmf7BZphSOBovIzYPVLquseTGEkU5l2UTnBOf5k0VLmTgPighNDLE9QtbViQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@inquirer/type@1.5.5':
     resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
@@ -2650,7 +2651,7 @@ packages:
     resolution: {integrity: sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.0.0
 
   '@ioredis/as-callback@3.0.0':
     resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
@@ -3403,8 +3404,8 @@ packages:
   '@types/node@18.19.39':
     resolution: {integrity: sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==}
 
-  '@types/node@22.10.7':
-    resolution: {integrity: sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==}
+  '@types/node@20.19.25':
+    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -8639,8 +8640,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -9916,83 +9917,6 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.60.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
-    dependencies:
-      '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.60.0(@types/node@22.10.7)
-      '@fluid-tools/version-tools': 0.60.0(@types/node@22.10.7)
-      '@fluidframework/build-tools': 0.60.0(@types/node@22.10.7)
-      '@fluidframework/bundle-size-tools': 0.60.0
-      '@inquirer/prompts': 7.2.3(@types/node@22.10.7)
-      '@microsoft/api-extractor': 7.54.0(@types/node@22.10.7)
-      '@oclif/core': 4.2.4
-      '@oclif/plugin-autocomplete': 3.2.18
-      '@oclif/plugin-commands': 4.1.17
-      '@oclif/plugin-help': 6.2.22
-      '@oclif/plugin-not-found': 3.2.37(@types/node@22.10.7)
-      '@octokit/core': 7.0.6
-      '@octokit/rest': 22.0.1
-      '@rushstack/node-core-library': 5.18.0(@types/node@22.10.7)
-      async: 3.2.6
-      azure-devops-node-api: 11.2.0
-      change-case: 3.1.0
-      cosmiconfig: 8.3.6(typescript@5.1.6)
-      danger: 13.0.4(encoding@0.1.13)
-      date-fns: 2.30.0
-      debug: 4.4.1(supports-color@8.1.1)
-      execa: 5.1.1
-      fflate: 0.8.2
-      fs-extra: 11.3.0
-      github-slugger: 2.0.0
-      globby: 11.1.0
-      gray-matter: 4.0.3
-      human-id: 4.1.1
-      issue-parser: 7.0.1
-      json5: 2.2.3
-      jssm: 5.104.1
-      jszip: 3.10.1
-      latest-version: 9.0.0
-      mdast: 3.0.0
-      mdast-util-heading-range: 4.0.0
-      mdast-util-to-string: 4.0.0
-      minimatch: 7.4.6
-      npm-check-updates: 16.14.20
-      oclif: 4.17.17(@types/node@22.10.7)
-      picocolors: 1.1.1
-      prettier: 3.2.5
-      prompts: 2.4.2
-      read-pkg-up: 7.0.1
-      remark: 15.0.1
-      remark-gfm: 4.0.0
-      remark-github: 12.0.0
-      remark-github-beta-blockquote-admonitions: 3.1.1
-      remark-toc: 9.0.0
-      replace-in-file: 7.2.0
-      resolve.exports: 2.0.2
-      semver: 7.7.2
-      simple-git: 3.27.0
-      sort-json: 2.0.1
-      sort-package-json: 1.57.0
-      strip-ansi: 6.0.1
-      table: 6.9.0
-      ts-morph: 22.0.0
-      type-fest: 2.19.0
-      unist-util-visit: 5.0.0
-      xml2js: 0.5.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/node'
-      - bluebird
-      - bufferutil
-      - encoding
-      - esbuild
-      - react-devtools-core
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
   '@fluid-tools/build-infrastructure@0.60.0(@types/node@18.19.39)':
     dependencies:
       '@fluid-tools/version-tools': 0.60.0(@types/node@18.19.39)
@@ -10005,32 +9929,6 @@ snapshots:
       globby: 11.1.0
       micromatch: 4.0.8
       oclif: 4.17.17(@types/node@18.19.39)
-      picocolors: 1.1.1
-      read-pkg-up: 7.0.1
-      semver: 7.7.2
-      simple-git: 3.27.0
-      sort-package-json: 1.57.0
-      type-fest: 2.19.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluid-tools/build-infrastructure@0.60.0(@types/node@22.10.7)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.60.0(@types/node@22.10.7)
-      '@manypkg/get-packages': 2.2.2
-      '@oclif/core': 4.2.4
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      detect-indent: 6.1.0
-      execa: 5.1.1
-      fs-extra: 11.3.0
-      globby: 11.1.0
-      micromatch: 4.0.8
-      oclif: 4.17.17(@types/node@22.10.7)
       picocolors: 1.1.1
       read-pkg-up: 7.0.1
       semver: 7.7.2
@@ -10061,61 +9959,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.60.0(@types/node@22.10.7)':
-    dependencies:
-      '@oclif/core': 4.2.4
-      '@oclif/plugin-autocomplete': 3.2.18
-      '@oclif/plugin-commands': 4.1.17
-      '@oclif/plugin-help': 6.2.22
-      '@oclif/plugin-not-found': 3.2.37(@types/node@22.10.7)
-      semver: 7.7.2
-      table: 6.9.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
   '@fluidframework/build-common@2.0.3': {}
 
   '@fluidframework/build-tools@0.60.0(@types/node@18.19.39)':
     dependencies:
       '@fluid-tools/version-tools': 0.60.0(@types/node@18.19.39)
-      '@manypkg/get-packages': 2.2.2
-      async: 3.2.6
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      date-fns: 2.30.0
-      debug: 4.4.1(supports-color@8.1.1)
-      detect-indent: 6.1.0
-      find-up: 7.0.0
-      fs-extra: 11.3.0
-      glob: 7.2.3
-      globby: 11.1.0
-      ignore: 5.3.2
-      json5: 2.2.3
-      lodash.isequal: 4.5.0
-      multimatch: 5.0.0
-      picocolors: 1.1.1
-      picomatch: 2.3.1
-      picospinner: 2.1.0
-      rimraf: 4.4.1
-      semver: 7.7.2
-      sort-package-json: 1.57.0
-      ts-deepmerge: 7.0.2
-      type-fest: 2.19.0
-      typescript: 5.4.5
-      yaml: 2.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/build-tools@0.60.0(@types/node@22.10.7)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.60.0(@types/node@22.10.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -10619,15 +10467,6 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
-  '@inquirer/checkbox@4.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
-      ansi-escapes: 4.3.2
-      yoctocolors-cjs: 2.1.2
-
   '@inquirer/confirm@3.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
@@ -10638,12 +10477,6 @@ snapshots:
       '@inquirer/core': 10.1.4(@types/node@18.19.39)
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
-
-  '@inquirer/confirm@5.1.3(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
 
   '@inquirer/core@10.1.4(@types/node@18.19.39)':
     dependencies:
@@ -10659,26 +10492,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@inquirer/core@10.1.4(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.2
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@inquirer/core@9.2.1':
     dependencies:
       '@inquirer/figures': 1.0.9
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.10.7
+      '@types/node': 20.19.25
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -10695,25 +10514,11 @@ snapshots:
       '@types/node': 18.19.39
       external-editor: 3.1.0
 
-  '@inquirer/editor@4.2.3(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
-      external-editor: 3.1.0
-
   '@inquirer/expand@4.0.6(@types/node@18.19.39)':
     dependencies:
       '@inquirer/core': 10.1.4(@types/node@18.19.39)
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
-      yoctocolors-cjs: 2.1.2
-
-  '@inquirer/expand@4.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/figures@1.0.9': {}
@@ -10729,36 +10534,17 @@ snapshots:
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
 
-  '@inquirer/input@4.1.3(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
-
   '@inquirer/number@3.0.6(@types/node@18.19.39)':
     dependencies:
       '@inquirer/core': 10.1.4(@types/node@18.19.39)
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
 
-  '@inquirer/number@3.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
-
   '@inquirer/password@4.0.6(@types/node@18.19.39)':
     dependencies:
       '@inquirer/core': 10.1.4(@types/node@18.19.39)
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
-      ansi-escapes: 4.3.2
-
-  '@inquirer/password@4.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
       ansi-escapes: 4.3.2
 
   '@inquirer/prompts@7.2.3(@types/node@18.19.39)':
@@ -10775,32 +10561,11 @@ snapshots:
       '@inquirer/select': 4.0.6(@types/node@18.19.39)
       '@types/node': 18.19.39
 
-  '@inquirer/prompts@7.2.3(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/checkbox': 4.0.6(@types/node@22.10.7)
-      '@inquirer/confirm': 5.1.3(@types/node@22.10.7)
-      '@inquirer/editor': 4.2.3(@types/node@22.10.7)
-      '@inquirer/expand': 4.0.6(@types/node@22.10.7)
-      '@inquirer/input': 4.1.3(@types/node@22.10.7)
-      '@inquirer/number': 3.0.6(@types/node@22.10.7)
-      '@inquirer/password': 4.0.6(@types/node@22.10.7)
-      '@inquirer/rawlist': 4.0.6(@types/node@22.10.7)
-      '@inquirer/search': 3.0.6(@types/node@22.10.7)
-      '@inquirer/select': 4.0.6(@types/node@22.10.7)
-      '@types/node': 22.10.7
-
   '@inquirer/rawlist@4.0.6(@types/node@18.19.39)':
     dependencies:
       '@inquirer/core': 10.1.4(@types/node@18.19.39)
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
-      yoctocolors-cjs: 2.1.2
-
-  '@inquirer/rawlist@4.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/search@3.0.6(@types/node@18.19.39)':
@@ -10809,14 +10574,6 @@ snapshots:
       '@inquirer/figures': 1.0.9
       '@inquirer/type': 3.0.2(@types/node@18.19.39)
       '@types/node': 18.19.39
-      yoctocolors-cjs: 2.1.2
-
-  '@inquirer/search@3.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/select@2.5.0':
@@ -10836,15 +10593,6 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
-  '@inquirer/select@4.0.6(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/core': 10.1.4(@types/node@22.10.7)
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@22.10.7)
-      '@types/node': 22.10.7
-      ansi-escapes: 4.3.2
-      yoctocolors-cjs: 2.1.2
-
   '@inquirer/type@1.5.5':
     dependencies:
       mute-stream: 1.0.0
@@ -10856,10 +10604,6 @@ snapshots:
   '@inquirer/type@3.0.2(@types/node@18.19.39)':
     dependencies:
       '@types/node': 18.19.39
-
-  '@inquirer/type@3.0.2(@types/node@22.10.7)':
-    dependencies:
-      '@types/node': 22.10.7
 
   '@ioredis/as-callback@3.0.0': {}
 
@@ -10951,27 +10695,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.28.21(@types/node@22.10.7)':
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 5.3.0(@types/node@22.10.7)
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@microsoft/api-extractor-model@7.31.3(@types/node@18.19.39)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
       '@rushstack/node-core-library': 5.18.0(@types/node@18.19.39)
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@microsoft/api-extractor-model@7.31.3(@types/node@22.10.7)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.18.0(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -10993,24 +10721,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.45.1(patch_hash=71d364447818fcf8b1b4ad4d13b8db7eb5a947ada6c7787558db23fa19eb9fc4)(@types/node@22.10.7)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.28.21(@types/node@22.10.7)
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 5.3.0(@types/node@22.10.7)
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.12.2(@types/node@22.10.7)
-      '@rushstack/ts-command-line': 4.21.4(@types/node@22.10.7)
-      lodash: 4.17.21
-      minimatch: 3.0.8
-      resolve: 1.22.8
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@microsoft/api-extractor@7.54.0(@types/node@18.19.39)':
     dependencies:
       '@microsoft/api-extractor-model': 7.31.3(@types/node@18.19.39)
@@ -11020,25 +10730,6 @@ snapshots:
       '@rushstack/rig-package': 0.6.0
       '@rushstack/terminal': 0.19.3(@types/node@18.19.39)
       '@rushstack/ts-command-line': 5.1.3(@types/node@18.19.39)
-      diff: 8.0.2
-      lodash: 4.17.21
-      minimatch: 10.0.3
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@microsoft/api-extractor@7.54.0(@types/node@22.10.7)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.31.3(@types/node@22.10.7)
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.18.0(@types/node@22.10.7)
-      '@rushstack/rig-package': 0.6.0
-      '@rushstack/terminal': 0.19.3(@types/node@22.10.7)
-      '@rushstack/ts-command-line': 5.1.3(@types/node@22.10.7)
       diff: 8.0.2
       lodash: 4.17.21
       minimatch: 10.0.3
@@ -11177,15 +10868,6 @@ snapshots:
   '@oclif/plugin-not-found@3.2.37(@types/node@18.19.39)':
     dependencies:
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
-      '@oclif/core': 4.2.4
-      ansis: 3.9.0
-      fast-levenshtein: 3.0.0
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@oclif/plugin-not-found@3.2.37(@types/node@22.10.7)':
-    dependencies:
-      '@inquirer/prompts': 7.2.3(@types/node@22.10.7)
       '@oclif/core': 4.2.4
       ansis: 3.9.0
       fast-levenshtein: 3.0.0
@@ -11444,19 +11126,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.39
 
-  '@rushstack/node-core-library@5.18.0(@types/node@22.10.7)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.0
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 22.10.7
-
   '@rushstack/node-core-library@5.3.0(@types/node@18.19.39)':
     dependencies:
       ajv: 8.13.0
@@ -11470,26 +11139,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.39
 
-  '@rushstack/node-core-library@5.3.0(@types/node@22.10.7)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.8
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 22.10.7
-
   '@rushstack/problem-matcher@0.1.1(@types/node@18.19.39)':
     optionalDependencies:
       '@types/node': 18.19.39
-
-  '@rushstack/problem-matcher@0.1.1(@types/node@22.10.7)':
-    optionalDependencies:
-      '@types/node': 22.10.7
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
@@ -11508,13 +11160,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.39
 
-  '@rushstack/terminal@0.12.2(@types/node@22.10.7)':
-    dependencies:
-      '@rushstack/node-core-library': 5.3.0(@types/node@22.10.7)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 22.10.7
-
   '@rushstack/terminal@0.19.3(@types/node@18.19.39)':
     dependencies:
       '@rushstack/node-core-library': 5.18.0(@types/node@18.19.39)
@@ -11522,14 +11167,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.19.39
-
-  '@rushstack/terminal@0.19.3(@types/node@22.10.7)':
-    dependencies:
-      '@rushstack/node-core-library': 5.18.0(@types/node@22.10.7)
-      '@rushstack/problem-matcher': 0.1.1(@types/node@22.10.7)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 22.10.7
 
   '@rushstack/tree-pattern@0.3.4': {}
 
@@ -11542,27 +11179,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@4.21.4(@types/node@22.10.7)':
-    dependencies:
-      '@rushstack/terminal': 0.12.2(@types/node@22.10.7)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@rushstack/ts-command-line@5.1.3(@types/node@18.19.39)':
     dependencies:
       '@rushstack/terminal': 0.19.3(@types/node@18.19.39)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@rushstack/ts-command-line@5.1.3(@types/node@22.10.7)':
-    dependencies:
-      '@rushstack/terminal': 0.19.3(@types/node@22.10.7)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -12095,9 +11714,9 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.10.7':
+  '@types/node@20.19.25':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.1': {}
 
@@ -16560,36 +16179,6 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  oclif@4.17.17(@types/node@22.10.7):
-    dependencies:
-      '@aws-sdk/client-cloudfront': empty-npm-package@1.0.0
-      '@aws-sdk/client-s3': empty-npm-package@1.0.0
-      '@inquirer/confirm': 3.2.0
-      '@inquirer/input': 2.3.0
-      '@inquirer/select': 2.5.0
-      '@oclif/core': 4.2.4
-      '@oclif/plugin-help': 6.2.22
-      '@oclif/plugin-not-found': 3.2.37(@types/node@22.10.7)
-      '@oclif/plugin-warn-if-update-available': 3.1.31
-      async-retry: 1.3.3
-      chalk: 4.1.2
-      change-case: 4.1.2
-      debug: 4.4.1(supports-color@8.1.1)
-      ejs: 3.1.10
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 8.1.0
-      github-slugger: 2.0.0
-      got: 13.0.0
-      lodash: 4.17.21
-      normalize-package-data: 6.0.2
-      semver: 7.7.2
-      sort-package-json: 2.14.0
-      tiny-jsonc: 1.0.2
-      validate-npm-package-name: 5.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -18360,7 +17949,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@22.10.7)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/gitresources-previous':
         specifier: npm:@fluidframework/gitresources@7.0.0
         version: '@fluidframework/gitresources@7.0.0'
@@ -124,8 +124,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-kafka-orderer-previous':
         specifier: npm:@fluidframework/server-kafka-orderer@7.0.0
         version: '@fluidframework/server-kafka-orderer@7.0.0'
@@ -230,8 +230,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-lambdas-previous':
         specifier: npm:@fluidframework/server-lambdas@7.0.0
         version: '@fluidframework/server-lambdas@7.0.0'
@@ -336,8 +336,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-lambdas-driver-previous':
         specifier: npm:@fluidframework/server-lambdas-driver@7.0.0
         version: '@fluidframework/server-lambdas-driver@7.0.0'
@@ -427,8 +427,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-local-server-previous':
         specifier: npm:@fluidframework/server-local-server@7.0.0
         version: '@fluidframework/server-local-server@7.0.0'
@@ -563,8 +563,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-memory-orderer-previous':
         specifier: npm:@fluidframework/server-memory-orderer@7.0.0
         version: '@fluidframework/server-memory-orderer@7.0.0'
@@ -621,8 +621,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/protocol-base-previous':
         specifier: npm:@fluidframework/protocol-base@7.0.0
         version: '@fluidframework/protocol-base@7.0.0'
@@ -733,8 +733,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-local-server':
         specifier: workspace:~
         version: link:../local-server
@@ -878,8 +878,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-local-server':
         specifier: workspace:~
         version: link:../local-server
@@ -1053,8 +1053,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-previous':
         specifier: npm:@fluidframework/server-services@7.0.0
         version: '@fluidframework/server-services@7.0.0'
@@ -1159,8 +1159,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-client-previous':
         specifier: npm:@fluidframework/server-services-client@7.0.0
         version: '@fluidframework/server-services-client@7.0.0'
@@ -1250,8 +1250,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-core-previous':
         specifier: npm:@fluidframework/server-services-core@7.0.0
         version: '@fluidframework/server-services-core@7.0.0'
@@ -1323,8 +1323,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-kafkanode-previous':
         specifier: npm:@fluidframework/server-services-ordering-kafkanode@7.0.0
         version: '@fluidframework/server-services-ordering-kafkanode@7.0.0'
@@ -1402,8 +1402,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-rdkafka-previous':
         specifier: npm:@fluidframework/server-services-ordering-rdkafka@7.0.0
         version: '@fluidframework/server-services-ordering-rdkafka@7.0.0'
@@ -1463,8 +1463,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-zookeeper-previous':
         specifier: npm:@fluidframework/server-services-ordering-zookeeper@7.0.0
         version: '@fluidframework/server-services-ordering-zookeeper@7.0.0'
@@ -1590,8 +1590,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-shared-previous':
         specifier: npm:@fluidframework/server-services-shared@7.0.0
         version: '@fluidframework/server-services-shared@7.0.0'
@@ -1675,8 +1675,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-telemetry-previous':
         specifier: npm:@fluidframework/server-services-telemetry@7.0.0
         version: '@fluidframework/server-services-telemetry@7.0.0'
@@ -1781,8 +1781,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-services-utils-previous':
         specifier: npm:@fluidframework/server-services-utils@7.0.0
         version: '@fluidframework/server-services-utils@7.0.0'
@@ -1905,8 +1905,8 @@ importers:
         specifier: ^0.60.0
         version: 0.60.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@fluidframework/server-test-utils-previous':
         specifier: npm:@fluidframework/server-test-utils@7.0.0
         version: '@fluidframework/server-test-utils@7.0.0'
@@ -2059,8 +2059,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/eslint-config-fluid':
-        specifier: ^6.1.0
-        version: 6.1.0(eslint@8.57.1)(typescript@5.1.6)
+        specifier: ^8.1.0
+        version: 8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=71d364447818fcf8b1b4ad4d13b8db7eb5a947ada6c7787558db23fa19eb9fc4)(@types/node@18.19.39)
@@ -2393,6 +2393,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.10.0':
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -2405,8 +2411,10 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@fluid-internal/eslint-plugin-fluid@0.2.0':
-    resolution: {integrity: sha512-KAES3hOge6htTmYCTjBObjhi1oaVkT+XPyFV7tgOgIicaS9PZgD9ErFV2wiFdWtZiqoThKFlZewfwWNd+mqeXg==}
+  '@fluid-internal/eslint-plugin-fluid@0.4.0':
+    resolution: {integrity: sha512-eynZFyJ1YbTUJmf4WtvF6AqmB7cnRhJv2Q/L7XdHVIjgwyoZWbmZhCP1FZ+hHIpkrLmmewFI0Kh+JhTKM/9m0w==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.37.0
 
   '@fluid-internal/mocha-test-setup@2.0.5':
     resolution: {integrity: sha512-oSPv7nJKbyhMBWzSIRsu1h1WXXOaT2/cwD5qSeKsUZTIUVXsd5FdIUOdV/vc7hAEoJI/JLXZeauVrJHe/qlv6g==}
@@ -2455,8 +2463,8 @@ packages:
   '@fluidframework/driver-definitions@2.0.5':
     resolution: {integrity: sha512-1jdEGpWg73ow3g7wEv/YnIKa5NzRqsOAbqsUQj6v3QCK6lDhwbUNibctyKSdhRaE18s42s06Ip5n15fqbeq76Q==}
 
-  '@fluidframework/eslint-config-fluid@6.1.0':
-    resolution: {integrity: sha512-jPVt7ylQsCyptYmhNPby57qOuNGzvjteDSy4/x+hKzibgJ76yqRAnTVMjXAeR9dlLUfiXydhOcecNvx4Zt3IGQ==}
+  '@fluidframework/eslint-config-fluid@8.1.0':
+    resolution: {integrity: sha512-SNuj/gKmx4zkgTQO24gF7e+UMe2n/V4MBQWjrO8YJ+vPOivw3RwJTQkJgiqqL2e5F659TTlwKt+tQ1OCDKvuPg==}
 
   '@fluidframework/gitresources@7.0.0':
     resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
@@ -3488,6 +3496,19 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.46.4':
+    resolution: {integrity: sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.46.4':
+    resolution: {integrity: sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@7.18.0':
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -3495,6 +3516,16 @@ packages:
   '@typescript-eslint/scope-manager@8.31.1':
     resolution: {integrity: sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.46.4':
+    resolution: {integrity: sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.46.4':
+    resolution: {integrity: sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@7.18.0':
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
@@ -3518,6 +3549,10 @@ packages:
     resolution: {integrity: sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.46.4':
+    resolution: {integrity: sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@7.18.0':
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -3533,6 +3568,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/typescript-estree@8.46.4':
+    resolution: {integrity: sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@7.18.0':
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -3546,12 +3587,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/utils@8.46.4':
+    resolution: {integrity: sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/visitor-keys@8.31.1':
     resolution: {integrity: sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.46.4':
+    resolution: {integrity: sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
@@ -3948,10 +4000,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  array-buffer-byte-length@1.0.1:
-    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
-    engines: {node: '>= 0.4'}
-
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -3981,10 +4029,6 @@ packages:
 
   array.prototype.tosorted@1.1.4:
     resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
-
-  arraybuffer.prototype.slice@1.0.3:
-    resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
 
   arraybuffer.prototype.slice@1.0.4:
@@ -4922,10 +4966,6 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
-  es-abstract@1.22.4:
-    resolution: {integrity: sha512-vZYJlk2u6qHYxBOTjAeg7qUxHdNfih64Uu2J8QqWgXZ2cri0ZpJAkzDUK/q593+mvKwlxyaxr6F1Q+3LKoQRgg==}
-    engines: {node: '>= 0.4'}
-
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
     engines: {node: '>= 0.4'}
@@ -4955,10 +4995,6 @@ packages:
 
   es-shim-unscopables@1.0.2:
     resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
-
-  es-to-primitive@1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
-    engines: {node: '>= 0.4'}
 
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
@@ -5037,39 +5073,24 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
-  eslint-module-utils@2.12.0:
-    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-
   eslint-plugin-eslint-comments@3.2.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-i@2.29.1:
-    resolution: {integrity: sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==}
-    engines: {node: '>=12'}
-    deprecated: Please migrate to the brand new `eslint-plugin-import-x` instead
+  eslint-plugin-import-x@4.16.1:
+    resolution: {integrity: sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^7.2.0 || ^8
+      '@typescript-eslint/utils': ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0
+      eslint-import-resolver-node: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
 
   eslint-plugin-jsdoc@55.0.5:
     resolution: {integrity: sha512-foZ/+Fm20JCYmP5msD4MpmFb0MxajkVJ15YMKxvQ7WJK0zI/iykkClpsuqbav3bLtDhaOalYxwRx0pGTqoQoRA==}
@@ -5435,10 +5456,6 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  function.prototype.name@1.1.6:
-    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
-    engines: {node: '>= 0.4'}
-
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
@@ -5498,10 +5515,6 @@ packages:
   get-stream@7.0.0:
     resolution: {integrity: sha512-ql6FW5b8tgMYvI4UaoxG3EQN3VyZ6VeQpxNBGg5BZ4xD4u+HJeprzhMMA4OCBEGQgSR+m87pstWMpiVW64W8Fw==}
     engines: {node: '>=16'}
-
-  get-symbol-description@1.0.2:
-    resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
-    engines: {node: '>= 0.4'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -5577,10 +5590,6 @@ packages:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
     engines: {node: '>=8'}
 
-  globalthis@1.0.3:
-    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
-    engines: {node: '>= 0.4'}
-
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -5635,10 +5644,6 @@ packages:
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
-  has-proto@1.0.3:
-    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
-    engines: {node: '>= 0.4'}
 
   has-proto@1.2.0:
     resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
@@ -5829,10 +5834,6 @@ packages:
   int64-buffer@0.1.10:
     resolution: {integrity: sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==}
 
-  internal-slot@1.0.7:
-    resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
-    engines: {node: '>= 0.4'}
-
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -5872,10 +5873,6 @@ packages:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
 
-  is-array-buffer@3.0.4:
-    resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
-    engines: {node: '>= 0.4'}
-
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -5890,9 +5887,6 @@ packages:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
     engines: {node: '>= 0.4'}
 
-  is-bigint@1.0.4:
-    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
-
   is-bigint@1.1.0:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
@@ -5900,10 +5894,6 @@ packages:
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
-
-  is-boolean-object@1.1.2:
-    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
-    engines: {node: '>= 0.4'}
 
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
@@ -5937,10 +5927,6 @@ packages:
 
   is-data-view@1.0.2:
     resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.0.5:
-    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
 
   is-date-object@1.1.0:
@@ -6014,10 +6000,6 @@ packages:
   is-natural-number@4.0.1:
     resolution: {integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==}
 
-  is-negative-zero@2.0.2:
-    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
-    engines: {node: '>= 0.4'}
-
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -6025,10 +6007,6 @@ packages:
   is-npm@6.0.0:
     resolution: {integrity: sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  is-number-object@1.0.7:
-    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
-    engines: {node: '>= 0.4'}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -6058,10 +6036,6 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
-  is-regex@1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
-    engines: {node: '>= 0.4'}
-
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -6073,9 +6047,6 @@ packages:
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
     engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.2:
-    resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
 
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
@@ -6089,10 +6060,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-string@1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
-    engines: {node: '>= 0.4'}
-
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -6100,10 +6067,6 @@ packages:
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
-
-  is-symbol@1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
-    engines: {node: '>= 0.4'}
 
   is-symbol@1.1.1:
     resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
@@ -6130,9 +6093,6 @@ packages:
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
-
-  is-weakref@1.0.2:
-    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
 
   is-weakref@1.1.1:
     resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
@@ -7731,10 +7691,6 @@ packages:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
 
-  regexp.prototype.flags@1.5.2:
-    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
-    engines: {node: '>= 0.4'}
-
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -7888,10 +7844,6 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
-  safe-array-concat@1.1.0:
-    resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
-    engines: {node: '>=0.4'}
-
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -7904,10 +7856,6 @@ packages:
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
-    engines: {node: '>= 0.4'}
-
-  safe-regex-test@1.0.3:
-    resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
     engines: {node: '>= 0.4'}
 
   safe-regex-test@1.1.0:
@@ -8296,19 +8244,9 @@ packages:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
     engines: {node: '>= 0.4'}
 
-  string.prototype.trim@1.2.8:
-    resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimend@1.0.7:
-    resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
-
   string.prototype.trimend@1.0.9:
     resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
     engines: {node: '>= 0.4'}
-
-  string.prototype.trimstart@1.0.7:
-    resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
 
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
@@ -8637,24 +8575,13 @@ packages:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
 
-  typed-array-byte-length@1.0.1:
-    resolution: {integrity: sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==}
-    engines: {node: '>= 0.4'}
-
   typed-array-byte-length@1.0.3:
     resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-offset@1.0.2:
-    resolution: {integrity: sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==}
     engines: {node: '>= 0.4'}
 
   typed-array-byte-offset@1.0.4:
     resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
     engines: {node: '>= 0.4'}
-
-  typed-array-length@1.0.4:
-    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
 
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
@@ -8698,9 +8625,6 @@ packages:
   uid2@1.0.0:
     resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
     engines: {node: '>= 4.0.0'}
-
-  unbox-primitive@1.0.2:
-    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -8918,9 +8842,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  which-boxed-primitive@1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -9786,6 +9707,11 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.10.0': {}
 
   '@eslint/eslintrc@2.1.4':
@@ -9804,13 +9730,14 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@fluid-internal/eslint-plugin-fluid@0.2.0(eslint@8.57.1)(typescript@5.1.6)':
+  '@fluid-internal/eslint-plugin-fluid@0.4.0(eslint@8.57.1)(typescript@5.1.6)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.1.6)
+      '@typescript-eslint/parser': 8.46.4(eslint@8.57.1)(typescript@5.1.6)
+      '@typescript-eslint/utils': 8.46.4(eslint@8.57.1)(typescript@5.1.6)
+      eslint: 8.57.1
       ts-morph: 22.0.0
     transitivePeerDependencies:
-      - eslint
       - supports-color
       - typescript
 
@@ -10266,9 +10193,9 @@ snapshots:
     dependencies:
       '@fluidframework/core-interfaces': 2.0.5
 
-  '@fluidframework/eslint-config-fluid@6.1.0(eslint@8.57.1)(typescript@5.1.6)':
+  '@fluidframework/eslint-config-fluid@8.1.0(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)(typescript@5.1.6)':
     dependencies:
-      '@fluid-internal/eslint-plugin-fluid': 0.2.0(eslint@8.57.1)(typescript@5.1.6)
+      '@fluid-internal/eslint-plugin-fluid': 0.4.0(eslint@8.57.1)(typescript@5.1.6)
       '@rushstack/eslint-patch': 1.12.0
       '@rushstack/eslint-plugin': 0.19.0(eslint@8.57.1)(typescript@5.1.6)
       '@rushstack/eslint-plugin-security': 0.11.0(eslint@8.57.1)(typescript@5.1.6)
@@ -10276,9 +10203,9 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.1.6)
       eslint-config-biome: 2.1.3
       eslint-config-prettier: 10.1.8(eslint@8.57.1)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       eslint-plugin-jsdoc: 55.0.5(eslint@8.57.1)
       eslint-plugin-promise: 7.2.1(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -10287,9 +10214,10 @@ snapshots:
       eslint-plugin-unicorn: 48.0.1(eslint@8.57.1)
       eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
     transitivePeerDependencies:
+      - '@typescript-eslint/utils'
       - eslint
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
+      - eslint-import-resolver-node
+      - eslint-plugin-import
       - supports-color
       - typescript
 
@@ -12274,6 +12202,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.46.4(eslint@8.57.1)(typescript@5.1.6)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 8.46.4
+      debug: 4.4.1(supports-color@8.1.1)
+      eslint: 8.57.1
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.46.4(typescript@5.1.6)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.1.6)
+      '@typescript-eslint/types': 8.46.4
+      debug: 4.4.1(supports-color@8.1.1)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
@@ -12283,6 +12232,15 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.31.1
       '@typescript-eslint/visitor-keys': 8.31.1
+
+  '@typescript-eslint/scope-manager@8.46.4':
+    dependencies:
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/visitor-keys': 8.46.4
+
+  '@typescript-eslint/tsconfig-utils@8.46.4(typescript@5.1.6)':
+    dependencies:
+      typescript: 5.1.6
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.1.6)':
     dependencies:
@@ -12301,6 +12259,8 @@ snapshots:
   '@typescript-eslint/types@8.31.1': {}
 
   '@typescript-eslint/types@8.44.1': {}
+
+  '@typescript-eslint/types@8.46.4': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.1.6)':
     dependencies:
@@ -12321,6 +12281,22 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.31.1
       '@typescript-eslint/visitor-keys': 8.31.1
+      debug: 4.4.1(supports-color@8.1.1)
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.46.4(typescript@5.1.6)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.46.4(typescript@5.1.6)
+      '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.1.6)
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/visitor-keys': 8.46.4
       debug: 4.4.1(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
@@ -12353,6 +12329,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.1.6)
+      eslint: 8.57.1
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
@@ -12361,6 +12348,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.31.1':
     dependencies:
       '@typescript-eslint/types': 8.31.1
+      eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.46.4':
+    dependencies:
+      '@typescript-eslint/types': 8.46.4
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.2.0': {}
@@ -12771,11 +12763,6 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  array-buffer-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      is-array-buffer: 3.0.4
-
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -12821,17 +12808,6 @@ snapshots:
       es-abstract: 1.24.0
       es-errors: 1.3.0
       es-shim-unscopables: 1.0.2
-
-  arraybuffer.prototype.slice@1.0.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.1
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.22.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      is-array-buffer: 3.0.4
-      is-shared-array-buffer: 1.0.2
 
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
@@ -13904,50 +13880,6 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-abstract@1.22.4:
-    dependencies:
-      array-buffer-byte-length: 1.0.1
-      arraybuffer.prototype.slice: 1.0.3
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.6
-      get-intrinsic: 1.3.0
-      get-symbol-description: 1.0.2
-      globalthis: 1.0.3
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.0.3
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      internal-slot: 1.0.7
-      is-array-buffer: 3.0.4
-      is-callable: 1.2.7
-      is-negative-zero: 2.0.2
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.2
-      is-string: 1.0.7
-      is-typed-array: 1.1.15
-      is-weakref: 1.0.2
-      object-inspect: 1.13.1
-      object-keys: 1.1.1
-      object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.2
-      safe-array-concat: 1.1.0
-      safe-regex-test: 1.0.3
-      string.prototype.trim: 1.2.8
-      string.prototype.trimend: 1.0.7
-      string.prototype.trimstart: 1.0.7
-      typed-array-buffer: 1.0.3
-      typed-array-byte-length: 1.0.1
-      typed-array-byte-offset: 1.0.2
-      typed-array-length: 1.0.4
-      unbox-primitive: 1.0.2
-      which-typed-array: 1.1.19
-
   es-abstract@1.24.0:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -14045,17 +13977,11 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
-  es-to-primitive@1.2.1:
-    dependencies:
-      is-callable: 1.2.7
-      is-date-object: 1.0.5
-      is-symbol: 1.0.4
-
   es-to-primitive@1.3.0:
     dependencies:
       is-callable: 1.2.7
-      is-date-object: 1.0.5
-      is-symbol: 1.0.4
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es6-object-assign@1.1.0: {}
 
@@ -14103,8 +14029,9 @@ snapshots:
       resolve: 1.22.10
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.1
@@ -14115,18 +14042,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.1.6)
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14136,21 +14052,22 @@ snapshots:
       eslint: 8.57.1
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.46.4(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
+      '@typescript-eslint/types': 8.44.1
+      comment-parser: 1.4.1
       debug: 4.4.1(supports-color@8.1.1)
-      doctrine: 3.0.0
       eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      get-tsconfig: 4.10.1
+      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 10.0.3
       semver: 7.7.2
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.46.4(eslint@8.57.1)(typescript@5.1.6)
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-jsdoc@55.0.5(eslint@8.57.1):
@@ -14213,7 +14130,7 @@ snapshots:
       ci-info: 3.8.0
       clean-regexp: 1.0.0
       eslint: 8.57.1
-      esquery: 1.5.0
+      esquery: 1.6.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.1
       jsesc: 3.0.2
@@ -14610,13 +14527,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  function.prototype.name@1.1.6:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.22.4
-      functions-have-names: 1.2.3
-
   function.prototype.name@1.1.8:
     dependencies:
       call-bind: 1.0.8
@@ -14689,12 +14599,6 @@ snapshots:
   get-stream@6.0.1: {}
 
   get-stream@7.0.0: {}
-
-  get-symbol-description@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -14788,10 +14692,6 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
-  globalthis@1.0.3:
-    dependencies:
-      define-properties: 1.2.1
-
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -14871,8 +14771,6 @@ snapshots:
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-
-  has-proto@1.0.3: {}
 
   has-proto@1.2.0:
     dependencies:
@@ -15075,12 +14973,6 @@ snapshots:
 
   int64-buffer@0.1.10: {}
 
-  internal-slot@1.0.7:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.2
-      side-channel: 1.0.4
-
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -15129,11 +15021,6 @@ snapshots:
       call-bind: 1.0.8
       has-tostringtag: 1.0.2
 
-  is-array-buffer@3.0.4:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.3.0
-
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -15148,10 +15035,6 @@ snapshots:
     dependencies:
       has-tostringtag: 1.0.2
 
-  is-bigint@1.0.4:
-    dependencies:
-      has-bigints: 1.0.2
-
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.0.2
@@ -15159,11 +15042,6 @@ snapshots:
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.2.0
-
-  is-boolean-object@1.1.2:
-    dependencies:
-      call-bind: 1.0.8
-      has-tostringtag: 1.0.2
 
   is-boolean-object@1.2.2:
     dependencies:
@@ -15199,10 +15077,6 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       is-typed-array: 1.1.15
-
-  is-date-object@1.0.5:
-    dependencies:
-      has-tostringtag: 1.0.2
 
   is-date-object@1.1.0:
     dependencies:
@@ -15262,15 +15136,9 @@ snapshots:
 
   is-natural-number@4.0.1: {}
 
-  is-negative-zero@2.0.2: {}
-
   is-negative-zero@2.0.3: {}
 
   is-npm@6.0.0: {}
-
-  is-number-object@1.0.7:
-    dependencies:
-      has-tostringtag: 1.0.2
 
   is-number-object@1.1.1:
     dependencies:
@@ -15291,11 +15159,6 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
-  is-regex@1.1.4:
-    dependencies:
-      call-bind: 1.0.8
-      has-tostringtag: 1.0.2
-
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -15307,10 +15170,6 @@ snapshots:
 
   is-set@2.0.3: {}
 
-  is-shared-array-buffer@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
@@ -15318,10 +15177,6 @@ snapshots:
   is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
-
-  is-string@1.0.7:
-    dependencies:
-      has-tostringtag: 1.0.2
 
   is-string@1.1.1:
     dependencies:
@@ -15331,10 +15186,6 @@ snapshots:
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
-
-  is-symbol@1.0.4:
-    dependencies:
-      has-symbols: 1.1.0
 
   is-symbol@1.1.1:
     dependencies:
@@ -15359,10 +15210,6 @@ snapshots:
       upper-case: 1.1.3
 
   is-weakmap@2.0.2: {}
-
-  is-weakref@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
 
   is-weakref@1.1.1:
     dependencies:
@@ -15551,7 +15398,7 @@ snapshots:
   jsx-ast-utils@3.3.3:
     dependencies:
       array-includes: 3.1.9
-      object.assign: 4.1.5
+      object.assign: 4.1.7
 
   jszip@3.10.1:
     dependencies:
@@ -17395,13 +17242,6 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
-  regexp.prototype.flags@1.5.2:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      set-function-name: 2.0.2
-
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -17580,13 +17420,6 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  safe-array-concat@1.1.0:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -17603,12 +17436,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       isarray: 2.0.5
-
-  safe-regex-test@1.0.3:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      is-regex: 1.1.4
 
   safe-regex-test@1.1.0:
     dependencies:
@@ -18105,7 +17932,7 @@ snapshots:
   string.prototype.repeat@1.0.0:
     dependencies:
       define-properties: 1.2.1
-      es-abstract: 1.22.4
+      es-abstract: 1.24.0
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -18117,30 +17944,12 @@ snapshots:
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
-  string.prototype.trim@1.2.8:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.22.4
-
-  string.prototype.trimend@1.0.7:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.22.4
-
   string.prototype.trimend@1.0.9:
     dependencies:
       call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  string.prototype.trimstart@1.0.7:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.22.4
 
   string.prototype.trimstart@1.0.8:
     dependencies:
@@ -18480,29 +18289,12 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typed-array-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.0.3
-      is-typed-array: 1.1.15
-
   typed-array-byte-length@1.0.3:
     dependencies:
       call-bind: 1.0.8
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-offset@1.0.2:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.0.3
       is-typed-array: 1.1.15
 
   typed-array-byte-offset@1.0.4:
@@ -18514,12 +18306,6 @@ snapshots:
       has-proto: 1.2.0
       is-typed-array: 1.1.15
       reflect.getprototypeof: 1.0.10
-
-  typed-array-length@1.0.4:
-    dependencies:
-      call-bind: 1.0.8
-      for-each: 0.3.5
-      is-typed-array: 1.1.15
 
   typed-array-length@1.0.7:
     dependencies:
@@ -18557,13 +18343,6 @@ snapshots:
   typewiselite@1.0.0: {}
 
   uid2@1.0.0: {}
-
-  unbox-primitive@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-      has-bigints: 1.0.2
-      has-symbols: 1.1.0
-      which-boxed-primitive: 1.0.2
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -18901,14 +18680,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  which-boxed-primitive@1.0.2:
-    dependencies:
-      is-bigint: 1.0.4
-      is-boolean-object: 1.1.2
-      is-number-object: 1.0.7
-      is-string: 1.0.7
-      is-symbol: 1.0.4
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

This PR upgrades the ESLint configuration across all server/routerlicious packages and implements workarounds for compatibility issues.

### ESLint Configuration Upgrade
- Upgraded `@fluidframework/eslint-config-fluid` from `^6.1.0` to `^8.1.0` across all packages
- Updated ESLint rule names to use `import-x` prefix (e.g., `import/no-nodejs-modules` → `import-x/no-nodejs-modules`)
- Updated `import/namespace` to `import-x/namespace` in inline eslint-disable comments
- Fixed deprecated API warnings and other ESLint violations

### Build Configuration Workarounds
- Added exclusion pattern `^server/routerlicious/packages/.*/package.json` to fluid-build for both `tsc-multi` and `fluid-build-tasks-tsc` tasks
- Addresses compatibility issues between updated ESLint config and server package structure

### Type Compatibility
- Added `@types/node@>=22` override to force Node.js v20 types, working around incompatibilities with packages using different type versions
- Updated pnpm overrides documentation to reflect the type version constraints

### Code Quality Improvements
- Fixed JSDoc links to use proper markdown link format in nexus/index.ts
- Added missing `@typescript-eslint/return-await` suppression for false positive in localOrdererSetup.ts
- Maintained existing rule overrides for areas requiring further cleanup (strict null checks, deprecated API usage)

All changes maintain backward compatibility while modernizing the linting infrastructure.