### PR TITLE
feat(eslint-config-fluid): Enable "recommended" rules in "minimal-deprecated" as warnings

### DIFF
--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -189,7 +189,7 @@ module.exports = {
 		"@typescript-eslint/explicit-module-boundary-types": "warn",
 
 		/**
-		 * Forbids the explicit use of the `any` type.
+		 * Disallows the explicit use of the `any` type.
 		 * @remarks Note: this will be promoted to "error" in a future release.
 		 */
 		"@typescript-eslint/no-explicit-any": [

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -167,10 +167,71 @@ module.exports = {
 			},
 		],
 
-		// ENABLED INTENTIONALLY
+		// #region ENABLED INTENTIONALLY
+
+		// Note: will be promoted to an error in the future.
+		"@typescript-eslint/consistent-type-exports": [
+			"warn",
+			{
+				fixMixedExportsWithInlineTypeSpecifier: true,
+			},
+		],
+
+		// Note: will be promoted to an error in the future.
+		"@typescript-eslint/consistent-type-imports": ["warn", { fixStyle: "inline-type-imports" }],
+
 		"@typescript-eslint/dot-notation": "error",
+
+		/**
+		 * Requires explicit typing for anything exported from a module.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/explicit-module-boundary-types": "warn",
+
+		/**
+		 * Forbids the explicit use of the `any` type.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/no-explicit-any": [
+			"warn",
+			{
+				ignoreRestArgs: true,
+			},
+		],
+
 		"@typescript-eslint/no-non-null-assertion": "error",
+
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
+
+		/**
+		 * Disallows calling a function with a value with type `any`.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/no-unsafe-argument": "warn",
+
+		/**
+		 * Disallows assigning any to a variable.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/no-unsafe-assignment": "warn",
+
+		/**
+		 * Disallows calling any variable that is typed as any.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/no-unsafe-call": "warn",
+
+		/**
+		 * Disallows member access on any variable that is typed as any.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/no-unsafe-member-access": "warn",
+
+		/**
+		 * Disallows returning a value with type any from a function.
+		 * @remarks Note: this will be promoted to "error" in a future release.
+		 */
+		"@typescript-eslint/no-unsafe-return": "warn",
 
 		// In some cases, type inference can be wrong, and this can cause a "flip-flop" of type changes in our
 		// API documentation. For example, type inference might decide a function returns a concrete type
@@ -211,6 +272,8 @@ module.exports = {
 		 */
 		"unused-imports/no-unused-imports": "error",
 
+		"no-void": "warn",
+		"require-atomic-updates": "warn",
 		"valid-typeof": "error",
 
 		/**
@@ -229,9 +292,17 @@ module.exports = {
 			},
 		],
 		"unicorn/no-new-buffer": "error",
+
+		/**
+		 * Warns if separators are inconsistent in number literals that contain separators.
+		 */
+		"unicorn/numeric-separators-style": ["warn", { onlyIfContainsSeparator: true }],
+
 		"unicorn/prefer-switch": "error",
 		"unicorn/prefer-ternary": "error",
 		"unicorn/prefer-type-error": "error",
+
+		// #endregion
 
 		// #region DISABLED INTENTIONALLY
 
@@ -242,7 +313,6 @@ module.exports = {
 		"@typescript-eslint/explicit-member-accessibility": "off",
 
 		"@typescript-eslint/member-ordering": "off",
-		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-unused-vars": "off",
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/typedef": "off",
@@ -270,13 +340,7 @@ module.exports = {
 		// Requires a lot of changes; enabled in the strict config
 		"@typescript-eslint/consistent-generic-constructors": "off",
 
-		// Off for minimal and recommended; enabled in the strict config
-		"@typescript-eslint/consistent-type-exports": "off",
-		"@typescript-eslint/consistent-type-imports": "off",
-
 		"func-call-spacing": "off", // Off because it conflicts with typescript-formatter
-		"no-void": "off",
-		"require-atomic-updates": "off",
 
 		/**
 		 * Superseded by `@typescript-eslint/dot-notation`.

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -177,7 +177,17 @@ module.exports = {
 			},
 		],
 
-		// Note: will be promoted to an error in the future.
+		/**
+		 * Enforces consistent usage of `import type` for type-only imports.
+		 *
+		 * This helps clearly separate types from runtime values, which can improve readability,
+		 * support for tree-shaking and bundling, and aligns with modern TypeScript best practices.
+		 *
+		 * @remarks
+		 * Note: this will be promoted to "error" in a future release.
+		 *
+		 * Docs: {@link https://typescript-eslint.io/rules/consistent-type-imports/}
+		 */
 		"@typescript-eslint/consistent-type-imports": ["warn", { fixStyle: "inline-type-imports" }],
 
 		"@typescript-eslint/dot-notation": "error",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -650,10 +650,16 @@
             "error"
         ],
         "@typescript-eslint/consistent-type-exports": [
-            "off"
+            "warn",
+            {
+                "fixMixedExportsWithInlineTypeSpecifier": true
+            }
         ],
         "@typescript-eslint/consistent-type-imports": [
-            "off"
+            "warn",
+            {
+                "fixStyle": "inline-type-imports"
+            }
         ],
         "@typescript-eslint/dot-notation": [
             "error",
@@ -679,7 +685,7 @@
             "off"
         ],
         "@typescript-eslint/explicit-module-boundary-types": [
-            "off"
+            "warn"
         ],
         "@typescript-eslint/func-call-spacing": [
             "off"
@@ -746,7 +752,10 @@
             "error"
         ],
         "@typescript-eslint/no-explicit-any": [
-            "off"
+            "warn",
+            {
+                "ignoreRestArgs": true
+            }
         ],
         "@typescript-eslint/no-extra-non-null-assertion": [
             "error"
@@ -858,13 +867,13 @@
             "error"
         ],
         "@typescript-eslint/no-unsafe-argument": [
-            "off"
+            "warn"
         ],
         "@typescript-eslint/no-unsafe-assignment": [
-            "off"
+            "warn"
         ],
         "@typescript-eslint/no-unsafe-call": [
-            "off"
+            "warn"
         ],
         "@typescript-eslint/no-unsafe-declaration-merging": [
             "error"
@@ -876,10 +885,10 @@
             "error"
         ],
         "@typescript-eslint/no-unsafe-member-access": [
-            "off"
+            "warn"
         ],
         "@typescript-eslint/no-unsafe-return": [
-            "error"
+            "warn"
         ],
         "@typescript-eslint/no-unsafe-unary-minus": [
             "error"
@@ -1733,7 +1742,7 @@
             "error"
         ],
         "no-void": [
-            "off",
+            "warn",
             {
                 "allowAsStatement": false
             }
@@ -1879,7 +1888,7 @@
             "off"
         ],
         "require-atomic-updates": [
-            "off",
+            "warn",
             {
                 "allowProperties": false
             }
@@ -2001,6 +2010,12 @@
         ],
         "unicorn/number-literal-case": [
             "off"
+        ],
+        "unicorn/numeric-separators-style": [
+            "warn",
+            {
+                "onlyIfContainsSeparator": true
+            }
         ],
         "unicorn/prefer-switch": [
             "error"


### PR DESCRIPTION
Part of a larger effort to collapse "recommended" into "minimal-deprecated" so we can remove the "minimal" config from the package.

Promotes rules explicitly enabled in "recommended" to "minimal" as warnings (for now). This will encourage developers to not introduce new violations and potentially fix existing ones while we do the larger config migration.