### PR TITLE
fix(benchmark tests): Ensure "benchmark end" event is emitted even if an error is thrown by the runner

### DIFF
--- a/tools/benchmark/src/ResultUtilities.ts
+++ b/tools/benchmark/src/ResultUtilities.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { BenchmarkResult, BenchmarkError, BenchmarkData, CustomData } from "./ResultTypes";
+import { timer } from "./timer";
+
+/**
+ * Wraps a function that returns CustomData, measuring its execution time
+ * and capturing either its result or exception.
+ * Returns a callback suitable for passing to emitResultsMocha.
+ * This is a generic utility that is neither mocha-specific nor time benchmark-specific.
+ */
+export function captureResults(
+	f: () => CustomData | Promise<CustomData>,
+): () => Promise<{ result: BenchmarkResult; exception?: Error }> {
+	return async () => {
+		const startTime = timer.now();
+
+		let customData: CustomData;
+		try {
+			customData = await f();
+		} catch (error) {
+			const benchmarkError: BenchmarkError = { error: (error as Error).message };
+			return { result: benchmarkError, exception: error as Error };
+		}
+
+		const elapsedSeconds = timer.toSeconds(startTime, timer.now());
+
+		const result: BenchmarkData = {
+			elapsedSeconds,
+			customData,
+		};
+
+		return { result };
+	};
+}

--- a/tools/benchmark/src/RunnerUtilities.ts
+++ b/tools/benchmark/src/RunnerUtilities.ts
@@ -5,11 +5,44 @@
 
 import type { Stats } from "./ResultTypes";
 import { assert } from "./assert.js";
+import type { BenchmarkResult, BenchmarkError, BenchmarkData, CustomData } from "./ResultTypes";
+import { timer } from "./timer";
 
 /**
  * This file contains generic utilities of use to a mocha reporter, especially for convenient formatting of textual
  * output to the command line.
  */
+
+/**
+ * Wraps a function that returns CustomData, measuring its execution time
+ * and capturing either its result or exception.
+ * Returns a callback suitable for passing to emitResultsMocha.
+ * This is a generic utility that is neither mocha-specific nor time benchmark-specific.
+ */
+export function captureResults(
+	f: () => CustomData | Promise<CustomData>,
+): () => Promise<{ result: BenchmarkResult; exception?: Error }> {
+	return async () => {
+		const startTime = timer.now();
+
+		let customData: CustomData;
+		try {
+			customData = await f();
+		} catch (error) {
+			const benchmarkError: BenchmarkError = { error: (error as Error).message };
+			return { result: benchmarkError, exception: error as Error };
+		}
+
+		const elapsedSeconds = timer.toSeconds(startTime, timer.now());
+
+		const result: BenchmarkData = {
+			elapsedSeconds,
+			customData,
+		};
+
+		return { result };
+	};
+}
 
 /**
  * Creates and returns a padding string consisting of `num` copies of `chr`

--- a/tools/benchmark/src/RunnerUtilities.ts
+++ b/tools/benchmark/src/RunnerUtilities.ts
@@ -3,9 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import type { Stats } from "./ResultTypes";
+import type {
+	BenchmarkResult,
+	BenchmarkError,
+	BenchmarkData,
+	CustomData,
+	Stats,
+} from "./ResultTypes";
 import { assert } from "./assert.js";
-import type { BenchmarkResult, BenchmarkError, BenchmarkData, CustomData } from "./ResultTypes";
 import { timer } from "./timer";
 
 /**

--- a/tools/benchmark/src/RunnerUtilities.ts
+++ b/tools/benchmark/src/RunnerUtilities.ts
@@ -3,51 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import type {
-	BenchmarkResult,
-	BenchmarkError,
-	BenchmarkData,
-	CustomData,
-	Stats,
-} from "./ResultTypes";
+import type { Stats } from "./ResultTypes";
 import { assert } from "./assert.js";
-import { timer } from "./timer";
 
 /**
  * This file contains generic utilities of use to a mocha reporter, especially for convenient formatting of textual
  * output to the command line.
  */
