### PR TITLE
fix(eslint-config-fluid): load ESM-only eslint-plugin-depend via ESM import

### DIFF
--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -22,7 +22,8 @@ module.exports = {
 		"plugin:@typescript-eslint/eslint-recommended",
 		"plugin:@typescript-eslint/recommended-type-checked",
 		"plugin:@typescript-eslint/stylistic-type-checked",
-		"plugin:depend/recommended",
+		// NOTE: eslint-plugin-depend is ESM-only and cannot be loaded via legacy config.
+		// It is configured directly in flat.mts for flat config consumers.
 		// import-x/recommended is the combination of import-x/errors and import-x/warnings
 		"plugin:import-x/recommended",
 		"plugin:import-x/typescript",
@@ -40,7 +41,9 @@ module.exports = {
 		sourceType: "module",
 		project: "./tsconfig.json",
 	},
-	plugins: ["depend", "import-x", "unicorn"],
+	// NOTE: eslint-plugin-depend is ESM-only and cannot be loaded via legacy config.
+	// It is configured directly in flat.mts for flat config consumers.
+	plugins: ["import-x", "unicorn"],
 	reportUnusedDisableDirectives: true,
 	rules: {
 		// Please keep entries alphabetized within a group
@@ -137,19 +140,8 @@ module.exports = {
 			},
 		],
 
-		// eslint-plugin-depend
-		"depend/ban-dependencies": [
-			"error",
-			{
-				allowed: [
-					// axios replacement with fetch is ongoing: https://github.com/microsoft/FluidFramework/pull/25592
-					"axios",
-
-					// fs-extra is well-maintained and provides a useful readJson/writeJson API which is what we mainly use.
-					"fs-extra",
-				],
-			},
-		],
+		// NOTE: eslint-plugin-depend is ESM-only and cannot be loaded via legacy config.
+		// The depend/ban-dependencies rule is configured in flat.mts for flat config consumers.
 
 		// #region eslint-plugin-import-x
 

--- a/common/build/eslint-config-fluid/flat.mts
+++ b/common/build/eslint-config-fluid/flat.mts
@@ -10,6 +10,8 @@
 import { FlatCompat } from "@eslint/eslintrc";
 import eslintJs from "@eslint/js";
 import type { Linter } from "eslint";
+// eslint-plugin-depend is ESM-only and must be imported directly for flat config
+import dependPlugin from "eslint-plugin-depend";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -63,6 +65,32 @@ const minimalDeprecated: FlatConfigArray = [
 		extends: [path.join(__dirname, "minimal-deprecated.js")],
 	}),
 ];
+
+// eslint-plugin-depend configuration.
+// This plugin is ESM-only and cannot be loaded via legacy config (FlatCompat),
+// so we configure it directly here for flat config consumers.
+const dependConfig = {
+	plugins: {
+		depend: dependPlugin,
+	},
+	rules: {
+		"depend/ban-dependencies": [
+			"error",
+			{
+				allowed: [
+					// axios replacement with fetch is ongoing: https://github.com/microsoft/FluidFramework/pull/25592
+					"axios",
+
+					// fs-extra is well-maintained and provides a useful readJson/writeJson API which is what we mainly use.
+					"fs-extra",
+				],
+			},
+		],
+	},
+};
+recommended.push(dependConfig);
+strict.push(dependConfig);
+minimalDeprecated.push(dependConfig);
 
 // Use projectService for automatic tsconfig discovery instead of manual project configuration.
 // This eliminates the need to manually configure project paths and handles test files automatically.

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -15,7 +14,8 @@
         "promise",
         "tsdoc",
         "unused-imports:unused-imports",
-        "@fluid-internal/fluid"
+        "@fluid-internal/fluid",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -15,7 +14,8 @@
         "promise",
         "tsdoc",
         "unused-imports:unused-imports",
-        "@fluid-internal/fluid"
+        "@fluid-internal/fluid",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -17,7 +16,8 @@
         "unused-imports:unused-imports",
         "@fluid-internal/fluid",
         "react",
-        "react-hooks:eslint-plugin-react-hooks@7.0.0"
+        "react-hooks:eslint-plugin-react-hooks@7.0.0",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -15,7 +14,8 @@
         "promise",
         "tsdoc",
         "unused-imports:unused-imports",
-        "@fluid-internal/fluid"
+        "@fluid-internal/fluid",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -15,7 +14,8 @@
         "promise",
         "tsdoc",
         "unused-imports:unused-imports",
-        "@fluid-internal/fluid"
+        "@fluid-internal/fluid",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -15,7 +14,8 @@
         "promise",
         "tsdoc",
         "unused-imports:unused-imports",
-        "@fluid-internal/fluid"
+        "@fluid-internal/fluid",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -7,7 +7,6 @@
         "@",
         "@eslint-community/eslint-comments",
         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.18.2",
-        "depend",
         "import-x:eslint-plugin-import-x@4.16.1",
         "unicorn:eslint-plugin-unicorn@54.0.0",
         "@rushstack",
@@ -15,7 +14,8 @@
         "promise",
         "tsdoc",
         "unused-imports:unused-imports",
-        "@fluid-internal/fluid"
+        "@fluid-internal/fluid",
+        "depend:eslint-plugin-depend@1.4.0"
     ],
     "rules": {
         "@babel/object-curly-spacing": [


### PR DESCRIPTION
## Problem

`eslint-plugin-depend` v1.4.0 is ESM-only (`"type": "module"` in its package.json) and cannot be loaded via `require()` in Node.js versions prior to 20.19.0.

When users on Node 20.17.0-20.18.x run ESLint, the `FlatCompat` wrapper tries to `require()` the plugin from the legacy config files, resulting in:

```
Error [ERR_REQUIRE_ESM]: Failed to load plugin 'depend' declared in '...'
require() of ES Module .../eslint-plugin-depend/lib/main.js not supported.
```

### Why this affects some users but not others

Node.js changed how `require()` handles ESM modules:
- **Node 20.17.0**: Introduced `--experimental-require-module` flag ([release notes](https://nodejs.org/en/blog/release/v20.17.0))
- **Node 20.19.0+**: `require(esm)` enabled by default ([release notes](https://nodejs.org/en/blog/release/v20.19.0/))
- **Node 22.12.0+ LTS**: `require(esm)` enabled by default ([release notes](https://nodejs.org/en/blog/release/v22.12.0))

Users on Node 20.17.0-20.18.x hit this error, while those on 20.19.0+ or 22.12.0+ don't.

### Workaround for affected users

Set the environment variable before running ESLint:
```bash
NODE_OPTIONS=--experimental-require-module
```

## Solution

- Remove `depend` plugin from `base.js` extends/plugins (legacy config cannot load ESM-only plugins via `require()`)
- Import `eslint-plugin-depend` directly in `flat.mts` via ESM import
- Configure the `depend/ban-dependencies` rule in `flat.mts`

This ensures the plugin loads correctly on all supported Node versions without requiring users to set environment variables or upgrade Node.

## Testing

Verified ESLint runs successfully on packages using the config (e.g., `@fluidframework/presence`, `@fluidframework/tree`).