### PR TITLE
fix(map): Deprecate clear event

### DIFF
--- a/.changeset/wacky-results-prove.md
+++ b/.changeset/wacky-results-prove.md
@@ -4,9 +4,9 @@
 "__section": breaking
 ---
 
-## directory: Path parameter added to `cleared` event
+directory: Path parameter added to `cleared` event
 
-The `clear` event for SharedDirectory did not include a `path` parameter indicating which directory was cleared. Therefore, the `clear` event is deprecated and will be removed in future release. Instead use the `cleared` event.
+The `clear` event for SharedDirectory did not include a `path` parameter indicating which directory was cleared. Therefore, the `clear` event is deprecated and will be removed in a future release. Instead use the `cleared` event.
 
 **Before:**
 ```typescript

--- a/.changeset/wacky-results-prove.md
+++ b/.changeset/wacky-results-prove.md
@@ -1,0 +1,25 @@
+---
+"fluid-framework": minor
+"@fluidframework/map": minor
+"__section": breaking
+---
+
+## directory: Path parameter added to clear event
+
+The `clear` event for SharedDirectory now includes a `path` parameter indicating which directory was cleared.
+
+**Before:**
+```typescript
+sharedDirectory.on("clear", (local, target) => {
+    // No way to know which subdirectory was cleared
+});
+```
+
+**After:**
+```typescript
+sharedDirectory.on("clear", (path, local, target) => {
+    // path tells you which directory was cleared (e.g., "/", "/subdir1", "/subdir2")
+});
+```
+
+This change provides better observability by allowing listeners to distinguish between clear operations on different subdirectories within the SharedDirectory hierarchy.

--- a/.changeset/wacky-results-prove.md
+++ b/.changeset/wacky-results-prove.md
@@ -4,9 +4,9 @@
 "__section": breaking
 ---
 
-## directory: Path parameter added to clear event
+## directory: Path parameter added to `cleared` event
 
-The `clear` event for SharedDirectory now includes a `path` parameter indicating which directory was cleared.
+The `clear` event for SharedDirectory did not include a `path` parameter indicating which directory was cleared. Therefore, the `clear` event is deprecated and will be removed in future release. Instead use the `cleared` event.
 
 **Before:**
 ```typescript
