### PR TITLE
Add TypeFactory types to tree-agent

### DIFF
--- a/.changeset/lemon-deer-walk.md
+++ b/.changeset/lemon-deer-walk.md
@@ -1,0 +1,88 @@
+---
+"@fluidframework/tree-agent": minor
+---
+
+tree-agent: New type factory system for method and property bindings
+
+The `@fluidframework/tree-agent` package now includes a custom type system (Type Factory) as an alternative to Zod for
+defining method and property types. This new system is available in the `/alpha` entry point and provides a familiar
+API for type definitions.
+
+## Key features
+
+- **Familiar API**: Use `tf.string()`, `tf.object()`, etc. - similar to Zod's syntax (where `tf` is aliased from
+  `typeFactory`)
+- **Same API surface**: The existing `expose`, `exposeProperty`, and `buildFunc` methods work with both Zod and Type
+  Factory types
+
+## Usage
+
+Import from the alpha entry point to use Type Factory types:
+
+```typescript
+import { typeFactory as tf, buildFunc, exposeMethodsSymbol } from "@fluidframework/tree-agent/alpha";
+import { SchemaFactory } from "@fluidframework/tree";
+
+const sf = new SchemaFactory("myApp");
+
+class TodoList extends sf.object("TodoList", {
+    items: sf.array(sf.string),
+}) {
+    public addItem(item: string): void {
+        this.items.insertAtEnd(item);
+    }
+
+    public static [exposeMethodsSymbol](methods) {
+        methods.expose(
+            TodoList,
+            "addItem",
+            buildFunc({ returns: tf.void() }, ["item", tf.string()])
+        );
+    }
+}
+```
+
+## Available types
+
+All common types are supported:
+
+- **Primitives**: `tf.string()`, `tf.number()`, `tf.boolean()`, `tf.void()`, `tf.undefined()`, `tf.null()`,
+  `tf.unknown()`
+- **Collections**: `tf.array(elementType)`, `tf.object({ shape })`, `tf.map(keyType, valueType)`,
+  `tf.record(keyType, valueType)`, `tf.tuple([types])`
+- **Utilities**: `tf.union([types])`, `tf.literal(value)`, `tf.optional(type)`, `tf.readonly(type)`
+- **Schema references**: `tf.instanceOf(SchemaClass)`
+
+## Migration from Zod
+
+You can migrate gradually - both Zod and Type Factory types work in the same codebase:
+
+**Before (Zod):**
+
+```typescript
+import { z } from "zod";
+import { buildFunc, exposeMethodsSymbol } from "@fluidframework/tree-agent";
+
+methods.expose(
+    MyClass,
+    "myMethod",
+    buildFunc({ returns: z.string() }, ["param", z.number()])
+);
+```
+
+**After (Type Factory):**
+
+```typescript
+import { typeFactory as tf, buildFunc, exposeMethodsSymbol } from "@fluidframework/tree-agent/alpha";
+
+methods.expose(
+    MyClass,
+    "myMethod",
+    buildFunc({ returns: tf.string() }, ["param", tf.number()])
+);
+```
+
+## Note on type safety
+
+The Type Factory type system does not currently provide compile-time type checking, though this may be added in the
+future. For applications requiring strict compile-time validation, Zod types remain fully supported.

--- a/.vale/config/vocabularies/fluid/accept.txt
+++ b/.vale/config/vocabularies/fluid/accept.txt
@@ -15,3 +15,4 @@ Datastore
 DDSes
 accessor
 accessors
+Zod

