### PR TITLE
(tree) Tag incremental summary APIs as @alpha

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -170,7 +170,7 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
 };
 
 // @alpha
-export function configuredSharedTreeAlpha(options: SharedTreeOptionsAlpha): ISharedObjectKind<ITree> & SharedObjectKind<ITree>;
+export function configuredSharedTreeAlpha(options: SharedTreeOptionsAlpha): SharedObjectKind<ITree>;
 
 // @beta
 export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
@@ -352,7 +352,7 @@ export namespace FluidSerializableAsTree {
     export type Data = JsonCompatible<IFluidHandle>;
     const // @system
     _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass_2<"com.fluidframework.serializable.object", NodeKind_2.Record, TreeRecordNodeUnsafe_2<readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>]> & WithType_2<"com.fluidframework.serializable.object", NodeKind_2.Record, unknown>, {
-    readonly [x: string]: string | number | IFluidHandle<unknown> | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | FluidSerializableObject | Array | null;
+    readonly [x: string]: string | number | IFluidHandle<unknown> | FluidSerializableObject | Array | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | null;
     }, false, readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>], undefined, unknown>;
     // @sealed
     export class FluidSerializableObject extends _APIExtractorWorkaroundObjectBase {
@@ -361,7 +361,7 @@ export namespace FluidSerializableAsTree {
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
     const // @system
     _APIExtractorWorkaroundArrayBase: TreeNodeSchemaClass_2<"com.fluidframework.serializable.array", NodeKind_2.Array, System_Unsafe_2.TreeArrayNodeUnsafe<readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>]> & WithType_2<"com.fluidframework.serializable.array", NodeKind_2.Array, unknown>, {
-    [Symbol.iterator](): Iterator<string | number | IFluidHandle<unknown> | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | FluidSerializableObject | Array | null, any, undefined>;
+    [Symbol.iterator](): Iterator<string | number | IFluidHandle<unknown> | FluidSerializableObject | Array | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | null, any, undefined>;
     }, false, readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>], undefined>;
     // (undocumented)
     export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;
@@ -566,7 +566,7 @@ export namespace JsonAsTree {
     }
     const // @system
     _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Record, TreeRecordNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Record, unknown>, {
-        readonly [x: string]: string | number | JsonObject | Array | System_Unsafe.InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
+        readonly [x: string]: string | number | System_Unsafe.InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined, unknown>;
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     // @system

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -169,6 +169,9 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
     [key: string]: ConciseTree<THandle>;
 };
 
+// @alpha
+export function configuredSharedTreeAlpha(options: SharedTreeOptionsAlpha): ISharedObjectKind<ITree> & SharedObjectKind<ITree>;
+
 // @beta
 export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
 
@@ -426,6 +429,15 @@ export type ImplicitFieldSchema = FieldSchema | ImplicitAllowedTypes;
 
 // @alpha
 export function importCompatibilitySchemaSnapshot(config: JsonCompatibleReadOnly): TreeViewConfiguration;
+
+// @alpha
+export type IncrementalEncodingPolicy = (nodeIdentifier: string | undefined, fieldKey: string) => boolean;
+
+// @alpha
+export function incrementalEncodingPolicyForAllowedTypes(rootSchema: TreeSchema): IncrementalEncodingPolicy;
+
+// @alpha
+export const incrementalSummaryHint: unique symbol;
 
 // @alpha
 export function independentInitializedView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & ICodecOptions, content: ViewContent): TreeViewAlpha<TSchema>;
@@ -1026,6 +1038,11 @@ export interface SharedTreeOptions extends Partial<CodecWriteOptions>, Partial<S
     readonly enableSharedBranches?: boolean;
 }
 
+// @alpha @input
+export interface SharedTreeOptionsAlpha extends SharedTreeOptionsBeta, SharedTreeFormatOptions {
+    shouldEncodeIncrementally?: IncrementalEncodingPolicy;
+}
+
 // @beta @input
 export type SharedTreeOptionsBeta = ForestOptions;
 
@@ -1475,6 +1492,7 @@ export interface TreeChangeEventsBeta<TNode extends TreeNode = TreeNode> extends
 // @alpha
 export enum TreeCompressionStrategy {
     Compressed = 0,
+    CompressedIncremental = 2,
     Uncompressed = 1
 }
 

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -566,7 +566,7 @@ export namespace JsonAsTree {
     }
     const // @system
     _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Record, TreeRecordNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Record, unknown>, {
-        readonly [x: string]: string | number | System_Unsafe.InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null;
+        readonly [x: string]: string | number | JsonObject | Array | System_Unsafe.InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined, unknown>;
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     // @system

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -170,7 +170,7 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
 };
 
 // @alpha
-export function configuredSharedTreeAlpha(options: SharedTreeOptionsAlpha): SharedObjectKind<ITree>;
+export function configuredSharedTreeAlpha(options: SharedTreeOptions): SharedObjectKind<ITree>;
 
 // @beta
 export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
@@ -1034,12 +1034,8 @@ export interface SharedTreeFormatOptions {
 }
 
 // @alpha @input
