### PR TITLE
build(lts): Fix issue that always skipped publish stage for LTS CI

### DIFF
--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -60,9 +60,22 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+      buildNumberInPatch: true
+
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -63,9 +63,21 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -101,9 +101,21 @@ schedules:
     - lts
   always: true
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml@self
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -63,9 +63,21 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -63,9 +63,21 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -63,9 +63,21 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -59,9 +59,22 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+      buildNumberInPatch: true
+
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publish: ${{ variables.publish }}
+    shouldPublish: ${{ variables.shouldPublish }}
+    canRelease: ${{ variables.canRelease }}
+    componentDetection: ${{ variables.componentDetection }}
+    release: ${{ variables.release }}
+    testBuild: ${{ variables.testBuild }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -104,6 +104,30 @@ parameters:
   type: boolean
   default: false
 
+# Indicates if this run is going to publish npm packages (and run extra steps necessary in that case) or not
+- name: publish
+  type: boolean
+
+# Indicates if we should or should not skip all publish stages
+- name: shouldPublish
+  type: boolean
+
+# Indicates if the build is from a branch that we can release from
+- name: canRelease
+  type: boolean
+
+# Indicates if we should run component detection (if we are publishing any artifacts)
+- name: componentDetection
+  type: boolean
+
+# Indicates the type of release (if any)
+- name: release
+  type: string
+
+# Indicates if this build is from a test branch
+- name: testBuild
+  type: boolean
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -151,18 +175,12 @@ extends:
         # basic ANSI color support though, so force that in the pipeline
         - name: FORCE_COLOR
           value: 1
-        - template: /tools/pipelines/templates/include-vars.yml@self
-          parameters:
-            publishOverride: '${{ parameters.publishOverride }}'
-            releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
         - group: ado-feeds
         - group: storage-vars
         # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
         # will be things like upgrading node or security fixes, not adding new features.
         - name: testCoverage
           value: false
-        - name: releaseBuildVar
-          value: $[variables.releaseBuild]
         templateContext:
           outputs:
           - ${{ if ne(parameters.taskPack, false) }}:
@@ -206,9 +224,6 @@ extends:
               # Show all task group conditions
 
               echo "
-              Pipeline Variables:
-                releaseBuild=$(releaseBuildVar)
-
               Override Parameters:
                 publishOverride=${{ parameters.publishOverride }}
                 releaseBuildOverride=${{ parameters.releaseBuildOverride }}
@@ -225,18 +240,21 @@ extends:
                 nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
 
               Computed variables:
-                shouldPublish=${{ variables.shouldPublish }}
-                componentDetection=${{ variables.componentDetection }}
-                publish=${{ variables.publish }}
-                canRelease=${{ variables.canRelease }}
-                targetBranchName = $(System.PullRequest.TargetBranch)
+                shouldPublish=${{ parameters.shouldPublish }}
+                componentDetection=${{ parameters.componentDetection }}
+                publish=${{ parameters.publish }}
+                canRelease=${{ parameters.canRelease }}
+                release=${{ parameters.release }}"
 
-                release=$(release)"
+              # Target Branch variable (PR policy related)
+              if [[ "$(Build.Reason)" == "PullRequest" ]]; then
+                echo "TargetBranchName=$(System.PullRequest.TargetBranch)"
+              fi
 
               # Error checking
-              if [[ "$(release)" == "release" ]]; then
-                if [[ "${{ variables.canRelease }}" == "False" ]]; then
-                  echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
+              if [[ "${{ parameters.release }}" == "release" ]]; then
+                if [[ "${{ parameters.canRelease }}" == "False" ]]; then
+                  echo "##vso[task.logissue type=error]Invalid branch $(Build.SourceBranch) for release"
                   exit -1;
                 fi
 
@@ -252,16 +270,16 @@ extends:
                 fi
               fi
 
-              if [[ "$(release)" == "prerelease" ]]; then
+              if [[ "${{ parameters.release }}" == "prerelease" ]]; then
                 if [[ "${{ parameters.buildNumberInPatch }}" == "true" ]]; then
                   echo "##vso[task.logissue type=error] Prerelease not allow for builds that put build number as the patch version"
                   exit -1;
                 fi
               fi
 
-              if [[ "$(release)" != "none" ]] && [[ "$(release)" != "" ]]; then
-                if [[ "${{ variables.publish }}" != "True" ]]; then
-                  echo "##vso[task.logissue type=error]'$(release)'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
+              if [[ "${{ parameters.release }}" != "none" ]] && [[ "${{ parameters.release }}" != "" ]]; then
+                if [[ "${{ parameters.publish }}" != "True" ]]; then
+                  echo "##vso[task.logissue type=error]'${{ parameters.release }}'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
                   exit -1;
                 fi
               fi
@@ -429,7 +447,9 @@ extends:
               fi
 
     # Publish stage
-    - ${{ if eq(variables.publish, true) }}:
+    - ${{ if eq(parameters.publish, true) }}:
       - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
         parameters:
           tagName: ${{ parameters.tagName }}
+          testBuild: ${{ parameters.testBuild }}
+          release: ${{ parameters.release }}

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -37,6 +37,11 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
+# Indicates the type of release (if any)
+- name: release
+  type: string
+  default: ''
+
 jobs:
 - deployment: publish_${{ replace(parameters.environment, '-', '_') }}
   displayName: Publish ${{ parameters.environment }}
@@ -48,6 +53,8 @@ jobs:
     - group: ado-feeds
     - name: version
       value: $[ stageDependencies.build.build.outputs['SetVersion.version']]
+    - name: release
+      value: ${{ parameters.release }}
     - name: isLatest
       value: $[ stageDependencies.build.build.outputs['SetVersion.isLatest']]
   strategy:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -11,11 +11,19 @@ parameters:
   type: object
   default: Small-eastus2
 
+# Indicates if this build is from a test branch
+- name: testBuild
+  type: boolean
+
+# Indicates the type of release (if any)
+- name: release
+  type: string
+
 stages:
 - stage: publish_npm_internal_test
   dependsOn: build
   displayName: Publish Internal Test Packages
-  condition: and(succeeded(), eq(variables['testBuild'], true))
+  condition: and(succeeded(), eq(${{ parameters.testBuild }}, true))
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -25,11 +33,12 @@ stages:
       pool: ${{ parameters.pool }}
       packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
       packageManager: pnpm
+      release: ${{ parameters.release }}
 
 - stage: publish_npm_internal
   dependsOn: build
   displayName: Publish Internal Packages
-  condition: and(succeeded(), eq(variables['testBuild'], false))
+  condition: and(succeeded(), eq(${{ parameters.testBuild }}, false))
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -39,11 +48,12 @@ stages:
       pool: ${{ parameters.pool }}
       packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
       packageManager: pnpm
+      release: ${{ parameters.release }}
 
 - stage: publish_npm_official
   dependsOn: build
   displayName: Publish Official Packages
-  condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
+  condition: and(succeeded(), or(eq('${{ parameters.release }}', 'release'), eq('${{ parameters.release }}', 'prerelease')))
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -55,3 +65,4 @@ stages:
       customEndPoint: npmjs
       tagName: ${{ parameters.tagName }}
       packageManager: pnpm
+      release: ${{ parameters.release }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -83,12 +83,12 @@ variables:
 
 # compute the release variable
 - ${{ if eq(parameters.releaseBuildOverride, 'none') }}:
-  - name: release
-    value: none
-- ${{ if ne(parameters.releaseBuildOverride, 'none') }}:
-  - ${{ if and(eq(variables.canRelease, true), eq(variables.shouldPublish, true)) }}:
+  - ${{ if eq(variables.shouldPublish, true) }}:
     - name: release
-      value: ${{ parameters.releaseBuildOverride }}
-  - ${{ if or(ne(variables.canRelease, true), ne(variables.shouldPublish, true)) }}:
+      value: $(release)
+  - ${{ if ne(variables.shouldPublish, true) }}:
     - name: release
       value: none
+- ${{ if ne(parameters.releaseBuildOverride, 'none') }}:
+  - name: release
+    value: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -83,12 +83,12 @@ variables:
 
 # compute the release variable
 - ${{ if eq(parameters.releaseBuildOverride, 'none') }}:
-  - ${{ if eq(variables.shouldPublish, true) }}:
+  - name: release
+    value: none
+- ${{ if ne(parameters.releaseBuildOverride, 'none') }}:
+  - ${{ if and(eq(variables.canRelease, true), eq(variables.shouldPublish, true)) }}:
     - name: release
-      value: $[variables.releaseBuild]
-  - ${{ if ne(variables.shouldPublish, true) }}:
+      value: ${{ parameters.releaseBuildOverride }}
+  - ${{ if or(ne(variables.canRelease, true), ne(variables.shouldPublish, true)) }}:
     - name: release
       value: none
-- ${{ if ne(parameters.releaseBuildOverride, 'none') }}:
-  - name: release
-    value: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -81,14 +81,6 @@ variables:
       eq(parameters.releaseImage, true)
     )}}
 
