### PR TITLE
refactor(examples): Add missing function return types

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -15,6 +15,12 @@ Key features:
 
 Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the legacy `.eslintrc.cjs` format remains supported for backward compatibility. Migration is optional and not required.
 
+### Rule Promotions
+
+The following rules have been promoted from `recommended` to `minimal-deprecated`:
+
+- `@typescript-eslint/explicit-function-return-type`
+
 ## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 
 ### eslint-plugin-eslint-comments replaced by @eslint-community/eslint-plugin-eslint-comments

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -15,12 +15,6 @@ Key features:
 
 Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the legacy `.eslintrc.cjs` format remains supported for backward compatibility. Migration is optional and not required.
 
-### Rule Promotions
-
-The following rules have been promoted from `recommended` to `minimal-deprecated`:
-
-- `@typescript-eslint/explicit-function-return-type`
-
 ## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 
 ### eslint-plugin-eslint-comments replaced by @eslint-community/eslint-plugin-eslint-comments

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -169,23 +169,8 @@ module.exports = {
 			},
 		],
 
-		// #region ENABLED INTENTIONALLY
+		// ENABLED INTENTIONALLY
 		"@typescript-eslint/dot-notation": "error",
-
-		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
-		// API documentation. For example, type inference might decide a function returns a concrete type
-		// instead of an interface. This has no runtime impact, but would cause compilation problems.
-		"@typescript-eslint/explicit-function-return-type": [
-			"error",
-			{
-				allowExpressions: true,
-				allowTypedFunctionExpressions: true,
-				allowHigherOrderFunctions: true,
-				allowDirectConstAssertionInArrowFunctions: true,
-				allowConciseArrowFunctionExpressionsStartingWithVoid: false,
-			},
-		],
-
 		"@typescript-eslint/no-non-null-assertion": "error",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
 
@@ -235,14 +220,13 @@ module.exports = {
 		"unicorn/prefer-ternary": "error",
 		"unicorn/prefer-type-error": "error",
 
-		// #endregion
-
 		// #region DISABLED INTENTIONALLY
 
 		/**
 		 * Disabled because we don't require that all variable declarations be explicitly typed.
 		 */
 		"@rushstack/typedef-var": "off",
+		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/explicit-member-accessibility": "off",
 
 		"@typescript-eslint/member-ordering": "off",

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -169,8 +169,23 @@ module.exports = {
 			},
 		],
 
-		// ENABLED INTENTIONALLY
+		// #region ENABLED INTENTIONALLY
 		"@typescript-eslint/dot-notation": "error",
+
+		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
+		// API documentation. For example, type inference might decide a function returns a concrete type
+		// instead of an interface. This has no runtime impact, but would cause compilation problems.
+		"@typescript-eslint/explicit-function-return-type": [
+			"error",
+			{
+				allowExpressions: true,
+				allowTypedFunctionExpressions: true,
+				allowHigherOrderFunctions: true,
+				allowDirectConstAssertionInArrowFunctions: true,
+				allowConciseArrowFunctionExpressionsStartingWithVoid: false,
+			},
+		],
+
 		"@typescript-eslint/no-non-null-assertion": "error",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
 