@@ -17,7 +17,7 @@ sharedDirectory.on("clear", (local, target) => {
 
 **After:**
 ```typescript
-sharedDirectory.on("clear", (path, local, target) => {
+sharedDirectory.on("cleared", (path, local, target) => {
     // path tells you which directory was cleared (e.g., "/", "/subdir1", "/subdir2")
 });
 ```

--- a/packages/dds/map/api-report/map.legacy.beta.api.md
+++ b/packages/dds/map/api-report/map.legacy.beta.api.md
@@ -78,7 +78,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }

--- a/packages/dds/map/api-report/map.legacy.beta.api.md
+++ b/packages/dds/map/api-report/map.legacy.beta.api.md
@@ -78,7 +78,9 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    (event: "clear", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    // @deprecated
+    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "cleared", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -40,7 +40,7 @@ import type {
 	IDirectoryEvents,
 	IDirectoryValueChanged,
 	ISharedDirectory,
-	ISharedDirectoryEventsInternal,
+	ISharedDirectoryEvents,
 	IValueChanged,
 } from "./interfaces.js";
 import type {
@@ -402,7 +402,7 @@ interface SequenceData {
  * @sealed
  */
 export class SharedDirectory
-	extends SharedObject<ISharedDirectoryEventsInternal>
+	extends SharedObject<ISharedDirectoryEvents>
 	implements ISharedDirectory
 {
 	/**
@@ -1570,7 +1570,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		if (!this.directory.isAttached()) {
 			this.sequencedStorageData.clear();
 			this.directory.emit("clear", true, this.directory);
-			this.directory.emit("clearInternal", this.absolutePath, true, this.directory);
+			this.directory.emit("cleared", this.absolutePath, true, this.directory);
 			return;
 		}
 
@@ -1582,7 +1582,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		this.pendingStorageData.push(pendingClear);
 
 		this.directory.emit("clear", true, this.directory);
-		this.directory.emit("clearInternal", this.absolutePath, true, this.directory);
+		this.directory.emit("cleared", this.absolutePath, true, this.directory);
 		const op: IDirectoryOperation = {
 			type: "clear",
 			path: this.absolutePath,
@@ -1909,7 +1909,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			// is no optimistically-applied local pending clear that would supersede this remote clear.
 			if (!this.pendingStorageData.some((entry) => entry.type === "clear")) {
 				this.directory.emit("clear", local, this.directory);
-				this.directory.emit("clearInternal", this.absolutePath, local, this.directory);
+				this.directory.emit("cleared", this.absolutePath, local, this.directory);
 			}
 
 			// For pending set operations, emit valueChanged events

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -153,6 +153,19 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 	/**
 	 * Emitted when the {@link ISharedDirectory} is cleared.
 	 *
+	 * @deprecated Use the "cleared" event instead which provides the path that was cleared.
+	 *
+	 * @remarks Listener parameters:
+	 *
+	 * - `local` - Whether the clear originated from this client.
+	 *
+	 * - `target` - The {@link ISharedDirectory} itself.
+	 */
+	(event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void);
+
+	/**
+	 * Emitted when the {@link ISharedDirectory} is cleared.
+	 *
 	 * @remarks Listener parameters:
 	 *
 	 * - `path` - The absolute path to the directory that was cleared.
@@ -162,7 +175,7 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 	 * - `target` - The {@link ISharedDirectory} itself.
 	 */
 	(
-		event: "clear",
+		event: "cleared",
 		listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void,
 	);
 
@@ -280,28 +293,6 @@ export interface IDirectoryEvents extends IEvent {
 	 * - `target` - The {@link IDirectory} itself.
 	 */
 	(event: "undisposed", listener: (target: IEventThisPlaceHolder) => void);
-}
-
-/**
- * Internal events for {@link ISharedDirectory}.
- * @internal
- */
-export interface ISharedDirectoryEventsInternal extends ISharedDirectoryEvents {
-	/**
-	 * Emitted when the {@link ISharedDirectory} is cleared.
-	 *
-	 * @remarks Listener parameters:
-	 *
-	 * - `path` - The absolute path to the directory that was cleared.
-	 *
-	 * - `local` - Whether the clear originated from this client.
-	 *
-	 * - `target` - The {@link ISharedDirectory} itself.
-	 */
-	(
-		event: "clearInternal",
-		listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void,
-	);
 }
 
 /**

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -155,11 +155,16 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 	 *
 	 * @remarks Listener parameters:
 	 *
+	 * - `path` - The absolute path to the directory that was cleared.
+	 *
 	 * - `local` - Whether the clear originated from this client.
 	 *
 	 * - `target` - The {@link ISharedDirectory} itself.
 	 */
-	(event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void);
+	(
+		event: "clear",
+		listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void,
+	);
 
 	/**
 	 * Emitted when a subdirectory is created.

--- a/packages/dds/map/src/test/directoryOracle.ts
+++ b/packages/dds/map/src/test/directoryOracle.ts
@@ -54,8 +54,7 @@ export class SharedDirectoryOracle {
 		// valueChanged fires globally on the root for ALL changes anywhere in the tree
 		// Only needs one listener on the root (includes 'path' field to indicate location)
 		this.sharedDir.on("valueChanged", this.onValueChanged);
-		// Use internal clearInternal event to track which directory was cleared
-		this.sharedDir.on("clearInternal", this.onClearInternal);
+		this.sharedDir.on("cleared", this.onCleared);
 		this.sharedDir.on("subDirectoryCreated", this.onSubDirCreated);
 		this.sharedDir.on("subDirectoryDeleted", this.onSubDirDeleted);
 
@@ -189,7 +188,7 @@ export class SharedDirectoryOracle {
 		}
 	};
 
-	private readonly onClearInternal = (path: string, local: boolean): void => {
+	private readonly onCleared = (path: string, local: boolean): void => {
 		// Clear keys; valueChanged events follow for keys with pending local operations
 		const absPath = path.startsWith("/") ? path : `/${path}`;
 		const dirNode1 = this.getDirNode(this.modelFromValueChanged, absPath);
@@ -372,7 +371,7 @@ export class SharedDirectoryOracle {
 
 	public dispose(): void {
 		this.sharedDir.off("valueChanged", this.onValueChanged);
-		this.sharedDir.off("clearInternal", this.onClearInternal);
+		this.sharedDir.off("cleared", this.onCleared);
 		this.sharedDir.off("subDirectoryCreated", this.onSubDirCreated);
 		this.sharedDir.off("subDirectoryDeleted", this.onSubDirDeleted);
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -800,7 +800,9 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    (event: "clear", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    // @deprecated
+    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "cleared", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -800,7 +800,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @beta @sealed @legacy
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }


### PR DESCRIPTION
This PR adds a new event `cleared` which includes `path` parameter in SharedDirectory. It addresses a limitation where listeners couldn't determine which subdirectory was cleared. 

As part of this the `clear` event is marked deprecated and will be removed in 2.90 or 3.0. 

[ADO#54326](https://dev.azure.com/fluidframework/internal/_workitems/edit/54326)