### PR TITLE
Add additional telemetry around summarize attempts

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2294,7 +2294,10 @@ export class ContainerRuntime
 
 			const defaultAction = (): void => {
 				if (summaryCollection.opsSinceLastAck > maxOpsSinceLastSummary) {
-					this.mc.logger.sendTelemetryEvent({ eventName: "SummaryStatus:Behind" });
+					this.mc.logger.sendTelemetryEvent({
+						eventName: "SummaryStatus:Behind",
+						opsWithoutSummary: summaryCollection.opsSinceLastAck,
+					});
 					// unregister default to no log on every op after falling behind
 					// and register summary ack handler to re-register this handler
 					// after successful summary

--- a/packages/runtime/container-runtime/src/summary/summarizerClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerClientElection.ts
@@ -91,6 +91,7 @@ export class SummarizerClientElection
 						lastSummaryAckSeqForClient: this.lastSummaryAckSeqForClient,
 						electionSequenceNumber,
 						nextElectedClientId: this.clientElection.peekNextElectedClient()?.clientId,
+						opsWithoutSummary,
 					});
 					this.lastReportedSeq = sequenceNumber;
 				}

--- a/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/runningSummarizer.ts
@@ -673,11 +673,12 @@ export class RunningSummarizer
 						numUnsummarizedNonRuntimeOps: this.heuristicData.numNonRuntimeOps,
 						isLastSummary,
 					});
-					this.mc.logger.sendErrorEvent(
+					summaryLogger.sendErrorEvent(
 						{
 							eventName: "SummarizeFailed",
 							maxAttempts: 1,
 							summaryAttempts: 1,
+							isLastSummary,
 						},
 						result.error,
 					);
@@ -726,7 +727,10 @@ export class RunningSummarizer
 				this.afterSummaryAction();
 			},
 		).catch((error) => {
-			this.mc.logger.sendErrorEvent({ eventName: "UnexpectedSummarizeError" }, error);
+			this.mc.logger.sendErrorEvent(
+				{ eventName: "UnexpectedSummarizeError", summarizeReason: reason },
+				error,
+			);
 		});
 	}
 
@@ -890,6 +894,8 @@ export class RunningSummarizer
 					eventName: "SummarizeFailed",
 					maxAttempts,
 					summaryAttempts: currentAttempt,
+					summarizeReason: reason,
+					isLastSummary: reason === "lastSummary",
 				},
 				error,
 			);

--- a/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summaryGenerator.ts
@@ -111,6 +111,8 @@ export class SummaryGenerator extends TypedEventEmitter<ISummarizerEvents> {
 			fullTree: summarizeOptions.fullTree ?? false,
 			timeSinceLastAttempt,
 			timeSinceLastSummary,
+			nonRuntimeOpsSinceLastSummary: this.heuristicData.numNonRuntimeOps,
+			runtimeOpsSinceLastSummary: this.heuristicData.numRuntimeOps,
 		};
 
 		const summarizeEvent = PerformanceEvent.start(
@@ -412,8 +414,6 @@ export class SummaryGenerator extends TypedEventEmitter<ISummarizerEvents> {
 					clientSequenceNumber: summaryData.clientSequenceNumber,
 					hasMissingOpData: this.heuristicData.hasMissingOpData,
 					opsSizesSinceLastSummary: this.heuristicData.totalOpsSize,
-					nonRuntimeOpsSinceLastSummary: this.heuristicData.numNonRuntimeOps,
-					runtimeOpsSinceLastSummary: this.heuristicData.numRuntimeOps,
 				};
 			}
 


### PR DESCRIPTION
[AB#54645](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/54645)
[AB#53718](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/53718)

_**Potential future:**_ We could expose some properties of `ISummarizeHeuristicsData` via the `ISummarizer` interface. For now, `opsWithoutSummary` on events related to `maxOpsSinceLastSummary ` should handle most cases.