### PR TITLE
Enable text-encoding-identifier-case in packages/dds

### DIFF
--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -30,7 +30,6 @@ const config: Linter.Config[] = [
 			"unicorn/no-await-expression-member": "off",
 			"unicorn/no-null": "off",
 			"unicorn/prefer-export-from": "off",
-			"unicorn/text-encoding-identifier-case": "off",
 		},
 	},
 	{

--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -130,7 +130,7 @@ export class SchemaSummarizer
 			0x3da /* there should not already be stored schema when loading stored schema */,
 		);
 
-		const schemaString = bufferToString(schemaBuffer, "utf-8");
+		const schemaString = bufferToString(schemaBuffer, "utf8");
 		// Currently no Fluid handles are used, so just use JSON.parse.
 		const decoded = this.codec.decode(JSON.parse(schemaString));
 		this.schema.apply(decoded);

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -126,7 +126,7 @@ export class EditManagerSummarizer<TChangeset>
 			0x42c /* There should not already be stored EditManager data when loading from summary */,
 		);
 
-		const summary = parse(bufferToString(schemaBuffer, "utf-8")) as JsonCompatibleReadOnly;
+		const summary = parse(bufferToString(schemaBuffer, "utf8")) as JsonCompatibleReadOnly;
 		const data = this.codec.decode(summary, { idCompressor: this.idCompressor });
 		this.editManager.loadSummaryData(data);
 	}

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -58,7 +58,7 @@ export function takeSnapshot(
 		writeFileSync(fullFile, data);
 	} else {
 		assert(exists, `test snapshot file does not exist: "${fullFile}"`);
-		const pastData = readFileSync(fullFile, "utf-8");
+		const pastData = readFileSync(fullFile, "utf8");
 		const message = `snapshot different for "${currentTestName}"`;
 		compare?.(data, pastData, message);
 		assert.equal(data, pastData, message);

--- a/packages/dds/tree/src/test/snapshots/utils.ts
+++ b/packages/dds/tree/src/test/snapshots/utils.ts
@@ -60,6 +60,7 @@ function serializeTree(parentHandle: string, tree: ISummaryTree, rootNodeName: s
 						? {
 								type: "blob",
 								content: JSON.parse(summaryObject.content) as JsonCompatibleReadOnly,
+								// eslint-disable-next-line unicorn/text-encoding-identifier-case -- snapshot output format, not an encoding parameter
 								encoding: "utf-8",
 							}
 						: {


### PR DESCRIPTION
Removes the unicorn/text-encoding-identifier-case: off override from the @fluidframework/tree package and fixes the resulting errors. Changes encoding parameter values from "utf-8" to "utf8" to use the preferred Node.js encoding identifier format. This is part of an ongoing effort to incrementally remove global ESLint rule overrides from eslint.config.mts and .eslintrc.cjs.

Inline Overrides Added
- src/test/snapshots/utils.ts:63 - The "utf-8" string is a metadata label serialized into snapshot JSON output, not an encoding parameter passed to Node.js APIs. Changing it would require regenerating 204 snapshot files. 