### PR TITLE
Enable unicorn/no-new-array in packages/tree

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -70,7 +70,6 @@ module.exports = {
 		"unicorn/no-array-method-this-argument": "off",
 		"unicorn/no-array-reduce": "off",
 		"unicorn/no-await-expression-member": "off",
-		"unicorn/no-new-array": "off",
 		"unicorn/no-null": "off",
 		"unicorn/no-object-as-default-parameter": "off",
 		"unicorn/no-useless-fallback-in-spread": "off",

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -43,7 +43,6 @@ const config: Linter.Config[] = [
 			"unicorn/no-array-method-this-argument": "off",
 			"unicorn/no-array-reduce": "off",
 			"unicorn/no-await-expression-member": "off",
-			"unicorn/no-new-array": "off",
 			"unicorn/no-null": "off",
 			"unicorn/no-object-as-default-parameter": "off",
 			"unicorn/no-useless-fallback-in-spread": "off",

--- a/packages/dds/tree/src/test/domains/json/canada.ts
+++ b/packages/dds/tree/src/test/domains/json/canada.ts
@@ -88,15 +88,14 @@ export function generateCanada(segmentLengths = originalSegmentLengths, seed = 1
 		// adding a very small amount of noise.
 		const noise = (x: number) => Math.trunc(x * 1000000) / 1000000 + noiseDist();
 
-		return new Array(len)
-			.fill(0)
-			.map(
-				() =>
-					[
-						(last_x = noise(clamp(-141, last_x + vxDist(), -52))),
-						(last_y = noise(clamp(41, last_y + vyDist(), 83))),
-					] as [number, number],
-			);
+		return Array.from(
+			{ length: len },
+			() =>
+				[
+					(last_x = noise(clamp(-141, last_x + vxDist(), -52))),
+					(last_y = noise(clamp(41, last_y + vyDist(), 83))),
+				] as [number, number],
+		);
 	});
 
 	return {

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -122,9 +122,10 @@ function createInitialTree(
 	childNodeByteSize: number,
 ): InsertableTreeNodeFromImplicitAllowedTypes<typeof Parent> {
 	const childNode = createTreeWithSize(childNodeByteSize);
-	const children: InsertableTreeNodeFromImplicitAllowedTypes<typeof Child>[] = new Array(
-		childNodes,
-	).fill(childNode);
+	const children: InsertableTreeNodeFromImplicitAllowedTypes<typeof Child>[] = Array.from(
+		{ length: childNodes },
+		() => childNode,
+	);
 	return children;
 }
 

--- a/packages/dds/tree/src/test/shared-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/tree.spec.ts
@@ -400,9 +400,9 @@ describe("treeApi", () => {
 
 	it("context", () => {
 		const schemaFactory = new SchemaFactory(undefined);
-		class Array extends schemaFactory.array("array", schemaFactory.number) {}
+		class ArrayNode extends schemaFactory.array("array", schemaFactory.number) {}
 		const view = getView(
-			new TreeViewConfiguration({ schema: Array, enableSchemaValidation: true }),
+			new TreeViewConfiguration({ schema: ArrayNode, enableSchemaValidation: true }),
 		);
 		view.initialize([1, 2, 3]);
 
@@ -412,7 +412,7 @@ describe("treeApi", () => {
 		assert(context !== undefined);
 
 		// Unhydrated
-		assert.equal(TreeAlpha.branch(new Array([1, 2, 3])), undefined);
+		assert.equal(TreeAlpha.branch(new ArrayNode([1, 2, 3])), undefined);
 	});
 
 	it("can cast to alpha", () => {

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -323,20 +323,20 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			name: "nested-sequence-change",
 			runScenario: async (takeSnapshot) => {
 				const sf = new SchemaFactory("test trees");
-				class Array extends sf.arrayRecursive('Array<["test trees.Recursive Map"]>', [
+				class ArrayNode extends sf.arrayRecursive('Array<["test trees.Recursive Map"]>', [
 					() => SequenceMap,
 				]) {}
-				class SequenceMap extends sf.mapRecursive("Recursive Map", [() => Array]) {}
+				class SequenceMap extends sf.mapRecursive("Recursive Map", [() => ArrayNode]) {}
 
 				const provider = new TestTreeProviderLite(1, factory, true);
 				const tree = provider.trees[0];
 				const view = tree.viewWith(
 					new TreeViewConfiguration({
-						schema: Array,
+						schema: ArrayNode,
 						enableSchemaValidation,
 					}),
 				);
-				view.initialize(new Array([]));
+				view.initialize(new ArrayNode([]));
 				provider.synchronizeMessages();
 
 				// We must make this shallow change to the sequence field as part of the same transaction as the
@@ -345,7 +345,10 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					view.root.insertAtStart(new SequenceMap([]));
 					const map = view.root[0];
 					const innerArray: SequenceMap[] = [];
-					map.set("foo", new Array([new SequenceMap([["bar", new Array(innerArray)]])]));
+					map.set(
+						"foo",
+						new ArrayNode([new SequenceMap([["bar", new ArrayNode(innerArray)]])]),
+					);
 					// Since innerArray is an array, not an actual node, this does nothing (other than ensure innerArray was copied and thus the tree was not modified by this change)
 					innerArray.push(new SequenceMap([]));
 				});


### PR DESCRIPTION
Removes the unicorn/no-new-array: off override from the @fluidframework/tree package and fixes the resulting errors. This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.

Renamed local schema classes from Array to ArrayNode to avoid shadowing the built-in Array constructor. These were false positives.

All violations were fixed without requiring eslint-disable comments.