### PR TITLE
Make fluidEpochNotProvided error retryable.

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -1583,10 +1583,6 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	);
 
 	it("blob upload before loading", async function () {
-		// TODO: AB#19035: Blob upload from an offline state does not currently work before establishing a connection on ODSP due to epoch not provided.
-		if (provider.driver.type === "odsp") {
-			this.skip();
-		}
 		const container = await loadContainerOffline(testContainerConfig, provider, { url });
 		const dataStore = (await container.container.getEntryPoint()) as ITestFluidObject;
 		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
@@ -1599,6 +1595,22 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const handle = await timeoutAwait(handleP, {
 			errorMsg: "Timeout on waiting for handleP",
 		});
+		map.set("blob handle", handle);
+
+		const container2 = await timeoutAwait(provider.loadTestContainer(testContainerConfig), {
+			errorMsg: "Timeout on waiting for container2 load",
+		});
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+
+		await timeoutAwait(provider.ensureSynchronized(), {
+			errorMsg: "Timeout on waiting for ensureSynchronized after creating container2",
+		});
+
+		const handleGet2: any = await timeoutAwait(map2.get("blob handle").get(), {
+			errorMsg: "Timeout on waiting for handleGet2",
+		});
+		assert.strictEqual(bufferToString(handleGet2, "utf8"), "blob contents");
 	});
 
 	it("offline blob upload", async function () {

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -1613,6 +1613,36 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		assert.strictEqual(bufferToString(handleGet2, "utf8"), "blob contents");
 	});
 
+	it("blob upload and attach before loading", async function () {
+		const container = await loadContainerOffline(testContainerConfig, provider, { url });
+		const dataStore = (await container.container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+
+		const handle = await dataStore.runtime.uploadBlob(stringToBuffer("blob contents", "utf8"));
+		map.set("blob handle", handle);
+		container.connect();
+		await timeoutAwait(waitForContainerConnection(container.container), {
+			errorMsg: "Timeout on waiting for container connection",
+		});
+		const handleGet1: any = await timeoutAwait(map.get("blob handle").get(), {
+			errorMsg: "Timeout on waiting for handleGet1",
+		});
+		assert.strictEqual(bufferToString(handleGet1, "utf8"), "blob contents");
+		const container2 = await timeoutAwait(provider.loadTestContainer(testContainerConfig), {
+			errorMsg: "Timeout on waiting for container2 load",
+		});
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+
+		await timeoutAwait(provider.ensureSynchronized(), {
+			errorMsg: "Timeout on waiting for ensureSynchronized after creating container2",
+		});
+		const handleGet2: any = await timeoutAwait(map2.get("blob handle").get(), {
+			errorMsg: "Timeout on waiting for handleGet2",
+		});
+		assert.strictEqual(bufferToString(handleGet2, "utf8"), "blob contents");
+	});
+
 	it("offline blob upload", async function () {
 		const container = await loader.resolve({ url });
 		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -250,6 +250,10 @@ export function createOdspNetworkError(
 				error = new FluidInvalidSchemaError(errorMessage, driverProps);
 				break;
 			}
+			if (innerMostErrorCode === "fluidEpochNotProvided") {
+				error = new RetryableError(errorMessage, OdspErrorTypes.usageError, driverProps);
+				break;
+			}
 			error = new NonRetryableError(
 				errorMessage,
 				DriverErrorTypes.genericNetworkError,


### PR DESCRIPTION
Test "blob upload before loading" was disabled due to 'ODSP fetch error [400]' response when uploading a blob while loading offline. This was due to missing the fluidEpoch value which is only available once we connect to the delta stream. The error didn't repro when `createBlobPayloadPending: true` because the server call was postpone until we attach the blob handle into a DDS. 
- Adding another test that recreates the same scenario as intended with createBlobPayloadPending
- make fluidEpochNotProvided error retryable so the call can be successful once we obtain the epoch value.

We also need to restructure some other blob stashed ops tests that behave similarly and could hide potential issues.