### PR TITLE
Revert "ci: remove unused pipeline variable (#26090)"

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -40,6 +40,9 @@ parameters:
   type: string
   default: "@fluid-private/test-end-to-end-tests"
 
+- name: testWorkspace
+  type: string
+
 - name: timeoutInMinutes
   type: number
   default: 60
@@ -230,6 +233,7 @@ stages:
 
               Pipeline Variables:
                 isTestBranch=${{ variables.isTestBranch }}
+                testWorkspace=${{ parameters.testWorkspace }}
                 testPackageFilePattern=${{ variables.testPackageFilePattern }}
                 testCommand=${{ parameters.testCommand }}
                 continueOnError=${{ parameters.continueOnError }}


### PR DESCRIPTION
This commit https://github.com/microsoft/FluidFramework/commit/d7daa26a861be603afa3eebaca2e2f647f300f8e broke our end-to-end and stress test pipelines because `testWorkspace` is still being used in those pipelines.