### PR TITLE
enable @typescript-eslint/no-unsafe-call in packages/tree

### DIFF
--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -26,7 +26,6 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/explicit-module-boundary-types": "off",
 			"@typescript-eslint/no-unsafe-argument": "off",
 			"@typescript-eslint/no-unsafe-assignment": "off",
-			"@typescript-eslint/no-unsafe-call": "off",
 			"@typescript-eslint/no-unsafe-member-access": "off",
 			"import-x/order": "off",
 			"jsdoc/require-description": "warn",

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -292,10 +292,7 @@ describe("Op Size", () => {
 	const currentTestOps: ISequencedDocumentMessage[] = [];
 
 	interface ITreeWithSubmitLocalMessage {
-		submitLocalMessage: (
-			content: ISequencedDocumentMessage,
-			localOpMetadata?: unknown,
-		) => void;
+		submitLocalMessage: (content: unknown, localOpMetadata?: unknown) => void;
 	}
 
 	function registerOpListener(
@@ -305,11 +302,8 @@ describe("Op Size", () => {
 		// TODO: better way to hook this up. Needs to detect local ops exactly once.
 		const treeInternal = tree as unknown as ITreeWithSubmitLocalMessage;
 		const oldSubmitLocalMessage = treeInternal.submitLocalMessage.bind(tree);
-		function submitLocalMessage(
-			content: ISequencedDocumentMessage,
-			localOpMetadata: unknown = undefined,
-		): void {
-			resultArray.push(content);
+		function submitLocalMessage(content: unknown, localOpMetadata?: unknown): void {
+			resultArray.push(content as ISequencedDocumentMessage);
 			oldSubmitLocalMessage(content, localOpMetadata);
 		}
 		treeInternal.submitLocalMessage = submitLocalMessage;

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -291,13 +291,20 @@ describe("Op Size", () => {
 	let currentBenchmarkName = "";
 	const currentTestOps: ISequencedDocumentMessage[] = [];
 
+	interface ITreeWithSubmitLocalMessage {
+		submitLocalMessage: (
+			content: ISequencedDocumentMessage,
+			localOpMetadata?: unknown,
+		) => void;
+	}
+
 	function registerOpListener(
 		tree: ITreePrivate,
 		resultArray: ISequencedDocumentMessage[],
 	): void {
 		// TODO: better way to hook this up. Needs to detect local ops exactly once.
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const oldSubmitLocalMessage = (tree as any).submitLocalMessage.bind(tree);
+		const treeInternal = tree as unknown as ITreeWithSubmitLocalMessage;
+		const oldSubmitLocalMessage = treeInternal.submitLocalMessage.bind(tree);
 		function submitLocalMessage(
 			content: ISequencedDocumentMessage,
 			localOpMetadata: unknown = undefined,
@@ -305,8 +312,7 @@ describe("Op Size", () => {
 			resultArray.push(content);
 			oldSubmitLocalMessage(content, localOpMetadata);
 		}
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		(tree as any).submitLocalMessage = submitLocalMessage;
+		treeInternal.submitLocalMessage = submitLocalMessage;
 	}
 
 	const getOperationsStats = (

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -834,8 +834,8 @@ describe("allowedTypes", () => {
 			const result = AnnotatedAllowedTypesInternal.create(input);
 			assert(Object.isFrozen(input));
 			assert.throws(() => {
-				// @ts-expect-error Array should be readonly, so this error is good.
-				result.push(stringSchema);
+				// Array should be readonly, so this error is good.
+				(result as unknown as unknown[]).push(stringSchema);
 			}, "TypeError: result.push is not a function");
 		});
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -539,12 +539,12 @@ export function spyOnMethod(
 	spy: () => void,
 ): () => void {
 	const { prototype } = methodClass;
-	const method = prototype[methodName];
+	const method: unknown = prototype[methodName];
 	assert(typeof method === "function", `Method does not exist: ${methodName}`);
 
 	const methodSpy = function (this: unknown, ...args: unknown[]): unknown {
 		spy();
-		return method.call(this, ...args);
+		return (method as (...args: unknown[]) => unknown).call(this, ...args);
 	};
 	prototype[methodName] = methodSpy;
 


### PR DESCRIPTION
Removes the @typescript-eslint/no-unsafe-call: off override from the @fluidframework/tree package and fixes the resulting errors. Replaces any type casts with properly typed interfaces and explicit type assertions to ensure type-safe function calls. This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.