### PR TITLE
Skip flaky test: 'Create data store with group id Non-Compat, Can create loadingGroupId'

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/initialSequenceNumberAndStashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/initialSequenceNumberAndStashedOps.spec.ts
@@ -33,8 +33,12 @@ describeCompat(
 
 		let provider: ITestObjectProvider;
 
-		beforeEach("setup", async () => {
+		beforeEach("setup", async function () {
 			provider = getTestObjectProvider();
+			// This test can be run against routerlicious once bug #55321 is fixed
+			if (provider.driver.type === "routerlicious") {
+				this.skip();
+			}
 		});
 
 		it("Can create loadingGroupId", async () => {


### PR DESCRIPTION
## Description

This test was timing out for FRS, and after looking into it I decided to skip it since the bug seems to be coming from the server. The container seems to be stuck in a 'EstablishingConnection' state when it tries to load the container using a pendingState.

This can be tested again once [AB#55321](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/55321) is fixed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Fixes: [AB#49831](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/49831)