### PR TITLE
fix(driver-utils): prevent unhandled rejection in getSnapshotTree prefetch

### DIFF
--- a/packages/loader/driver-utils/src/prefetchDocumentStorageService.ts
+++ b/packages/loader/driver-utils/src/prefetchDocumentStorageService.ts
@@ -31,13 +31,20 @@ export class PrefetchDocumentStorageService extends DocumentStorageServiceProxy 
 	public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
 		const p = this.internalStorageService.getSnapshotTree(version);
 		if (this.prefetchEnabled) {
-			// We don't care if the prefetch succeeds
-			void p.then((tree: ISnapshotTree | null | undefined) => {
-				if (tree === null || tree === undefined) {
-					return;
-				}
-				this.prefetchTree(tree);
-			});
+			// Fire-and-forget prefetch - we don't care if it succeeds.
+			// The .catch() prevents unhandled rejection when p rejects, since
+			// p.then() creates a derived promise that also rejects if p rejects.
+			// Callers awaiting the returned p will still receive the error.
+			void p
+				.then((tree: ISnapshotTree | null | undefined) => {
+					if (tree === null || tree === undefined) {
+						return;
+					}
+					this.prefetchTree(tree);
+				})
+				.catch(() => {
+					// Intentionally empty - error will be handled by caller awaiting p
+				});
 		}
 		return p;
 	}
@@ -81,8 +88,9 @@ export class PrefetchDocumentStorageService extends DocumentStorageServiceProxy 
 		this.prefetchTreeCore(tree, secondary);
 
 		for (const blob of secondary) {
-			// We don't care if the prefetch succeeds
-			void this.cachedRead(blob);
+			// Fire-and-forget prefetch. The .catch() prevents unhandled rejection
+			// since cachedRead is async and returns a separate promise chain.
+			this.cachedRead(blob).catch(() => {});
 		}
 	}
 
@@ -90,8 +98,9 @@ export class PrefetchDocumentStorageService extends DocumentStorageServiceProxy 
 		for (const [blobKey, blob] of Object.entries(tree.blobs)) {
 			if (blobKey.startsWith(".") || blobKey === "header" || blobKey.startsWith("quorum")) {
 				if (blob !== null) {
-					// We don't care if the prefetch succeeds
-					void this.cachedRead(blob);
+					// Fire-and-forget prefetch. The .catch() prevents unhandled rejection
+					// since cachedRead is async and returns a separate promise chain.
+					this.cachedRead(blob).catch(() => {});
 				}
 			} else if (!blobKey.startsWith("deltas")) {
 				if (blob !== null) {

--- a/packages/loader/driver-utils/src/prefetchDocumentStorageService.ts
+++ b/packages/loader/driver-utils/src/prefetchDocumentStorageService.ts
@@ -35,16 +35,14 @@ export class PrefetchDocumentStorageService extends DocumentStorageServiceProxy 
 			// The .catch() prevents unhandled rejection when p rejects, since
 			// p.then() creates a derived promise that also rejects if p rejects.
 			// Callers awaiting the returned p will still receive the error.
-			void p
-				.then((tree: ISnapshotTree | null | undefined) => {
-					if (tree === null || tree === undefined) {
-						return;
-					}
-					this.prefetchTree(tree);
-				})
-				.catch(() => {
-					// Intentionally empty - error will be handled by caller awaiting p
-				});
+			p.then((tree: ISnapshotTree | null | undefined) => {
+				if (tree === null || tree === undefined) {
+					return;
+				}
+				this.prefetchTree(tree);
+			}).catch(() => {
+				// Intentionally empty - error will be handled by caller awaiting p
+			});
 		}
 		return p;
 	}


### PR DESCRIPTION
## Summary

- Fix unhandled promise rejections in `PrefetchDocumentStorageService` fire-and-forget calls
- Add unit test for getSnapshotTree failure scenario

## Problem

This is a follow-up to PR #26151. After that fix was deployed, telemetry showed 349 `uncaughtException` errors from `ShreddedSummaryDocumentStorageService.readBlob` in test-service-load tinylicious tests.

**Root cause:** PR #26151 attached `.catch()` to the inner promise in `cachedRead()`, but that only handles ONE promise chain. The fire-and-forget callers create a DIFFERENT chain:

1. **`void this.cachedRead(blob)`** - `cachedRead` is async, so it returns a NEW promise wrapping the inner promise. The `.catch()` on the inner promise doesn't prevent unhandled rejection on the async function's returned promise.

2. **`void p.then(...)`** in `getSnapshotTree()` - creates a derived promise that also rejects when `p` rejects.

## Solution

Fix all three fire-and-forget patterns:

```typescript
// Before (inner promise handled, but async wrapper not):
void this.cachedRead(blob);

// After (handles the async function's returned promise):
this.cachedRead(blob).catch(() => {});
```

```typescript
// Before (derived promise not handled):
void p.then((tree) => this.prefetchTree(tree));

// After (handles the derived promise):
void p.then(...).catch(() => {});
```

## Test plan

- [x] New unit test for `getSnapshotTree` failure scenario
- [x] All 5 PrefetchDocumentStorageService tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: anthony-murphy <anthony.murphy@microsoft.com>