### PR TITLE
lint migration diff

### DIFF
--- a/common/build/eslint-config-fluid/flat.mts
+++ b/common/build/eslint-config-fluid/flat.mts
@@ -98,10 +98,14 @@ minimalDeprecated.push(dependConfig);
 // Note: tsconfigRootDir is not set here to allow the parser to discover the correct project root
 // from the location of the file being linted. This also allows the tsdoc plugin to find tsdoc.json
 // files in the correct location.
+// Note: project is explicitly set to null to override the project setting from the base eslintrc
+// config (via FlatCompat). Newer @typescript-eslint/parser versions error if both project and
+// projectService are enabled.
 const useProjectService = {
 	files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
 	languageOptions: {
 		parserOptions: {
+			project: null,
 			projectService: true,
 		},
 	},

--- a/examples/data-objects/text-editor/eslint.config.mts
+++ b/examples/data-objects/text-editor/eslint.config.mts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Linter } from "eslint";
+import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
+import sharedConfig from "../../eslint.config.data.mts";
+
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		files: ["**/*.jsx", "**/*.tsx"],
+		rules: {
+			"react/no-deprecated": "off",
+			"react-hooks/exhaustive-deps": ["error"],
+			"react-hooks/rules-of-hooks": "error",
+			"react/jsx-key": [
+				"error",
+				{
+					"checkFragmentShorthand": true,
+					"checkKeyMustBeforeSpread": true,
+					"warnOnDuplicates": true,
+				},
+			],
+			"react/jsx-boolean-value": ["error", "always"],
+			"react/jsx-fragments": "error",
+			"react/no-string-refs": "error",
+			"react/no-unstable-nested-components": [
+				"error",
+				{
+					"allowAsProps": true,
+				},
+			],
+			"react/self-closing-comp": "error",
+			"react/jsx-no-target-blank": "error",
+			"react/jsx-no-useless-fragment": [
+				"error",
+				{
+					"allowExpressions": true,
+				},
+			],
+			"react/prop-types": "off",
+		},
+	},
+];
+
+export default config;

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -42,17 +42,11 @@ const config: Linter.Config[] = [
 
 			// Causes eslint to stack-overflow in this package. Will need investigation.
 			"@typescript-eslint/no-unsafe-assignment": "off",
-
-			"@typescript-eslint/no-unsafe-call": "off",
-			"@typescript-eslint/no-unsafe-member-access": "off",
-
 			"import-x/order": "off",
 
 			// Set to a warning to encourage adding docs :)
 			"jsdoc/require-description": "warn",
-
-			"unicorn/consistent-function-scoping": "off",
-			"unicorn/no-array-method-this-argument": "off",
+			"unicorn/no-await-expression-member": "off",
 			"unicorn/no-null": "off",
 			"unicorn/prefer-export-from": "off",
 			"unicorn/text-encoding-identifier-case": "off",
@@ -65,6 +59,10 @@ const config: Linter.Config[] = [
 		rules: {
 			"@typescript-eslint/no-unused-vars": ["off"],
 			"@typescript-eslint/explicit-function-return-type": "off",
+			// Test files commonly define helper functions inside describe blocks for better readability
+			"unicorn/consistent-function-scoping": "off",
+			// Test files frequently use `as any` casts to access internal/hidden properties for testing
+			"@typescript-eslint/no-unsafe-member-access": "off",
 		},
 	},
 ];

--- a/packages/test/test-driver-definitions/eslint.config.mts
+++ b/packages/test/test-driver-definitions/eslint.config.mts
@@ -6,8 +6,6 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [
-	...recommended,
-];
+const config: Linter.Config[] = [...recommended];
 
 export default config;


### PR DESCRIPTION
The base branch has all of the traditional `.eslintrc.cjs` files that were in client and tools workspaces moved to `eslint.config.mts` (plus `examples/.eslintrc.data.cjs` to `examples/eslint.config.data.mts`) before they were removed by finalize PR #26054.

The updated branch has the original finalized PR #26054 plus the outstanding changes from #26211 that intends to restore comments and do some additional cleanup.