### PR TITLE
enabled global rule unicorn/no-array-for-each in packages/tree

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -67,7 +67,6 @@ module.exports = {
 
 		"unicorn/consistent-function-scoping": "off",
 		"unicorn/no-array-callback-reference": "off",
-		"unicorn/no-array-for-each": "off",
 		"unicorn/no-array-method-this-argument": "off",
 		"unicorn/no-array-reduce": "off",
 		"unicorn/no-await-expression-member": "off",

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -40,7 +40,6 @@ const config: Linter.Config[] = [
 			"jsdoc/require-description": "warn",
 			"unicorn/consistent-function-scoping": "off",
 			"unicorn/no-array-callback-reference": "off",
-			"unicorn/no-array-for-each": "off",
 			"unicorn/no-array-method-this-argument": "off",
 			"unicorn/no-array-reduce": "off",
 			"unicorn/no-await-expression-member": "off",

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -64,13 +64,16 @@ export function visitDelta(
 	const rootTransfers: Delta.DetachedNodeRename[] = [];
 	const rootDestructions: Delta.DetachedNodeDestruction[] = [];
 	const refreshers: NestedMap<Major, Minor, ITreeCursorSynchronous> = new Map();
-	delta.refreshers?.forEach(({ id: { major, minor }, trees }) => {
+	for (const {
+		id: { major, minor },
+		trees,
+	} of delta.refreshers ?? []) {
 		const treeCursors = nodeCursorsFromChunk(trees);
 		for (let i = 0; i < trees.topLevelLength; i += 1) {
 			const offsettedId = minor + i;
 			setInNestedMap(refreshers, major, offsettedId, treeCursors[i]);
 		}
-	});
+	}
 	const detachConfig: PassConfig = {
 		func: detachPass,
 		latestRevision,

--- a/packages/dds/tree/src/core/tree/visitorUtils.ts
+++ b/packages/dds/tree/src/core/tree/visitorUtils.ts
@@ -78,24 +78,40 @@ export function combineVisitors(visitors: readonly CombinableVisitor[]): Combine
 	return {
 		type: "Combined",
 		visitors: allVisitors,
-		free: () => visitors.forEach((v) => v.free()),
+		free: () => {
+			for (const v of visitors) {
+				v.free();
+			}
+		},
 		create: (...args) => {
-			allVisitors.forEach((v) => v.create(...args));
-			announcedVisitors.forEach((v) => v.afterCreate(...args));
+			for (const v of allVisitors) {
+				v.create(...args);
+			}
+			for (const v of announcedVisitors) {
+				v.afterCreate(...args);
+			}
 		},
 		destroy: (...args) => {
-			announcedVisitors.forEach((v) => v.beforeDestroy(...args));
-			allVisitors.forEach((v) => v.destroy(...args));
+			for (const v of announcedVisitors) {
+				v.beforeDestroy(...args);
+			}
+			for (const v of allVisitors) {
+				v.destroy(...args);
+			}
 		},
 		attach: (source: FieldKey, count: number, destination: PlaceIndex) => {
-			announcedVisitors.forEach((v) => v.beforeAttach(source, count, destination));
-			allVisitors.forEach((v) => v.attach(source, count, destination));
-			announcedVisitors.forEach((v) =>
+			for (const v of announcedVisitors) {
+				v.beforeAttach(source, count, destination);
+			}
+			for (const v of allVisitors) {
+				v.attach(source, count, destination);
+			}
+			for (const v of announcedVisitors) {
 				v.afterAttach(source, {
 					start: destination,
 					end: destination + count,
-				}),
-			);
+				});
+			}
 		},
 		detach: (
 			source: Range,
@@ -103,16 +119,36 @@ export function combineVisitors(visitors: readonly CombinableVisitor[]): Combine
 			id: DetachedNodeId,
 			isReplaced: boolean,
 		) => {
-			announcedVisitors.forEach((v) => v.beforeDetach(source, destination, isReplaced));
-			allVisitors.forEach((v) => v.detach(source, destination, id, isReplaced));
-			announcedVisitors.forEach((v) =>
-				v.afterDetach(source.start, source.end - source.start, destination, isReplaced),
-			);
+			for (const v of announcedVisitors) {
+				v.beforeDetach(source, destination, isReplaced);
+			}
+			for (const v of allVisitors) {
+				v.detach(source, destination, id, isReplaced);
+			}
+			for (const v of announcedVisitors) {
+				v.afterDetach(source.start, source.end - source.start, destination, isReplaced);
+			}
 		},
-		enterNode: (...args) => allVisitors.forEach((v) => v.enterNode(...args)),
-		exitNode: (...args) => allVisitors.forEach((v) => v.exitNode(...args)),
-		enterField: (...args) => allVisitors.forEach((v) => v.enterField(...args)),
-		exitField: (...args) => allVisitors.forEach((v) => v.exitField(...args)),
+		enterNode: (...args) => {
+			for (const v of allVisitors) {
+				v.enterNode(...args);
+			}
+		},
+		exitNode: (...args) => {
+			for (const v of allVisitors) {
+				v.exitNode(...args);
+			}
+		},
+		enterField: (...args) => {
+			for (const v of allVisitors) {
+				v.enterField(...args);
+			}
+		},
+		exitField: (...args) => {
+			for (const v of allVisitors) {
+				v.exitField(...args);
+			}
+		},
 	};
 }
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -276,7 +276,9 @@ export class ChunkedForest implements IEditableForest {
 		};
 
 		const announcedVisitors: AnnouncedVisitor[] = [];
-		this.deltaVisitors.forEach((getVisitor) => announcedVisitors.push(getVisitor()));
+		for (const getVisitor of this.deltaVisitors) {
+			announcedVisitors.push(getVisitor());
+		}
 		const combinedVisitor = combineVisitors([forestVisitor, ...announcedVisitors]);
 		this.activeVisitor = combinedVisitor;
 		return combinedVisitor;

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -171,7 +171,9 @@ export class ForestSummarizer
 					: undefined,
 		};
 		const encoded = this.codec.encode(fieldMap, encoderContext);
