### PR TITLE
feat: insulate branches from incomplete transaction changes

### DIFF
--- a/.changeset/ripe-poems-act.md
+++ b/.changeset/ripe-poems-act.md
@@ -15,4 +15,4 @@ This breaking change only affects the behavior of `TreeBranch` methods (currentl
 These new restrictions insulate branches and their dependents from experiencing incomplete transaction changes.
 This is important because incomplete transaction changes may not uphold application invariants.
 
-In scenarios that experience the new errors, application authors should consider whether the ongoing transaction can safely by closed before invoking these methods.
+In scenarios that experience the new errors, application authors should consider whether the ongoing transaction can safely be closed before invoking these methods.

--- a/.changeset/ripe-poems-act.md
+++ b/.changeset/ripe-poems-act.md
@@ -12,7 +12,7 @@ This breaking change only affects the behavior of `TreeBranch` methods (currentl
 * Invoking `TreeBranch.rebaseOnto(targetBranch)` now throws an error if a transaction is ongoing on the target branch.
   As before, it also throws an error if a transaction is ongoing on the source (i.e., `this`) branch.
 
-These new restrictions insulate branches and their dependents from experiencing incomplete transactions changes.
-This is important because incomplete transactions changes may not uphold application invariants.
+These new restrictions insulate branches and their dependents from experiencing incomplete transaction changes.
+This is important because incomplete transaction changes may not uphold application invariants.
 
 In scenarios that experience the new errors, application authors should consider whether the ongoing transaction can safely by closed before invoking these methods.

--- a/.changeset/ripe-poems-act.md
+++ b/.changeset/ripe-poems-act.md
@@ -1,0 +1,18 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": breaking
+---
+TreeBranch operations throw when called during transactions
+
+This breaking change only affects the behavior of `TreeBranch` methods (currently released as beta).
+* Invoking `TreeBranch.fork()` now throws an error if a transaction is ongoing on the branch.
+* Invoking `TreeBranch.merge(sourceBranch)` now throws an error if a transaction is ongoing on the source branch.
+  As before, it also throws an error if a transaction is ongoing on the target (i.e., `this`) branch.
+* Invoking `TreeBranch.rebaseOnto(targetBranch)` now throws an error if a transaction is ongoing on the target branch.
+  As before, it also throws an error if a transaction is ongoing on the source (i.e., `this`) branch.
+
+These new restrictions insulate branches and their dependents from experiencing incomplete transactions changes.
+This is important because incomplete transactions changes may not uphold application invariants.
+
+In scenarios that experience the new errors, application authors should consider whether the ongoing transaction can safely by closed before invoking these methods.

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -927,8 +927,10 @@ export class TreeCheckout implements ITreeCheckoutFork {
 				"Views cannot be merged into a view while it has a pending transaction.",
 			);
 		}
-		while (checkout.transaction.isInProgress()) {
-			checkout.transaction.commit();
+		if (checkout.transaction.isInProgress()) {
+			throw new UsageError(
+				"Views with an open transaction cannot be merged into another view.",
+			);
 		}
 		this.#transaction.activeBranch.merge(checkout.#transaction.activeBranch);
 		if (disposeMerged && !checkout.isSharedBranch) {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -825,6 +825,11 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.checkNotDisposed(
 			"The parent branch has already been disposed and can no longer create new branches.",
 		);
+		// Branching after an unfinished transaction would expose the application to a state where its invariants may be violated.
+		if (this.transaction.isInProgress()) {
+			throw new UsageError("A view cannot be forked while it has a pending transaction.");
+		}
+
 		this.editLock.checkUnlocked("Branching");
 		const anchors = new AnchorSet();
 		const branch = this.#transaction.activeBranch.fork();
@@ -882,10 +887,16 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			"The source of the branch rebase has been disposed and cannot be rebased.",
 		);
 		this.editLock.checkUnlocked("Rebasing");
-		assert(
-			!checkout.transaction.isInProgress(),
-			0x9af /* A view cannot be rebased while it has a pending transaction */,
-		);
+
+		if (this.transaction.isInProgress()) {
+			throw new UsageError(
+				"Views cannot be rebased onto a view that has a pending transaction.",
+			);
+		}
+		if (checkout.transaction.isInProgress()) {
+			throw new UsageError("A view cannot be rebased while it has a pending transaction.");
+		}
+
 		assert(
 			!checkout.isSharedBranch,
 			0xa5d /* Shared branches cannot be rebased onto another branch. */,
@@ -911,10 +922,11 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			"The source of the branch merge has been disposed and cannot be merged.",
 		);
 		this.editLock.checkUnlocked("Merging");
-		assert(
-			!this.transaction.isInProgress(),
-			0x9b0 /* Views cannot be merged into a view while it has a pending transaction */,
-		);
+		if (this.transaction.isInProgress()) {
+			throw new UsageError(
+				"Views cannot be merged into a view while it has a pending transaction.",
+			);
+		}
 		while (checkout.transaction.isInProgress()) {
 			checkout.transaction.commit();
 		}


### PR DESCRIPTION
These new restrictions insulate branches and their dependents from experiencing incomplete transaction changes.
This is important because incomplete transaction changes may not uphold application invariants.

## Breaking Changes

This breaking change only affects the behavior of `TreeBranch` methods (currently released as beta). These changes will be released in the next release (2.80) which allows breaking changes to beta APIs.
* Invoking `TreeBranch.fork()` now throws an error if a transaction is ongoing on the branch.
* Invoking `TreeBranch.merge(sourceBranch)` now throws an error if a transaction is ongoing on the source branch.
* Invoking `TreeBranch.rebaseOnto(targetBranch)` now throws an error if a transaction is ongoing on the target branch.
