### PR TITLE
build(client-devtools): full build helper script

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/README.md
+++ b/packages/tools/devtools/devtools-browser-extension/README.md
@@ -99,7 +99,7 @@ To run the automated end-to-end tests, run `npm run test:jest` in a terminal fro
 
 To use a local build of this extension in your browser:
 
-1. Build this package and its dependencies.
+1. Build webpack of this package using `npm run build:webpack`.
    Your extension files should be generated under the build output directory (`dist/bundle`) in this package directory.
 2. Load the unpacked extension in the browser by following [these instructions](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked).
     - For [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/about) users, your Linux files should be at a \\wsl$ path.

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -20,7 +20,7 @@
 		"build:test": "npm run build:test:esm && npm run build:test:cjs",
 		"build:test:cjs": "fluid-tsc commonjs --project ./e2e-tests/tsconfig.cjs.json",
 		"build:test:esm": "tsc --project ./e2e-tests/tsconfig.json",
-		"build:webpack": "npm run webpack",
+		"build:webpack": "fluid-build . --task webpack",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
 		"clean": "rimraf --glob coverage dist lib nyc \"**/*.tsbuildinfo\" \"**/*.build.log\"",


### PR DESCRIPTION
- Make `build:webpack` support automatic dependency building.
- Document build step required for local deploy.