### PR TITLE
Fix result folder path to work for vscode and npm terminal runs

### DIFF
--- a/packages/framework/tree-agent-langchain/src/test/dirname.cts
+++ b/packages/framework/tree-agent-langchain/src/test/dirname.cts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Problem:
+//   - `__dirname` is not defined in ESM
+//   - `import.meta.url` is not defined in CJS
+// Solution:
+//   - Export '__dirname' from a .cjs file in the same directory.
+//
+// Note that *.cjs files are always CommonJS, but can be imported from ESM.
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const _dirname = __dirname;

--- a/packages/framework/tree-agent-langchain/src/test/utils.ts
+++ b/packages/framework/tree-agent-langchain/src/test/utils.ts
@@ -29,6 +29,8 @@ import { ChatOpenAI } from "@langchain/openai";
 
 import { createLangchainChatModel } from "../chatModel.js";
 
+import { _dirname } from "./dirname.cjs";
+
 /**
  * Throw an error with the given message
  */
@@ -158,20 +160,7 @@ interface TestResult {
 	readonly duration: number;
 }
 
-/**
- * Determines the correct path for the integration test results folder based on the
- * current working directory. When running via npm, cwd is the package root
- * (tree-agent-langchain). When running via VS Code test runner, cwd is the test
- * root (tree-agent-langchain/src/test).
- */
-function getResultsFolderPath(): string {
-	const cwd = process.cwd();
-	return cwd.endsWith("tree-agent-langchain")
-		? join(cwd, "src/test/integration-test-results")
-		: join(cwd, "integration-test-results");
-}
-
-const resultsFolderPath = getResultsFolderPath();
+const resultsFolderPath = join(_dirname, "../../src/test/integration-test-results");
 
 function formatDate(date: Date): string {
 	return date
@@ -199,7 +188,7 @@ export function describeIntegrationTests(
 		let startTime: Date | undefined;
 		before(() => {
 			startTime = new Date();
-			mkdirSync(`${resultsFolderPath}/${formatDate(startTime)}`, { recursive: true });
+			mkdirSync(join(resultsFolderPath, formatDate(startTime)), { recursive: true });
 		});
 
 		after(() => {
@@ -211,7 +200,7 @@ export function describeIntegrationTests(
 				table += `| ${result.name} | ${result.provider} | ${(result.score * 100).toFixed(2)}% | ${Math.ceil(result.duration / 1000)} |\n`;
 			}
 			const resultsFile = openSync(
-				`${resultsFolderPath}/${formatDate(startTime)}/results.md`,
+				join(resultsFolderPath, formatDate(startTime), "results.md"),
 				"a",
 			);
 			appendFileSync(resultsFile, "# Results\n\n", { encoding: "utf8" });
@@ -359,7 +348,7 @@ export function describeIntegrationTests(
 			assert(startTime !== undefined, "Expected startTime to be set");
 			const { name, schema, initialTree, prompt, expected, options } = test;
 			const fd = openSync(
-				`${resultsFolderPath}/${formatDate(startTime)}/${name}-${provider}.md`,
+				join(resultsFolderPath, formatDate(startTime), `${name}-${provider}.md`),
 				"w",
 			);
 			const view = await queryDomain(

--- a/packages/framework/tree-agent-langchain/src/test/utils.ts
+++ b/packages/framework/tree-agent-langchain/src/test/utils.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "node:assert";
 import { appendFileSync, closeSync, mkdirSync, openSync } from "node:fs";
+import { join } from "node:path";
 
 import { oob, unreachableCase } from "@fluidframework/core-utils/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils";
@@ -157,7 +158,20 @@ interface TestResult {
 	readonly duration: number;
 }
 
-const resultsFolderPath = "./src/test/integration-test-results";
+/**
+ * Determines the correct path for the integration test results folder based on the
+ * current working directory. When running via npm, cwd is the package root
+ * (tree-agent-langchain). When running via VS Code test runner, cwd is the test
+ * root (tree-agent-langchain/src/test).
+ */
+function getResultsFolderPath(): string {
+	const cwd = process.cwd();
+	return cwd.endsWith("tree-agent-langchain")
+		? join(cwd, "src/test/integration-test-results")
+		: join(cwd, "integration-test-results");
+}
+
+const resultsFolderPath = getResultsFolderPath();
 
 function formatDate(date: Date): string {
 	return date


### PR DESCRIPTION
## Description

In tree-agent-langchain, when running integration tests the results are placed in different paths as the code currently doesn't handle having different working directories. This change figures out the the dirname using the new added file and adds the dir `integration-test-results` directory so that the test results can be written there. (Had to add `../../src/test/integration-test-results` because the tests actually get run in lib/test not src/test.) Note that this dir was always created whenever integration tests were run but was never tracked by git and should continue to not be.

## Reviewer Guidance

* Originally tried to do it by relative path using the current file's location. Tried using `import.meta.url` but that wasn't defined in CommonJS.  Tried directly using `__dirname` but that isn't defined in ESM
* Followed other tests that needed this and added a new `dirname.cjs` file that exports the dirname properly.
