### PR TITLE
improvement(eslint-plugin-fluid): Implement auto-fix for `no-hyphen-after-jsdoc-tag` rule and give better range info

### DIFF
--- a/common/build/eslint-plugin-fluid/src/test/no-hyphen-after-jsdoc-tag.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-hyphen-after-jsdoc-tag.test.js
@@ -38,21 +38,30 @@ describe(`Do not allow \`-\` following JSDoc/TSDoc tags (eslint ${eslintVersion}
 		const error1 = result.messages[0];
 		assert.strictEqual(error1.message, expectedErrorMessage);
 		assert.strictEqual(error1.line, 8);
-		assert.strictEqual(error1.column, 4); // 1-based, inclusive
-		assert.strictEqual(error1.endColumn, 13); // 1-based, exclusive
+		assert.strictEqual(error1.column, 12); // 1-based, inclusive
+		assert.strictEqual(error1.endColumn, 15); // 1-based, exclusive
+		assert.notEqual(error1.fix, undefined);
+		assert.deepEqual(error1.fix.range, [234, 237]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
+		assert.deepEqual(error1.fix.text, " "); // Replace hyphen and surrounding whitespace with a single space.
 
 		// Error 2
 		const error2 = result.messages[1];
 		assert.strictEqual(error2.message, expectedErrorMessage);
 		assert.strictEqual(error2.line, 9);
-		assert.strictEqual(error2.column, 4); // 1-based, inclusive
-		assert.strictEqual(error2.endColumn, 16); // 1-based, exclusive
+		assert.strictEqual(error2.column, 15); // 1-based, inclusive
+		assert.strictEqual(error2.endColumn, 19); // 1-based, exclusive
+		assert.notEqual(error2.fix, undefined);
+		assert.deepEqual(error2.fix.range, [274, 278]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
+		assert.deepEqual(error2.fix.text, " "); // Replace hyphen and surrounding whitespace with a single space.
 
 		// Error 3
 		const error3 = result.messages[2];
 		assert.strictEqual(error3.message, expectedErrorMessage);
 		assert.strictEqual(error3.line, 10);
-		assert.strictEqual(error3.column, 4); // 1-based, inclusive
-		assert.strictEqual(error3.endColumn, 13); // 1-based, exclusive
+		assert.strictEqual(error3.column, 12); // 1-based, inclusive
+		assert.strictEqual(error3.endColumn, 16); // 1-based, exclusive
+		assert.notEqual(error3.fix, undefined);
+		assert.deepEqual(error3.fix.range, [338, 342]); // 0-based global character index in the file. The start is inclusive, and the end is exclusive.
+		assert.deepEqual(error3.fix.text, " "); // Replace hyphen and surrounding whitespace with a single space.
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/test-cases/no-hyphen-after-jsdoc-tag/test.ts
+++ b/common/build/eslint-plugin-fluid/src/test/test-cases/no-hyphen-after-jsdoc-tag/test.ts
@@ -6,8 +6,8 @@
 /**
  * I am a test function with pretty standard docs, but all of my tags have hyphens after them :(
  * @remarks - Here are some remarks.
- * @deprecated - This function is deprecated, use something else.
- * @returns - The concatenated string.
+ * @deprecated -  This function is deprecated, use something else.
+ * @returns  -	The concatenated string.
  */
 function invalid<T>(param1: string, param2: T): string {
 	return `${param1} - ${param2}`;


### PR DESCRIPTION
Now reports the text range containing the hyphen character and surrounding whitespace, rather than the range containing the TSDoc tag. Also implements auto-fix behavior (replacing hyphen character and surrounding whitespace with a single space).