### PR TITLE
feat(eslint-config-fluid): Promote `@typescript-eslint/explicit-function-return-type` rule from recommended to minimal

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -84,6 +84,12 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 - `unicorn/prefer-string-replace-all`: Changed from `"off"` to `"warn"`
 - `unicorn/prefer-structured-clone`: New rule set to `"warn"`
 
+#### Rule promotions
+
+**recommended -> minimal**
+
+- `@typescript-eslint/explicit-function-return-type`
+
 ## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 
 ### eslint-plugin-eslint-comments replaced by @eslint-community/eslint-plugin-eslint-comments

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -172,6 +172,20 @@ module.exports = {
 		"@typescript-eslint/no-non-null-assertion": "error",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
 
+		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
+		// API documentation. For example, type inference might decide a function returns a concrete type
+		// instead of an interface. This has no runtime impact, but would cause compilation problems.
+		"@typescript-eslint/explicit-function-return-type": [
+			"error",
+			{
+				allowExpressions: true,
+				allowTypedFunctionExpressions: true,
+				allowHigherOrderFunctions: true,
+				allowDirectConstAssertionInArrowFunctions: true,
+				allowConciseArrowFunctionExpressionsStartingWithVoid: false,
+			},
+		],
+
 		"@typescript-eslint/no-restricted-imports": [
 			"error",
 			{
@@ -224,7 +238,6 @@ module.exports = {
 		 * Disabled because we don't require that all variable declarations be explicitly typed.
 		 */
 		"@rushstack/typedef-var": "off",
-		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/explicit-member-accessibility": "off",
 
 		"@typescript-eslint/member-ordering": "off",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -666,7 +666,14 @@
             }
         ],
         "@typescript-eslint/explicit-function-return-type": [
-            "off"
+            "error",
+            {
+                "allowExpressions": true,
+                "allowTypedFunctionExpressions": true,
+                "allowHigherOrderFunctions": true,
+                "allowDirectConstAssertionInArrowFunctions": true,
+                "allowConciseArrowFunctionExpressionsStartingWithVoid": false
+            }
         ],
         "@typescript-eslint/explicit-member-accessibility": [
             "off"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -30,20 +30,6 @@ module.exports = {
 		// This rule ensures that our Intellisense looks good by verifying the TSDoc syntax.
 		"tsdoc/syntax": "error",
 
-		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
-		// API documentation. For example, type inference might decide a function returns a concrete type
-		// instead of an interface. This has no runtime impact, but would cause compilation problems.
-		"@typescript-eslint/explicit-function-return-type": [
-			"error",
-			{
-				allowExpressions: true,
-				allowTypedFunctionExpressions: true,
-				allowHigherOrderFunctions: true,
-				allowDirectConstAssertionInArrowFunctions: true,
-				allowConciseArrowFunctionExpressionsStartingWithVoid: false,
-			},
-		],
-
 		// #region `unicorn` rule overrides
 
 		// TODO: Enable this rule and fix violations once eslint9 upgrade is done

--- a/experimental/dds/tree/.eslintrc.cjs
+++ b/experimental/dds/tree/.eslintrc.cjs
@@ -11,7 +11,7 @@ module.exports = {
 		// '@typescript-eslint/no-unused-vars': ['error', { args: 'none', varsIgnorePattern: '^_' }],
 
 		// This package is effectively deprecated. The below rules are disabled for ease of migration and will not be enabled.
-		"@typescript-eslint/explicit-function-return-type": "off",
+		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/no-shadow': 'off',
 		'no-shadow': 'off',
 		'@typescript-eslint/no-unsafe-return': 'off',

--- a/experimental/dds/tree/.eslintrc.cjs
+++ b/experimental/dds/tree/.eslintrc.cjs
@@ -10,7 +10,8 @@ module.exports = {
 		// TODO: Recover "noUnusedLocals" behavior as part of linting.  (This rule seems to be broken in the Fluid repo.)
 		// '@typescript-eslint/no-unused-vars': ['error', { args: 'none', varsIgnorePattern: '^_' }],
 
-		// Rules which could be re-enabled (by dropping these overrides, as they are enabled in base config) with some minor fixes:
+		// This package is effectively deprecated. The below rules are disabled for ease of migration and will not be enabled.
+		"@typescript-eslint/explicit-function-return-type": "off",
 		'@typescript-eslint/no-shadow': 'off',
 		'no-shadow': 'off',
 		'@typescript-eslint/no-unsafe-return': 'off',

--- a/experimental/dds/tree/eslint.config.mts
+++ b/experimental/dds/tree/eslint.config.mts
@@ -10,7 +10,6 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
-			// This package is effectively deprecated. The below rules are disabled for ease of migration and will not be enabled.
 			'@typescript-eslint/explicit-function-return-type': 'off',
 			'@typescript-eslint/no-shadow': 'off',
 			'no-shadow': 'off',

--- a/experimental/dds/tree/eslint.config.mts
+++ b/experimental/dds/tree/eslint.config.mts
@@ -10,6 +10,8 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
+			// This package is effectively deprecated. The below rules are disabled for ease of migration and will not be enabled.
+			"@typescript-eslint/explicit-function-return-type": "off",
 			'@typescript-eslint/no-shadow': 'off',
 			'no-shadow': 'off',
 			'@typescript-eslint/no-unsafe-return': 'off',

--- a/experimental/dds/tree/eslint.config.mts
+++ b/experimental/dds/tree/eslint.config.mts
@@ -11,7 +11,7 @@ const config: Linter.Config[] = [
 	{
 		rules: {
 			// This package is effectively deprecated. The below rules are disabled for ease of migration and will not be enabled.
-			"@typescript-eslint/explicit-function-return-type": "off",
+			'@typescript-eslint/explicit-function-return-type': 'off',
 			'@typescript-eslint/no-shadow': 'off',
 			'no-shadow': 'off',
 			'@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/dds/sequence/.eslintrc.cjs
+++ b/packages/dds/sequence/.eslintrc.cjs
@@ -12,9 +12,17 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// #region TODO: Fix violations and remove these rule disables
+
+		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+		"@typescript-eslint/explicit-function-return-type": "warn",
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+		"prefer-arrow-callback": "off",
+
+		// #endregion
 	},
 	settings: {
 		"import-x/extensions": [".ts", ".tsx", ".d.ts", ".js", ".jsx"],

--- a/packages/dds/sequence/eslint.config.mts
+++ b/packages/dds/sequence/eslint.config.mts
@@ -10,17 +10,11 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
-			// #region TODO: Fix violations and remove these rule disables
-
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
-
 			"@typescript-eslint/explicit-function-return-type": "warn",
 			"@typescript-eslint/no-use-before-define": "off",
 			"@typescript-eslint/strict-boolean-expressions": "off",
-
 			"prefer-arrow-callback": "off",
-
-			// #endregion
 		},
 	},
 ];

--- a/packages/dds/sequence/eslint.config.mts
+++ b/packages/dds/sequence/eslint.config.mts
@@ -10,9 +10,18 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
+
+			// #region TODO: Fix violations and remove these rule disables
+
+			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+			"@typescript-eslint/explicit-function-return-type": "warn",
 			"@typescript-eslint/no-use-before-define": "off",
 			"@typescript-eslint/strict-boolean-expressions": "off",
-			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+			"prefer-arrow-callback": "off",
+
+			// #endregion
 		},
 	},
 ];

--- a/packages/dds/sequence/eslint.config.mts
+++ b/packages/dds/sequence/eslint.config.mts
@@ -10,7 +10,6 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
-
 			// #region TODO: Fix violations and remove these rule disables
 
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",

--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -12,9 +12,16 @@ module.exports = {
 		project: ["./src/test/tsconfig.json"],
 	},
 	rules: {
-		"prefer-arrow-callback": "off",
-		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+		// #region TODO: Fix violations and remove these rule disables
+
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+		"@typescript-eslint/explicit-function-return-type": "warn",
+		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+
+		"prefer-arrow-callback": "off",
+
+		// #endregion
 
 		// This library is used in the browser, so we don't want dependencies on most node libraries.
 		"import-x/no-nodejs-modules": ["error"],

--- a/packages/test/test-end-to-end-tests/eslint.config.mts
+++ b/packages/test/test-end-to-end-tests/eslint.config.mts
@@ -10,9 +10,17 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
-			"prefer-arrow-callback": "off",
-			"@typescript-eslint/strict-boolean-expressions": "off",
+			// #region TODO: Fix violations and remove these rule disables
+
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+			"@typescript-eslint/explicit-function-return-type": "warn",
+			"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+
+			"prefer-arrow-callback": "off",
+
+			// #endregion
+
 			"import-x/no-nodejs-modules": ["error"],
 			"@typescript-eslint/no-restricted-imports": [
 				"error",

--- a/packages/test/test-end-to-end-tests/eslint.config.mts
+++ b/packages/test/test-end-to-end-tests/eslint.config.mts
@@ -10,17 +10,10 @@ const config: Linter.Config[] = [
 	...minimalDeprecated,
 	{
 		rules: {
-			// #region TODO: Fix violations and remove these rule disables
-
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
-
 			"@typescript-eslint/explicit-function-return-type": "warn",
-			"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
-
+			"@typescript-eslint/strict-boolean-expressions": "off",
 			"prefer-arrow-callback": "off",
-
-			// #endregion
-
 			"import-x/no-nodejs-modules": ["error"],
 			"@typescript-eslint/no-restricted-imports": [
 				"error",


### PR DESCRIPTION
Rule violations across most of the repo were already resolved. The remaining 3 packages with violations have been updated to temporarily disable the rule with TODOs to come back and fix.