### PR TITLE
refactor(tree): refactor SquashingTransactionStack

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/transaction.ts
+++ b/packages/dds/tree/src/shared-tree-core/transaction.ts
@@ -300,7 +300,9 @@ export class SquashingTransactionStack<
 								[transactionBranch.getHead(), removedCommits],
 								(c) => c === startHead,
 							);
-							this.branch.apply(squash(removedCommits));
+							if (removedCommits.length > 0) {
+								this.branch.apply(squash(removedCommits));
+							}
 							break;
 						}
 						default:

--- a/packages/dds/tree/src/shared-tree-core/transaction.ts
+++ b/packages/dds/tree/src/shared-tree-core/transaction.ts
@@ -130,7 +130,7 @@ export type OnPop = (result: TransactionResult) => void;
  * @remarks Using a stack allows transactions to nest - i.e. an inner transaction may be started while an outer transaction is already in progress.
  */
 export class TransactionStack implements Transactor, IDisposable {
-	readonly #stack: (Callbacks | void)[] = [];
+	readonly #stack: Callbacks[] = [];
 	readonly #onPush?: OnPush;
 
 	readonly #events = createEmitter<TransactionEvents>();
@@ -158,7 +158,7 @@ export class TransactionStack implements Transactor, IDisposable {
 
 	public start(): void {
 		this.ensureNotDisposed();
-		const onPushCurrent = hasSome(this.#stack) ? getLast(this.#stack)?.onPush : this.#onPush;
+		const onPushCurrent = hasSome(this.#stack) ? getLast(this.#stack).onPush : this.#onPush;
 		const { onPush, onPop } = onPushCurrent?.() ?? {};
 		this.#stack.push({ onPop, onPush: onPush ?? onPushCurrent });
 		this.#events.emit("started");

--- a/packages/dds/tree/src/shared-tree-core/transaction.ts
+++ b/packages/dds/tree/src/shared-tree-core/transaction.ts
@@ -14,7 +14,7 @@ import {
 	type GraphCommit,
 	type TaggedChange,
 } from "../core/index.js";
-import { getOrCreate } from "../util/index.js";
+import { getOrCreate, hasSome } from "../util/index.js";
 
 import type { SharedTreeBranch, SharedTreeBranchEvents } from "./branch.js";
 
@@ -93,11 +93,28 @@ export interface TransactionEvents {
 }
 
 /**
+ * Callbacks for transaction lifecycle events.
+ */
+export interface Callbacks {
+	/**
+	 * Called when the current transaction is popped from the {@link TransactionStack | stack}.
+	 */
+	readonly onPop?: OnPop;
+	/**
+	 * The function to call when a nested transaction is next pushed onto the {@link TransactionStack | stack}.
+	 * This function will keep being called for each nested transaction unless overridden by the returned `Callbacks`.
+	 * If none is provided, the parent transaction's {@link onPush} (if any) will be used,
+	 * eventually falling back to the {@link onPush} parameter passed to the {@link TransactionStack | stack} constructor (if any).
+	 */
+	readonly onPush?: OnPush;
+}
+
+/**
  * A function that will be called when a transaction is pushed to the {@link TransactionStack | stack}.
- * @remarks This function may return {@link OnPop | its complement} - another function that will be called when the transaction is popped from the stack.
+ * @remarks This function may return other functions that will be called when the transaction is popped from the stack or a nested transaction is pushed onto the stack.
  * This function runs just before the transaction begins, so if this is the beginning of an outermost (not nested) transaction then {@link Transactor.isInProgress} will be false during its execution.
  */
-export type OnPush = () => OnPop | void;
+export type OnPush = () => Callbacks | void;
 
 /**
  * A function that will be called when a transaction is popped from the {@link TransactionStack | stack}.
@@ -110,8 +127,8 @@ export type OnPop = (result: TransactionResult) => void;
  * @remarks Using a stack allows transactions to nest - i.e. an inner transaction may be started while an outer transaction is already in progress.
  */
 export class TransactionStack implements Transactor, IDisposable {
-	readonly #stack: (OnPop | void)[] = [];
-	readonly #onPush?: () => OnPop | void;
+	readonly #stack: (Callbacks | void)[] = [];
+	readonly #onPush?: OnPush;
 
 	readonly #events = createEmitter<TransactionEvents>();
 	public get events(): Listenable<TransactionEvents> {
@@ -127,7 +144,7 @@ export class TransactionStack implements Transactor, IDisposable {
 	 * Construct a new {@link TransactionStack}.
 	 * @param onPush - A {@link OnPush | function} that will be called when a transaction begins.
 	 */
-	public constructor(onPush?: () => OnPop | void) {
+	public constructor(onPush?: OnPush) {
 		this.#onPush = onPush;
 	}
 
@@ -138,7 +155,13 @@ export class TransactionStack implements Transactor, IDisposable {
 
 	public start(): void {
 		this.ensureNotDisposed();
-		this.#stack.push(this.#onPush?.());
+		const onPushCurrent = hasSome(this.#stack)
+			? // No `at` method available
+				// eslint-disable-next-line unicorn/prefer-at
+				this.#stack[this.#stack.length - 1]?.onPush
+			: this.#onPush;
+		const { onPush, onPop } = onPushCurrent?.() ?? {};
+		this.#stack.push({ onPop, onPush: onPush ?? onPushCurrent });
 		this.#events.emit("started");
 	}
 
@@ -148,7 +171,7 @@ export class TransactionStack implements Transactor, IDisposable {
 			throw new UsageError("No transaction to commit");
 		}
 		this.#events.emit("committing");
-		this.#stack.pop()?.(TransactionResult.Commit);
+		this.#stack.pop()?.onPop?.(TransactionResult.Commit);
 	}
 
 	public abort(): void {
@@ -157,7 +180,7 @@ export class TransactionStack implements Transactor, IDisposable {
 			throw new UsageError("No transaction to abort");
 		}
 		this.#events.emit("aborting");
-		this.#stack.pop()?.(TransactionResult.Abort);
+		this.#stack.pop()?.onPop?.(TransactionResult.Abort);
 	}
 
 	public dispose(): void {
@@ -185,7 +208,6 @@ export class SquashingTransactionStack<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
 > extends TransactionStack {
-	public readonly branch: SharedTreeBranch<TEditor, TChange>;
 	#transactionBranch?: SharedTreeBranch<TEditor, TChange>;
 
 	/**
@@ -245,55 +267,75 @@ export class SquashingTransactionStack<
 	 * @param branch - The {@link SquashingTransactionStack.branch | branch} that will be forked off of when a transaction begins.
 	 * @param squash - Called once when the outer-most transaction is committed to produce a single squashed change from the transaction's commits.
 	 * The change will be applied to the original {@link SquashingTransactionStack.branch | branch}.
-	 * @param onPush - {@link OnPush | A function} that will be called when a transaction is pushed to the {@link TransactionStack | stack}.
+	 * @param onPush - A function that will be called when a transaction is pushed to the {@link TransactionStack | stack}.
 	 */
 	public constructor(
-		branch: SharedTreeBranch<TEditor, TChange>,
+		public readonly branch: SharedTreeBranch<TEditor, TChange>,
 		squash: (commits: GraphCommit<TChange>[]) => TaggedChange<TChange>,
-		onPush?: OnPush,
+		onPush?: () => OnPop | void,
 	) {
-		super(() => {
-			// Keep track of the commit that each transaction was on when it started
-			// TODO:#8603: This may need to be computed differently if we allow rebasing during a transaction.
-			const startHead = this.activeBranch.getHead();
-			const onPop = onPush?.();
-			const transactionBranch = this.#transactionBranch ?? this.branch.fork();
-			this.setTransactionBranch(transactionBranch);
-			transactionBranch.editor.enterTransaction();
-			return (result) => {
-				assert(this.#transactionBranch !== undefined, 0xa98 /* Expected transaction branch */);
-				this.#transactionBranch.editor.exitTransaction();
-				switch (result) {
-					case TransactionResult.Abort:
-						// When a transaction is aborted, roll back all the transaction's changes on the current branch
-						this.#transactionBranch.removeAfter(startHead);
-						break;
-					case TransactionResult.Commit:
-						// If this was the outermost transaction closing...
-						if (!this.isInProgress()) {
-							if (this.#transactionBranch.getHead() !== startHead) {
-								// ...squash all the new commits on the transaction branch into a new commit on the original branch
-								const removedCommits: GraphCommit<TChange>[] = [];
-								findAncestor(
-									[this.#transactionBranch.getHead(), removedCommits],
-									(c) => c === startHead,
-								);
-								branch.apply(squash(removedCommits));
-							}
+		super(
+			// Invoked when an outer transaction starts
+			(): Callbacks => {
+				// Keep track of the commit that each transaction was on when it started
+				// TODO:#8603: This may need to be computed differently if we allow rebasing during a transaction.
+				const startHead = this.activeBranch.getHead();
+				const outerOnPop = onPush?.();
+				const transactionBranch = this.branch.fork(startHead);
+				this.setTransactionBranch(transactionBranch);
+				transactionBranch.editor.enterTransaction();
+				// Invoked when an outer transaction ends
+				const onOuterTransactionPop: OnPop = (result) => {
+					assert(!this.isInProgress(), "The outer transaction should be ending");
+					transactionBranch.editor.exitTransaction();
+					switch (result) {
+						case TransactionResult.Abort:
+							// When a transaction is aborted, roll back all the transaction's changes on the current branch
+							transactionBranch.removeAfter(startHead);
+							break;
+						case TransactionResult.Commit: {
+							// ...squash all the new commits on the transaction branch into a new commit on the original branch
+							const removedCommits: GraphCommit<TChange>[] = [];
+							findAncestor(
+								[transactionBranch.getHead(), removedCommits],
+								(c) => c === startHead,
+							);
+							this.branch.apply(squash(removedCommits));
+							break;
 						}
-						break;
-					default:
-						unreachableCase(result);
-				}
-				if (!this.isInProgress()) {
-					this.#transactionBranch.dispose();
+						default:
+							unreachableCase(result);
+					}
+					transactionBranch.dispose();
 					this.setTransactionBranch(undefined);
-				}
-				onPop?.(result);
-			};
-		});
-
-		this.branch = branch;
+					outerOnPop?.(result);
+				};
+				// Invoked when a nested transaction begins
+				const onNestedTransactionPush: OnPush = () => {
+					const nestedStartHead = this.activeBranch.getHead();
+					const nestedOuterOnPop = onPush?.();
+					transactionBranch.editor.enterTransaction();
+					return {
+						// Invoked when a nested transaction ends
+						onPop: (result) => {
+							transactionBranch.editor.exitTransaction();
+							switch (result) {
+								case TransactionResult.Abort:
+									// When a transaction is aborted, roll back all the transaction's changes on the current branch
+									transactionBranch.removeAfter(nestedStartHead);
+									break;
+								case TransactionResult.Commit:
+									break;
+								default:
+									unreachableCase(result);
+							}
+							nestedOuterOnPop?.(result);
+						},
+					};
+				};
+				return { onPop: onOuterTransactionPop, onPush: onNestedTransactionPush };
+			},
+		);
 	}
 
 	/** Updates the transaction branch (and therefore the active branch) and rebinds the branch events. */

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -7,8 +7,8 @@ import { strict as assert } from "node:assert";
 import {
 	SquashingTransactionStack,
 	SharedTreeBranch,
+	TransactionResult,
 	TransactionStack,
-	type OnPop,
 } from "../../shared-tree-core/index.js";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import {
@@ -77,41 +77,144 @@ describe("TransactionStacks", () => {
 	});
 
 	it("run a function when a transaction begins", () => {
-		let invoked = false;
+		let invoked = 0;
 		const transaction = new TransactionStack((): void => {
-			invoked = true;
+			invoked += 1;
 			assert.equal(transaction.isInProgress(), false);
 		});
 		transaction.start();
-		assert.equal(invoked, true);
+		assert.equal(invoked, 1);
+	});
+
+	it("run the top-level push function by default when a nested transaction begins", () => {
+		let invoked = 0;
+		const transaction = new TransactionStack((): void => {
+			invoked += 1;
+			assert.equal(transaction.isInProgress(), invoked > 1);
+		});
+		transaction.start();
+		assert.equal(invoked, 1);
+		transaction.start();
+		assert.equal(invoked, 2);
+		transaction.start();
+		assert.equal(invoked, 3);
+	});
+
+	it("run a provided nested push function when a nested transaction begins", () => {
+		let invokedOuter = 0;
+		let invokedInner1 = 0;
+		let invokedInner2 = 0;
+		const transaction: TransactionStack = new TransactionStack(() => {
+			invokedOuter += 1;
+			assert.equal(transaction.isInProgress(), false);
+			return {
+				onPush: () => {
+					invokedInner1 += 1;
+					assert.equal(transaction.isInProgress(), true);
+					return {
+						onPush: () => {
+							invokedInner2 += 1;
+							assert.equal(transaction.isInProgress(), true);
+						},
+					};
+				},
+			};
+		});
+		transaction.start();
+		assert.equal(invokedOuter, 1);
+		assert.equal(invokedInner1, 0);
+		assert.equal(invokedInner2, 0);
+		transaction.start();
+		assert.equal(invokedOuter, 1);
+		assert.equal(invokedInner1, 1);
+		assert.equal(invokedInner2, 0);
+		transaction.start();
+		assert.equal(invokedOuter, 1);
+		assert.equal(invokedInner1, 1);
+		assert.equal(invokedInner2, 1);
+		transaction.start();
+		assert.equal(invokedOuter, 1);
+		assert.equal(invokedInner1, 1);
+		assert.equal(invokedInner2, 2);
+	});
+
+	it("run a provided nested pop function when a nested transaction ends", () => {
+		let invokedOuter = 0;
+		let invokedInner1 = 0;
+		let invokedInner2 = 0;
+		const transaction: TransactionStack = new TransactionStack(() => {
+			return {
+				onPop: () => {
+					invokedOuter += 1;
+					assert.equal(transaction.isInProgress(), false);
+				},
+				onPush: () => {
+					return {
+						onPop: () => {
+							invokedInner1 += 1;
+							assert.equal(transaction.isInProgress(), true);
+						},
+						onPush: () => {
+							return {
+								onPop: () => {
+									invokedInner2 += 1;
+									assert.equal(transaction.isInProgress(), true);
+								},
+							};
+						},
+					};
+				},
+			};
+		});
+		transaction.start();
+		transaction.start();
+		transaction.start();
+		transaction.commit();
+		assert.equal(invokedOuter, 0);
+		assert.equal(invokedInner1, 0);
+		assert.equal(invokedInner2, 1);
+		transaction.commit();
+		assert.equal(invokedOuter, 0);
+		assert.equal(invokedInner1, 1);
+		assert.equal(invokedInner2, 1);
+		transaction.commit();
+		assert.equal(invokedOuter, 1);
+		assert.equal(invokedInner1, 1);
+		assert.equal(invokedInner2, 1);
 	});
 
 	it("run a function when a transaction aborts", () => {
-		let invoked = false;
-		const transaction = new TransactionStack((): OnPop => {
-			return () => {
-				invoked = true;
-				assert.equal(transaction.isInProgress(), false);
+		let invoked = 0;
+		const transaction: TransactionStack = new TransactionStack(() => {
+			return {
+				onPop: (result) => {
+					invoked += 1;
+					assert.equal(result, TransactionResult.Abort);
+					assert.equal(transaction.isInProgress(), false);
+				},
 			};
 		});
 		transaction.start();
-		assert.equal(invoked, false);
+		assert.equal(invoked, 0);
 		transaction.abort();
-		assert.equal(invoked, true);
+		assert.equal(invoked, 1);
 	});
 
 	it("run a function when a transaction commits", () => {
-		let invoked = false;
-		const transaction = new TransactionStack((): OnPop => {
-			return () => {
-				invoked = true;
-				assert.equal(transaction.isInProgress(), false);
+		let invoked = 0;
+		const transaction: TransactionStack = new TransactionStack(() => {
+			return {
+				onPop: (result) => {
+					invoked += 1;
+					assert.equal(result, TransactionResult.Commit);
+					assert.equal(transaction.isInProgress(), false);
+				},
 			};
 		});
 		transaction.start();
-		assert.equal(invoked, false);
+		assert.equal(invoked, 0);
 		transaction.commit();
-		assert.equal(invoked, true);
+		assert.equal(invoked, 1);
 	});
 
 	it("throw an error if committing without starting a transaction", () => {
@@ -154,8 +257,19 @@ describe("TransactionStacks", () => {
 	it("abort all transactions when disposed", () => {
 		let aborted = 0;
 		const transaction = new TransactionStack(() => {
-			return () => {
-				aborted += 1;
+			return {
+				onPop: () => {
+					assert.equal(aborted, 1);
+					aborted += 1;
+				},
+				onPush: () => {
+					return {
+						onPop: () => {
+							assert.equal(aborted, 0);
+							aborted += 1;
+						},
+					};
+				},
 			};
 		});
 		transaction.start();

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -259,16 +259,7 @@ describe("TransactionStacks", () => {
 		const transaction = new TransactionStack(() => {
 			return {
 				onPop: () => {
-					assert.equal(aborted, 1);
 					aborted += 1;
-				},
-				onPush: () => {
-					return {
-						onPop: () => {
-							assert.equal(aborted, 0);
-							aborted += 1;
-						},
-					};
 				},
 			};
 		});


### PR DESCRIPTION
## Description

Changes `TransactionStack` so that `onPush` callbacks can (in addition to returning a callback for the matching pop) return a new `onPush` callback to be invoked for nested transactions.

This change is leveraged by `SquashingTransactionStack` to do two things:
1. Separate the logic associated with inner transactions from the logic associated with outer transactions. This removes the need for repeated checking of `this.isInProgress()`.
2. Allow the logic for both inner and outer transactions to refer to state that the outer `onPush` logic sets up without having to assert.

These changes pave the way for future changes which will introduce more transaction state.

## Breaking Changes

None