### PR TITLE
fix(directory): Add path to clear event

### DIFF
--- a/.changeset/wacky-results-prove.md
+++ b/.changeset/wacky-results-prove.md
@@ -1,0 +1,25 @@
+---
+"fluid-framework": minor
+"@fluidframework/map": minor
+"__section": breaking
+---
+
+## directory: Path parameter added to clear event
+
+The `clear` event for SharedDirectory now includes a `path` parameter indicating which directory was cleared.
+
+**Before:**
+```typescript
+sharedDirectory.on("clear", (local, target) => {
+    // No way to know which subdirectory was cleared
+});
+```
+
+**After:**
+```typescript
+sharedDirectory.on("clear", (path, local, target) => {
+    // path tells you which directory was cleared (e.g., "/", "/subdir1", "/subdir2")
+});
+```
+
+This change provides better observability by allowing listeners to distinguish between clear operations on different subdirectories within the SharedDirectory hierarchy.

--- a/packages/dds/map/api-report/map.legacy.beta.api.md
+++ b/packages/dds/map/api-report/map.legacy.beta.api.md
@@ -78,7 +78,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -155,11 +155,16 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 	 *
 	 * @remarks Listener parameters:
 	 *
+	 * - `path` - The absolute path to the directory that was cleared.
+	 *
 	 * - `local` - Whether the clear originated from this client.
 	 *
 	 * - `target` - The {@link ISharedDirectory} itself.
 	 */
-	(event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void);
+	(
+		event: "clear",
+		listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void,
+	);
 
 	/**
 	 * Emitted when a subdirectory is created.

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -800,7 +800,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }


### PR DESCRIPTION
This PR adds a `path` parameter to the `clear` event in SharedDirectory. It addresses a limitation where listeners couldn't determine which subdirectory was cleared. 

[ADO#54326](https://dev.azure.com/fluidframework/internal/_workitems/edit/54326)