### PR TITLE
fix(merge-tree): Bump merge-tree snapshot perf test timeout

### DIFF
--- a/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
@@ -12,7 +12,7 @@ describe("MergeTree snapshots", () => {
 	let summary: ISummaryTree | undefined;
 
 	for (const summarySize of [10, 50, 100, 500, 1000, 5000, 10_000]) {
-		benchmark({
+		const test = benchmark({
 			type: BenchmarkType.Measurement,
 			title: `load snapshot with ${summarySize} segments`,
 			category: "snapshot loading",
@@ -33,5 +33,11 @@ describe("MergeTree snapshots", () => {
 				summary = undefined;
 			},
 		});
+
+		if (summarySize > 5000) {
+			const currentTimeout = test.timeout();
+			// Default value of 2 seconds causes failure around P95 for the largest snapshot size.
+			test.timeout(currentTimeout === 0 ? 0 : Math.max(5000, currentTimeout));
+		}
 	}
 });

--- a/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
@@ -36,7 +36,7 @@ describe("MergeTree snapshots", () => {
 
 		if (summarySize > 5000) {
 			const currentTimeout = test.timeout();
-			// Default value of 2 seconds causes failure around P95 for the largest snapshot size.
+			// Default value of 2 seconds causes failure around P95 for large snapshot sizes.
 			test.timeout(currentTimeout === 0 ? 0 : Math.max(5000, currentTimeout));
 		}
 	}


### PR DESCRIPTION
## Description

This test was timing out in CI around 5% of the time. Its average runtime on successes hovered near the 2 second limit.
