### PR TITLE
fix(gitrest): Remove object-sizeof in summary size checks

### DIFF
--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -73,7 +73,6 @@
 		"json-stringify-safe": "^5.0.1",
 		"memfs": "^3.4.12",
 		"nconf": "^0.11.4",
-		"object-sizeof": "^1.6.3",
 		"prettier": "~3.0.3",
 		"split": "^1.0.0",
 		"uuid": "^3.3.2",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -73,6 +73,7 @@
 		"json-stringify-safe": "^5.0.1",
 		"memfs": "^3.4.12",
 		"nconf": "^0.11.4",
+		"object-sizeof": "^2.6.5",
 		"prettier": "~3.0.3",
 		"split": "^1.0.0",
 		"uuid": "^3.3.2",

--- a/server/gitrest/packages/gitrest-base/src/test/gitManager.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/gitManager.spec.ts
@@ -11,7 +11,7 @@ import {
 	SystemErrors,
 } from "../utils";
 import { NullExternalStorageManager } from "../externalStorageManager";
-import sizeof from "object-sizeof";
+import { sizeof } from "../utils";
 
 /**
  * Get a string that cannot be compressed by zlib.

--- a/server/gitrest/packages/gitrest-base/src/test/helpers.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/helpers.spec.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import assert from "node:assert";
 import { sizeof } from "../utils";
 

--- a/server/gitrest/packages/gitrest-base/src/test/helpers.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/helpers.spec.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert";
+import { sizeof } from "../utils";
+
+describe("helpers", () => {
+	describe("sizeof", () => {
+		const data = "Hello, World!";
+		const dataSize = Buffer.byteLength(data, "utf8"); // 13 bytes
+
+		it("should return correct size for string", () => {
+			assert.strictEqual(sizeof(data), dataSize);
+		});
+		it("should return correct size for Buffer", () => {
+			const buffer = Buffer.from(data, "utf8");
+			assert.strictEqual(sizeof(buffer), dataSize);
+		});
+		it("should return correct size for ArrayBufferView", () => {
+			const uint8Array = new Uint8Array(Buffer.from(data, "utf8"));
+			assert.strictEqual(sizeof(uint8Array), dataSize);
+		});
+		it("should return correct size for Iterable string", () => {
+			function* iterator() {
+				for (const char of data) {
+					yield char;
+				}
+			}
+			const iterable = iterator();
+			assert.strictEqual(sizeof(iterable), dataSize);
+		});
+		it("should return correct size for Iterable ArrayBufferView", () => {
+			const uint8Array1 = new Uint8Array(Buffer.from(data.split(" ")[0], "utf8"));
+			const uint8Array2 = new Uint8Array(Buffer.from(data.split(" ")[1], "utf8"));
+			function* iterator() {
+				yield uint8Array1;
+				yield uint8Array2;
+			}
+			const iterable = iterator();
+			assert.strictEqual(sizeof(iterable), dataSize - 1); // space is 1 byte
+		});
+	});
+});

--- a/server/gitrest/packages/gitrest-base/src/utils/fileSystemBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/fileSystemBase.ts
@@ -8,10 +8,9 @@ import type { Mode, ObjectEncodingOptions, OpenMode, PathLike } from "node:fs";
 import type fsPromises from "node:fs/promises";
 import type { Stream } from "node:stream";
 
-import sizeof from "object-sizeof";
-
 import type { IFileSystemPromises } from "./definitions";
 import { filepathToString, FilesystemError, SystemErrors } from "./fileSystemHelper";
+import { sizeof } from "./helpers";
 
 export abstract class FsPromisesBase implements IFileSystemPromises {
 	public readonly promises?: IFileSystemPromises;

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type { PathLike, Stats, BigIntStats } from "fs";
-import * as path from "path";
+import type { PathLike, Stats, BigIntStats } from "node:fs";
+import * as path from "node:path";
+import { Stream } from "node:stream";
 
 import {
 	type IGetRefParamsExternal,
@@ -33,7 +34,6 @@ import {
 	BaseGitRestTelemetryProperties,
 	GitRestLumberEventName,
 } from "./gitrestTelemetryDefinitions";
-import { Stream } from "stream";
 
 /**
  * Validates that the input encoding is valid

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -385,7 +385,7 @@ export function sizeof(
 	if (ArrayBuffer.isView(data)) {
 		return data.byteLength;
 	}
-	if (data[Symbol.iterator] === "function") {
+	if (data[Symbol.iterator] !== undefined) {
 		let total = 0;
 		for (const item of data as Iterable<string | NodeJS.ArrayBufferView>) {
 			total += sizeof(item);
@@ -395,7 +395,7 @@ export function sizeof(
 	// AsyncIterables and Streams cannot be sized without consuming them.
 	// However, they are included in the function typing for compatibility with FS APIs.
 	// We do not currently use them in any size-limited write operations.
-	if (data[Symbol.asyncIterator] === "function") {
+	if (data[Symbol.asyncIterator] !== undefined) {
 		return -1; // Can't determine size of async iterable without consuming it.
 	}
 	return -1; // Unknown size (can't consume stream to determine size, or other unknown type).

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -54,6 +54,7 @@ export {
 	parseStorageRoutingId,
 	persistLatestFullSummaryInStorage,
 	retrieveLatestFullSummaryFromStorage,
+	sizeof,
 	validateBlobContent,
 	validateBlobEncoding,
 } from "./helpers";

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
@@ -5,7 +5,7 @@
 
 import { getRandomInt } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
-import { sizeof } from "../helpers";
+import sizeof from "object-sizeof";
 
 import type { ISystemError } from "../fileSystemHelper";
 

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
@@ -5,7 +5,7 @@
 
 import { getRandomInt } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
-import sizeof from "object-sizeof";
+import { sizeof } from "../helpers";
 
 import type { ISystemError } from "../fileSystemHelper";
 

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
@@ -7,7 +7,6 @@ import type * as git from "@fluidframework/gitresources";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { executeApiWithMetric } from "@fluidframework/server-services-utils";
-import { sizeof } from "./helpers";
 
 import type { IExternalWriterConfig, IRepositoryManager } from "./definitions";
 import {
@@ -15,6 +14,7 @@ import {
 	GitRestLumberEventName,
 	GitRestRepositoryApiCategory,
 } from "./gitrestTelemetryDefinitions";
+import { sizeof } from "./helpers";
 
 export interface IRepositoryManagerBaseOptions {
 	/**

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
@@ -7,7 +7,7 @@ import type * as git from "@fluidframework/gitresources";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { executeApiWithMetric } from "@fluidframework/server-services-utils";
-import sizeof from "object-sizeof";
+import { sizeof } from "./helpers";
 
 import type { IExternalWriterConfig, IRepositoryManager } from "./definitions";
 import {

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
         specifier: ^0.11.4
         version: 0.11.4
       object-sizeof:
-        specifier: ^1.6.3
-        version: 1.6.3
+        specifier: ^2.6.5
+        version: 2.6.5
       prettier:
         specifier: ~3.0.3
         version: 3.0.3
@@ -2038,9 +2038,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -4438,8 +4435,8 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  object-sizeof@1.6.3:
-    resolution: {integrity: sha512-LGtilAKuDGKCcvu1Xg3UvAhAeJJlFmblo3faltmOQ80xrGwAHxnauIXucalKdTEksHp/Pq9tZGz1hfyEmjFJPQ==}
+  object-sizeof@2.6.5:
+    resolution: {integrity: sha512-Mu3udRqIsKpneKjIEJ2U/s1KmEgpl+N6cEX1o+dDl2aZ+VW5piHqNgomqAk5YMsDoSkpcA8HnIKx1eqGTKzdfw==}
 
   object-treeify@4.0.1:
     resolution: {integrity: sha512-Y6tg5rHfsefSkfKujv2SwHulInROy/rCL5F4w0QOWxut8AnxYxf0YmNhTh95Zfyxpsudo66uqkux0ACFnyMSgQ==}
@@ -8662,11 +8659,6 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -11596,9 +11588,9 @@ snapshots:
 
   object-keys@1.1.1: {}
 
-  object-sizeof@1.6.3:
+  object-sizeof@2.6.5:
     dependencies:
-      buffer: 5.7.1
+      buffer: 6.0.3
 
   object-treeify@4.0.1: {}
 


### PR DESCRIPTION
## Description

This PR removes the use of `object-sizeof` from the summary size check flow.

## Context

The [object-sizeof](https://www.npmjs.com/package/object-sizeof) library has serious sizing inconsistencies, and has shown performance issues with large data sizes.

Using the current dependency version of object-sizeof (1.6), we can see a string of length 13 ("Hello, World!") shows up drastically different in a few scenarios:
```plaintext
Original string length: 13 // str.length
Sizeof original string: 26 bytes
Original buffer length: 13 // buffer.bytelength
Sizeof original buffer: 2186 bytes
Compressed string length: 21 // using Pako.deflate
Sizeof compressed string: 232 bytes
Compressed buffer length: 21 // using Pako.deflate
Sizeof compressed buffer: 232 bytes
```

Even after upgrading to object-sizeof v2.6, we can see some oddities
```plaintext
Original string length: 13 // str.length
Sizeof original string: 28 bytes
Original buffer length: 13 // buffer.bytelength
Sizeof original buffer: 13 bytes
Compressed string length: 21
Sizeof compressed string: 21 bytes
Compressed buffer length: 21
Sizeof compressed buffer: 21 bytes
```

Sizeof is known to do _some_ amount of internal multipliers to align sizes with ECMA storage values and memory allocation. For our use-case, we want storage-size, and we have the ability to use built-in size checks to achieve that.