-
-/**
- * Wraps a function that returns CustomData, measuring its execution time
- * and capturing either its result or exception.
- * Returns a callback suitable for passing to emitResultsMocha.
- * This is a generic utility that is neither mocha-specific nor time benchmark-specific.
- */
-export function captureResults(
-	f: () => CustomData | Promise<CustomData>,
-): () => Promise<{ result: BenchmarkResult; exception?: Error }> {
-	return async () => {
-		const startTime = timer.now();
-
-		let customData: CustomData;
-		try {
-			customData = await f();
-		} catch (error) {
-			const benchmarkError: BenchmarkError = { error: (error as Error).message };
-			return { result: benchmarkError, exception: error as Error };
-		}
-
-		const elapsedSeconds = timer.toSeconds(startTime, timer.now());
-
-		const result: BenchmarkData = {
-			elapsedSeconds,
-			customData,
-		};
-
-		return { result };
-	};
-}
 
 /**
  * Creates and returns a padding string consisting of `num` copies of `chr`

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -8,6 +8,7 @@ import type { Test } from "mocha";
 import type { BenchmarkDescription, MochaExclusiveOptions, Titled } from "../Configuration";
 import type { CustomData } from "../ResultTypes";
 import { prettyNumber } from "../RunnerUtilities";
+
 import { emitResultsMocha, captureResults } from "./runnerUtilities";
 
 /**

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -6,9 +6,9 @@
 import type { Test } from "mocha";
 
 import type { BenchmarkDescription, MochaExclusiveOptions, Titled } from "../Configuration";
-import type { BenchmarkData, BenchmarkError, CustomData } from "../ResultTypes";
+import type { CustomData } from "../ResultTypes";
 import { prettyNumber } from "../RunnerUtilities";
-import { timer } from "../timer";
+import { emitResultsMocha, captureResults } from "./runnerUtilities";
 
 /**
  * Options to configure a benchmark that reports custom measurements.
@@ -48,26 +48,14 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test {
 			},
 		};
 
-		const startTime = timer.now();
-
-		try {
-			await options.run(reporter);
-		} catch (error) {
-			const benchmarkError: BenchmarkError = { error: (error as Error).message };
-
-			test.emit("benchmark end", benchmarkError);
-
-			throw error;
-		}
-
-		const elapsedSeconds = timer.toSeconds(startTime, timer.now());
-
-		const results: BenchmarkData = {
-			elapsedSeconds,
-			customData,
-		};
-
-		test.emit("benchmark end", results);
+		// Emits the "benchmark end" event with the result
+		await emitResultsMocha(
+			captureResults(async () => {
+				await options.run(reporter);
+				return customData;
+			}),
+			test,
+		);
 	});
 	return test;
 }

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -7,9 +7,9 @@ import type { Test } from "mocha";
 
 import type { BenchmarkDescription, MochaExclusiveOptions, Titled } from "../Configuration";
 import type { CustomData } from "../ResultTypes";
-import { prettyNumber } from "../RunnerUtilities";
+import { prettyNumber, captureResults } from "../RunnerUtilities";
 
-import { emitResultsMocha, captureResults } from "./runnerUtilities";
+import { emitResultsMocha } from "./runnerUtilities";
 
 /**
  * Options to configure a benchmark that reports custom measurements.

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -7,7 +7,8 @@ import type { Test } from "mocha";
 
 import type { BenchmarkDescription, MochaExclusiveOptions, Titled } from "../Configuration";
 import type { CustomData } from "../ResultTypes";
-import { prettyNumber, captureResults } from "../RunnerUtilities";
+import { captureResults } from "../ResultUtilities";
+import { prettyNumber } from "../RunnerUtilities";
 
 import { emitResultsMocha } from "./runnerUtilities";
 

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -65,64 +65,74 @@ export function supportParentProcess<
 	const itFunction = args.only === true ? it.only : it;
 	const test = itFunction(args.title, async () => {
 		if (isParentProcess) {
-			// Instead of running the benchmark in this process, create a new process.
-			// See {@link isParentProcess} for why.
-			// Launch new process, with:
-			// - mocha filter to run only this test.
-			// - --parentProcess flag removed.
-			// - --childProcess flag added (so data will be returned via stdout as json)
+			await emitResultsMocha(async () => {
+				try {
+					// Instead of running the benchmark in this process, create a new process.
+					// See {@link isParentProcess} for why.
+					// Launch new process, with:
+					// - mocha filter to run only this test.
+					// - --parentProcess flag removed.
+					// - --childProcess flag added (so data will be returned via stdout as json)
 
-			// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
-			const command = process.argv0 ?? fail("there must be a command");
+					// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
+					const command = process.argv0 ?? fail("there must be a command");
 
-			// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
-			// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
-			// put in mocha's --node-option flag.
-			const childArgs = [...process.execArgv, ...process.argv.slice(1)];
-			const processFlagIndex = childArgs.indexOf("--parentProcess");
-			childArgs[processFlagIndex] = "--childProcess";
+					// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
+					// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
+					// put in mocha's --node-option flag.
+					const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+					const processFlagIndex = childArgs.indexOf("--parentProcess");
+					childArgs[processFlagIndex] = "--childProcess";
 
-			// Remove arguments for any existing test filters.
-			for (const flag of ["--grep", "--fgrep"]) {
-				const flagIndex = childArgs.indexOf(flag);
-				if (flagIndex > 0) {
-					// Remove the flag, and the argument after it (all these flags take one argument)
-					childArgs.splice(flagIndex, 2);
+					// Remove arguments for any existing test filters.
+					for (const flag of ["--grep", "--fgrep"]) {
+						const flagIndex = childArgs.indexOf(flag);
+						if (flagIndex > 0) {
+							// Remove the flag, and the argument after it (all these flags take one argument)
+							childArgs.splice(flagIndex, 2);
+						}
+					}
+
+					// Add test filter so child process only run the current test.
+					childArgs.push("--fgrep", test.fullTitle());
+
+					// Remove arguments for debugging if they're present; in order to debug child processes we need
+					// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
+					// of scope for now.
+					let inspectArgIndex: number = -1;
+					while (
+						(inspectArgIndex = childArgs.findIndex((x) =>
+							x.match(/^(--inspect|--debug).*/),
+						)) >= 0
+					) {
+						childArgs.splice(inspectArgIndex, 1);
+					}
+
+					// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
+					const childProcess = await import("node:child_process");
+					const result = childProcess.spawnSync(command, childArgs, { encoding: "utf8" });
+
+					if (result.error) {
+						fail(`Child process reported an error: ${result.error.message}`);
+					}
+
+					if (result.stderr !== "") {
+						fail(`Child process logged errors: ${result.stderr}`);
+					}
+
+					// Find the json blob in the child's output.
+					const output =
+						result.stdout.split("\n").find((s) => s.startsWith("{")) ??
+						fail(`child process must output a json blob. Got:\n${result.stdout}`);
+
+					return { result: JSON.parse(output) as BenchmarkResult };
+				} catch (error) {
+					return {
+						result: { error: (error as Error).message },
+						exception: error as Error,
+					};
 				}
