### PR TITLE
fix(client-presence): correct Attendee status

### DIFF
--- a/.changeset/vast-corners-share.md
+++ b/.changeset/vast-corners-share.md
@@ -2,7 +2,7 @@
 "@fluidframework/presence": minor
 "__section": fix
 ---
-Attendee status fixes
+Attendee status fixes on reconnect
 
 Fix "Connected" status for Attendees when local client reconnects (intermittent connection or transition from read-only to read-write connection).
 This includes no longer emitting incorrect "attendeeDisconnected" events.

--- a/.changeset/vast-corners-share.md
+++ b/.changeset/vast-corners-share.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/presence": minor
+"__section": fix
+---
+Attendee status fixes
+
+Fix "Connected" status for Attendees when local client reconnects (intermittent connection or transition from read-only to read-write connection).
+This includes no longer emitting incorrect "attendeeDisconnected" events.

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IAudience } from "@fluidframework/container-definitions";
 import type { InboundExtensionMessage } from "@fluidframework/container-runtime-definitions/internal";
 import type { IEmitter } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
@@ -108,7 +107,10 @@ export function isValueDirectory<T>(
  * High-level contract for manager of singleton Presence datastore
  */
 export interface PresenceDatastoreManager {
-	joinSession(clientId: ClientConnectionId): void;
+	joinSession(
+		clientId: ClientConnectionId,
+		alternateProvider: ClientConnectionId | undefined,
+	): void;
 	onDisconnected(): void;
 	getWorkspace<TSchema extends StatesWorkspaceSchema>(
 		internalWorkspaceAddress: `s:${WorkspaceAddress}`,
@@ -120,7 +122,7 @@ export interface PresenceDatastoreManager {
 		requestedContent: TSchema,
 	): NotificationsWorkspace<TSchema>;
 	processSignal(
-		message: InboundExtensionMessage<SignalMessages>,
+		message: InboundExtensionMessage<SignalMessages> & { clientId: ClientConnectionId },
 		local: boolean,
 		optional: boolean,
 	): void;
@@ -195,13 +197,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	private readonly targetedSignalSupport: boolean;
 
 	/**
-	 * When defined, this client is not recognized in the session.
-	 * Call when no longer caring about that condition. That way listeners are
-	 * cleaned up.
-	 */
-	private stopWaitingForSelfInAudience: undefined | (() => void);
-
-	/**
 	 * Tracks whether this client has complete snapshot level knowledge and
 	 * how that determination was reached.
 	 * - "alone": no other audience members detected at join
@@ -256,7 +251,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	}
 
 	private getAudienceInformation(selfClientId: ClientConnectionId): {
-		audience: IAudience;
 		selfPresent: boolean;
 		interactiveMembersExcludingSelf: {
 			all: Set<ClientConnectionId>;
@@ -282,7 +276,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			}
 		}
 		return {
-			audience,
 			selfPresent,
 			interactiveMembersExcludingSelf: {
 				all,
@@ -303,7 +296,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		// Lack of anyone likely means that this client is very freshly joined
 		// and has not received any Join Signals (type="join") from the service
 		// yet.
-		const { audience, selfPresent, interactiveMembersExcludingSelf } =
+		const { selfPresent, interactiveMembersExcludingSelf } =
 			this.getAudienceInformation(selfClientId);
 
 		if (selfPresent) {
@@ -320,13 +313,12 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			}
 		} else {
 			// When self is not represented, audience is an unreliable state,
-			// especially during a reconnect. Without an alternateProvider,
-			// defer join and judgement on complete snapshot until at least
-			// self is known to be present.
-			if (alternateProvider === undefined) {
-				this.listenForSelfInAudience(selfClientId, audience);
-				return;
-			}
+			// especially during a reconnect. An alternateProvider is expected
+			// to have been provided for this call to be useful (efficient).
+			assert(
+				alternateProvider !== undefined,
+				"Self is not in audience and no alternateProvider given",
+			);
 		}
 
 		// Broadcast join message to all clients
@@ -366,52 +358,8 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		});
 	}
 
-	private listenForSelfInAudience(selfClientId: string, audience: IAudience): void {
-		this.logger?.sendTelemetryEvent({
-			eventName: "JoinDeferred",
-			details: {
-				attendeeId: this.attendeeId,
-				connectionId: selfClientId,
-			},
-		});
-		// Prepare to join once self audience member joins.
-		// Alternatively, processSignal may force a join when a presence
-		// signal is received even without audience members (assumes
-		// audience signals were lost).
-		const joinWhenSelfAudienceMemberAdded = (addedClientId: ClientConnectionId): void => {
-			if (addedClientId !== selfClientId) {
-				// Keep listening
-				return;
-			}
-
-			// No need to force here by providing alternate provider as self is
-			// now present.
-			// Do avoid forcing so that reasonForCompleteSnapshot is set correctly
-			// if no others have been added.
-			this.stopWaitingAndJoin(selfClientId, /* alternateProvider */ undefined);
-		};
-		audience.on("addMember", joinWhenSelfAudienceMemberAdded);
-		this.stopWaitingForSelfInAudience = () => {
-			audience.off("addMember", joinWhenSelfAudienceMemberAdded);
-		};
-	}
-
-	private stopWaitingAndJoin(
-		selfClientId: ClientConnectionId,
-		alternateProvider: ClientConnectionId | undefined,
-	): void {
-		this.stopWaitingForSelfInAudience?.();
-		this.stopWaitingForSelfInAudience = undefined;
-		// Confirm not currently disconnected
-		if (this.runtime.getJoinedStatus() !== "disconnected") {
-			this.joinSession(selfClientId, alternateProvider);
-		}
-	}
-
 	public onDisconnected(): void {
 		delete this.reasonForCompleteSnapshot;
-		this.stopWaitingForSelfInAudience?.();
-		this.stopWaitingForSelfInAudience = undefined;
 	}
 
 	public getWorkspace<TSchema extends StatesWorkspaceSchema>(
@@ -693,7 +641,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	}
 
 	public processSignal(
-		message: InboundExtensionMessage<SignalMessages>,
+		message: InboundExtensionMessage<SignalMessages> & { clientId: ClientConnectionId },
 		local: boolean,
 		optional: boolean,
 	): void {
@@ -717,21 +665,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			return;
 		}
 
