### PR TITLE
re-enable unicorn/no-await-expression-member in packages/tree

### DIFF
--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -27,7 +27,6 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-unsafe-argument": "off",
 			"@typescript-eslint/no-unsafe-assignment": "off",
 			"jsdoc/require-description": "warn",
-			"unicorn/no-await-expression-member": "off",
 			"unicorn/no-null": "off",
 			"unicorn/prefer-export-from": "off",
 			"unicorn/text-encoding-identifier-case": "off",


### PR DESCRIPTION
re-enable unicorn/no-await-expression-member rule in packages/tree. This rule was enabled before and got unintentionally disabled. 