### PR TITLE
Make field kind upgrades monotonic

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -21,7 +21,6 @@ import {
 	FlexFieldKind,
 	type FullSchemaPolicy,
 	type ToDelta,
-	allowsTreeSchemaIdentifierSuperset,
 	referenceFreeFieldChangeRebaser,
 } from "../modular-schema/index.js";
 import {
@@ -76,15 +75,20 @@ export interface RequiredFieldEditor extends FieldEditor<OptionalChangeset> {
 }
 
 const optionalIdentifier = brandConst("Optional")<FieldKindIdentifier>();
+const requiredIdentifier = brandConst("Value")<FieldKindIdentifier>();
+const sequenceIdentifier = brandConst("Sequence")<FieldKindIdentifier>();
+const identifierFieldIdentifier = brandConst("Identifier")<FieldKindIdentifier>();
 
 /**
  * 0 or 1 items.
  */
 export const optional = new FlexFieldKind(optionalIdentifier, Multiplicity.Optional, {
 	changeHandler: optionalChangeHandler,
-	allowedMonotonicUpgrade: (types, other) =>
-		(other.kind === sequence.identifier || other.kind === optionalIdentifier) &&
-		allowsTreeSchemaIdentifierSuperset(types, other.types),
+	allowMonotonicUpgradeFrom: new Set([
+		identifierFieldIdentifier,
+		requiredIdentifier,
+		forbiddenFieldKindIdentifier,
+	]),
 });
 
 export const requiredFieldEditor: RequiredFieldEditor = {
@@ -103,51 +107,38 @@ export const requiredFieldChangeHandler: FieldChangeHandler<
 	editor: requiredFieldEditor,
 };
 
-const requiredIdentifier = brandConst("Value")<FieldKindIdentifier>();
-
 /**
  * Exactly one item.
  */
 export const required = new FlexFieldKind(requiredIdentifier, Multiplicity.Single, {
 	changeHandler: requiredFieldChangeHandler,
-	allowedMonotonicUpgrade: (types, other) =>
-		// By omitting Identifier here,
-		// this is making a policy choice that a schema upgrade cannot be done from required to identifier.
-		// Since an identifier can be upgraded into a required field,
-		// preventing the inverse helps ensure that schema upgrades are monotonic.
-		// Which direction is allowed is a subjective policy choice.
-		(other.kind === sequence.identifier ||
-			other.kind === requiredIdentifier ||
-			other.kind === optional.identifier) &&
-		allowsTreeSchemaIdentifierSuperset(types, other.types),
+	allowMonotonicUpgradeFrom: new Set([identifierFieldIdentifier]),
 });
-
-const sequenceIdentifier = brandConst("Sequence")<FieldKindIdentifier>();
 
 /**
  * 0 or more items.
  */
 export const sequence = new FlexFieldKind(sequenceIdentifier, Multiplicity.Sequence, {
 	changeHandler: sequenceFieldChangeHandler,
-	allowedMonotonicUpgrade: (types, other) =>
-		other.kind === sequenceIdentifier &&
-		allowsTreeSchemaIdentifierSuperset(types, other.types),
+	allowMonotonicUpgradeFrom: new Set([
+		required.identifier,
+		optional.identifier,
+		identifierFieldIdentifier,
+		forbiddenFieldKindIdentifier,
+	]),
 });
-
-const identifierFieldIdentifier = brandConst("Identifier")<FieldKindIdentifier>();
 
 /**
  * Exactly one identifier.
  */
 export const identifier = new FlexFieldKind(identifierFieldIdentifier, Multiplicity.Single, {
 	changeHandler: noChangeHandler,
-	allowedMonotonicUpgrade: (types, other) =>
-		// Allows upgrading from identifier to required: which way this upgrade is allowed to go is a subjective policy choice.
-		(other.kind === sequence.identifier ||
-			other.kind === requiredIdentifier ||
-			other.kind === optional.identifier ||
-			other.kind === identifierFieldIdentifier) &&
-		allowsTreeSchemaIdentifierSuperset(types, other.types),
+	// By omitting required here,
+	// this is making a policy choice that a schema upgrade cannot be done from required to identifier.
+	// Since an identifier can be upgraded into a required field,
+	// preventing the inverse helps ensure that schema upgrades are monotonic.
+	// Which direction is allowed is a subjective policy choice.
+	allowMonotonicUpgradeFrom: new Set([]),
 });
 
 /**
@@ -183,9 +174,7 @@ export const forbidden = new FlexFieldKind(
 	Multiplicity.Forbidden,
 	{
 		changeHandler: noChangeHandler,
-		// All multiplicities other than Value support empty.
-		allowedMonotonicUpgrade: (types, other) =>
-			fieldKinds.get(other.kind)?.multiplicity !== Multiplicity.Single,
+		allowMonotonicUpgradeFrom: new Set(),
 	},
 );
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -132,7 +132,6 @@ export function allowsValueSuperset(
  * This prevents infinite upgrade loops where two clients could keep upgrading between two schema.
  *
  * @remarks
- *
  * True if a client should be able to {@link TreeView.upgradeSchema} from a field schema using this field kind and `originalTypes` to `superset`.
  *
  * @privateRemarks

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { assert, fail } from "@fluidframework/core-utils/internal";
+import { assert, fail, unreachableCase } from "@fluidframework/core-utils/internal";
 
 import {
 	LeafNodeStoredSchema,
 	MapNodeStoredSchema,
+	Multiplicity,
 	ObjectNodeStoredSchema,
 	type TreeFieldStoredSchema,
 	type TreeNodeStoredSchema,
@@ -19,7 +20,7 @@ import {
 import { compareSets } from "../../util/index.js";
 
 import type { FullSchemaPolicy } from "./fieldKind.js";
-import { isNeverTree } from "./isNeverTree.js";
+import { isNeverField, isNeverTree } from "./isNeverTree.js";
 
 /**
  * Returns true iff `superset` is a superset of `original`.
@@ -125,16 +126,47 @@ export function allowsValueSuperset(
  * Returns true iff `superset` is a superset of `original`.
  *
  * This does not require a strict (aka proper) superset: equivalent schema will return true.
+ *
+ * @param monotonicOnly - If true, only allow changes of field kinds which are explicitly listed in {@link FieldKindOptions.allowMonotonicUpgradeFrom}.
+ * This prevents this function from considering two different schema as equivalent, preventing upgrades which would allow their inverse.
+ * This prevents infinite upgrade loops where two clients could keep upgrading between two schema.
+ *
+ * @remarks
+ *
+ * True if a client should be able to {@link TreeView.upgradeSchema} from a field schema using this field kind and `originalTypes` to `superset`.
+ *
+ * @privateRemarks
+ * See also {@link FieldKindOptions.allowMonotonicUpgradeFrom} for constraints on the implementation.
  */
 export function allowsFieldSuperset(
 	policy: FullSchemaPolicy,
 	originalData: TreeStoredSchema,
 	original: TreeFieldStoredSchema,
 	superset: TreeFieldStoredSchema,
+	monotonicOnly: boolean = true,
 ): boolean {
-	return (
-		policy.fieldKinds.get(original.kind) ?? fail(0xb1b /* missing kind */)
-	).allowedMonotonicUpgrade(policy, originalData, original.types, superset);
+	if (!monotonicOnly) {
+		if (isNeverField(policy, originalData, original)) {
+			return true;
+		}
+	}
+
+	if (!allowsTreeSchemaIdentifierSuperset(original.types, superset.types)) {
+		return false;
+	}
+
+	if (original.kind === superset.kind) {
+		return true;
+	}
+
+	const supersetKind = policy.fieldKinds.get(superset.kind) ?? fail(0xb1b /* missing kind */);
+
+	if (monotonicOnly) {
+		return supersetKind.options.allowMonotonicUpgradeFrom.has(original.kind);
+	} else {
+		const originalKind = policy.fieldKinds.get(original.kind) ?? fail("missing kind");
+		return allowsMultiplicitySuperset(originalKind.multiplicity, supersetKind.multiplicity);
+	}
 }
 
 /**
@@ -191,4 +223,31 @@ export function allowsRepoSuperset(
 	// Any schema in superset not in original are already known to be superset of original since they are "never" due to being missing.
 	// Therefore, we do not need to check them.
 	return true;
+}
+
+/**
+ * Returns true iff `superset` is a superset of `original`.
+ *
+ * This does not require a strict (aka proper) superset: equivalent schema will return true.
+ */
+export function allowsMultiplicitySuperset(
+	original: Multiplicity,
+	superset: Multiplicity,
+): boolean {
+	if (original === superset) {
+		return true;
+	}
+
+	switch (superset) {
+		case Multiplicity.Forbidden:
+			return false;
+		case Multiplicity.Optional:
+			return original === Multiplicity.Single || original === Multiplicity.Forbidden;
+		case Multiplicity.Single:
+			return false;
+		case Multiplicity.Sequence:
+			return true;
+		default:
+			return unreachableCase(superset);
+	}
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -169,7 +169,10 @@ function replaceRevisions(
 export const genericFieldKind: FlexFieldKind = new FlexFieldKind(
 	brandConst("ModularEditBuilder.Generic")<FieldKindIdentifier>(),
 	Multiplicity.Sequence,
-	{ changeHandler: genericChangeHandler, allowedMonotonicUpgrade: (types, other) => false },
+	{
+		changeHandler: genericChangeHandler,
+		allowMonotonicUpgradeFrom: new Set(),
+	},
 );
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -8,6 +8,7 @@ export {
 	allowsTreeSchemaIdentifierSuperset,
 	allowsFieldSuperset,
 	allowsTreeSuperset,
+	allowsMultiplicitySuperset,
 } from "./comparison.js";
 export { isNeverField, isNeverTree } from "./isNeverTree.js";
 export {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -113,5 +113,5 @@ export const valueHandler = {
 export const valueField = new FlexFieldKind(
 	brandConst("Value")<FieldKindIdentifier>(),
 	Multiplicity.Single,
-	{ changeHandler: valueHandler, allowedMonotonicUpgrade: (a, b) => false },
+	{ changeHandler: valueHandler, allowMonotonicUpgradeFrom: new Set() },
 );

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -165,7 +165,7 @@ const singleNodeHandler: FieldChangeHandler<SingleNodeChangeset> = {
 const singleNodeField = new FlexFieldKind(
 	brandConst("SingleNode")<FieldKindIdentifier>(),
 	Multiplicity.Single,
-	{ changeHandler: singleNodeHandler, allowedMonotonicUpgrade: (a, b) => false },
+	{ changeHandler: singleNodeHandler, allowMonotonicUpgradeFrom: new Set() },
 );
 
 export const fieldKindConfiguration: FieldKindConfiguration = new Map<
@@ -1172,7 +1172,7 @@ describe("ModularChangeFamily", () => {
 		} as unknown as FieldChangeHandler<HasRemovedRootsRefs, FieldEditor<HasRemovedRootsRefs>>;
 		const hasRemovedRootsRefsField = new FlexFieldKind(fieldKind, Multiplicity.Single, {
 			changeHandler: handler,
-			allowedMonotonicUpgrade: (a, b) => false,
+			allowMonotonicUpgradeFrom: new Set(),
 		});
 		const mockFieldKinds = new Map([[fieldKind, hasRemovedRootsRefsField]]);
 


### PR DESCRIPTION
## Description

At the flex-tree abstraction level, the handling of field kind changes has issues. This change clarifies the two kinds of upgrades we could allow (the current monotonic approach, and a possible future more flexible one). This also fixes a bug with never field handling which allowed some possible upgrade cycles which are supposed to be disallowed (but in practice are not useful schema and won't be used by the public API, so should not happen)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

