### PR TITLE
feat(eslint-config-fluid): Update `jsdoc/multiline-blocks` rule to permit single-line JSDoc/TSDoc comment syntax

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -92,7 +92,7 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 
 #### Rule modifications
 
-- `jsdoc/require-description`: Updated to allow single-line comments to be expressed as a single line. E.g. `/** Single-line comment */`.
+- `jsdoc/multiline-blocks`: Updated to allow single-line comments to be expressed as a single line. E.g. `/** Single-line comment */`.
 
 ## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -90,6 +90,10 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 
 - `@typescript-eslint/explicit-function-return-type`
 
+#### Rule modifications
+
+- `jsdoc/require-description`: Updated to allow single-line comments to be expressed as a single line. E.g. `/** Single-line comment */`.
+
 ## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 
 ### eslint-plugin-eslint-comments replaced by @eslint-community/eslint-plugin-eslint-comments

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1294,10 +1294,7 @@
             "error"
         ],
         "jsdoc/multiline-blocks": [
-            "error",
-            {
-                "noSingleLineBlocks": true
-            }
+            "error"
         ],
         "jsdoc/no-bad-blocks": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -1296,10 +1296,7 @@
             "error"
         ],
         "jsdoc/multiline-blocks": [
-            "error",
-            {
-                "noSingleLineBlocks": true
-            }
+            "error"
         ],
         "jsdoc/no-bad-blocks": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1294,10 +1294,7 @@
             "error"
         ],
         "jsdoc/multiline-blocks": [
-            "error",
-            {
-                "noSingleLineBlocks": true
-            }
+            "error"
         ],
         "jsdoc/no-bad-blocks": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -1304,10 +1304,7 @@
             "error"
         ],
         "jsdoc/multiline-blocks": [
-            "error",
-            {
-                "noSingleLineBlocks": true
-            }
+            "error"
         ],
         "jsdoc/no-bad-blocks": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1304,10 +1304,7 @@
             "error"
         ],
         "jsdoc/multiline-blocks": [
-            "error",
-            {
-                "noSingleLineBlocks": true
-            }
+            "error"
         ],
         "jsdoc/no-bad-blocks": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1290,10 +1290,7 @@
             "error"
         ],
         "jsdoc/multiline-blocks": [
-            "error",
-            {
-                "noSingleLineBlocks": true
-            }
+            "error"
         ],
         "jsdoc/no-bad-blocks": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -187,9 +187,9 @@ module.exports = {
 
 		/**
 		 * Ensures all JSDoc/TSDoc comments use the multi-line format for consistency.
-		 * See <https://github.com/gajus/eslint-plugin-jsdoc#user-content-eslint-plugin-jsdoc-rules-multiline-blocks>
+		 * See {@link https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/multiline-blocks.md}
 		 */
-		"jsdoc/multiline-blocks": ["error", { noSingleLineBlocks: true }],
+		"jsdoc/multiline-blocks": ["error"],
 
 		/**
 		 * Require the description (summary) component in JSDoc/TSDoc comments

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -186,7 +186,7 @@ module.exports = {
 		// #region eslint-plugin-jsdoc rules
 
 		/**
-		 * Ensures all JSDoc/TSDoc comments use the multi-line format for consistency.
+		 * Ensures JSDoc/TSDoc comments to use the consistent formatting.
 		 * See {@link https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/multiline-blocks.md}
 		 */
 		"jsdoc/multiline-blocks": ["error"],

--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -60,8 +60,6 @@ module.exports = {
 
 		"import-x/order": "off",
 
-		"jsdoc/multiline-blocks": "off",
-
 		// Set to a warning to encourage adding docs :)
 		"jsdoc/require-description": "warn",
 

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -36,7 +36,6 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-unsafe-call": "off",
 			"@typescript-eslint/no-unsafe-member-access": "off",
 			"import-x/order": "off",
-			"jsdoc/multiline-blocks": "off",
 			"jsdoc/require-description": "warn",
 			"unicorn/consistent-function-scoping": "off",
 			"unicorn/no-array-method-this-argument": "off",


### PR DESCRIPTION
Previously, all JSDoc/TSDoc comments were required to use multi-line syntax, regardless of how many lines the comment contained. This rule has been loosened to permit single-line syntax for single-line comments.

E.g.
```typescript
/**
 * I am a single-line comment.
 */
```

May now be expressed as:
```typescript
/** I am a single-line comment. */
```

This change stems from a discussion amongst a number of devs on the team quite some time ago. The decision from that discussion never apparently made its way into our config (the rule was just disabled in the tree package).