### PR TITLE
Tree(test): Re-enable and fix testing of ModularChangeset encoding

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1522,8 +1522,11 @@ export class ModularChangeFamily
 	}
 
 	public getRevisions(change: ModularChangeset): Set<RevisionTag | undefined> {
+		if (change.revisions === undefined || change.revisions.length === 0) {
+			return new Set([undefined]);
+		}
 		const aggregated: Set<RevisionTag | undefined> = new Set();
-		for (const revInfo of change.revisions ?? [{ revision: undefined }]) {
+		for (const revInfo of change.revisions) {
 			aggregated.add(revInfo.revision);
 		}
 		return aggregated;

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1435,8 +1435,8 @@ describe("ModularChangeFamily", () => {
 						{
 							...buildChangeset([]),
 							builds: newTupleBTree([
-								[[tag1 as RevisionTag | undefined, brand(1)], node1Chunk],
-								[[tag1, brand(2)], nodesChunk],
+								[[undefined, brand(1)], node1Chunk],
+								[[tag2, brand(2)], nodesChunk],
 							]),
 						},
 						tag1,
@@ -1449,7 +1449,7 @@ describe("ModularChangeFamily", () => {
 						{
 							...buildChangeset([]),
 							refreshers: newTupleBTree([
-								[[tag3 as RevisionTag | undefined, brand(1)], node1Chunk],
+								[[undefined, brand(1)], node1Chunk],
 								[[tag2, brand(2)], nodesChunk],
 							]),
 						},

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1053,7 +1053,7 @@ const testedFamilies = new WeakSet<ICodecFamily<unknown, unknown>>();
  */
 function registerValidationHook<TDecoded, TContext>(
 	family: ICodecFamily<TDecoded, TContext>,
-	versions: Iterable<FormatVersion>,
+	versions: readonly FormatVersion[],
 ): void {
 	let tested = testedVersionsByFamily.get(family);
 	if (tested === undefined) {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1104,7 +1104,7 @@ export function makeEncodingTestSuite<TDecoded, TEncoded, TContext>(
 	assertEquivalent: (a: TDecoded, b: TDecoded) => void = assertDeepEqual,
 	supportedVersions?: FormatVersion[],
 ): void {
-	const supportedVersionsToTest = supportedVersions ?? family.getSupportedFormats();
+	const supportedVersionsToTest = supportedVersions ?? [...family.getSupportedFormats()];
 	registerValidationHook(family, supportedVersionsToTest);
 
 	for (const version of supportedVersionsToTest) {


### PR DESCRIPTION
## Description

This PR does the following:
1. Fix a bug in `makeEncodingTestSuite` that prevented some tests from being run.
2. Broadens the set of test cases for ModularChangeset encoding.
3. Makes `ModularChangeFamily.getRevisions` more robust to malformed changes.

See PR comments on the changes for details

## Breaking Changes

None