### PR TITLE
refactor(tree): wrap delta marks in object

### DIFF
--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -196,10 +196,12 @@ export interface DetachedNodeRename {
 	readonly newId: DetachedNodeId;
 }
 
-/**
- * Represents a list of changes to the nodes in the field.
- * The index of each mark within the range of nodes, before
- * applying any of the changes, is not represented explicitly.
- * It corresponds to the sum of `mark.count` values for all previous marks for which `isAttachMark(mark)` is false.
- */
-export type FieldChanges = readonly Mark[];
+export interface FieldChanges {
+	/**
+	 * Represents a list of changes to the nodes in the field.
+	 * The index of each mark within the range of nodes, before
+	 * applying any of the changes, is not represented explicitly.
+	 * It corresponds to the sum of `mark.count` values for all previous marks for which `isAttachMark(mark)` is false.
+	 */
+	readonly marks: readonly Mark[];
+}

--- a/packages/dds/tree/src/core/tree/deltaUtil.ts
+++ b/packages/dds/tree/src/core/tree/deltaUtil.ts
@@ -20,7 +20,7 @@ export function deltaForRootInitialization(content: TreeChunk): Root {
 	const delta: Root = {
 		build: [{ id: buildId, trees: content }],
 		fields: new Map<FieldKey, FieldChanges>([
-			[rootFieldKey, [{ count: content.topLevelLength, attach: buildId }]],
+			[rootFieldKey, { marks: [{ count: content.topLevelLength, attach: buildId }] }],
 		]),
 	};
 	return delta;

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -402,7 +402,7 @@ function detachPass(
 	config: PassConfig,
 ): void {
 	let index = 0;
-	for (const mark of fieldChanges) {
+	for (const mark of fieldChanges.marks) {
 		if (mark.fields !== undefined) {
 			assert(
 				mark.attach === undefined || mark.detach !== undefined,
@@ -512,7 +512,7 @@ function attachPass(
 	config: PassConfig,
 ): void {
 	let index = 0;
-	for (const mark of fieldChanges) {
+	for (const mark of fieldChanges.marks) {
 		if (mark.attach !== undefined) {
 			for (let i = 0; i < mark.count; i += 1) {
 				const offsetAttachId = offsetDetachId(mark.attach, i);

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -230,7 +230,10 @@ export class ForestSummarizer
 				id: buildId,
 				trees: chunked,
 			});
-			fieldChanges.push([fieldKey, [{ count: chunked.topLevelLength, attach: buildId }]]);
+			fieldChanges.push([
+				fieldKey,
+				{ marks: [{ count: chunked.topLevelLength, attach: buildId }] },
+			]);
 		}
 
 		assert(this.forest.isEmpty, 0x797 /* forest must be empty */);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -60,7 +60,7 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
 			markList.push({ count: 1, fields: deltaFromChild(nodeChange) });
 			nodeIndex += 1;
 		}
-		return { local: markList };
+		return { local: { marks: markList } };
 	},
 	relevantRemovedRoots,
 	isEmpty: (change: GenericChangeset): boolean => change.length === 0,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2106,7 +2106,7 @@ function intoDeltaImpl(
 				return deltaFromNodeChange(nodeChange, nodeChanges, fieldKinds, global, rename);
 			},
 		);
-		if (fieldChanges !== undefined && fieldChanges.length > 0) {
+		if (fieldChanges !== undefined && fieldChanges.marks.length > 0) {
 			delta.set(field, fieldChanges);
 		}
 		for (const c of fieldGlobal ?? []) {

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -710,7 +710,7 @@ export function optionalFieldIntoDelta(
 	}
 
 	if (!markIsANoop) {
-		delta.local = [mark];
+		delta.local = { marks: [mark] };
 	}
 
 	return delta;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -191,7 +191,7 @@ export function sequenceFieldToDelta(
 	}
 	const delta: Mutable<FieldChangeDelta> = {};
 	if (local.length > 0) {
-		delta.local = local;
+		delta.local = { marks: local };
 	}
 	if (global.length > 0) {
 		delta.global = global;

--- a/packages/dds/tree/src/test/core/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/anchorSet.spec.ts
@@ -78,7 +78,9 @@ describe("AnchorSet", () => {
 			attach: moveId,
 		};
 
-		const delta = new Map([[rootFieldKey, [{ count: 1 }, moveOut, { count: 1 }, moveIn]]]);
+		const delta = new Map([
+			[rootFieldKey, { marks: [{ count: 1 }, moveOut, { count: 1 }, moveIn] }],
+		]);
 		applyTestDelta(delta, anchors);
 		checkEquality(anchors.locate(anchor0), makePath([rootFieldKey, 0]));
 		checkEquality(anchors.locate(anchor1), makePath([rootFieldKey, 2]));
@@ -90,7 +92,9 @@ describe("AnchorSet", () => {
 		const [anchors, anchor1, anchor2, anchor3] = setup();
 
 		const trees = chunkFromJsonableTrees([node, node]);
-		const fieldChanges: DeltaFieldChanges = [{ count: 4 }, { count: 2, attach: buildId }];
+		const fieldChanges: DeltaFieldChanges = {
+			marks: [{ count: 4 }, { count: 2, attach: buildId }],
+		};
 		applyTestDelta(makeFieldDelta(fieldChanges, makeFieldPath(fieldFoo)), anchors, {
 			build: [{ id: buildId, trees }],
 		});
@@ -231,10 +235,12 @@ describe("AnchorSet", () => {
 
 		const modify: DeltaMark = {
 			count: 1,
-			fields: new Map([[fieldBar, [{ count: 3 }, moveIn]]]),
+			fields: new Map([[fieldBar, { marks: [{ count: 3 }, moveIn] }]]),
 		};
 
-		const delta = new Map([[fieldFoo, [{ count: 3 }, moveOut, { count: 1 }, modify]]]);
+		const delta = new Map([
+			[fieldFoo, { marks: [{ count: 3 }, moveOut, { count: 1 }, modify] }],
+		]);
 		applyTestDelta(delta, anchors);
 		checkEquality(anchors.locate(anchor1), makePath([fieldFoo, 4], [fieldBar, 5]));
 		checkEquality(
@@ -459,7 +465,7 @@ describe("AnchorSet", () => {
 		};
 
 		log.expect([]);
-		applyTestDelta(new Map([[rootFieldKey, [detachMark]]]), anchors);
+		applyTestDelta(new Map([[rootFieldKey, { marks: [detachMark] }]]), anchors);
 
 		log.expect([
 			["root childrenChange", 1],
@@ -487,7 +493,9 @@ describe("AnchorSet", () => {
 				trees: chunkFromJsonableTrees([{ type: brand(stringSchema.identifier), value: "x" }]),
 			},
 		];
-		applyTestDelta(new Map([[rootFieldKey, [detachMark, insertMark]]]), anchors, { build });
+		applyTestDelta(new Map([[rootFieldKey, { marks: [detachMark, insertMark] }]]), anchors, {
+			build,
+		});
 
 		log.expect([
 			["root childrenChange", 2],
@@ -496,7 +504,7 @@ describe("AnchorSet", () => {
 		log.clear();
 
 		const insertAtFoo5 = makeFieldDelta(
-			[{ count: 5 }, insertMark],
+			{ marks: [{ count: 5 }, insertMark] },
 			makeFieldPath(fieldFoo, [rootFieldKey, 0]),
 		);
 		applyTestDelta(insertAtFoo5, anchors, { build });
@@ -504,7 +512,7 @@ describe("AnchorSet", () => {
 		log.expect([["root treeChange", 1]]);
 		log.clear();
 
-		applyTestDelta(new Map([[rootFieldKey, [detachMark]]]), anchors);
+		applyTestDelta(new Map([[rootFieldKey, { marks: [detachMark] }]]), anchors);
 		log.expect([
 			["root childrenChange", 1],
 			["root treeChange", 1],
@@ -656,7 +664,7 @@ function checkRemoved(
 
 function makeDelta(mark: DeltaMark, path: UpPath): DeltaFieldMap {
 	const fields: DeltaFieldMap = new Map([
-		[path.parentField, [{ count: path.parentIndex }, mark]],
+		[path.parentField, { marks: [{ count: path.parentIndex }, mark] }],
 	]);
 	if (path.parent === undefined) {
 		return fields;

--- a/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
@@ -28,13 +28,15 @@ describe("DeltaUtils", () => {
 			const nestedCursorInsert = new Map<FieldKey, DeltaFieldChanges>([
 				[
 					fooField,
-					[
-						{ count: 42 },
-						{
-							count: 1,
-							attach: detachId,
-						},
-					],
+					{
+						marks: [
+							{ count: 42 },
+							{
+								count: 1,
+								attach: detachId,
+							},
+						],
+					},
 				],
 			]);
 			const input: DeltaRoot = {
@@ -42,12 +44,14 @@ describe("DeltaUtils", () => {
 				fields: new Map<FieldKey, DeltaFieldChanges>([
 					[
 						fooField,
-						[
-							{
-								count: 1,
-								fields: nestedCursorInsert,
-							},
-						],
+						{
+							marks: [
+								{
+									count: 1,
+									fields: nestedCursorInsert,
+								},
+							],
+						},
 					],
 				]),
 				global: [{ id: detachId, fields: nestedCursorInsert }],
@@ -57,13 +61,15 @@ describe("DeltaUtils", () => {
 			const nestedMapTreeInsert = new Map<FieldKey, DeltaFieldChanges>([
 				[
 					fooField,
-					[
-						{ count: 42 },
-						{
-							count: 1,
-							attach: detachId,
-						},
-					],
+					{
+						marks: [
+							{ count: 42 },
+							{
+								count: 1,
+								attach: detachId,
+							},
+						],
+					},
 				],
 			]);
 			const expected: DeltaRoot<MapTree[]> = {
@@ -71,12 +77,14 @@ describe("DeltaUtils", () => {
 				fields: new Map<FieldKey, DeltaFieldChanges>([
 					[
 						fooField,
-						[
-							{
-								count: 1,
-								fields: nestedMapTreeInsert,
-							},
-						],
+						{
+							marks: [
+								{
+									count: 1,
+									fields: nestedMapTreeInsert,
+								},
+							],
+						},
 					],
 				]),
 				global: [{ id: detachId, fields: nestedMapTreeInsert }],

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -99,7 +99,7 @@ export const valueHandler = {
 			// These would have no real meaning to a delta consumer, but these delta are only used for testing.
 			const detach = makeDetachedNodeId(undefined, change.old);
 			const attach = makeDetachedNodeId(undefined, change.new);
-			delta.local = [{ count: 1, attach, detach }];
+			delta.local = { marks: [{ count: 1, attach, detach }] };
 		}
 		return delta;
 	},

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -188,11 +188,13 @@ describe("GenericField", () => {
 		]);
 
 		const expected: FieldChangeDelta = {
-			local: [
-				{ count: 1, fields: TestNodeId.deltaFromChild(nodeChange1) },
-				{ count: 1 },
-				{ count: 1, fields: TestNodeId.deltaFromChild(nodeChange2) },
-			],
+			local: {
+				marks: [
+					{ count: 1, fields: TestNodeId.deltaFromChild(nodeChange1) },
+					{ count: 1 },
+					{ count: 1, fields: TestNodeId.deltaFromChild(nodeChange2) },
+				],
+			},
 		};
 
 		const actual = genericChangeHandler.intoDelta(input, TestNodeId.deltaFromChild);

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -151,7 +151,9 @@ const singleNodeHandler: FieldChangeHandler<SingleNodeChangeset> = {
 	codecsFactory: (revisionTagCodec) => makeCodecFamily([[1, singleNodeCodec]]),
 	editor: singleNodeEditor,
 	intoDelta: (change, deltaFromChild): FieldChangeDelta => ({
-		local: [{ count: 1, fields: change === undefined ? undefined : deltaFromChild(change) }],
+		local: {
+			marks: [{ count: 1, fields: change === undefined ? undefined : deltaFromChild(change) }],
+		},
 	}),
 	relevantRemovedRoots: (change, relevantRemovedRootsFromChild) =>
 		change === undefined ? [] : relevantRemovedRootsFromChild(change),
@@ -1055,19 +1057,21 @@ describe("ModularChangeFamily", () => {
 
 	describe("intoDelta", () => {
 		it("fieldChanges", () => {
-			const nodeDelta: DeltaFieldChanges = [
-				{
-					count: 1,
-					fields: new Map([
-						[fieldA, [{ count: 1, detach: { minor: 0 }, attach: { minor: 1 } }]],
-					]),
-				},
-			];
+			const nodeDelta: DeltaFieldChanges = {
+				marks: [
+					{
+						count: 1,
+						fields: new Map([
+							[fieldA, { marks: [{ count: 1, detach: { minor: 0 }, attach: { minor: 1 } }] }],
+						]),
+					},
+				],
+			};
 
 			const expectedDelta: DeltaRoot = {
 				fields: new Map([
 					[fieldA, nodeDelta],
-					[fieldB, [{ count: 1, detach: { minor: 1 }, attach: { minor: 2 } }]],
+					[fieldB, { marks: [{ count: 1, detach: { minor: 1 }, attach: { minor: 2 } }] }],
 				]),
 			};
 

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -633,23 +633,25 @@ describe("ModularChangeFamily integration", () => {
 			const composedDelta = normalizeDelta(intoDelta(makeAnonChange(composed), fieldKinds));
 
 			const nodeAChanges: DeltaFieldMap = new Map([
-				[fieldB, [{ count: 1, attach: { minor: 1, major: tagForCompare } }]],
+				[fieldB, { marks: [{ count: 1, attach: { minor: 1, major: tagForCompare } }] }],
 			]);
 
 			const nodeBChanges: DeltaFieldMap = new Map([
-				[fieldC, [{ count: 1, attach: { minor: 2, major: tagForCompare } }]],
+				[fieldC, { marks: [{ count: 1, attach: { minor: 2, major: tagForCompare } }] }],
 			]);
 
 			const nodeCChanges: DeltaFieldMap = new Map([
-				[fieldC, [{ count: 1, detach: { minor: 3, major: tagForCompare } }]],
+				[fieldC, { marks: [{ count: 1, detach: { minor: 3, major: tagForCompare } }] }],
 			]);
 
-			const fieldAChanges: DeltaFieldChanges = [
-				{ count: 1, detach: { minor: 0, major: tagForCompare }, fields: nodeAChanges },
-				{ count: 1, attach: { minor: 0, major: tagForCompare } },
-				{ count: 1, detach: { minor: 1, major: tagForCompare }, fields: nodeBChanges },
-				{ count: 1, detach: { minor: 2, major: tagForCompare }, fields: nodeCChanges },
-			];
+			const fieldAChanges: DeltaFieldChanges = {
+				marks: [
+					{ count: 1, detach: { minor: 0, major: tagForCompare }, fields: nodeAChanges },
+					{ count: 1, attach: { minor: 0, major: tagForCompare } },
+					{ count: 1, detach: { minor: 1, major: tagForCompare }, fields: nodeBChanges },
+					{ count: 1, detach: { minor: 2, major: tagForCompare }, fields: nodeCChanges },
+				],
+			};
 
 			const expectedDelta: DeltaRoot = normalizeDelta({
 				fields: new Map([[fieldA, fieldAChanges]]),
@@ -691,17 +693,22 @@ describe("ModularChangeFamily integration", () => {
 				fields: new Map([
 					[
 						fieldA,
-						[
-							{
-								count: 1,
-								detach: { minor: 0, major: tagForCompare },
-								fields: new Map([
-									[fieldC, [{ count: 1, attach: { minor: 2, major: tagForCompare } }]],
-								]),
-							},
-						],
+						{
+							marks: [
+								{
+									count: 1,
+									detach: { minor: 0, major: tagForCompare },
+									fields: new Map([
+										[
+											fieldC,
+											{ marks: [{ count: 1, attach: { minor: 2, major: tagForCompare } }] },
+										],
+									]),
+								},
+							],
+						},
 					],
-					[fieldB, [{ count: 1, attach: { minor: 0, major: tagForCompare } }]],
+					[fieldB, { marks: [{ count: 1, attach: { minor: 0, major: tagForCompare } }] }],
 				]),
 			};
 
@@ -757,13 +764,17 @@ describe("ModularChangeFamily integration", () => {
 				fields: new Map([
 					[
 						fieldB,
-						[
-							{ count: 1 },
-							{
-								count: 1,
-								fields: new Map([[fieldC, [{ count: 1, attach: { major: tag2, minor: 2 } }]]]),
-							},
-						],
+						{
+							marks: [
+								{ count: 1 },
+								{
+									count: 1,
+									fields: new Map([
+										[fieldC, { marks: [{ count: 1, attach: { major: tag2, minor: 2 } }] }],
+									]),
+								},
+							],
+						},
 					],
 				]),
 			};
@@ -1033,8 +1044,8 @@ describe("ModularChangeFamily integration", () => {
 			};
 			const expected: DeltaRoot = {
 				fields: new Map([
-					[brand("foo"), [moveOut1, moveIn1]],
-					[brand("bar"), [moveOut2, moveIn2]],
+					[brand("foo"), { marks: [moveOut1, moveIn1] }],
+					[brand("bar"), { marks: [moveOut2, moveIn2] }],
 				]),
 			};
 			const actual = intoDelta(makeAnonChange(change), family.fieldKinds);
@@ -1095,8 +1106,8 @@ function normalizeDeltaFieldChanges(
 	genId: IdAllocator,
 	idMap: Map<number, number>,
 ): DeltaFieldChanges {
-	if (delta.length > 0) {
-		return delta.map((mark) => normalizeDeltaMark(mark, genId, idMap));
+	if (delta.marks.length > 0) {
+		return { marks: delta.marks.map((mark) => normalizeDeltaMark(mark, genId, idMap)) };
 	}
 
 	return delta;

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -687,7 +687,7 @@ describe("optionalField", () => {
 						fields: TestNodeId.deltaFromChild(nodeChange1),
 					},
 				],
-				local: [{ count: 1, attach: outerNodeId }],
+				local: { marks: [{ count: 1, attach: outerNodeId }] },
 			};
 
 			const actual = optionalFieldIntoDelta(change1.change, TestNodeId.deltaFromChild);
@@ -696,13 +696,15 @@ describe("optionalField", () => {
 
 		it("can be converted to a delta when restoring content", () => {
 			const expected: FieldChangeDelta = {
-				local: [
-					{
-						count: 1,
-						attach: { major: revertChange2.revision, minor: 2 },
-						detach: { major: revertChange2.revision, minor: 42 },
-					},
-				],
+				local: {
+					marks: [
+						{
+							count: 1,
+							attach: { major: revertChange2.revision, minor: 2 },
+							detach: { major: revertChange2.revision, minor: 42 },
+						},
+					],
+				},
 			};
 
 			const actual = optionalFieldIntoDelta(revertChange2.change, TestNodeId.deltaFromChild);
@@ -711,12 +713,14 @@ describe("optionalField", () => {
 
 		it("can be converted to a delta with only child changes", () => {
 			const expected: FieldChangeDelta = {
-				local: [
-					{
-						count: 1,
-						fields: TestNodeId.deltaFromChild(nodeChange2),
-					},
-				],
+				local: {
+					marks: [
+						{
+							count: 1,
+							fields: TestNodeId.deltaFromChild(nodeChange2),
+						},
+					],
+				},
 			};
 			assertFieldChangesEqual(
 				optionalFieldIntoDelta(change4.change, TestNodeId.deltaFromChild),

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
@@ -62,7 +62,7 @@ export function testToDelta(): void {
 		it("child change", () => {
 			const actual = toDelta(inlineRevision(Change.modify(0, childChange1), tag));
 			const markList: DeltaMark[] = [{ count: 1, fields: childChange1Delta }];
-			const expected: FieldChangeDelta = { local: markList };
+			const expected: FieldChangeDelta = { local: { marks: markList } };
 			assert.deepEqual(actual, expected);
 		});
 
@@ -85,7 +85,7 @@ export function testToDelta(): void {
 		it("insert", () => {
 			const changeset = Change.insert(0, 1, tag);
 			const expected = {
-				local: [{ count: 1, attach: { major: tag, minor: 0 } }],
+				local: { marks: [{ count: 1, attach: { major: tag, minor: 0 } }] },
 			};
 			const actual = toDelta(changeset);
 			assert.deepStrictEqual(actual, expected);
@@ -95,12 +95,14 @@ export function testToDelta(): void {
 			const changeset = Change.revive(0, 1, { revision: tag, localId: brand(0) }, tag2);
 			const actual = toDelta(changeset);
 			const expected: FieldChangeDelta = {
-				local: [
-					{
-						count: 1,
-						attach: { major: tag, minor: 0 },
-					},
-				],
+				local: {
+					marks: [
+						{
+							count: 1,
+							attach: { major: tag, minor: 0 },
+						},
+					],
+				},
 			};
 			assertFieldChangesEqual(actual, expected);
 		});
@@ -110,19 +112,21 @@ export function testToDelta(): void {
 			const changeset = [
 				Mark.revive(1, { revision: tag, localId: brand(0) }, { changes: nodeId }),
 			];
-			const fieldChanges = new Map([[fooField, []]]);
+			const fieldChanges = new Map([[fooField, { marks: [] }]]);
 			const deltaFromChild = (child: NodeId): DeltaFieldMap => {
 				assert.deepEqual(child, nodeId);
 				return fieldChanges;
 			};
 			const actual = sequenceFieldToDelta(changeset, deltaFromChild);
 			const expected: FieldChangeDelta = {
-				local: [
-					{
-						count: 1,
-						attach: { major: tag, minor: 0 },
-					},
-				],
+				local: {
+					marks: [
+						{
+							count: 1,
+							attach: { major: tag, minor: 0 },
+						},
+					],
+				},
 				global: [
 					{
 						id: { major: tag, minor: 0 },
@@ -136,12 +140,14 @@ export function testToDelta(): void {
 		it("remove", () => {
 			const changeset = [Mark.remove(10, brand(42))];
 			const expected: FieldChangeDelta = {
-				local: [
-					{
-						count: 10,
-						detach: detachId,
-					},
-				],
+				local: {
+					marks: [
+						{
+							count: 10,
+							detach: detachId,
+						},
+					],
+				},
 			};
 			const actual = toDelta(inlineRevision(changeset, tag));
 			assert.deepStrictEqual(actual, expected);
@@ -151,12 +157,14 @@ export function testToDelta(): void {
 			const detachIdOverride: SF.CellId = { revision: tag2, localId: brand(1) };
 			const changeset = [Mark.remove(10, brand(42), { idOverride: detachIdOverride })];
 			const expected: FieldChangeDelta = {
-				local: [
-					{
-						count: 10,
-						detach: { major: tag2, minor: 1 },
-					},
-				],
+				local: {
+					marks: [
+						{
+							count: 10,
+							detach: { major: tag2, minor: 1 },
+						},
+					],
+				},
 			};
 			const actual = toDelta(inlineRevision(changeset, tag));
 			assert.deepStrictEqual(actual, expected);
@@ -178,7 +186,7 @@ export function testToDelta(): void {
 				count: 10,
 			};
 			const markList: DeltaMark[] = [{ count: 42 }, moveOut, { count: 8 }, moveIn];
-			const expected: FieldChangeDelta = { local: markList };
+			const expected: FieldChangeDelta = { local: { marks: markList } };
 			const actual = toDelta(changeset);
 			assert.deepStrictEqual(actual, expected);
 		});
@@ -217,7 +225,7 @@ export function testToDelta(): void {
 				count: 3,
 			};
 			const markList: DeltaMark[] = [moveOut1, moveIn1, moveOut2, moveIn2, moveOut3, moveIn3];
-			const expected: FieldChangeDelta = { local: markList };
+			const expected: FieldChangeDelta = { local: { marks: markList } };
 			const actual = toDelta(changeset);
 			assert.deepStrictEqual(actual, expected);
 		});
@@ -246,7 +254,7 @@ export function testToDelta(): void {
 				{ count: 1, fields: childChange1Delta },
 			];
 			const expected: FieldChangeDelta = {
-				local: markList,
+				local: { marks: markList },
 			};
 			const actual = toDelta(inlineRevision(changeset, tag));
 			assert.deepStrictEqual(actual, expected);
@@ -257,7 +265,7 @@ export function testToDelta(): void {
 			const buildId = { major: tag, minor: 0 };
 			const expected: FieldChangeDelta = {
 				global: [{ id: buildId, fields: childChange1Delta }],
-				local: [{ count: 1, attach: buildId }],
+				local: { marks: [{ count: 1, attach: buildId }] },
 			};
 			const actual = toDelta(inlineRevision(changeset, tag));
 			assertFieldChangesEqual(actual, expected);
@@ -266,7 +274,7 @@ export function testToDelta(): void {
 		it("modify and remove => remove", () => {
 			const changeset = [Mark.remove(1, brand(42), { changes: childChange1 })];
 			const expected: FieldChangeDelta = {
-				local: [{ count: 1, detach: detachId, fields: childChange1Delta }],
+				local: { marks: [{ count: 1, detach: detachId, fields: childChange1Delta }] },
 			};
 			const actual = toDelta(inlineRevision(changeset, tag));
 			assertFieldChangesEqual(actual, expected);
@@ -275,9 +283,11 @@ export function testToDelta(): void {
 		it("modify and move-out => move-out", () => {
 			const changeset = [Mark.moveOut(1, moveId, { changes: childChange1 })];
 			const expected: FieldChangeDelta = {
-				local: [
-					{ count: 1, detach: { major: tag, minor: moveId }, fields: childChange1Delta },
-				],
+				local: {
+					marks: [
+						{ count: 1, detach: { major: tag, minor: moveId }, fields: childChange1Delta },
+					],
+				},
 			};
 			const actual = toDelta(inlineRevision(changeset, tag));
 			assertFieldChangesEqual(actual, expected);
@@ -288,12 +298,12 @@ export function testToDelta(): void {
 
 			const changeset = [Mark.insert(1, brand(0), { changes: nodeId })];
 			const nestedMoveDelta = new Map([
-				[fooField, [{ attach: { minor: moveId }, count: 42 }]],
+				[fooField, { marks: [{ attach: { minor: moveId }, count: 42 }] }],
 			]);
 			const buildId = { minor: 0 };
 			const expected: FieldChangeDelta = {
 				global: [{ id: buildId, fields: nestedMoveDelta }],
-				local: [{ count: 1, attach: buildId }],
+				local: { marks: [{ count: 1, attach: buildId }] },
 			};
 			const deltaFromChild = (child: NodeId): DeltaFieldMap => {
 				assert.deepEqual(child, nodeId);
@@ -327,7 +337,7 @@ export function testToDelta(): void {
 				const id = { minor: 2 };
 				const expected: FieldChangeDelta = {
 					rename: [{ oldId: buildId, newId: id, count: 2 }],
-					local: [{ count: 1 }, { count: 2, attach: id }],
+					local: { marks: [{ count: 1 }, { count: 2, attach: id }] },
 				};
 				assertFieldChangesEqual(delta, expected);
 			});
@@ -343,7 +353,7 @@ export function testToDelta(): void {
 
 				const id = { minor: 0 };
 				const expected: FieldChangeDelta = {
-					local: [{ count: 2, detach: id }],
+					local: { marks: [{ count: 2, detach: id }] },
 					rename: [{ count: 2, oldId: id, newId: { minor: 4 } }],
 				};
 				assertFieldChangesEqual(delta, expected);
@@ -382,12 +392,14 @@ export function testToDelta(): void {
 
 				const id = { minor: 0 };
 				const expected: FieldChangeDelta = {
-					local: [
-						{ count: 2, detach: id },
-						{ count: 1 },
-						{ count: 1 },
-						{ count: 2, attach: id },
-					],
+					local: {
+						marks: [
+							{ count: 2, detach: id },
+							{ count: 1 },
+							{ count: 1 },
+							{ count: 2, attach: id },
+						],
+					},
 				};
 				assertFieldChangesEqual(delta, expected);
 			});
@@ -403,7 +415,7 @@ export function testToDelta(): void {
 			const actual = toDelta(move);
 			const expected: FieldChangeDelta = {
 				rename: [{ count: 1, oldId: deltaNodeId, newId: { minor: 0 } }],
-				local: [{ count: 1, attach: { minor: 0 } }],
+				local: { marks: [{ count: 1, attach: { minor: 0 } }] },
 			};
 			assertFieldChangesEqual(actual, expected);
 		});
@@ -452,7 +464,7 @@ export function testToDelta(): void {
 				];
 				const actual = toDelta(inlineRevision(changeset, tag));
 				const expected: FieldChangeDelta = {
-					local: [{ count: 1 }, { count: 1, fields: childChange1Delta }],
+					local: { marks: [{ count: 1 }, { count: 1, fields: childChange1Delta }] },
 				};
 				assertFieldChangesEqual(actual, expected);
 			});

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -184,7 +184,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 		assert(forest.isEmpty);
 
-		const insert: DeltaFieldChanges = [{ count: 1, attach: { minor: 1 } }];
+		const insert: DeltaFieldChanges = { marks: [{ count: 1, attach: { minor: 1 } }] };
 		applyTestDelta(new Map([[brand("different root"), insert]]), forest, {
 			build: [{ id: { minor: 1 }, trees: chunkFromJsonTrees([[]]) }],
 		});
@@ -409,7 +409,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		cursor.clear();
 
 		const mark: DeltaMark = { count: 1, detach: detachId };
-		const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+		const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 		applyTestDelta(delta, forest, { destroy: [{ id: detachId, count: 1 }] });
 		applyTestDelta(delta, forest.anchors, { destroy: [{ id: detachId, count: 1 }] });
 
@@ -436,7 +436,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			{ jsonValidator: FormatValidatorBasic, minVersionForCollab: FluidClientVersion.v2_0 },
 		);
 		const delta: DeltaFieldMap = new Map<FieldKey, DeltaFieldChanges>([
-			[rootFieldKey, [mark]],
+			[rootFieldKey, { marks: [mark] }],
 		]);
 		applyTestDelta(delta, forest, { detachedFieldIndex });
 
@@ -552,7 +552,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		const clone = forest.clone(schema, forest.anchors);
 		const mark: DeltaMark = { count: 1, detach: detachId };
-		const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+		const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 		applyTestDelta(delta, clone);
 
 		// Check the clone has the new value
@@ -577,7 +577,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				moveToDetachedField(forest, cursor);
 
 				const mark: DeltaMark = { count: 1, detach: detachId };
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+				const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 				assert.throws(() => applyTestDelta(delta, forest));
 			});
 
@@ -593,7 +593,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				});
 
 				const mark: DeltaMark = { count: 1, detach: detachId };
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+				const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 				assert.throws(() => applyTestDelta(delta, forest));
 				assert.deepEqual(log, ["beforeChange"]);
 			});
@@ -609,7 +609,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			});
 
 			const mark: DeltaMark = { count: 1, detach: detachId };
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 			applyTestDelta(delta, forest);
 			assert.deepEqual(log, ["beforeChange"]);
 		});
@@ -625,9 +625,11 @@ export function testForest(config: ForestTestConfiguration): void {
 
 			const setField: DeltaMark = {
 				count: 1,
-				fields: new Map([[xField, [{ count: 1, detach: detachId, attach: buildId }]]]),
+				fields: new Map([
+					[xField, { marks: [{ count: 1, detach: detachId, attach: buildId }] }],
+				]),
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [setField]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [setField] }]]);
 			applyTestDelta(delta, forest, {
 				build: [
 					{
@@ -661,9 +663,11 @@ export function testForest(config: ForestTestConfiguration): void {
 
 			const setField: DeltaMark = {
 				count: 1,
-				fields: new Map([[xField, [{ count: 1, detach: detachId, attach: buildId }]]]),
+				fields: new Map([
+					[xField, { marks: [{ count: 1, detach: detachId, attach: buildId }] }],
+				]),
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [setField]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [setField] }]]);
 			applyTestDelta(delta, forest, {
 				build: [
 					{
@@ -700,7 +704,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				count: 1,
 				detach: detachId,
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 			applyTestDelta(delta, forest);
 
 			// Inspect resulting tree: should just have `2`.
@@ -731,7 +735,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				count: 1,
 				detach: detachId,
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [skip, mark]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [skip, mark] }]]);
 			applyTestDelta(delta, forest);
 
 			// Inspect resulting tree: should just have `1`.
@@ -751,7 +755,9 @@ export function testForest(config: ForestTestConfiguration): void {
 				testIdCompressor,
 			);
 
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [{ count: 1, attach: buildId }]]]);
+			const delta: DeltaFieldMap = new Map([
+				[rootFieldKey, { marks: [{ count: 1, attach: buildId }] }],
+			]);
 			applyTestDelta(delta, forest, {
 				build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
 			});
@@ -779,13 +785,13 @@ export function testForest(config: ForestTestConfiguration): void {
 				count: 1,
 				attach: moveId,
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [moveIn]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [moveIn] }]]);
 			applyTestDelta(delta, forest, {
 				build: [{ id: buildId, trees: chunkFromJsonTrees([{ x: 0 }]) }],
 				global: [
 					{
 						id: buildId,
-						fields: new Map([[xField, [moveOut]]]),
+						fields: new Map([[xField, { marks: [moveOut] }]]),
 					},
 				],
 			});
@@ -818,11 +824,11 @@ export function testForest(config: ForestTestConfiguration): void {
 			const modify: DeltaMark = {
 				count: 1,
 				fields: new Map([
-					[xField, [moveOut]],
-					[yField, [{ count: 1 }, moveIn]],
+					[xField, { marks: [moveOut] }],
+					[yField, { marks: [{ count: 1 }, moveIn] }],
 				]),
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [modify]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [modify] }]]);
 			applyTestDelta(delta, forest);
 			const reader = forest.allocateCursor();
 			moveToDetachedField(forest, reader);
@@ -844,7 +850,9 @@ export function testForest(config: ForestTestConfiguration): void {
 				testIdCompressor,
 			);
 
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [{ count: 1, attach: buildId }]]]);
+			const delta: DeltaFieldMap = new Map([
+				[rootFieldKey, { marks: [{ count: 1, attach: buildId }] }],
+			]);
 			applyTestDelta(delta, forest, {
 				build: [
 					{
@@ -869,7 +877,9 @@ export function testForest(config: ForestTestConfiguration): void {
 				global: [
 					{
 						id: buildId,
-						fields: new Map([[brand("newField"), [{ count: 1, attach: buildId2 }]]]),
+						fields: new Map([
+							[brand("newField"), { marks: [{ count: 1, attach: buildId2 }] }],
+						]),
 					},
 				],
 			});
@@ -903,10 +913,10 @@ export function testForest(config: ForestTestConfiguration): void {
 			const mark: DeltaMark = {
 				count: 1,
 				detach: detachId,
-				fields: new Map([[xField, [{ count: 1, detach: moveId }]]]),
+				fields: new Map([[xField, { marks: [{ count: 1, detach: moveId }] }]]),
 			};
 			const delta: DeltaFieldMap = new Map([
-				[rootFieldKey, [mark, { count: 1, attach: moveId }]],
+				[rootFieldKey, { marks: [mark, { count: 1, attach: moveId }] }],
 			]);
 			applyTestDelta(delta, forest);
 
@@ -933,29 +943,33 @@ export function testForest(config: ForestTestConfiguration): void {
 				fields: new Map([
 					[
 						xField,
-						[
-							{
-								count: 1,
-								detach: moveId,
-								fields: new Map([
-									[
-										fooField,
+						{
+							marks: [
+								{
+									count: 1,
+									detach: moveId,
+									fields: new Map([
 										[
+											fooField,
 											{
-												count: 1,
-												detach: detachId,
-												attach: buildId,
+												marks: [
+													{
+														count: 1,
+														detach: detachId,
+														attach: buildId,
+													},
+												],
 											},
 										],
-									],
-								]),
-							},
-						],
+									]),
+								},
+							],
+						},
 					],
-					[yField, [{ count: 1, attach: moveId }]],
+					[yField, { marks: [{ count: 1, attach: moveId }] }],
 				]),
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 			applyTestDelta(delta, forest, {
 				build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
 			});
@@ -983,22 +997,26 @@ export function testForest(config: ForestTestConfiguration): void {
 			const delta: DeltaFieldMap = new Map([
 				[
 					rootFieldKey,
-					[
-						{
-							count: 1,
-							fields: new Map([
-								[
-									xField,
+					{
+						marks: [
+							{
+								count: 1,
+								fields: new Map([
 									[
+										xField,
 										{
-											count: 1,
-											detach: detachId,
+											marks: [
+												{
+													count: 1,
+													detach: detachId,
+												},
+											],
 										},
 									],
-								],
-							]),
-						},
-					],
+								]),
+							},
+						],
+					},
 				],
 			]);
 			const expected: JsonCompatible[] = [{ y: 1 }];
@@ -1036,11 +1054,11 @@ export function testForest(config: ForestTestConfiguration): void {
 			const modify: DeltaMark = {
 				count: 1,
 				fields: new Map([
-					[xField, [moveOut]],
-					[yField, [moveIn]],
+					[xField, { marks: [moveOut] }],
+					[yField, { marks: [moveIn] }],
 				]),
 			};
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [modify]]]);
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [modify] }]]);
 			applyTestDelta(delta, forest);
 			const expectedCursor = singleJsonCursor({ y: 2 });
 			const expected: JsonableTree[] = [jsonableTreeFromCursor(expectedCursor)];
@@ -1067,7 +1085,9 @@ export function testForest(config: ForestTestConfiguration): void {
 		initializeForest(forest, fieldJsonCursor(content), testRevisionTagCodec, testIdCompressor);
 
 		forest.registerAnnouncedVisitor(acquireVisitor);
-		const delta: DeltaFieldMap = new Map([[rootFieldKey, [{ count: 1, attach: buildId }]]]);
+		const delta: DeltaFieldMap = new Map([
+			[rootFieldKey, { marks: [{ count: 1, attach: buildId }] }],
+		]);
 		applyTestDelta(delta, forest, {
 			build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
 		});

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -455,7 +455,7 @@ describe("SharedTreeChangeFamily", () => {
 				assert.equal(change3.type, "data");
 				const delta1 = intoDelta(tagChange(change1.innerChange, undefined));
 				const delta3 = intoDelta(tagChange(change3.innerChange, undefined));
-				const detachedNodeId = delta1.fields?.get(rootFieldKey)?.[0]?.detach;
+				const detachedNodeId = delta1.fields?.get(rootFieldKey)?.marks[0]?.detach;
 				const reference = delta3.rename?.[0]?.oldId;
 				assert.notEqual(reference, undefined);
 				assert.deepEqual(reference, detachedNodeId);

--- a/packages/dds/tree/src/test/testChange.spec.ts
+++ b/packages/dds/tree/src/test/testChange.spec.ts
@@ -74,7 +74,7 @@ describe("TestChange", () => {
 		const tag = mintRevisionTag();
 		const delta = TestChange.toDelta(tagChange(change1, tag));
 		const field: FieldKey = brand("testIntentions");
-		const expected = new Map([[field, [{ count: 2 }, { count: 3 }]]]);
+		const expected = new Map([[field, { marks: [{ count: 2 }, { count: 3 }] }]]);
 
 		assert.deepEqual(delta, expected);
 		assert.deepEqual(

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -194,7 +194,7 @@ function toDelta({ change }: TaggedChange<TestChange>): DeltaFieldMap {
 				// We represent the intentions as a list if node offsets in some imaginary field "testIntentions".
 				// This is purely for the sake of testing.
 				brand("testIntentions"),
-				change.intentions.map((i) => ({ count: i })),
+				{ marks: change.intentions.map((i) => ({ count: i })) },
 			],
 		]);
 	}
@@ -334,7 +334,7 @@ export function asDelta(intentions: number[]): DeltaRoot {
 	return intentions.length === 0
 		? emptyDelta
 		: {
-				fields: new Map([[rootKey, intentions.map((i) => ({ count: i }))]]),
+				fields: new Map([[rootKey, { marks: intentions.map((i) => ({ count: i })) }]]),
 			};
 }
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -565,7 +565,7 @@ export function spyOnMethod(
  * Determines whether or not the given delta has a visible impact on the document tree.
  */
 export function isDeltaVisible(fieldChanges: DeltaFieldChanges | undefined): boolean {
-	for (const mark of fieldChanges ?? []) {
+	for (const mark of fieldChanges?.marks ?? []) {
 		if (mark.attach !== undefined || mark.detach !== undefined) {
 			return true;
 		}


### PR DESCRIPTION
## Description

Refactors the delta data structure so that extra fields can be added alongside the array of marks. This will be used in the future to add information about whether nodes detached by the marks can safely by re-attached.

## Breaking Changes

None

## Reviewer Guidance

The refactor is in src/core/tree/delta.ts. The rest of the changes are mechanical, and I have already reviewed them once.