### PR TITLE
Make tree workspace test browser config use esm tests

### DIFF
--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
 	// File path is already set in .mocharc.cjs, so this should not be required,
 	// but something seems to be overriding that path, and this is needed to make it work.
-	// Also for unknown (but likely related reasons) this cannot be just "dist/test" which is used in the config.
+	// Also for unknown (but likely related reasons) this cannot be just "lib/test" which is used in the config.
 	// This is not limited to "spec.js" so that benchmarks are included (which will be run in correctness mode).
-	"mochaExplorer.files": ["dist/test/**/*.*js"],
+	"mochaExplorer.files": ["lib/test/**/*.*js"],
 	// "pruneFiles" is disabled because it causesd "source-map-support/register" to give `Unknown file extension ".ts"` errors.
 	// "mochaExplorer.pruneFiles": true,
 	"mochaExplorer.require": [


### PR DESCRIPTION
## Description

Adjust test browser config so it shows the esm versions of tests not the common JS versions. Both should behave the same, but we care more about ESM as all production use of our package uses ESM, and its generally more modern with better tooling support and might process slightly faster.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