-			}
-
-			// Add test filter so child process only run the current test.
-			childArgs.push("--fgrep", test.fullTitle());
-
-			// Remove arguments for debugging if they're present; in order to debug child processes we need
-			// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
-			// of scope for now.
-			let inspectArgIndex: number = -1;
-			while (
-				(inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >=
-				0
-			) {
-				childArgs.splice(inspectArgIndex, 1);
-			}
-
-			// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
-			const childProcess = await import("node:child_process");
-			const result = childProcess.spawnSync(command, childArgs, { encoding: "utf8" });
-
-			if (result.error) {
-				fail(`Child process reported an error: ${result.error.message}`);
-			}
-
-			if (result.stderr !== "") {
-				fail(`Child process logged errors: ${result.stderr}`);
-			}
-
-			// Find the json blob in the child's output.
-			const output =
-				result.stdout.split("\n").find((s) => s.startsWith("{")) ??
-				fail(`child process must output a json blob. Got:\n${result.stdout}`);
-
-			test.emit("benchmark end", JSON.parse(output));
+			}, test);
 			return;
 		}
 
@@ -132,7 +142,10 @@ export function supportParentProcess<
 					async () =>
 						args.run().then(
 							(result) => ({ result }),
-							(error) => ({ result: { error: (error as Error).message }, exception: error }),
+							(error) => ({
+								result: { error: (error as Error).message },
+								exception: error as Error,
+							}),
 						),
 					test,
 			  )

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -15,6 +15,7 @@ import {
 import type { BenchmarkResult } from "../ResultTypes";
 import { fail } from "../assert.js";
 import { Phase, runBenchmark } from "../runBenchmark";
+
 import { emitResultsMocha } from "./runnerUtilities";
 
 /**

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -12,9 +12,10 @@ import {
 	qualifiedTitle,
 	TestType,
 } from "../Configuration";
-import type { BenchmarkResult, BenchmarkError } from "../ResultTypes";
+import type { BenchmarkResult } from "../ResultTypes";
 import { fail } from "../assert.js";
 import { Phase, runBenchmark } from "../runBenchmark";
+import { emitResultsMocha } from "./runnerUtilities";
 
 /**
  * This is wrapper for Mocha's it function that runs a performance benchmark.
@@ -63,82 +64,80 @@ export function supportParentProcess<
 >(args: TArgs): Test {
 	const itFunction = args.only === true ? it.only : it;
 	const test = itFunction(args.title, async () => {
-		try {
-			if (isParentProcess) {
-				// Instead of running the benchmark in this process, create a new process.
-				// See {@link isParentProcess} for why.
-				// Launch new process, with:
-				// - mocha filter to run only this test.
-				// - --parentProcess flag removed.
-				// - --childProcess flag added (so data will be returned via stdout as json)
+		if (isParentProcess) {
+			// Instead of running the benchmark in this process, create a new process.
+			// See {@link isParentProcess} for why.
+			// Launch new process, with:
+			// - mocha filter to run only this test.
+			// - --parentProcess flag removed.
+			// - --childProcess flag added (so data will be returned via stdout as json)
 
-				// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
-				const command = process.argv0 ?? fail("there must be a command");
+			// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
+			const command = process.argv0 ?? fail("there must be a command");
 
-				// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
-				// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
-				// put in mocha's --node-option flag.
-				const childArgs = [...process.execArgv, ...process.argv.slice(1)];
-				const processFlagIndex = childArgs.indexOf("--parentProcess");
-				childArgs[processFlagIndex] = "--childProcess";
+			// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
+			// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
+			// put in mocha's --node-option flag.
+			const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+			const processFlagIndex = childArgs.indexOf("--parentProcess");
+			childArgs[processFlagIndex] = "--childProcess";
 
-				// Remove arguments for any existing test filters.
-				for (const flag of ["--grep", "--fgrep"]) {
-					const flagIndex = childArgs.indexOf(flag);
-					if (flagIndex > 0) {
-						// Remove the flag, and the argument after it (all these flags take one argument)
-						childArgs.splice(flagIndex, 2);
-					}
+			// Remove arguments for any existing test filters.
+			for (const flag of ["--grep", "--fgrep"]) {
+				const flagIndex = childArgs.indexOf(flag);
+				if (flagIndex > 0) {
+					// Remove the flag, and the argument after it (all these flags take one argument)
+					childArgs.splice(flagIndex, 2);
 				}
-
-				// Add test filter so child process only run the current test.
-				childArgs.push("--fgrep", test.fullTitle());
-
-				// Remove arguments for debugging if they're present; in order to debug child processes we need
-				// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
-				// of scope for now.
-				let inspectArgIndex: number = -1;
-				while (
-					(inspectArgIndex = childArgs.findIndex((x) =>
-						x.match(/^(--inspect|--debug).*/),
-					)) >= 0
-				) {
-					childArgs.splice(inspectArgIndex, 1);
-				}
-
-				// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
-				const childProcess = await import("node:child_process");
-				const result = childProcess.spawnSync(command, childArgs, { encoding: "utf8" });
-
-				if (result.error) {
-					fail(`Child process reported an error: ${result.error.message}`);
-				}
-
-				if (result.stderr !== "") {
-					fail(`Child process logged errors: ${result.stderr}`);
-				}
-
-				// Find the json blob in the child's output.
-				const output =
-					result.stdout.split("\n").find((s) => s.startsWith("{")) ??
-					fail(`child process must output a json blob. Got:\n${result.stdout}`);
-
-				test.emit("benchmark end", JSON.parse(output));
-				return;
 			}
 
