### PR TITLE
Move revertible API

### DIFF
--- a/.changeset/heavy-canyons-change.md
+++ b/.changeset/heavy-canyons-change.md
@@ -1,0 +1,57 @@
+---
+"@fluidframework/tree": minor
+"__section": deprecation
+---
+`getRevertible` has moved onto `ChangeMetadata`
+
+The `getRevertible` factory provided by the `changed` event is now exposed on the `ChangeMetadata` object instead of as
+the second callback parameter. The second parameter is deprecated and will be removed in a future release.
+
+## Why this change?
+
+Keeping all per-change data on `ChangeMetadata` makes the API:
+
+1. Easier to discover
+1. Easier to ignore
+1. Require less parameter churn to use
+1. Consistent with the `getChange` API, which is also only available on local commits.
+
+## Migration
+
+**Before (deprecated):**
+
+The `getRevertible` argument passed to the event had the following shape:
+
+|               | Data change         | Schema change |
+|---------------|---------------------|---------------|
+| Local change  | `() => Revertible`  | `undefined`   |
+| Remote change | `undefined`         | `undefined`   |
+
+```typescript
+checkout.events.on("changed", (_data, getRevertible) => {
+	if (getRevertible !== undefined) {
+		const revertible = getRevertible();
+		// ...
+	}
+});
+```
+
+**After:**
+
+The new `getRevertible` property has the following shape:
+
+|               | Data change         | Schema change     |
+|---------------|---------------------|-------------------|
+| Local change  | `() => Revertible`  | `() => undefined` |
+| Remote change | `undefined`         | `undefined`       |
+
+```typescript
+checkout.events.on("changed", ({ getRevertible }) => {
+	const revertible = getRevertible?.();
+	if (revertible !== undefined) {
+		// ...
+	}
+});
+```
+
+This applies potentially anywhere you listen to `changed` (for example on `TreeViewAlpha.events`/`TreeBranchEvents`).

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -138,9 +138,11 @@ export interface BranchableTree extends ViewableTree {
 export type ChangeMetadata = CommitMetadata & ({
     readonly isLocal: true;
     getChange(): JsonCompatibleReadOnly;
+    getRevertible(onDisposed?: (revertible: RevertibleAlpha) => void): RevertibleAlpha | undefined;
 } | {
     readonly isLocal: false;
     readonly getChange?: undefined;
+    readonly getRevertible?: undefined;
 });
 
 // @alpha

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -135,15 +135,7 @@ export interface BranchableTree extends ViewableTree {
 }
 
 // @alpha @sealed
-export type ChangeMetadata = CommitMetadata & ({
-    readonly isLocal: true;
-    getChange(): JsonCompatibleReadOnly;
-    getRevertible(onDisposed?: (revertible: RevertibleAlpha) => void): RevertibleAlpha | undefined;
-} | {
-    readonly isLocal: false;
-    readonly getChange?: undefined;
-    readonly getRevertible?: undefined;
-});
+export type ChangeMetadata = LocalChangeMetadata | RemoteChangeMetadata;
 
 // @alpha
 export function checkCompatibility(viewWhichCreatedStoredSchema: TreeViewConfiguration, view: TreeViewConfiguration): Omit<SchemaCompatibilityStatus, "canInitialize">;
@@ -705,6 +697,13 @@ export type Listenable<T extends object> = Listenable_2<T>;
 // @public @deprecated
 export type Listeners<T extends object> = Listeners_2<T>;
 
+// @alpha @sealed
+export interface LocalChangeMetadata extends CommitMetadata {
+    getChange(): JsonCompatibleReadOnly;
+    getRevertible(onDisposed?: (revertible: RevertibleAlpha) => void): RevertibleAlpha | undefined;
+    readonly isLocal: true;
+}
+
 // @public @sealed
 export interface MakeNominal {
 }
@@ -866,6 +865,13 @@ export type RecordNodeSchema<TName extends string = string, T extends ImplicitAl
 export const RecordNodeSchema: {
     readonly [Symbol.hasInstance]: (value: TreeNodeSchema) => value is RecordNodeSchema<string, ImplicitAllowedTypes, true, unknown>;
 };
+
+// @alpha @sealed
+export interface RemoteChangeMetadata extends CommitMetadata {
+    readonly getChange?: undefined;
+    readonly getRevertible?: undefined;
+    readonly isLocal: false;
+}
 
 // @alpha
 export function replaceConciseTreeHandles<T>(tree: ConciseTree, replacer: HandleConverter<T>): ConciseTree<T>;

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -175,6 +175,8 @@ export {
 	type GraphCommit,
 	CommitKind,
 	type CommitMetadata,
+	type LocalChangeMetadata,
+	type RemoteChangeMetadata,
 	type ChangeMetadata,
 	type RevisionTag,
 	RevisionTagSchema,

--- a/packages/dds/tree/src/core/rebase/index.ts
+++ b/packages/dds/tree/src/core/rebase/index.ts
@@ -12,6 +12,8 @@ export {
 	type GraphCommit,
 	CommitKind,
 	type CommitMetadata,
+	type LocalChangeMetadata,
+	type RemoteChangeMetadata,
 	type ChangeMetadata,
 	type RevisionTag,
 	RevisionTagSchema,

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -20,6 +20,7 @@ import {
 	brandedNumberType,
 	brandedStringType,
 } from "../../util/index.js";
+import type { RevertibleAlpha } from "../revertible.js";
 
 /**
  * The identifier for a particular session/user/client that can generate `GraphCommit`s
@@ -180,19 +181,48 @@ export interface CommitMetadata {
 export type ChangeMetadata = CommitMetadata &
 	(
 		| {
+				/**
+				 * Whether the change was made on the local machine/client or received from a remote client.
+				 */
 				readonly isLocal: true;
 				/**
-				 * A serializable object that encodes the change.
-				 * @remarks This change object can be {@link TreeBranchAlpha.applyChange | applied to another branch} in the same state as the one which generated it.
+				 * Returns a serializable object that encodes the change.
+				 * @remarks This is only available for local changes.
+				 * This change object can be {@link TreeBranchAlpha.applyChange | applied to another branch} in the same state as the one which generated it.
 				 * The change object must be applied to a SharedTree with the same IdCompressor session ID as it was created from.
 				 * @privateRemarks
 				 * This is a `SerializedChange` from treeCheckout.ts.
 				 */
 				getChange(): JsonCompatibleReadOnly;
+				/**
+				 * Returns an object (a {@link RevertibleAlpha | "revertible"}) that can be used to revert the change that produced this event.
+				 * @remarks This is only available for local changes.
+				 * If the change is not revertible (for example, it was a change to the application schema), then this will return `undefined`.
+				 * Revertibles should be disposed when they are no longer needed.
+				 * @param onDisposed - A callback that will be invoked when the `Revertible` is disposed.
+				 * This happens when the `Revertible` is disposed manually or when the `TreeView` that the `Revertible` belongs to is disposed - whichever happens first.
+				 * This is typically used to clean up any resources associated with the `Revertible` in the host application.
+				 * @throws an error if called outside the scope of the `changed` event that provided it.
+				 */
+				getRevertible(
+					onDisposed?: (revertible: RevertibleAlpha) => void,
+				): RevertibleAlpha | undefined;
 		  }
 		| {
+				/**
+				 * Whether the change was made on the local machine/client or received from a remote client.
+				 */
 				readonly isLocal: false;
+				/**
+				 * Returns a serializable object that encodes the change.
+				 * @remarks This is only available for local changes.
+				 */
 				readonly getChange?: undefined;
+				/**
+				 * Returns an object (a {@link RevertibleAlpha | "revertible"}) that can be used to revert the change that produced this event.
+				 * @remarks This is only available for local changes.
+				 */
+				readonly getRevertible?: undefined;
 		  }
 	);
 

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -202,7 +202,7 @@ export type ChangeMetadata = CommitMetadata &
 				 * @param onDisposed - A callback that will be invoked when the `Revertible` is disposed.
 				 * This happens when the `Revertible` is disposed manually or when the `TreeView` that the `Revertible` belongs to is disposed - whichever happens first.
 				 * This is typically used to clean up any resources associated with the `Revertible` in the host application.
-				 * @throws an error if called outside the scope of the `changed` event that provided it.
+				 * @throws Throws an error if called outside the scope of the `changed` event that provided it.
 				 */
 				getRevertible(
 					onDisposed?: (revertible: RevertibleAlpha) => void,

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -174,57 +174,64 @@ export interface CommitMetadata {
 }
 
 /**
- * Information about a commit that has been applied.
- *
+ * Information about a change that has been applied by the local client.
  * @sealed @alpha
  */
-export type ChangeMetadata = CommitMetadata &
-	(
-		| {
-				/**
-				 * Whether the change was made on the local machine/client or received from a remote client.
-				 */
-				readonly isLocal: true;
-				/**
-				 * Returns a serializable object that encodes the change.
-				 * @remarks This is only available for local changes.
-				 * This change object can be {@link TreeBranchAlpha.applyChange | applied to another branch} in the same state as the one which generated it.
-				 * The change object must be applied to a SharedTree with the same IdCompressor session ID as it was created from.
-				 * @privateRemarks
-				 * This is a `SerializedChange` from treeCheckout.ts.
-				 */
-				getChange(): JsonCompatibleReadOnly;
-				/**
-				 * Returns an object (a {@link RevertibleAlpha | "revertible"}) that can be used to revert the change that produced this event.
-				 * @remarks This is only available for local changes.
-				 * If the change is not revertible (for example, it was a change to the application schema), then this will return `undefined`.
-				 * Revertibles should be disposed when they are no longer needed.
-				 * @param onDisposed - A callback that will be invoked when the `Revertible` is disposed.
-				 * This happens when the `Revertible` is disposed manually or when the `TreeView` that the `Revertible` belongs to is disposed - whichever happens first.
-				 * This is typically used to clean up any resources associated with the `Revertible` in the host application.
-				 * @throws Throws an error if called outside the scope of the `changed` event that provided it.
-				 */
-				getRevertible(
-					onDisposed?: (revertible: RevertibleAlpha) => void,
-				): RevertibleAlpha | undefined;
-		  }
-		| {
-				/**
-				 * Whether the change was made on the local machine/client or received from a remote client.
-				 */
-				readonly isLocal: false;
-				/**
-				 * Returns a serializable object that encodes the change.
-				 * @remarks This is only available for local changes.
-				 */
-				readonly getChange?: undefined;
-				/**
-				 * Returns an object (a {@link RevertibleAlpha | "revertible"}) that can be used to revert the change that produced this event.
-				 * @remarks This is only available for local changes.
-				 */
-				readonly getRevertible?: undefined;
-		  }
-	);
+export interface LocalChangeMetadata extends CommitMetadata {
+	/**
+	 * Whether the change was made on the local machine/client or received from a remote client.
+	 */
+	readonly isLocal: true;
+	/**
+	 * Returns a serializable object that encodes the change.
+	 * @remarks This is only available for local changes.
+	 * This change object can be {@link TreeBranchAlpha.applyChange | applied to another branch} in the same state as the one which generated it.
+	 * The change object must be applied to a SharedTree with the same IdCompressor session ID as it was created from.
+	 * @privateRemarks
+	 * This is a `SerializedChange` from treeCheckout.ts.
+	 */
+	getChange(): JsonCompatibleReadOnly;
+	/**
+	 * Returns an object (a {@link RevertibleAlpha | "revertible"}) that can be used to revert the change that produced this event.
+	 * @remarks This is only available for local changes.
+	 * If the change is not revertible (for example, it was a change to the application schema), then this will return `undefined`.
+	 * Revertibles should be disposed when they are no longer needed.
+	 * @param onDisposed - A callback that will be invoked when the `Revertible` is disposed.
+	 * This happens when the `Revertible` is disposed manually or when the `TreeView` that the `Revertible` belongs to is disposed - whichever happens first.
+	 * This is typically used to clean up any resources associated with the `Revertible` in the host application.
+	 * @throws Throws an error if called outside the scope of the `changed` event that provided it.
+	 */
+	getRevertible(
+		onDisposed?: (revertible: RevertibleAlpha) => void,
+	): RevertibleAlpha | undefined;
+}
+
+/**
+ * Information about a change that has been applied by a remote client.
+ * @sealed @alpha
+ */
+export interface RemoteChangeMetadata extends CommitMetadata {
+	/**
+	 * Whether the change was made on the local machine/client or received from a remote client.
+	 */
+	readonly isLocal: false;
+	/**
+	 * Returns a serializable object that encodes the change.
+	 * @remarks This is only available for {@link LocalChangeMetadata | local changes}.
+	 */
+	readonly getChange?: undefined;
+	/**
+	 * Returns an object (a {@link RevertibleAlpha | "revertible"}) that can be used to revert the change that produced this event.
+	 * @remarks This is only available for {@link LocalChangeMetadata | local changes}.
+	 */
+	readonly getRevertible?: undefined;
+}
+
+/**
+ * Information about a {@link LocalChangeMetadata | local} or {@link RemoteChangeMetadata | remote} change that has been applied.
+ * @sealed @alpha
+ */
+export type ChangeMetadata = LocalChangeMetadata | RemoteChangeMetadata;
 
 /**
  * Creates a new graph commit object. This is useful for creating copies of commits with different parentage.

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -9,6 +9,8 @@ export {
 	CommitKind,
 	RevertibleStatus,
 	type CommitMetadata,
+	type LocalChangeMetadata,
+	type RemoteChangeMetadata,
 	type ChangeMetadata,
 	type RevertibleFactory,
 	type RevertibleAlphaFactory,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -132,8 +132,6 @@ export interface CheckoutEvents {
 	 * can use to filter on changes they care about e.g. local vs remote changes.
 	 *
 	 * @param data - information about the change
-	 * @param getRevertible - a function provided that allows users to get a revertible for the change. If not provided,
-	 * this change is not revertible.
 	 */
 	changed(data: ChangeMetadata, getRevertible?: RevertibleAlphaFactory): void;
 
@@ -566,6 +564,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 							change: encodedChange,
 						} satisfies SerializedChange;
 					},
