### PR TITLE
Enable no-useless-fallback-in-spread in packages/tree

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -69,7 +69,6 @@ module.exports = {
 		"unicorn/no-await-expression-member": "off",
 		"unicorn/no-new-array": "off",
 		"unicorn/no-null": "off",
-		"unicorn/no-useless-fallback-in-spread": "off",
 		"unicorn/prefer-export-from": "off",
 		"unicorn/text-encoding-identifier-case": "off",
 

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -43,7 +43,6 @@ const config: Linter.Config[] = [
 			"unicorn/no-await-expression-member": "off",
 			"unicorn/no-new-array": "off",
 			"unicorn/no-null": "off",
-			"unicorn/no-useless-fallback-in-spread": "off",
 			"unicorn/prefer-export-from": "off",
 			"unicorn/text-encoding-identifier-case": "off",
 		},

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -315,7 +315,7 @@ function rebaseMarkIgnoreChild(
 			if (currMark.changes !== undefined) {
 				moveRebasedChanges(currMark.changes, moveEffects, getEndpoint(baseMark));
 			}
-			rebasedMark = { ...(remains ?? {}), count: baseMark.count };
+			rebasedMark = { ...remains, count: baseMark.count };
 		} else {
 			rebasedMark = currMark;
 		}

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
@@ -94,7 +94,7 @@ export class SchemaFactoryAlpha<
 	} {
 		return objectSchema(scoped<TScope, TName, Name>(this, name), fields, true, {
 			...defaultSchemaFactoryObjectOptions,
-			...(options ?? {}),
+			...options,
 		});
 	}
 

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryBeta.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryBeta.ts
@@ -260,7 +260,7 @@ export class SchemaFactoryBeta<
 	> {
 		return objectSchema(scoped<TScope, TName, Name>(this, name), fields, true, {
 			...defaultSchemaFactoryObjectOptions,
-			...(options ?? {}),
+			...options,
 		});
 	}
 


### PR DESCRIPTION
Removes the unicorn/no-useless-fallback: off override from the @fluidframework/tree package and fixes the resulting errors. This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.