### PR TITLE
Fix TupleBTree to ensure order is consistent

### DIFF
--- a/packages/dds/tree/src/feature-libraries/changeAtomIdBTree.ts
+++ b/packages/dds/tree/src/feature-libraries/changeAtomIdBTree.ts
@@ -6,7 +6,15 @@
 import type { ChangeAtomId, ChangesetLocalId, RevisionTag } from "../core/index.js";
 import type { TupleBTree } from "../util/index.js";
 
-export type ChangeAtomIdBTree<V> = TupleBTree<[RevisionTag | undefined, ChangesetLocalId], V>;
+/**
+ * A BTree which uses ChangeAtomId flattened into a tuple as the key.
+ * @remarks
+ * Read values with {@link getFromChangeAtomIdMap} and write values with {@link setInChangeAtomIdMap}.
+ */
+export type ChangeAtomIdBTree<V> = TupleBTree<
+	readonly [RevisionTag | undefined, ChangesetLocalId],
+	V
+>;
 
 export function getFromChangeAtomIdMap<T>(
 	map: ChangeAtomIdBTree<T>,

--- a/packages/dds/tree/src/util/bTreeUtils.ts
+++ b/packages/dds/tree/src/util/bTreeUtils.ts
@@ -3,43 +3,54 @@
  * Licensed under the MIT License.
  */
 
-import { BTree } from "@tylerbu/sorted-btree-es6";
+import { BTree, defaultComparator, type DefaultComparable } from "@tylerbu/sorted-btree-es6";
 
 import { brand, type Brand } from "./brand.js";
+import { debugAssert } from "@fluidframework/core-utils/internal";
 
-export type TupleBTree<K, V> = Brand<BTree<K, V>, "TupleBTree">;
+/**
+ * A BTree which uses tuples (arrays) as the key.
+ * @remarks
+ * All keys must be the same length.
+ */
+export type TupleBTree<K extends readonly DefaultComparable[], V> = Brand<
+	BTree<K, V>,
+	"TupleBTree"
+>;
 
-export function newTupleBTree<K extends readonly unknown[], V>(
+/**
+ * Create a new {@link TupleBTree}.
+ */
+export function newTupleBTree<K extends readonly DefaultComparable[], V>(
 	entries?: [K, V][],
 ): TupleBTree<K, V> {
 	return brand(new BTree<K, V>(entries, compareTuples));
 }
 
-// This assumes that the arrays are the same length.
-function compareTuples(arrayA: readonly unknown[], arrayB: readonly unknown[]): number {
+/**
+ * Compares two tuples (arrays) element by element.
+ * @param arrayA - The first tuple to compare.
+ * @param arrayB - The second tuple to compare.
+ * @returns A negative number if arrayA \< arrayB, a positive number if arrayA \> arrayB, or 0 if they are equal.
+ */
+function compareTuples(
+	arrayA: readonly DefaultComparable[],
+	arrayB: readonly DefaultComparable[],
+): number {
+	debugAssert(
+		() =>
+			arrayA.length === arrayB.length || "compareTuples requires arrays of the same length",
+	);
 	for (let i = 0; i < arrayA.length; i++) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const a = arrayA[i] as any;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const b = arrayB[i] as any;
-
-		// Less-than and greater-than always return false if either value is undefined,
-		// so we handle undefined separately, treating it as less than all other values.
-		if (a === undefined && b !== undefined) {
-			return -1;
-		} else if (b === undefined && a !== undefined) {
-			return 1;
-		} else if (a < b) {
-			return -1;
-		} else if (a > b) {
-			return 1;
+		const result = defaultComparator(arrayA[i], arrayB[i]);
+		if (result !== 0) {
+			return result;
 		}
 	}
-
 	return 0;
 }
 
-export function mergeTupleBTrees<K extends readonly unknown[], V>(
+export function mergeTupleBTrees<K extends readonly DefaultComparable[], V>(
 	tree1: TupleBTree<K, V> | undefined,
 	tree2: TupleBTree<K, V> | undefined,
 	preferLeft = true,

--- a/packages/dds/tree/src/util/bTreeUtils.ts
+++ b/packages/dds/tree/src/util/bTreeUtils.ts
@@ -21,7 +21,7 @@ export type TupleBTree<K extends readonly DefaultComparable[], V> = Brand<
 /**
  * Create a new {@link TupleBTree}.
  */
-export function newTupleBTree<K extends readonly DefaultComparable[], V>(
+export function newTupleBTree<const K extends readonly DefaultComparable[], V>(
 	entries?: [K, V][],
 ): TupleBTree<K, V> {
 	return brand(new BTree<K, V>(entries, compareTuples));


### PR DESCRIPTION
## Description

TupleBTree  was lacking documentation about limitations on its keys, and its implementation also had the same bug that the BTree library used to have it its comparisons (which I fixed): it would fail to produce a consistent partial order for some cases of mixing numbers ad strings (and likely some other cases). I do not think this bug would impact our current usage, but it now uses the robust well tested comparison from the SortedBTree, as well as being less code and having stricter types which better reflect the actual limitations while supporting more cases.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

