### PR TITLE
Add api to remove a single entry from FluidCache

### DIFF
--- a/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
@@ -373,6 +373,7 @@ export interface IPersistedCache {
     get(entry: ICacheEntry): Promise<unknown>;
     put(entry: ICacheEntry, value: unknown): Promise<void>;
     removeEntries(file: IFileEntry): Promise<void>;
+    removeEntry?(entry: ICacheEntry): Promise<void>;
 }
 
 // @beta @legacy (undocumented)

--- a/packages/common/driver-definitions/src/cacheDefinitions.ts
+++ b/packages/common/driver-definitions/src/cacheDefinitions.ts
@@ -94,4 +94,10 @@ export interface IPersistedCache {
 	 * @param file - file entry to be deleted.
 	 */
 	removeEntries(file: IFileEntry): Promise<void>;
+
+	/**
+	 * Removes a specific entry from the cache.
+	 * @param entry - cache entry to be deleted.
+	 */
+	removeEntry?(entry: ICacheEntry): Promise<void>;
 }

--- a/packages/drivers/driver-web-cache/api-report/driver-web-cache.legacy.beta.api.md
+++ b/packages/drivers/driver-web-cache/api-report/driver-web-cache.legacy.beta.api.md
@@ -16,6 +16,8 @@ export class FluidCache implements IPersistedCache {
     put(entry: ICacheEntry, value: any): Promise<void>;
     // (undocumented)
     removeEntries(file: IFileEntry): Promise<void>;
+    // (undocumented)
+    removeEntry(entry: ICacheEntry): Promise<void>;
 }
 
 // @beta @legacy (undocumented)

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -117,7 +117,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_FluidCache": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/drivers/driver-web-cache/src/FluidCache.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCache.ts
@@ -244,6 +244,26 @@ export class FluidCache implements IPersistedCache {
 		}
 	}
 
+	public async removeEntry(entry: ICacheEntry): Promise<void> {
+		let db: IDBPDatabase<FluidCacheDBSchema> | undefined;
+		try {
+			db = await this.openDb();
+
+			const key = getKeyForCacheEntry(entry);
+			await db.delete(FluidDriverObjectStoreName, key);
+		} catch (error: any) {
+			this.logger.sendErrorEvent(
+				{
+					eventName: FluidCacheErrorEvent.FluidCacheDeleteSingleEntryError,
+					pkgVersion,
+				},
+				error,
+			);
+		} finally {
+			this.closeDb(db);
+		}
+	}
+
 	public async get(cacheEntry: ICacheEntry): Promise<any> {
 		const startTime = performance.now();
 

--- a/packages/drivers/driver-web-cache/src/fluidCacheTelemetry.ts
+++ b/packages/drivers/driver-web-cache/src/fluidCacheTelemetry.ts
@@ -10,6 +10,7 @@ export const enum FluidCacheGenericEvent {
 
 export const enum FluidCacheErrorEvent {
 	"FluidCacheDeleteOldEntriesError" = "FluidCacheDeleteOldEntriesError",
+	"FluidCacheDeleteSingleEntryError" = "FluidCacheDeleteSingleEntryError",
 	"FluidCacheGetError" = "FluidCacheGetError",
 	"FluidCachePutError" = "FluidCachePutError",
 	"FluidCacheUpdateUsageError" = "FluidCacheUpdateUsageError",

--- a/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
@@ -184,6 +184,37 @@ function getMockCacheEntry(itemKey: string, options?: { docId: string }): ICache
 			expect(await fluidCache.get(docId1Entry2)).toBeUndefined();
 		});
 
+		it("removes a specific entry without affecting other entries for the same document", async () => {
+			const fluidCache = getFluidCache();
+
+			const docId1Entry1 = getMockCacheEntry("docId1Entry1", {
+				docId: "docId1",
+			});
+			const docId1Entry2 = getMockCacheEntry("docId1Entry2", {
+				docId: "docId1",
+			});
+			const docId2Entry1 = getMockCacheEntry("docId2Entry1", {
+				docId: "docId2",
+			});
+
+			await fluidCache.put(docId1Entry1, { data: "entry1" });
+			await fluidCache.put(docId1Entry2, { data: "entry2" });
+			await fluidCache.put(docId2Entry1, { data: "entry3" });
+
+			// Verify all entries exist
+			expect(await fluidCache.get(docId1Entry1)).toEqual({ data: "entry1" });
+			expect(await fluidCache.get(docId1Entry2)).toEqual({ data: "entry2" });
+			expect(await fluidCache.get(docId2Entry1)).toEqual({ data: "entry3" });
+
+			// Remove only one specific entry from docId1
+			await fluidCache.removeEntry(docId1Entry1);
+
+			// Verify only the specified entry was removed
+			expect(await fluidCache.get(docId1Entry1)).toBeUndefined();
+			expect(await fluidCache.get(docId1Entry2)).toEqual({ data: "entry2" }); // Still exists
+			expect(await fluidCache.get(docId2Entry1)).toEqual({ data: "entry3" }); // Still exists
+		});
+
 		// The tests above test the public API of Fluid Cache.
 		//  Those tests should not break if we changed the implementation.
 		// The tests below test implementation details of the Fluid Cache, such as the usage of indexedDB.

--- a/packages/drivers/driver-web-cache/src/test/types/validateDriverWebCachePrevious.generated.ts
+++ b/packages/drivers/driver-web-cache/src/test/types/validateDriverWebCachePrevious.generated.ts
@@ -25,6 +25,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_FluidCache": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_FluidCache = requireAssignableTo<TypeOnly<old.FluidCache>, TypeOnly<current.FluidCache>>
 
 /*


### PR DESCRIPTION
## Description

Added api to remove a single entry from fluidCache

## Breaking Changes

Added an optional method for deleting a single entry from fluid cache - removeEntry.
It is not forward compatible, but it is still backwards compatible because it is optional.