### PR TITLE
fix(driver-utils): add missing return type to policies getter

### DIFF
--- a/packages/loader/driver-utils/src/test/prefetchDocumentStorageService.spec.ts
+++ b/packages/loader/driver-utils/src/test/prefetchDocumentStorageService.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "assert";
 
 import type {
 	IDocumentStorageService,
+	IDocumentStorageServicePolicies,
 	ISnapshotTree,
 } from "@fluidframework/driver-definitions/internal";
 
@@ -57,7 +58,7 @@ class MockStorageService implements Partial<IDocumentStorageService> {
 		};
 	}
 
-	public get policies() {
+	public get policies(): IDocumentStorageServicePolicies | undefined {
 		return undefined;
 	}
 }


### PR DESCRIPTION
## Summary
- Adds explicit return type to `policies` getter in test mock to satisfy `@typescript-eslint/explicit-function-return-type` rule

## Root cause
Race condition between two PRs:

| Event | Time (UTC) |
|-------|------------|
| PR #26151 created (prefetch fix) | Jan 7, 23:12 |
| PR #26149 merged (ESLint rule promotion) | Jan 8, 01:45 |
| PR #26151 merged | Jan 8, 18:38 |

PR #26151's CI ran before the ESLint rule was promoted in #26149. By the time #26151 was merged, the stricter linting rule was already in place, but CI wasn't re-run against the updated main branch.

## Test plan
- [x] ESLint passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)