### PR TITLE
Work around no longer functional assert tagging config

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -599,8 +599,8 @@ module.exports = {
 	},
 
 	assertTagging: {
-		// TODO: excluding packages under packages/test should not be required: there is a config file at packages/test/assertTagging.config.mjs which used to accomplish this but it stopped working.
-		enabledPaths: [/^common\/lib\/common-utils/i, /^experimental/i, /^packages\/(?!test)/i],
+		// TODO: AB#55437: excluding packages under packages/test should not be required: there is a config file at packages/test/assertTagging.config.mjs which used to accomplish this but it stopped working.
+		enabledPaths: [/^common\/lib\/common-utils/i, /^experimental/i, /^packages\/(?!test\/)/i],
 	},
 
 	// `flub bump` config. These settings influence `flub bump` behavior for a release group. These settings can be

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -599,7 +599,7 @@ module.exports = {
 	},
 
 	assertTagging: {
-		enabledPaths: [/^common\/lib\/common-utils/i, /^experimental/i, /^packages/i],
+		enabledPaths: [/^common\/lib\/common-utils/i, /^experimental/i, /^packages\/(?!test)/i],
 	},
 
 	// `flub bump` config. These settings influence `flub bump` behavior for a release group. These settings can be

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -599,6 +599,7 @@ module.exports = {
 	},
 
 	assertTagging: {
+		// TODO: excluding packages under packages/test should not be required: there is a config file at packages/test/assertTagging.config.mjs which used to accomplish this but it stopped working.
 		enabledPaths: [/^common\/lib\/common-utils/i, /^experimental/i, /^packages\/(?!test)/i],
 	},
 

--- a/packages/dds/test-dds-utils/assertTagging.config.mjs
+++ b/packages/dds/test-dds-utils/assertTagging.config.mjs
@@ -4,7 +4,7 @@
  */
 
 /**
- * @type {import("@fluid-tools/build-cli").AssertTaggingConfig}
+ * @type {import("@fluid-tools/build-cli").AssertTaggingPackageConfig}
  */
 export default {
 	// Disables assert tagging by listing an empty set of functions that should be tagged.

--- a/packages/dds/tree/assertTagging.config.mjs
+++ b/packages/dds/tree/assertTagging.config.mjs
@@ -4,7 +4,7 @@
  */
 
 /**
- * @type {import("@fluid-tools/build-cli").AssertTaggingConfig}
+ * @type {import("@fluid-tools/build-cli").AssertTaggingPackageConfig}
  */
 export default {
 	assertionFunctions: {

--- a/packages/runtime/test-runtime-utils/assertTagging.config.mjs
+++ b/packages/runtime/test-runtime-utils/assertTagging.config.mjs
@@ -4,6 +4,6 @@
  */
 
 /**
- * @type {import("@fluid-tools/build-cli").AssertTaggingConfig}
+ * @type {import("@fluid-tools/build-cli").AssertTaggingPackageConfig}
  */
 export default { assertionFunctions: { assertionFunctions: {} } };

--- a/packages/test/assertTagging.config.mjs
+++ b/packages/test/assertTagging.config.mjs
@@ -4,7 +4,7 @@
  */
 
 /**
- * @type {import("@fluid-tools/build-cli").AssertTaggingConfig}
+ * @type {import("@fluid-tools/build-cli").AssertTaggingPackageConfig}
  */
 export default {
 	// Disables assert tagging by listing an empty set of functions that should be tagged.

--- a/packages/test/assertTagging.config.mjs
+++ b/packages/test/assertTagging.config.mjs
@@ -5,6 +5,8 @@
 
 /**
  * @type {import("@fluid-tools/build-cli").AssertTaggingPackageConfig}
+ *
+ * TODO: This config file is not working as intended. There is a workaround in top level fluidBuild.config.cjs for now.
  */
 export default {
 	// Disables assert tagging by listing an empty set of functions that should be tagged.

--- a/packages/test/assertTagging.config.mjs
+++ b/packages/test/assertTagging.config.mjs
@@ -6,7 +6,7 @@
 /**
  * @type {import("@fluid-tools/build-cli").AssertTaggingPackageConfig}
  *
- * TODO: This config file is not working as intended. There is a workaround in top level fluidBuild.config.cjs for now.
+ * TODO: AB#55437: This config file is not working as intended. There is a workaround in top level fluidBuild.config.cjs for now.
  */
 export default {
 	// Disables assert tagging by listing an empty set of functions that should be tagged.


### PR DESCRIPTION
## Description

Our assert tagging started to try and tag packages under packages/test now ignoring the config which used to filter them out.

I have added a workaround in the package filter to unblock assert tagging for Monday's release.

I have filed a bug, and referenced it in the workaround.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

If you know how this used to work, and there that change was and if this new behavior is intentional, let me know.