### PR TITLE
Simple to stored fixes and cleanup

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1031,7 +1031,7 @@ export type SharedTreeOptionsBeta = ForestOptions;
 
 // @alpha @sealed
 export interface SimpleAllowedTypeAttributes {
-    readonly isStaged: boolean | undefined;
+    readonly isStaged: false | SchemaUpgrade | undefined;
 }
 
 // @alpha @sealed

--- a/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
@@ -5,7 +5,12 @@
 
 import { unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
-import { NodeKind, type TreeNodeSchema, type AllowedTypesFull } from "../core/index.js";
+import {
+	NodeKind,
+	type TreeNodeSchema,
+	type AllowedTypesFull,
+	SchemaUpgrade,
+} from "../core/index.js";
 import {
 	type FieldSchema,
 	type FieldSchemaAlpha,
@@ -91,7 +96,7 @@ function generateAllowedTypes(
 ): AllowedTypesFull {
 	const types = Array.from(allowed.entries(), ([id, attributes]) => {
 		const schema = context.get(id) ?? fail(0xb5a /* Missing schema */);
-		return (attributes.isStaged ?? false) ? factory.staged(schema) : schema;
+		return attributes.isStaged instanceof SchemaUpgrade ? factory.staged(schema) : schema;
 	});
 	// TODO: AB#53315: `AllowedTypesFullFromMixed` does not correctly handle the `(AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]` case.
 	// We have to cast here in order to produce an allowed types list that can be used in tree node factory methods (e.g., `SchemaFactoryAlpha.objectAlpha`).

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -262,7 +262,7 @@ export class AnnotatedAllowedTypesInternal<
 		const simpleAllowedTypes = new Map<string, SimpleAllowedTypeAttributes>();
 		for (const type of annotatedAllowedTypes.evaluate().types) {
 			simpleAllowedTypes.set(type.type.identifier, {
-				isStaged: type.metadata.stagedSchemaUpgrade !== undefined,
+				isStaged: type.metadata.stagedSchemaUpgrade ?? false,
 			});
 		}
 		return simpleAllowedTypes;

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -65,6 +65,7 @@ export {
 	createSchemaUpgrade,
 	AnnotatedAllowedTypesInternal,
 	normalizeAllowedTypesInternal,
+	SchemaUpgrade,
 } from "./allowedTypes.js";
 export type {
 	AnnotatedAllowedType,
@@ -80,7 +81,6 @@ export type {
 	AllowedTypeMetadata,
 	AnnotatedAllowedTypes,
 	AnnotateAllowedTypesList,
-	SchemaUpgrade,
 	AllowedTypesFullInternal,
 	AllowedTypesFull,
 	AllowedTypesFullFromMixed,
@@ -117,4 +117,5 @@ export {
 	type StoredSchemaGenerationOptions,
 	convertAllowedTypes,
 	allowedTypeFilter,
+	type StoredFromViewSchemaGenerationOptions,
 } from "./toStored.js";

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -118,4 +118,5 @@ export {
 	convertAllowedTypes,
 	allowedTypeFilter,
 	type StoredFromViewSchemaGenerationOptions,
+	ExpectStored,
 } from "./toStored.js";

--- a/packages/dds/tree/src/simple-tree/core/toStored.ts
+++ b/packages/dds/tree/src/simple-tree/core/toStored.ts
@@ -44,7 +44,7 @@ export function allowedTypeFilter(
 	if (options === ExpectStored) {
 		if (data.isStaged !== undefined) {
 			throw new UsageError(
-				"Failed to covert view schema to stored schema. The simple schema provided was indicated to a stored schema by the use of `ExpectStored`, but view schema specific content was encountered which requires a `StoredFromViewSchemaGenerationOptions` to process.",
+				"Failed to covert view schema to stored schema. The simple schema provided was indicated to be a stored schema by the use of `ExpectStored`, but view schema specific content was encountered which requires a `StoredFromViewSchemaGenerationOptions` to process.",
 			);
 		}
 		return true;
@@ -52,7 +52,7 @@ export function allowedTypeFilter(
 
 	if (data.isStaged === undefined) {
 		throw new UsageError(
-			"Failed to covert view schema to stored schema. The simple schema provided as the view schema was actually a stored schema. If this was intended used `ExpectStored` for the `StoredSchemaGenerationOptions` to indicate the input is already a stored schema and only a format conversion is required.",
+			"Failed to covert view schema to stored schema. The simple schema provided as the view schema was actually a stored schema. If this was intended, use `ExpectStored` for the `StoredSchemaGenerationOptions` to indicate the input is already a stored schema and only a format conversion is required.",
 		);
 	}
 

--- a/packages/dds/tree/src/simple-tree/core/toStored.ts
+++ b/packages/dds/tree/src/simple-tree/core/toStored.ts
@@ -44,7 +44,7 @@ export function allowedTypeFilter(
 	if (options === ExpectStored) {
 		if (data.isStaged !== undefined) {
 			throw new UsageError(
-				"ExpectStored indicated input schema should be a stored schema, but it had `isStaged` not set to `undefined`.",
+				"Failed to covert view schema to stored schema. The simple schema provided was indicated to a stored schema by the use of `ExpectStored`, but view schema specific content was encountered which requires a `StoredFromViewSchemaGenerationOptions` to process.",
 			);
 		}
 		return true;
@@ -52,7 +52,7 @@ export function allowedTypeFilter(
 
 	if (data.isStaged === undefined) {
 		throw new UsageError(
-			"Cannot interpret simple schema for a stored schema as view schema when converting it to a stored schema. This case must use ExpectStored to indicate input is already a stored schema.",
+			"Failed to covert view schema to stored schema. The simple schema provided as the view schema was actually a stored schema. If this was intended used `ExpectStored` for the `StoredSchemaGenerationOptions` to indicate the input is already a stored schema and only a format conversion is required.",
 		);
 	}
 
@@ -65,7 +65,7 @@ export function allowedTypeFilter(
 }
 
 /**
- * Converts an {@link SimpleAllowedTypes} to a stored schema.
+ * Converts a {@link SimpleAllowedTypes} to a stored schema.
  * @param schema - The schema to convert.
  * @param options - The options to use for filtering.
  * @returns The converted stored schema.

--- a/packages/dds/tree/src/simple-tree/core/toStored.ts
+++ b/packages/dds/tree/src/simple-tree/core/toStored.ts
@@ -4,18 +4,15 @@
  */
 
 import { brand } from "../../util/index.js";
-import {
-	normalizeAndEvaluateAnnotatedAllowedTypes,
-	type AnnotatedAllowedType,
-	type ImplicitAllowedTypes,
-	type SchemaUpgrade,
-} from "./allowedTypes.js";
+import type { SchemaUpgrade } from "./allowedTypes.js";
 import type { TreeNodeSchemaIdentifier, TreeTypeSet } from "../../core/index.js";
+import type { SimpleAllowedTypeAttributes, SimpleAllowedTypes } from "../simpleSchema.js";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * Options for generating a {@link TreeStoredSchema} from view schema.
  */
-export interface StoredSchemaGenerationOptions {
+export interface StoredFromViewSchemaGenerationOptions {
 	/**
 	 * Determines whether to include staged schema in the resulting stored schema.
 	 * @remarks
@@ -25,36 +22,63 @@ export interface StoredSchemaGenerationOptions {
 }
 
 /**
+ * Marker type indicating that the input schema is already a stored schema.
+ */
+export const ExpectStored = Symbol("ExpectStored");
+export type ExpectStored = typeof ExpectStored;
+
+export type StoredSchemaGenerationOptions =
+	| StoredFromViewSchemaGenerationOptions
+	| ExpectStored;
+
+/**
  * Filters an allowed type based on the provided options.
  * @param allowedType - The allowed type to filter.
  * @param options - The options to use for filtering.
  * @returns Whether the allowed type passes the filter.
  */
 export function allowedTypeFilter(
-	allowedType: AnnotatedAllowedType,
+	data: SimpleAllowedTypeAttributes,
 	options: StoredSchemaGenerationOptions,
 ): boolean {
-	// If the allowed type is staged, only include it if the options allow it.
-	if (allowedType.metadata.stagedSchemaUpgrade !== undefined) {
-		return options.includeStaged(allowedType.metadata.stagedSchemaUpgrade);
+	if (options === ExpectStored) {
+		if (data.isStaged !== undefined) {
+			throw new UsageError(
+				"ExpectStored indicated input schema should be a stored schema, but it had `isStaged` not set to `undefined`.",
+			);
+		}
+		return true;
 	}
-	return true;
+
+	if (data.isStaged === undefined) {
+		throw new UsageError(
+			"Cannot interpret simple schema for a stored schema as view schema when converting it to a stored schema. This case must use ExpectStored to indicate input is already a stored schema.",
+		);
+	}
+
+	// If the allowed type is staged, only include it if the options allow it.
+	if (data.isStaged === false) {
+		return true;
+	}
+
+	return options.includeStaged(data.isStaged);
 }
 
 /**
- * Converts an ImplicitAllowedTypes to a stored schema.
+ * Converts an {@link SimpleAllowedTypes} to a stored schema.
  * @param schema - The schema to convert.
  * @param options - The options to use for filtering.
  * @returns The converted stored schema.
  */
 export function convertAllowedTypes(
-	schema: ImplicitAllowedTypes,
+	schema: SimpleAllowedTypes,
 	options: StoredSchemaGenerationOptions,
 ): TreeTypeSet {
-	const filtered: TreeNodeSchemaIdentifier[] = normalizeAndEvaluateAnnotatedAllowedTypes(
-		schema,
-	)
-		.types.filter((allowedType) => allowedTypeFilter(allowedType, options))
-		.map((a) => brand(a.type.identifier));
+	const filtered: TreeNodeSchemaIdentifier[] = [];
+	for (const [type, data] of schema) {
+		if (allowedTypeFilter(data, options)) {
+			filtered.push(brand<TreeNodeSchemaIdentifier>(type));
+		}
+	}
 	return new Set(filtered);
 }

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -12,10 +12,9 @@ import type { InternalTreeNode, Unhydrated } from "./types.js";
 import type { UnionToIntersection } from "../../util/index.js";
 import type { AllowedTypesFullEvaluated, AllowedTypesFull } from "./allowedTypes.js";
 import type { Context } from "./context.js";
-import type { FieldKey, NodeData, TreeNodeStoredSchema } from "../../core/index.js";
+import type { FieldKey, NodeData } from "../../core/index.js";
 import type { UnhydratedFlexTreeField } from "./unhydratedFlexTree.js";
 import type { FactoryContent } from "../unhydratedFlexTreeFromInsertable.js";
-import type { StoredSchemaGenerationOptions } from "./toStored.js";
 
 /**
  * Schema for a {@link TreeNode} or {@link TreeLeafValue}.
@@ -389,11 +388,6 @@ export interface TreeNodeSchemaPrivateData {
 	 * Idempotent initialization function that pre-caches data and can dereference lazy schema references.
 	 */
 	idempotentInitialize(): TreeNodeSchemaInitializedData;
-
-	/**
-	 * Converts a the schema into a {@link TreeNodeStoredSchema}.
-	 */
-	toStored(options: StoredSchemaGenerationOptions): TreeNodeStoredSchema;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -260,7 +260,6 @@ export function isClassBasedSchema(
 export function createTreeNodeSchemaPrivateData(
 	schema: TreeNodeSchemaCore<string, NodeKind, boolean>,
 	childAllowedTypes: readonly AllowedTypesFull[],
-	toStored: TreeNodeSchemaPrivateData["toStored"],
 ): TreeNodeSchemaPrivateData {
 	const schemaValid = schemaAsTreeNodeValid(schema);
 	// Since this closes over the schema, ensure this schema is marked as most derived
@@ -270,7 +269,6 @@ export function createTreeNodeSchemaPrivateData(
 	return {
 		idempotentInitialize: () => schemaValid.oneTimeInitialize().oneTimeInitialized,
 		childAllowedTypes,
-		toStored,
 	};
 }
 

--- a/packages/dds/tree/src/simple-tree/fieldSchema.ts
+++ b/packages/dds/tree/src/simple-tree/fieldSchema.ts
@@ -29,7 +29,7 @@ import type {
 	InsertableTreeNodeFromImplicitAllowedTypes,
 	AllowedTypesFull,
 } from "./core/index.js";
-import { normalizeAllowedTypes } from "./core/index.js";
+import { AnnotatedAllowedTypesInternal, normalizeAllowedTypes } from "./core/index.js";
 
 import type { SimpleAllowedTypeAttributes, SimpleFieldSchema } from "./simpleSchema.js";
 import type { UnsafeUnknownSchema } from "./unsafeUnknownSchema.js";
@@ -413,16 +413,7 @@ export class FieldSchemaAlpha<
 	}
 
 	public get simpleAllowedTypes(): ReadonlyMap<string, SimpleAllowedTypeAttributes> {
-		const types = this.allowedTypesFull.evaluate().types;
-		const info = new Map<string, SimpleAllowedTypeAttributes>();
-
-		for (const type of types) {
-			info.set(type.type.identifier, {
-				isStaged: type.metadata.stagedSchemaUpgrade !== undefined,
-			});
-		}
-
-		return info;
+		return AnnotatedAllowedTypesInternal.evaluateSimpleAllowedTypes(this.allowedTypesFull);
 	}
 
 	protected constructor(

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -59,6 +59,8 @@ export {
 	type AllowedTypesFullFromMixed,
 	AnnotatedAllowedTypesInternal,
 	type NumberKeys,
+	ExpectStored,
+	createSchemaUpgrade,
 } from "./core/index.js";
 export { walkFieldSchema } from "./walkFieldSchema.js";
 export type { UnsafeUnknownSchema, Insertable } from "./unsafeUnknownSchema.js";

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -44,7 +44,7 @@ export {
 	type UnannotateAllowedTypesList,
 	type AllowedTypeMetadata,
 	type AnnotatedAllowedTypes,
-	type SchemaUpgrade,
+	SchemaUpgrade,
 	type LazyItem,
 	type FlexList,
 	type FlexListToUnion,

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
-import { LeafNodeStoredSchema, type TreeValue, ValueSchema } from "../core/index.js";
+import { type TreeValue, ValueSchema } from "../core/index.js";
 import {
 	type FlexTreeNode,
 	isFlexTreeNode,
@@ -64,7 +64,6 @@ export class LeafNodeSchema<Name extends string, const T extends ValueSchema>
 				): FlexContent => leafToFlexContent(data, this, allowedTypes),
 			})),
 		childAllowedTypes: [],
-		toStored: () => new LeafNodeStoredSchema(this.leafKind),
 	};
 	#initializedData: TreeNodeSchemaInitializedData | undefined;
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -45,7 +45,6 @@ import {
 	createTreeNodeSchemaPrivateData,
 	type FlexContent,
 	type TreeNodeSchemaPrivateData,
-	convertAllowedTypes,
 	withBufferedTreeEvents,
 	AnnotatedAllowedTypesInternal,
 } from "../../core/index.js";
@@ -68,7 +67,6 @@ import type {
 } from "./arrayNodeTypes.js";
 import { brand, type JsonCompatibleReadOnlyObject } from "../../../util/index.js";
 import { nullSchema } from "../../leafNodeSchema.js";
-import { arrayNodeStoredSchema } from "../../toStoredSchema.js";
 import type { SimpleAllowedTypeAttributes } from "../../simpleSchema.js";
 
 /**
@@ -1282,12 +1280,7 @@ export function arraySchema<
 		}
 
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-			return (privateData ??= createTreeNodeSchemaPrivateData(
-				this,
-				[normalizedTypes],
-				(storedOptions) =>
-					arrayNodeStoredSchema(convertAllowedTypes(info, storedOptions), persistedMetadata),
-			));
+			return (privateData ??= createTreeNodeSchemaPrivateData(this, [normalizedTypes]));
 		}
 	}
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -7,7 +7,6 @@ import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
-	FieldKinds,
 	isTreeValue,
 	type FlexibleNodeContent,
 	type FlexTreeNode,
@@ -42,7 +41,6 @@ import {
 	createTreeNodeSchemaPrivateData,
 	type FlexContent,
 	type TreeNodeSchemaPrivateData,
-	convertAllowedTypes,
 	AnnotatedAllowedTypesInternal,
 } from "../../core/index.js";
 import {
@@ -343,19 +341,7 @@ export function mapSchema<
 		}
 
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-			return (privateData ??= createTreeNodeSchemaPrivateData(
-				this,
-				[normalizedTypes],
-				(storedOptions) =>
-					new MapNodeStoredSchema(
-						{
-							kind: FieldKinds.optional.identifier,
-							types: convertAllowedTypes(info, storedOptions),
-							persistedMetadata,
-						},
-						persistedMetadata,
-					),
-			));
+			return (privateData ??= createTreeNodeSchemaPrivateData(this, [normalizedTypes]));
 		}
 	}
 	const schemaErased: MapNodeCustomizableSchema<

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -86,7 +86,7 @@ import {
 	type FactoryContentObject,
 	type InsertableContent,
 } from "../../unhydratedFlexTreeFromInsertable.js";
-import { convertField, convertFieldKind } from "../../toStoredSchema.js";
+import { convertFieldKind } from "../../toStoredSchema.js";
 import type { ObjectSchemaOptionsAlpha } from "../../api/index.js";
 
 /**
@@ -585,20 +585,6 @@ export function objectSchema<
 			return (privateData ??= createTreeNodeSchemaPrivateData(
 				this,
 				Array.from(CustomObjectNode.fields.values(), (schema) => schema.allowedTypesFull),
-				(storedOptions) => {
-					const fields: Map<FieldKey, TreeFieldStoredSchema> = new Map();
-					for (const fieldSchema of flexKeyMap.values()) {
-						assert(
-							fieldSchema.schema instanceof FieldSchemaAlpha,
-							0xc19 /* Expected FieldSchemaAlpha */,
-						);
-						fields.set(
-							brand(fieldSchema.storedKey),
-							convertField(fieldSchema.schema, storedOptions),
-						);
-					}
-					return new ObjectNodeStoredSchema(fields, nodeOptions.persistedMetadata);
-				},
 			));
 		}
 	}

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -31,7 +31,6 @@ import {
 	type FlexContent,
 	CompatibilityLevel,
 	type TreeNodeSchemaPrivateData,
-	convertAllowedTypes,
 	AnnotatedAllowedTypesInternal,
 } from "../../core/index.js";
 import { getTreeNodeSchemaInitializedData } from "../../createContext.js";
@@ -50,7 +49,6 @@ import type {
 	TreeRecordNode,
 } from "./recordNodeTypes.js";
 import {
-	FieldKinds,
 	isTreeValue,
 	type FlexTreeNode,
 	type FlexTreeOptionalField,
@@ -388,19 +386,7 @@ export function recordSchema<
 		}
 
 		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-			return (privateData ??= createTreeNodeSchemaPrivateData(
-				this,
-				[normalizedTypes],
-				(storedOptions) =>
-					new MapNodeStoredSchema(
-						{
-							kind: FieldKinds.optional.identifier,
-							types: convertAllowedTypes(info, storedOptions),
-							persistedMetadata,
-						},
-						persistedMetadata,
-					),
-			));
+			return (privateData ??= createTreeNodeSchemaPrivateData(this, [normalizedTypes]));
 		}
 	}
 

--- a/packages/dds/tree/src/simple-tree/simpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/simpleSchema.ts
@@ -193,6 +193,10 @@ export interface SimpleAllowedTypeAttributes {
 	 * New documents and schema upgrades will omit any staged schema.
 	 *
 	 * Undefined if derived from a stored schema.
+	 *
+	 * @privateRemarks
+	 * The false and undefined cases here are a bit odd.
+	 * This API should be reevaluated before stabilizing.
 	 */
 	readonly isStaged: false | SchemaUpgrade | undefined;
 }

--- a/packages/dds/tree/src/simple-tree/simpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/simpleSchema.ts
@@ -5,7 +5,7 @@
 
 import type { ValueSchema } from "../core/index.js";
 import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
-import type { NodeKind, SimpleNodeSchemaBase } from "./core/index.js";
+import type { NodeKind, SchemaUpgrade, SimpleNodeSchemaBase } from "./core/index.js";
 import type { FieldKind, FieldSchemaMetadata } from "./fieldSchema.js";
 
 /*
@@ -38,6 +38,15 @@ export interface SimpleNodeSchemaBaseAlpha<
 	 */
 	readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined;
 }
+
+/**
+ * {@link AllowedTypes} for a location in the tree, expressed for use in the Simple Schema layer of abstraction.
+ *
+ * @remarks
+ * Refers to the types by identifier.
+ * A {@link SimpleTreeSchema} is needed to resolve these identifiers to their schema {@link SimpleTreeSchema.definitions}.
+ */
+export type SimpleAllowedTypes = ReadonlyMap<string, SimpleAllowedTypeAttributes>;
 
 /**
  * A {@link SimpleNodeSchema} for an object node.
@@ -179,13 +188,13 @@ export type SimpleNodeSchema =
  */
 export interface SimpleAllowedTypeAttributes {
 	/**
-	 * True if this schema is included as a {@link SchemaStaticsBeta.staged | staged} schema upgrade,
+	 * {@link SchemaUpgrade} if this schema is included as a {@link SchemaStaticsBeta.staged | staged} schema upgrade,
 	 * allowing the view schema be compatible with stored schema with (post upgrade) or without it (pre-upgrade).
 	 * New documents and schema upgrades will omit any staged schema.
 	 *
 	 * Undefined if derived from a stored schema.
 	 */
-	readonly isStaged: boolean | undefined;
+	readonly isStaged: false | SchemaUpgrade | undefined;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/toStoredSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toStoredSchema.ts
@@ -143,7 +143,9 @@ export function toStoredSchema(
  * To correctly support view schema here, this would need to filter out unreferenced schema after excluding staged schema.
  * @see {@link ExpectStored}.
  */
-export function toSimpleStoredToStoredSchema(treeSchema: SimpleTreeSchema): TreeStoredSchema {
+export function simpleStoredSchemaToStoredSchema(
+	treeSchema: SimpleTreeSchema,
+): TreeStoredSchema {
 	const result: TreeStoredSchema = {
 		nodeSchema: transformMapValues(treeSchema.definitions, (schema) =>
 			getStoredSchema(schema, ExpectStored),

--- a/packages/dds/tree/src/simple-tree/toStoredSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toStoredSchema.ts
@@ -17,7 +17,6 @@ import {
 	type TreeNodeSchemaIdentifier,
 	type TreeNodeStoredSchema,
 	type TreeStoredSchema,
-	type TreeTypeSet,
 } from "../core/index.js";
 import { FieldKinds, type FlexFieldKind } from "../feature-libraries/index.js";
 import { brand, getOrCreate, type JsonCompatibleReadOnlyObject } from "../util/index.js";
@@ -25,23 +24,21 @@ import { brand, getOrCreate, type JsonCompatibleReadOnlyObject } from "../util/i
 import {
 	allowedTypeFilter,
 	convertAllowedTypes,
-	getTreeNodeSchemaPrivateData,
-	isClassBasedSchema,
 	NodeKind,
 	type SimpleNodeSchemaBase,
+	type StoredFromViewSchemaGenerationOptions,
 	type StoredSchemaGenerationOptions,
 } from "./core/index.js";
-import {
-	FieldKind,
-	FieldSchemaAlpha,
-	normalizeFieldSchema,
-	type ImplicitFieldSchema,
-} from "./fieldSchema.js";
-import type { SimpleFieldSchema, SimpleNodeSchema } from "./simpleSchema.js";
+import { FieldKind, normalizeFieldSchema, type ImplicitFieldSchema } from "./fieldSchema.js";
+import type {
+	SimpleAllowedTypes,
+	SimpleFieldSchema,
+	SimpleNodeSchema,
+} from "./simpleSchema.js";
 import { walkFieldSchema } from "./walkFieldSchema.js";
 
 const viewToStoredCache = new WeakMap<
-	StoredSchemaGenerationOptions,
+	StoredFromViewSchemaGenerationOptions,
 	WeakMap<ImplicitFieldSchema, TreeStoredSchema>
 >();
 
@@ -114,7 +111,11 @@ export function toStoredSchema(
 					),
 				);
 			},
-			allowedTypeFilter: (allowedType) => allowedTypeFilter(allowedType, options),
+			allowedTypeFilter: (allowedType) =>
+				allowedTypeFilter(
+					{ isStaged: allowedType.metadata.stagedSchemaUpgrade ?? false },
+					options,
+				),
 		});
 
 		const result: TreeStoredSchema = {
@@ -126,24 +127,15 @@ export function toStoredSchema(
 }
 
 /**
- * Normalizes an {@link ImplicitFieldSchema} into a {@link TreeFieldSchema}.
+ * Convert a {@link SimpleFieldSchema} into a {@link TreeFieldStoredSchema}.
  */
 export function convertField(
-	schema: SimpleFieldSchema | FieldSchemaAlpha,
+	schema: SimpleFieldSchema,
 	options: StoredSchemaGenerationOptions,
 ): TreeFieldStoredSchema {
 	const kind: FieldKindIdentifier =
 		convertFieldKind.get(schema.kind)?.identifier ?? fail(0xae3 /* Invalid field kind */);
-	let types: TreeTypeSet;
-	// eslint-disable-next-line unicorn/prefer-ternary
-	if (schema instanceof FieldSchemaAlpha) {
-		types = convertAllowedTypes(schema.allowedTypes, options);
-	} else {
-		const allowedTypesIdentifiers: ReadonlySet<string> = new Set(
-			schema.simpleAllowedTypes.keys(),
-		);
-		types = allowedTypesIdentifiers as TreeTypeSet;
-	}
+	const types = convertAllowedTypes(schema.simpleAllowedTypes, options);
 	return { kind, types, persistedMetadata: schema.persistedMetadata };
 }
 
@@ -168,9 +160,6 @@ export function getStoredSchema(
 	schema: SimpleNodeSchema,
 	options: StoredSchemaGenerationOptions,
 ): TreeNodeStoredSchema {
-	if (isClassBasedSchema(schema)) {
-		return getTreeNodeSchemaPrivateData(schema).toStored(options);
-	}
 	const kind = schema.kind;
 	switch (kind) {
 		case NodeKind.Leaf: {
@@ -178,10 +167,7 @@ export function getStoredSchema(
 		}
 		case NodeKind.Map:
 		case NodeKind.Record: {
-			const allowedTypesIdentifiers: ReadonlySet<string> = new Set(
-				schema.simpleAllowedTypes.keys(),
-			);
-			const types = allowedTypesIdentifiers as TreeTypeSet;
+			const types = convertAllowedTypes(schema.simpleAllowedTypes, options);
 			return new MapNodeStoredSchema(
 				{
 					kind: FieldKinds.optional.identifier,
@@ -193,11 +179,11 @@ export function getStoredSchema(
 			);
 		}
 		case NodeKind.Array: {
-			const allowedTypesIdentifiers: ReadonlySet<string> = new Set(
-				schema.simpleAllowedTypes.keys(),
+			return arrayNodeStoredSchema(
+				schema.simpleAllowedTypes,
+				options,
+				schema.persistedMetadata,
 			);
-			const types = allowedTypesIdentifiers as TreeTypeSet;
-			return arrayNodeStoredSchema(types, schema.persistedMetadata);
 		}
 		case NodeKind.Object: {
 			const fields: Map<FieldKey, TreeFieldStoredSchema> = new Map();
@@ -213,12 +199,13 @@ export function getStoredSchema(
 }
 
 export function arrayNodeStoredSchema(
-	types: TreeTypeSet,
+	schema: SimpleAllowedTypes,
+	options: StoredSchemaGenerationOptions,
 	persistedMetadata: JsonCompatibleReadOnlyObject | undefined,
 ): ObjectNodeStoredSchema {
 	const field = {
 		kind: FieldKinds.sequence.identifier,
-		types,
+		types: convertAllowedTypes(schema, options),
 		persistedMetadata,
 	};
 	const fields = new Map([[EmptyKey, field]]);

--- a/packages/dds/tree/src/test/simple-tree/api/getSimpleSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/getSimpleSchema.spec.ts
@@ -18,6 +18,8 @@ import {
 	type SimpleObjectNodeSchema,
 	type SimpleTreeSchema,
 } from "../../../simple-tree/index.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import { createSchemaUpgrade } from "../../../simple-tree/core/index.js";
 import { ValueSchema } from "../../../core/index.js";
 
 import {
@@ -584,7 +586,9 @@ describe("getSimpleSchema", () => {
 			const expected: SimpleTreeSchema = {
 				root: {
 					kind: FieldKind.Optional,
-					simpleAllowedTypes: new Map([[leafSchema.identifier, { isStaged: true }]]),
+					simpleAllowedTypes: new Map([
+						[leafSchema.identifier, { isStaged: createSchemaUpgrade() }],
+					]),
 					metadata: {},
 					persistedMetadata: undefined,
 				},

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFromSimple.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFromSimple.spec.ts
@@ -15,6 +15,7 @@ import {
 	type SimpleObjectNodeSchema,
 	isObjectNodeSchema,
 	SchemaFactoryAlpha,
+	SchemaUpgrade,
 } from "../../../simple-tree/index.js";
 import { exportSimpleSchema } from "../../../shared-tree/index.js";
 import { testTreeSchema } from "../../cursorTestSuite.js";
@@ -124,9 +125,9 @@ describe("schemaFromSimple", () => {
 			const simpleSchema = getSimpleSchema(root);
 			const rootField = simpleSchema.root;
 
-			assert.equal(
-				rootField.simpleAllowedTypes.get("com.fluidframework.leaf.string")?.isStaged,
-				true,
+			assert(
+				rootField.simpleAllowedTypes.get("com.fluidframework.leaf.string")?.isStaged instanceof
+					SchemaUpgrade,
 			);
 
 			assert.equal(
@@ -137,9 +138,9 @@ describe("schemaFromSimple", () => {
 			const viewSchema = generateSchemaFromSimpleSchema(simpleSchema);
 			const rootFieldView = viewSchema.root;
 
-			assert.equal(
-				rootFieldView.simpleAllowedTypes.get("com.fluidframework.leaf.string")?.isStaged,
-				true,
+			assert(
+				rootFieldView.simpleAllowedTypes.get("com.fluidframework.leaf.string")
+					?.isStaged instanceof SchemaUpgrade,
 			);
 
 			assert.equal(

--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -80,7 +80,7 @@ describe("toStoredSchema", () => {
 					) {
 						// If the document is relying on forwards compatibility options (staged schema or unknown optional fields),
 						// then we do not expect to be able to get the same stored schema as in the document by deriving a stored schema from the view schema.
-						// For cases just using staged schema, this does validate that the staged schema is being discarded due to restrictiveStoredSchemaGenerationOptions,
+						// For cases just using staged schema, this validates that the staged schema is being discarded due to restrictiveStoredSchemaGenerationOptions,
 						// but the main reason for this conditional is to avoid these cases breaking the "Matches document" case below.
 						it("Does not match document", () => {
 							const restrictive = toStoredSchema(
@@ -113,7 +113,7 @@ describe("toStoredSchema", () => {
 
 						// The restrictive case, used for initial schemas and upgrades, does not include any allowed types schema.
 						// The permissive case, used for unhydrated trees, includes all staged allowed types.
-						// They should be equal if an only iff there are no staged allowed types.
+						// They should be equal if an only if there are no staged allowed types.
 						if (testCase.hasStagedSchema) {
 							assert.notDeepEqual(restrictive, permissive);
 						} else {
@@ -124,10 +124,10 @@ describe("toStoredSchema", () => {
 							cursorForJsonableTreeField(testCase.treeFactory()),
 						);
 
-						// Our test case has a actual tree which is known to comply with its existing stored schema, and the test case's view schema.
+						// Our test case has an actual tree which is known to comply with its existing stored schema, and the test case's view schema.
 						// Therefore, the tree must be in schema for the permissive case, with the exception of any unknown optional fields.
 						// We can assert this here.
-						// This is a sanity check that the produced permissive schema actually allows the trees its supposed to.
+						// This is a sanity check that the produced permissive schema actually allows the trees it's supposed to.
 						// This could catch bugs where simple to stored to simple round trip is correct, but the corresponding stored schema is wrong.
 						isFieldInSchema(
 							tree,
@@ -158,7 +158,7 @@ describe("toStoredSchema", () => {
 								testCase.hasUnknownOptionalFields === true,
 						);
 
-						// These arn't the tests for "exportSimpleSchema", but toStored should work with them, so we can use them to check consistency and round trip.
+						// These aren't the tests for "exportSimpleSchema", but toStored should work with them, so we can use them to check consistency and round trip.
 						const simpleFromRestrictive = exportSimpleSchema(restrictive);
 						const simpleFromPermissive = exportSimpleSchema(permissive);
 

--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -111,7 +111,7 @@ describe("toStoredSchema", () => {
 							permissiveStoredSchemaGenerationOptions,
 						);
 
-						// The restrictive case, used for initial schemas and upgrades, does not include any allowed types schema.
+						// The restrictive case, used for initial schemas and upgrades, does not include any staged allowed types.
 						// The permissive case, used for unhydrated trees, includes all staged allowed types.
 						// They should be equal if an only if there are no staged allowed types.
 						if (testCase.hasStagedSchema) {

--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -176,8 +176,8 @@ describe("toStoredSchema", () => {
 
 						// To further ensure toStoredSchema works with the other schema transforming APIs,
 						// validate it with generateSchemaFromSimpleSchema to round trip through view schema.
-						// View schema generated from stored schema will never contain staged schema
-						// (they will either be already removed, or baked in with the fact they ere staged lost).
+						// View schema generated from stored schema will never contain staged schema:
+						// they will either have been removed, or baked in (with the fact they were staged having been lost).
 						const restrictive3 = toStoredSchema(
 							generateSchemaFromSimpleSchema(simpleFromRestrictive).root,
 							{

--- a/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
@@ -39,7 +39,6 @@ import {
 	type TreeNodeSchemaPrivateData,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../simple-tree/core/index.js";
-import { LeafNodeStoredSchema, ValueSchema } from "../../core/index.js";
 
 describe("TreeNodeValid", () => {
 	class MockFlexNode extends UnhydratedFlexTreeNode {
@@ -63,6 +62,7 @@ describe("TreeNodeValid", () => {
 			public static readonly metadata = {};
 			public static readonly info = numberSchema;
 			public static readonly implicitlyConstructable: false;
+			public static readonly simpleAllowedTypes = [];
 
 			public static override prepareInstance<T2>(
 				this: typeof TreeNodeValid<T2>,
@@ -104,11 +104,7 @@ describe("TreeNodeValid", () => {
 			}
 
 			public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-				return (privateData ??= createTreeNodeSchemaPrivateData(
-					this,
-					[],
-					() => new LeafNodeStoredSchema(ValueSchema.Null),
-				));
+				return (privateData ??= createTreeNodeSchemaPrivateData(this, []));
 			}
 
 			public constructor(input: number | InternalTreeNode) {
@@ -169,6 +165,7 @@ describe("TreeNodeValid", () => {
 			public static readonly info = numberSchema;
 			public static readonly implicitlyConstructable: false;
 			public static readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
+			public static readonly simpleAllowedTypes = [];
 
 			public static override buildRawNode<T2>(
 				this: typeof TreeNodeValid<T2>,
@@ -189,11 +186,7 @@ describe("TreeNodeValid", () => {
 			}
 
 			public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-				return (privateData ??= createTreeNodeSchemaPrivateData(
-					this,
-					[],
-					() => new LeafNodeStoredSchema(ValueSchema.Null),
-				));
+				return (privateData ??= createTreeNodeSchemaPrivateData(this, []));
 			}
 		}
 
@@ -234,6 +227,7 @@ describe("TreeNodeValid", () => {
 			public static readonly info = numberSchema;
 			public static readonly implicitlyConstructable: false;
 			public static readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
+			public static readonly simpleAllowedTypes = [];
 
 			public static override buildRawNode<T2>(
 				this: typeof TreeNodeValid<T2>,
@@ -262,11 +256,7 @@ describe("TreeNodeValid", () => {
 				return getTreeNodeSchemaInitializedData(this, handler);
 			}
 			public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
-				return (privateData ??= createTreeNodeSchemaPrivateData(
-					this,
-					[],
-					() => new LeafNodeStoredSchema(ValueSchema.Null),
-				));
+				return (privateData ??= createTreeNodeSchemaPrivateData(this, []));
 			}
 		}
 

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -91,9 +91,14 @@ interface TestTree {
  */
 export interface TestDocument extends TestTree, Omit<TestSimpleTree, "root"> {
 	/**
-	 * True if and only if the document had content in unknown optional fields.
+	 * True if and only if the document has content in unknown optional fields.
 	 */
 	readonly hasUnknownOptionalFields?: true;
+
+	/**
+	 * True if and only if the documents schema has unknown optional fields in the stored schema.
+	 */
+	readonly hasUnknownOptionalFieldSchema?: true;
 
 	/**
 	 * True if and only if the document had staged allowed types.
@@ -472,6 +477,7 @@ export const testDocuments: readonly TestDocument[] = [
 		ambiguous: false,
 		name: "AllowsUnknownOptionalFields",
 		schema: HasUnknownOptionalFields,
+		hasUnknownOptionalFieldSchema: true,
 		// Unknown optional fields are allowed but empty in this document.
 		policy: defaultSchemaPolicy,
 		schemaData: toInitialSchema(HasUnknownOptionalFieldsV2),
@@ -483,6 +489,7 @@ export const testDocuments: readonly TestDocument[] = [
 		name: "HasUnknownOptionalFields",
 		schema: HasUnknownOptionalFields,
 		hasUnknownOptionalFields: true,
+		hasUnknownOptionalFieldSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toInitialSchema(HasUnknownOptionalFieldsV2),
 		treeFactory: () =>

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1410,7 +1410,7 @@ export type SharedTreeOptionsBeta = ForestOptions;
 
 // @alpha @sealed
 export interface SimpleAllowedTypeAttributes {
-    readonly isStaged: boolean | undefined;
+    readonly isStaged: false | SchemaUpgrade | undefined;
 }
 
 // @alpha @sealed


### PR DESCRIPTION
## Description

The new alpha APIs for handling simple schema as stored schema did not work correctly for staged schema when the simple schema was not implemented by a full view schema. [AB#53901](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/53901)

Now that all the information needed to translate to stored schema is present on simple schema (Including the SchemUpgrade toke added in this change), it is possible to deduplicate the two code paths for simple schema to stored schema. This change does this deduplication, and also fixes the remaining code path to handle staged schema correctly.

Additionally, much more testing for this has been added.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
