### PR TITLE
Remove scheduled run in lts stress test pipeline

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -7,13 +7,6 @@ name: $(Build.BuildId)
 
 trigger: none
 pr: none
-schedules:
-- cron: "0 14 * * *" # Run every day at 7 am PST
-  displayName: LTS Branch Daily Stress Test Run
-  branches:
-    include:
-    - lts
-  always: true
 
 resources:
   pipelines:


### PR DESCRIPTION
#### Description

LTS branch has been failing Real Service Stress Test pipeline since September 14th, thus disabling the scheduled LTS run in the pipeline. 

#### Related PR

[Remove LTS trigger in Build - client packages](https://github.com/microsoft/FluidFramework/pull/25966)