@@ -220,13 +235,14 @@ module.exports = {
 		"unicorn/prefer-ternary": "error",
 		"unicorn/prefer-type-error": "error",
 
+		// #endregion
+
 		// #region DISABLED INTENTIONALLY
 
 		/**
 		 * Disabled because we don't require that all variable declarations be explicitly typed.
 		 */
 		"@rushstack/typedef-var": "off",
-		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/explicit-member-accessibility": "off",
 
 		"@typescript-eslint/member-ordering": "off",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -680,7 +680,14 @@
             "error"
         ],
         "@typescript-eslint/explicit-function-return-type": [
-            "off"
+            "error",
+            {
+                "allowExpressions": true,
+                "allowTypedFunctionExpressions": true,
+                "allowHigherOrderFunctions": true,
+                "allowDirectConstAssertionInArrowFunctions": true,
+                "allowConciseArrowFunctionExpressionsStartingWithVoid": false
+            }
         ],
         "@typescript-eslint/explicit-member-accessibility": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -680,14 +680,7 @@
             "error"
         ],
         "@typescript-eslint/explicit-function-return-type": [
-            "error",
-            {
-                "allowExpressions": true,
-                "allowTypedFunctionExpressions": true,
-                "allowHigherOrderFunctions": true,
-                "allowDirectConstAssertionInArrowFunctions": true,
-                "allowConciseArrowFunctionExpressionsStartingWithVoid": false
-            }
+            "off"
         ],
         "@typescript-eslint/explicit-member-accessibility": [
             "off"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -27,9 +27,6 @@ module.exports = {
 		"no-void": "error",
 		"require-atomic-updates": "error",
 
-		// This rule ensures that our Intellisense looks good by verifying the TSDoc syntax.
-		"tsdoc/syntax": "error",
-
 		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
 		// API documentation. For example, type inference might decide a function returns a concrete type
 		// instead of an interface. This has no runtime impact, but would cause compilation problems.

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -27,20 +27,6 @@ module.exports = {
 		"no-void": "error",
 		"require-atomic-updates": "error",
 
-		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
-		// API documentation. For example, type inference might decide a function returns a concrete type
-		// instead of an interface. This has no runtime impact, but would cause compilation problems.
-		"@typescript-eslint/explicit-function-return-type": [
-			"error",
-			{
-				allowExpressions: true,
-				allowTypedFunctionExpressions: true,
-				allowHigherOrderFunctions: true,
-				allowDirectConstAssertionInArrowFunctions: true,
-				allowConciseArrowFunctionExpressionsStartingWithVoid: false,
-			},
-		],
-
 		// #region `unicorn` rule overrides
 
 		// False positives on non-array `push` methods.

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -27,6 +27,9 @@ module.exports = {
 		"no-void": "error",
 		"require-atomic-updates": "error",
 
+		// This rule ensures that our Intellisense looks good by verifying the TSDoc syntax.
+		"tsdoc/syntax": "error",
+
 		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
 		// API documentation. For example, type inference might decide a function returns a concrete type
 		// instead of an interface. This has no runtime impact, but would cause compilation problems.

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -27,6 +27,20 @@ module.exports = {
 		"no-void": "error",
 		"require-atomic-updates": "error",
 
+		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
+		// API documentation. For example, type inference might decide a function returns a concrete type
+		// instead of an interface. This has no runtime impact, but would cause compilation problems.
+		"@typescript-eslint/explicit-function-return-type": [
+			"error",
+			{
+				allowExpressions: true,
+				allowTypedFunctionExpressions: true,
+				allowHigherOrderFunctions: true,
+				allowDirectConstAssertionInArrowFunctions: true,
+				allowConciseArrowFunctionExpressionsStartingWithVoid: false,
+			},
+		],
+
 		// #region `unicorn` rule overrides
 
 		// False positives on non-array `push` methods.

--- a/examples/apps/staging/src/container/groceryList/groceryList.ts
+++ b/examples/apps/staging/src/container/groceryList/groceryList.ts
@@ -74,7 +74,7 @@ class GroceryList implements IGroceryList {
 		}
 	}
 
-	public readonly addItem = (name: string) => {
+	public readonly addItem = (name: string): void => {
 		// Use timestamp as a hack for a consistent sortable order.
 		this.map.set(`${Date.now()}-${uuid()}`, name);
 	};
@@ -85,11 +85,11 @@ class GroceryList implements IGroceryList {
 		);
 	};
 
-	public readonly removeItem = (id: string) => {
+	public readonly removeItem = (id: string): void => {
 		this.map.delete(id);
 	};
 
-	private readonly onMapValueChanged = (changed: IValueChanged) => {
+	private readonly onMapValueChanged = (changed: IValueChanged): void => {
 		const changedId = changed.key;
 		const newName = this.map.get(changedId);
 		if (newName === undefined) {

--- a/examples/apps/staging/src/container/suggestionGroceryList.ts
+++ b/examples/apps/staging/src/container/suggestionGroceryList.ts
@@ -40,7 +40,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 	 */
 	private readonly _suggestionGroceryItems = new Map<string, SuggestionGroceryItem>();
 	private _inStagingMode = false;
-	public get inStagingMode() {
+	public get inStagingMode(): boolean {
 		return this._inStagingMode;
 	}
 
@@ -86,7 +86,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		}
 	}
 
-	public readonly addItem = (name: string) => {
+	public readonly addItem = (name: string): void => {
 		if (this._inStagingMode) {
 			// Use timestamp as a hack for a consistent sortable order.  Prefixed with 'z' to sort last.
 			const suggestedAddition = new SuggestionGroceryItem(
@@ -116,7 +116,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		);
 	};
 
-	public readonly removeItem = (id: string) => {
+	public readonly removeItem = (id: string): void => {
 		if (this._inStagingMode) {
 			const suggestedRemoval = this._suggestionGroceryItems.get(id);
 			if (suggestedRemoval !== undefined) {
@@ -133,8 +133,8 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		}
 	};
 
-	public readonly getSuggestions = () => {
-		const asyncGetSuggestions = async () => {
+	public readonly getSuggestions = (): void => {
+		const asyncGetSuggestions = async (): Promise<void> => {
 			const { adds, removals } = await getChangesFromHealthBot(this.groceryList);
 			// Check to make sure we are still in staging mode after we get the results - if not, then just
 			// discard the suggestions.  Alternatively, we could wait for the network call to return before
@@ -154,7 +154,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		asyncGetSuggestions().catch(console.error);
 	};
 
-	public readonly acceptSuggestions = () => {
+	public readonly acceptSuggestions = (): void => {
 		const adds = [...this._suggestionGroceryItems.values()].filter(
 			(item) => item.suggestion === "add",
 		);
@@ -175,7 +175,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		this._events.emit("leaveStagingMode");
 	};
 
-	public readonly rejectSuggestions = () => {
+	public readonly rejectSuggestions = (): void => {
 		for (const item of this._suggestionGroceryItems.values()) {
 			if (item.suggestion === "add") {
 				item.removeItem();
@@ -188,7 +188,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		this._events.emit("leaveStagingMode");
 	};
 
-	private readonly onItemAdded = (item: IGroceryItem) => {
+	private readonly onItemAdded = (item: IGroceryItem): void => {
 		const addedItem = new SuggestionGroceryItem(
 			item.id,
 			item.name,
@@ -207,7 +207,7 @@ export class SuggestionGroceryList implements ISuggestionGroceryList {
 		this._events.emit("itemAdded", addedItem);
 	};
 
-	private readonly onItemRemoved = (item: IGroceryItem) => {
+	private readonly onItemRemoved = (item: IGroceryItem): void => {
 		const removedItem = this._suggestionGroceryItems.get(item.id);
 		this._suggestionGroceryItems.delete(item.id);
 		this._events.emit("itemRemoved", removedItem);

--- a/examples/apps/staging/src/start.ts
+++ b/examples/apps/staging/src/start.ts
@@ -24,7 +24,7 @@ import {
 } from "./container/index.js";
 import { AppView, DebugView } from "./view/index.js";
 
-const updateTabForId = (id: string) => {
+const updateTabForId = (id: string): void => {
 	// Update the URL with the actual ID
 	location.hash = id;
 
@@ -32,7 +32,7 @@ const updateTabForId = (id: string) => {
 	document.title = id;
 };
 
-const render = (groceryList: ISuggestionGroceryList) => {
+const render = (groceryList: ISuggestionGroceryList): void => {
 	const appDiv = document.getElementById("app") as HTMLDivElement;
 	const appRoot = createRoot(appDiv);
 	appRoot.render(createElement(AppView, { groceryList }));

--- a/examples/apps/staging/src/view/appView.tsx
+++ b/examples/apps/staging/src/view/appView.tsx
@@ -13,11 +13,11 @@ export interface IAppViewProps {
 	groceryList: ISuggestionGroceryList;
 }
 
-export const AppView: FC<IAppViewProps> = ({ groceryList }: IAppViewProps) => {
+export const AppView: FC<IAppViewProps> = ({ groceryList }: IAppViewProps): JSX.Element => {
 	const [inStagingMode, setInStagingMode] = useState<boolean>(groceryList.inStagingMode);
 
 	useEffect(() => {
-		const handleStagingModeChanged = () => {
+		const handleStagingModeChanged = (): void => {
 			setInStagingMode(groceryList.inStagingMode);
 		};
 		groceryList.events.on("enterStagingMode", handleStagingModeChanged);
@@ -30,10 +30,10 @@ export const AppView: FC<IAppViewProps> = ({ groceryList }: IAppViewProps) => {
 
 	let actions;
 	if (inStagingMode) {
-		const onAcceptChanges = () => {
+		const onAcceptChanges = (): void => {
 			groceryList.acceptSuggestions();
 		};
-		const onRejectChanges = () => {
+		const onRejectChanges = (): void => {
 			groceryList.rejectSuggestions();
 		};
 		actions = (

--- a/examples/apps/staging/src/view/groceryListView.tsx
+++ b/examples/apps/staging/src/view/groceryListView.tsx
@@ -46,10 +46,10 @@ interface IAddItemViewProps {
 	readonly addItem: (name: string) => void;
 }
 
-const AddItemView: FC<IAddItemViewProps> = ({ addItem }: IAddItemViewProps) => {
+const AddItemView: FC<IAddItemViewProps> = ({ addItem }: IAddItemViewProps): JSX.Element => {
 	const nameRef = useRef<HTMLInputElement>(null);
 
-	const onAddItemButtonClick = () => {
+	const onAddItemButtonClick = (): void => {
 		if (nameRef.current === null) {
 			throw new Error("Couldn't get the new item info");
 		}
@@ -91,7 +91,7 @@ export const GroceryListView: FC<IGroceryListViewProps> = ({
 		groceryList.getItems(),
 	);
 	useEffect(() => {
-		const updateItems = () => {
+		const updateItems = (): void => {
 			// TODO: This blows away all the grocery items, making the granular add/delete events
 			// not so useful.  Is there a good way to make a more granular change?
 			setGroceryItems(groceryList.getItems());

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/src/fetchApp.ts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/src/fetchApp.ts
@@ -11,7 +11,7 @@ import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { OdspSampleCache } from "./odspPersistantCache.js";
 
-export function start(div: HTMLDivElement, odspAccessToken: string) {
+export function start(div: HTMLDivElement, odspAccessToken: string): void {
 	const binaryDiv = document.createElement("div");
 	binaryDiv.style.minHeight = "400px";
 	const binaryText = document.createElement("div");
@@ -90,7 +90,7 @@ export function start(div: HTMLDivElement, odspAccessToken: string) {
 }
 
 // eslint-disable-next-line import-x/no-deprecated
-function fetchButtonClick(mockLogger: MockLogger, div: HTMLDivElement) {
+function fetchButtonClick(mockLogger: MockLogger, div: HTMLDivElement): void {
 	const fields = new Set([
 		"eventName",
 		"attempts",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/src/odspPersistantCache.ts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/src/odspPersistantCache.ts
@@ -20,7 +20,7 @@ export class OdspSampleCache implements IPersistedCache {
 		return this.cache.get(getKeyForCacheEntry(entry));
 	}
 
-	async put(entry: ICacheEntry, value: any) {
+	async put(entry: ICacheEntry, value: any): Promise<void> {
 		this.cache.set(getKeyForCacheEntry(entry), value);
 	}
 

--- a/examples/benchmarks/tablebench/src/app.ts
+++ b/examples/benchmarks/tablebench/src/app.ts
@@ -10,11 +10,11 @@ import { Table } from "./tree/index.js";
 export { generateTable };
 export { Table };
 
-export async function initApp() {
+export async function initApp(): Promise<void> {
 	const { view } = await initFluid();
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	document.getElementById("run")!.addEventListener("click", () => {
+	document.getElementById("run")!.addEventListener("click", (): void => {
 		performance.mark("start");
 
 		for (const row of view.root) {

--- a/examples/benchmarks/tablebench/src/azure.ts
+++ b/examples/benchmarks/tablebench/src/azure.ts
@@ -31,7 +31,7 @@ const containerSchema = {
 
 const config = new TreeViewConfiguration({ schema: Table });
 
-export async function initFluid() {
+export async function initFluid(): Promise<{ view: TreeView<typeof Table> }> {
 	let container;
 	let view: TreeView<typeof Table>;
 
@@ -41,7 +41,7 @@ export async function initFluid() {
 		view = tree.viewWith(config);
 		view.initialize(generateTable(10000));
 		// TODO: Waiting for 'attach()' is a work around for https://dev.azure.com/fluidframework/internal/_workitems/edit/6805
-		await container.attach().then((containerId) => (location.hash = containerId));
+		await container.attach().then((containerId: string) => (location.hash = containerId));
 	} else {
 		({ container } = await client.getContainer(
 			location.hash.substring(1),

--- a/examples/benchmarks/tablebench/src/data.ts
+++ b/examples/benchmarks/tablebench/src/data.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IRandom, makeRandom } from "@fluid-private/stochastic-test-utils";
-import { InsertableTypedNode } from "@fluidframework/tree";
+import { type IRandom, makeRandom } from "@fluid-private/stochastic-test-utils";
+import type { InsertableTypedNode } from "@fluidframework/tree";
 
 import { Row } from "./tree/index.js";
 
@@ -24,7 +24,7 @@ export function generateRow(random: IRandom): InsertableTypedNode<typeof Row> {
 		["Baby Food", 255.28, 159.42],
 	]);
 
-	const toDollars = (n: number) => Math.round(n * 100) / 100;
+	const toDollars = (n: number): number => Math.round(n * 100) / 100;
 
 	const unitsSold = random.integer(2, 10000);
 	const totalRevenue = toDollars(unitPrice * unitsSold);
@@ -239,7 +239,7 @@ export function generateRow(random: IRandom): InsertableTypedNode<typeof Row> {
 	};
 }
 
-export function generateTable(rows: number, seed = 1) {
+export function generateTable(rows: number, seed = 1): InsertableTypedNode<typeof Row>[] {
 	const random = makeRandom(seed);
 
 	return Array.from({ length: rows }, () => generateRow(random)).sort(

--- a/examples/benchmarks/tablebench/src/test/table.bench.spec.ts
+++ b/examples/benchmarks/tablebench/src/test/table.bench.spec.ts
@@ -114,7 +114,7 @@ describe("Table", () => {
 			 * The column-major "object of arrays" form removes the redundancy of repeating column names in each row.
 			 * This is used when measuring the baseline size of the table.
 			 */
-			function transposeTable(rows: typeof data) {
+			function transposeTable(rows: typeof data): Record<string, unknown[]> {
 				return data.reduce(
 					(cols, row) => {
 						Object.entries(row).forEach(([key, value]) => {

--- a/examples/benchmarks/tablebench/src/test/utils.ts
+++ b/examples/benchmarks/tablebench/src/test/utils.ts
@@ -43,11 +43,11 @@ export function create<T>(factory: IChannelFactory<T>): {
 	return { channel, processAllMessages: () => runtimeFactory.processAllMessages() };
 }
 
-export function measureAttachmentSummary(channel: IChannel) {
+export function measureAttachmentSummary(channel: IChannel): number {
 	const { summary } = channel.getAttachSummary(/* fullTree: */ true);
 	return measureEncodedLength(JSON.stringify(summary));
 }
 
-export function measureEncodedLength(s: string) {
+export function measureEncodedLength(s: string): number {
 	return IsoBuffer.from(s).byteLength;
 }

--- a/examples/data-objects/clicker/src/agent.ts
+++ b/examples/data-objects/clicker/src/agent.ts
@@ -11,19 +11,19 @@ import { SharedCounter } from "@fluidframework/counter/legacy";
 export class ClickerAgent implements IFluidRunnable {
 	constructor(private readonly counter: SharedCounter) {}
 
-	public get IFluidRunnable() {
+	public get IFluidRunnable(): IFluidRunnable {
 		return this;
 	}
 
-	private readonly logIncrement = (incrementValue: number, currentValue: number) => {
+	private readonly logIncrement = (incrementValue: number, currentValue: number): void => {
 		console.log(`Incremented by ${incrementValue}. New value ${currentValue}`);
 	};
 
-	public async run() {
+	public async run(): Promise<void> {
 		this.counter.on("incremented", this.logIncrement);
 	}
 
-	public stop() {
+	public stop(): void {
 		this.counter.off("incremented", this.logIncrement);
 	}
 }

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -33,14 +33,14 @@ export class Clicker extends DataObject<{ Events: IClickerEvents }> {
 	/**
 	 * Do setup work here
 	 */
-	protected async initializingFirstTime() {
+	protected async initializingFirstTime(): Promise<void> {
 		const counter = SharedCounter.create(this.runtime);
 		this.root.set(counterKey, counter.handle);
 		const taskManager = TaskManager.create(this.runtime);
 		this.root.set(taskManagerKey, taskManager.handle);
 	}
 
-	protected async hasInitialized() {
+	protected async hasInitialized(): Promise<void> {
 		const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
 		this._counter = await counterHandle?.get();
 		const taskManagerHandle = this.root.get<IFluidHandle<TaskManager>>(taskManagerKey);
@@ -52,15 +52,15 @@ export class Clicker extends DataObject<{ Events: IClickerEvents }> {
 		this.setupAgent();
 	}
 
-	public increment() {
+	public increment(): void {
 		this.counter.increment(1);
 	}
 
-	public get value() {
+	public get value(): number {
 		return this.counter.value;
 	}
 
-	private setupAgent() {
+	private setupAgent(): void {
 		// We want to make sure that at any given time there is one (and only one) client executing the console log
 		// task. Each client will enter the queue on startup.
 		// Additionally, we use subscribeToTask() instead of volunteerForTask() since we always want to stay
@@ -80,14 +80,14 @@ export class Clicker extends DataObject<{ Events: IClickerEvents }> {
 		});
 	}
 
-	private get counter() {
+	private get counter(): SharedCounter {
 		if (this._counter === undefined) {
 			throw new Error("SharedCounter not initialized");
 		}
 		return this._counter;
 	}
 
-	private get taskManager() {
+	private get taskManager(): TaskManager {
 		if (this._taskManager === undefined) {
 			throw new Error("TaskManager not initialized");
 		}
@@ -115,13 +115,13 @@ export class ClickerReactView extends React.Component<ClickerProps, ClickerState
 		};
 	}
 
-	componentDidMount() {
+	componentDidMount(): void {
 		this.props.clicker.on("incremented", () => {
 			this.setState({ value: this.props.clicker.value });
 		});
 	}
 
-	render() {
+	render(): JSX.Element {
 		return (
 			<div>
 				<span className="clicker-value-class" id={`clicker-value-${Date.now().toString()}`}>
@@ -148,7 +148,9 @@ export const ClickerInstantiationFactory = new DataObjectFactory({
 	sharedObjects: [SharedCounter.getFactory(), TaskManager.getFactory()],
 });
 
-const clickerViewCallback = (clicker: Clicker) => <ClickerReactView clicker={clicker} />;
+const clickerViewCallback = (clicker: Clicker): JSX.Element => (
+	<ClickerReactView clicker={clicker} />
+);
 
 export const fluidExport = new ContainerViewRuntimeFactory<Clicker>(
 	ClickerInstantiationFactory,

--- a/examples/data-objects/codemirror/src/codeMirror.ts
+++ b/examples/data-objects/codemirror/src/codeMirror.ts
@@ -25,14 +25,17 @@ import { PresenceManager } from "./presence.js";
  * @internal
  */
 export class CodeMirrorComponent extends EventEmitter implements IFluidLoadable {
-	public static async load(runtime: IFluidDataStoreRuntime, existing: boolean) {
+	public static async load(
+		runtime: IFluidDataStoreRuntime,
+		existing: boolean,
+	): Promise<CodeMirrorComponent> {
 		const collection = new CodeMirrorComponent(runtime);
 		await collection.initialize(existing);
 
 		return collection;
 	}
 
-	public get IFluidLoadable() {
+	public get IFluidLoadable(): IFluidLoadable {
 		return this;
 	}
 
@@ -58,7 +61,7 @@ export class CodeMirrorComponent extends EventEmitter implements IFluidLoadable 
 		this.presenceManager = new PresenceManager(runtime);
 	}
 
-	private async initialize(existing: boolean) {
+	private async initialize(existing: boolean): Promise<void> {
 		if (!existing) {
 			this.root = SharedMap.create(this.runtime, "root");
 			const text = SharedString.create(this.runtime);
@@ -82,11 +85,14 @@ export class SmdeFactory implements IFluidDataStoreFactory {
 	public static readonly type = "@fluid-example/codemirror";
 	public readonly type = SmdeFactory.type;
 
-	public get IFluidDataStoreFactory() {
+	public get IFluidDataStoreFactory(): IFluidDataStoreFactory {
 		return this;
 	}
 
-	public async instantiateDataStore(context: IFluidDataStoreContext, existing: boolean) {
+	public async instantiateDataStore(
+		context: IFluidDataStoreContext,
+		existing: boolean,
+	): Promise<FluidDataStoreRuntime> {
 		return new FluidDataStoreRuntime(
 			context,
 			new Map(

--- a/examples/data-objects/codemirror/src/codeMirrorView.tsx
+++ b/examples/data-objects/codemirror/src/codeMirrorView.tsx
@@ -73,7 +73,7 @@ class CodeMirrorView {
 		}
 	}
 
-	private setupEditor() {
+	private setupEditor(): void {
 		this.codeMirror = CodeMirror.fromTextArea(
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			this.textArea!,

--- a/examples/data-objects/codemirror/src/index.ts
+++ b/examples/data-objects/codemirror/src/index.ts
@@ -4,7 +4,8 @@
  */
 
 import {
-	IFluidMountableViewEntryPoint,
+	type IFluidMountableView,
+	type IFluidMountableViewEntryPoint,
 	MountableView,
 	getDataStoreEntryPoint,
 } from "@fluid-example/example-utils";
@@ -56,9 +57,8 @@ class CodeMirrorFactory extends RuntimeFactoryHelper {
 				const view = React.createElement(CodeMirrorReactView, {
 					text: codeMirror.text,
 					presenceManager: codeMirror.presenceManager,
-				}) as any;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				let getMountableDefaultView = async (): Promise<any> => view;
+				}) as unknown as IFluidMountableView;
+				let getMountableDefaultView = async (): Promise<IFluidMountableView> => view;
 				if (MountableView.canMount(view)) {
 					getMountableDefaultView = async () => new MountableView(view);
 				}

--- a/examples/data-objects/codemirror/src/index.ts
+++ b/examples/data-objects/codemirror/src/index.ts
@@ -58,7 +58,7 @@ class CodeMirrorFactory extends RuntimeFactoryHelper {
 					presenceManager: codeMirror.presenceManager,
 				}) as any;
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				let getMountableDefaultView = async () => view;
+				let getMountableDefaultView = async (): Promise<any> => view;
 				if (MountableView.canMount(view)) {
 					getMountableDefaultView = async () => new MountableView(view);
 				}

--- a/examples/data-objects/codemirror/src/presence.ts
+++ b/examples/data-objects/codemirror/src/presence.ts
@@ -56,7 +56,7 @@ export class PresenceManager extends EventEmitter {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-	public send(location: {}) {
+	public send(location: {}): void {
 		if (this.runtime.connected) {
 			console.log(`sending new presence signal: ${JSON.stringify(location)}`);
 			this.runtime.submitSignal(this.presenceKey, location);

--- a/examples/data-objects/diceroller/src/index.ts
+++ b/examples/data-objects/diceroller/src/index.ts
@@ -10,7 +10,7 @@ import { DiceRoller, DiceRollerInstantiationFactory, DiceRollerView } from "./ma
 
 export { DiceRoller, DiceRollerInstantiationFactory } from "./main.js";
 
-const diceRollerViewCallback = (model: DiceRoller) =>
+const diceRollerViewCallback = (model: DiceRoller): JSX.Element =>
 	React.createElement(DiceRollerView, { model });
 
 /**

--- a/examples/data-objects/diceroller/src/main.tsx
+++ b/examples/data-objects/diceroller/src/main.tsx
@@ -40,7 +40,7 @@ export const DiceRollerView: React.FC<IDiceRollerViewProps> = (
 	const [diceValue, setDiceValue] = React.useState(props.model.value);
 
 	React.useEffect(() => {
-		const onDiceRolled = () => {
+		const onDiceRolled = (): void => {
 			setDiceValue(props.model.value);
 		};
 		props.model.on("diceRolled", onDiceRolled);
@@ -78,11 +78,11 @@ export class DiceRoller extends DataObject implements IDiceRoller {
 	 *
 	 * This method is used to perform Fluid object setup, which can include setting an initial schema or initial values.
 	 */
-	protected async initializingFirstTime() {
+	protected async initializingFirstTime(): Promise<void> {
 		this.root.set(diceValueKey, 1);
 	}
 
-	protected async hasInitialized() {
+	protected async hasInitialized(): Promise<void> {
 		this.root.on("valueChanged", (changed: IValueChanged) => {
 			if (changed.key === diceValueKey) {
 				this.emit("diceRolled");
@@ -90,12 +90,15 @@ export class DiceRoller extends DataObject implements IDiceRoller {
 		});
 	}
 
-	public get value() {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return this.root.get(diceValueKey);
+	public get value(): number {
+		const value = this.root.get<number>(diceValueKey);
+		if (value === undefined) {
+			throw new Error("Expected dice value");
+		}
+		return value;
 	}
 
-	public readonly roll = () => {
+	public readonly roll = (): void => {
 		const rollValue = Math.floor(Math.random() * 6) + 1;
 		this.root.set(diceValueKey, rollValue);
 	};

--- a/examples/data-objects/smde/src/index.ts
+++ b/examples/data-objects/smde/src/index.ts
@@ -4,7 +4,8 @@
  */
 
 import {
-	IFluidMountableViewEntryPoint,
+	type IFluidMountableView,
+	type IFluidMountableViewEntryPoint,
 	MountableView,
 	getDataStoreEntryPoint,
 } from "@fluid-example/example-utils";
@@ -52,9 +53,8 @@ class SmdeContainerFactory extends RuntimeFactoryHelper {
 
 				const view = React.createElement(SmdeReactView, {
 					smdeDataObject,
-				}) as any;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				let getMountableDefaultView = async (): Promise<any> => view;
+				}) as unknown as IFluidMountableView;
+				let getMountableDefaultView = async (): Promise<IFluidMountableView> => view;
 				if (MountableView.canMount(view)) {
 					getMountableDefaultView = async () => new MountableView(view);
 				}

--- a/examples/data-objects/smde/src/index.ts
+++ b/examples/data-objects/smde/src/index.ts
@@ -54,7 +54,7 @@ class SmdeContainerFactory extends RuntimeFactoryHelper {
 					smdeDataObject,
 				}) as any;
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				let getMountableDefaultView = async () => view;
+				let getMountableDefaultView = async (): Promise<any> => view;
 				if (MountableView.canMount(view)) {
 					getMountableDefaultView = async () => new MountableView(view);
 				}

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -14,7 +14,7 @@ import {
 	IFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions/legacy";
 // eslint-disable-next-line import-x/no-internal-modules -- #26904: `sequence` internals used in examples
-import { reservedTileLabelsKey } from "@fluidframework/sequence/internal";
+import { reservedTileLabelsKey, type ISharedString } from "@fluidframework/sequence/internal";
 import { ReferenceType, SharedString } from "@fluidframework/sequence/legacy";
 
 // eslint-disable-next-line import-x/no-internal-modules, import-x/no-unassigned-import
@@ -49,8 +49,8 @@ export class SmdeDataObject extends EventEmitter implements IFluidLoadable {
 	private root: ISharedMap | undefined;
 	private _text: SharedString | undefined;
 
-	public get text(): SharedString {
-		assert(!!this._text, "SharedString property missing!");
+	public get text(): ISharedString {
+		assert(this._text !== undefined, "SharedString property missing!");
 		return this._text;
 	}
 	constructor(private readonly runtime: IFluidDataStoreRuntime) {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -24,7 +24,10 @@ import "simplemde/dist/simplemde.min.css";
  * Data object storing the data to back a SimpleMDE editor.  Primarily just a SharedString.
  */
 export class SmdeDataObject extends EventEmitter implements IFluidLoadable {
-	public static async load(runtime: IFluidDataStoreRuntime, existing: boolean) {
+	public static async load(
+		runtime: IFluidDataStoreRuntime,
+		existing: boolean,
+	): Promise<SmdeDataObject> {
 		const collection = new SmdeDataObject(runtime);
 		await collection.initialize(existing);
 
@@ -36,17 +39,17 @@ export class SmdeDataObject extends EventEmitter implements IFluidLoadable {
 	public get handle(): IFluidHandle<this> {
 		return this.innerHandle;
 	}
-	public get IFluidHandle() {
+	public get IFluidHandle(): IFluidHandle<this> {
 		return this.innerHandle;
 	}
-	public get IFluidLoadable() {
+	public get IFluidLoadable(): IFluidLoadable {
 		return this;
 	}
 
 	private root: ISharedMap | undefined;
 	private _text: SharedString | undefined;
 
-	public get text() {
+	public get text(): SharedString {
 		assert(!!this._text, "SharedString property missing!");
 		return this._text;
 	}
@@ -56,7 +59,7 @@ export class SmdeDataObject extends EventEmitter implements IFluidLoadable {
 		this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
 	}
 
-	private async initialize(existing: boolean) {
+	private async initialize(existing: boolean): Promise<void> {
 		if (!existing) {
 			this.root = SharedMap.create(this.runtime, "root");
 			const text = SharedString.create(this.runtime);
@@ -80,11 +83,14 @@ export class SmdeFactory implements IFluidDataStoreFactory {
 	public static readonly type = "@fluid-example/smde";
 	public readonly type = SmdeFactory.type;
 
-	public get IFluidDataStoreFactory() {
+	public get IFluidDataStoreFactory(): IFluidDataStoreFactory {
 		return this;
 	}
 
-	public async instantiateDataStore(context: IFluidDataStoreContext, existing: boolean) {
+	public async instantiateDataStore(
+		context: IFluidDataStoreContext,
+		existing: boolean,
+	): Promise<FluidDataStoreRuntime> {
 		return new FluidDataStoreRuntime(
 			context,
 			new Map(

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -36,10 +36,10 @@ export class SmdeDataObject extends EventEmitter implements IFluidLoadable {
 
 	private readonly innerHandle: IFluidHandle<this>;
 
-	public get handle(): IFluidHandle<this> {
+	public get handle(): IFluidHandle<SmdeDataObject> {
 		return this.innerHandle;
 	}
-	public get IFluidHandle(): IFluidHandle<this> {
+	public get IFluidHandle(): IFluidHandle<SmdeDataObject> {
 		return this.innerHandle;
 	}
 	public get IFluidLoadable(): IFluidLoadable {

--- a/examples/data-objects/smde/src/smdeView.tsx
+++ b/examples/data-objects/smde/src/smdeView.tsx
@@ -42,7 +42,7 @@ class SmdeView {
 		}
 	}
 
-	private setupEditor() {
+	private setupEditor(): void {
 		const smde = new SimpleMDE({ element: this.textArea });
 		this.smde = smde;
 

--- a/examples/data-objects/todo/src/Todo/DataObject.ts
+++ b/examples/data-objects/todo/src/Todo/DataObject.ts
@@ -76,7 +76,7 @@ export class TodoListDataObject extends TreeDataObject {
 	 * This method was placed in the data object (instead of the TodoList schema class),
 	 * as we needed access to the runtime to create the `SharedString`.
 	 */
-	public async addTodoItem(props?: TodoItemProps) {
+	public async addTodoItem(props?: TodoItemProps): Promise<void> {
 		const title = SharedString.create(this.runtime);
 		const newItemText = props?.startingText ?? "New Item";
 		title.insertText(0, newItemText);

--- a/examples/data-objects/todo/src/index.tsx
+++ b/examples/data-objects/todo/src/index.tsx
@@ -8,7 +8,7 @@ import React from "react";
 
 import { TodoListDataObject, TodoListView } from "./Todo/index.js";
 
-const getDirectLink = (itemId: string) => {
+const getDirectLink = (itemId: string): string => {
 	const pathParts = window.location.pathname.split("/");
 	const containerName = pathParts[2];
 

--- a/examples/data-objects/webflow/src/clipboard/paste.ts
+++ b/examples/data-objects/webflow/src/clipboard/paste.ts
@@ -13,7 +13,7 @@ const enum ClipboardFormat {
 	text = "text/text",
 }
 
-export function paste(doc: FlowDocument, data: DataTransfer, position: number) {
+export function paste(doc: FlowDocument, data: DataTransfer, position: number): void {
 	let content: string;
 
 	/* eslint-disable no-cond-assign */
@@ -35,7 +35,7 @@ export function paste(doc: FlowDocument, data: DataTransfer, position: number) {
 
 const ignoredTags = [TagName.meta];
 
-function pasteChildren(doc: FlowDocument, root: Node, position: number) {
+function pasteChildren(doc: FlowDocument, root: Node, position: number): number {
 	let _position = position;
 
 	for (let child: Node | null = root.firstChild; child !== null; child = child.nextSibling) {

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -251,12 +251,12 @@ export class FlowDocument extends DataObject {
 	}
 
 	public insertText(position: number, text: string): void {
-		debug(`insertText(${position},"${text})")`);
+		debug(`insertText(${position},"${text}")`);
 		this.sharedString.insertText(position, text);
 	}
 
 	public replaceWithText(start: number, end: number, text: string): void {
-		debug(`replaceWithText(${start}, ${end}, "${text})")`);
+		debug(`replaceWithText(${start}, ${end}, "${text}")`);
 		this.sharedString.replaceText(start, end, text);
 	}
 

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -201,7 +201,7 @@ export class FlowDocument extends DataObject {
 		return marker.properties.handle.get();
 	}
 
-	public getSegmentAndOffset(position: number): { segment: ISegment; offset?: number } {
+	public getSegmentAndOffset(position: number): { segment: SharedStringSegment; offset?: number } {
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
 		return position === this.length
 			? { segment: endOfTextSegment, offset: 0 }
@@ -363,11 +363,11 @@ export class FlowDocument extends DataObject {
 		this.insertParagraph(start, tag);
 	}
 
-	public getStart(marker: Marker): Marker {
+	public getStart(marker: Marker): ISegment | undefined {
 		return this.getOppositeMarker(marker, /* "end".length = */ 3, "begin");
 	}
 
-	public getEnd(marker: Marker): Marker {
+	public getEnd(marker: Marker): ISegment | undefined {
 		return this.getOppositeMarker(marker, /* "begin".length = */ 5, "end");
 	}
 
@@ -418,7 +418,7 @@ export class FlowDocument extends DataObject {
 		startPos: number,
 		markerLabel: string,
 		forwards: boolean,
-	): LocalReferencePosition | undefined {
+	): Marker {
 		return this.sharedString.searchForMarker(startPos, markerLabel, forwards);
 	}
 
@@ -488,7 +488,7 @@ export class FlowDocument extends DataObject {
 		marker: Marker,
 		oldPrefixLength: number,
 		newPrefix: string,
-	): Marker {
+	): ISegment | undefined {
 		return this.sharedString.getMarkerFromId(
 			`${newPrefix}${marker.getId().slice(oldPrefixLength)}`,
 		);

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -201,7 +201,10 @@ export class FlowDocument extends DataObject {
 		return marker.properties.handle.get();
 	}
 
-	public getSegmentAndOffset(position: number): { segment: SharedStringSegment; offset?: number } {
+	public getSegmentAndOffset(position: number): {
+		segment: SharedStringSegment;
+		offset?: number;
+	} {
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
 		return position === this.length
 			? { segment: endOfTextSegment, offset: 0 }
@@ -414,11 +417,7 @@ export class FlowDocument extends DataObject {
 		this.sharedString.annotateRange(start, end, { attr });
 	}
 
-	public searchForMarker(
-		startPos: number,
-		markerLabel: string,
-		forwards: boolean,
-	): Marker {
+	public searchForMarker(startPos: number, markerLabel: string, forwards: boolean): Marker {
 		return this.sharedString.searchForMarker(startPos, markerLabel, forwards);
 	}
 

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -196,24 +196,24 @@ export class FlowDocument extends DataObject {
 		});
 	}
 
-	public async getComponentFromMarker(marker: Marker) {
+	public async getComponentFromMarker(marker: Marker): Promise<unknown> {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return marker.properties.handle.get();
 	}
 
-	public getSegmentAndOffset(position: number) {
+	public getSegmentAndOffset(position: number): { segment: ISegment; offset?: number } {
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
 		return position === this.length
 			? { segment: endOfTextSegment, offset: 0 }
 			: this.sharedString.getContainingSegment(position);
 	}
 
-	public getPosition(segment: ISegment) {
+	public getPosition(segment: ISegment): number {
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
 		return segment === endOfTextSegment ? this.length : this.sharedString.getPosition(segment);
 	}
 
-	public addLocalRef(position: number) {
+	public addLocalRef(position: number): LocalReferencePosition {
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
 		if (position >= this.length) {
 			return endOfTextReference;
@@ -230,7 +230,7 @@ export class FlowDocument extends DataObject {
 		return localRef;
 	}
 
-	public removeLocalRef(localRef: LocalReferencePosition) {
+	public removeLocalRef(localRef: LocalReferencePosition): void {
 		const segment = localRef.getSegment();
 
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
@@ -239,7 +239,7 @@ export class FlowDocument extends DataObject {
 		}
 	}
 
-	public localRefToPosition(localRef: ReferencePosition) {
+	public localRefToPosition(localRef: ReferencePosition): number {
 		// Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
 		if (localRef.getSegment() === endOfTextSegment) {
 			return this.length;
@@ -247,17 +247,17 @@ export class FlowDocument extends DataObject {
 		return this.sharedString.localReferencePositionToPosition(localRef);
 	}
 
-	public insertText(position: number, text: string) {
-		debug(`insertText(${position},"${text}")`);
+	public insertText(position: number, text: string): void {
+		debug(`insertText(${position},"${text})")`);
 		this.sharedString.insertText(position, text);
 	}
 
-	public replaceWithText(start: number, end: number, text: string) {
-		debug(`replaceWithText(${start}, ${end}, "${text}")`);
+	public replaceWithText(start: number, end: number, text: string): void {
+		debug(`replaceWithText(${start}, ${end}, "${text})")`);
 		this.sharedString.replaceText(start, end, text);
 	}
 
-	public remove(start: number, end: number) {
+	public remove(start: number, end: number): void {
 		let _start = start;
 		debug(`remove(${_start},${end})`);
 		const ops: IMergeTreeRemoveMsg[] = [];
@@ -328,7 +328,7 @@ export class FlowDocument extends DataObject {
 		});
 	}
 
-	public insertParagraph(position: number, tag?: TagName) {
+	public insertParagraph(position: number, tag?: TagName): void {
 		debug(`insertParagraph(${position})`);
 		this.sharedString.insertMarker(
 			position,
@@ -337,7 +337,7 @@ export class FlowDocument extends DataObject {
 		);
 	}
 
-	public insertLineBreak(position: number) {
+	public insertLineBreak(position: number): void {
 		debug(`insertLineBreak(${position})`);
 		this.sharedString.insertMarker(
 			position,
@@ -346,7 +346,7 @@ export class FlowDocument extends DataObject {
 		);
 	}
 
-	public setFormat(position: number, tag: TagName) {
+	public setFormat(position: number, tag: TagName): void {
 		const { start } = this.findParagraph(position);
 
 		// If inside an existing paragraph marker, update it with the new formatting tag.
@@ -363,30 +363,30 @@ export class FlowDocument extends DataObject {
 		this.insertParagraph(start, tag);
 	}
 
-	public getStart(marker: Marker) {
+	public getStart(marker: Marker): Marker {
 		return this.getOppositeMarker(marker, /* "end".length = */ 3, "begin");
 	}
 
-	public getEnd(marker: Marker) {
+	public getEnd(marker: Marker): Marker {
 		return this.getOppositeMarker(marker, /* "begin".length = */ 5, "end");
 	}
 
-	public annotate(start: number, end: number, props: PropertySet) {
+	public annotate(start: number, end: number, props: PropertySet): void {
 		this.sharedString.annotateRange(start, end, props);
 	}
 
-	public setCssStyle(start: number, end: number, style: string) {
+	public setCssStyle(start: number, end: number, style: string): void {
 		this.sharedString.annotateRange(start, end, { style });
 	}
 
-	public addCssClass(start: number, end: number, ...classNames: string[]) {
+	public addCssClass(start: number, end: number, ...classNames: string[]): void {
 		if (classNames.length > 0) {
 			const newClasses = classNames.join(" ");
 			this.updateCssClassList(start, end, (classList) => TokenList.set(classList, newClasses));
 		}
 	}
 
-	public removeCssClass(start: number, end: number, ...classNames: string[]) {
+	public removeCssClass(start: number, end: number, ...classNames: string[]): void {
 		this.updateCssClassList(start, end, (classList) =>
 			classNames.reduce(
 				(updatedList, className) => TokenList.unset(updatedList, className),
@@ -395,7 +395,7 @@ export class FlowDocument extends DataObject {
 		);
 	}
 
-	public toggleCssClass(start: number, end: number, ...classNames: string[]) {
+	public toggleCssClass(start: number, end: number, ...classNames: string[]): void {
 		// Pre-visit the range to see if any of the new styles have already been set.
 		// If so, change the add to a removal by setting the map value to 'undefined'.
 		const toAdd = classNames.slice(0);
@@ -410,15 +410,19 @@ export class FlowDocument extends DataObject {
 		this.addCssClass(start, end, ...toAdd);
 	}
 
-	public setAttr(start: number, end: number, attr: IHTMLAttributes) {
+	public setAttr(start: number, end: number, attr: IHTMLAttributes): void {
 		this.sharedString.annotateRange(start, end, { attr });
 	}
 
-	public searchForMarker(startPos: number, markerLabel: string, forwards: boolean) {
+	public searchForMarker(
+		startPos: number,
+		markerLabel: string,
+		forwards: boolean,
+	): LocalReferencePosition | undefined {
 		return this.sharedString.searchForMarker(startPos, markerLabel, forwards);
 	}
 
-	public findParagraph(position: number) {
+	public findParagraph(position: number): { start: number; end: number } {
 		const maybeStart = this.searchForMarker(position, DocTile.paragraph, /* forwards: */ true);
 		const start = maybeStart
 			? this.sharedString.localReferencePositionToPosition(maybeStart)
@@ -432,7 +436,7 @@ export class FlowDocument extends DataObject {
 		return { start, end };
 	}
 
-	public visitRange(callback: LeafAction, start = 0, end = this.length) {
+	public visitRange(callback: LeafAction, start = 0, end = this.length): void {
 		const _end = clamp(0, end, this.length);
 		const _start = clamp(0, start, end);
 
@@ -480,7 +484,11 @@ export class FlowDocument extends DataObject {
 		return s.join("");
 	}
 
-	private getOppositeMarker(marker: Marker, oldPrefixLength: number, newPrefix: string) {
+	private getOppositeMarker(
+		marker: Marker,
+		oldPrefixLength: number,
+		newPrefix: string,
+	): Marker {
 		return this.sharedString.getMarkerFromId(
 			`${newPrefix}${marker.getId().slice(oldPrefixLength)}`,
 		);
@@ -490,7 +498,7 @@ export class FlowDocument extends DataObject {
 		start: number,
 		end: number,
 		callback: (classList: string) => string,
-	) {
+	): void {
 		const updates: { span: SegmentSpan; classList: string }[] = [];
 
 		this.visitRange(

--- a/examples/data-objects/webflow/src/document/segmentspan.ts
+++ b/examples/data-objects/webflow/src/document/segmentspan.ts
@@ -58,7 +58,7 @@ export class SegmentSpan {
 			startOffset: number,
 			endOffset: number,
 		) => boolean | undefined,
-	) {
+	): void {
 		let startOffset = this._startOffset;
 		let position = this.firstPosition;
 		const final = this.endPosition;
@@ -80,7 +80,12 @@ export class SegmentSpan {
 		}
 	}
 
-	public append(position: number, segment: ISegment, startOffset: number, endOffset: number) {
+	public append(
+		position: number,
+		segment: ISegment,
+		startOffset: number,
+		endOffset: number,
+	): void {
 		this._segments.push(segment);
 		this.lastPosition = position;
 		this._endOffset = endOffset;
@@ -101,7 +106,7 @@ export class SegmentSpan {
 	 * Given an offset from the beginning of the span, returns the segment that contains the offset
 	 * as well as the offset from the segment start.
 	 */
-	public spanOffsetToSegmentOffset(spanOffset: number) {
+	public spanOffsetToSegmentOffset(spanOffset: number): { segment: ISegment; offset: number } {
 		let currentSpanOffset = spanOffset;
 		let segment: ISegment;
 		let offset = NaN;

--- a/examples/data-objects/webflow/src/editor/caret.ts
+++ b/examples/data-objects/webflow/src/editor/caret.ts
@@ -48,7 +48,7 @@ export class Caret {
 		});
 	}
 
-	public setSelection(start: number, end: number) {
+	public setSelection(start: number, end: number): void {
 		debug("  Cursor.setSelection(%d,%d):", start, end);
 		debug("    start:");
 		this.startRef = updateRef(this.doc, this.startRef, start);
@@ -56,7 +56,7 @@ export class Caret {
 		this.endRef = updateRef(this.doc, this.endRef, end);
 	}
 
-	public sync() {
+	public sync(): void {
 		debug("  Caret.sync()");
 		const { node: startNode, nodeOffset: startOffset } = this.positionToNodeOffset(
 			this.startRef,
@@ -80,12 +80,12 @@ export class Caret {
 		}
 	}
 
-	public collapseForward() {
+	public collapseForward(): void {
 		const { end } = this.selection;
 		this.setSelection(end, end);
 	}
 
-	private logWindowSelection(title: string) {
+	private logWindowSelection(title: string): void {
 		const { anchorNode, anchorOffset, focusNode, focusOffset } = window.getSelection();
 		debug(
 			"          %s: (%o:%d..%o:%d)",
@@ -115,7 +115,7 @@ export class Caret {
 		this.setSelection(start, end);
 	};
 
-	private positionToNodeOffset(ref: ReferencePosition) {
+	private positionToNodeOffset(ref: ReferencePosition): { node: Node; nodeOffset: number } {
 		let result: { node: Node; nodeOffset: number };
 
 		const position = this.doc.localRefToPosition(ref);
@@ -156,7 +156,7 @@ export class Caret {
 		return result;
 	}
 
-	private nodeOffsetToPosition(node: Node | Element, nodeOffset: number) {
+	private nodeOffsetToPosition(node: Node | Element, nodeOffset: number): number {
 		const segment = this.layout.nodeToSegment(node);
 		if (segment === eotSegment) {
 			return this.doc.length;

--- a/examples/data-objects/webflow/src/editor/editor.ts
+++ b/examples/data-objects/webflow/src/editor/editor.ts
@@ -62,7 +62,7 @@ export class Editor {
 		return this.caret.selection;
 	}
 
-	public remove() {
+	public remove(): void {
 		this.root.contentEditable = "false";
 		this.root.removeEventListener("paste", this.onPaste);
 		this.root.removeEventListener("keydown", this.onKeyDown);
@@ -71,7 +71,7 @@ export class Editor {
 		this.layout.remove();
 	}
 
-	private delete(e: Event, direction: Direction) {
+	private delete(e: Event, direction: Direction): void {
 		this.consume(e);
 
 		const caret = this.caret;
@@ -92,7 +92,7 @@ export class Editor {
 		caret.collapseForward();
 	}
 
-	private unlinkChildren(node: Node | HTMLElement) {
+	private unlinkChildren(node: Node | HTMLElement): void {
 		while (node.lastChild) {
 			const child = node.lastChild;
 			node.removeChild(child);
@@ -153,7 +153,7 @@ export class Editor {
 		}
 	};
 
-	private insertText(e: KeyboardEvent, text = e.key) {
+	private insertText(e: KeyboardEvent, text = e.key): void {
 		const { start, end } = this.caret.selection;
 		if (start === end) {
 			this.doc.insertText(end, text);
@@ -163,7 +163,7 @@ export class Editor {
 		this.caret.collapseForward();
 	}
 
-	private consume(e: Event) {
+	private consume(e: Event): void {
 		e.preventDefault();
 		e.stopPropagation();
 	}

--- a/examples/data-objects/webflow/src/host/searchmenu/index.ts
+++ b/examples/data-objects/webflow/src/host/searchmenu/index.ts
@@ -21,20 +21,20 @@ export class SearchMenuView extends View<ISearchMenuProps, ISearchMenuProps> {
 	private readonly inputElement = document.createElement("input");
 	private readonly datalistElement = document.createElement("datalist");
 
-	public show() {
+	public show(): void {
 		this.updateCommands();
 		const root = this.root as HTMLElement;
 		root.style.display = "inline-block";
 		this.inputElement.focus();
 	}
 
-	public hide() {
+	public hide(): void {
 		const root = this.root as HTMLElement;
 		root.blur();
 		root.style.display = "none";
 	}
 
-	protected onAttach(props: Readonly<ISearchMenuProps>) {
+	protected onAttach(props: Readonly<ISearchMenuProps>): Element {
 		const root = document.createElement("div");
 		root.classList.add("searchMenu");
 
@@ -62,7 +62,7 @@ export class SearchMenuView extends View<ISearchMenuProps, ISearchMenuProps> {
 		// Do nothing.
 	}
 
-	private updateCommands() {
+	private updateCommands(): void {
 		Dom.removeAllChildren(this.datalistElement);
 		this.datalistElement.append(
 			...this.state.commands
@@ -76,13 +76,13 @@ export class SearchMenuView extends View<ISearchMenuProps, ISearchMenuProps> {
 		);
 	}
 
-	private dismiss(e: KeyboardEvent) {
+	private dismiss(e: KeyboardEvent): void {
 		e.preventDefault();
 		e.stopPropagation();
 		this.hide();
 	}
 
-	private findCommand(text: string) {
+	private findCommand(text: string): ICommand | undefined {
 		for (const command of this.state.commands) {
 			if (command.name === text) {
 				debug(`Search Menu: ${command.name}`);
@@ -94,14 +94,14 @@ export class SearchMenuView extends View<ISearchMenuProps, ISearchMenuProps> {
 		return undefined;
 	}
 
-	private complete(e: KeyboardEvent, commit: boolean) {
+	private complete(e: KeyboardEvent, commit: boolean): void {
 		const command = commit ? this.findCommand(this.inputElement.value) : undefined;
 
 		this.dismiss(e);
 		this.state.onComplete(command);
 	}
 
-	private readonly onKeyDown = (e: KeyboardEvent) => {
+	private readonly onKeyDown = (e: KeyboardEvent): void => {
 		switch (e.code) {
 			case KeyCode.enter:
 				this.complete(e, true);

--- a/examples/data-objects/webflow/src/host/searchmenu/view.ts
+++ b/examples/data-objects/webflow/src/host/searchmenu/view.ts
@@ -22,18 +22,18 @@ export abstract class View<TInit extends TProps, TProps = {} | undefined>
 	private _root?: Element;
 	private listeners?: IListenerRegistration[];
 
-	public attach(parent: Element, init: Readonly<TInit>) {
+	public attach(parent: Element, init: Readonly<TInit>): void {
 		this._root = this.onAttach(init);
 		this.onUpdate(init);
 		console.assert(parent.hasChildNodes() === false);
 		parent.append(this._root);
 	}
 
-	public update(props: Readonly<TProps>) {
+	public update(props: Readonly<TProps>): void {
 		this.onUpdate(props);
 	}
 
-	public detach() {
+	public detach(): void {
 		const { root: root, listeners } = this;
 
 		const parent = root.parentNode;
@@ -53,7 +53,7 @@ export abstract class View<TInit extends TProps, TProps = {} | undefined>
 		this.listeners = undefined;
 	}
 
-	protected get root() {
+	protected get root(): Element | undefined {
 		return this._root;
 	}
 	protected abstract onAttach(init: Readonly<TInit>): Element;
@@ -64,7 +64,7 @@ export abstract class View<TInit extends TProps, TProps = {} | undefined>
 		target: EventTarget,
 		type: K | string,
 		listener: (ev: HTMLElementEventMap[K]) => any,
-	) {
+	): void {
 		const eventListener = listener as EventListener;
 		const registration: IListenerRegistration = { target, type, listener: eventListener };
 		const listeners = this.listeners;

--- a/examples/data-objects/webflow/src/host/webFlow.ts
+++ b/examples/data-objects/webflow/src/host/webFlow.ts
@@ -21,12 +21,12 @@ export class WebFlow extends DataObject {
 		return WebFlow.factory;
 	}
 
-	protected async initializingFirstTime() {
+	protected async initializingFirstTime(): Promise<void> {
 		const doc = await FlowDocument.getFactory().createChildInstance(this.context);
 		this.root.set("doc", doc.handle);
 	}
 
-	public async getFlowDocument() {
+	public async getFlowDocument(): Promise<FlowDocument> {
 		return this.root.get<IFluidHandle<FlowDocument>>("doc").get();
 	}
 }

--- a/examples/data-objects/webflow/src/html/css.ts
+++ b/examples/data-objects/webflow/src/html/css.ts
@@ -25,7 +25,7 @@ export function syncCss(
 	element: HTMLElement,
 	{ classList, style }: ICssProps,
 	className?: string,
-) {
+): void {
 	const classes = concat(className, classList);
 
 	if (!areStringsEquivalent(classes, element.className)) {
@@ -36,7 +36,7 @@ export function syncCss(
 	}
 }
 
-export function sameCss(segment: ISegment, { classList, style }: ICssProps) {
+export function sameCss(segment: ISegment, { classList, style }: ICssProps): boolean {
 	const actual = getCss(segment);
 	return (
 		areStringsEquivalent(actual.classList, classList) &&

--- a/examples/data-objects/webflow/src/html/formatters.ts
+++ b/examples/data-objects/webflow/src/html/formatters.ts
@@ -16,14 +16,14 @@ import { ICssProps, sameCss, syncCss } from "./css.js";
 import { debug } from "./debug.js";
 
 class HtmlFormatter extends RootFormatter<IFormatterState> {
-	public begin(layout: Layout) {
+	public begin(layout: Layout): IFormatterState {
 		// Note: Setting the whiteSpace style to "pre-wrap" has the side-effect of suppressing period insertion
 		//       on double space for MacOS.
 		(layout.cursor.parent as HTMLElement).style.whiteSpace = "pre-wrap";
 		return emptyObject;
 	}
 
-	public end() {}
+	public end(): void {}
 
 	public visit(layout: Layout, state: Readonly<IFormatterState>) {
 		const segment = layout.segment;
@@ -60,7 +60,7 @@ class HtmlFormatter extends RootFormatter<IFormatterState> {
 		}
 	}
 
-	public onChange() {}
+	public onChange(): void {}
 }
 
 interface ITagsState extends IFormatterState {
@@ -77,7 +77,7 @@ class TagsFormatter extends Formatter<ITagsState> {
 		layout: Layout,
 		init: Readonly<Partial<ITagsState>>,
 		prevState: Readonly<ITagsState>,
-	) {
+	): ITagsState {
 		const state: Partial<ITagsState> = prevState ? { ...prevState } : {};
 
 		const segment = layout.segment;
@@ -131,7 +131,7 @@ class TagsFormatter extends Formatter<ITagsState> {
 		}
 	}
 
-	public end(layout: Layout, state: Readonly<ITagsState>) {
+	public end(layout: Layout, state: Readonly<ITagsState>): void {
 		for (let i = state.popCount; i > 0; i--) {
 			layout.popNode();
 		}
@@ -147,7 +147,11 @@ class ParagraphFormatter extends Formatter<IParagraphState> {
 		super();
 	}
 
-	public begin(layout: Layout, init: IParagraphState, prevState: IParagraphState) {
+	public begin(
+		layout: Layout,
+		init: IParagraphState,
+		prevState: IParagraphState,
+	): IParagraphState {
 		const state: Partial<IParagraphState> = prevState ? { ...prevState } : {};
 
 		const segment = layout.segment;
@@ -155,7 +159,7 @@ class ParagraphFormatter extends Formatter<IParagraphState> {
 		state.root = layout.pushTag(tag);
 		syncCss(state.root, getCss(segment), undefined);
 
-		return state;
+		return state as IParagraphState;
 	}
 
 	public visit(layout: Layout, state: Readonly<IParagraphState>) {
@@ -186,7 +190,7 @@ class ParagraphFormatter extends Formatter<IParagraphState> {
 		}
 	}
 
-	public end(layout: Layout, state: Readonly<IParagraphState>) {
+	public end(layout: Layout, state: Readonly<IParagraphState>): void {
 		layout.emitTag(TagName.br);
 		layout.popNode();
 	}
@@ -202,12 +206,12 @@ class TextFormatter extends Formatter<ITextState> {
 		layout: Layout,
 		init: Readonly<Partial<ITextState>>,
 		prevState: Readonly<ITextState>,
-	) {
+	): ITextState {
 		const state: Partial<ITextState> = prevState ? { ...prevState } : {};
 		state.root = layout.pushTag(TagName.span);
 		state.css = getCss(layout.segment);
 		syncCss(state.root, state.css, undefined);
-		return state;
+		return state as ITextState;
 	}
 
 	public visit(layout: Layout, state: Readonly<ITextState>) {
@@ -231,7 +235,7 @@ class TextFormatter extends Formatter<ITextState> {
 		}
 	}
 
-	public end(layout: Layout, state: Readonly<ITextState>) {
+	public end(layout: Layout, state: Readonly<ITextState>): void {
 		layout.popNode();
 	}
 }

--- a/examples/data-objects/webflow/src/util/attr.ts
+++ b/examples/data-objects/webflow/src/util/attr.ts
@@ -18,7 +18,7 @@ export function getAttrs(segment: ISegment): Readonly<IHTMLAttributes> {
 	return properties?.attr || emptyObject;
 }
 
-export function syncAttrs(element: HTMLElement, attrs: IHTMLAttributes) {
+export function syncAttrs(element: HTMLElement, attrs: IHTMLAttributes): void {
 	// Remove any attributes not in attrs
 	for (const name of element.getAttributeNames()) {
 		if (!(name in attrs)) {

--- a/examples/data-objects/webflow/src/util/caret.ts
+++ b/examples/data-objects/webflow/src/util/caret.ts
@@ -36,7 +36,11 @@ function dispatchCaretEvent(
 	);
 }
 
-export function caretEnter(target: Element, direction: Direction, caretBounds: ICaretBounds) {
+export function caretEnter(
+	target: Element,
+	direction: Direction,
+	caretBounds: ICaretBounds,
+): boolean {
 	const focusable = target.querySelectorAll(":enabled, [tabindex]");
 	const focusTarget = (
 		getTabDirection(direction) > 0 ? focusable[0] : focusable[focusable.length - 1]
@@ -50,6 +54,10 @@ export function caretEnter(target: Element, direction: Direction, caretBounds: I
 	}
 }
 
-export function caretLeave(target: Element, direction: Direction, caretBounds: ICaretBounds) {
+export function caretLeave(
+	target: Element,
+	direction: Direction,
+	caretBounds: ICaretBounds,
+): boolean {
 	return dispatchCaretEvent(CaretEventType.leave, target, direction, caretBounds);
 }

--- a/examples/data-objects/webflow/src/util/direction.ts
+++ b/examples/data-objects/webflow/src/util/direction.ts
@@ -39,5 +39,5 @@ export function getDeltaY(direction: Direction): TabDirection {
 }
 
 export function getTabDirection(direction: Direction): TabDirection {
-	return (getDeltaX(direction) || getDeltaY(direction));
+	return getDeltaX(direction) || getDeltaY(direction);
 }

--- a/examples/data-objects/webflow/src/util/direction.ts
+++ b/examples/data-objects/webflow/src/util/direction.ts
@@ -30,14 +30,14 @@ export const enum TabDirection {
 	forward = 1,
 }
 
-export function getDeltaX(direction: Direction) {
+export function getDeltaX(direction: Direction): number {
 	return (direction << DirectionFlag.horizontalLsh) >> DirectionFlag.horizontalRsh;
 }
 
-export function getDeltaY(direction: Direction) {
+export function getDeltaY(direction: Direction): number {
 	return (direction << DirectionFlag.verticalLsh) >> DirectionFlag.verticalRsh;
 }
 
 export function getTabDirection(direction: Direction): TabDirection {
-	return getDeltaX(direction) || getDeltaY(direction);
+	return (getDeltaX(direction) || getDeltaY(direction)) as TabDirection;
 }

--- a/examples/data-objects/webflow/src/util/direction.ts
+++ b/examples/data-objects/webflow/src/util/direction.ts
@@ -30,14 +30,14 @@ export const enum TabDirection {
 	forward = 1,
 }
 
-export function getDeltaX(direction: Direction): number {
+export function getDeltaX(direction: Direction): TabDirection {
 	return (direction << DirectionFlag.horizontalLsh) >> DirectionFlag.horizontalRsh;
 }
 
-export function getDeltaY(direction: Direction): number {
+export function getDeltaY(direction: Direction): TabDirection {
 	return (direction << DirectionFlag.verticalLsh) >> DirectionFlag.verticalRsh;
 }
 
 export function getTabDirection(direction: Direction): TabDirection {
-	return (getDeltaX(direction) || getDeltaY(direction)) as TabDirection;
+	return (getDeltaX(direction) || getDeltaY(direction));
 }

--- a/examples/data-objects/webflow/src/util/dom.ts
+++ b/examples/data-objects/webflow/src/util/dom.ts
@@ -7,7 +7,7 @@ const isElement = (node: Node): node is Element => node.nodeType === Node.ELEMEN
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Dom {
-	public static removeAllChildren(parent: Node) {
+	public static removeAllChildren(parent: Node): void {
 		// External library uses `null`
 		// eslint-disable-next-line @rushstack/no-new-null
 		let firstChild: ChildNode | null;
@@ -20,7 +20,7 @@ export class Dom {
 	 * Inserts the given 'newChild' immediately after the given 'refChild'.  If 'refChild' is undefined,
 	 * inserts 'newChild' as the first child of 'parent'.
 	 */
-	public static insertAfter(parent: Node, newChild: Node, refChild: Node | null) {
+	public static insertAfter(parent: Node, newChild: Node, refChild: Node | null): void {
 		parent.insertBefore(newChild, refChild ? refChild.nextSibling : parent.firstChild);
 	}
 

--- a/examples/data-objects/webflow/src/util/localref.ts
+++ b/examples/data-objects/webflow/src/util/localref.ts
@@ -8,7 +8,11 @@ import { LocalReferencePosition } from "@fluidframework/sequence/legacy";
 import { debug } from "../document/debug.js";
 import { FlowDocument } from "../document/index.js";
 
-export function updateRef(doc: FlowDocument, ref: LocalReferencePosition, position: number) {
+export function updateRef(
+	doc: FlowDocument,
+	ref: LocalReferencePosition,
+	position: number,
+): LocalReferencePosition {
 	if (isNaN(position)) {
 		debug(`      ${position} (ignored)`);
 		return ref;
@@ -31,7 +35,7 @@ export function updateRef(doc: FlowDocument, ref: LocalReferencePosition, positi
 	return doc.addLocalRef(position);
 }
 
-export function extractRef(doc: FlowDocument, ref: LocalReferencePosition) {
+export function extractRef(doc: FlowDocument, ref: LocalReferencePosition): number {
 	const position = doc.localRefToPosition(ref);
 	doc.removeLocalRef(ref);
 	return position;

--- a/examples/data-objects/webflow/src/util/random.ts
+++ b/examples/data-objects/webflow/src/util/random.ts
@@ -6,4 +6,4 @@
 /**
  * Returns a pseudo-random string suitable for avoiding 'id' collisions between DOM elements.
  */
-export const randomId = () => Math.random().toString(36).slice(2);
+export const randomId = (): string => Math.random().toString(36).slice(2);

--- a/examples/data-objects/webflow/src/util/segment.ts
+++ b/examples/data-objects/webflow/src/util/segment.ts
@@ -5,7 +5,11 @@
 
 import { ISegment } from "@fluidframework/sequence/legacy";
 
-export function getSegmentRange(position: number, segment: ISegment, startOffset = 0) {
+export function getSegmentRange(
+	position: number,
+	segment: ISegment,
+	startOffset = 0,
+): { start: number; end: number } {
 	const start = position - Math.max(startOffset, 0);
 	return { start, end: start + segment.cachedLength };
 }

--- a/examples/data-objects/webflow/src/util/tag.ts
+++ b/examples/data-objects/webflow/src/util/tag.ts
@@ -17,7 +17,7 @@ const segmentKindToOppositeIdPrefix = {
 	[DocSegmentKind.endTags]: "b:",
 };
 
-export function createTags(tags: TagName[]) {
+export function createTags(tags: TagName[]): { root: HTMLElement; slot: HTMLElement } {
 	const root = document.createElement(tags[0]);
 	let slot: HTMLElement = root;
 	for (let i = 1; i < tags.length; i++) {
@@ -27,17 +27,17 @@ export function createTags(tags: TagName[]) {
 	return { root, slot };
 }
 
-export function addIdPrefix(kind: DocSegmentKind, id: string) {
+export function addIdPrefix(kind: DocSegmentKind, id: string): string {
 	const prefix = segmentKindToIdPrefix[kind];
 	return prefix ? `${prefix}${id}` : id;
 }
 
-export function removeIdPrefix(kind: DocSegmentKind, id: string) {
+export function removeIdPrefix(kind: DocSegmentKind, id: string): string {
 	const prefix = segmentKindToIdPrefix[kind];
 	return prefix ? id.slice(prefix.length) : id;
 }
 
-export function getIdForOpposite(kind: DocSegmentKind, id: string) {
+export function getIdForOpposite(kind: DocSegmentKind, id: string): string {
 	const oldPrefix = segmentKindToIdPrefix[kind];
 	const newPrefix = segmentKindToOppositeIdPrefix[kind];
 

--- a/examples/data-objects/webflow/src/util/tokenlist.ts
+++ b/examples/data-objects/webflow/src/util/tokenlist.ts
@@ -5,7 +5,10 @@
 
 import { CharCode } from "./charcode.js";
 
-export function findToken(tokenList: string, token: string) {
+export function findToken(
+	tokenList: string,
+	token: string,
+): { start: number; end: number } | undefined {
 	if (tokenList) {
 		for (let start = 0; start >= 0; start = tokenList.indexOf(" ", start + 1)) {
 			start = tokenList.indexOf(token, start);
@@ -30,7 +33,10 @@ export function findToken(tokenList: string, token: string) {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace TokenList {
-	export function set(tokenList: string | undefined, token: string | undefined) {
+	export function set(
+		tokenList: string | undefined,
+		token: string | undefined,
+	): string | undefined {
 		return !tokenList // If the list is empty
 			? token // ...the token becomes the new list.
 			: !token || findToken(tokenList, token)
@@ -38,7 +44,7 @@ export namespace TokenList {
 				: `${tokenList} ${token}`; // ...otherwise append the token to the list.
 	}
 
-	export function unset(tokenList: string, token: string) {
+	export function unset(tokenList: string, token: string): string {
 		const span = findToken(tokenList, token);
 		if (!span) {
 			return tokenList;
@@ -55,7 +61,7 @@ export namespace TokenList {
 		tokenList: string | undefined,
 		toAdd: string[],
 		toRemove: Set<string>,
-	) {
+	): void {
 		if (!tokenList) {
 			// If the token list is empty, the 'toAdd' and 'toRemove'
 			return; // lists remain unchanged.

--- a/examples/data-objects/webflow/src/util/utilities.ts
+++ b/examples/data-objects/webflow/src/util/utilities.ts
@@ -7,5 +7,5 @@ export const done = Promise.resolve();
 export const emptyObject = Object.freeze({});
 export const emptyArray = Object.freeze([] as any[]);
 
-export const clamp = (min: number, value: number, max: number) =>
+export const clamp = (min: number, value: number, max: number): number =>
 	Math.min(Math.max(min, value), max);

--- a/examples/data-objects/webflow/src/view/formatter.ts
+++ b/examples/data-objects/webflow/src/view/formatter.ts
@@ -26,7 +26,7 @@ export abstract class Formatter<TState extends IFormatterState> {
 
 	public abstract end(layout: Layout, state: Readonly<TState>);
 
-	public toString() {
+	public toString(): string {
 		return this.constructor.name;
 	}
 }
@@ -34,7 +34,7 @@ export abstract class Formatter<TState extends IFormatterState> {
 export abstract class RootFormatter<TState extends IFormatterState> extends Formatter<TState> {
 	public abstract onChange(layout: Layout, e: SequenceEvent);
 
-	public prepare(layout: Layout, start: number, end: number) {
+	public prepare(layout: Layout, start: number, end: number): { start: number; end: number } {
 		return { start, end };
 	}
 }
@@ -60,10 +60,10 @@ export class BootstrapFormatter<
 		throw new Error();
 	}
 
-	public onChange(layout: Layout, e: SequenceEvent) {
+	public onChange(layout: Layout, e: SequenceEvent): void {
 		this.formatter.onChange(layout, e);
 	}
-	public prepare(layout: Layout, start: number, end: number) {
+	public prepare(layout: Layout, start: number, end: number): { start: number; end: number } {
 		return this.formatter.prepare(layout, start, end);
 	}
 }

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -363,7 +363,7 @@ export class Layout extends EventEmitter {
 		return element;
 	}
 
-	public emitText(text: string): Text {
+	public emitText(text: string): ChildNode {
 		// Note: Removing and inserting a new text node has the side-effect of reseting the caret blink.
 		//       Because text nodes are always leaves, this is harmless.
 		let existing = this.next;

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -159,13 +159,13 @@ export class Layout extends EventEmitter {
 		debug("end: initial sync");
 	}
 
-	public remove() {
+	public remove(): void {
 		this.doc.removeListener("sequenceDelta", this.onChange);
 		this.doc.removeListener("maintenance", this.onChange);
 		Dom.removeAllChildren(this.root);
 	}
 
-	public sync(start = 0, end = this.doc.length) {
+	public sync(start = 0, end = this.doc.length): void {
 		let _start = start;
 		let _end = end;
 
@@ -293,7 +293,7 @@ export class Layout extends EventEmitter {
 	public pushFormat<TState extends IFormatterState>(
 		formatter: Readonly<Formatter<TState>>,
 		init: Readonly<Partial<TState>>,
-	) {
+	): void {
 		const depth = this.formatStack.length;
 
 		const segment = this.segment;
@@ -330,7 +330,7 @@ export class Layout extends EventEmitter {
 		this.formatStack.push(Object.freeze({ formatter, state: Object.freeze(state) }));
 	}
 
-	public popFormat(count = 1) {
+	public popFormat(count = 1): void {
 		let _count = count;
 		while (_count-- > 0) {
 			const { formatter, state } = this.formatStack.pop();
@@ -340,7 +340,7 @@ export class Layout extends EventEmitter {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-	public pushTag<T extends {}>(tag: TagName, props?: T) {
+	public pushTag<T extends {}>(tag: TagName, props?: T): HTMLElement {
 		const element = this.elementForTag(tag);
 		if (props) {
 			Object.assign(element, props);
@@ -349,12 +349,12 @@ export class Layout extends EventEmitter {
 		return element;
 	}
 
-	public popTag(count = 1) {
+	public popTag(count = 1): void {
 		this.popNode(count);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-	public emitTag<T extends {}>(tag: TagName, props?: T) {
+	public emitTag<T extends {}>(tag: TagName, props?: T): HTMLElement {
 		const element = this.elementForTag(tag);
 		if (props) {
 			Object.assign(element, props);
@@ -363,7 +363,7 @@ export class Layout extends EventEmitter {
 		return element;
 	}
 
-	public emitText(text: string) {
+	public emitText(text: string): Text {
 		// Note: Removing and inserting a new text node has the side-effect of reseting the caret blink.
 		//       Because text nodes are always leaves, this is harmless.
 		let existing = this.next;
@@ -375,7 +375,7 @@ export class Layout extends EventEmitter {
 		return existing;
 	}
 
-	public pushNode(node: Node) {
+	public pushNode(node: Node): void {
 		debug("    pushNode(%o@%d)", node, this.position);
 
 		this.emitNode(node);
@@ -387,7 +387,7 @@ export class Layout extends EventEmitter {
 		}
 	}
 
-	public emitNode(node: Node) {
+	public emitNode(node: Node): void {
 		debug("    emitNode(%o@%d)", node, this.position);
 
 		const top = this._cursor;
@@ -405,7 +405,7 @@ export class Layout extends EventEmitter {
 		this.nodeToSegmentMap.set(node, this.segment);
 	}
 
-	public popNode(count = 1) {
+	public popNode(count = 1): void {
 		let _count = count;
 		while (_count-- > 0) {
 			const cursor = this._cursor;
@@ -419,12 +419,15 @@ export class Layout extends EventEmitter {
 		assert(this.root.contains(this.cursor.parent));
 	}
 
-	public nodeToSegment(node: Node): ISegment {
+	public nodeToSegment(node: Node): ISegment | undefined {
 		const seg = this.nodeToSegmentMap.get(node);
 		return seg && (!segmentIsRemoved(seg) ? seg : undefined);
 	}
 
-	public segmentAndOffsetToNodeAndOffset(segment: ISegment, offset: number) {
+	public segmentAndOffsetToNodeAndOffset(
+		segment: ISegment,
+		offset: number,
+	): { node: Node | null; nodeOffset: number } {
 		const checkpoint = this.segmentToCheckpoint.get(segment);
 		if (!checkpoint) {
 			return { node: null, nodeOffset: NaN };
@@ -453,7 +456,10 @@ export class Layout extends EventEmitter {
 		return { node: null, nodeOffset: NaN };
 	}
 
-	private segmentAndOffsetToNodeAndOffsetHelper(cursor: ILayoutCursor, offset: number) {
+	private segmentAndOffsetToNodeAndOffsetHelper(
+		cursor: ILayoutCursor,
+		offset: number,
+	): { node: Node; nodeOffset: number } {
 		let _offset = offset;
 		let { previous: node } = cursor;
 
@@ -489,7 +495,7 @@ export class Layout extends EventEmitter {
 		}
 	}
 
-	private elementForTag(tag: TagName) {
+	private elementForTag(tag: TagName): HTMLElement {
 		const existing = this.next;
 		// Reuse the existing element if possible, otherwise create a new one.  Note that
 		// 'layout.pushNode(..)' will clean up the old node if needed.
@@ -505,7 +511,7 @@ export class Layout extends EventEmitter {
 		segment: ISegment,
 		startOffset: number,
 		endOffset: number,
-	) {
+	): void {
 		assert.strictEqual(this.pending.size, 0);
 
 		this._position = position;
@@ -537,14 +543,14 @@ export class Layout extends EventEmitter {
 		assert.notStrictEqual(this.emitted, this.pending);
 	}
 
-	private removePending() {
+	private removePending(): void {
 		for (const node of this.pending) {
 			this.removeNode(node);
 		}
 		this.pending.clear();
 	}
 
-	private endSegment(lastInvalidated: number) {
+	private endSegment(lastInvalidated: number): boolean {
 		this.removePending();
 		const previous = this.segmentToCheckpoint.get(this.segment);
 
@@ -573,7 +579,7 @@ export class Layout extends EventEmitter {
 		return shouldContinue;
 	}
 
-	private restoreCheckpoint(checkpoint: LayoutCheckpoint) {
+	private restoreCheckpoint(checkpoint: LayoutCheckpoint): void {
 		const { formatStack, cursor } = checkpoint;
 		this.formatStack = formatStack.map((formatInfo) => ({ ...formatInfo }));
 		this._cursor = { ...cursor };
@@ -582,7 +588,7 @@ export class Layout extends EventEmitter {
 		assert(this.root.contains(cursor.parent));
 	}
 
-	private removeNode(node: Node) {
+	private removeNode(node: Node): void {
 		debug("        removed %o", node);
 		this.nodeToSegmentMap.delete(node);
 		if (node.parentNode) {
@@ -590,7 +596,7 @@ export class Layout extends EventEmitter {
 		}
 	}
 
-	private removeSegment(segment: ISegment) {
+	private removeSegment(segment: ISegment): void {
 		const emitted = this.segmentToEmitted.get(segment);
 		if (emitted) {
 			for (const node of emitted) {
@@ -628,14 +634,14 @@ export class Layout extends EventEmitter {
 		ref: ReferencePosition | undefined,
 		fn: (a: number, b: number) => number,
 		limit: number,
-	) {
+	): number {
 		return fn(
 			position === undefined ? limit : position,
 			ref === undefined ? limit : doc.localRefToPosition(ref),
 		);
 	}
 
-	private invalidate(start: number, end: number) {
+	private invalidate(start: number, end: number): void {
 		let _start = start;
 		let _end = end;
 		// Union the delta range with the current invalidated range (if any).
@@ -652,7 +658,7 @@ export class Layout extends EventEmitter {
 		});
 	}
 
-	private render() {
+	private render(): void {
 		const doc = this.doc;
 		const start = extractRef(doc, this.startInvalid);
 		this.startInvalid = undefined;


### PR DESCRIPTION
In preparation for globally enabling an eslint rule that requires them.