### PR TITLE
Fix assert in VersionedSummarizer

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/versionedSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/versionedSummarizer.ts
@@ -44,7 +44,8 @@ export abstract class VersionedSummarizer<TVersion extends number> implements Su
 	) {
 		assert(
 			this.supportedVersions.has(this.writeVersion),
-			`Write version ${this.writeVersion} must be supported.`,
+			"Unsupported write version requested.",
+			() => `Write version ${this.writeVersion} requested but not supported with key ${key}.`,
 		);
 	}
 


### PR DESCRIPTION
## Description

Fix invalid assert.

This used to error with:

> $ pnpm run policy-check:asserts
> ...
> ERROR: Template expressions are not supported in assertions (they'll be replaced by a short code anyway). Use a string literal instead.
> .../packages/dds/tree/src/shared-tree-core/versionedSummarizer.ts:47

This uses the newish debug message provider to preserve the more detailed message for debug builds while allowing the production one to be tagged.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

