### PR TITLE
fix(tree): commit enrichment after transaction abort

### DIFF
--- a/.changeset/spicy-grapes-leave.md
+++ b/.changeset/spicy-grapes-leave.md
@@ -6,6 +6,6 @@
 Fixed bug in sending of revert edits after an aborted transaction
 
 Aborting a transaction used to put the tree in a state that would trigger an assert when sending some undo/redo edits to peers.
-This would prevent to undo/redo edit from being sent and put the tree in a broken state that prevented any further edits.
+This would prevent some undo/redo edits from being sent, and would put the tree in a broken state that prevented any further edits.
 This issue could not have caused document corruption, so reopening the document was a possible remedy.
 Aborting a transaction no longer puts the tree in such a state, so it is safe to perform undo/redo edits after that.

--- a/.changeset/spicy-grapes-leave.md
+++ b/.changeset/spicy-grapes-leave.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Fixed bug in sending of revert edits after an aborted transaction
+
+Aborting a transaction used to put the tree in a state that would trigger an assert when sending some undo/redo edits to peers.
+This would prevent to undo/redo edit from being sent and put the tree in a broken state that prevented any further edits.
+This issue could not have caused document corruption, so reopening the document was a possible remedy.
+Aborting a transaction no longer puts the tree in such a state, so it is safe to perform undo/redo edits after that.

--- a/.changeset/spicy-grapes-leave.md
+++ b/.changeset/spicy-grapes-leave.md
@@ -6,6 +6,6 @@
 Fixed bug in sending of revert edits after an aborted transaction
 
 Aborting a transaction used to put the tree in a state that would trigger an assert when sending some undo/redo edits to peers.
