### PR TITLE
build(client): add pnpm supply chain security settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,6 +3,17 @@ frozen-lockfile=true
 strict-peer-dependencies=true
 link-workspace-packages=true
 
+# Use time-based resolution to avoid pulling in the newest packages from npm.
+# This delays ingestion of newly published packages, which helps avoid supply chain attacks.
+resolution-mode=time-based
+
+# Block packages published less than 24 hours ago to avoid supply chain attacks.
+minimum-release-age=1440
+
+# Block transitive dependencies from using exotic sources (git, tarballs).
+# Only direct dependencies can use those - all subdeps must come from the registry.
+block-exotic-subdeps=true
+
 # Disable pnpm update notifications since we use corepack to install package managers
 update-notifier=false
 # Use the number of cores on the machine by default.

--- a/.npmrc
+++ b/.npmrc
@@ -14,6 +14,12 @@ minimum-release-age=1440
 # Only direct dependencies can use those - all subdeps must come from the registry.
 block-exotic-subdeps=true
 
+# Fail installation if a package's trust/verification level decreases compared to earlier releases.
+trust-policy=no-downgrade
+
+# Fail installation if dependencies have unreviewed build scripts.
+strict-dep-builds=true
+
 # Disable pnpm update notifications since we use corepack to install package managers
 update-notifier=false
 # Use the number of cores on the machine by default.


### PR DESCRIPTION
## Summary

Adds pnpm security settings to reduce exposure to supply chain attacks:

- **`resolution-mode=time-based`**: Prefer subdependency versions that existed when direct dependencies were published, rather than always pulling the newest matching version
- **`minimum-release-age=1440`**: Block packages published less than 24 hours ago, giving the community time to identify malicious releases
- **`block-exotic-subdeps=true`**: Prevent transitive dependencies from using git repos or tarball URLs; only direct dependencies can use exotic sources
- **`trust-policy=no-downgrade`**: Fail installation if a package's verification/trust level decreases compared to earlier releases
- **`strict-dep-builds=true`**: Fail installation if dependencies have unreviewed build scripts (works with existing `onlyBuiltDependencies` allowlist)