### PR TITLE
(compat) Incremenent layer compat generation for Fluid layers to 3

### DIFF
--- a/packages/drivers/local-driver/src/localLayerCompatState.ts
+++ b/packages/drivers/local-driver/src/localLayerCompatState.ts
@@ -19,7 +19,7 @@ export const localDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	/**
 	 * The current generation of the Local Driver layer.
 	 */
-	generation: 2,
+	generation: 3,
 	/**
 	 * The features supported by the Local Driver layer across the Driver / Loader boundary.
 	 */

--- a/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
+++ b/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
@@ -19,7 +19,7 @@ export const odspDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	/**
 	 * The current generation of the ODSP Driver layer.
 	 */
-	generation: 2,
+	generation: 3,
 	/**
 	 * The features supported by the ODSP Driver layer across the Driver / Loader boundary.
 	 */

--- a/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
@@ -19,7 +19,7 @@ export const r11sDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	/**
 	 * The current generation of the Routerlicious Driver layer.
 	 */
-	generation: 2,
+	generation: 3,
 	/**
 	 * The features supported by the Routerlicious Driver layer across the Driver / Loader boundary.
 	 */

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -27,7 +27,7 @@ export const loaderCoreCompatDetails = {
 	/**
 	 * The current generation of the Loader layer.
 	 */
-	generation: 2,
+	generation: 3,
 };
 
 /**

--- a/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
+++ b/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
@@ -31,7 +31,7 @@ export const runtimeCoreCompatDetails = {
 	/**
 	 * The current generation of the Runtime layer.
 	 */
-	generation: 2,
+	generation: 3,
 } as const;
 
 /**

--- a/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
+++ b/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
@@ -20,13 +20,13 @@ import { pkgVersion } from "./packageVersion.js";
  */
 export const dataStoreCoreCompatDetails = {
 	/**
-	 * The package version of the Runtime layer.
+	 * The package version of the DataStore layer.
 	 */
 	pkgVersion,
 	/**
-	 * The current generation of the Runtime layer.
+	 * The current generation of the DataStore layer.
 	 */
-	generation: 2,
+	generation: 3,
 };
 
 /**


### PR DESCRIPTION
This change updates the `generation` for the Fluid layers to 3. This should be updated every month. The last `generation` 2 was released in [2.72.0](https://github.com/microsoft/FluidFramework/releases/tag/client_v2.72.0) which was more than a month ago.

Note: The logic to update this automatically is in but it requires a change in build-tools. This PR is in progress - https://github.com/microsoft/FluidFramework/pull/26015. But we have decided to wait for the next release to complete this PR because there may not be enough time to merge that PR, release build-tools and integrate that in to the main Fluid repo.