### PR TITLE
Refactor FormatVersioning to use stricEnum

### DIFF
--- a/packages/dds/tree/src/core/tree/detachedFieldIndexFormatCommon.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexFormatCommon.ts
@@ -5,21 +5,18 @@
 
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
 
-import { brandedNumberType, type Brand } from "../../util/index.js";
+import { brandedNumberType, strictEnum, type Values } from "../../util/index.js";
 
 import type { ForestRootId } from "./detachedFieldIndexTypes.js";
 
 /**
  * The format version for the detached field index.
  */
-export const DetachedFieldIndexFormatVersion = {
+export const DetachedFieldIndexFormatVersion = strictEnum("DetachedFieldIndexFormatVersion", {
 	v1: 1,
 	v2: 2,
-} as const;
-export type DetachedFieldIndexFormatVersion = Brand<
-	(typeof DetachedFieldIndexFormatVersion)[keyof typeof DetachedFieldIndexFormatVersion],
-	"DetachedFieldIndexFormatVersion"
->;
+});
+export type DetachedFieldIndexFormatVersion = Values<typeof DetachedFieldIndexFormatVersion>;
 
 /**
  * The ID of a detached node. Is not globally unique on.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -28,6 +28,7 @@ import {
 	brandedNumberType,
 	type Brand,
 	type JsonCompatibleReadOnly,
+	unbrand,
 } from "../../../util/index.js";
 import { TreeCompressionStrategy } from "../../treeCompressionUtils.js";
 
@@ -158,12 +159,12 @@ export function makeFieldBatchCodec(options: CodecWriteOptions): FieldBatchCodec
 		| typeof schemaCompressedEncodeV2;
 	let encodedFieldBatchType: typeof EncodedFieldBatchV1 | typeof EncodedFieldBatchV2;
 	switch (writeVersion) {
-		case FieldBatchFormatVersion.v1:
+		case unbrand(FieldBatchFormatVersion.v1):
 			uncompressedEncodeFn = uncompressedEncodeV1;
 			schemaCompressedEncodeFn = schemaCompressedEncodeV1;
 			encodedFieldBatchType = EncodedFieldBatchV1;
 			break;
-		case FieldBatchFormatVersion.v2:
+		case unbrand(FieldBatchFormatVersion.v2):
 			uncompressedEncodeFn = uncompressedEncodeV2;
 			schemaCompressedEncodeFn = schemaCompressedEncodeV2;
 			encodedFieldBatchType = EncodedFieldBatchV2;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format.ts
@@ -13,19 +13,16 @@ import {
 	IdentifierOrIndex,
 	ShapeIndex,
 } from "./formatGeneric.js";
-import { brand, type Brand } from "../../../util/index.js";
+import { strictEnum, type Values } from "../../../util/index.js";
 
 /**
  * The format version for the field batch.
  */
-export const FieldBatchFormatVersion = {
+export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
 	v1: 1,
 	v2: 2,
-} as const;
-export type FieldBatchFormatVersion = Brand<
-	(typeof FieldBatchFormatVersion)[keyof typeof FieldBatchFormatVersion],
-	"FieldBatchFormatVersion"
->;
+});
+export type FieldBatchFormatVersion = Values<typeof FieldBatchFormatVersion>;
 
 // Compatible versions used for format/version validation.
 // TODO: A proper version update policy will need to be documented.
@@ -219,13 +216,13 @@ export type EncodedAnyShape = Static<typeof EncodedAnyShape>;
 export type EncodedIncrementalChunkShape = Static<typeof EncodedIncrementalChunkShape>;
 
 export const EncodedFieldBatchV1 = EncodedFieldBatchGeneric(
-	brand<FieldBatchFormatVersion>(FieldBatchFormatVersion.v1),
+	FieldBatchFormatVersion.v1,
 	EncodedChunkShape,
 );
 export type EncodedFieldBatchV1 = Static<typeof EncodedFieldBatchV1>;
 
 export const EncodedFieldBatchV2 = EncodedFieldBatchGeneric(
-	brand<FieldBatchFormatVersion>(FieldBatchFormatVersion.v2),
+	FieldBatchFormatVersion.v2,
 	EncodedChunkShape,
 );
 export type EncodedFieldBatchV2 = Static<typeof EncodedFieldBatchV2>;

