### PR TITLE
ci: use shallow clones in test pipelines to speed up checkout

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -62,6 +62,11 @@ extends:
       jobs:
       - job: run_policy_check
         steps:
+        # Use shallow clone since policy checks only need current file state,
+        # not git history or version detection.
+        - checkout: self
+          clean: true
+          fetchDepth: 1
         - template: /tools/pipelines/templates/include-use-node-version.yml@self
         - template: /tools/pipelines/templates/include-install-pnpm.yml@self
           parameters:

--- a/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
+++ b/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
@@ -41,6 +41,10 @@ stages:
     - job: Job
       displayName: Check for DDS package changes
       steps:
+      # Use fetchDepth: 2 because the job uses 'git diff HEAD~1' to check for changes
+      - checkout: self
+        clean: true
+        fetchDepth: 2
       - ${{ each package in parameters.packages }}:
         - task: PowerShell@2
           inputs:

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -29,7 +29,10 @@ parameters:
   default: $(Agent.TempDirectory)
 
 steps:
+# Use shallow clone since this pipeline only runs pre-built tests from artifacts;
+# no git history or version detection is needed.
 - checkout: ff_pipeline_host
+  fetchDepth: 1
 
 - task: Bash@3
   displayName: Print parameter/variable values for troubleshooting

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -187,9 +187,11 @@ stages:
         - name: artifactPipeline
           value: Build - client packages
         steps:
-        # Setup
+        # Setup. Use shallow clone since we only need current files to run tests;
+        # no git history is needed.
         - checkout: ff_pipeline_host
           clean: true
+          fetchDepth: 1
 
         # Install self-signed cert for R11s deployment in local cert store
         - ${{ if ne(parameters.r11sSelfSignedCertSecureFile, '') }}:
@@ -254,9 +256,11 @@ stages:
 
         # Set up Docker environment if running against docker
         - ${{ if eq(parameters.runAgainstDocker, true) }}:
-          # Checks out FluidFramework repo
+          # Checks out FluidFramework repo. Use shallow clone since we only need
+          # the docker-compose files; no git history or version detection is needed.
           - checkout: self
             clean: true
+            fetchDepth: 1
           - task: Docker@2
             displayName: 'Login to container registry'
             inputs:


### PR DESCRIPTION
## Summary

Adds `fetchDepth` settings to checkout steps in ADO pipelines that don't require git history or version detection. This reduces checkout time and network bandwidth.

**Changes:**
- `repo-policy-check.yml`: Add explicit checkout with `fetchDepth: 1` (only needs current file state for policy checks)
- `include-conditionally-run-stress-tests.yml`: Add checkout with `fetchDepth: 2` (uses `git diff HEAD~1` to detect changed packages)
- `include-test-perf-benchmarks.yml`: Add `fetchDepth: 1` to `ff_pipeline_host` checkout (runs pre-built test artifacts)
- `include-test-real-service.yml`: Add `fetchDepth: 1` to both `ff_pipeline_host` and `self` checkouts (runs pre-built test artifacts)

**Not changed:** Build pipelines that use `flub generate buildVersion` are intentionally unchanged since they require full git tag history for version detection.