### PR TITLE
Enable unicorn/consistent-destructuring rule in tree package 

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -65,7 +65,6 @@ module.exports = {
 		// Set to a warning to encourage adding docs :)
 		"jsdoc/require-description": "warn",
 
-		"unicorn/consistent-destructuring": "off",
 		"unicorn/consistent-function-scoping": "off",
 		"unicorn/explicit-length-check": "off",
 		"unicorn/no-array-callback-reference": "off",

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -38,7 +38,6 @@ const config: Linter.Config[] = [
 			"import/order": "off",
 			"jsdoc/multiline-blocks": "off",
 			"jsdoc/require-description": "warn",
-			"unicorn/consistent-destructuring": "off",
 			"unicorn/consistent-function-scoping": "off",
 			"unicorn/explicit-length-check": "off",
 			"unicorn/no-array-callback-reference": "off",

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1990,6 +1990,9 @@ export function updateRefreshers(
 	const {
 		fieldChanges,
 		nodeChanges,
+		nodeToParent,
+		nodeAliases,
+		crossFieldKeys,
 		maxId,
 		revisions,
 		constraintViolationCount,
@@ -2001,9 +2004,9 @@ export function updateRefreshers(
 	return makeModularChangeset({
 		fieldChanges,
 		nodeChanges,
-		nodeToParent: change.nodeToParent,
-		nodeAliases: change.nodeAliases,
-		crossFieldKeys: change.crossFieldKeys,
+		nodeToParent,
+		nodeAliases,
+		crossFieldKeys,
 		maxId: maxId as number,
 		revisions,
 		constraintViolationCount,
@@ -2932,9 +2935,13 @@ function buildModularChangesetFromNode(props: {
 }): ModularChangeset {
 	const {
 		path,
-		nodeId = { localId: brand(props.idAllocator.allocate()), revision: props.revision },
+		idAllocator,
+		revision,
+		nodeChanges,
+		nodeChange,
+		nodeId = { localId: brand(idAllocator.allocate()), revision },
 	} = props;
-	setInChangeAtomIdMap(props.nodeChanges, nodeId, props.nodeChange);
+	setInChangeAtomIdMap(nodeChanges, nodeId, nodeChange);
 	const fieldChangeset = genericFieldKind.changeHandler.editor.buildChildChanges([
 		[path.parentIndex, nodeId],
 	]);

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -269,7 +269,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 		genId: IdAllocator<ChangesetLocalId>,
 		revision: RevisionTag | undefined,
 	): OptionalChangeset => {
-		const { moves, childChanges } = change;
+		const { moves, childChanges, valueReplace } = change;
 
 		const invertIdMap = new RegisterMap<RegisterId>();
 		const invertedMoves: Move[] = [];
@@ -277,13 +277,13 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 			invertIdMap.set(src, dst);
 			invertedMoves.push([dst, src]);
 		}
-		if (change.valueReplace !== undefined) {
-			const effectfulDst = getEffectfulDst(change.valueReplace);
+		if (valueReplace !== undefined) {
+			const effectfulDst = getEffectfulDst(valueReplace);
 			if (effectfulDst !== undefined) {
-				invertIdMap.set("self", change.valueReplace.dst);
+				invertIdMap.set("self", valueReplace.dst);
 			}
-			if (change.valueReplace.src !== undefined) {
-				invertIdMap.set(change.valueReplace.src, "self");
+			if (valueReplace.src !== undefined) {
+				invertIdMap.set(valueReplace.src, "self");
 			}
 		}
 
@@ -294,10 +294,10 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 			}),
 		};
 
-		if (change.valueReplace !== undefined) {
-			if (isReplaceEffectful(change.valueReplace)) {
+		if (valueReplace !== undefined) {
+			if (isReplaceEffectful(valueReplace)) {
 				const replace: Mutable<Replace> =
-					change.valueReplace.src === undefined
+					valueReplace.src === undefined
 						? {
 								isEmpty: true,
 								dst: makeChangeAtomId(genId.allocate(), revision),
@@ -305,14 +305,14 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 						: {
 								isEmpty: false,
 								dst: isRollback
-									? change.valueReplace.src
+									? valueReplace.src
 									: makeChangeAtomId(genId.allocate(), revision),
 							};
-				if (change.valueReplace.isEmpty === false) {
-					replace.src = change.valueReplace.dst;
+				if (valueReplace.isEmpty === false) {
+					replace.src = valueReplace.dst;
 				}
 				inverted.valueReplace = replace;
-			} else if (!isRollback && change.valueReplace.src === "self") {
+			} else if (!isRollback && valueReplace.src === "self") {
 				inverted.valueReplace = {
 					isEmpty: false,
 					src: "self",

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -972,14 +972,14 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	}
 	public removeRange(start?: number, end?: number): void {
 		const field = getSequenceField(this);
-		const { length } = field;
+		const { length, editor } = field;
 		const removeStart = start ?? 0;
 		validateIndex(removeStart, field, "TreeArrayNode.removeRange", true);
 
 		const removeEnd = Math.min(length, end ?? length);
 		validateIndexRange(removeStart, removeEnd, field, "TreeArrayNode.removeRange");
 
-		field.editor.remove(removeStart, removeEnd - removeStart);
+		editor.remove(removeStart, removeEnd - removeStart);
 	}
 	public moveToStart(sourceIndex: number, source?: ReadonlyArrayNode): void {
 		const sourceArray = source ?? this;

--- a/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
+++ b/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
@@ -94,12 +94,11 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 		numberOfEditsToRebase,
 		numberOfEditsToVerifyAssociativity,
 		groupSubSuites,
+		skipRebaseOverCompose,
 	} = definedOptions;
 
 	// Skip the "Rebase over compose" suite if specified to in the suite options.
-	const rebaseOverComposeDescribe = definedOptions.skipRebaseOverCompose
-		? describe.skip
-		: describe;
+	const rebaseOverComposeDescribe = skipRebaseOverCompose ? describe.skip : describe;
 
 	const [outerFixture, innerFixture] = groupSubSuites
 		? [it, (title: string, fn: () => void) => fn()]

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -741,15 +741,15 @@ export function makeOpGenerator(
 					(): Synchronize => ({
 						type: "synchronizeTrees",
 					}),
-					weights.synchronizeTrees,
+					synchronizeTrees,
 				],
-				[() => schemaEditGenerator, weights.schema],
+				[() => schemaEditGenerator, schema],
 				[
 					() => makeConstraintEditGenerator(weights),
 					constraintWeight,
 					(state: FuzzTestState) => viewFromState(state).checkout.transaction.isInProgress(),
 				],
-				[() => makeBranchEditGenerator(weights), weights.fork + weights.merge],
+				[() => makeBranchEditGenerator(weights), fork + merge],
 			] as const
 		)
 			.filter(([, weight]) => weight > 0)

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -92,10 +92,9 @@ describe("SchematizingSimpleTreeView", () => {
 				new MockNodeIdentifierManager(),
 			);
 
-			const { compatibility } = view;
-			assert.equal(compatibility.canView, false);
-			assert.equal(compatibility.canUpgrade, false);
-			assert.equal(compatibility.canInitialize, true);
+			assert.equal(view.compatibility.canView, false);
+			assert.equal(view.compatibility.canUpgrade, false);
+			assert.equal(view.compatibility.canInitialize, true);
 
 			view.initialize(5);
 			assert.equal(view.root, 5);
@@ -122,10 +121,9 @@ describe("SchematizingSimpleTreeView", () => {
 					new MockNodeIdentifierManager(),
 				);
 
-				const { compatibility } = view;
-				assert.equal(compatibility.canView, false);
-				assert.equal(compatibility.canUpgrade, false);
-				assert.equal(compatibility.canInitialize, true);
+				assert.equal(view.compatibility.canView, false);
+				assert.equal(view.compatibility.canUpgrade, false);
+				assert.equal(view.compatibility.canInitialize, true);
 
 				view.initialize({ content: 5 });
 				assert.equal(view.root.content, 5);
@@ -138,10 +136,9 @@ describe("SchematizingSimpleTreeView", () => {
 					new MockNodeIdentifierManager(),
 				);
 
-				const { compatibility } = view;
-				assert.equal(compatibility.canView, false);
-				assert.equal(compatibility.canUpgrade, false);
-				assert.equal(compatibility.canInitialize, true);
+				assert.equal(view.compatibility.canView, false);
+				assert.equal(view.compatibility.canUpgrade, false);
+				assert.equal(view.compatibility.canInitialize, true);
 
 				const node = new SimpleTestObject({ content: 5 });
 				assert.equal(Tree.status(node), TreeStatus.New);


### PR DESCRIPTION
Removes the unicorn/consistent-destructuring: off override from the @fluidframework/tree package and fixes the resulting t errors. This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs. 

 ESLint Configuration:                                                                                               
  - Removed "unicorn/consistent-destructuring": "off" from packages/dds/tree/.eslintrc.cjs                            
  - Removed "unicorn/consistent-destructuring": "off" from packages/dds/tree/eslint.config.mts                        
                                                                                                                      
  Code Fixes:                                                                                                         
  Refactored code to use consistent destructuring patterns. The unicorn/consistent-destructuring rule requires that   
  when you destructure properties from an object, you should destructure all properties you intend to use rather than 
  mixing destructuring with direct property access.  