### PR TITLE
improvement(client-presence): cleanup `any` use

### DIFF
--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -58,8 +58,8 @@ export function getPresenceAlpha(fluidContainer: IFluidContainer): PresenceWithN
 // @beta @system
 export namespace InternalTypes {
     // @system
-    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<any>, TManager> = {
-        instanceBase: new (...args: any[]) => any;
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
     } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
         initialData?: {
             value: TValue;
@@ -84,7 +84,7 @@ export namespace InternalTypes {
         name: string;
     }
     // @system
-    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<any>> {
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
     }
     // @system
     export type StateValue<T> = T & StateValueBrand<T>;
@@ -126,9 +126,9 @@ export namespace InternalUtilityTypes {
     // @system
     export type IfNotificationListener<Event, IfListener, Else> = Event extends (...args: infer P) => void ? InternalUtilityTypes_2.IfSameType<P, JsonSerializable<P>, IfListener, Else> : Else;
     // @system
-    export type JsonDeserializedParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? JsonDeserialized<P> : never;
+    export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonDeserialized<P> : never;
     // @system
-    export type JsonSerializableParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? JsonSerializable<P> : never;
+    export type JsonSerializableParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonSerializable<P> : never;
     // @system
     export type NotificationListeners<E> = {
         [P in keyof E as IfNotificationListener<E[P], P, never>]: E[P];
@@ -310,7 +310,7 @@ export type NotificationSubscriptions<E extends InternalUtilityTypes.Notificatio
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends NotificationsManager<any>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
+    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly notifications: StatesWorkspaceEntries<TSchema>;
     readonly presence: PresenceWithNotifications;
 }
@@ -318,7 +318,7 @@ export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSc
 // @alpha
 export interface NotificationsWorkspaceSchema {
     // (undocumented)
-    [key: string]: InternalTypes.ManagerFactory<typeof key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<any>>;
+    [key: string]: InternalTypes.ManagerFactory<typeof key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>;
 }
 
 // @beta @sealed
@@ -388,7 +388,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;
@@ -407,7 +407,7 @@ export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTyp
 
 // @beta
 export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -55,8 +55,8 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 // @beta @system
 export namespace InternalTypes {
     // @system
-    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<any>, TManager> = {
-        instanceBase: new (...args: any[]) => any;
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
     } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
         initialData?: {
             value: TValue;
@@ -81,7 +81,7 @@ export namespace InternalTypes {
         name: string;
     }
     // @system
-    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<any>> {
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
     }
     // @system
     export type StateValue<T> = T & StateValueBrand<T>;
@@ -316,7 +316,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;
@@ -335,7 +335,7 @@ export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTyp
 
 // @beta
 export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -61,8 +61,8 @@ export function getPresenceFromDataStoreContext(context: IFluidDataStoreContext)
 // @beta @system
 export namespace InternalTypes {
     // @system
-    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<any>, TManager> = {
-        instanceBase: new (...args: any[]) => any;
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
     } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
         initialData?: {
             value: TValue;
@@ -87,7 +87,7 @@ export namespace InternalTypes {
         name: string;
     }
     // @system
-    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<any>> {
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
     }
     // @system
     export type StateValue<T> = T & StateValueBrand<T>;
@@ -129,9 +129,9 @@ export namespace InternalUtilityTypes {
     // @system
     export type IfNotificationListener<Event, IfListener, Else> = Event extends (...args: infer P) => void ? InternalUtilityTypes_2.IfSameType<P, JsonSerializable<P>, IfListener, Else> : Else;
     // @system
-    export type JsonDeserializedParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? JsonDeserialized<P> : never;
+    export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonDeserialized<P> : never;
     // @system
-    export type JsonSerializableParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? JsonSerializable<P> : never;
+    export type JsonSerializableParameters<T extends (...args: any[]) => unknown> = T extends (...args: infer P) => unknown ? JsonSerializable<P> : never;
     // @system
     export type NotificationListeners<E> = {
         [P in keyof E as IfNotificationListener<E[P], P, never>]: E[P];
@@ -313,7 +313,7 @@ export type NotificationSubscriptions<E extends InternalUtilityTypes.Notificatio
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends NotificationsManager<any>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
+    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly notifications: StatesWorkspaceEntries<TSchema>;
     readonly presence: PresenceWithNotifications;
 }
@@ -321,7 +321,7 @@ export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSc
 // @alpha
 export interface NotificationsWorkspaceSchema {
     // (undocumented)
-    [key: string]: InternalTypes.ManagerFactory<typeof key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<any>>;
+    [key: string]: InternalTypes.ManagerFactory<typeof key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>>;
 }
 
 // @beta @sealed
@@ -391,7 +391,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;
@@ -410,7 +410,7 @@ export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTyp
 
 // @beta
 export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
+    [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<unknown>>;
 }
 
 // @beta @system

--- a/packages/framework/presence/eslint.config.mts
+++ b/packages/framework/presence/eslint.config.mts
@@ -11,7 +11,6 @@ const config: Linter.Config[] = [
 	{
 		rules: {
 			"@typescript-eslint/consistent-indexed-object-style": "off",
-			"@typescript-eslint/no-explicit-any": "off",
 			"import-x/no-internal-modules": [
 				"error",
 				{
@@ -28,7 +27,6 @@ const config: Linter.Config[] = [
 	{
 		files: ["*.spec.ts", "src/test/**"],
 		rules: {
-			"@typescript-eslint/no-explicit-any": "error",
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 			"import-x/no-nodejs-modules": [
 				"error",

--- a/packages/framework/presence/src/exposedInternalTypes.ts
+++ b/packages/framework/presence/src/exposedInternalTypes.ts
@@ -108,7 +108,10 @@ export namespace InternalTypes {
 	 *
 	 * @system
 	 */
-	export declare class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<any>> {
+	export declare class StateDatastoreHandle<
+		TKey,
+		TValue extends ValueDirectoryOrState<unknown>,
+	> {
 		private readonly StateDatastoreHandle: StateDatastoreHandle<TKey, TValue>;
 	}
 
@@ -141,9 +144,9 @@ export namespace InternalTypes {
 	 */
 	export type ManagerFactory<
 		TKey extends string,
-		TValue extends ValueDirectoryOrState<any>,
+		TValue extends ValueDirectoryOrState<unknown>,
 		TManager,
-	> = { instanceBase: new (...args: any[]) => any } & ((
+	> = { instanceBase: new (...args: any[]) => unknown } & ((
 		key: TKey,
 		datastoreHandle: StateDatastoreHandle<TKey, TValue>,
 	) => {

--- a/packages/framework/presence/src/exposedUtilityTypes.ts
+++ b/packages/framework/presence/src/exposedUtilityTypes.ts
@@ -58,9 +58,9 @@ export namespace InternalUtilityTypes {
 	 *
 	 * @system
 	 */
-	export type JsonDeserializedParameters<T extends (...args: any[]) => any> = T extends (
+	export type JsonDeserializedParameters<T extends (...args: any[]) => unknown> = T extends (
 		...args: infer P
-	) => any
+	) => unknown
 		? JsonDeserialized<P>
 		: never;
 
@@ -69,9 +69,9 @@ export namespace InternalUtilityTypes {
 	 *
 	 * @system
 	 */
-	export type JsonSerializableParameters<T extends (...args: any[]) => any> = T extends (
+	export type JsonSerializableParameters<T extends (...args: any[]) => unknown> = T extends (
 		...args: infer P
-	) => any
+	) => unknown
 		? JsonSerializable<P>
 		: never;
 }

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -89,7 +89,7 @@ export function handleFromDatastore<
  */
 export function datastoreFromHandle<
 	TKey extends string,
-	TValue extends InternalTypes.ValueDirectoryOrState<any>,
+	TValue extends InternalTypes.ValueDirectoryOrState<unknown>,
 >(handle: InternalTypes.StateDatastoreHandle<TKey, TValue>): StateDatastore<TKey, TValue> {
 	return handle as unknown as StateDatastore<TKey, TValue>;
 }

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -5,6 +5,7 @@
 
 import type { BroadcastControls } from "./broadcastControls.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
+import type { InternalUtilityTypes } from "./exposedUtilityTypes.js";
 import type { NotificationsManager } from "./notificationsManager.js";
 import type { Presence, PresenceWithNotifications } from "./presence.js";
 
@@ -50,7 +51,10 @@ export interface StatesWorkspaceSchema {
 	/**
 	 * Key-value pairs of State objects registered with the {@link StatesWorkspace}.
 	 */
-	[key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
+	[key: string]: StatesWorkspaceEntry<
+		typeof key,
+		InternalTypes.ValueDirectoryOrState<unknown>
+	>;
 }
 
 /**
@@ -91,7 +95,7 @@ export interface StatesWorkspace<
 	 */
 	add<
 		TKey extends string,
-		TValue extends InternalTypes.ValueDirectoryOrState<any>,
+		TValue extends InternalTypes.ValueDirectoryOrState<unknown>,
 		TManager extends TManagerConstraints,
 	>(
 		key: TKey,
@@ -132,7 +136,7 @@ export interface NotificationsWorkspaceSchema {
 	[key: string]: InternalTypes.ManagerFactory<
 		typeof key,
 		InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
-		NotificationsManager<any>
+		NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>
 	>;
 }
 
@@ -157,8 +161,8 @@ export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSc
 	 */
 	add<
 		TKey extends string,
-		TValue extends InternalTypes.ValueDirectoryOrState<any>,
-		TManager extends NotificationsManager<any>,
+		TValue extends InternalTypes.ValueDirectoryOrState<unknown>,
+		TManager extends NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>,
 	>(
 		key: TKey,
 		manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>,


### PR DESCRIPTION
`unknown` no longer appears to cause the trouble for `ValueDirectoryOrState` that it once did.

Then cleanup accumulated `any` uses that were likely never needed and enable no-explicit-any rule.