### PR TITLE
fix(eslint-plugin-fluid): Fix false-positives in `no-markdown-links-in-jsdoc`

### DIFF
--- a/common/build/eslint-plugin-fluid/CHANGELOG.md
+++ b/common/build/eslint-plugin-fluid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @fluidframework/eslint-plugin-fluid Changelog
 
+## [0.4.1](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.4.1)
+
+Fixes false positives in the following rules:
+
+- `@fluid-internal/fluid/no-hyphen-after-jsdoc-tag`
+- `@fluid-internal/fluid/no-markdown-links-in-jsdoc`
+
 ## [0.4.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.4.0)
 
 Updates plugin to be compatible with both ESLint 8 and ESLint 9.

--- a/common/build/eslint-plugin-fluid/package.json
+++ b/common/build/eslint-plugin-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/eslint-plugin-fluid",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Custom ESLint rules for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -46,9 +46,11 @@ function findMarkdownLinksInPlainText(plainTextNode) {
  * @returns {MarkdownLinkInfo[]} The list of found Markdown links.
  */
 function findMarkdownLinks(commentBodyNode) {
-	// Walk down first node of the tree until we find a leaf.
-	// If it's plain text, and starts with a hyphen, return true.
-	// Otherwise, return false.
+	// Walk down all children to find all plain text nodes.
+	// Search those nodes for Markdown links.
+	// We only search plain text because we want to ignore link syntax that may appear in other
+	// contexts like code spans / code blocks where they would not be interpreted as links, and
+	// where they may exist to serve as examples, etc.
 	if (commentBodyNode.kind === DocNodeKind.PlainText) {
 		return findMarkdownLinksInPlainText(/** @type {DocPlainText} */ (commentBodyNode));
 	}

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -122,7 +122,8 @@ const rule = {
 					}
 
 					/**
-					 * @param {DocNode} node
+					 * Checks the provided comment block for Markdown-syntax links and report eslint errors for them.
+					 * @param {DocNode} node - The comment block to check.
 					 * @returns {void}
 					 */
 					function checkCommentBlock(node) {

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -31,6 +31,13 @@ function findMarkdownLinksInPlainText(plainTextNode) {
 	const textRange =
 		plainTextNode.textExcerpt?.getContainingTextRange() ??
 		fail("Expected textExcerpt to be defined.");
+	// RegEx explanation:
+	// \[        - Match the opening square bracket
+	// ([^\]]+)  - Capture group 1: Match one or more characters that are not a closing square bracket (the link text)
+	// \]        - Match the closing square bracket
+	// \(        - Match the opening parenthesis
+	// ([^)]+)   - Capture group 2: Match one or more characters that are not a closing parenthesis (the link target)
+	// \)        - Match the closing parenthesis
 	const matches = plainTextNode.text.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);
 	return Array.from(matches, (match) => ({
 		linkText: match[1],

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -23,9 +23,9 @@ const { DocNodeKind, TSDocParser } = require("@microsoft/tsdoc");
 const parser = new TSDocParser();
 
 /**
- * Checks if a comment text starts with a hyphen.
+ * Finds instances of Markdown-syntax links within the provided plain text.
  * @param {DocPlainText} plainTextNode - The plain text node to check.
- * @returns {MarkdownLinkInfo[]}
+ * @returns {MarkdownLinkInfo[]} The list of found Markdown links.
  */
 function findMarkdownLinksInPlainText(plainTextNode) {
 	const textRange =
@@ -41,9 +41,9 @@ function findMarkdownLinksInPlainText(plainTextNode) {
 }
 
 /**
- * Checks if a comment body starts with a hyphen.
+ * Finds instances of Markdown-syntax links within the provided comment body.
  * @param { DocNode } commentBodyNode - The doc node representing the body of the comment.
- * @returns {MarkdownLinkInfo[]}
+ * @returns {MarkdownLinkInfo[]} The list of found Markdown links.
  */
 function findMarkdownLinks(commentBodyNode) {
 	// Walk down first node of the tree until we find a leaf.
@@ -63,7 +63,9 @@ function findMarkdownLinks(commentBodyNode) {
 }
 
 /**
- * JSDoc/TSDoc tags do not require a hyphen after them.
+ * Eslint rule to disallow Markdown link syntax in JSDoc/TSDoc comments.
+ * `{@link}` syntax should be used instead.
+ *
  * @type {RuleModule}
  */
 const rule = {

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -3,8 +3,70 @@
  * Licensed under the MIT License.
  */
 
-// eslint-plugin-no-markdown-comments/lib/rules/no-markdown-links-in-comments.js
-module.exports = {
+//@ts-check
+/**
+ * @typedef {import("eslint").Rule.RuleModule} RuleModule
+ * @typedef {import('@microsoft/tsdoc').DocNode} DocNode
+ * @typedef {import('@microsoft/tsdoc').DocPlainText} DocPlainText
+ *
+ * @typedef {{
+ * 	linkText: string;
+ * 	linkTarget: string;
+ * 	startIndex: number;
+ * 	endIndex: number;
+ * }} MarkdownLinkInfo
+ */
+
+const { fail } = require("node:assert");
+const { DocNodeKind, TSDocParser } = require("@microsoft/tsdoc");
+
+const parser = new TSDocParser();
+
+/**
+ * Checks if a comment text starts with a hyphen.
+ * @param {DocPlainText} plainTextNode - The plain text node to check.
+ * @returns {MarkdownLinkInfo[]}
+ */
+function findMarkdownLinksInPlainText(plainTextNode) {
+	const textRange =
+		plainTextNode.textExcerpt?.getContainingTextRange() ??
+		fail("Expected textExcerpt to be defined.");
+	const matches = plainTextNode.text.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);
+	return Array.from(matches, (match) => ({
+		linkText: match[1],
+		linkTarget: match[2],
+		startIndex: textRange.pos + match.index,
+		endIndex: textRange.pos + match.index + match[0].length,
+	}));
+}
+
+/**
+ * Checks if a comment body starts with a hyphen.
+ * @param { DocNode } commentBodyNode - The doc node representing the body of the comment.
+ * @returns {MarkdownLinkInfo[]}
+ */
+function findMarkdownLinks(commentBodyNode) {
+	// Walk down first node of the tree until we find a leaf.
+	// If it's plain text, and starts with a hyphen, return true.
+	// Otherwise, return false.
+	if (commentBodyNode.kind === DocNodeKind.PlainText) {
+		return findMarkdownLinksInPlainText(/** @type {DocPlainText} */ (commentBodyNode));
+	}
+
+	const childNodes = commentBodyNode.getChildNodes();
+
+	const links = [];
+	for (const childNode of childNodes) {
+		links.push(...findMarkdownLinks(childNode));
+	}
+	return links;
+}
+
+/**
+ * JSDoc/TSDoc tags do not require a hyphen after them.
+ * @type {RuleModule}
+ */
+const rule = {
 	meta: {
 		type: "problem",
 		docs: {
@@ -32,33 +94,70 @@ module.exports = {
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
-					// +2 for the leading "/*", which is omitted by `comment.value`, but included in `comment.range`.
-					const commentStartIndex = comment.range[0] + 2;
+					if (comment.range === undefined) {
+						continue;
+					}
 
-					const matches = comment.value.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);
-					for (const match of matches) {
-						const [fullMatch, text, url] = match;
+					const commentStartIndex = comment.range[0];
 
-						const startIndex = commentStartIndex + match.index;
-						const endIndex = startIndex + fullMatch.length;
+					// TSDoc parser requires the surrounding "/**" and "*/", but eslint strips those off in `comment.value`.
+					const parserContext = parser.parseString(`/**${comment.value}*/`);
+					const parsedComment = parserContext.docComment;
 
-						context.report({
-							loc: {
-								start: sourceCode.getLocFromIndex(startIndex),
-								end: sourceCode.getLocFromIndex(endIndex),
-							},
-							messageId: "markdownLink",
-							fix(fixer) {
-								const trimmedText = text?.trim();
+					const blocksToCheck = [
+						...parsedComment.customBlocks,
+						...parsedComment.seeBlocks,
+					];
+					if (parsedComment.remarksBlock) {
+						blocksToCheck.push(parsedComment.remarksBlock);
+					}
+					if (parsedComment.privateRemarks) {
+						blocksToCheck.push(parsedComment.privateRemarks);
+					}
+					if (parsedComment.deprecatedBlock) {
+						blocksToCheck.push(parsedComment.deprecatedBlock);
+					}
+					if (parsedComment.returnsBlock) {
+						blocksToCheck.push(parsedComment.returnsBlock);
+					}
+
+					/**
+					 * @param {DocNode} node
+					 * @returns {void}
+					 */
+					function checkCommentBlock(node) {
+						const links = findMarkdownLinks(node);
+						for (const link of links) {
+							const startIndex = commentStartIndex + link.startIndex - 1;
+							const endIndex = commentStartIndex + link.endIndex - 1;
+
+							context.report({
+								loc: {
+									start: sourceCode.getLocFromIndex(startIndex),
+									end: sourceCode.getLocFromIndex(endIndex),
+								},
+								messageId: "markdownLink",
+								fix(fixer) {
+								const trimmedText = link.linkText.trim();
 								const tsdocLink = trimmedText
-									? `{@link ${url} | ${trimmedText}}`
-									: `{@link ${url}}`;
+									? `{@link ${link.linkTarget} | ${trimmedText}}`
+									: `{@link ${link.linkTarget}}`;
 								return fixer.replaceTextRange([startIndex, endIndex], tsdocLink);
 							},
-						});
+							});
+						}
+					}
+
+					// Note: the TSDoc format makes it difficult to extract the range information for the block content specifically.
+					// Instead, we just report the range for the tag itself.
+					checkCommentBlock(parsedComment.summarySection);
+					for (const block of blocksToCheck) {
+						checkCommentBlock(block.content);
 					}
 				}
 			},
 		};
 	},
 };
+
+module.exports = rule;

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -141,12 +141,15 @@ const rule = {
 								},
 								messageId: "markdownLink",
 								fix(fixer) {
-								const trimmedText = link.linkText.trim();
-								const tsdocLink = trimmedText
-									? `{@link ${link.linkTarget} | ${trimmedText}}`
-									: `{@link ${link.linkTarget}}`;
-								return fixer.replaceTextRange([startIndex, endIndex], tsdocLink);
-							},
+									const trimmedText = link.linkText.trim();
+									const tsdocLink = trimmedText
+										? `{@link ${link.linkTarget} | ${trimmedText}}`
+										: `{@link ${link.linkTarget}}`;
+									return fixer.replaceTextRange(
+										[startIndex, endIndex],
+										tsdocLink,
+									);
+								},
 							});
 						}
 					}

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -33,12 +33,12 @@ function findMarkdownLinksInPlainText(plainTextNode) {
 		fail("Expected textExcerpt to be defined.");
 	// RegEx explanation:
 	// \[        - Match the opening square bracket
-	// ([^\]]+)  - Capture group 1: Match one or more characters that are not a closing square bracket (the link text)
+	// ([^\]]*)  - Capture group 1: Match zero or more characters that are not a closing square bracket (the link text)
 	// \]        - Match the closing square bracket
 	// \(        - Match the opening parenthesis
-	// ([^)]+)   - Capture group 2: Match one or more characters that are not a closing parenthesis (the link target)
+	// ([^)]*)   - Capture group 2: Match zero or more characters that are not a closing parenthesis (the link target)
 	// \)        - Match the closing parenthesis
-	const matches = plainTextNode.text.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g);
+	const matches = plainTextNode.text.matchAll(/\[([^\]]*)\]\(([^)]*)\)/g);
 	return Array.from(matches, (match) => ({
 		linkText: match[1],
 		linkTarget: match[2],
@@ -151,7 +151,7 @@ const rule = {
 								messageId: "markdownLink",
 								fix(fixer) {
 									const trimmedText = link.linkText.trim();
-									const tsdocLink = trimmedText
+									const tsdocLink = trimmedText.length > 0
 										? `{@link ${link.linkTarget} | ${trimmedText}}`
 										: `{@link ${link.linkTarget}}`;
 									return fixer.replaceTextRange(

--- a/common/build/eslint-plugin-fluid/src/test/no-markdown-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-markdown-links-in-jsdoc.test.js
@@ -24,20 +24,34 @@ describe(`Do not allow Markdown links in JSDoc/TSDoc comments (eslint ${eslintVe
 
 	it("Should report errors for Markdown links in block comments", async function () {
 		const result = await lintFile("test.ts");
-		assert.strictEqual(result.errorCount, 1);
+		assert.strictEqual(result.errorCount, 2);
 
-		const error = result.messages[0];
+		const error1 = result.messages[0];
 		assert.strictEqual(
-			error.message,
+			error1.message,
 			"Markdown link syntax (`[text](url)`) is not allowed in JSDoc/TSDoc comments. Use `{@link url|text}` syntax instead.",
 		);
-		assert.strictEqual(error.line, 10);
-		assert.strictEqual(error.column, 51); // 1-based, inclusive
-		assert.strictEqual(error.endColumn, 75); // 1-based, exclusive
+		assert.strictEqual(error1.line, 10);
+		assert.strictEqual(error1.column, 51); // 1-based, inclusive
+		assert.strictEqual(error1.endColumn, 75); // 1-based, exclusive
 
 		// Test auto-fix
-		assert.notEqual(error.fix, undefined);
-		assert.deepEqual(error.fix.range, [259, 283]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
-		assert.deepEqual(error.fix.text, "{@link https://bing.com | bing}");
+		assert.notEqual(error1.fix, undefined);
+		assert.deepEqual(error1.fix.range, [259, 283]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
+		assert.deepEqual(error1.fix.text, "{@link https://bing.com | bing}");
+
+		const error2 = result.messages[1];
+		assert.strictEqual(
+			error2.message,
+			"Markdown link syntax (`[text](url)`) is not allowed in JSDoc/TSDoc comments. Use `{@link url|text}` syntax instead.",
+		);
+		assert.strictEqual(error2.line, 11);
+		assert.strictEqual(error2.column, 23); // 1-based, inclusive
+		assert.strictEqual(error2.endColumn, 27); // 1-based, exclusive
+
+		// Test auto-fix
+		assert.notEqual(error2.fix, undefined);
+		assert.deepEqual(error2.fix.range, [307, 311]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
+		assert.deepEqual(error2.fix.text, "{@link }");
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/test-cases/no-markdown-links-in-jsdoc/test.ts
+++ b/common/build/eslint-plugin-fluid/src/test/test-cases/no-markdown-links-in-jsdoc/test.ts
@@ -8,6 +8,7 @@
 // TSDoc comment with a Markdown link should be flagged.
 /**
  * TSDoc comment with link using Markdown syntax: [bing](https://bing.com).
+ * And an empty link: []().
  */
 const tsdocCommentWithMarkdownLink = "invalid";
 

--- a/common/build/eslint-plugin-fluid/src/test/test-cases/no-markdown-links-in-jsdoc/test.ts
+++ b/common/build/eslint-plugin-fluid/src/test/test-cases/no-markdown-links-in-jsdoc/test.ts
@@ -37,4 +37,15 @@ const blockCommentWithMarkdownLink = "valid";
 // Line comment with link using Markdown syntax: [bing](https://bing.com).
 const lineCommentWithMarkdownLink = "valid";
 
+// Link syntax in code blocks should not be flagged
+/**
+ * `[bing](https://bing.com)`
+ *
+ * @example
+ * ```
+ * [bing](https://bing.com)
+ * ```
+ */
+const linkInCodeBlocks = "valid";
+
 // #endregion


### PR DESCRIPTION
Also bumps package version for publishing.

[AB#51719](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/51719)