### PR TITLE
Exclude webpack output from format checking

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -19,7 +19,7 @@
 			"**/.next", // NextJS
 
 			// Webpack output
-			"**/webpack/*",
+			"**/webpack/**",
 
 			// test collateral
 			"**/_package.json",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -18,6 +18,9 @@
 			"**/*.done.build.log",
 			"**/.next", // NextJS
 
+			// Webpack output
+			"**/webpack/*",
+
 			// test collateral
 			"**/_package.json",
 			"**/fluid-runner/src/test/localOdspSnapshots/**",


### PR DESCRIPTION
Currently, running `pnpm webpack` followed by `pnpm check:format:repo` results in format check failures, as the webpacked output from `@fluid-example/odspsnapshotfetch-perftestapp` is placed in a `/webpack` output directory.  In general I think this is a good pattern and would not suggest changing it.

So instead this PR adds this pattern to the biome exclusions list.