-This would prevent some undo/redo edits from being sent, and would put the tree in a broken state that prevented any further edits.
+This would prevent some undo/redo edits from being sent and would put the tree in a broken state that prevented any further edits.
 This issue could not have caused document corruption, so reopening the document was a possible remedy.
 Aborting a transaction no longer puts the tree in such a state, so it is safe to perform undo/redo edits after that.

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -84,7 +84,7 @@ export {
 	isCursor,
 	DetachedFieldIndex,
 	type ReadOnlyDetachedFieldIndex,
-	type DetachedFieldIndexSnapshot,
+	type DetachedFieldIndexCheckpoint,
 	type ForestRootId,
 	getDetachedFieldContainingPath,
 	aboveRootPlaceholder,

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -83,6 +83,8 @@ export {
 	CursorMarker,
 	isCursor,
 	DetachedFieldIndex,
+	type ReadOnlyDetachedFieldIndex,
+	type DetachedFieldIndexSnapshot,
 	type ForestRootId,
 	getDetachedFieldContainingPath,
 	aboveRootPlaceholder,

--- a/packages/dds/tree/src/core/tree/detachedFieldIndex.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndex.ts
@@ -42,7 +42,7 @@ import { makeDetachedFieldIndexCodec } from "./detachedFieldIndexCodecs.js";
  */
 export interface ReadOnlyDetachedFieldIndex {
 	/**
-	 * Creates a deep clone of this DetachedFieldIndex.
+	 * Creates a deep clone of this `DetachedFieldIndex`.
 	 */
 	clone(): DetachedFieldIndex;
 
@@ -53,13 +53,13 @@ export interface ReadOnlyDetachedFieldIndex {
 	toFieldKey(id: ForestRootId): FieldKey;
 
 	/**
-	 * Returns the FieldKey associated with the given id.
+	 * Returns the `ForestRootId` associated with the given id.
 	 * Returns undefined if no such id is known to the index.
 	 */
 	tryGetEntry(id: Delta.DetachedNodeId): ForestRootId | undefined;
 
 	/**
-	 * Returns the FieldKey associated with the given id.
+	 * Returns the `ForestRootId` associated with the given id.
 	 * Fails if no such id is known to the index.
 	 */
 	getEntry(id: Delta.DetachedNodeId): ForestRootId;

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -119,7 +119,7 @@ export {
 
 export {
 	DetachedFieldIndex,
-	type DetachedFieldIndexSnapshot,
+	type DetachedFieldIndexCheckpoint,
 	type ReadOnlyDetachedFieldIndex,
 } from "./detachedFieldIndex.js";
 

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -117,7 +117,11 @@ export {
 	type ChunkedCursor,
 } from "./chunk.js";
 
-export { DetachedFieldIndex } from "./detachedFieldIndex.js";
+export {
+	DetachedFieldIndex,
+	type DetachedFieldIndexSnapshot,
+	type ReadOnlyDetachedFieldIndex,
+} from "./detachedFieldIndex.js";
 
 export { getCodecTreeForDetachedFieldIndexFormat } from "./detachedFieldIndexCodecs.js";
 export { type DetachedFieldIndexFormatVersion } from "./detachedFieldIndexFormatCommon.js";

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -457,12 +457,12 @@ export class TreeCheckout implements ITreeCheckoutFork {
 				const disposeForks = this.disposeForksAfterTransaction
 					? trackForksForDisposal(this)
 					: undefined;
-				// When each transaction is started, take a snapshot of the current state of removed roots
-				const removedRootsSnapshot = this._removedRoots.createSnapshot();
+				// When each transaction is started, make a restorable checkpoint of the current state of removed roots
+				const restoreRemovedRoots = this._removedRoots.createCheckpoint();
 				return (result) => {
 					switch (result) {
 						case TransactionResult.Abort:
-							removedRootsSnapshot.restore();
+							restoreRemovedRoots();
 							break;
 						case TransactionResult.Commit:
 							if (!this.transaction.isInProgress()) {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -48,6 +48,7 @@ import {
 	type TreeNodeStoredSchema,
 	LeafNodeStoredSchema,
 	diffHistories,
+	type ReadOnlyDetachedFieldIndex,
 } from "../core/index.js";
 import {
 	type FieldBatchCodec,
@@ -406,7 +407,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly revisionTagCodec: RevisionTagCodec,
 		private readonly idCompressor: IIdCompressor,
-		public removedRoots: DetachedFieldIndex = makeDetachedFieldIndex(
+		private readonly _removedRoots: DetachedFieldIndex = makeDetachedFieldIndex(
 			"repair",
 			revisionTagCodec,
 			idCompressor,
@@ -419,6 +420,10 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.#transaction = this.createTransactionStack(branch);
 		this.editLock = new EditLock(this.#transaction.activeBranchEditor);
 		this.registerForBranchEvents();
+	}
+
+	public get removedRoots(): ReadOnlyDetachedFieldIndex {
+		return this._removedRoots;
 	}
 
 	private registerForBranchEvents(): void {
@@ -441,7 +446,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			(commits) => {
 				const revision = this.mintRevisionTag();
 				for (const transactionStep of commits) {
-					this.removedRoots.updateMajor(transactionStep.revision, revision);
+					this._removedRoots.updateMajor(transactionStep.revision, revision);
 				}
 
 				const squashedChange = this.changeFamily.rebaser.compose(commits);
@@ -453,11 +458,11 @@ export class TreeCheckout implements ITreeCheckoutFork {
 					? trackForksForDisposal(this)
 					: undefined;
 				// When each transaction is started, take a snapshot of the current state of removed roots
-				const removedRootsSnapshot = this.removedRoots.clone();
+				const removedRootsSnapshot = this._removedRoots.createSnapshot();
 				return (result) => {
 					switch (result) {
 						case TransactionResult.Abort:
-							this.removedRoots = removedRootsSnapshot;
+							removedRootsSnapshot.restore();
 							break;
 						case TransactionResult.Commit:
 							if (!this.transaction.isInProgress()) {
@@ -566,7 +571,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			if (innerChange.type === "data") {
 				const delta = intoDelta(tagChange(innerChange.innerChange, revision));
 				this.withCombinedVisitor((visitor) => {
-					visitDelta(delta, visitor, this.removedRoots, revision);
+					visitDelta(delta, visitor, this._removedRoots, revision);
 				});
 			} else if (innerChange.type === "schema") {
 				// Schema changes from a current to a new schema are expected to be backwards compatible.
@@ -597,14 +602,14 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.withCombinedVisitor((visitor) => {
 			revisions.forEach((revision) => {
 				// get all the roots last created or used by the revision
-				const roots = this.removedRoots.getRootsLastTouchedByRevision(revision);
+				const roots = this._removedRoots.getRootsLastTouchedByRevision(revision);
 
 				// get the detached field for the root and delete it from the removed roots
 				for (const root of roots) {
-					visitor.destroy(this.removedRoots.toFieldKey(root), 1);
+					visitor.destroy(this._removedRoots.toFieldKey(root), 1);
 				}
 
-				this.removedRoots.deleteRootsLastTouchedByRevision(revision);
+				this._removedRoots.deleteRootsLastTouchedByRevision(revision);
 			});
 		});
 	};
@@ -774,7 +779,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			this.mintRevisionTag,
 			this.revisionTagCodec,
 			this.idCompressor,
-			this.removedRoots.clone(),
+			this._removedRoots.clone(),
 			this.logger,
 			this.breaker,
 			this.disposeForksAfterTransaction,
@@ -894,8 +899,8 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.assertNoUntrackedRoots();
 		const trees: [string | number | undefined, number, JsonableTree][] = [];
 		const cursor = this.forest.allocateCursor("getRemovedRoots");
-		for (const { id, root } of this.removedRoots.entries()) {
-			const parentField = this.removedRoots.toFieldKey(root);
+		for (const { id, root } of this._removedRoots.entries()) {
+			const parentField = this._removedRoots.toFieldKey(root);
 			this.forest.moveCursorToPath({ parent: undefined, parentField, parentIndex: 0 }, cursor);
 			const tree = jsonableTreeFromCursor(cursor);
 			// This method is used for tree consistency comparison.
@@ -915,7 +920,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	public load(): void {
 		// Set the tip revision as the latest relevant revision for any removed roots that are loaded from a summary - this allows them to be garbage collected later.
 		// When a load happens, the head of the trunk and the head of the local/main branch must be the same (this is enforced by SharedTree).
-		this.removedRoots.setRevisionsForLoadedData(this.#transaction.branch.getHead().revision);
+		this._removedRoots.setRevisionsForLoadedData(this.#transaction.branch.getHead().revision);
 		// The content of the checkout (e.g. the forest) has (maybe) changed, so fire an afterBatch event.
 		this.#events.emit("afterBatch");
 	}
@@ -987,8 +992,8 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	private assertNoUntrackedRoots(): void {
 		const cursor = this.forest.getCursorAboveDetachedFields();
 		const rootFields = new Set([rootFieldKey]);
-		for (const { root } of this.removedRoots.entries()) {
-			rootFields.add(this.removedRoots.toFieldKey(root));
+		for (const { root } of this._removedRoots.entries()) {
+			rootFields.add(this._removedRoots.toFieldKey(root));
 		}
 
 		if (!cursor.firstField()) {

--- a/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
@@ -563,31 +563,31 @@ describe("DetachedFieldIndex methods", () => {
 		assert.notEqual(detachedIndex.toFieldKey(rootId), detachedIndex.toFieldKey(rootId2));
 	});
 
-	describe("snapshotting", () => {
-		it("loading a snapshot restores the index state", () => {
+	describe("checkpoints", () => {
+		it("invoking a checkpoint restores the index state", () => {
 			const index = makeDetachedFieldIndex();
 			const revisionTag1 = mintRevisionTag();
 			index.createEntry(makeDetachedNodeId(revisionTag1, 1));
 
 			const originalData = index.encode();
-			const snapshot = index.createSnapshot();
+			const restore = index.createCheckpoint();
 
 			// Make changes to the index
 			index.deleteEntry(makeDetachedNodeId(revisionTag1, 1));
 			index.createEntry(makeDetachedNodeId(revisionTag1, 2), revisionTag1);
 			assert.notDeepEqual(index.encode(), originalData);
 
-			snapshot.restore();
+			restore();
 			assert.deepEqual(index.encode(), originalData);
 		});
 
-		it("multiple snapshots can exist for the same index", () => {
+		it("multiple checkpoints can exist for the same index", () => {
 			const index = makeDetachedFieldIndex();
 			const revisionTag1 = mintRevisionTag();
 			index.createEntry(makeDetachedNodeId(revisionTag1, 1));
 
 			const originalData = index.encode();
-			const snapshot1 = index.createSnapshot();
+			const restore1 = index.createCheckpoint();
 
 			// Make changes to the index
 			index.deleteEntry(makeDetachedNodeId(revisionTag1, 1));
@@ -595,36 +595,36 @@ describe("DetachedFieldIndex methods", () => {
 			assert.notDeepEqual(index.encode(), originalData);
 
 			const changedData = index.encode();
-			const snapshot2 = index.createSnapshot();
+			const restore2 = index.createCheckpoint();
 
-			snapshot1.restore();
+			restore1();
 			assert.deepEqual(index.encode(), originalData);
 
-			snapshot2.restore();
+			restore2();
 			assert.deepEqual(index.encode(), changedData);
 		});
 
-		it("a snapshot can be restored multiple times", () => {
+		it("a checkpoint can be restored multiple times", () => {
 			const index = makeDetachedFieldIndex();
 			const revisionTag1 = mintRevisionTag();
 			index.createEntry(makeDetachedNodeId(revisionTag1, 1));
 
 			const originalData = index.encode();
-			const snapshot = index.createSnapshot();
+			const restore = index.createCheckpoint();
 
 			// Make changes to the index
 			index.deleteEntry(makeDetachedNodeId(revisionTag1, 1));
 			index.createEntry(makeDetachedNodeId(revisionTag1, 2), revisionTag1);
 			assert.notDeepEqual(index.encode(), originalData);
 
-			snapshot.restore();
+			restore();
 			assert.deepEqual(index.encode(), originalData);
 
 			// Make more changes to the index
 			index.createEntry(makeDetachedNodeId(revisionTag1, 3), revisionTag1);
 			assert.notDeepEqual(index.encode(), originalData);
 
-			snapshot.restore();
+			restore();
 			assert.deepEqual(index.encode(), originalData);
 		});
 	});

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -321,7 +321,7 @@ describe("SharedTreeCore", () => {
 		assert.deepEqual([...root1], ["A", "B"]);
 		assert.deepEqual([...root2], ["A", "B"]);
 
-		// Make an additional changes to ensure that all changes from the previous transactions were flushed
+		// Make additional changes to ensure that all changes from the previous transactions were flushed
 		// and that future edits that require refreshers work as expected.
 		const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(
 			provider.trees[0].kernel.checkout.events,
@@ -346,7 +346,7 @@ describe("SharedTreeCore", () => {
 		unsubscribe();
 	});
 
-	it("Tolerates aborting  an inner transaction", async () => {
+	it("Tolerates aborting an inner transaction", async () => {
 		const provider = new TestTreeProviderLite(2);
 		const view1 = provider.trees[0].viewWith(
 			new TreeViewConfiguration({
@@ -384,7 +384,7 @@ describe("SharedTreeCore", () => {
 		assert.deepEqual([...root1], ["B"]);
 		assert.deepEqual([...root2], ["B"]);
 
-		// Make an additional changes to ensure that all changes from the previous transactions were flushed
+		// Make additional changes to ensure that all changes from the previous transactions were flushed
 		// and that future edits that require refreshers work as expected.
 		const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(
 			provider.trees[0].kernel.checkout.events,

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -82,8 +82,8 @@ const removeRoot: SharedTreeChange = {
 const revision1 = testIdCompressor.generateCompressedId();
 
 interface TestChangeEnricher {
-	forest: IEditableForest;
-	removedRoots: DetachedFieldIndex;
+	borrowedForest: IEditableForest;
+	borrowedRemovedRoots: DetachedFieldIndex;
 	fork(): SharedTreeMutableChangeEnricher & TestChangeEnricher;
 }
 
@@ -110,17 +110,17 @@ export function setupEnricher() {
 describe("SharedTreeChangeEnricher", () => {
 	it("applies tip changes to fork", () => {
 		const { enricher, fork } = setupEnricher();
-		assert.deepEqual(jsonTreeFromForest(enricher.forest), [content]);
-		assert.deepEqual(Array.from(enricher.removedRoots.entries()), []);
+		assert.deepEqual(jsonTreeFromForest(enricher.borrowedForest), [content]);
+		assert.deepEqual(Array.from(enricher.borrowedRemovedRoots.entries()), []);
 
 		fork.applyTipChange(removeRoot, revision1);
 
-		assert.deepEqual(jsonTreeFromForest(fork.forest), []);
-		assert.equal(Array.from(fork.removedRoots.entries()).length, 1);
+		assert.deepEqual(jsonTreeFromForest(fork.borrowedForest), []);
+		assert.equal(Array.from(fork.borrowedRemovedRoots.entries()).length, 1);
 
 		// The original enricher should not have been modified
-		assert.deepEqual(jsonTreeFromForest(enricher.forest), [content]);
-		assert.deepEqual(Array.from(enricher.removedRoots.entries()), []);
+		assert.deepEqual(jsonTreeFromForest(enricher.borrowedForest), [content]);
+		assert.deepEqual(Array.from(enricher.borrowedRemovedRoots.entries()), []);
 	});
 
 	it("updates enrichments", () => {


### PR DESCRIPTION
## Description

Aborting a transaction used to put the tree in a state that would trigger an assert when sending some undo/redo edits to peers.
This would prevent some undo/redo edits from being sent and would put the tree in a broken state that prevented any further edits.
This issue could not have caused document corruption, so reopening the document was a possible remedy.

After this PR, aborting a transaction no longer puts the tree in such a state, so it is safe to perform undo/redo edits after that.

This bug was due to the fact that `TreeCheckout` overwrote its `DetachedFieldIndex` member with a new instance when performing a transaction rollback but had no way of informing the `SharedTreeReadonlyChangeEnricher` that it should now be reading from the new instance during change enrichment.

This PR fixes the bug by ensuring that a given `TreeCheckout` instance always uses the same `DetachedFieldIndex` instance. This requires introducing a way of snapshotting and (on transaction rollback) restoring the `DetachedFieldIndex` state that does not require replacing the instance.

This PR also reduces the `DetachedFieldIndex` API surface made available to `SharedTreeReadonlyChangeEnricher` by introducing the `ReadOnlyDetachedFieldIndex` interface. This is not required as part of this change and could be done in a separate PR.

## Breaking Changes

None

## Reviewer Guidance

Let me know if you think it's worth spinning up a separate PR for the introduction of `ReadOnlyDetachedFieldIndex`.