--- a/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
+++ b/packages/framework/tree-agent/api-report/tree-agent.alpha.api.md
@@ -60,20 +60,16 @@ export interface ExposedMethods {
 
 // @alpha
 export interface ExposedProperties {
-    // (undocumented)
     exposeProperty<S extends BindableSchema & Ctor, K extends string & ExposableKeys<InstanceType<S>>, TZ extends ZodTypeAny>(schema: S, name: K, def: {
         schema: TZ;
         description?: string;
     } & ReadOnlyRequirement<InstanceType<S>, K> & TypeMatchOrError<InstanceType<S>[K], infer<TZ>>): void;
-    // (undocumented)
     exposeProperty<S extends BindableSchema & Ctor, K extends string & ExposableKeys<InstanceType<S>>>(schema: S, name: K, def: {
         schema: TypeFactoryType;
         description?: string;
         readOnly?: boolean;
     }): void;
-    // (undocumented)
     exposeProperty<S extends BindableSchema & Ctor, K extends string & ExposableKeys<InstanceType<S>>>(schema: S, name: K, tfType: TypeFactoryType): void;
-    // (undocumented)
     instanceOf<T extends TreeNodeSchemaClass>(schema: T): ZodType<InstanceType<T>, ZodTypeDef, InstanceType<T>>;
 }
 
@@ -85,25 +81,19 @@ export const exposePropertiesSymbol: unique symbol;
 
 // @alpha
 export interface FunctionDef<Args extends readonly Arg[], Return extends z.ZodTypeAny | TypeFactoryType, Rest extends z.ZodTypeAny | TypeFactoryType | null = null> {
-    // (undocumented)
     args: Args;
-    // (undocumented)
     description?: string;
-    // (undocumented)
     rest?: Rest;
-    // (undocumented)
     returns: Return;
 }
 
 // @alpha
 export interface IExposedMethods {
-    // (undocumented)
     [exposeMethodsSymbol](methods: ExposedMethods): void;
 }
 
 // @alpha
 export interface IExposedProperties {
-    // (undocumented)
     [exposePropertiesSymbol]?(properties: ExposedProperties): void;
 }
 
@@ -146,14 +136,14 @@ export type MethodKeys<T> = {
 
 // @alpha
 export class PropertyDef {
-    constructor(name: string, description: string | undefined, schema: ZodTypeAny | TypeFactoryType, readOnly: boolean);
-    // (undocumented)
+    constructor(
+    name: string,
+    description: string | undefined,
+    schema: ZodTypeAny | TypeFactoryType,
+    readOnly: boolean);
     readonly description: string | undefined;
-    // (undocumented)
     readonly name: string;
-    // (undocumented)
     readonly readOnly: boolean;
-    // (undocumented)
     readonly schema: ZodTypeAny | TypeFactoryType;
 }
 
@@ -230,140 +220,109 @@ export const typeFactory: {
     instanceOf<T extends TreeNodeSchemaClass_2>(schema: T): TypeFactoryInstanceOf;
 };
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryArray extends TypeFactoryType {
-    // (undocumented)
     readonly element: TypeFactoryType;
-    // (undocumented)
     readonly _kind: "array";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryBoolean extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "boolean";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryInstanceOf extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "instanceof";
-    // (undocumented)
     readonly schema: ObjectNodeSchema;
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryLiteral extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "literal";
-    // (undocumented)
     readonly value: string | number | boolean;
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryMap extends TypeFactoryType {
-    // (undocumented)
     readonly keyType: TypeFactoryType;
-    // (undocumented)
     readonly _kind: "map";
-    // (undocumented)
     readonly valueType: TypeFactoryType;
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryNull extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "null";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryNumber extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "number";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryObject extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "object";
-    // (undocumented)
     readonly shape: Record<string, TypeFactoryType>;
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryOptional extends TypeFactoryType {
-    // (undocumented)
     readonly innerType: TypeFactoryType;
-    // (undocumented)
     readonly _kind: "optional";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryReadonly extends TypeFactoryType {
-    // (undocumented)
     readonly innerType: TypeFactoryType;
-    // (undocumented)
     readonly _kind: "readonly";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryRecord extends TypeFactoryType {
-    // (undocumented)
     readonly keyType: TypeFactoryType;
-    // (undocumented)
     readonly _kind: "record";
-    // (undocumented)
     readonly valueType: TypeFactoryType;
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryString extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "string";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryTuple extends TypeFactoryType {
-    // (undocumented)
     readonly items: readonly TypeFactoryType[];
-    // (undocumented)
     readonly _kind: "tuple";
-    // (undocumented)
     readonly rest?: TypeFactoryType;
 }
 
 // @alpha
 export interface TypeFactoryType {
-    // (undocumented)
     readonly _kind: TypeFactoryTypeKind;
 }
 
 // @alpha
 export type TypeFactoryTypeKind = "string" | "number" | "boolean" | "void" | "undefined" | "null" | "unknown" | "array" | "object" | "record" | "map" | "tuple" | "union" | "literal" | "optional" | "readonly" | "instanceof";
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryUndefined extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "undefined";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryUnion extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "union";
-    // (undocumented)
     readonly options: readonly TypeFactoryType[];
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryUnknown extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "unknown";
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface TypeFactoryVoid extends TypeFactoryType {
-    // (undocumented)
     readonly _kind: "void";
 }
 

--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -37,6 +37,9 @@ export {
 	type BindableSchema,
 	type Ctor,
 	type Infer,
+	type InferZod,
+	type InferArgsZod,
+	type InferTypeFactory,
 	type IExposedMethods,
 } from "./methodBinding.js";
 export type {
@@ -50,3 +53,39 @@ export type {
 	TypeMatchOrError,
 	IfEquals,
 } from "./propertyBinding.js";
+
+/**
+ * Custom type system for defining method and property types without zod dependency.
+ * @alpha
+ */
+export {
+	typeFactory,
+	isTypeFactoryType,
+	instanceOfsTypeFactory,
+} from "./treeAgentTypes.js";
+
+/**
+ * Type interfaces for the type factory type system.
+ * @alpha
+ */
+export type {
+	TypeFactoryType,
+	TypeFactoryTypeKind,
+	TypeFactoryString,
+	TypeFactoryNumber,
+	TypeFactoryBoolean,
+	TypeFactoryVoid,
+	TypeFactoryUndefined,
+	TypeFactoryNull,
+	TypeFactoryUnknown,
+	TypeFactoryArray,
+	TypeFactoryObject,
+	TypeFactoryRecord,
+	TypeFactoryMap,
+	TypeFactoryTuple,
+	TypeFactoryUnion,
+	TypeFactoryLiteral,
+	TypeFactoryOptional,
+	TypeFactoryReadonly,
+	TypeFactoryInstanceOf,
+} from "./treeAgentTypes.js";

--- a/packages/framework/tree-agent/src/index.ts
+++ b/packages/framework/tree-agent/src/index.ts
@@ -54,20 +54,12 @@ export type {
 	IfEquals,
 } from "./propertyBinding.js";
 
-/**
- * Custom type system for defining method and property types without zod dependency.
- * @alpha
- */
 export {
 	typeFactory,
 	isTypeFactoryType,
 	instanceOfsTypeFactory,
 } from "./treeAgentTypes.js";
 
-/**
- * Type interfaces for the type factory type system.
- * @alpha
- */
 export type {
 	TypeFactoryType,
 	TypeFactoryTypeKind,

--- a/packages/framework/tree-agent/src/methodBinding.ts
+++ b/packages/framework/tree-agent/src/methodBinding.ts
@@ -75,9 +75,21 @@ export interface FunctionDef<
 	Return extends z.ZodTypeAny | TypeFactoryType,
 	Rest extends z.ZodTypeAny | TypeFactoryType | null = null,
 > {
+	/**
+	 * Optional description of the function.
+	 */
 	description?: string;
+	/**
+	 * The function's parameters.
+	 */
 	args: Args;
+	/**
+	 * Optional rest parameter type.
+	 */
 	rest?: Rest;
+	/**
+	 * The function's return type.
+	 */
 	returns: Return;
 }
 
@@ -234,6 +246,9 @@ export const exposeMethodsSymbol: unique symbol = Symbol("run");
  * @alpha
  */
 export interface IExposedMethods {
+	/**
+	 * Static method that exposes methods of this schema class to an agent.
+	 */
 	[exposeMethodsSymbol](methods: ExposedMethods): void;
 }
 

--- a/packages/framework/tree-agent/src/propertyBinding.ts
+++ b/packages/framework/tree-agent/src/propertyBinding.ts
@@ -75,9 +75,21 @@ export type TypeMatchOrError<Expected, Received> = [Received] extends [Expected]
  */
 export class PropertyDef {
 	public constructor(
+		/**
+		 * The name of the property.
+		 */
 		public readonly name: string,
+		/**
+		 * Optional description of the property.
+		 */
 		public readonly description: string | undefined,
+		/**
+		 * The schema defining the property's type (either Zod or TypeFactory).
+		 */
 		public readonly schema: ZodTypeAny | TypeFactoryType,
+		/**
+		 * Whether the property is readonly.
+		 */
 		public readonly readOnly: boolean,
 	) {}
 }
@@ -87,7 +99,9 @@ export class PropertyDef {
  * @alpha
  */
 export interface ExposedProperties {
-	// Overload for Zod types with compile-time checking
+	/**
+	 * Expose a property with Zod type checking.
+	 */
 	exposeProperty<
 		S extends BindableSchema & Ctor,
 		K extends string & ExposableKeys<InstanceType<S>>,
@@ -99,7 +113,9 @@ export interface ExposedProperties {
 			TypeMatchOrError<InstanceType<S>[K], ZodInfer<TZ>>,
 	): void;
 
-	// Overload for type factory types without compile-time checking - with metadata
+	/**
+	 * Expose a property with type factory type and metadata.
+	 */
 	exposeProperty<
 		S extends BindableSchema & Ctor,
 		K extends string & ExposableKeys<InstanceType<S>>,
@@ -109,12 +125,17 @@ export interface ExposedProperties {
 		def: { schema: TypeFactoryType; description?: string; readOnly?: boolean },
 	): void;
 
-	// Overload for type factory types without compile-time checking - simple form
+	/**
+	 * Expose a property with type factory type (simple form).
+	 */
 	exposeProperty<
 		S extends BindableSchema & Ctor,
 		K extends string & ExposableKeys<InstanceType<S>>,
 	>(schema: S, name: K, tfType: TypeFactoryType): void;
 
+	/**
+	 * Create a Zod type that references a SharedTree schema class.
+	 */
 	instanceOf<T extends TreeNodeSchemaClass>(
 		schema: T,
 	): ZodType<InstanceType<T>, ZodTypeDef, InstanceType<T>>;
@@ -135,6 +156,9 @@ export interface ExposedProperties {
  * @alpha
  */
 export interface IExposedProperties {
+	/**
+	 * Static method that exposes properties of this schema class to an agent.
+	 */
 	[exposePropertiesSymbol]?(properties: ExposedProperties): void;
 }
 

--- a/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
+++ b/packages/framework/tree-agent/src/renderSchemaTypeScript.ts
@@ -18,7 +18,13 @@ import { z } from "zod";
 import type { BindableSchema, FunctionWrapper } from "./methodBinding.js";
 import { getExposedMethods } from "./methodBinding.js";
 import { getExposedProperties, type PropertyDef } from "./propertyBinding.js";
+import {
+	instanceOfsTypeFactory,
+	renderTypeFactoryTypeScript,
+} from "./renderTypeFactoryTypeScript.js";
 import { instanceOfs, renderZodTypeScript } from "./renderZodTypeScript.js";
+import type { TypeFactoryOptional, TypeFactoryType } from "./treeAgentTypes.js";
+import { isTypeFactoryType } from "./treeAgentTypes.js";
 import { getFriendlyName, isNamedSchema, llmDefault, unqualifySchema } from "./utils.js";
 
 interface BoundMembers {
@@ -434,7 +440,7 @@ function renderPropertyLines(properties: Record<string, PropertyDef>): string[] 
 			}
 		}
 		const modifier = property.readOnly ? "readonly " : "";
-		lines.push(`${modifier}${name}: ${renderZodType(property.schema)};`);
+		lines.push(`${modifier}${name}: ${renderType(property.schema)};`);
 	}
 	return lines;
 }
@@ -443,13 +449,13 @@ function formatMethod(name: string, method: FunctionWrapper): string {
 	const args: string[] = [];
 	for (const [argName, argType] of method.args) {
 		const { innerType, optional } = unwrapOptional(argType);
-		const renderedType = renderZodType(innerType);
+		const renderedType = renderType(innerType);
 		args.push(`${argName}${optional ? "?" : ""}: ${renderedType}`);
 	}
 	if (method.rest !== null) {
-		args.push(`...rest: ${renderZodType(method.rest)}[]`);
+		args.push(`...rest: ${renderType(method.rest)}[]`);
 	}
-	return `${name}(${args.join(", ")}): ${renderZodType(method.returns)};`;
+	return `${name}(${args.join(", ")}): ${renderType(method.returns)};`;
 }
 
 function renderLeaf(leafKind: ValueSchema): string {
@@ -482,7 +488,15 @@ function formatExpression(
 /**
  * Detects optional zod wrappers so argument lists can keep TypeScript optional markers in sync.
  */
-function unwrapOptional(type: z.ZodTypeAny): { innerType: z.ZodTypeAny; optional: boolean } {
+function unwrapOptional(type: z.ZodTypeAny | TypeFactoryType): {
+	innerType: z.ZodTypeAny | TypeFactoryType;
+	optional: boolean;
+} {
+	// Handle type factory optional type
+	if (isTypeFactoryType(type) && type._kind === "optional") {
+		return { innerType: (type as TypeFactoryOptional).innerType, optional: true };
+	}
+	// Handle Zod optional type
 	if (type instanceof z.ZodOptional) {
 		const inner = type.unwrap() as z.ZodTypeAny;
 		return { innerType: inner, optional: true };
@@ -516,8 +530,10 @@ function ensureNoMemberConflicts(
 }
 
 /**
- * Converts schema metadata into TypeScript declarations suitable for prompt inclusion.
+ * Dispatches to the correct renderer based on whether the type is Zod or type factory.
  */
-function renderZodType(type: z.ZodTypeAny): string {
-	return renderZodTypeScript(type, getFriendlyName, instanceOfs);
+function renderType(type: z.ZodTypeAny | TypeFactoryType): string {
+	return isTypeFactoryType(type)
+		? renderTypeFactoryTypeScript(type, getFriendlyName, instanceOfsTypeFactory)
+		: renderZodTypeScript(type, getFriendlyName, instanceOfs);
 }

--- a/packages/framework/tree-agent/src/renderTypeFactoryTypeScript.ts
+++ b/packages/framework/tree-agent/src/renderTypeFactoryTypeScript.ts
@@ -1,0 +1,259 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import type { ObjectNodeSchema, TreeNodeSchema } from "@fluidframework/tree/alpha";
+
+import type {
+	TypeFactoryType,
+	TypeFactoryArray,
+	TypeFactoryObject,
+	TypeFactoryTuple,
+	TypeFactoryRecord,
+	TypeFactoryMap,
+	TypeFactoryLiteral,
+	TypeFactoryOptional,
+	TypeFactoryReadonly,
+	TypeFactoryUnion,
+} from "./treeAgentTypes.js";
+
+export { instanceOfsTypeFactory } from "./treeAgentTypes.js";
+
+/**
+ * Converts type factory type definitions into TypeScript declaration text.
+ * @alpha
+ */
+export function renderTypeFactoryTypeScript(
+	typeFactoryType: TypeFactoryType,
+	getFriendlyName: (schema: TreeNodeSchema) => string,
+	instanceOfLookup: WeakMap<TypeFactoryType, ObjectNodeSchema>,
+): string {
+	let result = "";
+	let startOfLine = true;
+	let indent = 0;
+
+	appendType(typeFactoryType, TypePrecedence.Union);
+	return result;
+
+	function appendType(type: TypeFactoryType, minPrecedence = TypePrecedence.Object): void {
+		const shouldParenthesize = getTypePrecedence(type) < minPrecedence;
+		if (shouldParenthesize) {
+			append("(");
+		}
+		appendTypeDefinition(type);
+		if (shouldParenthesize) {
+			append(")");
+		}
+	}
+
+	function append(s: string): void {
+		if (startOfLine) {
+			result += "    ".repeat(indent);
+			startOfLine = false;
+		}
+		result += s;
+	}
+
+	function appendNewLine(): void {
+		append("\n");
+		startOfLine = true;
+	}
+
+	function appendTypeDefinition(type: TypeFactoryType): void {
+		switch (type._kind) {
+			case "string": {
+				append("string");
+				return;
+			}
+			case "number": {
+				append("number");
+				return;
+			}
+			case "boolean": {
+				append("boolean");
+				return;
+			}
+			case "void": {
+				append("void");
+				return;
+			}
+			case "undefined": {
+				append("undefined");
+				return;
+			}
+			case "null": {
+				append("null");
+				return;
+			}
+			case "unknown": {
+				append("unknown");
+				return;
+			}
+			case "array": {
+				appendArrayType(type as TypeFactoryArray);
+				return;
+			}
+			case "object": {
+				appendObjectType(type as TypeFactoryObject);
+				return;
+			}
+			case "union": {
+				appendUnionTypes((type as TypeFactoryUnion).options, TypePrecedence.Union);
+				return;
+			}
+			case "tuple": {
+				appendTupleType(type as TypeFactoryTuple);
+				return;
+			}
+			case "record": {
+				appendRecordType(type as TypeFactoryRecord);
+				return;
+			}
+			case "map": {
+				appendMapType(type as TypeFactoryMap);
+				return;
+			}
+			case "literal": {
+				appendLiteral((type as TypeFactoryLiteral).value);
+				return;
+			}
+			case "optional": {
+				appendUnionTypes(
+					[(type as TypeFactoryOptional).innerType, { _kind: "undefined" }],
+					TypePrecedence.Union,
+				);
+				return;
+			}
+			case "readonly": {
+				appendReadonlyType(type as TypeFactoryReadonly);
+				return;
+			}
+			case "instanceof": {
+				const schema = instanceOfLookup.get(type);
+				if (schema === undefined) {
+					throw new UsageError(
+						"instanceof type not found in lookup - this typically indicates the type was not created via typeFactory.instanceOf",
+					);
+				}
+				append(getFriendlyName(schema));
+				return;
+			}
+			default: {
+				throw new UsageError(
+					`Unsupported type when formatting helper types: ${String(type._kind ?? "unknown")}. Expected one of: string, number, boolean, void, undefined, null, unknown, array, object, union, tuple, record, map, literal, optional, readonly, instanceof.`,
+				);
+			}
+		}
+	}
+
+	function appendArrayType(arrayType: TypeFactoryArray): void {
+		appendType(arrayType.element, TypePrecedence.Object);
+		append("[]");
+	}
+
+	function appendObjectType(objectType: TypeFactoryObject): void {
+		append("{");
+		appendNewLine();
+		indent++;
+		for (const [name, propertyType] of Object.entries(objectType.shape)) {
+			append(name);
+			if (propertyType._kind === "optional") {
+				append("?");
+				append(": ");
+				appendType((propertyType as TypeFactoryOptional).innerType);
+			} else {
+				append(": ");
+				appendType(propertyType);
+			}
+			append(";");
+			appendNewLine();
+		}
+		indent--;
+		append("}");
+	}
+
+	function appendUnionTypes(
+		types: readonly TypeFactoryType[],
+		minPrecedence: TypePrecedence,
+	): void {
+		let first = true;
+		for (const innerType of types) {
+			if (!first) {
+				append(" | ");
+			}
+			appendType(innerType, minPrecedence);
+			first = false;
+		}
+	}
+
+	function appendTupleType(tupleType: TypeFactoryTuple): void {
+		append("[");
+		let first = true;
+		for (const innerType of tupleType.items) {
+			if (!first) {
+				append(", ");
+			}
+			if (innerType._kind === "optional") {
+				appendType((innerType as TypeFactoryOptional).innerType, TypePrecedence.Object);
+				append("?");
+			} else {
+				appendType(innerType);
+			}
+			first = false;
+		}
+		if (tupleType.rest !== undefined) {
+			if (!first) {
+				append(", ");
+			}
+			append("...");
+			appendType(tupleType.rest, TypePrecedence.Object);
+			append("[]");
+		}
+		append("]");
+	}
+
+	function appendRecordType(recordType: TypeFactoryRecord): void {
+		append("Record<");
+		appendType(recordType.keyType, TypePrecedence.Union);
+		append(", ");
+		appendType(recordType.valueType, TypePrecedence.Union);
+		append(">");
+	}
+
+	function appendMapType(mapType: TypeFactoryMap): void {
+		append("Map<");
+		appendType(mapType.keyType, TypePrecedence.Union);
+		append(", ");
+		appendType(mapType.valueType, TypePrecedence.Union);
+		append(">");
+	}
+
+	function appendLiteral(value: string | number | boolean): void {
+		append(JSON.stringify(value));
+	}
+
+	function appendReadonlyType(readonlyType: TypeFactoryReadonly): void {
+		append("Readonly<");
+		appendType(readonlyType.innerType);
+		append(">");
+	}
+}
+
+const enum TypePrecedence {
+	Union = 0,
+	Intersection = 1,
+	Object = 2,
+}
+
+function getTypePrecedence(type: TypeFactoryType): TypePrecedence {
+	switch (type._kind) {
+		case "union": {
+			return TypePrecedence.Union;
+		}
+		default: {
+			return TypePrecedence.Object;
+		}
+	}
+}

--- a/packages/framework/tree-agent/src/test/typeFactory.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeFactory.spec.ts
@@ -3,12 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
-/* eslint-disable unicorn/no-null */
-
 import { strict as assert } from "node:assert";
 
 import { SchemaFactory } from "@fluidframework/tree/internal";
@@ -71,16 +65,16 @@ describe("type factories", () => {
 			const arrayType = tf.array(tf.string());
 			assert(isTypeFactoryType(arrayType));
 			assert.equal(arrayType._kind, "array");
-			assert(isTypeFactoryType((arrayType as any).element));
-			assert.equal((arrayType as any).element._kind, "string");
+			assert(isTypeFactoryType(arrayType.element));
+			assert.equal(arrayType.element._kind, "string");
 		});
 
 		it("creates object type", () => {
 			const objectType = tf.object({ name: tf.string(), age: tf.number() });
 			assert(isTypeFactoryType(objectType));
 			assert.equal(objectType._kind, "object");
-			const shape = (objectType as any).shape;
-			assert(shape);
+			const shape = objectType.shape;
+			assert(shape !== undefined);
 			assert(isTypeFactoryType(shape.name));
 			assert.equal(shape.name._kind, "string");
 			assert(isTypeFactoryType(shape.age));
@@ -91,23 +85,23 @@ describe("type factories", () => {
 			const recordType = tf.record(tf.string(), tf.number());
 			assert(isTypeFactoryType(recordType));
 			assert.equal(recordType._kind, "record");
-			assert(isTypeFactoryType((recordType as any).keyType));
-			assert(isTypeFactoryType((recordType as any).valueType));
+			assert(isTypeFactoryType(recordType.keyType));
+			assert(isTypeFactoryType(recordType.valueType));
 		});
 
 		it("creates map type", () => {
 			const mapType = tf.map(tf.string(), tf.number());
 			assert(isTypeFactoryType(mapType));
 			assert.equal(mapType._kind, "map");
-			assert(isTypeFactoryType((mapType as any).keyType));
-			assert(isTypeFactoryType((mapType as any).valueType));
+			assert(isTypeFactoryType(mapType.keyType));
+			assert(isTypeFactoryType(mapType.valueType));
 		});
 
 		it("creates tuple type", () => {
 			const tupleType = tf.tuple([tf.string(), tf.number()]);
 			assert(isTypeFactoryType(tupleType));
 			assert.equal(tupleType._kind, "tuple");
-			const items = (tupleType as any).items;
+			const items = tupleType.items;
 			assert(Array.isArray(items));
 			assert.equal(items.length, 2);
 			assert(isTypeFactoryType(items[0]));
@@ -118,7 +112,7 @@ describe("type factories", () => {
 			const tupleType = tf.tuple([tf.string()], tf.number());
 			assert(isTypeFactoryType(tupleType));
 			assert.equal(tupleType._kind, "tuple");
-			const rest = (tupleType as any).rest;
+			const rest = tupleType.rest;
 			assert(isTypeFactoryType(rest));
 			assert.equal(rest._kind, "number");
 		});
@@ -127,7 +121,7 @@ describe("type factories", () => {
 			const unionType = tf.union([tf.string(), tf.number()]);
 			assert(isTypeFactoryType(unionType));
 			assert.equal(unionType._kind, "union");
-			const options = (unionType as any).options;
+			const options = unionType.options;
 			assert(Array.isArray(options));
 			assert.equal(options.length, 2);
 		});
@@ -136,14 +130,14 @@ describe("type factories", () => {
 			const literalType = tf.literal("hello");
 			assert(isTypeFactoryType(literalType));
 			assert.equal(literalType._kind, "literal");
-			assert.equal((literalType as any).value, "hello");
+			assert.equal(literalType.value, "hello");
 		});
 
 		it("creates optional type", () => {
 			const optionalType = tf.optional(tf.string());
 			assert(isTypeFactoryType(optionalType));
 			assert.equal(optionalType._kind, "optional");
-			const innerType = (optionalType as any).innerType;
+			const innerType = optionalType.innerType;
 			assert(isTypeFactoryType(innerType));
 			assert.equal(innerType._kind, "string");
 		});
@@ -152,7 +146,7 @@ describe("type factories", () => {
 			const readonlyType = tf.readonly(tf.array(tf.string()));
 			assert(isTypeFactoryType(readonlyType));
 			assert.equal(readonlyType._kind, "readonly");
-			const innerType = (readonlyType as any).innerType;
+			const innerType = readonlyType.innerType;
 			assert(isTypeFactoryType(innerType));
 			assert.equal(innerType._kind, "array");
 		});
@@ -162,15 +156,15 @@ describe("type factories", () => {
 			const instanceOfType = tf.instanceOf(MyClass);
 			assert(isTypeFactoryType(instanceOfType));
 			assert.equal(instanceOfType._kind, "instanceof");
-			assert.equal((instanceOfType as any).schema, MyClass);
+			assert.equal(instanceOfType.schema, MyClass);
 			// Verify it's registered in the lookup
 			assert.equal(instanceOfsTypeFactory.get(instanceOfType), MyClass);
 		});
 
 		it("throws error for instanceOf with non-ObjectNodeSchema", () => {
-			const arraySchema = sf.array(sf.string);
+			class ArraySchema extends sf.array("ArraySchema", sf.string) {}
 			assert.throws(
-				() => tf.instanceOf(arraySchema as any),
+				() => tf.instanceOf(ArraySchema),
 				/typeFactory\.instanceOf only supports ObjectNodeSchema-based schema classes/,
 			);
 		});
@@ -190,8 +184,8 @@ describe("type factories", () => {
 			const tupleType = tf.tuple([], tf.string());
 			assert(isTypeFactoryType(tupleType));
 			assert.equal(tupleType._kind, "tuple");
-			assert.equal((tupleType as any).items.length, 0);
-			assert(isTypeFactoryType((tupleType as any).rest));
+			assert.equal(tupleType.items.length, 0);
+			assert(isTypeFactoryType(tupleType.rest));
 		});
 	});
 
@@ -203,6 +197,7 @@ describe("type factories", () => {
 		});
 
 		it("returns false for non-Type Factory types", () => {
+			// eslint-disable-next-line unicorn/no-null
 			assert(!isTypeFactoryType(null));
 			assert(!isTypeFactoryType(undefined));
 			assert(!isTypeFactoryType("string"));

--- a/packages/framework/tree-agent/src/test/typeFactory.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeFactory.spec.ts
@@ -1,0 +1,214 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+/* eslint-disable unicorn/no-null */
+
+import { strict as assert } from "node:assert";
+
+import { SchemaFactory } from "@fluidframework/tree/internal";
+
+import {
+	typeFactory as tf,
+	isTypeFactoryType,
+	instanceOfsTypeFactory,
+} from "../treeAgentTypes.js";
+
+const sf = new SchemaFactory("test");
+
+describe("type factories", () => {
+	describe("primitive types", () => {
+		it("creates string type", () => {
+			const stringType = tf.string();
+			assert(isTypeFactoryType(stringType));
+			assert.equal(stringType._kind, "string");
+		});
+
+		it("creates number type", () => {
+			const numberType = tf.number();
+			assert(isTypeFactoryType(numberType));
+			assert.equal(numberType._kind, "number");
+		});
+
+		it("creates boolean type", () => {
+			const booleanType = tf.boolean();
+			assert(isTypeFactoryType(booleanType));
+			assert.equal(booleanType._kind, "boolean");
+		});
+
+		it("creates void type", () => {
+			const voidType = tf.void();
+			assert(isTypeFactoryType(voidType));
+			assert.equal(voidType._kind, "void");
+		});
+
+		it("creates undefined type", () => {
+			const undefinedType = tf.undefined();
+			assert(isTypeFactoryType(undefinedType));
+			assert.equal(undefinedType._kind, "undefined");
+		});
+
+		it("creates null type", () => {
+			const nullType = tf.null();
+			assert(isTypeFactoryType(nullType));
+			assert.equal(nullType._kind, "null");
+		});
+
+		it("creates unknown type", () => {
+			const unknownType = tf.unknown();
+			assert(isTypeFactoryType(unknownType));
+			assert.equal(unknownType._kind, "unknown");
+		});
+	});
+
+	describe("complex types", () => {
+		it("creates array type", () => {
+			const arrayType = tf.array(tf.string());
+			assert(isTypeFactoryType(arrayType));
+			assert.equal(arrayType._kind, "array");
+			assert(isTypeFactoryType((arrayType as any).element));
+			assert.equal((arrayType as any).element._kind, "string");
+		});
+
+		it("creates object type", () => {
+			const objectType = tf.object({ name: tf.string(), age: tf.number() });
+			assert(isTypeFactoryType(objectType));
+			assert.equal(objectType._kind, "object");
+			const shape = (objectType as any).shape;
+			assert(shape);
+			assert(isTypeFactoryType(shape.name));
+			assert.equal(shape.name._kind, "string");
+			assert(isTypeFactoryType(shape.age));
+			assert.equal(shape.age._kind, "number");
+		});
+
+		it("creates record type", () => {
+			const recordType = tf.record(tf.string(), tf.number());
+			assert(isTypeFactoryType(recordType));
+			assert.equal(recordType._kind, "record");
+			assert(isTypeFactoryType((recordType as any).keyType));
+			assert(isTypeFactoryType((recordType as any).valueType));
+		});
+
+		it("creates map type", () => {
+			const mapType = tf.map(tf.string(), tf.number());
+			assert(isTypeFactoryType(mapType));
+			assert.equal(mapType._kind, "map");
+			assert(isTypeFactoryType((mapType as any).keyType));
+			assert(isTypeFactoryType((mapType as any).valueType));
+		});
+
+		it("creates tuple type", () => {
+			const tupleType = tf.tuple([tf.string(), tf.number()]);
+			assert(isTypeFactoryType(tupleType));
+			assert.equal(tupleType._kind, "tuple");
+			const items = (tupleType as any).items;
+			assert(Array.isArray(items));
+			assert.equal(items.length, 2);
+			assert(isTypeFactoryType(items[0]));
+			assert(isTypeFactoryType(items[1]));
+		});
+
+		it("creates tuple type with rest", () => {
+			const tupleType = tf.tuple([tf.string()], tf.number());
+			assert(isTypeFactoryType(tupleType));
+			assert.equal(tupleType._kind, "tuple");
+			const rest = (tupleType as any).rest;
+			assert(isTypeFactoryType(rest));
+			assert.equal(rest._kind, "number");
+		});
+
+		it("creates union type", () => {
+			const unionType = tf.union([tf.string(), tf.number()]);
+			assert(isTypeFactoryType(unionType));
+			assert.equal(unionType._kind, "union");
+			const options = (unionType as any).options;
+			assert(Array.isArray(options));
+			assert.equal(options.length, 2);
+		});
+
+		it("creates literal type", () => {
+			const literalType = tf.literal("hello");
+			assert(isTypeFactoryType(literalType));
+			assert.equal(literalType._kind, "literal");
+			assert.equal((literalType as any).value, "hello");
+		});
+
+		it("creates optional type", () => {
+			const optionalType = tf.optional(tf.string());
+			assert(isTypeFactoryType(optionalType));
+			assert.equal(optionalType._kind, "optional");
+			const innerType = (optionalType as any).innerType;
+			assert(isTypeFactoryType(innerType));
+			assert.equal(innerType._kind, "string");
+		});
+
+		it("creates readonly type", () => {
+			const readonlyType = tf.readonly(tf.array(tf.string()));
+			assert(isTypeFactoryType(readonlyType));
+			assert.equal(readonlyType._kind, "readonly");
+			const innerType = (readonlyType as any).innerType;
+			assert(isTypeFactoryType(innerType));
+			assert.equal(innerType._kind, "array");
+		});
+
+		it("creates instanceOf type with ObjectNodeSchema", () => {
+			class MyClass extends sf.object("MyClass", {}) {}
+			const instanceOfType = tf.instanceOf(MyClass);
+			assert(isTypeFactoryType(instanceOfType));
+			assert.equal(instanceOfType._kind, "instanceof");
+			assert.equal((instanceOfType as any).schema, MyClass);
+			// Verify it's registered in the lookup
+			assert.equal(instanceOfsTypeFactory.get(instanceOfType), MyClass);
+		});
+
+		it("throws error for instanceOf with non-ObjectNodeSchema", () => {
+			const arraySchema = sf.array(sf.string);
+			assert.throws(
+				() => tf.instanceOf(arraySchema as any),
+				/typeFactory\.instanceOf only supports ObjectNodeSchema-based schema classes/,
+			);
+		});
+
+		it("throws error for empty union", () => {
+			assert.throws(() => tf.union([]), /typeFactory\.union requires at least one option/);
+		});
+
+		it("throws error for empty tuple without rest", () => {
+			assert.throws(
+				() => tf.tuple([]),
+				/typeFactory\.tuple requires at least one item or a rest type/,
+			);
+		});
+
+		it("allows tuple with only rest type", () => {
+			const tupleType = tf.tuple([], tf.string());
+			assert(isTypeFactoryType(tupleType));
+			assert.equal(tupleType._kind, "tuple");
+			assert.equal((tupleType as any).items.length, 0);
+			assert(isTypeFactoryType((tupleType as any).rest));
+		});
+	});
+
+	describe("isTypeFactoryType type guard", () => {
+		it("returns true for Type Factory types", () => {
+			assert(isTypeFactoryType(tf.string()));
+			assert(isTypeFactoryType(tf.number()));
+			assert(isTypeFactoryType(tf.object({})));
+		});
+
+		it("returns false for non-Type Factory types", () => {
+			assert(!isTypeFactoryType(null));
+			assert(!isTypeFactoryType(undefined));
+			assert(!isTypeFactoryType("string"));
+			assert(!isTypeFactoryType(42));
+			assert(!isTypeFactoryType({}));
+			assert(!isTypeFactoryType({ _kind: "fake" }));
+		});
+	});
+});

--- a/packages/framework/tree-agent/src/test/typeFactoryRendering.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeFactoryRendering.spec.ts
@@ -1,0 +1,328 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { SchemaFactory } from "@fluidframework/tree/internal";
+
+import {
+	instanceOfsTypeFactory,
+	renderTypeFactoryTypeScript,
+} from "../renderTypeFactoryTypeScript.js";
+import { typeFactory as tf } from "../treeAgentTypes.js";
+
+const sf = new SchemaFactory("test");
+
+describe("renderTypeFactoryTypeScript", () => {
+	describe("primitive types", () => {
+		it("renders string type", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.string(),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "string");
+		});
+
+		it("renders number type", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.number(),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "number");
+		});
+
+		it("renders boolean type", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.boolean(),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "boolean");
+		});
+
+		it("renders void type", () => {
+			const result = renderTypeFactoryTypeScript(tf.void(), () => "", instanceOfsTypeFactory);
+			assert.equal(result, "void");
+		});
+
+		it("renders undefined type", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.undefined(),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "undefined");
+		});
+
+		it("renders null type", () => {
+			const result = renderTypeFactoryTypeScript(tf.null(), () => "", instanceOfsTypeFactory);
+			assert.equal(result, "null");
+		});
+
+		it("renders unknown type", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.unknown(),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "unknown");
+		});
+	});
+
+	describe("array types", () => {
+		it("renders simple array", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.array(tf.string()),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "string[]");
+		});
+
+		it("renders nested array", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.array(tf.array(tf.number())),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "number[][]");
+		});
+	});
+
+	describe("object types", () => {
+		it("renders simple object", () => {
+			const objectType = tf.object({
+				name: tf.string(),
+				age: tf.number(),
+			});
+			const result = renderTypeFactoryTypeScript(objectType, () => "", instanceOfsTypeFactory);
+			assert.equal(
+				result,
+				`{
+    name: string;
+    age: number;
+}`,
+			);
+		});
+
+		it("renders empty object", () => {
+			const result = renderTypeFactoryTypeScript(
+				tf.object({}),
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(
+				result,
+				`{
+}`,
+			);
+		});
+
+		it("renders object with optional property", () => {
+			const objectType = tf.object({
+				name: tf.string(),
+				nickname: tf.optional(tf.string()),
+			});
+			const result = renderTypeFactoryTypeScript(objectType, () => "", instanceOfsTypeFactory);
+			assert.equal(
+				result,
+				`{
+    name: string;
+    nickname?: string;
+}`,
+			);
+		});
+	});
+
+	describe("union types", () => {
+		it("renders simple union", () => {
+			const unionType = tf.union([tf.string(), tf.number()]);
+			const result = renderTypeFactoryTypeScript(unionType, () => "", instanceOfsTypeFactory);
+			assert.equal(result, "string | number");
+		});
+
+		it("renders union with optional as union with undefined", () => {
+			const optionalType = tf.optional(tf.string());
+			const result = renderTypeFactoryTypeScript(
+				optionalType,
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "string | undefined");
+		});
+	});
+
+	describe("record types", () => {
+		it("renders record type", () => {
+			const recordType = tf.record(tf.string(), tf.number());
+			const result = renderTypeFactoryTypeScript(recordType, () => "", instanceOfsTypeFactory);
+			assert.equal(result, "Record<string, number>");
+		});
+	});
+
+	describe("map types", () => {
+		it("renders map type", () => {
+			const mapType = tf.map(tf.string(), tf.number());
+			const result = renderTypeFactoryTypeScript(mapType, () => "", instanceOfsTypeFactory);
+			assert.equal(result, "Map<string, number>");
+		});
+	});
+
+	describe("tuple types", () => {
+		it("renders simple tuple", () => {
+			const tupleType = tf.tuple([tf.string(), tf.number()]);
+			const result = renderTypeFactoryTypeScript(tupleType, () => "", instanceOfsTypeFactory);
+			assert.equal(result, "[string, number]");
+		});
+
+		it("renders tuple with rest", () => {
+			const tupleType = tf.tuple([tf.string()], tf.number());
+			const result = renderTypeFactoryTypeScript(tupleType, () => "", instanceOfsTypeFactory);
+			assert.equal(result, "[string, ...number[]]");
+		});
+
+		it("renders tuple with optional element", () => {
+			const tupleType = tf.tuple([tf.string(), tf.optional(tf.number())]);
+			const result = renderTypeFactoryTypeScript(tupleType, () => "", instanceOfsTypeFactory);
+			assert.equal(result, "[string, number?]");
+		});
+	});
+
+	describe("literal types", () => {
+		it("renders string literal", () => {
+			const literalType = tf.literal("hello");
+			const result = renderTypeFactoryTypeScript(
+				literalType,
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, '"hello"');
+		});
+
+		it("renders number literal", () => {
+			const literalType = tf.literal(42);
+			const result = renderTypeFactoryTypeScript(
+				literalType,
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "42");
+		});
+
+		it("renders boolean literal", () => {
+			const literalType = tf.literal(true);
+			const result = renderTypeFactoryTypeScript(
+				literalType,
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "true");
+		});
+	});
+
+	describe("readonly types", () => {
+		it("renders readonly type", () => {
+			const readonlyType = tf.readonly(tf.string());
+			const result = renderTypeFactoryTypeScript(
+				readonlyType,
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "Readonly<string>");
+		});
+	});
+
+	describe("instanceOf", () => {
+		it("renders instanceOf type using getFriendlyName", () => {
+			class MyClass extends sf.object("MyClass", {}) {}
+			const instanceOfType = tf.instanceOf(MyClass);
+			const result = renderTypeFactoryTypeScript(
+				instanceOfType,
+				(schema) => {
+					if (schema === MyClass) return "MyClass";
+					return "Unknown";
+				},
+				instanceOfsTypeFactory,
+			);
+			assert.equal(result, "MyClass");
+		});
+	});
+
+	describe("complex nested types", () => {
+		it("renders complex nested structure", () => {
+			const complexType = tf.object({
+				items: tf.array(
+					tf.object({
+						id: tf.number(),
+						tags: tf.optional(tf.array(tf.string())),
+					}),
+				),
+				metadata: tf.record(tf.string(), tf.union([tf.string(), tf.number()])),
+			});
+			const result = renderTypeFactoryTypeScript(
+				complexType,
+				() => "",
+				instanceOfsTypeFactory,
+			);
+			assert.equal(
+				result,
+				`{
+    items: {
+        id: number;
+        tags?: string[];
+    }[];
+    metadata: Record<string, string | number>;
+}`,
+			);
+		});
+	});
+
+	describe("error paths", () => {
+		it("throws UsageError for missing instanceof lookup", () => {
+			class MyClass extends sf.object("MyClass", {}) {}
+			const instanceOfType = tf.instanceOf(MyClass);
+			// Create an empty lookup that doesn't have the type
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-arguments
+			const emptyLookup = new WeakMap<any, any>();
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			assert.throws(
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+				() => renderTypeFactoryTypeScript(instanceOfType, () => "", emptyLookup),
+				/instanceof type not found in lookup/,
+			);
+		});
+
+		it("throws UsageError for unsupported type kind", () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+			const invalidType = { _kind: "invalid" } as any;
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			assert.throws(
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+				() => renderTypeFactoryTypeScript(invalidType, () => "", instanceOfsTypeFactory),
+				/Unsupported type when formatting helper types: invalid/,
+			);
+		});
+
+		it("error message lists expected type kinds", () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+			const invalidType = { _kind: "invalid" } as any;
+			try {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+				renderTypeFactoryTypeScript(invalidType, () => "", instanceOfsTypeFactory);
+				assert.fail("Expected error to be thrown");
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+			} catch (error: any) {
+				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+				assert(error.message.includes("Expected one of:"));
+				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+				assert(error.message.includes("string"));
+				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+				assert(error.message.includes("instanceof"));
+			}
+		});
+	});
+});

--- a/packages/framework/tree-agent/src/treeAgentTypes.ts
+++ b/packages/framework/tree-agent/src/treeAgentTypes.ts
@@ -1,0 +1,380 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import type { TreeNodeSchemaClass } from "@fluidframework/tree/alpha";
+import { ObjectNodeSchema } from "@fluidframework/tree/alpha";
+
+/**
+ * Type kinds for the type factory type system.
+ * @alpha
+ */
+export type TypeFactoryTypeKind =
+	| "string"
+	| "number"
+	| "boolean"
+	| "void"
+	| "undefined"
+	| "null"
+	| "unknown"
+	| "array"
+	| "object"
+	| "record"
+	| "map"
+	| "tuple"
+	| "union"
+	| "literal"
+	| "optional"
+	| "readonly"
+	| "instanceof";
+
+/**
+ * Base interface for type factory types.
+ * @alpha
+ */
+export interface TypeFactoryType {
+	readonly _kind: TypeFactoryTypeKind;
+}
+
+/**
+ * Set of valid type factory type kinds for efficient validation.
+ * @internal
+ */
+const validTypeKinds: ReadonlySet<TypeFactoryTypeKind> = new Set<TypeFactoryTypeKind>([
+	"string",
+	"number",
+	"boolean",
+	"void",
+	"undefined",
+	"null",
+	"unknown",
+	"array",
+	"object",
+	"record",
+	"map",
+	"tuple",
+	"union",
+	"literal",
+	"optional",
+	"readonly",
+	"instanceof",
+]);
+
+/**
+ * Type guard to check if a value is a type factory type.
+ * @alpha
+ */
+export function isTypeFactoryType(value: unknown): value is TypeFactoryType {
+	if (typeof value !== "object" || value === null || !("_kind" in value)) {
+		return false;
+	}
+	const kind = (value as { _kind: unknown })._kind;
+	return typeof kind === "string" && validTypeKinds.has(kind as TypeFactoryTypeKind);
+}
+
+// Primitive type factories
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryString extends TypeFactoryType {
+	readonly _kind: "string";
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryNumber extends TypeFactoryType {
+	readonly _kind: "number";
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryBoolean extends TypeFactoryType {
+	readonly _kind: "boolean";
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryVoid extends TypeFactoryType {
+	readonly _kind: "void";
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryUndefined extends TypeFactoryType {
+	readonly _kind: "undefined";
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryNull extends TypeFactoryType {
+	readonly _kind: "null";
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryUnknown extends TypeFactoryType {
+	readonly _kind: "unknown";
+}
+
+// Complex type interfaces
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryArray extends TypeFactoryType {
+	readonly _kind: "array";
+	readonly element: TypeFactoryType;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryObject extends TypeFactoryType {
+	readonly _kind: "object";
+	readonly shape: Record<string, TypeFactoryType>;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryRecord extends TypeFactoryType {
+	readonly _kind: "record";
+	readonly keyType: TypeFactoryType;
+	readonly valueType: TypeFactoryType;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryMap extends TypeFactoryType {
+	readonly _kind: "map";
+	readonly keyType: TypeFactoryType;
+	readonly valueType: TypeFactoryType;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryTuple extends TypeFactoryType {
+	readonly _kind: "tuple";
+	readonly items: readonly TypeFactoryType[];
+	readonly rest?: TypeFactoryType;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryUnion extends TypeFactoryType {
+	readonly _kind: "union";
+	readonly options: readonly TypeFactoryType[];
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryLiteral extends TypeFactoryType {
+	readonly _kind: "literal";
+	readonly value: string | number | boolean;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryOptional extends TypeFactoryType {
+	readonly _kind: "optional";
+	readonly innerType: TypeFactoryType;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryReadonly extends TypeFactoryType {
+	readonly _kind: "readonly";
+	readonly innerType: TypeFactoryType;
+}
+
+/**
+ * @alpha
+ */
+export interface TypeFactoryInstanceOf extends TypeFactoryType {
+	readonly _kind: "instanceof";
+	readonly schema: ObjectNodeSchema;
+}
+
+/**
+ * Namespace containing type factory functions.
+ * @alpha
+ */
+export const typeFactory = {
+	/**
+	 * Create a string type.
+	 * @alpha
+	 */
+	string(): TypeFactoryString {
+		return { _kind: "string" };
+	},
+
+	/**
+	 * Create a number type.
+	 * @alpha
+	 */
+	number(): TypeFactoryNumber {
+		return { _kind: "number" };
+	},
+
+	/**
+	 * Create a boolean type.
+	 * @alpha
+	 */
+	boolean(): TypeFactoryBoolean {
+		return { _kind: "boolean" };
+	},
+
+	/**
+	 * Create a void type.
+	 * @alpha
+	 */
+	void(): TypeFactoryVoid {
+		return { _kind: "void" };
+	},
+
+	/**
+	 * Create an undefined type.
+	 * @alpha
+	 */
+	undefined(): TypeFactoryUndefined {
+		return { _kind: "undefined" };
+	},
+
+	/**
+	 * Create a null type.
+	 * @alpha
+	 */
+	null(): TypeFactoryNull {
+		return { _kind: "null" };
+	},
+
+	/**
+	 * Create an unknown type.
+	 * @alpha
+	 */
+	unknown(): TypeFactoryUnknown {
+		return { _kind: "unknown" };
+	},
+
+	/**
+	 * Create an array type.
+	 * @alpha
+	 */
+	array(element: TypeFactoryType): TypeFactoryArray {
+		return { _kind: "array", element };
+	},
+
+	/**
+	 * Create an object type.
+	 * @alpha
+	 */
+	object(shape: Record<string, TypeFactoryType>): TypeFactoryObject {
+		return { _kind: "object", shape };
+	},
+
+	/**
+	 * Create a record type.
+	 * @alpha
+	 */
+	record(keyType: TypeFactoryType, valueType: TypeFactoryType): TypeFactoryRecord {
+		return { _kind: "record", keyType, valueType };
+	},
+
+	/**
+	 * Create a map type.
+	 * @alpha
+	 */
+	map(keyType: TypeFactoryType, valueType: TypeFactoryType): TypeFactoryMap {
+		return { _kind: "map", keyType, valueType };
+	},
+
+	/**
+	 * Create a tuple type.
+	 * @alpha
+	 */
+	tuple(items: readonly TypeFactoryType[], rest?: TypeFactoryType): TypeFactoryTuple {
+		if (items.length === 0 && rest === undefined) {
+			throw new UsageError(
+				"typeFactory.tuple requires at least one item or a rest type. Empty tuples are not supported.",
+			);
+		}
+		return rest === undefined ? { _kind: "tuple", items } : { _kind: "tuple", items, rest };
+	},
+
+	/**
+	 * Create a union type.
+	 * @alpha
+	 */
+	union(options: readonly TypeFactoryType[]): TypeFactoryUnion {
+		if (options.length === 0) {
+			throw new UsageError(
+				"typeFactory.union requires at least one option. Empty unions are not valid TypeScript types.",
+			);
+		}
+		return { _kind: "union", options };
+	},
+
+	/**
+	 * Create a literal type.
+	 * @alpha
+	 */
+	literal(value: string | number | boolean): TypeFactoryLiteral {
+		return { _kind: "literal", value };
+	},
+
+	/**
+	 * Create an optional type.
+	 * @alpha
+	 */
+	optional(innerType: TypeFactoryType): TypeFactoryOptional {
+		return { _kind: "optional", innerType };
+	},
+
+	/**
+	 * Create a readonly type.
+	 * @alpha
+	 */
+	readonly(innerType: TypeFactoryType): TypeFactoryReadonly {
+		return { _kind: "readonly", innerType };
+	},
+
+	/**
+	 * Create an instanceOf type for a SharedTree schema class.
+	 * @alpha
+	 */
+	instanceOf<T extends TreeNodeSchemaClass>(schema: T): TypeFactoryInstanceOf {
+		if (!(schema instanceof ObjectNodeSchema)) {
+			throw new UsageError(
+				`typeFactory.instanceOf only supports ObjectNodeSchema-based schema classes (created via SchemaFactory.object). ` +
+					`Pass a schema class that extends from an object schema (e.g., sf.object(...)), not primitive, array, or map schemas.`,
+			);
+		}
+		const instanceOfType: TypeFactoryInstanceOf = {
+			_kind: "instanceof",
+			schema,
+		};
+		instanceOfsTypeFactory.set(instanceOfType, schema);
+		return instanceOfType;
+	},
+};
+
+/**
+ * A lookup from type factory instanceOf types to their corresponding ObjectNodeSchema.
+ * @alpha
+ */
+export const instanceOfsTypeFactory = new WeakMap<TypeFactoryInstanceOf, ObjectNodeSchema>();

--- a/packages/framework/tree-agent/src/treeAgentTypes.ts
+++ b/packages/framework/tree-agent/src/treeAgentTypes.ts
@@ -35,6 +35,9 @@ export type TypeFactoryTypeKind =
  * @alpha
  */
 export interface TypeFactoryType {
+	/**
+	 * The kind of type this represents.
+	 */
 	readonly _kind: TypeFactoryTypeKind;
 }
 
@@ -77,136 +80,243 @@ export function isTypeFactoryType(value: unknown): value is TypeFactoryType {
 // Primitive type factories
 
 /**
+ * Represents a string type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryString extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "string";
 }
 
 /**
+ * Represents a number type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryNumber extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "number";
 }
 
 /**
+ * Represents a boolean type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryBoolean extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "boolean";
 }
 
 /**
+ * Represents a void type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryVoid extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "void";
 }
 
 /**
+ * Represents an undefined type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryUndefined extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "undefined";
 }
 
 /**
+ * Represents a null type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryNull extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "null";
 }
 
 /**
+ * Represents an unknown type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryUnknown extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "unknown";
 }
 
 // Complex type interfaces
 
 /**
+ * Represents an array type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryArray extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "array";
+	/**
+	 * The type of elements in the array.
+	 */
 	readonly element: TypeFactoryType;
 }
 
 /**
+ * Represents an object type with a fixed shape in the type factory system.
  * @alpha
  */
 export interface TypeFactoryObject extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "object";
+	/**
+	 * The shape of the object, mapping property names to their types.
+	 */
 	readonly shape: Record<string, TypeFactoryType>;
 }
 
 /**
+ * Represents a record type (index signature) in the type factory system.
  * @alpha
  */
 export interface TypeFactoryRecord extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "record";
+	/**
+	 * The type of the record's keys.
+	 */
 	readonly keyType: TypeFactoryType;
+	/**
+	 * The type of the record's values.
+	 */
 	readonly valueType: TypeFactoryType;
 }
 
 /**
+ * Represents a Map type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryMap extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "map";
+	/**
+	 * The type of the map's keys.
+	 */
 	readonly keyType: TypeFactoryType;
+	/**
+	 * The type of the map's values.
+	 */
 	readonly valueType: TypeFactoryType;
 }
 
 /**
+ * Represents a tuple type with fixed-length items and optional rest elements in the type factory system.
  * @alpha
  */
 export interface TypeFactoryTuple extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "tuple";
+	/**
+	 * The fixed-length items in the tuple.
+	 */
 	readonly items: readonly TypeFactoryType[];
+	/**
+	 * Optional rest element type for variable-length tuples.
+	 */
 	readonly rest?: TypeFactoryType;
 }
 
 /**
+ * Represents a union type in the type factory system.
  * @alpha
  */
 export interface TypeFactoryUnion extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "union";
+	/**
+	 * The possible types in the union.
+	 */
 	readonly options: readonly TypeFactoryType[];
 }
 
 /**
+ * Represents a literal type (specific string, number, or boolean value) in the type factory system.
  * @alpha
  */
 export interface TypeFactoryLiteral extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "literal";
+	/**
+	 * The specific literal value.
+	 */
 	readonly value: string | number | boolean;
 }
 
 /**
+ * Represents an optional type modifier in the type factory system.
  * @alpha
  */
 export interface TypeFactoryOptional extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "optional";
+	/**
+	 * The inner type that is optional.
+	 */
 	readonly innerType: TypeFactoryType;
 }
 
 /**
+ * Represents a readonly type modifier in the type factory system.
  * @alpha
  */
 export interface TypeFactoryReadonly extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "readonly";
+	/**
+	 * The inner type that is readonly.
+	 */
 	readonly innerType: TypeFactoryType;
 }
 
 /**
+ * Represents an instanceof type that references a SharedTree schema class in the type factory system.
  * @alpha
  */
 export interface TypeFactoryInstanceOf extends TypeFactoryType {
+	/**
+	 * {@inheritDoc TypeFactoryType._kind}
+	 */
 	readonly _kind: "instanceof";
+	/**
+	 * The SharedTree schema class to reference.
+	 */
 	readonly schema: ObjectNodeSchema;
 }
 


### PR DESCRIPTION
This adds a new language for declaring schema method signatures for use by the LLM. See the changeset for details.

In a future PR, we will remove the old way of doing it - with zod - which will allow us to remove our dependency on the zod library.

Why remove zod?

* It reduces bundle size. We are not actually using any of the interesting runtime capabilities of zod, only the type definitions, so all that is code is being downloaded needlessly.
* It's a semantic mismatch for our purposes. Zod is primarily designed to validate JSON on import. We are not doing that, we are just using it as a language to express TS types.
* It doesn't have all the capabilities we need - for example, it can't model (without kludgery) types that are different on read vs. write.
* We rely on its internal details to examine the types. Furthermore, we don't implement the full space of its types (and we don't want to).