-		const selfClientId = this.runtime.getClientId();
-		assert(selfClientId !== undefined, "Received signal without clientId");
-
-		// Check for undesired case of receiving a remote presence signal
-		// without having been alerted to self audience join. (Perhaps join
-		// signal was dropped.)
-		// In practice it is commonly observed that local signals can be
-		// returned ahead of audience join notification. So, it is reasonable
-		// to expect that audience join notification may be delayed until after
-		// other presence signals are received. One is enough to get things
-		// rolling.
-		if (this.stopWaitingForSelfInAudience !== undefined) {
-			this.stopWaitingAndJoin(selfClientId, /* alternateProvider */ message.clientId);
-		}
-
 		const timeModifier =
 			received -
 			(this.averageLatency + message.content.avgLatency + message.content.sendTimestamp);
@@ -751,6 +684,9 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			// Update join response requests that are now satisfied.
 			const joinResponseFor = message.content.joinResponseFor;
 			if (joinResponseFor) {
+				const selfClientId = this.runtime.getClientId();
+				assert(selfClientId !== undefined, "Received signal without clientId");
+
 				let justGainedCompleteSnapshot = false;
 				if (joinResponseFor.includes(selfClientId)) {
 					if (this.reasonForCompleteSnapshot) {

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -306,8 +306,8 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		const { audience, selfPresent, interactiveMembersExcludingSelf } =
 			this.getAudienceInformation(selfClientId);
 
-		if (interactiveMembersExcludingSelf.all.size === 0 && alternateProvider !== undefined) {
-			if (selfPresent) {
+		if (selfPresent) {
+			if (interactiveMembersExcludingSelf.all.size === 0) {
 				// If there aren't any members connected except self, then this client
 				// must have complete information.
 				this.reasonForCompleteSnapshot = "alone";
@@ -317,9 +317,13 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 				// has complete information, but the other(s) should respond to
 				// ClientJoin soon rectifying that and covering for bad incomplete
 				// responses this client sent in the meantime.
-			} else {
-				// No one is known. Not even self. Defer judgement on
-				// complete snapshot until at least self is known to be present.
+			}
+		} else {
+			// When self is not represented, audience is an unreliable state,
+			// especially during a reconnect. Without an alternateProvider,
+			// defer join and judgement on complete snapshot until at least
+			// self is known to be present.
+			if (alternateProvider === undefined) {
 				this.listenForSelfInAudience(selfClientId, audience);
 				return;
 			}

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -646,7 +646,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		optional: boolean,
 	): void {
 		const received = Date.now();
-		assert(message.clientId !== null, 0xa3a /* Map received signal without clientId */);
 		if (!isPresenceMessage(message)) {
 			assert(optional, "Unrecognized message type in critical message");
 			return;

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -37,16 +37,15 @@ export interface SystemWorkspaceDatastore {
 }
 
 class SessionClient implements Attendee {
-	/**
-	 * Order is used to track the most recent client connection
-	 * during a session.
-	 */
-	public order: number = 0;
-
 	private connectionStatus: AttendeeStatus = AttendeeStatus.Disconnected;
 
 	public constructor(
 		public readonly attendeeId: AttendeeId,
+		/**
+		 * Order is used to track the most recent client connection
+		 * during a session.
+		 */
+		public order: number = 0,
 		public connectionId: ClientConnectionId | undefined = undefined,
 	) {}
 
@@ -153,15 +152,13 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			revealOpaqueJson(remoteDatastore.clientToSessionId),
 		)) {
 			const attendeeId = value.value;
-			const { attendee, isJoining } = this.ensureAttendee(
+			const { attendee, isJoining } = this.ensureAttendee({
 				attendeeId,
 				clientConnectionId,
-				/* order */ value.rev,
-				// If the attendee is present in audience OR if the attendee update is from the sending remote client itself,
-				// then the attendee is considered connected.
-				/* isConnected */ senderConnectionId === clientConnectionId ||
-					audienceMembers.has(clientConnectionId),
-			);
+				order: value.rev,
+				isSender: senderConnectionId === clientConnectionId,
+				isInAudience: audienceMembers.has(clientConnectionId),
+			});
 			// If the attendee is joining the session, add them to the list of joining attendees to be announced later.
 			if (isJoining) {
 				postUpdateActions.push(() => this.events.emit("attendeeConnected", attendee));
@@ -184,6 +181,11 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			0xaad /* Local client should be 'Disconnected' before adding new connection. */,
 		);
 
+		assert(
+			this.audience.getMember(clientConnectionId) !== undefined,
+			"Local client must be in audience for presence to handle added connection.",
+		);
+
 		this.datastore.clientToSessionId[clientConnectionId] = {
 			rev: this.selfAttendee.order++,
 			timestamp: Date.now(),
@@ -191,22 +193,40 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		};
 
 		// Mark 'Connected' remote attendees connections as stale
+		// Performance note: This will visit attendees multiple times as the
+		// attendee map has attendeeIds and connectionIds entries that point to
+		// the same attendee. But the getConnectionStatus check is cheap and
+		// staleConnectionClients set will handle duplicates.
+		this.staleConnectionClients.clear();
 		for (const staleConnectionClient of this.attendees.values()) {
 			if (staleConnectionClient.getConnectionStatus() === AttendeeStatus.Connected) {
 				this.staleConnectionClients.add(staleConnectionClient);
 			}
 		}
 
-		// Update the self attendee
+		// Update the self attendee connection information, but not connection
+		// status yet. Connection status will be updated once audience confirms
+		// connection. It is only once our connection is known to audience that
+		// audience can be used to track other attendees' connection statuses
+		// and we seek to present a consistent view.
+		// In between onConnectionAdded and audience confirmation, the audience
+		// will go through a refresh that may remove all members.
 		this.selfAttendee.connectionId = clientConnectionId;
 		this.selfAttendee.setConnected();
 		this.attendees.set(clientConnectionId, this.selfAttendee);
 
 		this.staleConnectionTimer.setTimeout(() => {
+			const consideredDisconnected = [];
 			for (const client of this.staleConnectionClients) {
-				client.setDisconnected();
+				// Confirm that audience no longer has connection. It is possible
+				// but unlikely that no one mentioned the attendee in this period
+				// and that they were never disconnected.
+				if (this.audience.getMember(client.getConnectionId()) === undefined) {
+					consideredDisconnected.push(client);
+					client.setDisconnected();
+				}
 			}
-			for (const client of this.staleConnectionClients) {
+			for (const client of consideredDisconnected) {
 				this.events.emit("attendeeDisconnected", client);
 			}
 			this.staleConnectionClients.clear();
@@ -222,6 +242,13 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		// If the local connection is being removed, clear the stale connection timer
 		if (attendee === this.selfAttendee) {
 			this.staleConnectionTimer.clearTimeout();
+		} else {
+			// When self is not connected, audience may go through a refresh that
+			// removes members and adds them back. Defer any removals until self
+			// is connected implying audience is stable.
+			if (this.selfAttendee.getConnectionStatus() !== AttendeeStatus.Connected) {
+				return;
+			}
 		}
 
 		// If the last known connectionID is different from the connection ID being removed, the attendee has reconnected,
@@ -261,34 +288,61 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 	 * in the attendee map. If not present, SessionClient is created and added
 	 * to map. If present, make sure the current connection ID is updated.
 	 */
-	private ensureAttendee(
-		attendeeId: AttendeeId,
-		clientConnectionId: ClientConnectionId,
-		order: number,
-		isConnected: boolean,
-	): { attendee: SessionClient; isJoining: boolean } {
+	private ensureAttendee({
+		attendeeId,
+		clientConnectionId,
+		order,
+		isSender,
+		isInAudience,
+	}: {
+		attendeeId: AttendeeId;
+		clientConnectionId: ClientConnectionId;
+		order: number;
+		isSender: boolean;
+		isInAudience: boolean;
+	}): { attendee: SessionClient; isJoining: boolean } {
 		let attendee = this.attendees.get(attendeeId);
+		let isConnected = false;
 		let isJoining = false;
 
 		if (attendee === undefined) {
 			// New attendee. Create SessionClient and add session ID based
 			// entry to map.
-			attendee = new SessionClient(attendeeId, clientConnectionId);
+			attendee = new SessionClient(attendeeId, order, clientConnectionId);
 			this.attendees.set(attendeeId, attendee);
-			if (isConnected) {
+			// If the attendee update is from the sending remote client itself
+			// OR if the attendee is present in audience,
+			// then the attendee is considered connected. (Otherwise, leave
+			// state as disconnected - default.)
+			if (isSender || isInAudience) {
+				isConnected = true;
 				attendee.setConnected();
 				isJoining = true;
 			}
-		} else if (order > attendee.order) {
-			// The given association is newer than the one we have.
-			// Update the order and current connection ID.
-			attendee.order = order;
-			// Known attendee is joining the session if they are currently disconnected
-			if (attendee.getConnectionStatus() === AttendeeStatus.Disconnected && isConnected) {
+		} else {
+			// Known attendee is considered connected if
+			isConnected =
+				// this information is at least up to date with current knowledge
+				order >= attendee.order &&
+				// AND in the audience OR
+				(isInAudience ||
+					// not in audience, but client is the sender and has newer
+					// info. (Assume that audience is out of date and attendee
+					// is joining.)
+					(isSender && order > attendee.order));
+
+			if (order > attendee.order) {
+				// The given association is newer than the one we have.
+				// Update the order and current connection ID.
+				attendee.order = order;
+				attendee.connectionId = clientConnectionId;
+			}
+
+			// Known attendee is joining the session if they are currently disconnected.
+			if (isConnected && attendee.getConnectionStatus() === AttendeeStatus.Disconnected) {
 				attendee.setConnected();
 				isJoining = true;
 			}
-			attendee.connectionId = clientConnectionId;
 		}
 
 		if (isConnected) {

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -80,8 +80,9 @@ export interface SystemWorkspace
 	 * Must be called when the current client acquires a new connection.
 	 *
 	 * @param clientConnectionId - The new client connection ID.
+	 * @param audienceOutOfDate - When true, audience cannot be used as authoritative.
 	 */
-	onConnectionAdded(clientConnectionId: ClientConnectionId): void;
+	onConnectionAdded(clientConnectionId: ClientConnectionId, audienceOutOfDate: boolean): void;
 
 	/**
 	 * Removes the client connection ID from the system workspace.
@@ -175,62 +176,73 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		return postUpdateActions;
 	}
 
-	public onConnectionAdded(clientConnectionId: ClientConnectionId): void {
+	public onConnectionAdded(
+		clientConnectionId: ClientConnectionId,
+		audienceOutOfDate: boolean,
+	): void {
 		assert(
 			this.selfAttendee.getConnectionStatus() === AttendeeStatus.Disconnected,
 			0xaad /* Local client should be 'Disconnected' before adding new connection. */,
 		);
 
+		const selfInAudience = this.audience.getMember(clientConnectionId) !== undefined;
 		assert(
-			this.audience.getMember(clientConnectionId) !== undefined,
+			selfInAudience || audienceOutOfDate,
 			"Local client must be in audience for presence to handle added connection.",
 		);
 
-		this.datastore.clientToSessionId[clientConnectionId] = {
-			rev: this.selfAttendee.order++,
-			timestamp: Date.now(),
-			value: this.selfAttendee.attendeeId,
-		};
-
-		// Mark 'Connected' remote attendees connections as stale
-		// Performance note: This will visit attendees multiple times as the
-		// attendee map has attendeeIds and connectionIds entries that point to
-		// the same attendee. But the getConnectionStatus check is cheap and
-		// staleConnectionClients set will handle duplicates.
-		this.staleConnectionClients.clear();
-		for (const staleConnectionClient of this.attendees.values()) {
-			if (staleConnectionClient.getConnectionStatus() === AttendeeStatus.Connected) {
-				this.staleConnectionClients.add(staleConnectionClient);
-			}
+		if (!(clientConnectionId in this.datastore.clientToSessionId)) {
+			this.datastore.clientToSessionId[clientConnectionId] = {
+				rev: this.selfAttendee.order++,
+				timestamp: Date.now(),
+				value: this.selfAttendee.attendeeId,
+			};
 		}
 
 		// Update the self attendee connection information, but not connection
-		// status yet. Connection status will be updated once audience confirms
-		// connection. It is only once our connection is known to audience that
+		// status yet. Connection status is updated once self is in audience -
+		// see later. It is only once our connection is known to audience that
 		// audience can be used to track other attendees' connection statuses
-		// and we seek to present a consistent view.
-		// In between onConnectionAdded and audience confirmation, the audience
-		// will go through a refresh that may remove all members.
+		// and we seek to present a consistent view locally.
 		this.selfAttendee.connectionId = clientConnectionId;
-		this.selfAttendee.setConnected();
 		this.attendees.set(clientConnectionId, this.selfAttendee);
 
-		this.staleConnectionTimer.setTimeout(() => {
-			const consideredDisconnected = [];
-			for (const client of this.staleConnectionClients) {
-				// Confirm that audience no longer has connection. It is possible
-				// but unlikely that no one mentioned the attendee in this period
-				// and that they were never disconnected.
-				if (this.audience.getMember(client.getConnectionId()) === undefined) {
-					consideredDisconnected.push(client);
-					client.setDisconnected();
+		if (selfInAudience) {
+			// Mark 'Connected' remote attendees connections as stale
+			// Performance note: This will visit attendees multiple times as the
+			// attendee map has attendeeIds and connectionIds entries that point to
+			// the same attendee. But the getConnectionStatus check is cheap and
+			// staleConnectionClients.add will handle duplicates.
+			this.staleConnectionClients.clear();
+			for (const staleConnectionClient of this.attendees.values()) {
+				if (staleConnectionClient.getConnectionStatus() === AttendeeStatus.Connected) {
+					this.staleConnectionClients.add(staleConnectionClient);
 				}
 			}
-			for (const client of consideredDisconnected) {
-				this.events.emit("attendeeDisconnected", client);
+
+			this.staleConnectionTimer.setTimeout(this.resolveStaleConnections.bind(this), 30_000);
+
+			this.selfAttendee.setConnected();
+			// TODO: AB#56686: self-Attendee never announced as Connected - Emit this event once there are tests in place
+			// this.events.emit("attendeeConnected", this.selfAttendee);
+		}
+	}
+
+	private resolveStaleConnections(): void {
+		const consideredDisconnected = [];
+		for (const client of this.staleConnectionClients) {
+			// Confirm that audience no longer has connection. It is possible
+			// but unlikely that no one mentioned the attendee in this period
+			// and that they were never disconnected.
+			if (this.audience.getMember(client.getConnectionId()) === undefined) {
+				consideredDisconnected.push(client);
+				client.setDisconnected();
 			}
-			this.staleConnectionClients.clear();
-		}, 30_000);
+		}
+		for (const client of consideredDisconnected) {
+			this.events.emit("attendeeDisconnected", client);
+		}
+		this.staleConnectionClients.clear();
 	}
 
 	public removeClientConnectionId(clientConnectionId: ClientConnectionId): void {

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -483,7 +483,7 @@ describe("Presence", () => {
 							// Act - disconnect & reconnect local client
 							runtime.disconnect(); // Simulate local client disconnect
 							clock.tick(1000);
-							runtime.connect("client6"); // Simulate local client reconnect with new connection id
+							runtime.connect("client8", "client2"); // Simulate local client reconnect with new connection id
 
 							// Verify - attendee with stale connection should still be 'Connected' after 15 seconds
 							clock.tick(15_001);
@@ -528,7 +528,7 @@ describe("Presence", () => {
 							// Act - disconnect, reconnect for 15 second, disconnect local client again, then advance timer
 							runtime.disconnect(); // First disconnect
 							clock.tick(1000);
-							runtime.connect("client6"); // Reconnect
+							runtime.connect("client8", "client2"); // Reconnect
 							clock.tick(15_000); // Advance 15 seconds
 							runtime.disconnect(); // Disconnect again
 							clock.tick(600_000); // Advance 10 minutes
@@ -556,7 +556,7 @@ describe("Presence", () => {
 							// Act - disconnect, reconnect, process rejoin signal from known attendee after 15s, then advance timer
 							runtime.disconnect();
 							clock.tick(1000);
-							runtime.connect("client6");
+							runtime.connect("client8", "client2");
 							clock.tick(15_000);
 							processJoinSignals([rejoinAttendeeSignal]);
 							clock.tick(600_000);
@@ -584,7 +584,7 @@ describe("Presence", () => {
 							// Act - disconnect, reconnect, process datatstore update signal from known attendee before 30s delay, then advance timer
 							runtime.disconnect();
 							clock.tick(1000);
-							runtime.connect("client6");
+							runtime.connect("client8", "client2");
 							clock.tick(15_000);
 							processSignal(
 								[],
@@ -624,7 +624,7 @@ describe("Presence", () => {
 							// Act - disconnect, reconnect, remove remote client connection, then advance timer
 							runtime.disconnect();
 							clock.tick(1000);
-							runtime.connect("client6");
+							runtime.connect("client8", "client2");
 							clock.tick(15_001);
 							runtime.audience.removeMember(initialAttendeeConnectionId); // Remove remote client connection before 30s timeout
 							// Confirm that `attendeeDisconnected` is announced for when active attendee disconnects
@@ -660,13 +660,13 @@ describe("Presence", () => {
 							// Act - disconnect & reconnect local client multiple times with 15s delay
 							runtime.disconnect();
 							clock.tick(1000);
-							runtime.connect("client6");
+							runtime.connect("client8", "client2");
 
 							clock.tick(15_001);
 
 							runtime.disconnect();
 							clock.tick(1000);
-							runtime.connect("client7");
+							runtime.connect("client9", "client8");
 
 							// Verify - attendee with stale connection should still be connected after 15 seconds
 							clock.tick(15_001);

--- a/packages/runtime/container-runtime-definitions/src/containerExtension.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerExtension.ts
@@ -303,7 +303,14 @@ export type JoinedStatus =
  */
 export interface ExtensionHostEvents {
 	"disconnected": () => void;
+	/**
+	 * @privateRemarks There are no known listeners to this event. `presence`
+	 * package listens to Signal-based Audience `addMember` event for self.
+	 */
 	"joined": (props: { clientId: ClientConnectionId; canWrite: boolean }) => void;
+	/**
+	 * @privateRemarks There are no known listeners to this event.
+	 */
 	"operabilityChanged": (canWrite: boolean) => void;
 }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1829,7 +1829,9 @@ export class ContainerRuntime
 			validateSummaryHeuristicConfiguration(this.summaryConfiguration);
 		}
 
-		this.summariesDisabled = isSummariesDisabled(this.summaryConfiguration);
+		this.summariesDisabled =
+			isSummariesDisabled(this.summaryConfiguration) ||
+			this.mc.config.getBoolean("Fluid.ContainerRuntime.Test.DisableSummaries") === true;
 
 		this.maxConsecutiveReconnects =
 			this.mc.config.getNumber(maxConsecutiveReconnectsKey) ?? defaultMaxConsecutiveReconnects;

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -130,6 +130,16 @@ const getOrCreateContainer = async (params: {
 	const client = new AzureClient({
 		connection: connectionProps,
 		logger,
+		configProvider: {
+			getRawConfig: (v: string) => {
+				// At higher client counts, summarizer will get invoked, taking up resources
+				// and spewing telemetry. None of current tests need summarization, so disable it.
+				if (v === "Fluid.ContainerRuntime.Test.DisableSummaries") {
+					return true;
+				}
+				return undefined;
+			},
+		},
 	});
 	let services: AzureContainerServices;
 	if (containerId === undefined) {


### PR DESCRIPTION
according to actual Audience behavior. [AB#56268](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/56268)

Pay attention to connectivity only while self-client is a member of the [Signal-based] Audience. Attendee status can only be properly represented while self client is a member of the audience. Otherwise, audience might be in the process of refreshing.

Also fix [AB#56270](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/56270) - PresenceDatastoreManager check for alternateProvider (alternate primary join provider nomination) such that Join signal is actually deferred (improving overall Join performance) until self is known in audience.

Relocate "joined" sense to PresenceManager
- Move and simplify logic (from PresenceDatastoreManager) to handle Join timing. SystemWorkspace (that manages Attendees) should be coordinated as-well; so, keep all of the logic for when to Join in PresenceManager.
- Now self-Attendee status should reflect when Presence as a whole thinks it has joined.

Future: self-Attendee connect event "attendeeConnected" should be announced.

Add a container-runtime test option to disable Summarizer such that Presence multi-client tests are more efficient and reliable (no Summarizer needed).