-export interface SharedTreeOptions extends Partial<CodecWriteOptions>, Partial<SharedTreeFormatOptions>, SharedTreeOptionsBeta {
+export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecWriteOptions>, Partial<SharedTreeFormatOptions> {
     readonly enableSharedBranches?: boolean;
-}
-
-// @alpha @input
-export interface SharedTreeOptionsAlpha extends SharedTreeOptionsBeta, SharedTreeFormatOptions {
     shouldEncodeIncrementally?: IncrementalEncodingPolicy;
 }
 

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -352,7 +352,7 @@ export namespace FluidSerializableAsTree {
     export type Data = JsonCompatible<IFluidHandle>;
     const // @system
     _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass_2<"com.fluidframework.serializable.object", NodeKind_2.Record, TreeRecordNodeUnsafe_2<readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>]> & WithType_2<"com.fluidframework.serializable.object", NodeKind_2.Record, unknown>, {
-    readonly [x: string]: string | number | IFluidHandle<unknown> | FluidSerializableObject | Array | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | null;
+    readonly [x: string]: string | number | IFluidHandle<unknown> | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | FluidSerializableObject | Array | null;
     }, false, readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>], undefined, unknown>;
     // @sealed
     export class FluidSerializableObject extends _APIExtractorWorkaroundObjectBase {
@@ -361,7 +361,7 @@ export namespace FluidSerializableAsTree {
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
     const // @system
     _APIExtractorWorkaroundArrayBase: TreeNodeSchemaClass_2<"com.fluidframework.serializable.array", NodeKind_2.Array, System_Unsafe_2.TreeArrayNodeUnsafe<readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>]> & WithType_2<"com.fluidframework.serializable.array", NodeKind_2.Array, unknown>, {
-    [Symbol.iterator](): Iterator<string | number | IFluidHandle<unknown> | FluidSerializableObject | Array | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | null, any, undefined>;
+    [Symbol.iterator](): Iterator<string | number | IFluidHandle<unknown> | System_Unsafe_2.InsertableTypedNodeUnsafe<LeafSchema_2<"boolean", boolean>, LeafSchema_2<"boolean", boolean>> | FluidSerializableObject | Array | null, any, undefined>;
     }, false, readonly [() => typeof FluidSerializableObject, () => typeof Array, LeafSchema_2<"string", string>, LeafSchema_2<"number", number>, LeafSchema_2<"boolean", boolean>, LeafSchema_2<"null", null>, LeafSchema_2<"handle", IFluidHandle<unknown>>], undefined>;
     // (undocumented)
     export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -29,11 +29,7 @@ import {
 	type Brand,
 	type JsonCompatibleReadOnly,
 } from "../../../util/index.js";
-import {
-	TreeCompressionStrategy,
-	TreeCompressionStrategyExtended,
-	type TreeCompressionStrategyPrivate,
-} from "../../treeCompressionUtils.js";
+import { TreeCompressionStrategy } from "../../treeCompressionUtils.js";
 
 import { decode } from "./chunkDecoding.js";
 import type { FieldBatch } from "./fieldBatch.js";
@@ -109,7 +105,7 @@ export interface IncrementalDecoder {
 export interface IncrementalEncoderDecoder extends IncrementalEncoder, IncrementalDecoder {}
 
 export interface FieldBatchEncodingContext {
-	readonly encodeType: TreeCompressionStrategyPrivate;
+	readonly encodeType: TreeCompressionStrategy;
 	readonly idCompressor: IIdCompressor;
 	readonly originatorId: SessionId;
 	readonly schema?: SchemaAndPolicy;
@@ -190,7 +186,7 @@ export function makeFieldBatchCodec(options: CodecWriteOptions): FieldBatchCodec
 				case TreeCompressionStrategy.Uncompressed:
 					encoded = uncompressedEncodeFn(data);
 					break;
-				case TreeCompressionStrategyExtended.CompressedIncremental:
+				case TreeCompressionStrategy.CompressedIncremental:
 					assert(
 						writeVersion >= FieldBatchFormatVersion.v2,
 						"Unsupported FieldBatchFormatVersion for incremental encoding; must be v2 or higher",

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/incrementalEncodingPolicy.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/incrementalEncodingPolicy.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { FieldKey, TreeNodeSchemaIdentifier } from "../../../core/index.js";
-
 /**
  * Policy to determine whether a node / field should be incrementally encoded.
  * @param nodeIdentifier - The identifier of the node containing the field.
@@ -16,18 +14,19 @@ import type { FieldKey, TreeNodeSchemaIdentifier } from "../../../core/index.js"
  * but allows reuse of previously encoded unchanged subtrees.
  * Thus it should only be enabled for large subtrees which are modified infrequently.
  * TODO: AB#9068: Measure the actual overhead.
+ * @alpha
  */
 export type IncrementalEncodingPolicy = (
-	nodeIdentifier: TreeNodeSchemaIdentifier | undefined,
-	fieldKey: FieldKey,
+	nodeIdentifier: string | undefined,
+	fieldKey: string,
 ) => boolean;
 
 /**
  * Default policy for incremental encoding is to not encode incrementally.
  */
 export const defaultIncrementalEncodingPolicy: IncrementalEncodingPolicy = (
-	nodeIdentifier: TreeNodeSchemaIdentifier | undefined,
-	fieldKey: FieldKey,
+	nodeIdentifier: string | undefined,
+	fieldKey: string,
 ): boolean => {
 	return false;
 };

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -48,7 +48,7 @@ import {
 	ForestIncrementalSummaryBuilder,
 	forestSummaryContentKey,
 } from "./incrementalSummaryBuilder.js";
-import { TreeCompressionStrategyExtended } from "../treeCompressionUtils.js";
+import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 /**
@@ -85,7 +85,7 @@ export class ForestSummarizer implements Summarizable {
 		this.codec = makeForestSummarizerCodec(options, fieldBatchCodec);
 		this.incrementalSummaryBuilder = new ForestIncrementalSummaryBuilder(
 			encoderContext.encodeType ===
-				TreeCompressionStrategyExtended.CompressedIncremental /* enableIncrementalSummary */,
+				TreeCompressionStrategy.CompressedIncremental /* enableIncrementalSummary */,
 			(cursor: ITreeCursorSynchronous) => this.forest.chunkField(cursor),
 			shouldEncodeIncrementally,
 			initialSequenceNumber,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -190,11 +190,7 @@ export {
 	type Observer,
 } from "./flex-tree/index.js";
 
-export {
-	TreeCompressionStrategy,
-	TreeCompressionStrategyExtended,
-	type TreeCompressionStrategyPrivate,
-} from "./treeCompressionUtils.js";
+export { TreeCompressionStrategy } from "./treeCompressionUtils.js";
 
 export { valueSchemaAllows } from "./valueUtilities.js";
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -40,10 +40,7 @@ import {
 	chunkFieldSingle,
 	defaultChunkPolicy,
 } from "../chunked-forest/index.js";
-import {
-	TreeCompressionStrategy,
-	type TreeCompressionStrategyPrivate,
-} from "../treeCompressionUtils.js";
+import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
 
 import type { FieldChangeEncodingContext, FieldChangeHandler } from "./fieldChangeHandler.js";
 import type {
@@ -81,7 +78,7 @@ export function makeModularChangeCodecFamily(
 	>,
 	fieldsCodec: FieldBatchCodec,
 	codecOptions: ICodecOptions,
-	chunkCompressionStrategy: TreeCompressionStrategyPrivate = TreeCompressionStrategy.Compressed,
+	chunkCompressionStrategy: TreeCompressionStrategy = TreeCompressionStrategy.Compressed,
 ): ICodecFamily<ModularChangeset, ChangeEncodingContext> {
 	return makeCodecFamily(
 		Array.from(fieldKindConfigurations.entries(), ([version, fieldKinds]) => [
@@ -121,7 +118,7 @@ function makeModularChangeCodec(
 	>,
 	fieldsCodec: FieldBatchCodec,
 	codecOptions: ICodecOptions,
-	chunkCompressionStrategy: TreeCompressionStrategyPrivate = TreeCompressionStrategy.Compressed,
+	chunkCompressionStrategy: TreeCompressionStrategy = TreeCompressionStrategy.Compressed,
 ): ModularChangeCodec {
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 	const getMapEntry = ({ kind, formatVersion }: FieldKindConfigurationEntry) => {

--- a/packages/dds/tree/src/feature-libraries/treeCompressionUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCompressionUtils.ts
@@ -20,23 +20,9 @@ export enum TreeCompressionStrategy {
 	 * Use this when debugging or testing and needing to inspect encoded tree content.
 	 */
 	Uncompressed = 1,
-}
-
-/**
- * A private extension of {@link TreeCompressionStrategy} for strategies that are not intended for public use just yet.
- */
-export enum TreeCompressionStrategyExtended {
 	/**
-	 * Optimized for encoded size, same as TreeCompressionStrategy.Compressed. It also enables incremental encoding
+	 * Optimized for encoded size, same as TreeCompressionStrategy.Compressed but it enables incremental encoding
 	 * of the data.
-	 * @remarks
-	 * TODO: AB#41865
-	 * This needs to be stabilized to allow opting into it.
-	 * It could possibly be made the default instead of {@link TreeCompressionStrategy.Compressed}.
 	 */
 	CompressedIncremental = 2,
 }
-
-export type TreeCompressionStrategyPrivate =
-	| TreeCompressionStrategy
-	| TreeCompressionStrategyExtended;

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -52,11 +52,13 @@ export {
 	type TreeIndex,
 	type TreeIndexKey,
 	type TreeIndexNodes,
+	type IncrementalEncodingPolicy,
 } from "./feature-libraries/index.js";
 
 export {
 	type ITreeInternal,
 	type SharedTreeOptions,
+	type SharedTreeOptionsAlpha,
 	type SharedTreeOptionsBeta,
 	type ForestType,
 	type SharedTreeFormatOptions,
@@ -287,10 +289,13 @@ export {
 	exportCompatibilitySchemaSnapshot,
 	importCompatibilitySchemaSnapshot,
 	checkCompatibility,
+	incrementalSummaryHint,
+	incrementalEncodingPolicyForAllowedTypes,
 } from "./simple-tree/index.js";
 export {
 	SharedTree,
 	configuredSharedTree,
+	configuredSharedTreeAlpha,
 	configuredSharedTreeBeta,
 	configuredSharedTreeBetaLegacy,
 } from "./treeFactory.js";

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -58,7 +58,6 @@ export {
 export {
 	type ITreeInternal,
 	type SharedTreeOptions,
-	type SharedTreeOptionsAlpha,
 	type SharedTreeOptionsBeta,
 	type ForestType,
 	type SharedTreeFormatOptions,

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -27,7 +27,7 @@ export {
 	type SummaryElementParser,
 	type SummaryElementStringifier,
 	type ClonableSchemaAndPolicy,
-	type SharedTreeCoreOptionsInternal as SharedTreCoreOptionsInternal,
+	type SharedTreeCoreOptionsInternal,
 } from "./sharedTreeCore.js";
 
 export type { ResubmitMachine } from "./resubmitMachine.js";

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -7,6 +7,7 @@ export {
 	type ITreePrivate,
 	type SharedTreeOptionsInternal,
 	type SharedTreeOptions,
+	type SharedTreeOptionsAlpha,
 	type SharedTreeOptionsBeta,
 	SharedTreeKernel,
 	getBranch,

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -7,7 +7,6 @@ export {
 	type ITreePrivate,
 	type SharedTreeOptionsInternal,
 	type SharedTreeOptions,
-	type SharedTreeOptionsAlpha,
 	type SharedTreeOptionsBeta,
 	SharedTreeKernel,
 	getBranch,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -74,7 +74,7 @@ import {
 	type ClonableSchemaAndPolicy,
 	getCodecTreeForEditManagerFormatWithChange,
 	getCodecTreeForMessageFormatWithChange,
-	type SharedTreCoreOptionsInternal,
+	type SharedTreeCoreOptionsInternal,
 	MessageFormatVersion,
 	SharedTreeCore,
 	EditManagerFormatVersion,
@@ -655,28 +655,19 @@ export function getCodecTreeForSharedTreeFormat(
 export type SharedTreeOptionsBeta = ForestOptions;
 
 /**
- * Configuration options for SharedTree.
+ * Configuration options for SharedTree with alpha features.
  * @alpha @input
  */
 export interface SharedTreeOptions
-	extends Partial<CodecWriteOptions>,
-		Partial<SharedTreeFormatOptions>,
-		SharedTreeOptionsBeta {
+	extends SharedTreeOptionsBeta,
+		Partial<CodecWriteOptions>,
+		Partial<SharedTreeFormatOptions> {
 	/**
 	 * Experimental feature flag to enable shared branches.
 	 * This feature is not yet complete and should not be used in production.
 	 * Defaults to false.
 	 */
 	readonly enableSharedBranches?: boolean;
-}
-
-/**
- * Configuration options for SharedTree with alpha features.
- * @alpha @input
- */
-export interface SharedTreeOptionsAlpha
-	extends SharedTreeOptionsBeta,
-		SharedTreeFormatOptions {
 	/**
 	 * Returns whether a node / field should be incrementally encoded.
 	 * @remarks
@@ -686,9 +677,8 @@ export interface SharedTreeOptionsAlpha
 }
 
 export interface SharedTreeOptionsInternal
-	extends Partial<SharedTreCoreOptionsInternal>,
-		Partial<ForestOptions>,
-		Partial<SharedTreeOptionsAlpha> {
+	extends Partial<SharedTreeOptions>,
+		Partial<SharedTreeCoreOptionsInternal> {
 	disposeForksAfterTransaction?: boolean;
 }
 
@@ -817,6 +807,7 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	shouldEncodeIncrementally: defaultIncrementalEncodingPolicy,
 	editManagerFormatSelector: clientVersionToEditManagerFormatVersion,
 	messageFormatSelector: clientVersionToMessageFormatVersion,
+	enableSharedBranches: false,
 };
 
 /**

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -64,7 +64,6 @@ import {
 	makeSchemaCodec,
 	makeTreeChunker,
 	type IncrementalEncodingPolicy,
-	type TreeCompressionStrategyPrivate,
 } from "../feature-libraries/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { FormatV1 } from "../feature-libraries/schema-index/index.js";
@@ -671,17 +670,26 @@ export interface SharedTreeOptions
 	readonly enableSharedBranches?: boolean;
 }
 
-export interface SharedTreeOptionsInternal
-	extends Partial<SharedTreCoreOptionsInternal>,
-		Partial<ForestOptions>,
-		Partial<SharedTreeFormatOptionsInternal> {
-	disposeForksAfterTransaction?: boolean;
+/**
+ * Configuration options for SharedTree with alpha features.
+ * @alpha @input
+ */
+export interface SharedTreeOptionsAlpha
+	extends SharedTreeOptionsBeta,
+		SharedTreeFormatOptions {
 	/**
 	 * Returns whether a node / field should be incrementally encoded.
 	 * @remarks
 	 * See {@link IncrementalEncodingPolicy}.
 	 */
 	shouldEncodeIncrementally?: IncrementalEncodingPolicy;
+}
+
+export interface SharedTreeOptionsInternal
+	extends Partial<SharedTreCoreOptionsInternal>,
+		Partial<ForestOptions>,
+		Partial<SharedTreeOptionsAlpha> {
+	disposeForksAfterTransaction?: boolean;
 }
 
 /**
@@ -705,11 +713,6 @@ export interface SharedTreeFormatOptions {
 	 * default: TreeCompressionStrategy.Compressed
 	 */
 	treeEncodeType: TreeCompressionStrategy;
-}
-
-export interface SharedTreeFormatOptionsInternal
-	extends Omit<SharedTreeFormatOptions, "treeEncodeType"> {
-	treeEncodeType: TreeCompressionStrategyPrivate;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -677,7 +677,7 @@ export interface SharedTreeOptions
 }
 
 export interface SharedTreeOptionsInternal
-	extends Partial<SharedTreeOptions>,
+	extends SharedTreeOptions,
 		Partial<SharedTreeCoreOptionsInternal> {
 	disposeForksAfterTransaction?: boolean;
 }

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -23,7 +23,7 @@ import {
 	ModularChangeFamily,
 	type ModularChangeset,
 	type TreeChunk,
-	type TreeCompressionStrategyPrivate,
+	type TreeCompressionStrategy,
 	fieldKindConfigurations,
 	fieldKinds,
 	makeModularChangeCodecFamily,
@@ -61,7 +61,7 @@ export class SharedTreeChangeFamily
 		revisionTagCodec: RevisionTagCodec,
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: CodecWriteOptions,
-		chunkCompressionStrategy?: TreeCompressionStrategyPrivate,
+		chunkCompressionStrategy?: TreeCompressionStrategy,
 		private readonly idCompressor?: IIdCompressor,
 	) {
 		const modularChangeCodec = makeModularChangeCodecFamily(

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -51,7 +51,7 @@ import {
 } from "../core/index.js";
 import {
 	type FieldBatchCodec,
-	type TreeCompressionStrategyPrivate,
+	type TreeCompressionStrategy,
 	allowsRepoSuperset,
 	buildForest,
 	createNodeIdentifierManager,
@@ -287,7 +287,7 @@ export function createTreeCheckout(
 		forest?: IEditableForest;
 		fieldBatchCodec?: FieldBatchCodec;
 		removedRoots?: DetachedFieldIndex;
-		chunkCompressionStrategy?: TreeCompressionStrategyPrivate;
+		chunkCompressionStrategy?: TreeCompressionStrategy;
 		logger?: ITelemetryLoggerExt;
 		breaker?: Breakable;
 		disposeForksAfterTransaction?: boolean;

--- a/packages/dds/tree/src/simple-tree/api/incrementalAllowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/api/incrementalAllowedTypes.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import type { FieldKey, TreeNodeSchemaIdentifier } from "../../core/index.js";
 import { getTreeNodeSchemaPrivateData, type AllowedTypesFull } from "../core/index.js";
 import { isObjectNodeSchema } from "../node-kinds/index.js";
 import type { TreeSchema } from "./configuration.js";
 import type { IncrementalEncodingPolicy } from "../../feature-libraries/index.js";
 import { oneFromIterable } from "../../util/index.js";
 import { assert } from "@fluidframework/core-utils/internal";
+import type { FieldKey } from "../../core/index.js";
 
 /**
- * A symbol when present in the {@link AnnotatedAllowedTypes.metadata.custom} property as true, opts in the allowed
+ * A symbol when present in the {@link AnnotatedAllowedTypes.metadata}'s `custom` property as true, opts in the allowed
  * types to incremental summary optimization.
  * These allowed types will be optimized during summary such that if they don't change across summaries,
  * they will not be encoded and their content will not be included in the summary that is uploaded to the service.
  * @remarks
- * See {@link getShouldIncrementallySummarizeAllowedTypes} for more details.
+ * See {@link incrementalEncodingPolicyForAllowedTypes} for more details.
  *
  * Use {@link SchemaStaticsBeta.types} to add this metadata to allowed types in a schema.
  * @example
@@ -29,6 +29,7 @@ import { assert } from "@fluidframework/core-utils/internal";
  *   }),
  * }) {}
  * ```
+ * @alpha
  */
 export const incrementalSummaryHint: unique symbol = Symbol("IncrementalSummaryHint");
 
@@ -44,31 +45,30 @@ function isIncrementalSummaryHintInAllowedTypes(allowedTypes: AllowedTypesFull):
 }
 
 /**
- * This helper function {@link getShouldIncrementallySummarizeAllowedTypes} can be used to generate a callback function
- * of type {@link IncrementalEncodingPolicy}.
- * This callback can be passed as the value for {@link SharedTreeOptionsInternal.shouldEncodeFieldIncrementally} parameter
+ * This helper function {@link incrementalEncodingPolicyForAllowedTypes} can be used to generate a callback function
+ * of type {@link IncrementalEncodingPolicy}. It determines if each {@link AllowedTypes} in a schema should be
+ * incrementally summarized.
+ * This callback can be passed as the value for {@link SharedTreeOptionsAlpha.shouldEncodeIncrementally} parameter
  * when creating the tree.
- * It will be called for each {@link AllowedTypes} in the schema to determine if it should be incrementally summarized.
  *
  * @param rootSchema - The schema for the root of the tree.
- * @returns A callback function of type {@link IncrementalEncodingPolicy} which can be used to determine if a field
- * should be incrementally summarized based on whether it is an allowed types with the
- * {@link incrementalAllowedTypesMetadata} metadata.
+ * @returns A callback function of type {@link IncrementalEncodingPolicy} which determines if allowed types should
+ * be incrementally summarized based on whether they have opted in via the {@link incrementalSummaryHint} metadata.
  *
  * @remarks
  * This only works for forest type {@link ForestTypeOptimized} and compression strategy
- * {@link TreeCompressionStrategyExtended.CompressedIncremental}.
+ * {@link TreeCompressionStrategy.CompressedIncremental}.
  *
- * The {@link incrementalAllowedTypesMetadata} will be replaced with a specialized metadata property once the
+ * @privateRemarks
+ * The {@link incrementalSummaryHint} will be replaced with a specialized metadata property once the
  * incremental summary feature and APIs are stabilized.
+ *
+ * @alpha
  */
-export function getShouldIncrementallySummarizeAllowedTypes(
+export function incrementalEncodingPolicyForAllowedTypes(
 	rootSchema: TreeSchema,
 ): IncrementalEncodingPolicy {
-	return (
-		targetNodeIdentifier: TreeNodeSchemaIdentifier | undefined,
-		targetFieldKey: FieldKey,
-	) => {
+	return (targetNodeIdentifier: string | undefined, targetFieldKey: string) => {
 		if (targetNodeIdentifier === undefined) {
 			// Root fields cannot be allowed types, so we don't incrementally summarize them.
 			return false;
@@ -85,7 +85,9 @@ export function getShouldIncrementallySummarizeAllowedTypes(
 		}
 
 		if (isObjectNodeSchema(targetNode)) {
-			const targetPropertyKey = targetNode.storedKeyToPropertyKey.get(targetFieldKey);
+			const targetPropertyKey = targetNode.storedKeyToPropertyKey.get(
+				targetFieldKey as FieldKey,
+			);
 			if (targetPropertyKey !== undefined) {
 				const fieldSchema = targetNode.fields.get(targetPropertyKey);
 				if (fieldSchema !== undefined) {

--- a/packages/dds/tree/src/simple-tree/api/incrementalAllowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/api/incrementalAllowedTypes.ts
@@ -48,7 +48,7 @@ function isIncrementalSummaryHintInAllowedTypes(allowedTypes: AllowedTypesFull):
  * This helper function {@link incrementalEncodingPolicyForAllowedTypes} can be used to generate a callback function
  * of type {@link IncrementalEncodingPolicy}. It determines if each {@link AllowedTypes} in a schema should be
  * incrementally summarized.
- * This callback can be passed as the value for {@link SharedTreeOptionsAlpha.shouldEncodeIncrementally} parameter
+ * This callback can be passed as the value for {@link SharedTreeOptions.shouldEncodeIncrementally} parameter
  * when creating the tree.
  *
  * @param rootSchema - The schema for the root of the tree.

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -164,7 +164,7 @@ export { generateSchemaFromSimpleSchema } from "./schemaFromSimple.js";
 export { toSimpleTreeSchema } from "./viewSchemaToSimpleSchema.js";
 export type { TreeChangeEvents } from "./treeChangeEvents.js";
 export {
-	getShouldIncrementallySummarizeAllowedTypes,
+	incrementalEncodingPolicyForAllowedTypes,
 	incrementalSummaryHint,
 } from "./incrementalAllowedTypes.js";
 export {

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -186,7 +186,7 @@ export {
 	KeyEncodingOptions,
 	type TreeParsingOptions,
 	incrementalSummaryHint,
-	getShouldIncrementallySummarizeAllowedTypes,
+	incrementalEncodingPolicyForAllowedTypes,
 	type SchemaFactory_base,
 } from "./api/index.js";
 export type {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -592,8 +592,8 @@ describe("chunkTree", () => {
 		});
 		it("incremental", () => {
 			const shouldEncodeIncrementally: IncrementalEncodingPolicy = (
-				nodeIdentifier: TreeNodeSchemaIdentifier | undefined,
-				fieldKey: FieldKey,
+				nodeIdentifier: string | undefined,
+				fieldKey: string,
 			) => {
 				if (nodeIdentifier === structValue.identifier && fieldKey === "x") {
 					return true;
@@ -671,8 +671,8 @@ describe("chunkTree", () => {
 		});
 		it("incrementalField", () => {
 			const shouldEncodeIncrementally: IncrementalEncodingPolicy = (
-				nodeIdentifier: TreeNodeSchemaIdentifier | undefined,
-				fieldKey: FieldKey,
+				nodeIdentifier: string | undefined,
+				fieldKey: string,
 			) => {
 				if (nodeIdentifier === structValue.identifier && fieldKey === "x") {
 					return true;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/codecs.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/codecs.spec.ts
@@ -15,7 +15,6 @@ import {
 } from "../../../../feature-libraries/chunked-forest/codec/index.js";
 import {
 	TreeCompressionStrategy,
-	TreeCompressionStrategyExtended,
 	cursorForJsonableTreeField,
 	jsonableTreeFromFieldCursor,
 } from "../../../../feature-libraries/index.js";
@@ -64,7 +63,7 @@ describe("makeFieldBatchCodec", () => {
 		});
 	});
 
-	describe("TreeCompressionStrategyExtended.CompressedIncremental", () => {
+	describe("TreeCompressionStrategy.CompressedIncremental", () => {
 		it("succeeds for minVersionForCollab FluidClientVersion.v2_73", () => {
 			const codec = makeFieldBatchCodec({
 				jsonValidator: ajvValidator,
@@ -73,7 +72,7 @@ describe("makeFieldBatchCodec", () => {
 
 			const input = cursorForJsonableTreeField([simpleTestData]);
 			const context = {
-				encodeType: TreeCompressionStrategyExtended.CompressedIncremental,
+				encodeType: TreeCompressionStrategy.CompressedIncremental,
 				originatorId: testIdCompressor.localSessionId,
 				idCompressor: testIdCompressor,
 			};
@@ -89,7 +88,7 @@ describe("makeFieldBatchCodec", () => {
 
 			const input = cursorForJsonableTreeField([simpleTestData]);
 			const context = {
-				encodeType: TreeCompressionStrategyExtended.CompressedIncremental,
+				encodeType: TreeCompressionStrategy.CompressedIncremental,
 				originatorId: testIdCompressor.localSessionId,
 				idCompressor: testIdCompressor,
 			};

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert, fail } from "node:assert";
 
 import type {
-	FieldKey,
 	ITreeCursorSynchronous,
 	TreeChunk,
 	TreeFieldStoredSchema,
@@ -353,8 +352,8 @@ describe("schemaBasedEncoding", () => {
 			const testReferenceId: ChunkReferenceId = brand(123);
 			const mockIncrementalEncoder: IncrementalEncoder = {
 				shouldEncodeIncrementally: (
-					nodeIdentifier: TreeNodeSchemaIdentifier | undefined,
-					fieldKey: FieldKey,
+					nodeIdentifier: string | undefined,
+					fieldKey: string,
 				): boolean => {
 					return (
 						nodeIdentifier === HasOptionalFields.identifier && fieldKey === "incrementalField"

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -20,6 +20,7 @@ import {
 	SharedTreeKernel,
 	type ITreePrivate,
 	type SharedTreeOptions,
+	type SharedTreeOptionsAlpha,
 	type SharedTreeOptionsBeta,
 	type SharedTreeOptionsInternal,
 	type SharedTreeKernelView,
@@ -146,6 +147,16 @@ export function configuredSharedTreeBetaLegacy(
 	options: SharedTreeOptionsBeta,
 ): ISharedObjectKind<ITree> & SharedObjectKind<ITree> {
 	return configuredSharedTree(options);
+}
+
+/**
+ * {@link configuredSharedTreeBeta} but including {@link SharedTreeOptionsAlpha} options.
+ * @alpha
+ */
+export function configuredSharedTreeAlpha(
+	options: SharedTreeOptionsAlpha,
+): ISharedObjectKind<ITree> & SharedObjectKind<ITree> {
+	return configuredSharedTreeInternal(options);
 }
 
 /**

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -20,7 +20,6 @@ import {
 	SharedTreeKernel,
 	type ITreePrivate,
 	type SharedTreeOptions,
-	type SharedTreeOptionsAlpha,
 	type SharedTreeOptionsBeta,
 	type SharedTreeOptionsInternal,
 	type SharedTreeKernelView,
@@ -150,11 +149,11 @@ export function configuredSharedTreeBetaLegacy(
 }
 
 /**
- * {@link configuredSharedTreeBeta} but including {@link SharedTreeOptionsAlpha} options.
+ * {@link configuredSharedTreeBeta} but including the alpha {@link SharedTreeOptions}.
  * @alpha
  */
 export function configuredSharedTreeAlpha(
-	options: SharedTreeOptionsAlpha,
+	options: SharedTreeOptions,
 ): SharedObjectKind<ITree> {
 	return configuredSharedTreeInternal(options);
 }
@@ -206,10 +205,9 @@ export function resolveOptions(options: SharedTreeOptions): SharedTreeOptionsInt
 	const internal: SharedTreeOptionsInternal = {
 		...resolveSharedBranchesOptions(options.enableSharedBranches),
 	};
-	copyProperty(options, "forest", internal);
-	copyProperty(options, "jsonValidator", internal);
-	copyProperty(options, "minVersionForCollab", internal);
-	copyProperty(options, "treeEncodeType", internal);
+	for (const optionName of Object.keys(options)) {
+		copyProperty(options, optionName, internal);
+	}
 	return internal;
 }
 

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -155,7 +155,7 @@ export function configuredSharedTreeBetaLegacy(
  */
 export function configuredSharedTreeAlpha(
 	options: SharedTreeOptionsAlpha,
-): ISharedObjectKind<ITree> & SharedObjectKind<ITree> {
+): SharedObjectKind<ITree> {
 	return configuredSharedTreeInternal(options);
 }
 

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -155,7 +155,7 @@ export function configuredSharedTreeBetaLegacy(
 export function configuredSharedTreeAlpha(
 	options: SharedTreeOptions,
 ): SharedObjectKind<ITree> {
-	return configuredSharedTreeInternal(options);
+	return configuredSharedTree(options);
 }
 
 /**

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -179,6 +179,9 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
 // @alpha
 export function configuredSharedTree(options: SharedTreeOptions): SharedObjectKind<ITree>;
 
+// @alpha
+export function configuredSharedTreeAlpha(options: SharedTreeOptionsAlpha): SharedObjectKind<ITree>;
+
 // @beta
 export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
 
@@ -740,6 +743,15 @@ export type ImplicitFieldSchema = FieldSchema | ImplicitAllowedTypes;
 
 // @alpha
 export function importCompatibilitySchemaSnapshot(config: JsonCompatibleReadOnly): TreeViewConfiguration;
+
+// @alpha
+export type IncrementalEncodingPolicy = (nodeIdentifier: string | undefined, fieldKey: string) => boolean;
+
+// @alpha
+export function incrementalEncodingPolicyForAllowedTypes(rootSchema: TreeSchema): IncrementalEncodingPolicy;
+
+// @alpha
+export const incrementalSummaryHint: unique symbol;
 
 // @alpha
 export function independentInitializedView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & ICodecOptions, content: ViewContent): TreeViewAlpha<TSchema>;
@@ -1405,6 +1417,11 @@ export interface SharedTreeOptions extends Partial<CodecWriteOptions>, Partial<S
     readonly enableSharedBranches?: boolean;
 }
 
+// @alpha @input
+export interface SharedTreeOptionsAlpha extends SharedTreeOptionsBeta, SharedTreeFormatOptions {
+    shouldEncodeIncrementally?: IncrementalEncodingPolicy;
+}
+
 // @beta @input
 export type SharedTreeOptionsBeta = ForestOptions;
 
@@ -1868,6 +1885,7 @@ export interface TreeChangeEventsBeta<TNode extends TreeNode = TreeNode> extends
 // @alpha
 export enum TreeCompressionStrategy {
     Compressed = 0,
+    CompressedIncremental = 2,
     Uncompressed = 1
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -180,7 +180,7 @@ export type ConciseTree<THandle = IFluidHandle> = Exclude<TreeLeafValue, IFluidH
 export function configuredSharedTree(options: SharedTreeOptions): SharedObjectKind<ITree>;
 
 // @alpha
-export function configuredSharedTreeAlpha(options: SharedTreeOptionsAlpha): SharedObjectKind<ITree>;
+export function configuredSharedTreeAlpha(options: SharedTreeOptions): SharedObjectKind<ITree>;
 
 // @beta
 export function configuredSharedTreeBeta(options: SharedTreeOptionsBeta): SharedObjectKind<ITree>;
@@ -1413,12 +1413,8 @@ export interface SharedTreeFormatOptions {
 }
 
 // @alpha @input
-export interface SharedTreeOptions extends Partial<CodecWriteOptions>, Partial<SharedTreeFormatOptions>, SharedTreeOptionsBeta {
+export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecWriteOptions>, Partial<SharedTreeFormatOptions> {
     readonly enableSharedBranches?: boolean;
-}
-
-// @alpha @input
-export interface SharedTreeOptionsAlpha extends SharedTreeOptionsBeta, SharedTreeFormatOptions {
     shouldEncodeIncrementally?: IncrementalEncodingPolicy;
 }
 


### PR DESCRIPTION
The APIs neede to enable incremental summary have been tagged as @ alpha so that they can be used by applications.
The list of APIs that are marked @ alpha:
- `configuredSharedTreeAlpha` - This is a new API which is similar to `configuredSharedTreeBeta` but has a couple more options exposed for configuring incremental summaries.
- `SharedTreeOptionsAlpha` - Extension of `SharedTreeOptionsBeta` that includes options to enable incremental summarization.
- `IncrementalEncodingPolicy` - Policy type to determine whether a node / field should be incrementally encoded.
- `incrementalEncodingPolicyForAllowedTypes` - This function returns an `IncrementalEncodingPolicy` which will determine if `AllowedTypes` are opted into incremental summarization.
- `incrementalSummaryHint` - This is a symbol that should be put in the metadata property of `AllowedTypes` to opt-in these types to be incrementally summarized.

[AB#54252](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/54252)
[AB#46028](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/46028)