### PR TITLE
Upgraded 'layerIncompatibilityError' and 'ILayerIncompatibilityError' to @legacy @beta

### DIFF
--- a/.changeset/solid-teams-swim.md
+++ b/.changeset/solid-teams-swim.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/core-interfaces": minor
+"__section": breaking
+---
+Added layerIncompatibilityError to FluidErrorTypes
+
+The Fluid error type `layerIncompatibilityError` is added to `FluidErrorTypes` and is now @legacy @beta.
+It was added as @legacy @alpha in version 2.72.0.
+The corresponding interface `ILayerIncompatibilityError` for errors of type `layerIncompatibilityError` is now also @legacy @beta.
+
+See [this issue](https://github.com/microsoft/FluidFramework/issues/25813) for more details.

--- a/.changeset/solid-teams-swim.md
+++ b/.changeset/solid-teams-swim.md
@@ -1,11 +1,14 @@
 ---
+"@fluidframework/container-definitions": minor
 "@fluidframework/core-interfaces": minor
+"@fluidframework/driver-definitions": minor
+"@fluidframework/odsp-driver-definitions": minor
 "__section": breaking
 ---
-Added layerIncompatibilityError to FluidErrorTypes
+Added layerIncompatibilityError to FluidErrorTypes, ContainerErrorTypes, DriverErrorTypes and OdspErrorTypes
 
-The Fluid error type `layerIncompatibilityError` is added to `FluidErrorTypes` and is now @legacy @beta.
-It was added as @legacy @alpha in version 2.72.0.
+The Fluid error type `layerIncompatibilityError` is added to `FluidErrorTypes`  and is now @legacy @beta. It is also added to `ContainerErrorTypes`, `DriverErrorTypes` and `OdspErrorTypes` which extend `FluidErrorTypes`.
+`layerIncompatibilityError` was added as @legacy @alpha in version 2.72.0.
 The corresponding interface `ILayerIncompatibilityError` for errors of type `layerIncompatibilityError` is now also @legacy @beta.
 
 See [this issue](https://github.com/microsoft/FluidFramework/issues/25813) for more details.

--- a/.changeset/solid-teams-swim.md
+++ b/.changeset/solid-teams-swim.md
@@ -7,7 +7,7 @@
 ---
 Added layerIncompatibilityError to FluidErrorTypes, ContainerErrorTypes, DriverErrorTypes and OdspErrorTypes
 
-The Fluid error type `layerIncompatibilityError` is added to `FluidErrorTypes`  and is now @legacy @beta. It is also added to `ContainerErrorTypes`, `DriverErrorTypes` and `OdspErrorTypes` which extend `FluidErrorTypes`.
+The Fluid error type `layerIncompatibilityError` is added to `FluidErrorTypes` and is now @legacy @beta. It is also added to `ContainerErrorTypes`, `DriverErrorTypes` and `OdspErrorTypes` which extend `FluidErrorTypes`.
 `layerIncompatibilityError` was added as @legacy @alpha in version 2.72.0.
 The corresponding interface `ILayerIncompatibilityError` for errors of type `layerIncompatibilityError` is now also @legacy @beta.
 

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
@@ -81,6 +81,7 @@ export const ContainerErrorTypes: {
     readonly dataCorruptionError: "dataCorruptionError";
     readonly dataProcessingError: "dataProcessingError";
     readonly usageError: "usageError";
+    readonly layerIncompatibilityError: "layerIncompatibilityError";
 };
 
 // @beta @legacy

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -111,7 +111,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_ContainerErrorTypes": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -781,6 +781,7 @@ declare type old_as_current_for_TypeAlias_ContainerErrorTypes = requireAssignabl
  * typeValidation.broken:
  * "TypeAlias_ContainerErrorTypes": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_ContainerErrorTypes = requireAssignableTo<TypeOnly<current.ContainerErrorTypes>, TypeOnly<old.ContainerErrorTypes>>
 
 /*

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -29,6 +29,7 @@ export const FluidErrorTypes: {
     readonly dataCorruptionError: "dataCorruptionError";
     readonly dataProcessingError: "dataProcessingError";
     readonly usageError: "usageError";
+    readonly layerIncompatibilityError: "layerIncompatibilityError";
 };
 
 // @beta @legacy (undocumented)
@@ -36,12 +37,12 @@ export type FluidErrorTypes = (typeof FluidErrorTypes)[keyof typeof FluidErrorTy
 
 // @alpha @legacy
 export const FluidErrorTypesAlpha: {
-    readonly layerIncompatibilityError: "layerIncompatibilityError";
     readonly genericError: "genericError";
     readonly throttlingError: "throttlingError";
     readonly dataCorruptionError: "dataCorruptionError";
     readonly dataProcessingError: "dataProcessingError";
     readonly usageError: "usageError";
+    readonly layerIncompatibilityError: "layerIncompatibilityError";
 };
 
 // @alpha @legacy (undocumented)
@@ -310,12 +311,12 @@ export interface IFluidLoadable extends IProvideFluidLoadable {
     readonly handle: IFluidHandle;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILayerIncompatibilityError extends IErrorBase {
     readonly actualDifferenceInMonths: number;
     readonly compatibilityRequirementsInMonths: number;
     readonly details: string;
-    readonly errorType: typeof FluidErrorTypesAlpha.layerIncompatibilityError;
+    readonly errorType: typeof FluidErrorTypes.layerIncompatibilityError;
     readonly incompatibleLayer: string;
     readonly incompatibleLayerVersion: string;
     readonly layer: string;

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
@@ -29,6 +29,7 @@ export const FluidErrorTypes: {
     readonly dataCorruptionError: "dataCorruptionError";
     readonly dataProcessingError: "dataProcessingError";
     readonly usageError: "usageError";
+    readonly layerIncompatibilityError: "layerIncompatibilityError";
 };
 
 // @beta @legacy (undocumented)
@@ -295,6 +296,18 @@ export const IFluidLoadable: keyof IProvideFluidLoadable;
 // @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     readonly handle: IFluidHandle;
+}
+
+// @beta @legacy
+export interface ILayerIncompatibilityError extends IErrorBase {
+    readonly actualDifferenceInMonths: number;
+    readonly compatibilityRequirementsInMonths: number;
+    readonly details: string;
+    readonly errorType: typeof FluidErrorTypes.layerIncompatibilityError;
+    readonly incompatibleLayer: string;
+    readonly incompatibleLayerVersion: string;
+    readonly layer: string;
+    readonly layerVersion: string;
 }
 
 // @beta @legacy

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -161,7 +161,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_FluidErrorTypes": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/common/core-interfaces/src/error.ts
+++ b/packages/common/core-interfaces/src/error.ts
@@ -34,6 +34,16 @@ export const FluidErrorTypes = {
 	 * Error indicating an API is being used improperly resulting in an invalid operation.
 	 */
 	usageError: "usageError",
+
+	/**
+	 * Error indicating that two Fluid layers are incompatible. For instance, if the Loader layer is
+	 * not compatible with the Runtime layer, the container create / load will fail with an error of this type.
+	 * In most cases, the layer compatibility validation happens during container load / create causing it to
+	 * fail with this error type.
+	 * In some cases such as for the Runtime and DataStore layer compatibility, the incompatibility may be detected
+	 * during data store loads. In such cases, the data store load will fail with this error type.
+	 */
+	layerIncompatibilityError: "layerIncompatibilityError",
 } as const;
 
 /**
@@ -47,15 +57,6 @@ export type FluidErrorTypes = (typeof FluidErrorTypes)[keyof typeof FluidErrorTy
  */
 export const FluidErrorTypesAlpha = {
 	...FluidErrorTypes,
-	/**
-	 * Error indicating that two Fluid layers are incompatible. For instance, if the Loader layer is
-	 * not compatible with the Runtime layer, the container create / load will fail with an error of this type.
-	 * In most cases, the layer compatibility validation happens during container load / create causing it to
-	 * fail with this error type.
-	 * In some cases such as for the Runtime and DataStore layer compatibility, the incompatibility may be detected
-	 * during data store loads. In such cases, the data store load will fail with this error type.
-	 */
-	layerIncompatibilityError: "layerIncompatibilityError",
 } as const;
 
 /**
@@ -155,13 +156,13 @@ export interface IThrottlingWarning extends IErrorBase {
 /**
  * Layer incompatibility error indicating that two Fluid layers are incompatible. For instance, if the Loader layer is
  * not compatible with the Runtime layer, the container will be disposed with this error.
- * @legacy @alpha
+ * @legacy @beta
  */
 export interface ILayerIncompatibilityError extends IErrorBase {
 	/**
 	 * {@inheritDoc IErrorBase.errorType}
 	 */
-	readonly errorType: typeof FluidErrorTypesAlpha.layerIncompatibilityError;
+	readonly errorType: typeof FluidErrorTypes.layerIncompatibilityError;
 	/**
 	 * The layer that is reporting the incompatibility.
 	 */

--- a/packages/common/core-interfaces/src/error.ts
+++ b/packages/common/core-interfaces/src/error.ts
@@ -36,8 +36,10 @@ export const FluidErrorTypes = {
 	usageError: "usageError",
 
 	/**
-	 * Error indicating that two Fluid layers are incompatible. For instance, if the Loader layer is
-	 * not compatible with the Runtime layer, the container create / load will fail with an error of this type.
+	 * Error indicating that two Fluid layers are incompatible.
+	 * @remarks
+	 * For instance, if the Loader layer is not compatible with the Runtime layer, the container create / load
+	 * will fail with an error of this type.
 	 * In most cases, the layer compatibility validation happens during container load / create causing it to
 	 * fail with this error type.
 	 * In some cases such as for the Runtime and DataStore layer compatibility, the incompatibility may be detected

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -556,6 +556,7 @@ declare type old_as_current_for_TypeAlias_FluidErrorTypes = requireAssignableTo<
  * typeValidation.broken:
  * "TypeAlias_FluidErrorTypes": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_FluidErrorTypes = requireAssignableTo<TypeOnly<current.FluidErrorTypes>, TypeOnly<old.FluidErrorTypes>>
 
 /*

--- a/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
@@ -30,6 +30,7 @@ export const DriverErrorTypes: {
     readonly genericError: "genericError";
     readonly throttlingError: "throttlingError";
     readonly usageError: "usageError";
+    readonly layerIncompatibilityError: "layerIncompatibilityError";
 };
 
 // @beta @legacy

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.beta.api.md
@@ -240,6 +240,7 @@ export const OdspErrorTypes: {
     readonly genericError: "genericError";
     readonly throttlingError: "throttlingError";
     readonly usageError: "usageError";
+    readonly layerIncompatibilityError: "layerIncompatibilityError";
 };
 
 // @beta @legacy (undocumented)

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -106,7 +106,17 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IOdspError": {
+				"backCompat": false
+			},
+			"TypeAlias_OdspError": {
+				"backCompat": false
+			},
+			"TypeAlias_OdspErrorTypes": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -160,6 +160,7 @@ declare type old_as_current_for_Interface_IOdspError = requireAssignableTo<TypeO
  * typeValidation.broken:
  * "Interface_IOdspError": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IOdspError = requireAssignableTo<TypeOnly<current.IOdspError>, TypeOnly<old.IOdspError>>
 
 /*
@@ -520,6 +521,7 @@ declare type old_as_current_for_TypeAlias_OdspError = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "TypeAlias_OdspError": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_OdspError = requireAssignableTo<TypeOnly<current.OdspError>, TypeOnly<old.OdspError>>
 
 /*
@@ -538,6 +540,7 @@ declare type old_as_current_for_TypeAlias_OdspErrorTypes = requireAssignableTo<T
  * typeValidation.broken:
  * "TypeAlias_OdspErrorTypes": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_OdspErrorTypes = requireAssignableTo<TypeOnly<current.OdspErrorTypes>, TypeOnly<old.OdspErrorTypes>>
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
@@ -30,7 +30,7 @@ import {
 	runtimeCoreCompatDetails,
 } from "@fluidframework/container-runtime/internal";
 import {
-	FluidErrorTypesAlpha,
+	FluidErrorTypes,
 	type ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces/internal";
 import {
@@ -225,7 +225,7 @@ function getExpectedErrorEvents(
 	const expectedErrorEvents: ExpectedEvents = [
 		{
 			eventName: "fluid:telemetry:Container:ContainerDispose",
-			errorType: FluidErrorTypesAlpha.layerIncompatibilityError,
+			errorType: FluidErrorTypes.layerIncompatibilityError,
 		},
 	];
 
@@ -242,7 +242,7 @@ function getExpectedErrorEvents(
 		// during data store realization, so we expect this error event to be logged.
 		expectedErrorEvents.unshift({
 			eventName: "fluid:telemetry:FluidDataStoreContext:RealizeError",
-			errorType: FluidErrorTypesAlpha.layerIncompatibilityError,
+			errorType: FluidErrorTypes.layerIncompatibilityError,
 		});
 	} else if (layer2 === "dataStore" && flow === "create") {
 		// In create flows, the layer compat validation in the Runtime layer happens during data store runtime
@@ -251,7 +251,7 @@ function getExpectedErrorEvents(
 		// data store runtime attach flow, so we do not expect this error event to be logged.
 		expectedErrorEvents.unshift({
 			eventName: "fluid:telemetry:FluidDataStoreContext:AttachRuntimeError",
-			errorType: FluidErrorTypesAlpha.layerIncompatibilityError,
+			errorType: FluidErrorTypes.layerIncompatibilityError,
 		});
 	}
 

--- a/packages/utils/telemetry-utils/src/error.ts
+++ b/packages/utils/telemetry-utils/src/error.ts
@@ -6,7 +6,6 @@
 import type { IErrorBase, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import {
 	FluidErrorTypes,
-	FluidErrorTypesAlpha,
 	type IGenericError,
 	type ILayerIncompatibilityError,
 	type IUsageError,
@@ -235,7 +234,7 @@ export class LayerIncompatibilityError
 	extends LoggingError
 	implements ILayerIncompatibilityError
 {
-	public readonly errorType = FluidErrorTypesAlpha.layerIncompatibilityError;
+	public readonly errorType = FluidErrorTypes.layerIncompatibilityError;
 	public readonly layer: string;
 	public readonly layerVersion: string;
 	public readonly incompatibleLayer: string;

--- a/packages/utils/telemetry-utils/src/fluidErrorBase.ts
+++ b/packages/utils/telemetry-utils/src/fluidErrorBase.ts
@@ -5,7 +5,7 @@
 
 import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import {
-	FluidErrorTypesAlpha,
+	FluidErrorTypes,
 	type ILayerIncompatibilityError,
 } from "@fluidframework/core-interfaces/internal";
 
@@ -123,7 +123,5 @@ export function isFluidError(error: unknown): error is IFluidErrorBase {
 export function isLayerIncompatibilityError(
 	error: unknown,
 ): error is ILayerIncompatibilityError {
-	return (
-		isFluidError(error) && error.errorType === FluidErrorTypesAlpha.layerIncompatibilityError
-	);
+	return isFluidError(error) && error.errorType === FluidErrorTypes.layerIncompatibilityError;
 }


### PR DESCRIPTION
This PR upgrades the `layerIncompatibilityError` error type and `ILayerIncompatibilityError` interface from legacy alpha to legacy beta status. The error type was originally introduced by https://github.com/microsoft/FluidFramework/pull/25784 in release 2.72.0 and is now being promoted to a more stable API level.
- Moved `layerIncompatibilityError` from `FluidErrorTypesAlpha` to `FluidErrorTypes`.
- Updated the `ILayerIncompatibilityError` interface to reference the beta error type.
- Updated all usages across the codebase to use the new beta references.

[AB#54417](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/54417)