### PR TITLE
Skip snapshot refresh test against t9s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -149,7 +149,12 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 	it("snapshot was refreshed after some time", async function () {
 		const provider = getTestObjectProvider();
 		// TODO: This test is consistently failing when ran against AFR. See ADO:7893
-		if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
+		// For tinylicious failures, see AB#57757.
+		if (
+			(provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") ||
+			provider.driver.type === "t9s" ||
+			provider.driver.type === "tinylicious"
+		) {
 			this.skip();
 		}
 		const getLatestSnapshotInfoP = new Deferred<void>();


### PR DESCRIPTION
Due to #26103, this test is now flaky and times out on tinylicious. Skip the test for now and address it in [AB#57757](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/57757). 