### PR TITLE
Enabled unicorn/enable-no-lonely global rule in packages/dds/tree

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -73,7 +73,6 @@ module.exports = {
 		"unicorn/no-array-method-this-argument": "off",
 		"unicorn/no-array-reduce": "off",
 		"unicorn/no-await-expression-member": "off",
-		"unicorn/no-lonely-if": "off",
 		"unicorn/no-negated-condition": "off",
 		"unicorn/no-new-array": "off",
 		"unicorn/no-null": "off",

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -46,7 +46,6 @@ const config: Linter.Config[] = [
 			"unicorn/no-array-method-this-argument": "off",
 			"unicorn/no-array-reduce": "off",
 			"unicorn/no-await-expression-member": "off",
-			"unicorn/no-lonely-if": "off",
 			"unicorn/no-negated-condition": "off",
 			"unicorn/no-new-array": "off",
 			"unicorn/no-null": "off",

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -424,10 +424,8 @@ export class AnchorSet implements AnchorLocator {
 	 * Does not add a ref!
 	 */
 	public find(path: UpPath): PathNode | undefined {
-		if (path instanceof PathNode) {
-			if (path.anchorSet === this) {
-				return path;
-			}
+		if (path instanceof PathNode && path.anchorSet === this) {
+			return path;
 		}
 		const parent = path.parent ?? this.root;
 		const parentPath = this.find(parent);

--- a/packages/dds/tree/src/core/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/core/tree/treeTextFormat.ts
@@ -165,15 +165,11 @@ export function genericTreeDeleteIfEmpty<T>(
 	removeMapObject: boolean,
 ): void {
 	const children = getGenericTreeFieldMap(node, false);
-	if (Object.prototype.hasOwnProperty.call(children, key)) {
-		if (children[key]?.length === 0) {
-			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-			delete children[key];
-			if (removeMapObject) {
-				if (Object.keys(children).length === 0) {
-					delete node.fields;
-				}
-			}
+	if (Object.prototype.hasOwnProperty.call(children, key) && children[key]?.length === 0) {
+		// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+		delete children[key];
+		if (removeMapObject && Object.keys(children).length === 0) {
+			delete node.fields;
 		}
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -464,13 +464,12 @@ function getSharedPrefixLength(pathA: readonly UpPath[], pathB: readonly UpPath[
 	while (sharedDepth < minDepth) {
 		const detachStep = pathA[sharedDepth] ?? oob();
 		const attachStep = pathB[sharedDepth] ?? oob();
-		if (detachStep !== attachStep) {
-			if (
-				detachStep.parentField !== attachStep.parentField ||
-				detachStep.parentIndex !== attachStep.parentIndex
-			) {
-				break;
-			}
+		if (
+			detachStep !== attachStep &&
+			(detachStep.parentField !== attachStep.parentField ||
+				detachStep.parentIndex !== attachStep.parentIndex)
+		) {
+			break;
 		}
 		sharedDepth += 1;
 	}

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -230,16 +230,15 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 	 * This path is not valid to hold onto across edits: this must be recalled for each edit.
 	 */
 	public getFieldPathForEditing(): NormalizedFieldUpPath {
-		if (!this.isFreed()) {
-			if (
-				// Only allow editing if we are the root document field...
-				(this.parent === undefined && this.anchor.fieldKey === rootFieldKey) ||
+		if (
+			!this.isFreed() &&
+			// Only allow editing if we are the root document field...
+			((this.parent === undefined && this.anchor.fieldKey === rootFieldKey) ||
 				// ...or are under a node in the document
 				(this.parent !== undefined &&
-					treeStatusFromAnchorCache(this.parent.anchorNode) === TreeStatus.InDocument)
-			) {
-				return this.getFieldPath();
-			}
+					treeStatusFromAnchorCache(this.parent.anchorNode) === TreeStatus.InDocument))
+		) {
+			return this.getFieldPath();
 		}
 
 		throw new UsageError("Editing only allowed on fields with TreeStatus.InDocument status");

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -144,10 +144,8 @@ export function allowsFieldSuperset(
 	superset: TreeFieldStoredSchema,
 	monotonicOnly: boolean = true,
 ): boolean {
-	if (!monotonicOnly) {
-		if (isNeverField(policy, originalData, original)) {
-			return true;
-		}
+	if (!monotonicOnly && isNeverField(policy, originalData, original)) {
+		return true;
 	}
 
 	if (!allowsTreeSchemaIdentifierSuperset(original.types, superset.types)) {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -365,10 +365,12 @@ export class SharedTreeKernel
 			}
 		});
 		checkout.events.on("beforeBatch", (event) => {
-			if (event.type === "append" && this.sharedObject.isAttached()) {
-				if (checkout.transaction.isInProgress()) {
-					enricher.addTransactionCommits(event.newCommits);
-				}
+			if (
+				event.type === "append" &&
+				this.sharedObject.isAttached() &&
+				checkout.transaction.isInProgress()
+			) {
+				enricher.addTransactionCommits(event.newCommits);
 			}
 		});
 	}

--- a/packages/dds/tree/src/simple-tree/api/discrepancies.ts
+++ b/packages/dds/tree/src/simple-tree/api/discrepancies.ts
@@ -462,18 +462,19 @@ function* computeObjectNodeDiscrepancies(
 		}
 
 		// If the stored schema has a field that's not in the view schema
-		if (!viewKeys.has(fieldKey)) {
-			// When the application has opted into it, we allow viewing documents which have additional
-			// optional fields in the stored schema that are not present in the view schema.
-			if (!view.allowUnknownOptionalFields || schema.kind !== FieldKinds.optional.identifier) {
-				yield {
-					identifier,
-					fieldKey,
-					mismatch: "fieldKind",
-					view: storedEmptyFieldSchema.kind,
-					stored: schema.kind,
-				} satisfies FieldKindDiscrepancy;
-			}
+		// When the application has opted into it, we allow viewing documents which have additional
+		// optional fields in the stored schema that are not present in the view schema.
+		if (
+			!viewKeys.has(fieldKey) &&
+			(!view.allowUnknownOptionalFields || schema.kind !== FieldKinds.optional.identifier)
+		) {
+			yield {
+				identifier,
+				fieldKey,
+				mismatch: "fieldKind",
+				view: storedEmptyFieldSchema.kind,
+				stored: schema.kind,
+			} satisfies FieldKindDiscrepancy;
 		}
 	}
 }

--- a/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
@@ -187,13 +187,11 @@ export function convertObjectNodeSchema(
 		copyProperty(fieldSchema.metadata, "description", output);
 		properties[key] = output;
 
-		if (fieldSchema.kind !== FieldKind.Optional) {
-			if (
-				options.requireFieldsWithDefaults ||
-				fieldSchema.props?.defaultProvider === undefined
-			) {
-				required.push(key);
-			}
+		if (
+			fieldSchema.kind !== FieldKind.Optional &&
+			(options.requireFieldsWithDefaults || fieldSchema.props?.defaultProvider === undefined)
+		) {
+			required.push(key);
 		}
 	}
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -710,10 +710,8 @@ function shallowCompatibilityTest(
 
 	// If the schema has a required key which is not present in the input object, reject it.
 	for (const [fieldKey, fieldSchema] of schema.fields) {
-		if (fieldSchema.requiresValue) {
-			if (getFieldProperty(data, fieldKey) === undefined) {
-				return CompatibilityLevel.None;
-			}
+		if (fieldSchema.requiresValue && getFieldProperty(data, fieldKey) === undefined) {
+			return CompatibilityLevel.None;
 		}
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -591,10 +591,8 @@ function testPartialOrder<T>(
 			}
 
 			for (const c of values) {
-				if (compare(a, b) && compare(b, c)) {
-					if (!compare(a, c)) {
-						transitivity.push([a, b, c]);
-					}
+				if (compare(a, b) && compare(b, c) && !compare(a, c)) {
+					transitivity.push([a, b, c]);
 				}
 			}
 		}

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -92,14 +92,12 @@ export function useSnapshotDirectory(dirPath: string = "files"): void {
 	// Basic sanity check to avoid accidentally creating snapshots outside of the blessed folder.
 	assert(normalizedDir.startsWith(snapshotsFolder));
 
-	if (regenerateSnapshots) {
-		// This whole function is run (once per call to useSnapshotDirectory) during the test discovery phase.
-		// Snapshots are generated during the test execution phase (after the discovery phase),
-		// so the removal of the directory here is not interleaved with the (re)generation of the snapshots.
-		if (existsSync(snapshotsFolder)) {
-			console.log(`removing snapshot directory: ${snapshotsFolder}`);
-			rmSync(snapshotsFolder, { recursive: true, force: true });
-		}
+	// This whole function is run (once per call to useSnapshotDirectory) during the test discovery phase.
+	// Snapshots are generated during the test execution phase (after the discovery phase),
+	// so the removal of the directory here is not interleaved with the (re)generation of the snapshots.
+	if (regenerateSnapshots && existsSync(snapshotsFolder)) {
+		console.log(`removing snapshot directory: ${snapshotsFolder}`);
+		rmSync(snapshotsFolder, { recursive: true, force: true });
 	}
 
 	before((): void => {

--- a/packages/dds/tree/src/util/breakable.ts
+++ b/packages/dds/tree/src/util/breakable.ts
@@ -221,15 +221,15 @@ export function breakingClass<Target extends abstract new (...args: any[]) => Wi
 			if (!doNotWrap.has(key)) {
 				doNotWrap.add(key);
 				const descriptor = Reflect.getOwnPropertyDescriptor(prototype, key);
-				if (descriptor !== undefined) {
-					// Method
-					if (typeof descriptor.value === "function") {
-						if (!isBreaker(descriptor.value)) {
-							// This does not affect the original class, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
-							descriptor.value = breakingMethod(descriptor.value);
-							Object.defineProperty(DecoratedBreakable.prototype, key, descriptor);
-						}
-					}
+				// Method
+				if (
+					descriptor !== undefined &&
+					typeof descriptor.value === "function" &&
+					!isBreaker(descriptor.value)
+				) {
+					// This does not affect the original class, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
+					descriptor.value = breakingMethod(descriptor.value);
+					Object.defineProperty(DecoratedBreakable.prototype, key, descriptor);
 				}
 			}
 		}


### PR DESCRIPTION
Removes the unicorn/no-lonely-if: off override from the @fluidframework/tree package and fixes the resulting errors. Combines nested if statements that are the only statement in their parent if block (without an else) into single conditions using &&. 

This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.

All fixes follow the same pattern - combining nested conditions with &&:
