### PR TITLE
fix(container-runtime): propagate fullTree flag through trySummarizeWithRetries

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarization/onDemandSummarizerApi.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/onDemandSummarizerApi.spec.ts
@@ -100,6 +100,20 @@ describeCompat("on-demand summarizer api", "NoCompat", (getTestObjectProvider, a
 		const endEvents = getPerformanceEvents("end");
 		assert.strictEqual(startEvents.length, 1, "start telemetry missing");
 		assert.strictEqual(endEvents.length, 1, "end telemetry missing");
+
+		// Verify that fullTree flag is false (default) in the summarizer telemetry
+		const summarizeGenerateEvents = logger.events.filter(
+			(e) => e.eventName === "fluid:telemetry:Summarizer:Running:Summarize_generate",
+		);
+		assert(
+			summarizeGenerateEvents.length >= 1,
+			"should have at least one Summarize_generate event",
+		);
+		assert.strictEqual(
+			summarizeGenerateEvents[0].fullTree,
+			false,
+			"fullTree flag should be false in Summarize_generate telemetry when config is not enabled",
+		);
 	});
 
 	it("summarizes successfully with fullTree gate on", async function () {
@@ -130,6 +144,21 @@ describeCompat("on-demand summarizer api", "NoCompat", (getTestObjectProvider, a
 		const endEvents = getPerformanceEvents("end");
 		assert.strictEqual(startEvents.length, 1, "start telemetry missing");
 		assert.strictEqual(endEvents.length, 1, "end telemetry missing");
+
+		// Verify that fullTree flag is propagated to the summarizer telemetry
+		// This validates that the fullTree option is properly passed through when retryOnFailure is true
+		const summarizeGenerateEvents = logger.events.filter(
+			(e) => e.eventName === "fluid:telemetry:Summarizer:Running:Summarize_generate",
+		);
+		assert(
+			summarizeGenerateEvents.length >= 1,
+			"should have at least one Summarize_generate event",
+		);
+		assert.strictEqual(
+			summarizeGenerateEvents[0].fullTree,
+			true,
+			"fullTree flag should be true in Summarize_generate telemetry when config is enabled",
+		);
 	});
 
 	it("fails gracefully when summary upload throws", async () => {


### PR DESCRIPTION
## Description

Fixes a bug where `loadSummarizerContainerAndMakeSummary` wasn't propagating the `fullTree` flag to `trySummarizeWithRetries`, causing incremental summaries to always be generated even when full tree summaries were requested via the `Fluid.Summarizer.FullTree.OnDemand` config flag.

In`trySummarizeWithRetries` we hardcode `fullTree: false`, so this meant the `fullTree` option was silently ignored when retry logic was enabled.

## Solution

- Added `summarizeOptions` parameter to `trySummarizeWithRetries` to accept the caller's options
- Added `summarizeOptions` parameter to `summarizeOnDemandWithRetries` to pass through options
- Updated `summarizeOnDemand` to pass `summarizeOptions` when calling `summarizeOnDemandWithRetries`

## Testing

Added telemetry verification to existing e2e tests to validate that:
- `fullTree` is `false` in `Summarize_generate` telemetry when config is not set
- `fullTree` is `true` in `Summarize_generate` telemetry when `Fluid.Summarizer.FullTree.OnDemand` config is enabled