### PR TITLE
fix(lts): Fix issue that always skipped publish stage for LTS CI

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -101,9 +101,16 @@ schedules:
     - lts
   always: true
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml@self
   parameters:
+    publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -104,6 +104,7 @@ schedules:
 extends:
   template: templates/build-npm-package.yml@self
   parameters:
+    publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -101,16 +101,9 @@ schedules:
     - lts
   always: true
 
-variables:
-  - template: /tools/pipelines/templates/include-vars.yml@self
-    parameters:
-      publishOverride: '${{ parameters.publishOverride }}'
-      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-
 extends:
   template: templates/build-npm-package.yml@self
   parameters:
-    publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -101,10 +101,16 @@ schedules:
     - lts
   always: true
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml@self
   parameters:
-    publish: ${{ parameters.publish }}
+    publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -116,6 +116,7 @@ extends:
     componentDetection: ${{ variables.componentDetection }}
     release: ${{ variables.release }}
     testBuild: ${{ variables.testBuild }}
+    releaseBuild: ${{ variables.releaseBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -116,7 +116,6 @@ extends:
     componentDetection: ${{ variables.componentDetection }}
     release: ${{ variables.release }}
     testBuild: ${{ variables.testBuild }}
-    releaseBuild: ${{ variables.releaseBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -104,7 +104,7 @@ schedules:
 extends:
   template: templates/build-npm-package.yml@self
   parameters:
-    publish: ${{ variables.publish }}
+    publish: ${{ parameters.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -111,6 +111,11 @@ extends:
   template: templates/build-npm-package.yml@self
   parameters:
     publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -240,17 +240,17 @@ extends:
                 nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
 
               Computed variables:
-                shouldPublish=$(shouldPublish)
-                componentDetection=$(componentDetection)
-                publish=$(publish)
-                canRelease=$(canRelease)
+                shouldPublish=${{ parameters.shouldPublish }}
+                componentDetection=${{ parameters.componentDetection }}
+                publish=${{ parameters.publish }}
+                canRelease=${{ parameters.canRelease }}
                 targetBranchName = $(System.PullRequest.TargetBranch)
 
-                release=$(release)"
+                release=${{ parameters.release }}"
 
               # Error checking
-              if [[ "$(release)" == "release" ]]; then
-                if [[ "$(canRelease)" == "False" ]]; then
+              if [[ "${{ parameters.release }}" == "release" ]]; then
+                if [[ "${{ parameters.canRelease }}" == "False" ]]; then
                   echo "##vso[task.logissue type=error]Invalid branch $(Build.SourceBranch) for release"
                   exit -1;
                 fi
@@ -267,16 +267,16 @@ extends:
                 fi
               fi
 
-              if [[ "$(release)" == "prerelease" ]]; then
+              if [[ "${{ parameters.release }}" == "prerelease" ]]; then
                 if [[ "${{ parameters.buildNumberInPatch }}" == "true" ]]; then
                   echo "##vso[task.logissue type=error] Prerelease not allow for builds that put build number as the patch version"
                   exit -1;
                 fi
               fi
 
-              if [[ "$(release)" != "none" ]] && [[ "$(release)" != "" ]]; then
-                if [[ "$(publish)" != "True" ]]; then
-                  echo "##vso[task.logissue type=error]'$(release)'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
+              if [[ "${{ parameters.release }}" != "none" ]] && [[ "${{ parameters.release }}" != "" ]]; then
+                if [[ "${{ parameters.publish }}" != "True" ]]; then
+                  echo "##vso[task.logissue type=error]'${{ parameters.release }}'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
                   exit -1;
                 fi
               fi

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -176,8 +176,6 @@ extends:
         # will be things like upgrading node or security fixes, not adding new features.
         - name: testCoverage
           value: false
-        - name: releaseBuildVar
-          value: $[variables.releaseBuild]
         templateContext:
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:
@@ -221,9 +219,6 @@ extends:
               # Show all task group conditions
 
               echo "
-              Pipeline Variables:
-                releaseBuild=$(releaseBuildVar)
-
               Override Parameters:
                 publishOverride=${{ parameters.publishOverride }}
                 releaseBuildOverride=${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -108,6 +108,21 @@ parameters:
 - name: publish
   type: boolean
 
+- name: shouldPublish
+  type: boolean
+
+- name: canRelease
+  type: boolean
+
+- name: componentDetection
+  type: boolean
+
+- name: release
+  type: string
+
+- name: testBuild
+  type: boolean
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -433,3 +448,5 @@ extends:
       - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
         parameters:
           tagName: ${{ parameters.tagName }}
+          testBuild: ${{ parameters.testBuild }}
+          release: ${{ parameters.release }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -185,8 +185,6 @@ extends:
         # will be things like upgrading node or security fixes, not adding new features.
         - name: testCoverage
           value: false
-        - name: releaseBuildVar
-          value: ${{ parameters.releaseBuild }}
         templateContext:
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:
@@ -230,9 +228,6 @@ extends:
               # Show all task group conditions
 
               echo "
-              Pipeline Variables:
-                releaseBuild=$(releaseBuildVar)
-
               Override Parameters:
                 publishOverride=${{ parameters.publishOverride }}
                 releaseBuildOverride=${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -140,6 +140,11 @@ extends:
     # Install / Build / Test Stage
     - stage: build
       displayName: Build Stage
+      variables:
+      - template: /tools/pipelines/templates/include-vars.yml@self
+        parameters:
+          publishOverride: '${{ parameters.publishOverride }}'
+          releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
       jobs:
       # Job - Build
       - job: build
@@ -151,10 +156,6 @@ extends:
         # basic ANSI color support though, so force that in the pipeline
         - name: FORCE_COLOR
           value: 1
-        - template: /tools/pipelines/templates/include-vars.yml@self
-          parameters:
-            publishOverride: '${{ parameters.publishOverride }}'
-            releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
         - group: ado-feeds
         - group: storage-vars
         # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -104,6 +104,10 @@ parameters:
   type: boolean
   default: false
 
+# Indicates if this run is going to publish npm packages (and run extra steps necessary in that case) or not
+- name: publish
+  type: boolean
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -140,11 +144,6 @@ extends:
     # Install / Build / Test Stage
     - stage: build
       displayName: Build Stage
-      variables:
-      - template: /tools/pipelines/templates/include-vars.yml@self
-        parameters:
-          publishOverride: '${{ parameters.publishOverride }}'
-          releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
       jobs:
       # Job - Build
       - job: build
@@ -156,6 +155,10 @@ extends:
         # basic ANSI color support though, so force that in the pipeline
         - name: FORCE_COLOR
           value: 1
+        - template: /tools/pipelines/templates/include-vars.yml@self
+          parameters:
+            publishOverride: '${{ parameters.publishOverride }}'
+            releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
         - group: ado-feeds
         - group: storage-vars
         # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
@@ -430,7 +433,7 @@ extends:
               fi
 
     # Publish stage
-    - ${{ if eq(variables.publish, true) }}:
+    - ${{ if eq(parameters.publish, true) }}:
       - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
         parameters:
           tagName: ${{ parameters.tagName }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -128,10 +128,6 @@ parameters:
 - name: testBuild
   type: boolean
 
-# Indicates if this build is a release build
-- name: releaseBuild
-  type: string
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -155,10 +155,6 @@ extends:
         # basic ANSI color support though, so force that in the pipeline
         - name: FORCE_COLOR
           value: 1
-        - template: /tools/pipelines/templates/include-vars.yml@self
-          parameters:
-            publishOverride: '${{ parameters.publishOverride }}'
-            releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
         - group: ado-feeds
         - group: storage-vars
         # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
@@ -229,18 +225,18 @@ extends:
                 nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
 
               Computed variables:
-                shouldPublish=${{ variables.shouldPublish }}
-                componentDetection=${{ variables.componentDetection }}
-                publish=${{ variables.publish }}
-                canRelease=${{ variables.canRelease }}
+                shouldPublish=$(shouldPublish)
+                componentDetection=$(componentDetection)
+                publish=$(publish)
+                canRelease=$(canRelease)
                 targetBranchName = $(System.PullRequest.TargetBranch)
 
                 release=$(release)"
 
               # Error checking
               if [[ "$(release)" == "release" ]]; then
-                if [[ "${{ variables.canRelease }}" == "False" ]]; then
-                  echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
+                if [[ "$(canRelease)" == "False" ]]; then
+                  echo "##vso[task.logissue type=error]Invalid branch $(Build.SourceBranch) for release"
                   exit -1;
                 fi
 
@@ -264,7 +260,7 @@ extends:
               fi
 
               if [[ "$(release)" != "none" ]] && [[ "$(release)" != "" ]]; then
-                if [[ "${{ variables.publish }}" != "True" ]]; then
+                if [[ "$(publish)" != "True" ]]; then
                   echo "##vso[task.logissue type=error]'$(release)'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
                   exit -1;
                 fi

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -128,6 +128,10 @@ parameters:
 - name: testBuild
   type: boolean
 
+# Indicates if this build is a release build
+- name: releaseBuild
+  type: string
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -182,7 +186,7 @@ extends:
         - name: testCoverage
           value: false
         - name: releaseBuildVar
-          value: $[coalesce(variables.releaseBuild, 'false')]
+          value: ${{ parameters.releaseBuild }}
         templateContext:
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -149,25 +149,25 @@ extends:
       - job: build
         displayName: Build
         pool: ${{ parameters.poolBuild }}
-        variables:
-        # We use 'chalk' to colorize output, which auto-detects color support in the
-        # running terminal.  The log output shown in Azure DevOps job runs only has
-        # basic ANSI color support though, so force that in the pipeline
-        - name: FORCE_COLOR
-          value: 1
-        - template: /tools/pipelines/templates/include-vars.yml@self
-          parameters:
-            publishOverride: '${{ parameters.publishOverride }}'
-            releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-        - group: ado-feeds
-        - group: storage-vars
-        # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
-        # will be things like upgrading node or security fixes, not adding new features.
-        - name: testCoverage
-          value: false
-        - name: releaseBuildVar
-          value: $[variables.releaseBuild]
         templateContext:
+          variables:
+          # We use 'chalk' to colorize output, which auto-detects color support in the
+          # running terminal.  The log output shown in Azure DevOps job runs only has
+          # basic ANSI color support though, so force that in the pipeline
+          - name: FORCE_COLOR
+            value: 1
+          - template: /tools/pipelines/templates/include-vars.yml@self
+            parameters:
+              publishOverride: '${{ parameters.publishOverride }}'
+              releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+          - group: ado-feeds
+          - group: storage-vars
+          # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
+          # will be things like upgrading node or security fixes, not adding new features.
+          - name: testCoverage
+            value: false
+          - name: releaseBuildVar
+            value: $[variables.releaseBuild]
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:
             - output: pipelineArtifact

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -108,18 +108,23 @@ parameters:
 - name: publish
   type: boolean
 
+# Indicates if we should or should not skip all publish stages
 - name: shouldPublish
   type: boolean
 
+# Indicates if the build is from a branch that we can release from
 - name: canRelease
   type: boolean
 
+# Indicates if we should run component detection (if we are publishing any artifacts)
 - name: componentDetection
   type: boolean
 
+# Indicates the type of release (if any)
 - name: release
   type: string
 
+# Indicates if this build is from a test branch
 - name: testBuild
   type: boolean
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -181,6 +181,8 @@ extends:
         # will be things like upgrading node or security fixes, not adding new features.
         - name: testCoverage
           value: false
+        - name: releaseBuildVar
+          value: $[coalesce(variables.releaseBuild, 'false')]
         templateContext:
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:
@@ -224,6 +226,9 @@ extends:
               # Show all task group conditions
 
               echo "
+              Pipeline Variables:
+                releaseBuild=$(releaseBuildVar)
+
               Override Parameters:
                 publishOverride=${{ parameters.publishOverride }}
                 releaseBuildOverride=${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -149,25 +149,25 @@ extends:
       - job: build
         displayName: Build
         pool: ${{ parameters.poolBuild }}
+        variables:
+        # We use 'chalk' to colorize output, which auto-detects color support in the
+        # running terminal.  The log output shown in Azure DevOps job runs only has
+        # basic ANSI color support though, so force that in the pipeline
+        - name: FORCE_COLOR
+          value: 1
+        - template: /tools/pipelines/templates/include-vars.yml@self
+          parameters:
+            publishOverride: '${{ parameters.publishOverride }}'
+            releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+        - group: ado-feeds
+        - group: storage-vars
+        # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
+        # will be things like upgrading node or security fixes, not adding new features.
+        - name: testCoverage
+          value: false
+        - name: releaseBuildVar
+          value: $[variables.releaseBuild]
         templateContext:
-          variables:
-          # We use 'chalk' to colorize output, which auto-detects color support in the
-          # running terminal.  The log output shown in Azure DevOps job runs only has
-          # basic ANSI color support though, so force that in the pipeline
-          - name: FORCE_COLOR
-            value: 1
-          - template: /tools/pipelines/templates/include-vars.yml@self
-            parameters:
-              publishOverride: '${{ parameters.publishOverride }}'
-              releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-          - group: ado-feeds
-          - group: storage-vars
-          # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
-          # will be things like upgrading node or security fixes, not adding new features.
-          - name: testCoverage
-            value: false
-          - name: releaseBuildVar
-            value: $[variables.releaseBuild]
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:
             - output: pipelineArtifact

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -37,6 +37,10 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
+- name: release
+  type: string
+  default: ''
+
 jobs:
 - deployment: publish_${{ replace(parameters.environment, '-', '_') }}
   displayName: Publish ${{ parameters.environment }}
@@ -48,6 +52,8 @@ jobs:
     - group: ado-feeds
     - name: version
       value: $[ stageDependencies.build.build.outputs['SetVersion.version']]
+    - name: release
+      value: ${{ parameters.release }}
     - name: isLatest
       value: $[ stageDependencies.build.build.outputs['SetVersion.isLatest']]
   strategy:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -37,6 +37,7 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
+# Indicates the type of release (if any)
 - name: release
   type: string
   default: ''

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -11,11 +11,17 @@ parameters:
   type: object
   default: Small-eastus2
 
+- name: testBuild
+  type: boolean
+
+- name: release
+  type: string
+
 stages:
 - stage: publish_npm_internal_test
   dependsOn: build
   displayName: Publish Internal Test Packages
-  condition: and(succeeded(), eq(variables['testBuild'], true))
+  condition: and(succeeded(), eq(${{ parameters.testBuild }}, true))
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -25,11 +31,12 @@ stages:
       pool: ${{ parameters.pool }}
       packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
       packageManager: pnpm
+      release: ${{ parameters.release }}
 
 - stage: publish_npm_internal
   dependsOn: build
   displayName: Publish Internal Packages
-  condition: and(succeeded(), eq(variables['testBuild'], false))
+  condition: and(succeeded(), eq(${{ parameters.testBuild }}, false))
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -39,11 +46,12 @@ stages:
       pool: ${{ parameters.pool }}
       packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
       packageManager: pnpm
+      release: ${{ parameters.release }}
 
 - stage: publish_npm_official
   dependsOn: build
   displayName: Publish Official Packages
-  condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
+  condition: and(succeeded(), or(eq('${{ parameters.release }}', 'release'), eq('${{ parameters.release }}', 'prerelease')))
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -55,3 +63,4 @@ stages:
       customEndPoint: npmjs
       tagName: ${{ parameters.tagName }}
       packageManager: pnpm
+      release: ${{ parameters.release }}

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -11,9 +11,11 @@ parameters:
   type: object
   default: Small-eastus2
 
+# Indicates if this build is from a test branch
 - name: testBuild
   type: boolean
 
+# Indicates the type of release (if any)
 - name: release
   type: string
 


### PR DESCRIPTION
## Description

This PR resolves an issue from https://github.com/microsoft/FluidFramework/pull/25931 where we were always skipping the publish stage of the LTS build CI due to variables not being passed properly. This prevents us from using internal packages for testing pipelines and releasing from the LTS branch.

We will need to merge this PR to confirm if this this fixes the issue, since we only publish internal packages for non-test branches.