### PR TITLE
improvement(client-presence): misc cleanup

### DIFF
--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -11,12 +11,7 @@ import type {
 
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { AttendeeId, Attendee } from "./presence.js";
-import type {
-	OutboundAcknowledgementMessage,
-	OutboundClientJoinMessage,
-	OutboundDatastoreUpdateMessage,
-	SignalMessages,
-} from "./protocol.js";
+import type { OutboundPresenceMessage, SignalMessages } from "./protocol.js";
 
 /**
  * Presence {@link ContainerExtension} version of {@link @fluidframework/container-runtime-definitions#ExtensionRuntimeProperties}
@@ -43,28 +38,14 @@ export interface ClientRecord<TValue extends ValidatableValueDirectoryOrState<un
 }
 
 /**
- * This interface is a subset of ExtensionHost (and mostly of
- * FluidDataStoreRuntime) that is needed by the Presence States.
- *
- * @privateRemarks
- * Replace with non-DataStore based interface.
+ * This interface is a subset of ExtensionHost that is needed by the Presence States.
  */
-export type IEphemeralRuntime = Omit<ExtensionHost, "logger" | "submitAddressedSignal"> &
-	// Apart from tests, there is always a logger. So this could be promoted to required.
-	Partial<Pick<ExtensionHost, "logger">> & {
-		/**
-		 * Submits the signal to be sent to other clients.
-		 * @param type - Type of the signal.
-		 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
-		 * @param targetClientId - When specified, the signal is only sent to the provided client id.
-		 */
-		submitSignal: (
-			message:
-				| OutboundAcknowledgementMessage
-				| OutboundClientJoinMessage
-				| OutboundDatastoreUpdateMessage,
-		) => void;
-	};
+export type IEphemeralRuntime = Omit<ExtensionHost, "submitAddressedSignal"> & {
+	/**
+	 * Submits the signal to be sent to other clients.
+	 */
+	submitSignal: (message: OutboundPresenceMessage) => void;
+};
 
 /**
  * Contract for State Managers as used by a States Workspace (`PresenceStatesImpl`)

--- a/packages/framework/presence/src/internalUtils.ts
+++ b/packages/framework/presence/src/internalUtils.ts
@@ -190,8 +190,6 @@ export type FlattenUnionWithOptionals<T> = InternalUtilityTypes.FlattenIntersect
  *
  * @param state - The state to check
  * @returns True if the state has a value and is therefore a {@link ValidatableRequiredState}
- *
- * @system
  */
 export function isValueRequiredState<T>(
 	state: ValidatableRequiredState<T> | ValidatableOptionalState<T>,

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -237,7 +237,7 @@ class LatestValueManagerImpl<T, Key extends string>
  * @param value - The object to clone
  * @returns A shallow clone of the input value
  */
-export function shallowCloneNullableObject<T extends object | null>(value: T): T {
+function shallowCloneNullableObject<T extends object | null>(value: T): T {
 	return value === null ? value : shallowCloneObject(value);
 }
 

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -97,7 +97,7 @@ function isPresenceMessage(
  * @param obj - The object to check
  * @returns True if the object is a {@link ValidatableValueDirectory}
  */
-export function isValueDirectory<T>(
+function isValueDirectory<T>(
 	obj: ValidatableValueDirectory<T> | ValidatableOptionalState<T>,
 ): obj is ValidatableValueDirectory<T> {
 	return "items" in obj;
@@ -234,7 +234,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	public constructor(
 		private readonly attendeeId: AttendeeId,
 		private readonly runtime: IEphemeralRuntime,
-		private readonly logger: ITelemetryLoggerExt | undefined,
+		private readonly logger: ITelemetryLoggerExt,
 		private readonly events: IEmitter<PresenceEvents>,
 		private readonly presence: Presence,
 		systemWorkspaceDatastore: SystemWorkspaceDatastore,
@@ -345,7 +345,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 				updateProviders,
 			},
 		});
-		this.logger?.sendTelemetryEvent({
+		this.logger.sendTelemetryEvent({
 			eventName: "JoinRequested",
 			details: {
 				attendeeId: this.attendeeId,
@@ -372,12 +372,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			return existing.internal.ensureContent(requestedContent, controls);
 		}
 
-		let workspaceDatastore: ValueElementMap<StatesWorkspaceSchema> | undefined =
-			this.datastore[internalWorkspaceAddress];
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
-		if (workspaceDatastore === undefined) {
-			workspaceDatastore = this.datastore[internalWorkspaceAddress] = {};
-		}
+		const workspaceDatastore = (this.datastore[internalWorkspaceAddress] ??= {});
 
 		const localUpdate = (
 			states: { [key: string]: ClientUpdateEntry },
@@ -606,16 +601,16 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		const secondaryRequestors: [ClientConnectionId, number][] = [];
 		if (this.broadcastRequests.size > 0) {
 			content.joinResponseFor = [...this.broadcastRequests.keys()];
-			if (this.logger) {
-				// Build telemetry data
-				for (const [requestor, { responseOrder }] of this.broadcastRequests.entries()) {
-					if (responseOrder === undefined) {
-						primaryRequestors.push(requestor);
-					} else {
-						secondaryRequestors.push([requestor, responseOrder]);
-					}
+
+			// Build telemetry data
+			for (const [requestor, { responseOrder }] of this.broadcastRequests.entries()) {
+				if (responseOrder === undefined) {
+					primaryRequestors.push(requestor);
+				} else {
+					secondaryRequestors.push([requestor, responseOrder]);
 				}
 			}
+
 			this.broadcastRequests.clear();
 		}
 
@@ -628,7 +623,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			content,
 		});
 		if (content.joinResponseFor) {
-			this.logger?.sendTelemetryEvent({
+			this.logger.sendTelemetryEvent({
 				eventName: "JoinResponse",
 				details: {
 					type: "broadcastAll",
@@ -697,7 +692,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 							// No response was expected. This might happen when
 							// either cautionary ClientJoin signal is received
 							// by audience member that was unknown.
-							this.logger?.sendTelemetryEvent({
+							this.logger.sendTelemetryEvent({
 								eventName: "JoinResponseWhenAlone",
 								details: {
 									attendeeId: this.attendeeId,

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -86,23 +86,20 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 			this.datastoreManager.getWorkspace(`n:${workspaceAddress}`, requestedContent),
 	};
 
-	private readonly mc: MonitoringContext | undefined = undefined;
+	private readonly mc: MonitoringContext;
 
 	public constructor(
 		private readonly runtime: IEphemeralRuntime,
 		attendeeId: AttendeeId,
 	) {
-		const logger = runtime.logger;
-		if (logger) {
-			this.mc = createChildMonitoringContext({ logger, namespace: "Presence" });
-			this.mc.logger.sendTelemetryEvent({ eventName: "PresenceInstantiated" });
-		}
+		this.mc = createChildMonitoringContext({ logger: runtime.logger, namespace: "Presence" });
+		this.mc.logger.sendTelemetryEvent({ eventName: "PresenceInstantiated" });
 
 		[this.datastoreManager, this.systemWorkspace] = setupSubComponents(
 			attendeeId,
 			runtime,
 			this.events,
-			this.mc?.logger,
+			this.mc.logger,
 			this,
 		);
 		this.attendees = this.systemWorkspace;
@@ -222,7 +219,7 @@ function setupSubComponents(
 	runtime: IEphemeralRuntime,
 	events: Listenable<PresenceEvents & AttendeesEvents> &
 		IEmitter<PresenceEvents & AttendeesEvents>,
-	logger: ITelemetryLoggerExt | undefined,
+	logger: ITelemetryLoggerExt,
 	presence: Presence,
 ): [PresenceDatastoreManager, SystemWorkspace] {
 	const systemWorkspaceDatastore: SystemWorkspaceDatastore = {

--- a/packages/framework/presence/src/test/mockEphemeralRuntime.ts
+++ b/packages/framework/presence/src/test/mockEphemeralRuntime.ts
@@ -8,6 +8,7 @@ import { strict as assert } from "node:assert";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
 import { MockAudience, MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
+import { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal";
 
 import type { ClientConnectionId } from "../baseTypes.js";
 import type { IEphemeralRuntime } from "../internalTypes.js";
@@ -75,7 +76,7 @@ function makeMockAudience(clients: ClientData[]): MockAudience {
 export class MockEphemeralRuntime implements IEphemeralRuntime {
 	public clientId: string | undefined;
 	public joined: boolean = false;
-	public logger?: ITelemetryBaseLogger;
+	public logger: ITelemetryBaseLogger;
 	public readonly quorum: MockQuorumClients;
 	public readonly audience: MockAudience;
 
@@ -92,12 +93,10 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 	}
 
 	public constructor(
-		logger?: ITelemetryBaseLogger,
+		logger: ITelemetryBaseLogger = new EventAndErrorTrackingLogger(),
 		public readonly signalsExpected: Parameters<IEphemeralRuntime["submitSignal"]>[] = [],
 	) {
-		if (logger !== undefined) {
-			this.logger = logger;
-		}
+		this.logger = logger;
 
 		const numWriteClients = 6;
 		const clientsData = buildClientDataArray(

--- a/packages/framework/presence/src/test/testUtils.ts
+++ b/packages/framework/presence/src/test/testUtils.ts
@@ -147,6 +147,7 @@ function createProcessSignal(
 		// the network and Presence can safely mutate it.
 		presence.processSignal(
 			addressChain,
+			// eslint-disable-next-line unicorn/prefer-structured-clone -- not structural clone, but filters to JSON-serializable data
 			JSON.parse(JSON.stringify(signalMessage)) as InboundExtensionMessage<SignalMessages>,
 			local,
 		);


### PR DESCRIPTION
- remove unused `export`s
- remove extraneous `@system` tag for internal type
- cleanup `IEphemeralRuntime`
  - make `logger` required in even under test (clean up nullable logger usage)
  - correct `submitSignal` docs and use protocol union
- address `@typescript-eslint/prefer-nullish-coalescing` suppression (the suppression comment was wrong)
- suppress `unicorn/prefer-structured-clone` in test where action is filter and not exact clone