-		fieldMap.forEach((value) => value.free());
+		for (const value of fieldMap.values()) {
+			value.free();
+		}
 
 		this.incrementalSummaryBuilder.completeSummary({
 			incrementalSummaryContext,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -148,9 +148,9 @@ function makeModularChangeCodec(
 		],
 	]);
 
-	fieldKinds.forEach((entry, identifier) => {
+	for (const [identifier, entry] of fieldKinds) {
 		fieldChangesetCodecs.set(identifier, getMapEntry(entry));
-	});
+	}
 
 	const getFieldChangesetCodec = (
 		fieldKind: FieldKindIdentifier,
@@ -391,7 +391,7 @@ function makeModularChangeCodec(
 		};
 
 		const map: ModularChangeset["builds"] = newTupleBTree();
-		encoded.builds.forEach((build) => {
+		for (const build of encoded.builds) {
 			// EncodedRevisionTag cannot be an array so this ensures that we can isolate the tuple
 			const revision =
 				build[1] === undefined ? context.revision : revisionTagCodec.decode(build[1], context);
@@ -404,7 +404,7 @@ function makeModularChangeCodec(
 			for (const [id, chunk] of decodedChunks) {
 				map.set([revision, id], chunk);
 			}
-		});
+		}
 
 		return map;
 	}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2082,8 +2082,12 @@ function intoDeltaImpl(
 		if (fieldChanges !== undefined && fieldChanges.length > 0) {
 			delta.set(field, fieldChanges);
 		}
-		fieldGlobal?.forEach((c) => global.push(c));
-		fieldRename?.forEach((r) => rename.push(r));
+		for (const c of fieldGlobal ?? []) {
+			global.push(c);
+		}
+		for (const r of fieldRename ?? []) {
+			rename.push(r);
+		}
 	}
 	return delta;
 }

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -308,7 +308,9 @@ export class ObjectForest implements IEditableForest, WithBreakable {
 
 		const forestVisitor = new Visitor(this);
 		const announcedVisitors: AnnouncedVisitor[] = [];
-		this.deltaVisitors.forEach((getVisitor) => announcedVisitors.push(getVisitor()));
+		for (const getVisitor of this.deltaVisitors) {
+			announcedVisitors.push(getVisitor());
+		}
 		const combinedVisitor = combineVisitors([forestVisitor, ...announcedVisitors]);
 		this.activeVisitor = combinedVisitor;
 		return combinedVisitor;

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -400,5 +400,9 @@ export function onForkTransitive<T extends { events: Listenable<{ fork(t: T): vo
 			onFork(fork);
 		}),
 	);
-	return () => offs.forEach((off) => off());
+	return () => {
+		for (const off of offs) {
+			off();
+		}
+	};
 }

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -455,7 +455,9 @@ export class SchematizingSimpleTreeView<
 			this.flexTreeContext[disposeSymbol]();
 			this.flexTreeContext = undefined;
 		}
-		this.flexTreeViewUnregisterCallbacks.forEach((unregister) => unregister());
+		for (const unregister of this.flexTreeViewUnregisterCallbacks) {
+			unregister();
+		}
 		this.flexTreeViewUnregisterCallbacks.clear();
 		anchors.slots.delete(SimpleContextSlot);
 	}
