### PR TITLE
refactor(server): replace deprecated common-utils `performance` dependencies

### DIFF
--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { performance } from "@fluidframework/common-utils";
+import { performance } from "@fluidframework/server-services-client";
 import {
 	type IClient,
 	type IClientJoin,

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -38,7 +38,6 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"dependencies": {
-		"@fluidframework/common-utils": "^3.1.0",
 		"@fluidframework/gitresources": "workspace:~",
 		"@fluidframework/protocol-definitions": "^3.2.0",
 		"@fluidframework/server-kafka-orderer": "workspace:~",

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -651,6 +651,10 @@ export class NetworkInformation {
 // @internal (undocumented)
 export function parseToken(tenantId: string, authorization: string | undefined): string | undefined;
 
+// @internal
+const performance_2: Performance;
+export { performance_2 as performance }
+
 // @internal (undocumented)
 export function promiseTimeout(mSec: number, promise: Promise<any>): Promise<any>;
 

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -41,6 +41,7 @@ export {
 	parseToken,
 } from "./historian";
 export type { IAlfredTenant, ISession } from "./interfaces";
+export { performance } from "./performance";
 export { promiseTimeout } from "./promiseTimeout";
 export { RestLessClient, RestLessFieldNames } from "./restLessClient";
 export {

--- a/server/routerlicious/packages/services-client/src/performance.ts
+++ b/server/routerlicious/packages/services-client/src/performance.ts
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Isomorphic access to the {@link https://developer.mozilla.org/en-US/docs/Web/API/Performance|Performance API}.
+ *
+ * @internal
+ */
+export const performance = globalThis.performance;

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -13,6 +13,7 @@ import {
 } from "axios";
 import safeStringify from "json-stringify-safe";
 import { v4 as uuid } from "uuid";
+import { performance } from "./performance";
 
 import {
 	CallingServiceHeaderName,

--- a/server/routerlicious/packages/services-core/src/test/trace.spec.ts
+++ b/server/routerlicious/packages/services-core/src/test/trace.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "assert";
 import sinon from "sinon";
+import { performance } from "@fluidframework/server-services-client";
 import { StageTrace } from "../trace";
-import { performance } from "@fluidframework/common-utils";
 
 describe("StageTrace", () => {
 	let clock: sinon.SinonFakeTimers;

--- a/server/routerlicious/packages/services-core/src/trace.ts
+++ b/server/routerlicious/packages/services-core/src/trace.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { performance } from "@fluidframework/common-utils";
+import { performance } from "@fluidframework/server-services-client";
 
 /**
  * @internal

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitter } from "events";
-import type * as http from "http";
-import { performance } from "perf_hooks";
+import { EventEmitter } from "node:events";
+import type * as http from "node:http";
 
+import { performance } from "@fluidframework/server-services-client";
 import type * as core from "@fluidframework/server-services-core";
 import {
 	BaseTelemetryProperties,

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -52,7 +52,6 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
-		"@fluidframework/common-utils": "^3.1.0",
 		"json-stringify-safe": "^5.0.1",
 		"path-browserify": "^1.0.1",
 		"serialize-error": "^8.1.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -51,7 +51,6 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
-		"@fluidframework/common-utils": "^3.1.0",
 		"@fluidframework/protocol-definitions": "^3.2.0",
 		"@fluidframework/server-services-client": "workspace:~",
 		"@fluidframework/server-services-core": "workspace:~",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -666,9 +666,6 @@ importers:
 
   packages/routerlicious:
     dependencies:
-      '@fluidframework/common-utils':
-        specifier: ^3.1.0
-        version: 3.1.0
       '@fluidframework/gitresources':
         specifier: workspace:~
         version: link:../gitresources
@@ -971,9 +968,6 @@ importers:
 
   packages/services:
     dependencies:
-      '@fluidframework/common-utils':
-        specifier: ^3.1.0
-        version: 3.1.0
       '@fluidframework/protocol-definitions':
         specifier: ^3.2.0
         version: 3.2.0
@@ -1650,9 +1644,6 @@ importers:
 
   packages/services-telemetry:
     dependencies:
-      '@fluidframework/common-utils':
-        specifier: ^3.1.0
-        version: 3.1.0
       json-stringify-safe:
         specifier: ^5.0.1
         version: 5.0.1


### PR DESCRIPTION
## Description

The isomorhic `performance` export from `@fluidframework/common-utils` has been deprecated for some time. This PR replaces it with a new `@fluidframework/server-services-client` export.

I also removed any dependencies on common-utils that were not used
