### PR TITLE
Make options optional in independentView

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -443,7 +443,7 @@ export const incrementalSummaryHint: unique symbol;
 export function independentInitializedView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & ICodecOptions, content: ViewContent): TreeViewAlpha<TSchema>;
 
 // @alpha
-export function independentView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & {
+export function independentView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options?: ForestOptions & {
     idCompressor?: IIdCompressor | undefined;
 }): TreeViewAlpha<TSchema>;
 

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -72,7 +72,7 @@ import { combineChunks } from "../feature-libraries/index.js";
  */
 export function independentView<const TSchema extends ImplicitFieldSchema>(
 	config: TreeViewConfiguration<TSchema>,
-	options: ForestOptions & { idCompressor?: IIdCompressor | undefined },
+	options?: ForestOptions & { idCompressor?: IIdCompressor | undefined },
 ): TreeViewAlpha<TSchema> {
 	return createIndependentTreeAlpha(options).viewWith(config) as TreeViewAlpha<TSchema>;
 }

--- a/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
@@ -155,7 +155,7 @@ describe("staged schema upgrade", () => {
 			schema: schemaA,
 		});
 
-		const viewA = independentView(configA, {});
+		const viewA = independentView(configA);
 		viewA.initialize(5);
 
 		assert.deepEqual(viewA.root, 5);

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -757,7 +757,7 @@ export const incrementalSummaryHint: unique symbol;
 export function independentInitializedView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & ICodecOptions, content: ViewContent): TreeViewAlpha<TSchema>;
 
 // @alpha
