### PR TITLE
Benchmark: Bump version in main to 0.53.0 ahead of the 0.52.0 release

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @fluid-tools/benchmark
 
+## 0.52.0
+
+-   Removed the production dependency on `chai`. The package now uses a minimal internal assertion utility instead.
+-   Fixed an issue where the "benchmark end" event was not emitted if an error was thrown by the runner.
+
 ## 0.51.0
 
 -   `BenchmarkTimer` (provided to `CustomBenchmark.benchmarkFnCustom`) now has a `timeBatch` utility to simplify its use in the common cases.

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.52.0",
+	"version": "0.53.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Once this merges, we'll tag and release the previous commit as 0.52.0

Will wait for #26131 before merging