-			const stats = await args.run();
-			// Create and run a benchmark if we are in perfMode, else run the passed in function normally
-			if (isInPerformanceTestingMode) {
-				test.emit("benchmark end", stats);
+			// Add test filter so child process only run the current test.
+			childArgs.push("--fgrep", test.fullTitle());
+
+			// Remove arguments for debugging if they're present; in order to debug child processes we need
+			// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
+			// of scope for now.
+			let inspectArgIndex: number = -1;
+			while (
+				(inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >=
+				0
+			) {
+				childArgs.splice(inspectArgIndex, 1);
 			}
-		} catch (error) {
-			const benchmarkError: BenchmarkError = { error: (error as Error).message };
 
-			test.emit("benchmark end", benchmarkError);
+			// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
+			const childProcess = await import("node:child_process");
+			const result = childProcess.spawnSync(command, childArgs, { encoding: "utf8" });
 
-			throw error;
+			if (result.error) {
+				fail(`Child process reported an error: ${result.error.message}`);
+			}
+
+			if (result.stderr !== "") {
+				fail(`Child process logged errors: ${result.stderr}`);
+			}
+
+			// Find the json blob in the child's output.
+			const output =
+				result.stdout.split("\n").find((s) => s.startsWith("{")) ??
+				fail(`child process must output a json blob. Got:\n${result.stdout}`);
+
+			test.emit("benchmark end", JSON.parse(output));
+			return;
 		}
+
+		// Only emit results in perfMode
+		await (isInPerformanceTestingMode
+			? emitResultsMocha(
+					async () =>
+						args.run().then(
+							(result) => ({ result }),
+							(error) => ({ result: { error: (error as Error).message }, exception: error }),
+						),
+					test,
+			  )
+			: // In non-perf mode, just run the function without emitting
+			  args.run());
 	});
 	return test;
 }

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -12,7 +12,7 @@ import {
 	qualifiedTitle,
 	TestType,
 } from "../Configuration";