--- a/packages/dds/tree/src/feature-libraries/forest-summary/formatCommon.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/formatCommon.ts
@@ -6,21 +6,18 @@
 import { type Static, Type } from "@sinclair/typebox";
 
 import { schemaFormatV1 } from "../../core/index.js";
-import type { Brand } from "../../util/index.js";
+import { strictEnum, type Values } from "../../util/index.js";
 import { EncodedFieldBatch } from "../chunked-forest/index.js";
 
 /**
  * The format version for the forest.
  */
-export const ForestFormatVersion = {
+export const ForestFormatVersion = strictEnum("ForestFormatVersion", {
 	v1: 1,
 	/** This format supports incremental encoding */
 	v2: 2,
-} as const;
-export type ForestFormatVersion = Brand<
-	(typeof ForestFormatVersion)[keyof typeof ForestFormatVersion],
-	"ForestFormatVersion"
->;
+});
+export type ForestFormatVersion = Values<typeof ForestFormatVersion>;
 
 export const validVersions = new Set([...Object.values(ForestFormatVersion)]);
 

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -29,7 +29,7 @@ import type {
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import { brand, type JsonCompatibleReadOnly } from "../util/index.js";
+import { brand, unbrand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { SummaryData } from "./editManager.js";
 import { makeV1CodecWithVersion } from "./editManagerCodecsV1toV4.js";
@@ -134,20 +134,20 @@ export function makeEditManagerCodecs<TChangeset>(
 		>,
 	][] = Array.from(editManagerFormatVersions, (version) => {
 		switch (version) {
-			case EditManagerFormatVersion.v1:
-			case EditManagerFormatVersion.v2:
+			case unbrand(EditManagerFormatVersion.v1):
+			case unbrand(EditManagerFormatVersion.v2):
 				return [version, makeDiscontinuedCodecVersion(options, version, "2.73.0")];
-			case EditManagerFormatVersion.v3:
-			case EditManagerFormatVersion.v4: {
+			case unbrand(EditManagerFormatVersion.v3):
+			case unbrand(EditManagerFormatVersion.v4): {
 				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
 				return [
 					version,
 					makeV1CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
-			case EditManagerFormatVersion.v5:
+			case unbrand(EditManagerFormatVersion.v5):
 				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
-			case EditManagerFormatVersion.vSharedBranches: {
+			case unbrand(EditManagerFormatVersion.vSharedBranches): {
 				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
 				return [
 					version,

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -12,7 +12,7 @@ import {
 	RevisionTagSchema,
 	SessionIdSchema,
 } from "../core/index.js";
-import { type Brand, brandedNumberType } from "../util/index.js";
+import { type Brand, brandedNumberType, strictEnum, type Values } from "../util/index.js";
 import type { EncodedBranchId } from "./branch.js";
 
 /**
@@ -123,7 +123,7 @@ export const EncodedSharedBranch = <ChangeSchema extends TSchema>(tChange: Chang
 /**
  * The format version for the EditManager.
  */
-export const EditManagerFormatVersion = {
+export const EditManagerFormatVersion = strictEnum("editManager.FormatVersion", {
 	/**
 	 * Introduced and retired prior to 2.0.
 	 * Reading and writing capability removed in 2.73.0.
@@ -161,18 +161,15 @@ export const EditManagerFormatVersion = {
 	 * Only used for testing shared branches.
 	 */
 	vSharedBranches: "shared-branches|v0.1",
-} as const;
-export type EditManagerFormatVersion = Brand<
-	(typeof EditManagerFormatVersion)[keyof typeof EditManagerFormatVersion],
-	"EditManagerFormatVersion"
->;
+});
+export type EditManagerFormatVersion = Values<typeof EditManagerFormatVersion>;
 export const supportedEditManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> =
 	new Set([
 		EditManagerFormatVersion.v3,
 		EditManagerFormatVersion.v4,
 		EditManagerFormatVersion.vSharedBranches,
-	] as EditManagerFormatVersion[]);
+	]);
 export const editManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> = new Set(
-	Object.values(EditManagerFormatVersion) as EditManagerFormatVersion[],
+	Object.values(EditManagerFormatVersion),
 );
 /* eslint-enable @typescript-eslint/explicit-function-return-type */

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -29,7 +29,7 @@ import type {
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import { brand, type JsonCompatibleReadOnly } from "../util/index.js";
+import { brand, unbrand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { DecodedMessage } from "./messageTypes.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
@@ -132,9 +132,9 @@ export function makeMessageCodecs<TChangeset>(
 		>,
 	][] = Array.from(messageFormatVersions).map((version) => {
 		switch (version) {
-			case MessageFormatVersion.undefined:
-			case MessageFormatVersion.v1:
-			case MessageFormatVersion.v2: {
+			case unbrand(MessageFormatVersion.undefined):
+			case unbrand(MessageFormatVersion.v1):
+			case unbrand(MessageFormatVersion.v2): {
 				const versionOrUndefined =
 					version === MessageFormatVersion.undefined ? undefined : version;
 				return [
@@ -142,8 +142,8 @@ export function makeMessageCodecs<TChangeset>(
 					makeDiscontinuedCodecVersion(options, versionOrUndefined, "2.73.0"),
 				];
 			}
-			case MessageFormatVersion.v3:
-			case MessageFormatVersion.v4: {
+			case unbrand(MessageFormatVersion.v3):
+			case unbrand(MessageFormatVersion.v4): {
 				const changeCodec = changeCodecs.resolve(
 					dependentChangeFormatVersion.lookup(version),
 				).json;
@@ -152,9 +152,9 @@ export function makeMessageCodecs<TChangeset>(
 					makeV1ToV4CodecWithVersion(changeCodec, revisionTagCodec, options, version),
 				];
 			}
-			case MessageFormatVersion.v5:
+			case unbrand(MessageFormatVersion.v5):
 				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
-			case MessageFormatVersion.vSharedBranches: {
+			case unbrand(MessageFormatVersion.vSharedBranches): {
 				const changeCodec = changeCodecs.resolve(
 					dependentChangeFormatVersion.lookup(version),
 				).json;

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -136,7 +136,7 @@ export function makeMessageCodecs<TChangeset>(
 			case unbrand(MessageFormatVersion.v1):
 			case unbrand(MessageFormatVersion.v2): {
 				const versionOrUndefined =
-					version === MessageFormatVersion.undefined ? undefined : version;
+					version === unbrand(MessageFormatVersion.undefined) ? undefined : version;
 				return [
 					versionOrUndefined,
 					makeDiscontinuedCodecVersion(options, versionOrUndefined, "2.73.0"),

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import type { Brand } from "../util/index.js";
+import { strictEnum, type Values } from "../util/index.js";
 
 /**
  * The format version for the message.
  */
-export const MessageFormatVersion = {
+export const MessageFormatVersion = strictEnum("MessageFormatVersion", {
 	/**
 	 * NOTE: this is written as `undefined` rather than `0` in the wire format.
 	 * Introduced and retired prior to 2.0.
@@ -52,16 +52,14 @@ export const MessageFormatVersion = {
 	 * Only used for testing shared branches.
 	 */
 	vSharedBranches: "shared-branches|v0.1",
-} as const;
-export type MessageFormatVersion = Brand<
-	(typeof MessageFormatVersion)[keyof typeof MessageFormatVersion],
-	"MessageFormatVersion"
->;
+});
+export type MessageFormatVersion = Values<typeof MessageFormatVersion>;
+
 export const supportedMessageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set([
 	MessageFormatVersion.v3,
 	MessageFormatVersion.v4,
 	MessageFormatVersion.vSharedBranches,
-] as MessageFormatVersion[]);
+]);
 export const messageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set(
-	Object.values(MessageFormatVersion) as MessageFormatVersion[],
+	Object.values(MessageFormatVersion),
 );


### PR DESCRIPTION
Refactored the following from the current "as const" pattern to use strictEnum. This will allow for stronger type safety:
- MessageFormatVersion
- EditManagerFormatVersion
- FieldBatchFormatVersion
- DetachedFieldIndexFormatVersion
- ForestFormatVersion 

Added corresponding unbrand calls in switch statements to handle branded types returned by strictEnum in:
- MessageCodecs.ts
- EditManagerCodecs.ts
- Codecs.ts 