### PR TITLE
fix(fluid-build): move @types/glob to dependencies

### DIFF
--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -42,6 +42,7 @@
 	"dependencies": {
 		"@fluid-tools/version-tools": "workspace:~",
 		"@manypkg/get-packages": "^2.2.2",
+		"@types/glob": "^7.2.0",
 		"async": "^3.2.6",
 		"date-fns": "^3.6.0",
 		"debug": "^4.4.3",
@@ -73,7 +74,6 @@
 		"@fluidframework/eslint-config-fluid": "^8.1.0",
 		"@types/async": "^3.2.25",
 		"@types/fs-extra": "^11.0.4",
-		"@types/glob": "^7.2.0",
 		"@types/lodash.isequal": "^4.5.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^22.19.1",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@manypkg/get-packages':
         specifier: ^2.2.2
         version: 2.2.2
+      '@types/glob':
+        specifier: ^7.2.0
+        version: 7.2.0
       async:
         specifier: ^3.2.6
         version: 3.2.6
@@ -610,9 +613,6 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
-      '@types/glob':
-        specifier: ^7.2.0
-        version: 7.2.0
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8


### PR DESCRIPTION
## Problem
The `glob.IOptions` type is exported in the public API of build-tools, so the types need to be a prod dep, not a devDep.
