### PR TITLE
fix(azure-e2e-tests): Update ephemeral summary trees to format v3

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/ephemeralSummaryTrees.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/ephemeralSummaryTrees.ts
@@ -1617,7 +1617,7 @@ const tree7 = {
 																						value: {
 																							type: "blob",
 																							content:
-																								'{"trunk":[],"branches":[],"version":2}',
+																								'{"trunk":[],"branches":[],"version":3}',
 																							encoding: "utf8",
 																						},
 																						unreferenced: undefined,
@@ -1874,7 +1874,7 @@ const tree8 = {
 																						value: {
 																							type: "blob",
 																							content:
-																								'{"trunk":[],"branches":[],"version":2}',
+																								'{"trunk":[],"branches":[],"version":3}',
 																							encoding: "utf8",
 																						},
 																						unreferenced: undefined,


### PR DESCRIPTION
## Description

This change updates the ephemeral summary trees used in Azure client E2E tests to use EditManager format version 3 instead of version 2. 

The SharedTree ephemeral container tests are consistently failing in our Service Clients E2E pipeline with the error: `Cannot decode data to format 2. The codec was discontinued in FF version 2.73.0.`. 

The problem here is the ephemeral summary trees in `ephemeralSummaryTrees.ts` were originally created with Fluid Framework version 2.0.0-rc.4.0.0 and used EditManager format version 2, which has been discontinued as of version 2.73.0. The fix here is updating the EditManager format version from 2 to 3 in the `tree7` and `tree8` summary trees, which are used by:
- `createContainerWithSharedTree` 
- `createLoadContainerWithSharedTree`

I verfied this change by running "test:realsvc:azure" locally to run these tests against AFR. 


## Reviewer Guidance

I see that the removal was done in this https://github.com/microsoft/FluidFramework/pull/25893. My knowledge of EditManager codec format versions is limited, but it seems v3 and v2 share the same structure. I verfied this change by manually running the real service tests but unsure if additional changes would need to made here as well. 

