### PR TITLE
readonlyInStagingMode default to false

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -156,7 +156,7 @@ export interface ISharedObjectRegistry {
 }
 
 const defaultPolicies: IFluidDataStorePolicies = {
-	readonlyInStagingMode: true,
+	readonlyInStagingMode: false,
 };
 
 /**

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -319,11 +319,13 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
  */
 export interface IFluidDataStorePolicies {
 	/**
-	 * When set to true, data stores will appear to be readonly while in staging mode.
+	 * When set to true, the data store will appear readonly while in staging mode.
 	 *
 	 * @remarks
-	 * This policy is useful for data stores that do not support staging mode, such as those using consensus DDS.
-	 * It ensures that the data store appears readonly during staging mode to discourage unsupported operations.
+	 * In staging mode, operations are held locally until committed, so consensus-based operations
+	 * (e.g., `ConsensusRegisterCollection`, `ConsensusQueue`, `TaskManager`) won't resolve their promises until
+	 * staging mode exits. Set this to `true` for data stores that depend on consensus acknowledgments
+	 * to prevent modifications that would leave the data store in an unresponsive state.
 	 */
 	readonly readonlyInStagingMode: boolean;
 }

--- a/packages/test/local-server-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/stagingMode.spec.ts
@@ -128,9 +128,6 @@ class DataObjectWithStagingMode extends DataObject {
 const dataObjectFactory = new DataObjectFactory({
 	type: "TheDataObject",
 	ctor: DataObjectWithStagingMode,
-	policies: {
-		readonlyInStagingMode: false,
-	},
 });
 
 // a simple container runtime factory with a single datastore aliased as default.


### PR DESCRIPTION
This pull request makes a small change to the default data store policies in the `dataStoreRuntime.ts` file. The change updates the default setting for `readonlyInStagingMode` to be `false` instead of `true`, allowing data stores to be writable in staging mode by default. This is to aid prototyping. StagingMode is still alpha, so this breaking change is acceptable.