### PR TITLE
Add unit tests for annotating a single multi-character segment 

### DIFF
--- a/packages/dds/merge-tree/src/test/client.walkSegments.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.walkSegments.spec.ts
@@ -5,6 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
+import type { ISegmentInternal } from "../mergeTreeNodes.js";
+
 import { TestClient } from "./testClient.js";
 
 describe("client.applyMsg", () => {
@@ -64,5 +66,31 @@ describe("client.applyMsg", () => {
 		);
 		assert.equal(segCount, 2);
 		assert.equal(segLen, 4);
+	});
+
+	it("Walk single multi-character segment", () => {
+		client.removeRangeLocal(0, client.getLength());
+		client.insertTextLocal(0, "Blocker");
+		client.annotateRangeLocal(0, 7, { bold: true });
+		let segCount = 0;
+		const segLengths: number[] = [];
+		client.walkSegments(
+			(s: ISegmentInternal) => {
+				segCount++;
+				segLengths.push(s.cachedLength);
+				return true;
+			},
+			0,
+			client.getLength(),
+			undefined,
+			true,
+		);
+		assert.equal(segCount, 1, `Expected one segment, saw ${segCount} segments`);
+		assert.equal(
+			segLengths.length,
+			1,
+			`Expected one segment length, saw ${segLengths.length} lengths`,
+		);
+		assert.equal(segLengths[0], 7, `Expected segment length 7, saw ${segLengths[0]}`);
 	});
 });

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -19,6 +19,7 @@ import {
 	reservedMarkerSimpleTypeKey,
 	reservedTileLabelsKey,
 	revertMergeTreeDeltaRevertibles,
+	type ISegmentInternal,
 } from "@fluidframework/merge-tree/internal";
 import {
 	MockContainerRuntimeFactory,
@@ -185,6 +186,35 @@ describe("SharedString", () => {
 					`Properties are not empty at position ${i}`,
 				);
 			}
+		});
+
+		it("can annotate single multi-character segment", () => {
+			sharedString.insertText(0, "Blocker");
+			sharedString.annotateRange(0, 7, { bold: true });
+			let segmentCount = 0;
+			const segmentLengths: number[] = [];
+			sharedString.walkSegments(
+				(segment: ISegmentInternal) => {
+					segmentCount++;
+					segmentLengths.push(segment.cachedLength);
+					return true;
+				},
+				0,
+				sharedString.getLength(),
+				undefined,
+				true,
+			);
+			assert.equal(segmentCount, 1, `Expected one segment, saw ${segmentCount} segments`);
+			assert.equal(
+				segmentLengths.length,
+				1,
+				`Expected one segment length, saw ${segmentLengths.length} lengths`,
+			);
+			assert.equal(
+				segmentLengths[0],
+				7,
+				`Expected segment length 7, saw ${segmentLengths[0]}`,
+			);
 		});
 
 		it("can insert marker", () => {
@@ -576,6 +606,56 @@ describe("SharedString", () => {
 					"Could not annotate props in remote string",
 				);
 			}
+		});
+
+		it("can annotate single multi-character segment", () => {
+			sharedString.insertText(0, "Blocker");
+			sharedString.annotateRange(0, 7, { bold: true });
+			containerRuntimeFactory.processAllMessages();
+
+			let segmentCount = 0;
+			const segmentLengths: number[] = [];
+			sharedString.walkSegments(
+				(segment: ISegmentInternal) => {
+					segmentCount++;
+					segmentLengths.push(segment.cachedLength);
+					return true;
+				},
+				0,
+				sharedString.getLength(),
+				undefined,
+				true,
+			);
+			assert.equal(segmentCount, 1, `Expected one segment, saw ${segmentCount} segments`);
+			assert.equal(
+				segmentLengths.length,
+				1,
+				`Expected one segment length, saw ${segmentLengths.length} lengths`,
+			);
+			assert.equal(
+				segmentLengths[0],
+				7,
+				`Expected segment length 7, saw ${segmentLengths[0]}`,
+			);
+
+			segmentCount = 0;
+			const segmentLengths2: number[] = [];
+			sharedString2.walkSegments((segment: ISegmentInternal) => {
+				segmentCount++;
+				segmentLengths2.push(segment.cachedLength);
+				return true;
+			});
+			assert.equal(segmentCount, 1, `Expected one segment, saw ${segmentCount} segments`);
+			assert.equal(
+				segmentLengths2.length,
+				1,
+				`Expected one segment length, saw ${segmentLengths2.length} lengths`,
+			);
+			assert.equal(
+				segmentLengths2[0],
+				7,
+				`Expected segment length 7, saw ${segmentLengths2[0]}`,
+			);
 		});
 
 		it("can insert marker", () => {

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -188,7 +188,7 @@ describe("SharedString", () => {
 			}
 		});
 
-		it("can annotate single multi-character segment", () => {
+		it("can annotate single multi-character segment in a local SharedString", () => {
 			sharedString.insertText(0, "Blocker");
 			sharedString.annotateRange(0, 7, { bold: true });
 			let segmentCount = 0;
@@ -608,7 +608,7 @@ describe("SharedString", () => {
 			}
 		});
 
-		it("can annotate single multi-character segment", () => {
+		it("can annotate single multi-character segment with a remote SharedString", () => {
 			sharedString.insertText(0, "Blocker");
 			sharedString.annotateRange(0, 7, { bold: true });
 			containerRuntimeFactory.processAllMessages();

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -640,11 +640,17 @@ describe("SharedString", () => {
 
 			segmentCount = 0;
 			const segmentLengths2: number[] = [];
-			sharedString2.walkSegments((segment: ISegmentInternal) => {
-				segmentCount++;
-				segmentLengths2.push(segment.cachedLength);
-				return true;
-			});
+			sharedString2.walkSegments(
+				(segment: ISegmentInternal) => {
+					segmentCount++;
+					segmentLengths2.push(segment.cachedLength);
+					return true;
+				},
+				0,
+				sharedString.getLength(),
+				undefined,
+				true,
+			);
 			assert.equal(segmentCount, 1, `Expected one segment, saw ${segmentCount} segments`);
 			assert.equal(
 				segmentLengths2.length,


### PR DESCRIPTION
Ensure that single segments with more than one character do not get split when the full range is annotated. 

[AB#51785](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/51785)