### PR TITLE
fix(tree): handle ID ranges in revision replacement

### DIFF
--- a/packages/dds/tree/src/core/rebase/changeRebaser.ts
+++ b/packages/dds/tree/src/core/rebase/changeRebaser.ts
@@ -121,13 +121,14 @@ export interface RevisionReplacer {
 
 	/**
 	 * Returns the updated ID for the given ID.
-	 * @param id - The ID to update.
+	 * @param id - The ID of the first change atom to update.
+	 * @param count - The number node in the contiguous range of change atoms to update. Defaults to 1.
 	 * @returns an updated ID iff the given `id` needs updating, otherwise returns the given `id`.
 	 * @remarks
 	 * This function always maps the same input {@link ChangeAtomId.revision | revision} and {@link ChangeAtomId.localId | local ID} to the same output revision local ID.
 	 * This means multiple references to the same atom of change will remain consistent after revision replacement.
 	 */
-	getUpdatedAtomId<T extends ChangeAtomId>(id: T): T;
+	getUpdatedAtomId<T extends ChangeAtomId>(id: T, count?: number): T;
 }
 
 export interface TaggedChange<TChangeset, TTag = RevisionTag | undefined> {

--- a/packages/dds/tree/src/core/rebase/changeRebaser.ts
+++ b/packages/dds/tree/src/core/rebase/changeRebaser.ts
@@ -122,7 +122,7 @@ export interface RevisionReplacer {
 	/**
 	 * Returns the updated ID for the given ID.
 	 * @param id - The ID of the first change atom to update.
-	 * @param count - The number node in the contiguous range of change atoms to update. Defaults to 1.
+	 * @param count - The number of contiguous change atoms to update. Defaults to 1.
 	 * @returns an updated ID iff the given `id` needs updating, otherwise returns the given `id`.
 	 * @remarks
 	 * This function always maps the same input {@link ChangeAtomId.revision | revision} and {@link ChangeAtomId.localId | local ID} to the same output revision local ID.

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -122,7 +122,7 @@ export function taggedOptAtomId(
 	return taggedAtomId(id, revision);
 }
 
-export function offsetChangeAtomId(id: ChangeAtomId, offset: number): ChangeAtomId {
+export function offsetChangeAtomId<T extends ChangeAtomId>(id: T, offset: number): T {
 	return { ...id, localId: brand(id.localId + offset) };
 }
 

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -255,8 +255,10 @@ export function mintCommit<TChange>(
 
 export type ChangeAtomIdRangeMap<V> = RangeMap<ChangeAtomId, V>;
 
-export function newChangeAtomIdRangeMap<V>(): ChangeAtomIdRangeMap<V> {
-	return new RangeMap(offsetChangeAtomId, subtractChangeAtomIds);
+export function newChangeAtomIdRangeMap<V>(
+	offsetValue?: (value: V, offset: number) => V,
+): ChangeAtomIdRangeMap<V> {
+	return new RangeMap(offsetChangeAtomId, subtractChangeAtomIds, offsetValue);
 }
 
 export function subtractChangeAtomIds(a: ChangeAtomId, b: ChangeAtomId): number {

--- a/packages/dds/tree/src/feature-libraries/changeAtomIdBTree.ts
+++ b/packages/dds/tree/src/feature-libraries/changeAtomIdBTree.ts
@@ -23,6 +23,18 @@ export function getFromChangeAtomIdMap<T>(
 	return map.get([id.revision, id.localId]);
 }
 
+export function getPairOrNextLowerFromChangeAtomIdMap<T>(
+	map: ChangeAtomIdBTree<T>,
+	id: ChangeAtomId,
+): [ChangeAtomId, T] | undefined {
+	const found = map.getPairOrNextLower([id.revision, id.localId]);
+	if (found === undefined) {
+		return undefined;
+	}
+	const [[revision, localId], value] = found;
+	return [{ revision, localId }, value];
+}
+
 export function setInChangeAtomIdMap<T>(
 	map: ChangeAtomIdBTree<T>,
 	id: ChangeAtomId,

--- a/packages/dds/tree/src/feature-libraries/changeAtomIdBTree.ts
+++ b/packages/dds/tree/src/feature-libraries/changeAtomIdBTree.ts
@@ -23,18 +23,6 @@ export function getFromChangeAtomIdMap<T>(
 	return map.get([id.revision, id.localId]);
 }
 
-export function getPairOrNextLowerFromChangeAtomIdMap<T>(
-	map: ChangeAtomIdBTree<T>,
-	id: ChangeAtomId,
-): [ChangeAtomId, T] | undefined {
-	const found = map.getPairOrNextLower([id.revision, id.localId]);
-	if (found === undefined) {
-		return undefined;
-	}
-	const [[revision, localId], value] = found;
-	return [{ revision, localId }, value];
-}
-
 export function setInChangeAtomIdMap<T>(
 	map: ChangeAtomIdBTree<T>,
 	id: ChangeAtomId,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/defaultRevisionReplacer.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/defaultRevisionReplacer.ts
@@ -6,7 +6,6 @@
 import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
-	areEqualChangeAtomIds,
 	newChangeAtomIdRangeMap,
 	offsetChangeAtomId,
 	type ChangeAtomId,
@@ -21,7 +20,6 @@ import {
 	newIntegerRangeMap,
 	type RangeMap,
 	type Mutable,
-	hasSome,
 } from "../../util/index.js";
 
 const offsetChangesetLocalId = (value: ChangesetLocalId, offset: number): ChangesetLocalId =>

--- a/packages/dds/tree/src/feature-libraries/modular-schema/defaultRevisionReplacer.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/defaultRevisionReplacer.ts
@@ -22,12 +22,15 @@ import {
 	hasSingle,
 } from "../../util/index.js";
 
+const offsetChangesetLocalId = (value: ChangesetLocalId, offset: number): ChangesetLocalId =>
+	brand(value + offset);
+
 export class DefaultRevisionReplacer implements RevisionReplacer {
 	/**
 	 * Mapping from (obsolete revision tag, original local id) to the updated local id.
 	 */
 	private readonly updatedLocalIds: ChangeAtomIdRangeMap<ChangesetLocalId> =
-		newChangeAtomIdRangeMap();
+		newChangeAtomIdRangeMap(offsetChangesetLocalId);
 	/**
 	 * The set of local IDs already used in the scope of the updated revision.
 	 */

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1766,7 +1766,7 @@ function replaceCrossFieldKeyTableRevisions(
 	const updated: CrossFieldKeyTable = newCrossFieldKeyTable();
 	for (const entry of table.entries()) {
 		const key = entry.start;
-		const updatedKey: CrossFieldKey = replacer.getUpdatedAtomId(key);
+		const updatedKey: CrossFieldKey = replacer.getUpdatedAtomId(key, entry.length);
 
 		const field = entry.value;
 		const normalizedFieldId = normalizeFieldId(field, nodeAliases);

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/defaultRevisionReplacer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/defaultRevisionReplacer.spec.ts
@@ -14,6 +14,7 @@ import { brandConst } from "../../../util/index.js";
 describe("DefaultRevisionReplacer", () => {
 	const obsoleteRev1: RevisionTag = "obsoleteRev1" as RevisionTag;
 	const obsoleteRev2: RevisionTag = "obsoleteRev2" as RevisionTag;
+	const obsoleteRev3: RevisionTag = "obsoleteRev3" as RevisionTag;
 	const otherRev: RevisionTag = "otherRev" as RevisionTag;
 	const updatedRev: RevisionTag = "updatedRev" as RevisionTag;
 	const localId1 = brandConst(1)<ChangesetLocalId>();
@@ -72,14 +73,18 @@ describe("DefaultRevisionReplacer", () => {
 		it("generates new local IDs when there is a conflict", () => {
 			const replacer = new DefaultRevisionReplacer(
 				updatedRev,
-				new Set([obsoleteRev1, obsoleteRev2]),
+				new Set([obsoleteRev1, obsoleteRev2, obsoleteRev3]),
 			);
 			const id1 = makeChangeAtomId(localId1, obsoleteRev1);
 			const id2 = makeChangeAtomId(localId1, obsoleteRev2);
 			const result1 = replacer.getUpdatedAtomId(id1);
-			const result2 = replacer.getUpdatedAtomId(id2);
 			assert.equal(result1.localId, id1.localId);
+			const result2 = replacer.getUpdatedAtomId(id2);
 			assert.notDeepEqual(result2, result1);
+			const id3 = makeChangeAtomId(result2.localId, obsoleteRev3);
+			const result3 = replacer.getUpdatedAtomId(id3);
+			assert.notDeepEqual(result3, result1);
+			assert.notDeepEqual(result3, result2);
 		});
 
 		it("returns consistent updated ID for repeated calls with same obsolete ID", () => {
@@ -120,7 +125,7 @@ describe("DefaultRevisionReplacer", () => {
 			assert.deepEqual(actual, expected);
 		});
 
-		it("handles count > 1 when all IDs in the range were previously updated", () => {
+		it("handles count > 1 when all IDs in the range were previously updated in a single block", () => {
 			const replacer = new DefaultRevisionReplacer(updatedRev, new Set([obsoleteRev1]));
 			const id = makeChangeAtomId(localId1, obsoleteRev1);
 			const expected = makeChangeAtomId(localId1, updatedRev);
@@ -132,13 +137,36 @@ describe("DefaultRevisionReplacer", () => {
 			assert.deepEqual(actual23, offsetChangeAtomId(expected, 1));
 		});
 
-		it("throws when some but not all IDs in the range were previously updated", () => {
+		it("handles count > 1 when all IDs in the range were previously updated in separate blocks", () => {
+			const replacer = new DefaultRevisionReplacer(updatedRev, new Set([obsoleteRev1]));
 			const id = makeChangeAtomId(localId1, obsoleteRev1);
+			replacer.getUpdatedAtomId(id, 2);
+			replacer.getUpdatedAtomId(offsetChangeAtomId(id, 2), 1);
+
+			const actual123 = replacer.getUpdatedAtomId(id, 3);
+			assert.deepEqual(actual123, makeChangeAtomId(localId1, updatedRev));
+		});
+
+		it("handles count > 1 when some IDs in the range were previously updated with the same local IDs", () => {
+			const obsoleteInRev1 = makeChangeAtomId(localId1, obsoleteRev1);
+			const expected = makeChangeAtomId(localId1, updatedRev);
 			for (let i = 0; i < 3; i++) {
 				const replacer = new DefaultRevisionReplacer(updatedRev, new Set([obsoleteRev1]));
-				replacer.getUpdatedAtomId(offsetChangeAtomId(id, i), 1);
-				assert.throws(() => replacer.getUpdatedAtomId(id, 3));
+				replacer.getUpdatedAtomId(offsetChangeAtomId(obsoleteInRev1, i), 1);
+				const actual123 = replacer.getUpdatedAtomId(obsoleteInRev1, 3);
+				assert.deepEqual(actual123, expected);
 			}
+		});
+
+		// TODO: Handle non-contiguous ranges
+		it("throw an error when it encounters a case it does not support", () => {
+			const obsoleteRevisions = new Set([obsoleteRev1, obsoleteRev2]);
+			const obsoleteInRev1 = makeChangeAtomId(localId1, obsoleteRev1);
+			const obsoleteInRev2 = makeChangeAtomId(localId2, obsoleteRev2);
+			const replacer = new DefaultRevisionReplacer(updatedRev, obsoleteRevisions);
+			replacer.getUpdatedAtomId(obsoleteInRev2, 100);
+			replacer.getUpdatedAtomId(offsetChangeAtomId(obsoleteInRev1, 1), 1);
+			assert.throws(() => replacer.getUpdatedAtomId(obsoleteInRev1, 2));
 		});
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -62,7 +62,7 @@ export const cases: {
 		undefined /* revision */,
 	),
 	pin: [createPinMark(4, brand(0))],
-	rename: [createRenameMark(3, brand(2), brand(3))],
+	rename: [createRenameMark(3, brand(2), brand(20))],
 	move: createMoveChangeset(1, 2, 4, undefined /* revision */),
 	moveAndRemove: [
 		createMoveOutMark(1, brand(0)),
@@ -78,7 +78,7 @@ export const cases: {
 	),
 	transient_insert: [
 		{ count: 1 },
-		createRemoveMark(2, brand(2), { cellId: { localId: brand(1) } }),
+		createRemoveMark(2, brand(4), { cellId: { localId: brand(1) } }),
 	],
 };
 

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -321,15 +321,15 @@ export interface RangeQueryEntry<K, V> extends RangeQueryResult<K, V> {
 	readonly value: V;
 }
 
-export function newIntegerRangeMap<V>(): RangeMap<number, V> {
+export function newIntegerRangeMap<V, K extends number = number>(): RangeMap<K, V> {
 	return new RangeMap(offsetInteger, subtractIntegers);
 }
 
-function offsetInteger(key: number, offset: number): number {
-	return key + offset;
+function offsetInteger<K extends number>(key: K, offset: number): K {
+	return (key + offset) as K;
 }
 
-function subtractIntegers(a: number, b: number): number {
+function subtractIntegers<K extends number>(a: K, b: K): number {
 	return a - b;
 }
 


### PR DESCRIPTION
## Description

The revision replacement logic introduced in https://github.com/microsoft/FluidFramework/pull/26106 did not correctly handle cases where a contiguous range of IDs need updating. This PR adds support for the more straightforward cases while leaving cases that would require splitting marks (or amending prior replacement results) unhandled. This is enough to satisfy all current usages.

The revision replacement code is only used in tests, so throwing an error when an unhandled case is encountered is tolerable. We hope to completely remove the need for revision replacement in the future.

## Breaking Changes

None
