### PR TITLE
Make squash parameter required on internal plumbing

### DIFF
--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -547,7 +547,7 @@ export abstract class SharedObjectCore<
 			setConnectionState: (connected: boolean) => {
 				this.setConnectionState(connected);
 			},
-			reSubmit: (content: unknown, localOpMetadata: unknown, squash?: boolean) => {
+			reSubmit: (content: unknown, localOpMetadata: unknown, squash: boolean) => {
 				this.reSubmit(content, localOpMetadata, squash);
 			},
 			applyStashedOp: (content: unknown): void => {
@@ -655,13 +655,11 @@ export abstract class SharedObjectCore<
 	 * reconnection.
 	 * @param content - The content of the original message.
 	 * @param localOpMetadata - The local metadata associated with the original message.
-	 * @param squash - Optional. If `true`, the message will be resubmitted in a squashed form. If `undefined` or `false`,
-	 * the legacy behavior (no squashing) will be used. Defaults to `false` for backward compatibility.
+	 * @param squash - If `true`, the message will be resubmitted in a squashed form. If `false`,
+	 * the legacy behavior (no squashing) will be used.
 	 */
-	private reSubmit(content: unknown, localOpMetadata: unknown, squash?: boolean): void {
-		// Back-compat: squash argument may not be provided by container-runtime layer.
-		// Default to previous behavior (no squash).
-		if (squash ?? false) {
+	private reSubmit(content: unknown, localOpMetadata: unknown, squash: boolean): void {
+		if (squash) {
 			this.reSubmitSquashed(content, localOpMetadata);
 		} else {
 			this.reSubmitCore(content, localOpMetadata);

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -114,7 +114,7 @@ export interface ClientSpec {
 export interface ChangeConnectionState {
 	type: "changeConnectionState";
 	connected: boolean;
-	squash?: boolean;
+	squash: boolean;
 }
 
 /**
@@ -685,6 +685,7 @@ export function mixinReconnect<
 					const op: ChangeConnectionState = {
 						type: "changeConnectionState",
 						connected: !state.client.containerRuntime.connected,
+						squash: false,
 					};
 					if (options.testSquashResubmit === true && op.connected && state.random.bool(0.5)) {
 						op.squash = true;

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -287,6 +287,7 @@ describe("DDS Fuzz Harness", () => {
 											return {
 												type: "changeConnectionState",
 												connected: false,
+												squash: false,
 											};
 										},
 									),
@@ -380,6 +381,7 @@ describe("DDS Fuzz Harness", () => {
 								return {
 									type: "changeConnectionState",
 									connected: false,
+									squash: false,
 								};
 							},
 						),

--- a/packages/dds/test-dds-utils/src/utils.ts
+++ b/packages/dds/test-dds-utils/src/utils.ts
@@ -32,7 +32,7 @@ export function reconnectAndSquash(
 	): (() => void) => {
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		const originalReSubmit = runtime.reSubmit;
-		runtime.reSubmit = (content: unknown, localOpMetadata: unknown, squash?: boolean) =>
+		runtime.reSubmit = (content: unknown, localOpMetadata: unknown, squash: boolean) =>
 			originalReSubmit.call(runtime, content, localOpMetadata, options.squash);
 		return () => {
 			runtime.reSubmit = originalReSubmit;

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1820,7 +1820,7 @@ export class ComposableChannelCollection
 		type: string,
 		content: unknown,
 		localOpMetadata: unknown,
-		squash?: boolean,
+		squash: boolean,
 	): void {
 		// If the cast is incorrect and type is not one of the three supported,
 		// reSubmitContainerMessage will assert.

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -793,7 +793,7 @@ export class ChannelCollection
 			| OutboundContainerRuntimeAttachMessage
 			| ContainerRuntimeAliasMessage,
 		localOpMetadata: unknown,
-		squash: boolean | undefined,
+		squash: boolean,
 	): void => {
 		switch (message.type) {
 			case ContainerMessageType.Attach:
@@ -813,7 +813,7 @@ export class ChannelCollection
 	protected readonly resubmitDataStoreOp = (
 		envelope: IEnvelope<FluidDataStoreMessage>,
 		localOpMetadata: unknown,
-		squash: boolean | undefined,
+		squash: boolean,
 	): void => {
 		const context = this.contexts.get(envelope.address);
 		// If the data store has been deleted, log an error and throw an error. If there are local changes for a

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1096,7 +1096,7 @@ export abstract class FluidDataStoreContext
 	public reSubmit(
 		message: FluidDataStoreMessage,
 		localOpMetadata: unknown,
-		squash?: boolean,
+		squash: boolean,
 	): void {
 		assert(!!this.channel, 0x14b /* "Channel must exist when resubmitting ops" */);
 		this.channel.reSubmit(message.type, message.content, localOpMetadata, squash);

--- a/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
@@ -85,7 +85,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
-    reSubmit(type: DataStoreMessageType, content: any, localOpMetadata: unknown, squash?: boolean): void;
+    reSubmit(type: DataStoreMessageType, content: any, localOpMetadata: unknown, squash: boolean): void;
     rollback?(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
     // (undocumented)
     get rootRoutingContext(): this;

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -51,7 +51,7 @@ export interface IChannelContext {
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult>;
 
-	reSubmit(content: unknown, localOpMetadata: unknown, squash?: boolean): void;
+	reSubmit(content: unknown, localOpMetadata: unknown, squash: boolean): void;
 
 	applyStashedOp(content: unknown): unknown;
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1282,7 +1282,7 @@ export class FluidDataStoreRuntime
 		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 		content: any,
 		localOpMetadata: unknown,
-		squash?: boolean,
+		squash: boolean,
 	): void {
 		this.verifyNotClosed();
 

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -318,7 +318,7 @@ describe("FluidDataStoreRuntime.isDirty tracking", () => {
 		);
 
 		// Resubmit the op (simulating reconnect). Should still be dirty
-		runtime.reSubmit(DataStoreMessageType.ChannelOp, { address: "foo" }, undefined);
+		runtime.reSubmit(DataStoreMessageType.ChannelOp, { address: "foo" }, undefined, false);
 		assert.strictEqual(
 			runtime.isDirty,
 			true,
@@ -350,7 +350,7 @@ describe("FluidDataStoreRuntime.isDirty tracking", () => {
 		);
 
 		// Resubmit the op (simulating reconnect). Should be clean since resubmit didn't result in a new op
-		runtime.reSubmit(DataStoreMessageType.ChannelOp, { address: "foo" }, undefined);
+		runtime.reSubmit(DataStoreMessageType.ChannelOp, { address: "foo" }, undefined, false);
 		assert.strictEqual(
 			runtime.isDirty,
 			false,
@@ -372,7 +372,7 @@ describe("FluidDataStoreRuntime.isDirty tracking", () => {
 		assert.strictEqual(runtime.isDirty, true, "Runtime should be dirty after attach op");
 
 		// Resubmit same attach op
-		runtime.reSubmit(DataStoreMessageType.Attach, attachMessage, undefined);
+		runtime.reSubmit(DataStoreMessageType.Attach, attachMessage, undefined, false);
 		assert.strictEqual(
 			runtime.isDirty,
 			true,

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -144,7 +144,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     processSignal(message: IInboundSignalMessage, local: boolean): void;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
-    reSubmit(type: string, content: any, localOpMetadata: unknown, squash?: boolean): void;
+    reSubmit(type: string, content: any, localOpMetadata: unknown, squash: boolean): void;
     rollback?(type: string, content: any, localOpMetadata: unknown): void;
     // (undocumented)
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -135,7 +135,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     processSignal(message: IInboundSignalMessage, local: boolean): void;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
-    reSubmit(type: string, content: any, localOpMetadata: unknown, squash?: boolean): void;
+    reSubmit(type: string, content: any, localOpMetadata: unknown, squash: boolean): void;
     rollback?(type: string, content: any, localOpMetadata: unknown): void;
     // (undocumented)
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -429,7 +429,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	 * See remarks about squashing contract on `CommitStagedChangesOptionsExperimental`.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO (#28746): breaking change
-	reSubmit(type: string, content: any, localOpMetadata: unknown, squash?: boolean): void;
+	reSubmit(type: string, content: any, localOpMetadata: unknown, squash: boolean): void;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO (#28746): breaking change
 	applyStashedOp(content: any): Promise<unknown>;

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.beta.api.md
@@ -191,7 +191,7 @@ export class MockDeltaConnection implements IDeltaConnection {
     // (undocumented)
     processMessages(messageCollection: IRuntimeMessageCollection): void;
     // (undocumented)
-    reSubmit(content: any, localOpMetadata: unknown, squash?: boolean): void;
+    reSubmit(content: any, localOpMetadata: unknown, squash: boolean): void;
     // (undocumented)
     rollback?(message: any, localOpMetadata: unknown): void;
     // (undocumented)
@@ -490,7 +490,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
-    reSubmit(content: any, localOpMetadata: unknown, squash?: boolean): void;
+    reSubmit(content: any, localOpMetadata: unknown, squash: boolean): void;
     // (undocumented)
     rollback?(message: any, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -115,7 +115,7 @@ export class MockDeltaConnection implements IDeltaConnection {
 		this.handler?.processMessages?.(messageCollection);
 	}
 
-	public reSubmit(content: any, localOpMetadata: unknown, squash?: boolean): void {
+	public reSubmit(content: any, localOpMetadata: unknown, squash: boolean): void {
 		this.handler?.reSubmit(content, localOpMetadata, squash);
 	}
 
@@ -426,7 +426,11 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 			if (pendingMessage.content.type === "idAllocation") {
 				this.submit(pendingMessage.content, pendingMessage.localOpMetadata);
 			} else {
-				this.dataStoreRuntime.reSubmit(pendingMessage.content, pendingMessage.localOpMetadata);
+				this.dataStoreRuntime.reSubmit(
+					pendingMessage.content,
+					pendingMessage.localOpMetadata,
+					false,
+				);
 			}
 		});
 	}
@@ -1191,7 +1195,7 @@ export class MockFluidDataStoreRuntime
 		return null as any as IResponse;
 	}
 
-	public reSubmit(content: any, localOpMetadata: unknown, squash?: boolean): void {
+	public reSubmit(content: any, localOpMetadata: unknown, squash: boolean): void {
 		this.deltaConnections.forEach((dc) => {
 			dc.reSubmit(content, localOpMetadata, squash);
 		});


### PR DESCRIPTION
## Description

Make the `squash` parameter required on a number of functions only currently intended to be called internally (but which are exposed in the legacy API surface). The optionality of squashing on the main entry point (`commitStagedChanges`) has been preserved. See #25762 for more details.

## Breaking Changes

Direct callers of this function can pass `false` where they previously passed no argument.
The breaking change here is largely only at compile time, as the falsiness of `undefined` ends up resulting in equivalent behavior at the usage site in Fluid code.
