### PR TITLE
Split out getConfigForMinVersionForCollab, add use of it in tree fixing 5 bugs

### DIFF
--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
@@ -5,6 +5,10 @@
 
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
+import {
+	getConfigForMinVersionForCollab,
+	lowestMinVersionForCollab,
+} from "@fluidframework/runtime-utils/internal";
 
 import {
 	type CodecTree,
@@ -31,9 +35,12 @@ import { brand } from "../../util/index.js";
 function clientVersionToDetachedFieldVersion(
 	clientVersion: MinimumVersionForCollab,
 ): DetachedFieldIndexFormatVersion {
-	return clientVersion < FluidClientVersion.v2_52
-		? brand(DetachedFieldIndexFormatVersion.v1)
-		: brand(DetachedFieldIndexFormatVersion.v2);
+	return brand(
+		getConfigForMinVersionForCollab(clientVersion, {
+			[lowestMinVersionForCollab]: DetachedFieldIndexFormatVersion.v1,
+			[FluidClientVersion.v2_52]: DetachedFieldIndexFormatVersion.v2,
+		}),
+	);
 }
 
 export function makeDetachedFieldIndexCodec(

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -5,6 +5,10 @@
 
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
+import {
+	getConfigForMinVersionForCollab,
+	lowestMinVersionForCollab,
+} from "@fluidframework/runtime-utils/internal";
 
 import {
 	type CodecTree,
@@ -133,9 +137,12 @@ export type FieldBatchCodec = IJsonCodec<
 function clientVersionToFieldBatchVersion(
 	clientVersion: MinimumVersionForCollab,
 ): FieldBatchFormatVersion {
-	return clientVersion < FluidClientVersion.v2_73
-		? brand(FieldBatchFormatVersion.v1)
-		: brand(FieldBatchFormatVersion.v2);
+	return brand(
+		getConfigForMinVersionForCollab(clientVersion, {
+			[lowestMinVersionForCollab]: FieldBatchFormatVersion.v1,
+			[FluidClientVersion.v2_73]: FieldBatchFormatVersion.v2,
+		}),
+	);
 }
 
 export function makeFieldBatchCodec(options: CodecWriteOptions): FieldBatchCodec {

--- a/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
@@ -4,6 +4,10 @@
  */
 
 import { fail, unreachableCase } from "@fluidframework/core-utils/internal";
+import {
+	getConfigForMinVersionForCollab,
+	lowestMinVersionForCollab,
+} from "@fluidframework/runtime-utils/internal";
 
 import {
 	type CodecTree,
@@ -40,9 +44,12 @@ import type { MinimumVersionForCollab } from "@fluidframework/runtime-definition
 export function clientVersionToSchemaVersion(
 	clientVersion: MinimumVersionForCollab,
 ): SchemaFormatVersion {
-	return clientVersion < FluidClientVersion.v2_43
-		? brand(SchemaFormatVersion.v1)
-		: brand(SchemaFormatVersion.v2);
+	return brand(
+		getConfigForMinVersionForCollab(clientVersion, {
+			[lowestMinVersionForCollab]: SchemaFormatVersion.v1,
+			[FluidClientVersion.v2_43]: SchemaFormatVersion.v2,
+		}),
+	);
 }
 
 export function getCodecTreeForSchemaFormat(

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -5,6 +5,10 @@
 
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import { unreachableCase } from "@fluidframework/core-utils/internal";
+import {
+	getConfigForMinVersionForCollab,
+	lowestMinVersionForCollab,
+} from "@fluidframework/runtime-utils/internal";
 
 import {
 	type CodecTree,
@@ -50,10 +54,13 @@ export function clientVersionToEditManagerFormatVersion(
 	clientVersion: MinimumVersionForCollab,
 	writeVersionOverride?: EditManagerFormatVersion,
 ): EditManagerFormatVersion {
-	const compatibleVersion: EditManagerFormatVersion =
-		clientVersion < FluidClientVersion.v2_43
-			? brand(EditManagerFormatVersion.v3)
-			: brand(EditManagerFormatVersion.v4);
+	const compatibleVersion: EditManagerFormatVersion = brand(
+		getConfigForMinVersionForCollab(clientVersion, {
+			[lowestMinVersionForCollab]: EditManagerFormatVersion.v3,
+			[FluidClientVersion.v2_43]: EditManagerFormatVersion.v4,
+		}),
+	);
+
 	return writeVersionOverride ?? compatibleVersion;
 }
 

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -6,6 +6,11 @@
 import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {
+	getConfigForMinVersionForCollab,
+	lowestMinVersionForCollab,
+} from "@fluidframework/runtime-utils/internal";
+
+import {
 	type CodecTree,
 	type CodecWriteOptions,
 	type DependentFormatVersion,
@@ -46,10 +51,12 @@ export function clientVersionToMessageFormatVersion(
 	clientVersion: MinimumVersionForCollab,
 	writeVersionOverride?: MessageFormatVersion,
 ): MessageFormatVersion {
-	const compatibleVersion: MessageFormatVersion =
-		clientVersion < FluidClientVersion.v2_43
-			? brand(MessageFormatVersion.v3)
-			: brand(MessageFormatVersion.v4);
+	const compatibleVersion: MessageFormatVersion = brand(
+		getConfigForMinVersionForCollab(clientVersion, {
+			[lowestMinVersionForCollab]: MessageFormatVersion.v3,
+			[FluidClientVersion.v2_43]: MessageFormatVersion.v4,
+		}),
+	);
 	return writeVersionOverride ?? compatibleVersion;
 }
 

--- a/packages/runtime/runtime-utils/src/compatibilityBase.ts
+++ b/packages/runtime/runtime-utils/src/compatibilityBase.ts
@@ -125,27 +125,44 @@ export function getConfigsForMinVersionForCollab<T extends Record<SemanticVersio
 	const defaultConfigs: Partial<T> = {};
 	// Iterate over configMap to get default values for each option.
 	for (const [key, config] of Object.entries(configMap)) {
-		const entries: [string, unknown][] = Object.entries(config); // Assigning this to a typed variable to convert the "any" into unknown.
-		// Validate and strongly type the versions from the configMap.
-		const versions: [MinimumVersionForCollab, unknown][] = entries.map(([version, value]) => {
-			validateMinimumVersionForCollab(version);
-			return [version, value];
-		});
-		// Sort the versions in descending order to find the largest compatible entry.
-		// TODO: Enforcing a sorted order might be a good idea. For now tolerates any order.
-		versions.sort((a, b) => compare(b[0], a[0]));
-		// For each config, we iterate over the keys and check if minVersionForCollab is greater than or equal to the version.
-		// If so, we set it as the default value for the option.
-		for (const [version, value] of versions) {
-			if (gte(minVersionForCollab, version)) {
-				defaultConfigs[key] = value;
-				break;
-			}
-		}
-		assert(key in defaultConfigs, "missing config map entry");
+		defaultConfigs[key] = getConfigForMinVersionForCollab(
+			minVersionForCollab,
+			config as ConfigMapEntry<unknown>,
+		);
 	}
-	// We have populated very key, so casting away the Partial is now safe:
+	// We have populated every key, so casting away the Partial is now safe:
 	return defaultConfigs as T;
+}
+
+/**
+ * Returns a default configuration given minVersionForCollab and {@link ConfigMapEntry}.
+ *
+ * @privateRemarks
+ * The extra `Record` type for the `configMap` is just used to allow the body of this function to be more type-safe due to limitations of generic types in TypeScript.
+ * It should have no impact on the user of this function.
+ * @internal
+ */
+export function getConfigForMinVersionForCollab<T>(
+	minVersionForCollab: MinimumVersionForCollab,
+	config: ConfigMapEntry<T>,
+): T {
+	const entries: [string, unknown][] = Object.entries(config); // Assigning this to a typed variable to convert the "any" into unknown.
+	// Validate and strongly type the versions from the configMap.
+	const versions: [MinimumVersionForCollab, unknown][] = entries.map(([version, value]) => {
+		validateMinimumVersionForCollab(version);
+		return [version, value];
+	});
+	// Sort the versions in descending order to find the largest compatible entry.
+	// TODO: Enforcing a sorted order might be a good idea. For now tolerates any order.
+	versions.sort((a, b) => compare(b[0], a[0]));
+	// For each config, we iterate over the keys and check if minVersionForCollab is greater than or equal to the version.
+	// If so, we set it as the default value for the option.
+	for (const [version, value] of versions) {
+		if (gte(minVersionForCollab, version)) {
+			return value as T;
+		}
+	}
+	fail("No config map entry for version");
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/compatibilityBase.ts
+++ b/packages/runtime/runtime-utils/src/compatibilityBase.ts
@@ -137,9 +137,6 @@ export function getConfigsForMinVersionForCollab<T extends Record<SemanticVersio
 /**
  * Returns a default configuration given minVersionForCollab and {@link ConfigMapEntry}.
  *
- * @privateRemarks
- * The extra `Record` type for the `configMap` is just used to allow the body of this function to be more type-safe due to limitations of generic types in TypeScript.
- * It should have no impact on the user of this function.
  * @internal
  */
 export function getConfigForMinVersionForCollab<T>(

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -65,6 +65,7 @@ export {
 	configValueToMinVersionForCollab,
 	defaultMinVersionForCollab,
 	validateConfigMapOverrides,
+	getConfigForMinVersionForCollab,
 	getConfigsForMinVersionForCollab,
 	isValidMinVersionForCollab,
 	validateMinimumVersionForCollab,

--- a/packages/runtime/runtime-utils/src/test/compatUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/compatUtils.spec.ts
@@ -19,12 +19,31 @@ import {
 	checkValidMinVersionForCollabVerbose,
 	cleanedPackageVersion,
 	validateMinimumVersionForCollab,
+	getConfigForMinVersionForCollab,
 } from "../compatibilityBase.js";
 import { pkgVersion } from "../packageVersion.js";
 
 describe("compatibilityBase", () => {
 	it("cleanedPackageVersion", () => {
 		validateMinimumVersionForCollab(cleanedPackageVersion);
+	});
+
+	// The getConfigsForMinVersionForCollab tests provide a lot of coverage for this function as well.
+	describe("getConfigForMinVersionForCollab", () => {
+		it("minimal", () => {
+			const config = getConfigForMinVersionForCollab("2.2.0", { "1.0.0": "X" });
+			assert.equal(config, "X");
+		});
+		it("sorting", () => {
+			// These checks are designed toi fail if the items are not sorted according to semver, and are either left as ordered or sorted lexically.
+			const config = { "1.0.0": "A", "1.500.0": "D", "1.58.0": "B", "1.60.0": "C" };
+			assert.equal(getConfigForMinVersionForCollab("1.50.0", config), "A");
+			assert.equal(getConfigForMinVersionForCollab("1.58.0", config), "B");
+			assert.equal(getConfigForMinVersionForCollab("1.59.0", config), "B");
+			assert.equal(getConfigForMinVersionForCollab("1.60.0", config), "C");
+			assert.equal(getConfigForMinVersionForCollab("1.400.0", config), "C");
+			assert.equal(getConfigForMinVersionForCollab("1.500.0", config), "D");
+		});
 	});
 
 	describe("getConfigsForMinVersionForCollab", () => {

--- a/packages/runtime/runtime-utils/src/test/compatUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/compatUtils.spec.ts
@@ -35,7 +35,7 @@ describe("compatibilityBase", () => {
 			assert.equal(config, "X");
 		});
 		it("sorting", () => {
-			// These checks are designed toi fail if the items are not sorted according to semver, and are either left as ordered or sorted lexically.
+			// These checks are designed to fail if the items are not sorted according to semver, and are either left as ordered or sorted lexically.
 			const config = { "1.0.0": "A", "1.500.0": "D", "1.58.0": "B", "1.60.0": "C" };
 			assert.equal(getConfigForMinVersionForCollab("1.50.0", config), "A");
 			assert.equal(getConfigForMinVersionForCollab("1.58.0", config), "B");


### PR DESCRIPTION
## Description

Expose getConfigForMinVersionForCollab.

Use it in tree fixing that clientVersionToDetachedFieldVersion and 4 other similar cases in tree codecs that did not compare version strings correctly (used lexical string ordering, which would put 2.6.0 ahead of 2.52.0, enabling the new format when it should be disabled.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
