### PR TITLE
refactor(tree): use string version tags for shared-branches formats

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -253,6 +253,7 @@ export interface ICodecFamily<TDecoded, TContext = void> {
  * A version stamp for encoded data.
  *
  * Strings are used for formats that are not yet officially supported.
+ * When such formats become officially supported/stable, they will be switched to using a number.
  * Undefined is tolerated to enable the scenario where data was not initially versioned.
  */
 export type FormatVersion = number | string | undefined;

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -252,9 +252,10 @@ export interface ICodecFamily<TDecoded, TContext = void> {
 /**
  * A version stamp for encoded data.
  *
+ * Strings are used for formats that are not yet officially supported.
  * Undefined is tolerated to enable the scenario where data was not initially versioned.
  */
-export type FormatVersion = number | undefined;
+export type FormatVersion = number | string | undefined;
 
 /**
  * A format version which is dependent on some parent format version.

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -125,7 +125,7 @@ export function makeDiscontinuedCodecVersion<
  */
 export function makeVersionDispatchingCodec<TDecoded, TContext>(
 	family: ICodecFamily<TDecoded, TContext>,
-	options: ICodecOptions & { writeVersion: number },
+	options: ICodecOptions & { writeVersion: number | string },
 ): IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext> {
 	const writeCodec = family.resolve(options.writeVersion).json;
 	const supportedVersions = new Set(family.getSupportedFormats());

--- a/packages/dds/tree/src/codec/versioned/format.ts
+++ b/packages/dds/tree/src/codec/versioned/format.ts
@@ -6,6 +6,7 @@
 import { type Static, Type } from "@sinclair/typebox";
 
 export const Versioned = Type.Object({
-	version: Type.Number(),
+	// String versions are used for formats that are not yet officially supported.
+	version: Type.Union([Type.Number(), Type.String()]),
 });
 export type Versioned = Static<typeof Versioned>;

--- a/packages/dds/tree/src/codec/versioned/format.ts
+++ b/packages/dds/tree/src/codec/versioned/format.ts
@@ -6,7 +6,9 @@
 import { type Static, Type } from "@sinclair/typebox";
 
 export const Versioned = Type.Object({
-	// String versions are used for formats that are not yet officially supported.
+	/**
+	 * String versions are used for formats that are not yet officially supported. See {@link FormatVersion} for details.
+	 */
 	version: Type.Union([Type.Number(), Type.String()]),
 });
 export type Versioned = Static<typeof Versioned>;

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -145,6 +145,8 @@ export function makeEditManagerCodecs<TChangeset>(
 					makeV1CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
+			case EditManagerFormatVersion.v5:
+				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
 			case EditManagerFormatVersion.vSharedBranches: {
 				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
 				return [

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -33,7 +33,7 @@ import { brand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { SummaryData } from "./editManager.js";
 import { makeV1CodecWithVersion } from "./editManagerCodecsV1toV4.js";
-import { makeV5CodecWithVersion } from "./editManagerCodecsV5.js";
+import { makeSharedBranchesCodecWithVersion } from "./editManagerCodecsVSharedBranches.js";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {
 	EditManagerFormatVersion,
@@ -70,7 +70,7 @@ export function clientVersionToEditManagerFormatVersion(
 export function editManagerFormatVersionSelectorForSharedBranches(
 	clientVersion: MinimumVersionForCollab,
 ): EditManagerFormatVersion {
-	return brand(EditManagerFormatVersion.v5);
+	return brand(EditManagerFormatVersion.vSharedBranches);
 }
 
 export interface EditManagerCodecOptions {
@@ -145,11 +145,11 @@ export function makeEditManagerCodecs<TChangeset>(
 					makeV1CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
-			case EditManagerFormatVersion.v5: {
+			case EditManagerFormatVersion.vSharedBranches: {
 				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
 				return [
 					version,
-					makeV5CodecWithVersion(changeCodec, revisionTagCodec, options, version),
+					makeSharedBranchesCodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
 			default:

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -25,7 +25,7 @@ import {
 } from "../util/index.js";
 
 import type { SharedBranchSummaryData, SummaryData } from "./editManager.js";
-import { EncodedEditManager } from "./editManagerFormatV5.js";
+import { EncodedEditManager } from "./editManagerFormatVSharedBranches.js";
 import { decodeSharedBranch, encodeSharedBranch } from "./editManagerCodecsCommons.js";
 import type { EncodedSharedBranch } from "./editManagerFormatCommons.js";
 import type { BranchId } from "./branch.js";
@@ -35,7 +35,7 @@ export interface EditManagerEncodingContext {
 	readonly schema?: SchemaAndPolicy;
 }
 
-export function makeV5CodecWithVersion<TChangeset>(
+export function makeSharedBranchesCodecWithVersion<TChangeset>(
 	changeCodec: IMultiFormatCodec<
 		TChangeset,
 		JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -78,7 +78,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				);
 				assert(
 					data.originator !== undefined,
-					0xc65 /* Cannot encode V5 summary without originator */,
+					"Cannot encode vSharedBranches summary without originator",
 				);
 				const json: Mutable<EncodedEditManager<TChangeset>> = {
 					main: mainBranch,

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -137,11 +137,12 @@ export const EditManagerFormatVersion = {
 	/**
 	 * Introduced prior to 2.0 and used beyond.
 	 * Reading capability must be maintained for backwards compatibility.
-	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.43.0.
+	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.2.0.
 	 */
 	v3: 3,
 	/**
-	 * Was inadvertently released in 2.43.0 (through usages of configuredSharedTree) and remains available.
+	 * Introduced in 2.2.0.
+	 * Was inadvertently made usable for writing in 2.43.0 (through configuredSharedTree) and remains available.
 	 * Reading capability must be maintained for backwards compatibility.
 	 * Writing capability could be dropped in favor of {@link EditManagerFormatVersion.v3},
 	 * but doing so would make the pattern of writable versions more complex and gain little
@@ -151,7 +152,7 @@ export const EditManagerFormatVersion = {
 	/**
 	 * This version number was used internally for testing shared branches.
 	 * This format was never made stable.
-	 * This version number is kept here solely to avoid reusing the number, it is not supported for either reading or writing.
+	 * This version number is kept here solely to avoid reusing the number: it is not supported for either reading or writing.
 	 * @deprecated - use {@link EditManagerFormatVersion.vSharedBranches} for testing shared branches.
 	 */
 	v5: 5,

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -136,22 +136,21 @@ export const EditManagerFormatVersion = {
 	v2: 2,
 	/**
 	 * Introduced prior to 2.0 and used beyond.
-	 * Reading capability is currently maintained for backwards compatibility, but it could be removed in the future.
-	 * Writing capability needs to be maintained.
+	 * Reading capability must be maintained for backwards compatibility.
+	 * Writing capability needs to be maintained for cross-version compatibility, may be removed in FF 3.0.
 	 */
 	v3: 3,
 	/**
 	 * Was inadvertently released in 2.43.0 (through usages of configuredSharedTree) and remains available.
 	 * Reading capability must be maintained for backwards compatibility.
 	 * Writing capability needs to be maintained.
-	 * @privateRemarks TODO: stop writing this version.
 	 */
 	v4: 4,
 	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
-	v5: 5,
+	vSharedBranches: "shared-branches|v0.1",
 } as const;
 export type EditManagerFormatVersion = Brand<
 	(typeof EditManagerFormatVersion)[keyof typeof EditManagerFormatVersion],
@@ -161,7 +160,7 @@ export const supportedEditManagerFormatVersions: ReadonlySet<EditManagerFormatVe
 	new Set([
 		EditManagerFormatVersion.v3,
 		EditManagerFormatVersion.v4,
-		EditManagerFormatVersion.v5,
+		EditManagerFormatVersion.vSharedBranches,
 	] as EditManagerFormatVersion[]);
 export const editManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> = new Set(
 	Object.values(EditManagerFormatVersion) as EditManagerFormatVersion[],

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -137,15 +137,24 @@ export const EditManagerFormatVersion = {
 	/**
 	 * Introduced prior to 2.0 and used beyond.
 	 * Reading capability must be maintained for backwards compatibility.
-	 * Writing capability needs to be maintained for cross-version compatibility, may be removed in FF 3.0.
+	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.43.0.
 	 */
 	v3: 3,
 	/**
 	 * Was inadvertently released in 2.43.0 (through usages of configuredSharedTree) and remains available.
 	 * Reading capability must be maintained for backwards compatibility.
-	 * Writing capability needs to be maintained.
+	 * Writing capability could be dropped in favor of {@link EditManagerFormatVersion.v3},
+	 * but doing so would make the pattern of writable versions more complex and gain little
+	 * because most of the logic for this format is shared with {@link EditManagerFormatVersion.v3}.
 	 */
 	v4: 4,
+	/**
+	 * This version number was used internally for testing shared branches.
+	 * This format was never made stable.
+	 * This version number is kept here solely to avoid reusing the number, it is not supported for either reading or writing.
+	 * @deprecated - use {@link EditManagerFormatVersion.vSharedBranches} for testing shared branches.
+	 */
+	v5: 5,
 	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatVSharedBranches.ts
@@ -15,7 +15,7 @@ const noAdditionalProps: ObjectOptions = { additionalProperties: false };
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 export interface EncodedEditManager<TChangeset> {
-	readonly version: typeof EditManagerFormatVersion.v5;
+	readonly version: typeof EditManagerFormatVersion.vSharedBranches;
 	readonly originator: SessionId;
 	readonly main: EncodedSharedBranch<TChangeset>;
 	readonly branches?: readonly EncodedSharedBranch<TChangeset>[];
@@ -24,7 +24,7 @@ export interface EncodedEditManager<TChangeset> {
 export const EncodedEditManager = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 	Type.Object(
 		{
-			version: Type.Union([Type.Literal(EditManagerFormatVersion.v5)]),
+			version: Type.Literal(EditManagerFormatVersion.vSharedBranches),
 			originator: SessionIdSchema,
 			main: EncodedSharedBranch(tChange),
 			branches: Type.Optional(Type.Array(EncodedSharedBranch(tChange))),

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -14,14 +14,14 @@ import type {
 } from "../core/index.js";
 import type { JsonCompatibleReadOnly } from "../util/index.js";
 
-import { Message } from "./messageFormatV5.js";
+import { Message } from "./messageFormatVSharedBranches.js";
 import type { DecodedMessage } from "./messageTypes.js";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import type { MessageEncodingContext } from "./messageCodecs.js";
 import { decodeBranchId, encodeBranchId } from "./branchIdCodec.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
 
-export function makeV5CodecWithVersion<TChangeset>(
+export function makeSharedBranchesCodecWithVersion<TChangeset>(
 	changeCodec: ChangeFamilyCodec<TChangeset>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
@@ -30,7 +30,7 @@ export function makeV5CodecWithVersion<TChangeset>(
 		ChangeEncodingContext
 	>,
 	options: ICodecOptions,
-	version: typeof MessageFormatVersion.v5,
+	version: typeof MessageFormatVersion.vSharedBranches,
 ): IJsonCodec<
 	DecodedMessage<TChangeset>,
 	JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -152,6 +152,8 @@ export function makeMessageCodecs<TChangeset>(
 					makeV1ToV4CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
+			case MessageFormatVersion.v5:
+				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
 			case MessageFormatVersion.vSharedBranches: {
 				const changeCodec = changeCodecs.resolve(
 					dependentChangeFormatVersion.lookup(version),

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -34,7 +34,7 @@ import { brand, type JsonCompatibleReadOnly } from "../util/index.js";
 import type { DecodedMessage } from "./messageTypes.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import { makeV1ToV4CodecWithVersion } from "./messageCodecV1ToV4.js";
-import { makeV5CodecWithVersion } from "./messageCodecV5.js";
+import { makeSharedBranchesCodecWithVersion } from "./messageCodecVSharedBranches.js";
 import { MessageFormatVersion, messageFormatVersions } from "./messageFormat.js";
 
 export interface MessageEncodingContext {
@@ -79,7 +79,7 @@ function messageFormatVersionFromOptions(
 export function messageFormatVersionSelectorForSharedBranches(
 	clientVersion: MinimumVersionForCollab,
 ): MessageFormatVersion {
-	return brand(MessageFormatVersion.v5);
+	return brand(MessageFormatVersion.vSharedBranches);
 }
 
 export function makeMessageCodec<TChangeset>(
@@ -152,13 +152,13 @@ export function makeMessageCodecs<TChangeset>(
 					makeV1ToV4CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
-			case MessageFormatVersion.v5: {
+			case MessageFormatVersion.vSharedBranches: {
 				const changeCodec = changeCodecs.resolve(
 					dependentChangeFormatVersion.lookup(version),
 				).json;
 				return [
 					version,
-					makeV5CodecWithVersion(changeCodec, revisionTagCodec, options, version),
+					makeSharedBranchesCodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
 			default:

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -28,11 +28,12 @@ export const MessageFormatVersion = {
 	/**
 	 * Introduced prior to 2.0 and used beyond.
 	 * Reading capability must be maintained for backwards compatibility.
-	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.43.0.
+	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.2.0.
 	 */
 	v3: 3,
 	/**
-	 * Was inadvertently released in 2.43.0 (through usages of configuredSharedTree) and remains available.
+	 * Introduced in 2.2.0.
+	 * Was inadvertently made usable for writing in 2.43.0 (through configuredSharedTree) and remains available.
 	 * Reading capability must be maintained for backwards compatibility.
 	 * Writing capability could be dropped in favor of {@link MessageFormatVersion.v3},
 	 * but doing so would make the pattern of writable versions more complex and gain little
@@ -42,7 +43,7 @@ export const MessageFormatVersion = {
 	/**
 	 * This version number was used internally for testing shared branches.
 	 * This format was never made stable.
-	 * This version number is kept here solely to avoid reusing the number, it is not supported for either reading or writing.
+	 * This version number is kept here solely to avoid reusing the number: it is not supported for either reading or writing.
 	 * @deprecated - use {@link MessageFormatVersion.vSharedBranches} for testing shared branches.
 	 */
 	v5: 5,

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -27,22 +27,21 @@ export const MessageFormatVersion = {
 	v2: 2,
 	/**
 	 * Introduced prior to 2.0 and used beyond.
-	 * Reading capability is currently maintained for backwards compatibility, but it could be removed in the future.
-	 * Writing capability needs to be maintained.
+	 * Reading capability must be maintained for backwards compatibility.
+	 * Writing capability needs to be maintained for cross-version compatibility, may be removed in FF 3.0.
 	 */
 	v3: 3,
 	/**
 	 * Was inadvertently released in 2.43.0 (through usages of configuredSharedTree) and remains available.
 	 * Reading capability must be maintained for backwards compatibility.
 	 * Writing capability needs to be maintained.
-	 * @privateRemarks TODO: stop writing this version.
 	 */
 	v4: 4,
 	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
-	v5: 5,
+	vSharedBranches: "shared-branches|v0.1",
 } as const;
 export type MessageFormatVersion = Brand<
 	(typeof MessageFormatVersion)[keyof typeof MessageFormatVersion],
@@ -51,7 +50,7 @@ export type MessageFormatVersion = Brand<
 export const supportedMessageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set([
 	MessageFormatVersion.v3,
 	MessageFormatVersion.v4,
-	MessageFormatVersion.v5,
+	MessageFormatVersion.vSharedBranches,
 ] as MessageFormatVersion[]);
 export const messageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set(
 	Object.values(MessageFormatVersion) as MessageFormatVersion[],

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -28,15 +28,24 @@ export const MessageFormatVersion = {
 	/**
 	 * Introduced prior to 2.0 and used beyond.
 	 * Reading capability must be maintained for backwards compatibility.
-	 * Writing capability needs to be maintained for cross-version compatibility, may be removed in FF 3.0.
+	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.43.0.
 	 */
 	v3: 3,
 	/**
 	 * Was inadvertently released in 2.43.0 (through usages of configuredSharedTree) and remains available.
 	 * Reading capability must be maintained for backwards compatibility.
-	 * Writing capability needs to be maintained.
+	 * Writing capability could be dropped in favor of {@link MessageFormatVersion.v3},
+	 * but doing so would make the pattern of writable versions more complex and gain little
+	 * because most of the logic for this format is shared with {@link MessageFormatVersion.v3}.
 	 */
 	v4: 4,
+	/**
+	 * This version number was used internally for testing shared branches.
+	 * This format was never made stable.
+	 * This version number is kept here solely to avoid reusing the number, it is not supported for either reading or writing.
+	 * @deprecated - use {@link MessageFormatVersion.vSharedBranches} for testing shared branches.
+	 */
+	v5: 5,
 	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.

--- a/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
@@ -9,6 +9,7 @@ import { type TSchema, Type } from "@sinclair/typebox";
 import { type EncodedRevisionTag, RevisionTagSchema, SessionIdSchema } from "../core/index.js";
 import type { JsonCompatibleReadOnly } from "../util/index.js";
 import type { EncodedBranchId } from "./branch.js";
+import { MessageFormatVersion } from "./messageFormat.js";
 
 /**
  * The format of messages that SharedTree sends and receives.
@@ -30,12 +31,9 @@ export interface Message {
 	readonly branchId?: EncodedBranchId;
 
 	/**
-	 * The version of the message. This controls how the message is encoded.
-	 *
-	 * This was not set historically and was added before making any breaking changes to the format.
-	 * For that reason, absence of a 'version' field is synonymous with version 1.
+	 * The version of the message format.
 	 */
-	readonly version?: number;
+	readonly version: typeof MessageFormatVersion.vSharedBranches;
 }
 
 // Return type is intentionally derived.
@@ -46,5 +44,5 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 		originatorId: SessionIdSchema,
 		changeset: Type.Optional(tChange),
 		branchId: Type.Optional(Type.Number()),
-		version: Type.Optional(Type.Number()),
+		version: Type.Literal(MessageFormatVersion.vSharedBranches),
 	});

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -589,7 +589,7 @@ export const changeFormatVersionForEditManager = DependentFormatVersion.fromPair
 		brand<SharedTreeChangeFormatVersion>(4),
 	],
 	[
-		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v5),
+		brand<EditManagerFormatVersion>(EditManagerFormatVersion.vSharedBranches),
 		brand<SharedTreeChangeFormatVersion>(4),
 	],
 ]);
@@ -610,7 +610,7 @@ export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs([
 		brand<SharedTreeChangeFormatVersion>(4),
 	],
 	[
-		brand<MessageFormatVersion>(MessageFormatVersion.v5),
+		brand<MessageFormatVersion>(MessageFormatVersion.vSharedBranches),
 		brand<SharedTreeChangeFormatVersion>(4),
 	],
 ]);

--- a/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
@@ -151,7 +151,7 @@ interface TestCase {
 	readonly name: string;
 	readonly data: DetachedFieldSummaryData;
 	/** The set of versions that this test case is valid for */
-	readonly validFor?: ReadonlySet<number>;
+	readonly validFor?: ReadonlySet<number | string>;
 	/** The id compressor to use for this test case */
 	readonly idCompressor: IIdCompressor;
 }

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -9,7 +9,11 @@ import type { ChangeEncodingContext } from "../../../core/index.js";
 import { FormatValidatorBasic } from "../../../external-utilities/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { makeEditManagerCodecs } from "../../../shared-tree-core/editManagerCodecs.js";
-import type { SharedBranchSummaryData, SummaryData } from "../../../shared-tree-core/index.js";
+import {
+	EditManagerFormatVersion,
+	type SharedBranchSummaryData,
+	type SummaryData,
+} from "../../../shared-tree-core/index.js";
 import { brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import {
@@ -211,11 +215,13 @@ export function testCodec() {
 			family,
 			testCases,
 			assertEquivalentSummaryDataIgnoreOriginator,
-			[3, 4],
-			[1, 2],
+			[EditManagerFormatVersion.v3, EditManagerFormatVersion.v4],
+			[EditManagerFormatVersion.v1, EditManagerFormatVersion.v2],
 		);
 
-		makeEncodingTestSuite(family, testCases, undefined, [5]);
+		makeEncodingTestSuite(family, testCases, undefined, [
+			EditManagerFormatVersion.vSharedBranches,
+		]);
 
 		// TODO: testing EditManagerSummarizer class itself, specifically for attachment and normal summaries.
 		// TODO: format compatibility tests to detect breaking of existing documents.

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -216,7 +216,7 @@ export function testCodec() {
 			testCases,
 			assertEquivalentSummaryDataIgnoreOriginator,
 			[EditManagerFormatVersion.v3, EditManagerFormatVersion.v4],
-			[EditManagerFormatVersion.v1, EditManagerFormatVersion.v2],
+			[EditManagerFormatVersion.v1, EditManagerFormatVersion.v2, EditManagerFormatVersion.v5],
 		);
 
 		makeEncodingTestSuite(family, testCases, undefined, [

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -29,6 +29,7 @@ import {
 	testRevisionTagCodec,
 } from "../utils.js";
 import { currentVersion, DependentFormatVersion } from "../../codec/index.js";
+import { MessageFormatVersion } from "../../shared-tree-core/index.js";
 
 const commit1 = {
 	revision: mintRevisionTag(),
@@ -150,7 +151,13 @@ describe("message codec", () => {
 		},
 	);
 
-	makeEncodingTestSuite(family, testCases, undefined, [3, 4, 5], [undefined, 1, 2]);
+	makeEncodingTestSuite(
+		family,
+		testCases,
+		undefined,
+		[MessageFormatVersion.v3, MessageFormatVersion.v4, MessageFormatVersion.vSharedBranches],
+		[undefined, MessageFormatVersion.v1, MessageFormatVersion.v2],
+	);
 
 	describe("dispatching codec", () => {
 		const codec = makeMessageCodec(

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -156,7 +156,7 @@ describe("message codec", () => {
 		testCases,
 		undefined,
 		[MessageFormatVersion.v3, MessageFormatVersion.v4, MessageFormatVersion.vSharedBranches],
-		[undefined, MessageFormatVersion.v1, MessageFormatVersion.v2],
+		[undefined, MessageFormatVersion.v1, MessageFormatVersion.v2, MessageFormatVersion.v5],
 	);
 
 	describe("dispatching codec", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2323,8 +2323,8 @@ describe("SharedTree", () => {
 		});
 	});
 
-	describe("Shared Tree format v5 enablement via `configuredSharedTree`", () => {
-		it("can create a SharedTree with format v5 enabled", async () => {
+	describe("Shared Tree format vSharedBranches enablement via `configuredSharedTree`", () => {
+		it("can create a SharedTree with format vSharedBranches enabled", async () => {
 			// Create and initialize the runtime factory
 			const runtime = new MockSharedTreeRuntime();
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2323,8 +2323,8 @@ describe("SharedTree", () => {
 		});
 	});
 
-	describe("Shared Tree format vSharedBranches enablement via `configuredSharedTree`", () => {
-		it("can create a SharedTree with format vSharedBranches enabled", async () => {
+	describe("Schema v2 format enablement via `configuredSharedTree`", () => {
+		it("can create a SharedTree with schema format v2 enabled", async () => {
 			// Create and initialize the runtime factory
 			const runtime = new MockSharedTreeRuntime();
 


### PR DESCRIPTION
## Description

* Allows versioned codecs to use string literals as version tags. This allows strings to be used for format versions that are still in development (i.e., not officially supported).
* Update codecs and formats that are specific to shared branches so they use a string version tag.
* Fix the comments on `EditManagerFormatVersion` and `MessageFormatVersion` members.

## Breaking Changes

Existing documents that were created using a SharedTree instance that was configured to use shared branches will no longer be loadable. Cross-version collaboration will fail with earlier clients that are configured to use shared branches. Note that we did not and still do not make guarantees about such scenarios.