### PR TITLE
build(client-presence): fix gen-version build order dependency

### DIFF
--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -166,7 +166,8 @@
 			],
 			"build:esnext:main": [
 				"^api",
-				"^build:esnext"
+				"^build:esnext",
+				"build:genver"
 			],
 			"check:exports:bundle-release-tags": [
 				"build:esnext"
@@ -180,7 +181,8 @@
 			],
 			"tsc:main": [
 				"^api",
-				"^tsc"
+				"^tsc",
+				"build:genver"
 			]
 		}
 	},


### PR DESCRIPTION
Since packageVersion.ts is used it should be updated before compiling main code.