### PR TITLE
(compat) Rename the flub layerCompatGeneration command to compatLayerGeneration in package.json

### DIFF
--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -97,7 +97,7 @@
 		"eslint:fix": "eslint --quiet --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
-		"layerGeneration:gen": "flub generate layerCompatGeneration --dir . -v",
+		"layerGeneration:gen": "flub generate compatLayerGeneration --dir . -v",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha && npm run test:jest",


### PR DESCRIPTION
The `layerCompatGeneration` command was renamed to `compatLayerGeneration` in https://github.com/microsoft/FluidFramework/pull/25951.

This change udpates the client-utils's package.json script that call it to use the new name.