### PR TITLE
test(odsp-client): Disable ODSP client E2E tests pending FIC-enabled tenant setup

### DIFF
--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -20,7 +20,16 @@ const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderB
 	getRawConfig: (name: string): ConfigTypes => settings[name],
 });
 
-describe("Fluid audience", () => {
+/**
+ * ODSP client E2E tests are currently disabled due to authentication failures
+ * ("The Host-provided token fetcher threw an error"). These tests require tenant
+ * configuration updates to work with FIC (Federated Identity Credentials) enabled
+ * tenants due to new security policies.
+ *
+ * Tracked by: {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/54427}
+ * Tests should be re-enabled once FIC-enabled tenant setup is complete.
+ */
+describe.skip("Fluid audience", () => {
 	const connectTimeoutMs = 10_000;
 	let client: OdspClient;
 	let schema: ContainerSchema;

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
@@ -14,7 +14,16 @@ import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";
 
-describe("Container create scenarios", () => {
+/**
+ * ODSP client E2E tests are currently disabled due to authentication failures
+ * ("The Host-provided token fetcher threw an error"). These tests require tenant
+ * configuration updates to work with FIC (Federated Identity Credentials) enabled
+ * tenants due to new security policies.
+ *
+ * Tracked by: {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/54427}
+ * Tests should be re-enabled once FIC-enabled tenant setup is complete.
+ */
+describe.skip("Container create scenarios", () => {
 	const connectTimeoutMs = 10_000;
 	let client: OdspClient;
 	let schema: ContainerSchema;

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
@@ -16,7 +16,16 @@ import { createOdspClient, getCredentials } from "./OdspClientFactory.js";
 import { CounterTestDataObject, TestDataObject } from "./TestDataObject.js";
 import { mapWait } from "./utils.js";
 
-describe("Fluid data updates", () => {
+/**
+ * ODSP client E2E tests are currently disabled due to authentication failures
+ * ("The Host-provided token fetcher threw an error"). These tests require tenant
+ * configuration updates to work with FIC (Federated Identity Credentials) enabled
+ * tenants due to new security policies.
+ *
+ * Tracked by: {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/54427}
+ * Tests should be re-enabled once FIC-enabled tenant setup is complete.
+ */
+describe.skip("Fluid data updates", () => {
 	const connectTimeoutMs = 10_000;
 	let client: OdspClient;
 	const schema = {


### PR DESCRIPTION
## Description

This change disables ODSP client E2E tests that are failing with "The Host-provided token fetcher threw an error" authentication failures. These tests require tenant configuration updates to work with FIC (Federated Identity Credentials) enabled tenants due to new security policies.

Tests will be re-enabled once FIC-enabled tenant setup is complete (ADO#54427).