### PR TITLE
Remove unneeded eslint config rule overrides

### DIFF
--- a/packages/dds/ink/.eslintrc.cjs
+++ b/packages/dds/ink/.eslintrc.cjs
@@ -8,17 +8,5 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
-	rules: {
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-	},
+	rules: {},
 };

--- a/packages/dds/ink/eslint.config.mts
+++ b/packages/dds/ink/eslint.config.mts
@@ -6,31 +6,6 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...recommended,
-	{
-		rules: {
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
-		},
-	},
-];
+const config: Linter.Config[] = [...recommended];
 
 export default config;

--- a/packages/dds/matrix/.eslintrc.cjs
+++ b/packages/dds/matrix/.eslintrc.cjs
@@ -10,19 +10,8 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove this override and fix violations
 		"@typescript-eslint/no-shadow": "off",
-		"space-before-function-paren": "off", // Off because it conflicts with typescript-formatter
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 	overrides: [
 		{

--- a/packages/dds/matrix/eslint.config.mts
+++ b/packages/dds/matrix/eslint.config.mts
@@ -11,26 +11,6 @@ const config: Linter.Config[] = [
 	{
 		rules: {
 			"@typescript-eslint/no-shadow": "off",
-			"space-before-function-paren": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 	{

--- a/packages/dds/shared-object-base/.eslintrc.cjs
+++ b/packages/dds/shared-object-base/.eslintrc.cjs
@@ -8,17 +8,5 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
-	rules: {
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-	},
+	rules: {},
 };

--- a/packages/dds/shared-object-base/eslint.config.mts
+++ b/packages/dds/shared-object-base/eslint.config.mts
@@ -6,31 +6,6 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...recommended,
-	{
-		rules: {
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
-		},
-	},
-];
+const config: Linter.Config[] = [...recommended];
 
 export default config;

--- a/packages/dds/shared-summary-block/.eslintrc.cjs
+++ b/packages/dds/shared-summary-block/.eslintrc.cjs
@@ -8,17 +8,5 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
-	rules: {
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-	},
+	rules: {},
 };

--- a/packages/dds/shared-summary-block/eslint.config.mts
+++ b/packages/dds/shared-summary-block/eslint.config.mts
@@ -6,31 +6,6 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...recommended,
-	{
-		rules: {
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
-		},
-	},
-];
+const config: Linter.Config[] = [...recommended];
 
 export default config;

--- a/packages/dds/test-dds-utils/.eslintrc.cjs
+++ b/packages/dds/test-dds-utils/.eslintrc.cjs
@@ -9,21 +9,11 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove this override and fix violations
 		"@typescript-eslint/strict-boolean-expressions": "off",
+
 		// This package implements test utils to be run under Node.JS.
 		"import-x/no-nodejs-modules": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 
 		"depend/ban-dependencies": [
 			"error",

--- a/packages/dds/test-dds-utils/eslint.config.mts
+++ b/packages/dds/test-dds-utils/eslint.config.mts
@@ -12,29 +12,10 @@ const config: Linter.Config[] = [
 		rules: {
 			"@typescript-eslint/strict-boolean-expressions": "off",
 			"import-x/no-nodejs-modules": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
 			"depend/ban-dependencies": [
 				"error",
 				{
 					"allowed": ["execa"],
-				},
-			],
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
 				},
 			],
 		},

--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -32,19 +32,6 @@ module.exports = {
 		// TODO: Remove this override once this config has been updated to extend the "strict" base config.
 		"@typescript-eslint/explicit-member-accessibility": "error",
 
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-
-		// #endregion
-
 		// #region TODO:AB#6983: Remove these overrides and fix violations
 
 		"@typescript-eslint/explicit-module-boundary-types": "off",

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -23,13 +23,6 @@ const config: Linter.Config[] = [
 				},
 			],
 			"@typescript-eslint/explicit-member-accessibility": "error",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
 			"@typescript-eslint/explicit-module-boundary-types": "off",
 			"@typescript-eslint/no-unsafe-argument": "off",
 			"@typescript-eslint/no-unsafe-assignment": "off",
@@ -47,18 +40,6 @@ const config: Linter.Config[] = [
 			"unicorn/no-useless-fallback-in-spread": "off",
 			"unicorn/prefer-export-from": "off",
 			"unicorn/text-encoding-identifier-case": "off",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 	{

--- a/packages/drivers/odsp-driver/.eslintrc.cjs
+++ b/packages/drivers/odsp-driver/.eslintrc.cjs
@@ -18,18 +18,6 @@ module.exports = {
 		"unicorn/text-encoding-identifier-case": "off",
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-
 		// Disabled because the rule is crashing on this package - AB#51780
 		"@typescript-eslint/unbound-method": "off",
 	},

--- a/packages/drivers/odsp-driver/eslint.config.mts
+++ b/packages/drivers/odsp-driver/eslint.config.mts
@@ -15,26 +15,7 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 			"unicorn/text-encoding-identifier-case": "off",
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
 			"@typescript-eslint/unbound-method": "off",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 	{

--- a/packages/drivers/odsp-urlResolver/.eslintrc.cjs
+++ b/packages/drivers/odsp-urlResolver/.eslintrc.cjs
@@ -9,19 +9,8 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove these overrides and fix violations
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 };

--- a/packages/drivers/odsp-urlResolver/eslint.config.mts
+++ b/packages/drivers/odsp-urlResolver/eslint.config.mts
@@ -12,25 +12,6 @@ const config: Linter.Config[] = [
 		rules: {
 			"@typescript-eslint/no-use-before-define": "off",
 			"@typescript-eslint/strict-boolean-expressions": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 ];

--- a/packages/drivers/tinylicious-driver/.eslintrc.cjs
+++ b/packages/drivers/tinylicious-driver/.eslintrc.cjs
@@ -9,18 +9,7 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove this override and fix violations
 		"@typescript-eslint/strict-boolean-expressions": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 };

--- a/packages/drivers/tinylicious-driver/eslint.config.mts
+++ b/packages/drivers/tinylicious-driver/eslint.config.mts
@@ -11,25 +11,6 @@ const config: Linter.Config[] = [
 	{
 		rules: {
 			"@typescript-eslint/strict-boolean-expressions": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 ];

--- a/packages/framework/agent-scheduler/.eslintrc.cjs
+++ b/packages/framework/agent-scheduler/.eslintrc.cjs
@@ -9,18 +9,7 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove this override and fix violations
 		"@typescript-eslint/strict-boolean-expressions": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 };

--- a/packages/framework/agent-scheduler/eslint.config.mts
+++ b/packages/framework/agent-scheduler/eslint.config.mts
@@ -11,25 +11,6 @@ const config: Linter.Config[] = [
 	{
 		rules: {
 			"@typescript-eslint/strict-boolean-expressions": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 ];

--- a/packages/framework/attributor/.eslintrc.cjs
+++ b/packages/framework/attributor/.eslintrc.cjs
@@ -8,19 +8,7 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
-	rules: {
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-	},
+	rules: {},
 	overrides: [
 		{
 			// Rules only for test files

--- a/packages/framework/attributor/eslint.config.mts
+++ b/packages/framework/attributor/eslint.config.mts
@@ -9,29 +9,6 @@ import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts"
 const config: Linter.Config[] = [
 	...recommended,
 	{
-		rules: {
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
-		},
-	},
-	{
 		files: ["*.spec.ts", "src/test/**"],
 		rules: {
 			"import-x/no-nodejs-modules": [

--- a/packages/framework/dds-interceptions/.eslintrc.cjs
+++ b/packages/framework/dds-interceptions/.eslintrc.cjs
@@ -8,17 +8,5 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
-	rules: {
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-	},
+	rules: {},
 };

--- a/packages/framework/dds-interceptions/eslint.config.mts
+++ b/packages/framework/dds-interceptions/eslint.config.mts
@@ -6,31 +6,6 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...recommended,
-	{
-		rules: {
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
-		},
-	},
-];
+const config: Linter.Config[] = [...recommended];
 
 export default config;

--- a/packages/framework/oldest-client-observer/.eslintrc.cjs
+++ b/packages/framework/oldest-client-observer/.eslintrc.cjs
@@ -8,17 +8,5 @@ module.exports = {
 	parserOptions: {
 		project: "./tsconfig.json",
 	},
-	rules: {
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
-	},
+	rules: {},
 };

--- a/packages/framework/oldest-client-observer/eslint.config.mts
+++ b/packages/framework/oldest-client-observer/eslint.config.mts
@@ -6,31 +6,6 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...recommended,
-	{
-		rules: {
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
-		},
-	},
-];
+const config: Linter.Config[] = [...recommended];
 
 export default config;

--- a/packages/framework/synthesize/.eslintrc.cjs
+++ b/packages/framework/synthesize/.eslintrc.cjs
@@ -9,19 +9,8 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove these overrides and fix violations
 		"@typescript-eslint/no-unsafe-return": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 };

--- a/packages/framework/synthesize/eslint.config.mts
+++ b/packages/framework/synthesize/eslint.config.mts
@@ -12,25 +12,6 @@ const config: Linter.Config[] = [
 		rules: {
 			"@typescript-eslint/no-unsafe-return": "off",
 			"@typescript-eslint/strict-boolean-expressions": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 ];

--- a/packages/framework/undo-redo/.eslintrc.cjs
+++ b/packages/framework/undo-redo/.eslintrc.cjs
@@ -10,20 +10,9 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove these overrides and fix violations
 		"@typescript-eslint/no-use-before-define": "off",
 		"no-case-declarations": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 	overrides: [
 		{

--- a/packages/framework/undo-redo/eslint.config.mts
+++ b/packages/framework/undo-redo/eslint.config.mts
@@ -12,25 +12,6 @@ const config: Linter.Config[] = [
 		rules: {
 			"@typescript-eslint/no-use-before-define": "off",
 			"no-case-declarations": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 	{

--- a/packages/tools/changelog-generator-wrapper/.eslintrc.cjs
+++ b/packages/tools/changelog-generator-wrapper/.eslintrc.cjs
@@ -20,17 +20,5 @@ module.exports = {
 		"@typescript-eslint/no-var-requires": "off",
 		"@typescript-eslint/explicit-function-return-type": "off",
 		"unicorn/prefer-module": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 };

--- a/packages/tools/changelog-generator-wrapper/eslint.config.mts
+++ b/packages/tools/changelog-generator-wrapper/eslint.config.mts
@@ -14,25 +14,6 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-var-requires": "off",
 			"@typescript-eslint/explicit-function-return-type": "off",
 			"unicorn/prefer-module": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 ];

--- a/packages/utils/odsp-doclib-utils/.eslintrc.cjs
+++ b/packages/utils/odsp-doclib-utils/.eslintrc.cjs
@@ -9,20 +9,9 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// TODO: remove these overrides and fix violations
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"no-case-declarations": "off",
-
-		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
-		"@typescript-eslint/consistent-type-exports": [
-			"error",
-			{ fixMixedExportsWithInlineTypeSpecifier: true },
-		],
-		"@typescript-eslint/consistent-type-imports": [
-			"error",
-			{ fixStyle: "inline-type-imports" },
-		],
-		"@typescript-eslint/no-import-type-side-effects": "error",
-		// #endregion
 	},
 };

--- a/packages/utils/odsp-doclib-utils/eslint.config.mts
+++ b/packages/utils/odsp-doclib-utils/eslint.config.mts
@@ -13,25 +13,6 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-use-before-define": "off",
 			"@typescript-eslint/strict-boolean-expressions": "off",
 			"no-case-declarations": "off",
-			"@typescript-eslint/consistent-type-imports": [
-				"error",
-				{
-					"fixStyle": "inline-type-imports",
-				},
-			],
-			"@typescript-eslint/no-import-type-side-effects": "error",
-		},
-	},
-	{
-		files: ["**/*.{ts,tsx}"],
-		ignores: ["**/src/test/**", "**/tests/**", "**/*.spec.ts", "**/*.test.ts"],
-		rules: {
-			"@typescript-eslint/consistent-type-exports": [
-				"error",
-				{
-					"fixMixedExportsWithInlineTypeSpecifier": true,
-				},
-			],
 		},
 	},
 ];


### PR DESCRIPTION
The removals include removing rules that were added first at the package level, then added to the base config (which has long since been done) and removing unneeded disables.