### PR TITLE
build: Revert type-fest removal from "build(client): upgrade some dev deps (#26016)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"rimraf": "^6.1.2",
 		"run-script-os": "^1.1.6",
 		"syncpack": "^13.0.4",
+		"type-fest": "^2.19.0",
 		"typescript": "~5.4.5"
 	},
 	"packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       syncpack:
         specifier: ^13.0.4
         version: 13.0.4(typescript@5.4.5)
+      type-fest:
+        specifier: ^2.19.0
+        version: 2.19.0
       typescript:
         specifier: ~5.4.5
         version: 5.4.5


### PR DESCRIPTION
This slightly reverts commit 7d88924a553ec32a331b2812c0581cf8bfa0857c by restoring client root dev dependency on `type-fest` that is required by imports of `@fluidframework/build-tools` but is not declared as a regular dependency.