### PR TITLE
Added validation that clientSequenceNumbers are always increasing when receiving ops

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -148,20 +148,6 @@ function logIfFalse(
 }
 
 /**
- * Properties of a message that are safe to log for debugging purposes.
- */
-type SafeMessageProperties = Pick<
-	ISequencedDocumentMessage,
-	| "type"
-	| "clientId"
-	| "sequenceNumber"
-	| "clientSequenceNumber"
-	| "referenceSequenceNumber"
-	| "minimumSequenceNumber"
-	| "timestamp"
->;
-
-/**
  * Manages the flow of both inbound and outbound messages. This class ensures that shared objects receive delta
  * messages in order regardless of possible network conditions or timings causing out of order delivery.
  */
@@ -208,7 +194,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	 * Map of clientId to the last observed message from that client. This is used to validate
 	 * that clientSequenceNumbers are always increasing for a given clientId.
 	 */
-	private readonly lastObservedMessageByClient = new Map<string, SafeMessageProperties>();
+	private readonly lastObservedMessageByClient = new Map<string, ISequencedDocumentMessage>();
 
 	/**
 	 * Count the number of noops sent by the client which may not be acked
@@ -881,7 +867,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	// reuse.
 	// Also payload goes to telemetry, so no content or anything else that shouldn't be logged for privacy reasons
 	// Note: It's possible for a duplicate op to be broadcasted and have everything the same except the timestamp.
-	private comparableMessagePayload(m: SafeMessageProperties): string {
+	private comparableMessagePayload(m: ISequencedDocumentMessage): string {
 		return `${m.clientId}-${m.type}-${m.sequenceNumber}-${m.minimumSequenceNumber}-${m.referenceSequenceNumber}-${m.timestamp}`;
 	}
 

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -341,7 +341,7 @@ describe("Loader", () => {
 
 					// TS 5.1.6: Workaround 'TS2339: Property 'readonly' does not exist on type 'never'.'
 					//
-					//           After observering that 'forceReadonly' has been asserted to be both true and
+					//           After observing that 'forceReadonly' has been asserted to be both true and
 					//           false, TypeScript coerces 'connectionManager' to 'never'.  Wrapping the
 					//           assertion in lambda avoids this.
 					const assertReadonlyIs = (expected: boolean): void => {
@@ -453,7 +453,7 @@ describe("Loader", () => {
 					assert(expectedError !== undefined, "Expected error to be raised");
 					assert.match(
 						expectedError.message,
-						/Found two messages with the same clientSequenceNumber/,
+						/Found two messages with non-contiguous clientSequenceNumber/,
 					);
 				});
 
@@ -484,7 +484,7 @@ describe("Loader", () => {
 					assert(expectedError !== undefined, "Expected error to be raised");
 					assert.match(
 						expectedError.message,
-						/Found two messages with the same clientSequenceNumber/,
+						/Found two messages with non-contiguous clientSequenceNumber/,
 					);
 				});
 
@@ -603,7 +603,7 @@ describe("Loader", () => {
 					assert(expectedError !== undefined, "Expected error to be raised");
 					assert.match(
 						expectedError.message,
-						/Found two messages with the same clientSequenceNumber/,
+						/Found two messages with non-contiguous clientSequenceNumber/,
 					);
 				});
 
@@ -633,7 +633,7 @@ describe("Loader", () => {
 					assert(expectedError !== undefined, "Expected error to be raised");
 					assert.match(
 						expectedError.message,
-						/Found two messages with the same clientSequenceNumber/,
+						/Found two messages with non-contiguous clientSequenceNumber/,
 					);
 				});
 
@@ -666,7 +666,7 @@ describe("Loader", () => {
 					assert(expectedError !== undefined, "Expected error to be raised");
 					assert.match(
 						expectedError.message,
-						/Found two messages with the same clientSequenceNumber/,
+						/Found two messages with non-contiguous clientSequenceNumber/,
 					);
 				});
 			});


### PR DESCRIPTION
Added validation that the clientSequenceNumbers for a given client are always increasing. Currently, if the clientSequenceNumber for a client is repeated (say, the same op is sequenced twice by the service), it doesn't fail when the op is received in delta manager. It instead fails later when the op is processed for consumption. For exampls, we have been seeing failures with assert 0x645 which is thrown by id compressor when it sees these duplicate ops.

With this validation, these failures should be deteced as soon as the op is received by the delta manager with a much clear data corruption error because the document is corrupted in these scenarios.

[AB#53297](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/53297)