### PR TITLE
test(tree): Update table snapshot test to use stored keys

### DIFF
--- a/packages/dds/tree/src/test/snapshots/output/table-schema-json/data (verbose).json
+++ b/packages/dds/tree/src/test/snapshots/output/table-schema-json/data (verbose).json
@@ -1,7 +1,7 @@
 {
   "type": "com.fluidframework.table<test>.TableRoot",
   "fields": {
-    "table": {
+    "": {
       "type": "com.fluidframework.table<test>.Table",
       "fields": {
         "rows": {

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -1885,7 +1885,9 @@ describe("TableFactory unit tests", () => {
 			});
 
 			takeJsonSnapshot(
-				TreeAlpha.exportVerbose(table, {}) as unknown as JsonCompatibleReadOnly,
+				TreeAlpha.exportVerbose(table, {
+					keys: KeyEncodingOptions.allStoredKeys,
+				}) as unknown as JsonCompatibleReadOnly,
 			);
 		});
 


### PR DESCRIPTION
Adds missing test coverage for the API's stored keys representation (property keys are covered by concise format tests).