### PR TITLE
fix(local-server-stress-tests): defer containerObjectMap registration during staging mode

### DIFF
--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -289,14 +289,41 @@ export class DefaultStressDataObject extends StressDataObject {
 		)) as any as ISharedMap;
 	}
 
+	/**
+	 * Objects created during staging mode that need to be registered in containerObjectMap
+	 * after staging mode exits. We defer the write to avoid it being rolled back on discard.
+	 */
+	private readonly _pendingContainerObjectRegistrations: ContainerObjects[] = [];
+
 	public registerLocallyCreatedObject(obj: ContainerObjects): void {
 		if (obj.handle !== undefined) {
 			const handle = toFluidHandleInternal(obj.handle);
-			if (this.containerObjectMap.get(handle.absolutePath) === undefined) {
+			if (this.inStagingMode()) {
+				// Defer registration until staging mode exits to avoid rollback on discard
+				this._pendingContainerObjectRegistrations.push(obj);
+			} else if (this.containerObjectMap.get(handle.absolutePath) === undefined) {
 				this.containerObjectMap.set(handle.absolutePath, { tag: obj.tag, type: obj.type });
 			}
 		}
 		this._locallyCreatedObjects.push(obj);
+	}
+
+	/**
+	 * Flushes pending containerObjectMap registrations that were deferred during staging mode.
+	 */
+	private flushPendingContainerObjectRegistrations(): void {
+		for (const obj of this._pendingContainerObjectRegistrations) {
+			if (obj.handle !== undefined) {
+				const handle = toFluidHandleInternal(obj.handle);
+				if (this.containerObjectMap.get(handle.absolutePath) === undefined) {
+					this.containerObjectMap.set(handle.absolutePath, {
+						tag: obj.tag,
+						type: obj.type,
+					});
+				}
+			}
+		}
+		this._pendingContainerObjectRegistrations.length = 0;
 	}
 
 	private stageControls: StageControlsAlpha | undefined;
@@ -325,6 +352,10 @@ export class DefaultStressDataObject extends StressDataObject {
 			this.stageControls.discardChanges();
 		}
 		this.stageControls = undefined;
+
+		// Flush any pending containerObjectMap registrations that were deferred during staging mode.
+		// This happens after staging mode exits so the writes won't be rolled back.
+		this.flushPendingContainerObjectRegistrations();
 	}
 }
 

--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -295,38 +295,19 @@ export class DefaultStressDataObject extends StressDataObject {
 	 */
 	private readonly _pendingContainerObjectRegistrations: ContainerObjects[] = [];
 
-	/**
-	 * Registers an object to the containerObjectMap if not already present.
-	 */
-	private registerToContainerObjectMap(obj: ContainerObjects): void {
-		if (obj.handle !== undefined) {
-			const handle = toFluidHandleInternal(obj.handle);
-			if (this.containerObjectMap.get(handle.absolutePath) === undefined) {
-				this.containerObjectMap.set(handle.absolutePath, { tag: obj.tag, type: obj.type });
-			}
-		}
-	}
-
 	public registerLocallyCreatedObject(obj: ContainerObjects): void {
 		if (obj.handle !== undefined) {
 			if (this.inStagingMode()) {
 				// Defer registration until staging mode exits to avoid rollback on discard
 				this._pendingContainerObjectRegistrations.push(obj);
 			} else {
-				this.registerToContainerObjectMap(obj);
+				const handle = toFluidHandleInternal(obj.handle);
+				if (this.containerObjectMap.get(handle.absolutePath) === undefined) {
+					this.containerObjectMap.set(handle.absolutePath, { tag: obj.tag, type: obj.type });
+				}
 			}
 		}
 		this._locallyCreatedObjects.push(obj);
-	}
-
-	/**
-	 * Flushes pending containerObjectMap registrations that were deferred during staging mode.
-	 */
-	private flushPendingContainerObjectRegistrations(): void {
-		for (const obj of this._pendingContainerObjectRegistrations) {
-			this.registerToContainerObjectMap(obj);
-		}
-		this._pendingContainerObjectRegistrations.length = 0;
 	}
 
 	private stageControls: StageControlsAlpha | undefined;
@@ -358,7 +339,13 @@ export class DefaultStressDataObject extends StressDataObject {
 
 		// Flush any pending containerObjectMap registrations that were deferred during staging mode.
 		// This happens after staging mode exits so the writes won't be rolled back.
-		this.flushPendingContainerObjectRegistrations();
+		for (const obj of this._pendingContainerObjectRegistrations) {
+			const handle = toFluidHandleInternal(obj.handle);
+			if (this.containerObjectMap.get(handle.absolutePath) === undefined) {
+				this.containerObjectMap.set(handle.absolutePath, { tag: obj.tag, type: obj.type });
+			}
+		}
+		this._pendingContainerObjectRegistrations.length = 0;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix containerObjectMap registration during staging mode to prevent rollback issues
- When a data store is created during staging mode and then discarded, the containerObjectMap.set() was rolled back, but the data store still existed locally
- When the data store was later attached by storing its handle in a DDS, other clients couldn't find it

## Changes
- Defer containerObjectMap registration during staging mode by adding to a pending list
- Flush pending registrations when staging mode exits (both commit and discard)
- This ensures registration ops are never part of the staged batch and can't be rolled back

## Test plan
- [x] All 200 local-server-stress-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)