### PR TITLE
Enabled unicorn/no-zero-fractions in packages/tree

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -74,7 +74,6 @@ module.exports = {
 		"unicorn/no-null": "off",
 		"unicorn/no-object-as-default-parameter": "off",
 		"unicorn/no-useless-fallback-in-spread": "off",
-		"unicorn/no-zero-fractions": "off",
 		"unicorn/prefer-export-from": "off",
 		"unicorn/text-encoding-identifier-case": "off",
 

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -47,7 +47,6 @@ const config: Linter.Config[] = [
 			"unicorn/no-null": "off",
 			"unicorn/no-object-as-default-parameter": "off",
 			"unicorn/no-useless-fallback-in-spread": "off",
-			"unicorn/no-zero-fractions": "off",
 			"unicorn/prefer-export-from": "off",
 			"unicorn/text-encoding-identifier-case": "off",
 		},

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -106,7 +106,7 @@ describe("Fuzz - Top-Level", () => {
 		};
 		const options: Partial<DDSFuzzSuiteOptions> = {
 			...baseOptions,
-			reconnectProbability: 0.0,
+			reconnectProbability: 0,
 			rollbackProbability: 0,
 			defaultTestCount: runsPerBatch,
 			rebaseProbability: 0.2,

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -257,7 +257,7 @@ const BENCHMARK_NODE_COUNT = 100;
 const sizes = [
 	{ percentile: 0.1, word: "small" },
 	{ percentile: 0.5, word: "medium" },
-	{ percentile: 1.0, word: "large" },
+	{ percentile: 1, word: "large" },
 ];
 
 const styles = [

--- a/packages/dds/tree/src/test/simple-tree/list.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/list.spec.ts
@@ -578,10 +578,10 @@ describe("List", () => {
 				check(["a", "b"], -2.5); // Truncated to -2 - first element
 				// Non-integer indices at and close to the valid "edges"
 				check(["a", "b"], 1.999999); // Truncated to -1 - second element
-				check(["a", "b"], 2.0); // Truncated to -2 - first element
+				check(["a", "b"], 2); // Truncated to -2 - first element
 				check(["a", "b"], 2.000001); // Truncated to -2 - first element
 				check(["a", "b"], -2.999999); // Truncated to -2 - first element
-				check(["a", "b"], -3.0); // Truncated to -3 - out of bounds
+				check(["a", "b"], -3); // Truncated to -3 - out of bounds
 				check(["a", "b"], -3.000001); // Truncated to -3 - out of bounds
 				check(["a", "b"], -3.5); // Truncated to -3 - out of bounds
 				// Extreme values


### PR DESCRIPTION
Removes the unicorn/no-zero-fractions: off override from the @fluidframework/tree package and fixes the resulting errors. Replaces number literals with zero fractions (e.g., 1.0) with their integer equivalents (e.g., 1). This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.