### PR TITLE
build(client): Remove LTS trigger in Build - client packages

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -18,7 +18,6 @@ resources:
       - release/*
       - main
       - next
-      - lts
   repositories:
   - repository: ff_pipeline_host
     type: git


### PR DESCRIPTION
#### Description

LTS branch has been failing Real Service Stress Test pipeline since September 14th, thus disabling the LTS trigger from the `Build - client packages` until fix is applied. 


#### Related PR

[Disable LTS Schedule Run](https://github.com/microsoft/FluidFramework/compare/lts...test/lts-remove-schedule?expand=1)