@@ -470,7 +472,9 @@ export class SchematizingSimpleTreeView<
 	public dispose(): void {
 		this.disposed = true;
 		this.disposeFlexView();
-		this.unregisterCallbacks.forEach((unregister) => unregister());
+		for (const unregister of this.unregisterCallbacks) {
+			unregister();
+		}
 		this.checkout.forest.anchors.slots.delete(ViewSlot);
 		this.currentCompatibility = undefined;
 		this.onDispose?.();

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -585,7 +585,9 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.#events.emit("afterBatch");
 		this.editLock.unlock();
 		if (event.type === "append") {
-			event.newCommits.forEach((commit) => this.validateCommit(commit));
+			for (const commit of event.newCommits) {
+				this.validateCommit(commit);
+			}
 		}
 	};
 
@@ -647,7 +649,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		// When the branch is trimmed, we can garbage collect any repair data whose latest relevant revision is one of the
 		// trimmed revisions.
 		this.withCombinedVisitor((visitor) => {
-			revisions.forEach((revision) => {
+			for (const revision of revisions) {
 				// get all the roots last created or used by the revision
 				const roots = this._removedRoots.getRootsLastTouchedByRevision(revision);
 
@@ -657,7 +659,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 				}
 
 				this._removedRoots.deleteRootsLastTouchedByRevision(revision);
-			});
+			}
 		});
 	};
 
