### PR TITLE
build(client-presence): fix eslint from clean build

### DIFF
--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -173,7 +173,7 @@
 				"build:esnext"
 			],
 			"eslint": [
-				"build:esnext",
+				"api-extractor:esnext",
 				"^build:test:esm"
 			],
 			"tsc:experimental": [


### PR DESCRIPTION
Test files import public entrypoints and thus they must be generated to perform linting of test files.