### PR TITLE
improvement(eslint-config-fluid): Disable eslint rule that yields false positives

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -74,6 +74,8 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 
 - `unicorn/import-style`: Changed from `"error"` to `"off"`
 - `unicorn/consistent-destructuring`: Changed from `"error"` to `"off"`
+- `unicorn/no-array-callback-reference`: Changed from `"error"` to `"off"`
+    - Yields false positives for calls to `map` methods on non-array types.
 
 **Unicorn rules changed to warnings** (to surface occurrences without breaking builds):
 

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -2050,7 +2050,7 @@
             "error"
         ],
         "unicorn/no-array-callback-reference": [
-            "error"
+            "off"
         ],
         "unicorn/no-array-for-each": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -2169,7 +2169,7 @@
             "error"
         ],
         "unicorn/no-array-callback-reference": [
-            "error"
+            "off"
         ],
         "unicorn/no-array-for-each": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -2050,7 +2050,7 @@
             "error"
         ],
         "unicorn/no-array-callback-reference": [
-            "error"
+            "off"
         ],
         "unicorn/no-array-for-each": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -2089,7 +2089,7 @@
             "error"
         ],
         "unicorn/no-array-callback-reference": [
-            "error"
+            "off"
         ],
         "unicorn/no-array-for-each": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -2089,7 +2089,7 @@
             "error"
         ],
         "unicorn/no-array-callback-reference": [
-            "error"
+            "off"
         ],
         "unicorn/no-array-for-each": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -2046,7 +2046,7 @@
             "error"
         ],
         "unicorn/no-array-callback-reference": [
-            "error"
+            "off"
         ],
         "unicorn/no-array-for-each": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -57,6 +57,9 @@ module.exports = {
 		// False positives on non-array `push` methods.
 		"unicorn/no-array-push-push": "off",
 
+		// False positives on non-array `map` methods.
+		"unicorn/no-array-callback-reference": "off",
+
 		"unicorn/empty-brace-spaces": "off",
 
 		// Rationale: Destructuring of `Array.entries()` in order to get the index variable results in a

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -57,7 +57,7 @@ module.exports = {
 		// False positives on non-array `push` methods.
 		"unicorn/no-array-push-push": "off",
 
-		// False positives on non-array `map` methods.
+		// False positives on non-array methods.
 		"unicorn/no-array-callback-reference": "off",
 
 		"unicorn/empty-brace-spaces": "off",

--- a/examples/benchmarks/bubblebench/ot/src/proxy/tree.ts
+++ b/examples/benchmarks/bubblebench/ot/src/proxy/tree.ts
@@ -36,7 +36,7 @@ const arrayPatch = {
 			consumer(
 				item
 					.map((value, index) => json1.insertOp([...path, start + index], value))
-					// eslint-disable-next-line unicorn/no-array-reduce, unicorn/no-array-callback-reference
+					// eslint-disable-next-line unicorn/no-array-reduce
 					.reduce(json1.type.compose),
 			);
 			return target.push(...item);

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -525,7 +525,7 @@ export class SharedDirectory
 	// TODO: Use `unknown` instead (breaking change).
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public forEach(callback: (value: any, key: string, map: Map<string, any>) => void): void {
-		// eslint-disable-next-line unicorn/no-array-for-each, unicorn/no-array-callback-reference
+		// eslint-disable-next-line unicorn/no-array-for-each
 		this.root.forEach(callback);
 	}
 

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -124,7 +124,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	// TODO: Use `unknown` instead (breaking change).
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void {
-		// eslint-disable-next-line unicorn/no-array-for-each, unicorn/no-array-callback-reference
+		// eslint-disable-next-line unicorn/no-array-for-each
 		this.kernel.forEach(callbackFn);
 	}
 

--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -66,7 +66,6 @@ module.exports = {
 		"jsdoc/require-description": "warn",
 
 		"unicorn/consistent-function-scoping": "off",
-		"unicorn/no-array-callback-reference": "off",
 		"unicorn/no-array-for-each": "off",
 		"unicorn/no-array-method-this-argument": "off",
 		"unicorn/no-array-reduce": "off",

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -39,7 +39,6 @@ const config: Linter.Config[] = [
 			"jsdoc/multiline-blocks": "off",
 			"jsdoc/require-description": "warn",
 			"unicorn/consistent-function-scoping": "off",
-			"unicorn/no-array-callback-reference": "off",
 			"unicorn/no-array-for-each": "off",
 			"unicorn/no-array-method-this-argument": "off",
 			"unicorn/no-array-reduce": "off",

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -391,7 +391,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		documentId: string,
 		logger: ITelemetryLoggerExt,
 	): SocketReference {
-		// eslint-disable-next-line unicorn/no-array-callback-reference, unicorn/no-array-method-this-argument
+		// eslint-disable-next-line unicorn/no-array-method-this-argument
 		const existingSocketReference = SocketReference.find(key, logger);
 		if (existingSocketReference) {
 			return existingSocketReference;

--- a/packages/framework/tree-agent/src/test/prompt.spec.ts
+++ b/packages/framework/tree-agent/src/test/prompt.spec.ts
@@ -189,7 +189,7 @@ describe("Prompt generation", () => {
 		{
 			const view = getView(
 				sf.object("ObjectWithMap", {
-					map: sf.map(sf.string), // eslint-disable-line unicorn/no-array-callback-reference
+					map: sf.map(sf.string),
 				}),
 				{ map: {} },
 			);

--- a/packages/framework/tree-agent/src/test/schemaUtils.spec.ts
+++ b/packages/framework/tree-agent/src/test/schemaUtils.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable unicorn/no-array-callback-reference */
-
 import { strict as assert } from "node:assert";
 
 import { SchemaFactoryAlpha } from "@fluidframework/tree/alpha";
@@ -279,5 +277,3 @@ describe("findNamedSchemas", () => {
 		assert.ok(!identifiers.includes("number"));
 	});
 });
-
-/* eslint-enable unicorn/no-array-callback-reference */


### PR DESCRIPTION
Disables `unicorn/no-array-callback-reference`, which yields false positives for non-array methods with the same name as array methods.