### PR TITLE
build(client): fix api entrypoint task dependencies

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -49,7 +49,7 @@ module.exports = {
 			script: false,
 		},
 		"compile": {
-			dependsOn: ["commonjs", "build:esnext", "build:test", "build:copy"],
+			dependsOn: ["commonjs", "build:esnext", "^api", "build:test", "build:copy"],
 			script: false,
 		},
 		"commonjs": {
@@ -78,9 +78,9 @@ module.exports = {
 		// Generic build:test script should be replaced by :esm or :cjs specific versions.
 		// "tsc" would be nice to eliminate from here, but plenty of packages still focus
 		// on CommonJS.
-		"build:test": ["typetests:gen", "tsc"],
-		"build:test:cjs": ["typetests:gen", "tsc"],
-		"build:test:esm": ["typetests:gen", "build:esnext"],
+		"build:test": ["typetests:gen", "tsc", "api-extractor:commonjs", "api-extractor:esnext"],
+		"build:test:cjs": ["typetests:gen", "tsc", "api-extractor:commonjs"],
+		"build:test:esm": ["typetests:gen", "build:esnext", "api-extractor:esnext"],
 		"api": {
 			dependsOn: ["api-extractor:commonjs", "api-extractor:esnext"],
 			script: false,


### PR DESCRIPTION
This partially reverts "build: streamline by removing unneeded build deps (#25733)" (commit ee07c7525607eb4cd61fb279ec23a58f6da1dc7c).

It lets "compile" task only depend on ancestor "api" and preserves the commented out line removal.

To make the build more efficient, API entrypoint generation should be made distinct from api-extractor reports.