@@ -1120,7 +1122,9 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	private validateCommit(commit: GraphCommit<SharedTreeChange>): void {
 		const validated = getOrCreate(this.#validatedCommits, commit, () => []);
 		if (validated !== true) {
-			validated.forEach((fn) => fn(commit));
+			for (const fn of validated) {
+				fn(commit);
+			}
 			this.#validatedCommits.set(commit, true);
 		}
 	}
@@ -1248,8 +1252,12 @@ function trackForksForDisposal(checkout: TreeCheckout): () => void {
 	let disposed = false;
 	return () => {
 		assert(!disposed, 0xaa9 /* Forks may only be disposed once */);
-		forks.forEach((fork) => fork.dispose());
-		onDisposeUnSubscribes.forEach((unsubscribe) => unsubscribe());
+		for (const fork of forks) {
+			fork.dispose();
+		}
+		for (const unsubscribe of onDisposeUnSubscribes) {
+			unsubscribe();
+		}
 		onForkUnSubscribe();
 		disposed = true;
 	};

--- a/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
@@ -110,9 +110,9 @@ function convertArrayNodeSchema(schema: SimpleArrayNodeSchema): JsonArrayNodeSch
 	const allowedTypesIdentifiers: ReadonlySet<string> = new Set(
 		schema.simpleAllowedTypes.keys(),
 	);
-	allowedTypesIdentifiers.forEach((type) => {
+	for (const type of allowedTypesIdentifiers) {
 		allowedTypes.push(createSchemaRef(type));
-	});
+	}
 
 	const items: JsonFieldSchema = hasSingle(allowedTypes)
 		? allowedTypes[0]
@@ -216,9 +216,9 @@ function convertRecordLikeNodeSchema(
 	const allowedTypesIdentifiers: ReadonlySet<string> = new Set(
 		schema.simpleAllowedTypes.keys(),
 	);
-	allowedTypesIdentifiers.forEach((type) => {
+	for (const type of allowedTypesIdentifiers) {
 		allowedTypes.push(createSchemaRef(type));
-	});
+	}
 
 	const output = {
 		type: "object",

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -393,7 +393,9 @@ class KernelEventBuffer implements Listenable<KernelEvents> {
 		newSource: Listenable<KernelEvents> & HasListeners<KernelEvents>,
 	): void {
 		// Unsubscribe from the old source
-		this.#disposeSourceListeners.forEach((off) => off());
+		for (const off of this.#disposeSourceListeners.values()) {
+			off();
+		}
 		this.#disposeSourceListeners.clear();
 
 		this.#eventSource = newSource;
@@ -513,7 +515,9 @@ class KernelEventBuffer implements Listenable<KernelEvents> {
 		);
 
 		this.#disposeOnFlushListener();
-		this.#disposeSourceListeners.forEach((off) => off());
+		for (const off of this.#disposeSourceListeners.values()) {
+			off();
+		}
 		this.#disposeSourceListeners.clear();
 
 		this.#childrenChangedBuffer.clear();

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -543,11 +543,11 @@ const TreeNodeWithArrayFeatures = (() => {
 	> extends TreeNodeValid<Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>> {}
 
 	// Modify TreeNodeWithArrayFeaturesUntyped to add the members from Array.prototype
-	arrayPrototypeKeys.forEach((key) => {
+	for (const key of arrayPrototypeKeys) {
 		Object.defineProperty(TreeNodeWithArrayFeaturesUntyped.prototype, key, {
 			value: Array.prototype[key],
 		});
-	});
+	}
 
 	return TreeNodeWithArrayFeaturesUntyped as unknown as typeof NodeWithArrayFeatures;
 })();

--- a/packages/dds/tree/src/test/domains/json/citm.ts
+++ b/packages/dds/tree/src/test/domains/json/citm.ts
@@ -351,7 +351,7 @@ function generateEventAndPerformance(
 	const eventSubTopicIdSet = new Set<number>();
 	if (numTopicsToInclude > 0) {
 		let processedTopicIdCount = 0;
-		eventTopicIdSet.forEach((topicId) => {
+		for (const topicId of eventTopicIdSet) {
 			const topicSubTopicIds = topicSubTopics[`${topicId}`];
 			// This reserves atleast 1 subtopicId to be added for each topic id.
 			const unprocessedTopicIds = eventTopicIdSet.size - processedTopicIdCount;
@@ -374,7 +374,7 @@ function generateEventAndPerformance(
 				eventSubTopicIdSet.add(subTopicIdToAdd);
 			}
 			processedTopicIdCount++;
-		});
+		}
 	}
 
 	// All logo strings in the original follow this pattern. and have a 48.913% chance of being null
@@ -423,7 +423,7 @@ function generateEventAndPerformance(
 		seatCategoryId: number;
 	}[] = [];
 	const availableAreaIds = Object.keys(areaNames);
-	prices.forEach((priceObject) => {
+	for (const priceObject of prices) {
 		const numAreaIdsToAdd = random.integer(1, Math.min(availableAreaIds.length, 16));
 		const areas = [];
 		for (let i = 0; i < numAreaIdsToAdd; i++) {
@@ -436,7 +436,7 @@ function generateEventAndPerformance(
 			areas,
 			seatCategoryId: priceObject.seatCategoryId,
 		});
-	});
+	}
 	const performance: Performance = {
 		eventId: event.id,
 		id: idNumberCounter,

--- a/packages/dds/tree/src/test/domains/json/twitter.ts
+++ b/packages/dds/tree/src/test/domains/json/twitter.ts
@@ -635,10 +635,10 @@ export function isJapaneseSymbolOrPunctuation(ch: string) {
  */
 export function parseSentencesIntoWords(inputSentences: string[]) {
 	const outputSentences: string[][] = [];
-	inputSentences.forEach((inputSentence) => {
+	for (const inputSentence of inputSentences) {
 		const sentenceWords: string[] = [];
 		const spaceSeparatedWords: string[] = inputSentence.split(" ");
-		spaceSeparatedWords.forEach((potentialWord) => {
+		for (const potentialWord of spaceSeparatedWords) {
 			const innerWords: string[] = [];
 			let previousChar: string | undefined;
 			let currentWord = "";
@@ -671,11 +671,13 @@ export function parseSentencesIntoWords(inputSentences: string[]) {
 			if (currentWord.length > 0) {
 				innerWords.push(currentWord);
 			}
-			innerWords.forEach((word) => sentenceWords.push(word));
-		});
+			for (const word of innerWords) {
+				sentenceWords.push(word);
+			}
+		}
 
 		outputSentences.push(sentenceWords);
-	});
+	}
 
 	return outputSentences;
 }

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -383,10 +383,10 @@ describe("chunkTree", () => {
 				idCompressor: undefined,
 			});
 			assert.equal(chunks.length, length);
-			chunks.forEach((chunk, index) => {
+			for (const [index, chunk] of chunks.entries()) {
 				assert(chunk instanceof BasicChunk);
 				assertChunkCursorEquals(chunk, [fieldData[index]]);
-			});
+			}
 		});
 
 		it("respects chunk policy for sequence chunking", () => {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
@@ -35,9 +35,9 @@ import { JsonAsTree } from "../../../jsonDomainSchema.js";
 
 // Validate a few aspects of shapes that are easier to verify here than via checking the cursor.
 function validateShape(shape: ChunkShape): void {
-	shape.positions.forEach((info, positionIndex) => {
+	for (const [positionIndex, info] of shape.positions.entries()) {
 		if (info === undefined) {
-			return;
+			continue;
 		}
 		assert.equal(
 			info.parent,
@@ -56,7 +56,7 @@ function validateShape(shape: ChunkShape): void {
 				assert.equal(element.parent, info);
 			}
 		}
-	});
+	}
 }
 
 describe("uniformChunk", () => {

--- a/packages/dds/tree/src/test/feature-libraries/indexing/treeIndex.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/indexing/treeIndex.spec.ts
@@ -162,6 +162,7 @@ describe("tree indexes", () => {
 				assertSameElements(index, expectedEntries);
 
 				const set = new Map(expectedEntries);
+				// eslint-disable-next-line unicorn/no-array-for-each -- Testing forEach API (third param is the map)
 				index.forEach((value, key, i) => {
 					assert.equal(i, index);
 					assert.deepEqual(value, set.get(key));
@@ -329,6 +330,7 @@ describe("tree indexes", () => {
 					assertSameElements(index, expectedEntries);
 
 					const set = new Map(expectedEntries);
+					// eslint-disable-next-line unicorn/no-array-for-each -- Testing forEach API (third param is the map)
 					index.forEach((value, key, i) => {
 						assert.equal(i, index);
 						assert.deepEqual(value, set.get(key));
@@ -444,6 +446,7 @@ describe("tree indexes", () => {
 
 		assert.throws(() => [...index.allEntries()]);
 		assert.throws(() => [...index.entries()]);
+		// eslint-disable-next-line unicorn/no-array-for-each -- Testing forEach API on disposed index
 		assert.throws(() => index.forEach(() => {}));
 		assert.throws(() => index.get(childId));
 		assert.throws(() => index.has(childId));

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
@@ -30,7 +30,7 @@ export function testSnapshots() {
 				const dir = path.join("sequence-field", `V${version}`);
 				useSnapshotDirectory(dir);
 				const codec = family.resolve(version);
-				marks.forEach((mark, index) => {
+				for (const [index, mark] of marks.entries()) {
 					it(`${index} - ${"type" in mark ? mark.type : "NoOp"}`, () => {
 						const changeset = [mark];
 						const encoded = codec.json.encode(changeset, {
@@ -40,7 +40,7 @@ export function testSnapshots() {
 						});
 						takeJsonSnapshot(encoded);
 					});
-				});
+				}
 			});
 		}
 	});

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldUtils.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldUtils.test.ts
@@ -27,12 +27,13 @@ export function testUtils() {
 	describe("Utils", () => {
 		describe("round-trip splitMark and tryMergeMarks", () => {
 			const marks = generatePopulatedMarks(testIdCompressor);
-			[
+			const allMarks = [
 				...marks,
 				...marks
 					.filter((mark) => !areInputCellsEmpty(mark))
 					.map((mark) => ({ ...mark, vestigialEndpoint })),
-			].forEach((mark, index) => {
+			];
+			for (const [index, mark] of allMarks.entries()) {
 				it(`${index}: ${"type" in mark ? mark.type : "NoOp"}`, () => {
 					const splitable: SF.Mark = { ...mark, count: 3 };
 					delete splitable.changes;
@@ -41,7 +42,7 @@ export function testUtils() {
 					const merged = tryMergeMarks(part1, part2);
 					assert.deepEqual(merged, splitable);
 				});
-			});
+			}
 		});
 	});
 }

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -939,7 +939,9 @@ function trackTrimmed(
 ): ReadonlySet<RevisionTag> {
 	const trimmedCommits = new Set<RevisionTag>();
 	branch.events.on("ancestryTrimmed", (trimmedRevisions) => {
-		trimmedRevisions.forEach((revision) => trimmedCommits.add(revision));
+		for (const revision of trimmedRevisions) {
+			trimmedCommits.add(revision);
+		}
 	});
 	return trimmedCommits;
 }

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -407,7 +407,7 @@ export function runUnitTestScenario(
 					bunchRefNumber,
 					"main",
 				);
-				commits.forEach((commit) => {
+				for (const commit of commits) {
 					assert(
 						commit.sessionId === bunchSessionId &&
 							commit.seqNumber === bunchSeqNumber &&
@@ -415,7 +415,7 @@ export function runUnitTestScenario(
 						"All commits must be part of the same bunch",
 					);
 					trunk.push({ intention: commit.intention, seq: commit.seqNumber });
-				});
+				}
 				summarizer.addSequencedChanges(
 					commits,
 					commits[0].sessionId,

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -2095,9 +2095,13 @@ describe("Editing", () => {
 						}
 						present[iPeer][affectedNode] = presence;
 					}
-					peers.forEach((peer) => peer.rebaseOnto(tree));
+					for (const peer of peers) {
+						peer.rebaseOnto(tree);
+					}
 					expectJsonTree([tree, ...peers], startState);
-					peerUndoStacks.forEach(({ unsubscribe }) => unsubscribe());
+					for (const { unsubscribe } of peerUndoStacks) {
+						unsubscribe();
+					}
 				});
 			}
 

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -330,9 +330,9 @@ describe("Op Size", () => {
 	};
 
 	const saveAndResetCurrentOps = () => {
-		currentTestOps.forEach((op) =>
-			getOrAddEmptyToMap(opsByBenchmarkName, currentBenchmarkName).push(op),
-		);
+		for (const op of currentTestOps) {
+			getOrAddEmptyToMap(opsByBenchmarkName, currentBenchmarkName).push(op);
+		}
 		currentTestOps.length = 0;
 	};
 
@@ -350,9 +350,9 @@ describe("Op Size", () => {
 			// Currently tests can pass when no data is collected, so throw here in that case to ensure tests don't break and start collecting no data.
 			assert(currentTestOps.length > 0);
 		}
-		currentTestOps.forEach((op) =>
-			getOrAddEmptyToMap(opsByBenchmarkName, currentBenchmarkName).push(op),
-		);
+		for (const op of currentTestOps) {
+			getOrAddEmptyToMap(opsByBenchmarkName, currentBenchmarkName).push(op);
+		}
 		currentTestOps.length = 0;
 	});
 

--- a/packages/dds/tree/src/test/simple-tree/list.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/list.spec.ts
@@ -454,37 +454,49 @@ describe("List", () => {
 				describe("every()", () => {
 					const check = test3("every");
 
-					tests.forEach(check);
+					for (const test of tests) {
+						check(test);
+					}
 				});
 
 				describe("filter()", () => {
 					const check = test3("filter");
 
-					tests.forEach(check);
+					for (const test of tests) {
+						check(test);
+					}
 				});
 
 				describe("find()", () => {
 					const check = test3("find");
 
-					tests.forEach(check);
+					for (const test of tests) {
+						check(test);
+					}
 				});
 
 				describe("findIndex()", () => {
 					const check = test3("findIndex");
 
-					tests.forEach(check);
+					for (const test of tests) {
+						check(test);
+					}
 				});
 
 				describe("forEach()", () => {
 					const check = test3("forEach");
 
-					tests.forEach(check);
+					for (const test of tests) {
+						check(test);
+					}
 				});
 
 				describe("map()", () => {
 					const check = test3("map");
 
-					tests.forEach(check);
+					for (const test of tests) {
+						check(test);
+					}
 				});
 
 				describe("reduce()", () => {
@@ -493,7 +505,9 @@ describe("List", () => {
 						return previous.concat(value, index);
 					});
 
-					[[], ["a"], ["a", "b"]].forEach((init) => check(init, []));
+					for (const init of [[], ["a"], ["a", "b"]]) {
+						check(init, []);
+					}
 				});
 
 				describe("reduceRight()", () => {
@@ -502,7 +516,9 @@ describe("List", () => {
 						return previous.concat(value, index);
 					});
 
-					[[], ["a"], ["a", "b"]].forEach((init) => check(init, []));
+					for (const init of [[], ["a"], ["a", "b"]]) {
+						check(init, []);
+					}
 				});
 			});
 
@@ -642,7 +658,9 @@ describe("List", () => {
 					test2("some", array, noInit, predicate);
 				};
 
-				[[], ["a"], ["b"], ["b", "c"], ["b", "c", "c"]].forEach(check);
+				for (const array of [[], ["a"], ["b"], ["b", "c"], ["b", "c", "c"]]) {
+					check(array);
+				}
 			});
 
 			describe("toLocaleString()", () => {
@@ -659,7 +677,9 @@ describe("List", () => {
 				// TODO: Pass explicit locale when permitted by TS lib.
 				// For now, the results should at least be consistent on the same machine.
 				// In 'en' locale, we're expecting to see a comma thousands separator.
-				[[1000, 2000, 3000]].forEach(check);
+				for (const array of [[1000, 2000, 3000]]) {
+					check(array);
+				}
 			});
 
 			describe("toString()", () => {
@@ -674,7 +694,9 @@ describe("List", () => {
 				};
 
 				// We do not expect to see a thousands separator.
-				[[1000, 2000, 3000]].forEach(check);
+				for (const array of [[1000, 2000, 3000]]) {
+					check(array);
+				}
 			});
 		});
 	});

--- a/packages/dds/tree/src/test/simple-tree/mapNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapNode.spec.ts
@@ -37,12 +37,12 @@ describeHydration(
 				class Schema extends schemaFactory.map("x", Child) {}
 				const node = init(Schema, new Map([["a", new Map()]]));
 				const log: string[] = [];
-				node.forEach((child, key) => {
+				for (const [key, child] of node) {
 					isTreeNode(child);
 					assert.equal(child, node.get("a"));
 					assert(Tree.is(child, Child));
 					log.push(key);
-				});
+				}
 				assert.deepEqual(log, ["a"]);
 			});
 
@@ -62,6 +62,7 @@ describeHydration(
 					assert.equal(child, 1);
 					assert.equal(map, node);
 				}
+				// eslint-disable-next-line unicorn/no-array-for-each -- Testing thisArg binding behavior
 				node.forEach(callback, thisArg);
 				assert.deepEqual(log, ["b"]);
 			});
@@ -153,6 +154,7 @@ describeHydration(
 		it("forEach", () => {
 			const root = init(schema, initialTree);
 			const result: [string, string][] = [];
+			// eslint-disable-next-line unicorn/no-array-for-each -- Testing forEach API (third param is the map)
 			root.map.forEach((v, k, m) => {
 				result.push([k, v]);
 				assert.equal(m, root.map);
@@ -167,6 +169,7 @@ describeHydration(
 		it("forEach (bound)", () => {
 			const root = init(schema, initialTree);
 			const result: [string, string][] = [];
+			// eslint-disable-next-line unicorn/no-array-for-each -- Testing thisArg binding behavior
 			root.map.forEach(function (this: typeof result, v, k, m) {
 				this.push([k, v]); // Accessing `result` via `this` to ensure that `thisArg` is respected
 				assert.equal(m, root.map);

--- a/packages/dds/tree/src/test/simple-tree/primitives.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/primitives.spec.ts
@@ -137,7 +137,9 @@ describe("Primitives", () => {
 
 	describe("boolean", () => {
 		const schema = schemaFactory.boolean;
-		[true, false].forEach((value) => checkExact(schema, value));
+		for (const value of [true, false]) {
+			checkExact(schema, value);
+		}
 	});
 
 	describe("number", () => {
@@ -145,7 +147,7 @@ describe("Primitives", () => {
 			const schema = schemaFactory.number;
 
 			// Test a handful of extreme values to sanity check that they round-trip as expected.
-			[
+			for (const value of [
 				-Number.MAX_VALUE,
 				Number.MIN_SAFE_INTEGER,
 				-Number.MIN_VALUE,
@@ -153,37 +155,41 @@ describe("Primitives", () => {
 				Number.MIN_VALUE,
 				Number.MAX_SAFE_INTEGER,
 				Number.MAX_VALUE,
-			].forEach((value) => checkExact(schema, value));
+			]) {
+				checkExact(schema, value);
+			}
 
 			// JSON coerces non-finite numbers to 'null'.  If 'null' violates schema,
 			// this must throw a TypeError.
-			[Number.NEGATIVE_INFINITY, Number.NaN, Number.POSITIVE_INFINITY].forEach((value) => {
+			for (const value of [Number.NEGATIVE_INFINITY, Number.NaN, Number.POSITIVE_INFINITY]) {
 				checkThrows(schema, value);
-			});
+			}
 
 			// JSON coerces -0 to 0.  This succeeds because it does not change the type.
-			[-0].forEach((value) => {
+			for (const value of [-0]) {
 				checkCoerced(schema, value);
-			});
+			}
 		});
 
 		describe("with schema [_.number, _.null]", () => {
 			// JSON coerces non-finite numbers to 'null'.  This succeeds when 'null' is
 			// permitted by schema.
 			const schema = [schemaFactory.number, schemaFactory.null] as const;
-			[Number.NEGATIVE_INFINITY, Number.NaN, Number.POSITIVE_INFINITY].forEach((value) =>
-				checkCoerced(schema, value),
-			);
+			for (const value of [Number.NEGATIVE_INFINITY, Number.NaN, Number.POSITIVE_INFINITY]) {
+				checkCoerced(schema, value);
+			}
 		});
 	});
 
 	describe("string", () => {
 		const schema = schemaFactory.string;
-		[
+		for (const value of [
 			"", // empty string
 			"!~", // printable ascii range
 			"比特币", // non-ascii range
 			"😂💁🏼‍♂️💁🏼‍💁‍♂", // surrogate pairs with glyph modifiers
-		].forEach((value) => checkExact(schema, value));
+		]) {
+			checkExact(schema, value);
+		}
 	});
 });

--- a/packages/dds/tree/src/test/testChange.spec.ts
+++ b/packages/dds/tree/src/test/testChange.spec.ts
@@ -103,7 +103,9 @@ describe("TestChange", () => {
 		change: TaggedChange<TestChange>,
 		...baseChanges: TaggedChange<TestChange>[]
 	): TestChange {
-		baseChanges.forEach((base) => deepFreeze(base));
+		for (const base of baseChanges) {
+			deepFreeze(base);
+		}
 		deepFreeze(change);
 
 		const composed = TestChange.composeList(baseChanges.map((c) => c.change));

--- a/packages/dds/tree/src/test/util/nestedMap.spec.ts
+++ b/packages/dds/tree/src/test/util/nestedMap.spec.ts
@@ -200,6 +200,7 @@ describe("NestedMap unit tests", () => {
 
 		// Enumerate and count entries
 		let entryCount = 0;
+		// eslint-disable-next-line unicorn/no-array-for-each -- Testing SizedNestedMap.forEach API
 		map.forEach(() => {
 			entryCount++;
 		});

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -501,9 +501,9 @@ export class TestTreeProviderLite {
 	public synchronizeMessages(options?: { count?: number; flush?: boolean }): void {
 		const flush = options?.flush ?? true;
 		if (flush) {
-			this.containerRuntimeMap.forEach((containerRuntime) => {
+			for (const containerRuntime of this.containerRuntimeMap.values()) {
 				containerRuntime.flush();
-			});
+			}
 		}
 
 		const count = options?.count;

--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -177,11 +177,11 @@ export function nestedMapToFlatList<Key1, Key2, Value>(
 	map: ReadonlyNestedMap<Key1, Key2, Value>,
 ): [Key1, Key2, Value][] {
 	const list: [Key1, Key2, Value][] = [];
-	map.forEach((innerMap, key1) => {
-		innerMap.forEach((val, key2) => {
+	for (const [key1, innerMap] of map) {
+		for (const [key2, val] of innerMap) {
 			list.push([key1, key2, val]);
-		});
-	});
+		}
+	}
 	return list;
 }
 
@@ -202,11 +202,11 @@ export function forEachInNestedMap<Key1, Key2, Value>(
 	map: ReadonlyNestedMap<Key1, Key2, Value>,
 	delegate: (value: Value, key1: Key1, key2: Key2) => void,
 ): void {
-	map.forEach((innerMap, keyFirst) => {
-		innerMap.forEach((val, keySecond) => {
+	for (const [keyFirst, innerMap] of map) {
+		for (const [keySecond, val] of innerMap) {
 			delegate(val, keyFirst, keySecond);
-		});
-	});
+		}
+	}
 }
 
 /**
@@ -221,14 +221,14 @@ export function mapNestedMap<Key1, Key2, ValueIn, ValueOut = ValueIn>(
 	delegate: (value: ValueIn, key1: Key1, key2: Key2) => ValueOut,
 ): NestedMap<Key1, Key2, ValueOut> {
 	const output = new Map<Key1, Map<Key2, ValueOut>>();
-	input.forEach((inputInnerMap, keyFirst) => {
+	for (const [keyFirst, inputInnerMap] of input) {
 		const outputInnerMap = new Map<Key2, ValueOut>();
-		inputInnerMap.forEach((val, keySecond) => {
+		for (const [keySecond, val] of inputInnerMap) {
 			const mappedValue = delegate(val, keyFirst, keySecond);
 			outputInnerMap.set(keySecond, mappedValue);
-		});
+		}
 		output.set(keyFirst, outputInnerMap);
-	});
+	}
 	return output;
 }
 


### PR DESCRIPTION
Summary

Removes the unicorn/no-array-for-each: off override from the @fluidframework/tree package and fixes the resulting errors. Refactors .forEach() calls to use for...of loops. This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.

  | Override Name             | Errors Fixed | Files Touched | Overrides Still Required |
  |---------------------------|--------------|---------------|--------------------------|
  | unicorn/no-array-for-each | 84           | 31            | 7 (inline)               |

*Files touched exclude eslint.config.mts & .eslintrc.cjs
  
Why Inline Overrides Were Needed

  7 inline eslint-disable-next-line comments were required to preserve test integrity. All overrides are in test files that verify the custom forEach API of Map-like tree nodes:

  - thisArg binding tests (2): Verify that forEach(callback, thisArg) correctly binds this inside the callback
  - Third parameter tests (3): Verify that forEach passes the collection as the third argument (forEach((v, k, map) => ...))
  - SizedNestedMap iteration (1): SizedNestedMap.forEach iterates all flattened entries while its Symbol.iterator only iterates outer map entries
  - Disposed state tests (1): Verify that forEach throws when called on a disposed collection

These tests cannot use for...of because they specifically test forEach-only features.