-# compute the release variable
-- ${{ if eq(parameters.releaseBuildOverride, 'none') }}:
-  - ${{ if eq(variables.shouldPublish, true) }}:
-    - name: release
-      value: none
-  - ${{ if ne(variables.shouldPublish, true) }}:
-    - name: release
-      value: none
-- ${{ if ne(parameters.releaseBuildOverride, 'none') }}:
-  - name: release
-    value: ${{ parameters.releaseBuildOverride }}
+# Release will always eval to the override value. By default it will be none.
+- name: release
+  value: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -85,7 +85,7 @@ variables:
 - ${{ if eq(parameters.releaseBuildOverride, 'none') }}:
   - ${{ if eq(variables.shouldPublish, true) }}:
     - name: release
-      value: $(release)
+      value: ${{ parameters.releaseBuildOverride }}
   - ${{ if ne(variables.shouldPublish, true) }}:
     - name: release
       value: none

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -85,7 +85,7 @@ variables:
 - ${{ if eq(parameters.releaseBuildOverride, 'none') }}:
   - ${{ if eq(variables.shouldPublish, true) }}:
     - name: release
-      value: ${{ parameters.releaseBuildOverride }}
+      value: none
   - ${{ if ne(variables.shouldPublish, true) }}:
     - name: release
       value: none


### PR DESCRIPTION
## Description

This PR resolves an issue from https://github.com/microsoft/FluidFramework/pull/25931 where we were always skipping the publish stage of the LTS build CI due to variables not being passed properly. This prevents us from using internal packages for testing pipelines and releasing from the LTS branch.

We will need to merge this PR to confirm if this this fixes the issue, since we only publish internal packages for non-test branches.