### PR TITLE
fix(task-manager): Set abandoned flag when subscription ends

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -494,6 +494,7 @@ export class TaskManagerClass
 			}
 			removeListeners();
 			this.subscribedTasks.delete(taskId);
+			abandoned = true;
 		};
 
 		const checkIfRolledBack = (eventTaskId: string): void => {
@@ -503,6 +504,7 @@ export class TaskManagerClass
 
 			removeListeners();
 			this.subscribedTasks.delete(taskId);
+			abandoned = true;
 		};
 
 		setupListeners();

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -40,10 +40,5 @@ describe("Local Server Stress", () => {
 		},
 		// skipMinimization: true,
 		// Use skip, replay, and only properties to control which seeds run.
-		skip: [
-			11, // container closes with 0xc3d, and then test fails due to closed container
-			53, // 0xc3d
-			173, // 0xc3d
-		],
 	});
 });


### PR DESCRIPTION
This pull request introduces a couple of small but important changes. It updates the task abandonment logic in the `TaskManagerClass` to ensure the `abandoned` flag is set correctly when listeners are removed, and it also removes the list of skipped seeds from the local server stress test configuration.

Task management improvements:
* Ensured the `abandoned` flag is set to `true` when listeners are removed and a task is unsubscribed in the `TaskManagerClass` (`taskManager.ts`). [[1]](diffhunk://#diff-94209c787cdc23fbc877631d841786a633de81042c76f7224adfadf326fc0b3fR497) [[2]](diffhunk://#diff-94209c787cdc23fbc877631d841786a633de81042c76f7224adfadf326fc0b3fR507)

Testing configuration updates:
* Removed the `skip` list from the local server stress test configuration, so previously skipped seeds will now be included in test runs (`localServerStress.spec.ts`).