-import type { BenchmarkResult } from "../ResultTypes";
+import type { BenchmarkResult, BenchmarkError } from "../ResultTypes";
 import { fail } from "../assert.js";
 import { Phase, runBenchmark } from "../runBenchmark";
 
@@ -99,8 +99,9 @@ export function supportParentProcess<
 				// of scope for now.
 				let inspectArgIndex: number = -1;
 				while (
-					(inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >=
-					0
+					(inspectArgIndex = childArgs.findIndex((x) =>
+						x.match(/^(--inspect|--debug).*/),
+					)) >= 0
 				) {
 					childArgs.splice(inspectArgIndex, 1);
 				}

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -63,72 +63,80 @@ export function supportParentProcess<
 >(args: TArgs): Test {
 	const itFunction = args.only === true ? it.only : it;
 	const test = itFunction(args.title, async () => {
-		if (isParentProcess) {
-			// Instead of running the benchmark in this process, create a new process.
-			// See {@link isParentProcess} for why.
-			// Launch new process, with:
-			// - mocha filter to run only this test.
-			// - --parentProcess flag removed.
-			// - --childProcess flag added (so data will be returned via stdout as json)
+		try {
+			if (isParentProcess) {
+				// Instead of running the benchmark in this process, create a new process.
+				// See {@link isParentProcess} for why.
+				// Launch new process, with:
+				// - mocha filter to run only this test.
+				// - --parentProcess flag removed.
+				// - --childProcess flag added (so data will be returned via stdout as json)
 
-			// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
-			const command = process.argv0 ?? fail("there must be a command");
+				// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
+				const command = process.argv0 ?? fail("there must be a command");
 
-			// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
-			// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
-			// put in mocha's --node-option flag.
-			const childArgs = [...process.execArgv, ...process.argv.slice(1)];
-			const processFlagIndex = childArgs.indexOf("--parentProcess");
-			childArgs[processFlagIndex] = "--childProcess";
+				// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
+				// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
+				// put in mocha's --node-option flag.
+				const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+				const processFlagIndex = childArgs.indexOf("--parentProcess");
+				childArgs[processFlagIndex] = "--childProcess";
 
-			// Remove arguments for any existing test filters.
-			for (const flag of ["--grep", "--fgrep"]) {
-				const flagIndex = childArgs.indexOf(flag);
-				if (flagIndex > 0) {
-					// Remove the flag, and the argument after it (all these flags take one argument)
-					childArgs.splice(flagIndex, 2);
+				// Remove arguments for any existing test filters.
+				for (const flag of ["--grep", "--fgrep"]) {
+					const flagIndex = childArgs.indexOf(flag);
+					if (flagIndex > 0) {
+						// Remove the flag, and the argument after it (all these flags take one argument)
+						childArgs.splice(flagIndex, 2);
+					}
 				}
+
+				// Add test filter so child process only run the current test.
+				childArgs.push("--fgrep", test.fullTitle());
+
+				// Remove arguments for debugging if they're present; in order to debug child processes we need
+				// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
+				// of scope for now.
+				let inspectArgIndex: number = -1;
+				while (
+					(inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >=
+					0
+				) {
+					childArgs.splice(inspectArgIndex, 1);
+				}
+
+				// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
+				const childProcess = await import("node:child_process");
+				const result = childProcess.spawnSync(command, childArgs, { encoding: "utf8" });
+
+				if (result.error) {
+					fail(`Child process reported an error: ${result.error.message}`);
+				}
+
+				if (result.stderr !== "") {
+					fail(`Child process logged errors: ${result.stderr}`);
+				}
+
+				// Find the json blob in the child's output.
+				const output =
+					result.stdout.split("\n").find((s) => s.startsWith("{")) ??
+					fail(`child process must output a json blob. Got:\n${result.stdout}`);
+
+				test.emit("benchmark end", JSON.parse(output));
+				return;
 			}
 
-			// Add test filter so child process only run the current test.
-			childArgs.push("--fgrep", test.fullTitle());
-
-			// Remove arguments for debugging if they're present; in order to debug child processes we need
-			// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
-			// of scope for now.
-			let inspectArgIndex: number = -1;
-			while (
-				(inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >=
-				0
-			) {
-				childArgs.splice(inspectArgIndex, 1);
+			const stats = await args.run();
+			// Create and run a benchmark if we are in perfMode, else run the passed in function normally
+			if (isInPerformanceTestingMode) {
+				test.emit("benchmark end", stats);
 			}
+		} catch (error) {
+			const benchmarkError: BenchmarkError = { error: (error as Error).message };
 
-			// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
-			const childProcess = await import("node:child_process");
-			const result = childProcess.spawnSync(command, childArgs, { encoding: "utf8" });
+			test.emit("benchmark end", benchmarkError);
 
-			if (result.error) {
-				fail(`Child process reported an error: ${result.error.message}`);
-			}
-
-			if (result.stderr !== "") {
-				fail(`Child process logged errors: ${result.stderr}`);
-			}
-
-			// Find the json blob in the child's output.
-			const output =
-				result.stdout.split("\n").find((s) => s.startsWith("{")) ??
-				fail(`child process must output a json blob. Got:\n${result.stdout}`);
-
-			test.emit("benchmark end", JSON.parse(output));
-			return;
-		}
-
-		const stats = await args.run();
-		// Create and run a benchmark if we are in perfMode, else run the passed in function normally
-		if (isInPerformanceTestingMode) {
-			test.emit("benchmark end", stats);
+			throw error;
 		}
 	});
 	return test;

--- a/tools/benchmark/src/mocha/runnerUtilities.ts
+++ b/tools/benchmark/src/mocha/runnerUtilities.ts
@@ -5,39 +5,7 @@
 
 import type { Test } from "mocha";
 
-import type { BenchmarkResult, BenchmarkError, BenchmarkData, CustomData } from "../ResultTypes";
-import { timer } from "../timer";
-
-/**
- * Wraps a function that returns CustomData, measuring its execution time
- * and capturing either its result or exception.
- * Returns a callback suitable for passing to emitResultsMocha.
- * This is a generic utility that is neither mocha-specific nor time benchmark-specific.
- */
-export function captureResults(
-	f: () => CustomData | Promise<CustomData>,
-): () => Promise<{ result: BenchmarkResult; exception?: Error }> {
-	return async () => {
-		const startTime = timer.now();
-
-		let customData: CustomData;
-		try {
-			customData = await f();
-		} catch (error) {
-			const benchmarkError: BenchmarkError = { error: (error as Error).message };
-			return { result: benchmarkError, exception: error as Error };
-		}
-
-		const elapsedSeconds = timer.toSeconds(startTime, timer.now());
-
-		const result: BenchmarkData = {
-			elapsedSeconds,
-			customData,
-		};
-
-		return { result };
-	};
-}
+import type { BenchmarkResult } from "../ResultTypes";
 
 /**
  * Executes a function, emits the results to a mocha test, and throws any exception.

--- a/tools/benchmark/src/mocha/runnerUtilities.ts
+++ b/tools/benchmark/src/mocha/runnerUtilities.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Test } from "mocha";
+
+import type { BenchmarkResult, BenchmarkError, BenchmarkData, CustomData } from "../ResultTypes";
+import { timer } from "../timer";
+
+/**
+ * Wraps a function that returns CustomData, measuring its execution time
+ * and capturing either its result or exception.
+ * Returns a callback suitable for passing to emitResultsMocha.
+ * This is a generic utility that is neither mocha-specific nor time benchmark-specific.
+ */
+export function captureResults(
+	f: () => CustomData | Promise<CustomData>,
+): () => Promise<{ result: BenchmarkResult; exception?: Error }> {
+	return async () => {
+		const startTime = timer.now();
+
+		let customData: CustomData;
+		try {
+			customData = await f();
+		} catch (error) {
+			const benchmarkError: BenchmarkError = { error: (error as Error).message };
+			return { result: benchmarkError, exception: error as Error };
+		}
+
+		const elapsedSeconds = timer.toSeconds(startTime, timer.now());
+
+		const result: BenchmarkData = {
+			elapsedSeconds,
+			customData,
+		};
+
+		return { result };
+	};
+}
+
+/**
+ * Executes a function, emits the results to a mocha test, and throws any exception.
+ * This handles mocha-specific result emission.
+ */
+export async function emitResultsMocha(
+	f: () => Promise<{ result: BenchmarkResult; exception?: Error }>,
+	test: Test,
+): Promise<void> {
+	const { exception, result } = await f();
+	test.emit("benchmark end", result);
+	if (exception !== undefined) {
+		throw exception;
+	}
+}


### PR DESCRIPTION
## Description

Fixes [AB#55270](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/55270)

One of my benchmark tests fails intermittently with the error `runtime benchmarks Non-Compat completed with status 'failed' without reporting any data.`

This indicates that the "benchmark end" event was never emitted.  I added a try-catch to see if that fixes it.