+					getRevertible: (onDisposed) => getRevertible?.(onDisposed),
 				};
 
 				this.#events.emit("changed", metadata, getRevertible);

--- a/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -227,12 +227,13 @@ function init(state: UndoRedoFuzzTestState) {
 	state.unsubscribe = [];
 	for (const client of state.clients) {
 		const checkout = viewFromState(state, client).checkout;
-		const unsubscribe = checkout.events.on("changed", (commit, getRevertible) => {
-			if (getRevertible !== undefined) {
-				if (commit.kind === CommitKind.Undo) {
-					redoStack.push(getRevertible());
+		const unsubscribe = checkout.events.on("changed", ({ kind, getRevertible }) => {
+			const revertible = getRevertible?.();
+			if (revertible !== undefined) {
+				if (kind === CommitKind.Undo) {
+					redoStack.push(revertible);
 				} else {
-					undoStack.push(getRevertible());
+					undoStack.push(revertible);
 				}
 			}
 		});

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1446,9 +1446,12 @@ describe("SharedTree", () => {
 
 			function makeUndoableEdit(peer: Peer, edit: () => void): Revertible {
 				const undos: Revertible[] = [];
-				const unsubscribe = peer.view.events.on("changed", ({ kind }, getRevertible) => {
-					if (kind !== CommitKind.Undo && getRevertible !== undefined) {
-						undos.push(getRevertible());
+				const unsubscribe = peer.view.events.on("changed", ({ kind, getRevertible }) => {
+					if (kind !== CommitKind.Undo) {
+						const revertible = getRevertible?.();
+						if (revertible !== undefined) {
+							undos.push(revertible);
+						}
 					}
 				});
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -17,7 +17,6 @@ import {
 	RevertibleStatus,
 	CommitKind,
 	EmptyKey,
-	type RevertibleFactory,
 	type NormalizedFieldUpPath,
 	TreeStoredSchemaRepository,
 } from "../../core/index.js";
@@ -200,7 +199,7 @@ describe("sharedTreeView", () => {
 				const checkout = provider.trees[0].kernel.checkout;
 
 				const log: string[] = [];
-				const unsubscribe = checkout.events.on("changed", (data, getRevertible) =>
+				const unsubscribe = checkout.events.on("changed", ({ getRevertible }) =>
 					log.push(getRevertible === undefined ? "not-revertible" : "revertible"),
 				);
 
@@ -993,9 +992,9 @@ describe("sharedTreeView", () => {
 	describe("revertibles", () => {
 		itView("can be generated for changes made to the local branch", ({ view }) => {
 			const revertiblesCreated: Revertible[] = [];
-			const unsubscribe = view.events.on("changed", (_, getRevertible) => {
-				assert(getRevertible !== undefined, "commit should be revertible");
-				const revertible = getRevertible();
+			const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
+				const revertible = getRevertible?.();
+				assert(revertible !== undefined, "commit should be revertible");
 				assert.equal(revertible.status, RevertibleStatus.Valid);
 				revertiblesCreated.push(revertible);
 			});
@@ -1021,9 +1020,9 @@ describe("sharedTreeView", () => {
 			({ view }) => {
 				const revertiblesCreated: Revertible[] = [];
 
-				const unsubscribe = view.events.on("changed", (_, getRevertible) => {
-					assert(getRevertible !== undefined, "commit should be revertible");
-					const revertible = getRevertible(onRevertibleDisposed);
+				const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
+					const revertible = getRevertible?.(onRevertibleDisposed);
+					assert(revertible !== undefined, "commit should be revertible");
 					assert.equal(revertible.status, RevertibleStatus.Valid);
 					revertiblesCreated.push(revertible);
 				});
@@ -1059,8 +1058,8 @@ describe("sharedTreeView", () => {
 		itView(
 			"revertibles cannot be acquired outside of the changed event callback",
 			({ view }) => {
-				let acquireRevertible: RevertibleFactory | undefined;
-				const unsubscribe = view.events.on("changed", (_, getRevertible) => {
+				let acquireRevertible: (() => void) | undefined;
+				const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
 					assert(getRevertible !== undefined, "commit should be revertible");
 					acquireRevertible = getRevertible;
 				});
@@ -1074,15 +1073,13 @@ describe("sharedTreeView", () => {
 
 		itView("revertibles cannot be acquired more than once", ({ view }) => {
 			const revertiblesCreated: Revertible[] = [];
-			const unsubscribe1 = view.events.on("changed", (_, getRevertible) => {
-				assert(getRevertible !== undefined, "commit should be revertible");
-				const revertible = getRevertible();
-				assert.equal(revertible.status, RevertibleStatus.Valid);
+			const unsubscribe1 = view.events.on("changed", ({ getRevertible }) => {
+				const revertible = getRevertible?.();
+				assert.equal(revertible?.status, RevertibleStatus.Valid);
 				revertiblesCreated.push(revertible);
 			});
-			const unsubscribe2 = view.events.on("changed", (_, getRevertible) => {
-				assert(getRevertible !== undefined, "commit should be revertible");
-				assert.throws(() => getRevertible());
+			const unsubscribe2 = view.events.on("changed", ({ getRevertible }) => {
+				assert.throws(() => getRevertible?.());
 			});
 
 			view.root.insertAtStart("A");
@@ -1092,9 +1089,9 @@ describe("sharedTreeView", () => {
 
 		itView("disposed revertibles cannot be released or reverted", ({ view }) => {
 			const revertiblesCreated: Revertible[] = [];
-			const unsubscribe = view.events.on("changed", (_, getRevertible) => {
-				assert(getRevertible !== undefined, "commit should be revertible");
-				const r = getRevertible();
+			const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
+				const r = getRevertible?.();
+				assert(r !== undefined, "commit should be revertible");
 				assert.equal(r.status, RevertibleStatus.Valid);
 				revertiblesCreated.push(r);
 			});
@@ -1117,10 +1114,9 @@ describe("sharedTreeView", () => {
 		itView("changed events have the correct commit kinds", ({ view }) => {
 			const revertiblesCreated: Revertible[] = [];
 			const commitKinds: CommitKind[] = [];
-			const unsubscribe = view.events.on("changed", ({ kind }, getRevertible) => {
-				assert(getRevertible !== undefined, "commit should be revertible");
-				const revertible = getRevertible();
-				assert.equal(revertible.status, RevertibleStatus.Valid);
+			const unsubscribe = view.events.on("changed", ({ kind, getRevertible }) => {
+				const revertible = getRevertible?.();
+				assert(revertible !== undefined, "commit should be revertible");
 				revertiblesCreated.push(revertible);
 				commitKinds.push(kind);
 			});
@@ -1138,9 +1134,9 @@ describe("sharedTreeView", () => {
 			const treeBranch = tree.branch();
 			const viewBranch = asAlpha(treeBranch.viewWith(view.config));
 			const revertiblesCreated: Revertible[] = [];
-			const unsubscribe = viewBranch.events.on("changed", (_, getRevertible) => {
-				assert(getRevertible !== undefined, "commit should be revertible");
-				const r = getRevertible(onRevertibleDisposed);
+			const unsubscribe = viewBranch.events.on("changed", ({ getRevertible }) => {
+				const r = getRevertible?.(onRevertibleDisposed);
+				assert(r !== undefined, "commit should be revertible");
 				assert.equal(r.status, RevertibleStatus.Valid);
 				revertiblesCreated.push(r);
 			});
@@ -1192,7 +1188,7 @@ describe("sharedTreeView", () => {
 		for (const ageToTest of [0, 1, 5]) {
 			itView(`Telemetry logs track reversion age (${ageToTest})`, ({ view, logger }) => {
 				let revertible: Revertible | undefined;
-				const unsubscribe = view.events.on("changed", (_, getRevertible) => {
+				const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
 					assert(getRevertible !== undefined, "Expected commit to be revertible.");
 					// Only save off the first revertible, as it's the only one we'll use.
 					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
@@ -1285,14 +1281,14 @@ describe("sharedTreeView", () => {
 			let revertible: Revertible | undefined;
 			expectErrorDuringEdit({
 				setup: (view) => {
-					const unsubscribe = view.events.on("changed", (_, getRevertible) => {
+					const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
 						revertible = getRevertible?.();
 					});
 					view.root.number = 4;
 					unsubscribe();
 					assert(revertible !== undefined, "Expected revertible to be created.");
 				},
-				duringEdit: (view) => revertible?.revert(),
+				duringEdit: () => revertible?.revert(),
 				error: "Reverting a commit is forbidden during a nodeChanged or treeChanged event",
 			});
 		});

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -200,7 +200,7 @@ describe("sharedTreeView", () => {
 
 				const log: string[] = [];
 				const unsubscribe = checkout.events.on("changed", ({ getRevertible }) =>
-					log.push(getRevertible === undefined ? "not-revertible" : "revertible"),
+					log.push(getRevertible?.() === undefined ? "not-revertible" : "revertible"),
 				);
 
 				assert.deepEqual(log, []);

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -494,7 +494,7 @@ describe("Undo and redo", () => {
 		view.initialize({ foo: 1 });
 		assert.equal(tree.isAttached(), false);
 		let revertible: Revertible | undefined;
-		view.events.on("changed", (_, getRevertible) => {
+		view.events.on("changed", ({ getRevertible }) => {
 			revertible = getRevertible?.();
 		});
 		view.root.foo = 2;
@@ -510,7 +510,7 @@ describe("Undo and redo", () => {
 		const view = getView(new TreeViewConfiguration({ schema: Schema }));
 		view.initialize({ foo: 1 });
 		let revertible: Revertible | undefined;
-		view.events.on("changed", (_, getRevertible) => {
+		view.events.on("changed", ({ getRevertible }) => {
 			revertible = getRevertible?.();
 		});
 		view.root.foo = 2;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -145,9 +145,11 @@ export interface BranchableTree extends ViewableTree {
 export type ChangeMetadata = CommitMetadata & ({
     readonly isLocal: true;
     getChange(): JsonCompatibleReadOnly;
+    getRevertible(onDisposed?: (revertible: RevertibleAlpha) => void): RevertibleAlpha | undefined;
 } | {
     readonly isLocal: false;
     readonly getChange?: undefined;
+    readonly getRevertible?: undefined;
 });
 
 // @alpha

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -142,15 +142,7 @@ export interface BranchableTree extends ViewableTree {
 }
 
 // @alpha @sealed
-export type ChangeMetadata = CommitMetadata & ({
-    readonly isLocal: true;
-    getChange(): JsonCompatibleReadOnly;
-    getRevertible(onDisposed?: (revertible: RevertibleAlpha) => void): RevertibleAlpha | undefined;
-} | {
-    readonly isLocal: false;
-    readonly getChange?: undefined;
-    readonly getRevertible?: undefined;
-});
+export type ChangeMetadata = LocalChangeMetadata | RemoteChangeMetadata;
 
 // @alpha
 export function checkCompatibility(viewWhichCreatedStoredSchema: TreeViewConfiguration, view: TreeViewConfiguration): Omit<SchemaCompatibilityStatus, "canInitialize">;
@@ -1059,6 +1051,13 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
+// @alpha @sealed
+export interface LocalChangeMetadata extends CommitMetadata {
+    getChange(): JsonCompatibleReadOnly;
+    getRevertible(onDisposed?: (revertible: RevertibleAlpha) => void): RevertibleAlpha | undefined;
+    readonly isLocal: true;
+}
+
 // @public @sealed
 export interface MakeNominal {
 }
@@ -1231,6 +1230,13 @@ export type RecordNodeSchema<TName extends string = string, T extends ImplicitAl
 export const RecordNodeSchema: {
     readonly [Symbol.hasInstance]: (value: TreeNodeSchema) => value is RecordNodeSchema<string, ImplicitAllowedTypes, true, unknown>;
 };
+
+// @alpha @sealed
+export interface RemoteChangeMetadata extends CommitMetadata {
+    readonly getChange?: undefined;
+    readonly getRevertible?: undefined;
+    readonly isLocal: false;
+}
 
 // @alpha
 export function replaceConciseTreeHandles<T>(tree: ConciseTree, replacer: HandleConverter<T>): ConciseTree<T>;


### PR DESCRIPTION
This tweaks the `getRevertible` API to be more consistent with other emerging alpha APIs. It also improves the documentation.

Alpha API changes only (and none are breaking). See changeset for details.