-export function independentView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options: ForestOptions & {
+export function independentView<const TSchema extends ImplicitFieldSchema>(config: TreeViewConfiguration<TSchema>, options?: ForestOptions & {
     idCompressor?: IIdCompressor_2 | undefined;
 }): TreeViewAlpha<TSchema>;
 

--- a/packages/framework/react/src/test/reactSharedTreeView.spec.tsx
+++ b/packages/framework/react/src/test/reactSharedTreeView.spec.tsx
@@ -73,7 +73,7 @@ describe("reactSharedTreeView", () => {
 				);
 
 				it("TreeViewComponent", () => {
-					const view = independentView(new TreeViewConfiguration({ schema: Item }), {});
+					const view = independentView(new TreeViewConfiguration({ schema: Item }));
 					const content = <TreeViewComponent viewComponent={View} tree={{ treeView: view }} />;
 					const rendered = render(content, { reactStrictMode });
 

--- a/packages/framework/tree-agent-langchain/src/test/utils.ts
+++ b/packages/framework/tree-agent-langchain/src/test/utils.ts
@@ -114,7 +114,7 @@ async function queryDomain<TSchema extends ImplicitFieldSchema>(
 		readonly log?: (text: string) => void;
 	},
 ): Promise<TreeView<TSchema>> {
-	const view = independentView(new TreeViewConfiguration({ schema }), {});
+	const view = independentView(new TreeViewConfiguration({ schema }));
 	view.initialize(initialTree);
 	const client = createLangchainChatModel(createLlmClient(provider));
 	const logger = options?.log === undefined ? undefined : { log: options.log };

--- a/packages/framework/tree-agent-ses/src/test/ses.spec.ts
+++ b/packages/framework/tree-agent-ses/src/test/ses.spec.ts
@@ -37,7 +37,7 @@ describe.skip("SES edit executor", () => {
 	});
 
 	it("passes globals to the compartment", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
 		const editor = createSesEditExecutor({
 			lockdownOptions,
@@ -60,7 +60,7 @@ describe.skip("SES edit executor", () => {
 	});
 
 	it("returns a code error when SES blocks the generated code", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
 		const editor = createSesEditExecutor({ lockdownOptions });
 		const model: SharedTreeChatModel = {

--- a/packages/framework/tree-agent/src/test/agent.spec.ts
+++ b/packages/framework/tree-agent/src/test/agent.spec.ts
@@ -24,7 +24,7 @@ const editToolName = "EditTreeTool";
 
 describe("Semantic Agent", () => {
 	it("returns messages from queries", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		const model: SharedTreeChatModel = {
 			async query(message) {
@@ -37,7 +37,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("can apply an edit from a query", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		const code = `context.root = "Edited";`;
 		const model: SharedTreeChatModel = {
@@ -56,7 +56,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("can apply multiple edits from a query", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		let editCount = 0;
 		const firstEdit = `
@@ -87,7 +87,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("does not allow editing if edit function name is not provided", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		const model: SharedTreeChatModel = {
 			async query({ edit }) {
@@ -103,7 +103,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("handles malformed edit code", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		let callCount = 0;
 		const model: SharedTreeChatModel = {
@@ -126,7 +126,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("handles edit code that causes runtime errors", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		let callCount = 0;
 		const model: SharedTreeChatModel = {
@@ -154,7 +154,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("limits the number of sequential edits", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
 		let callCount = 0;
 		const model: SharedTreeChatModel = {
@@ -186,7 +186,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("does not allow editing after query completes", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
 		let stolenEditCallback: ((js: string) => Promise<EditResult>) | undefined;
 		const model: SharedTreeChatModel = {
@@ -208,7 +208,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("does not roll back if a failed edit is followed by a successful edit in the same query", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		const model: SharedTreeChatModel = {
 			editToolName,
@@ -228,7 +228,7 @@ describe("Semantic Agent", () => {
 
 	it("rolls back if a successful edit is followed by a failed edit in the same query", async () => {
 		// First edit succeeds, but the second fails, so the tree should remain unchanged.
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
 		const model: SharedTreeChatModel = {
 			editToolName,
@@ -249,7 +249,7 @@ describe("Semantic Agent", () => {
 	});
 
 	it("supplies the system prompt as context", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("X");
 		const contexts: string[] = [];
 		const model: SharedTreeChatModel = {
@@ -282,9 +282,9 @@ describe("Semantic Agent", () => {
 			startColor: Color,
 			endColor: Color,
 		}) {}
-		const view = independentView(new TreeViewConfiguration({ schema: Gradient }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: Gradient }));
 		view.initialize({ startColor: { r: 0, g: 0, b: 0 }, endColor: { r: 0, g: 0, b: 0 } });
-		const code = `const white = context.create.Color({ r: 255, g: 255, b: 255 }); 
+		const code = `const white = context.create.Color({ r: 255, g: 255, b: 255 });
 context.root = context.create.Gradient({ startColor: white, endColor: white });`;
 		const model: SharedTreeChatModel = {
 			editToolName,
@@ -305,7 +305,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 			class Person extends sfLocal.object("Person", {
 				name: sfLocal.required(sfLocal.string),
 			}) {}
-			const view = independentView(new TreeViewConfiguration({ schema: Person }), {});
+			const view = independentView(new TreeViewConfiguration({ schema: Person }));
 			view.initialize(new Person({ name: "Alice" }));
 			const model: SharedTreeChatModel = {
 				editToolName,
@@ -326,7 +326,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 				name: sfLocal.required(sfLocal.string),
 				age: sfLocal.required(sfLocal.number),
 			}) {}
-			const view = independentView(new TreeViewConfiguration({ schema: Person }), {});
+			const view = independentView(new TreeViewConfiguration({ schema: Person }));
 			view.initialize(new Person({ name: "Alice", age: 25 }));
 			const model: SharedTreeChatModel = {
 				editToolName,
@@ -349,7 +349,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 				value: sfLocal.required(sfLocal.string),
 			}) {}
 			class Parent extends sfLocal.object("Parent", { child: Child }) {}
-			const view = independentView(new TreeViewConfiguration({ schema: Parent }), {});
+			const view = independentView(new TreeViewConfiguration({ schema: Parent }));
 			view.initialize(new Parent({ child: new Child({ value: "Initial" }) }));
 			const model: SharedTreeChatModel = {
 				editToolName,
@@ -372,7 +372,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 				value: sfLocal.required(sfLocal.string),
 			}) {}
 			class Parent extends sfLocal.object("Parent", { child: Child }) {}
-			const view = independentView(new TreeViewConfiguration({ schema: Parent }), {});
+			const view = independentView(new TreeViewConfiguration({ schema: Parent }));
 			view.initialize(new Parent({ child: new Child({ value: "Initial" }) }));
 			const model: SharedTreeChatModel = {
 				editToolName,
@@ -392,7 +392,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 		it("provides working isArray helper", async () => {
 			const sfLocal = new SchemaFactory("TestIsArray");
 			const NumberArray = sfLocal.array(sfLocal.number);
-			const view = independentView(new TreeViewConfiguration({ schema: NumberArray }), {});
+			const view = independentView(new TreeViewConfiguration({ schema: NumberArray }));
 			view.initialize([1, 2, 3]);
 			const model: SharedTreeChatModel = {
 				editToolName,
@@ -412,7 +412,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 		it("provides working isMap helper", async () => {
 			const sfLocal = new SchemaFactory("TestIsMap");
 			class NumberMap extends sfLocal.map("NumberMap", sfLocal.number) {}
-			const view = independentView(new TreeViewConfiguration({ schema: NumberMap }), {});
+			const view = independentView(new TreeViewConfiguration({ schema: NumberMap }));
 			view.initialize(new NumberMap(new Map([["x", 1]])));
 			const model: SharedTreeChatModel = {
 				editToolName,
@@ -431,7 +431,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 	});
 
 	it("supplies additional context if the tree changes between queries", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
 		const contexts: string[] = [];
 		const model: SharedTreeChatModel = {
@@ -470,7 +470,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 			child: Child,
 		}) {}
 
-		const view = independentView(new TreeViewConfiguration({ schema: Parent }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: Parent }));
 		view.initialize(new Parent({ child: new Child({ value: "Initial" }) }));
 		let context = "";
 		const model: SharedTreeChatModel = {
@@ -496,7 +496,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 	});
 
 	it("runs custom editors", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		const model: SharedTreeChatModel = {
 			editToolName,
@@ -520,7 +520,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 	});
 
 	it("catches errors from custom editors", async () => {
-		const view = independentView(new TreeViewConfiguration({ schema: sf.string }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Content");
 		const model: SharedTreeChatModel = {
 			editToolName,
@@ -549,7 +549,7 @@ context.root = context.create.Gradient({ startColor: white, endColor: white });`
 			child: Child,
 			values: NumberMap,
 		}) {}
-		const view = independentView(new TreeViewConfiguration({ schema: Parent }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: Parent }));
 		view.initialize(
 			new Parent({
 				child: new Child({ value: "Initial" }),

--- a/packages/framework/tree-agent/src/test/prompt.spec.ts
+++ b/packages/framework/tree-agent/src/test/prompt.spec.ts
@@ -316,7 +316,7 @@ function getView<TSchema extends ImplicitFieldSchema>(
 	schema: TSchema,
 	initialTree: InsertableField<TSchema>,
 ): TreeView<TSchema> {
-	const view = independentView(new TreeViewConfiguration({ schema }), {});
+	const view = independentView(new TreeViewConfiguration({ schema }));
 	view.initialize(initialTree);
 	return view;
 }

--- a/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeGeneration.spec.ts
@@ -263,7 +263,7 @@ type MapWithProperty = Map<string, string> & {
 	});
 
 	it("includes TypeScript types for node schema", () => {
-		const view = independentView(new TreeViewConfiguration({ schema: TestTodoAppSchema }), {});
+		const view = independentView(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
 		view.initialize(initialAppState);
 
 		const schema = getSimpleSchema(view.schema);
@@ -302,7 +302,7 @@ function getDomainSchemaString<TSchema extends ImplicitFieldSchema>(
 	schemaClass: TSchema,
 	initialValue: InsertableField<TSchema>,
 ): string {
-	const view = independentView(new TreeViewConfiguration({ schema: schemaClass }), {});
+	const view = independentView(new TreeViewConfiguration({ schema: schemaClass }));
 	view.initialize(initialValue);
 	const schema = getSimpleSchema(view.schema);
 	const { domainTypes } = generateEditTypesForPrompt(view.schema, schema);


### PR DESCRIPTION
## Description

Makes `options` in `independentView` optional to stop having to pass in `{}` every time.
