### PR TITLE
feat(api): make custom DDS APIs internal [2.90.0]

### DIFF
--- a/.changeset/custom-dds-removal-datastore-definitions.md
+++ b/.changeset/custom-dds-removal-datastore-definitions.md
@@ -1,0 +1,20 @@
+---
+"@fluidframework/datastore-definitions": major
+"__section": breaking
+---
+
+IChannelFactory is now internal
+
+The `IChannelFactory` interface is intended for internal Fluid Framework use only. It is
+required to implement custom DDS factories, which is not supported for external use.
+This export has been moved to internal and is no longer available in the public API.
+
+Note: Other channel-related interfaces (`IChannel`, `IChannelAttributes`, `IChannelServices`,
+`IChannelStorageService`, `IDeltaConnection`, `IDeltaHandler`) remain in the legacy API as
+they are transitively referenced by `IChannel` and `IFluidDataStoreRuntime`. However, without
+access to `IChannelFactory` and the `SharedObject`/`SharedObjectCore` base classes (which are
+also now internal in `@fluidframework/shared-object-base`), implementing custom DDSes is not
+possible.
+
+Applications should use SharedTree or another existing DDS type (SharedMap, SharedCell, etc.)
+rather than implementing custom DDSes.

--- a/.changeset/custom-dds-removal-shared-object-base.md
+++ b/.changeset/custom-dds-removal-shared-object-base.md
@@ -1,0 +1,14 @@
+---
+"@fluidframework/shared-object-base": major
+"__section": breaking
+---
+
+SharedObject, SharedObjectCore, ISharedObject, ISharedObjectEvents, createSharedObjectKind, and ISharedObjectKind are now internal
+
+These APIs are intended for internal Fluid Framework use only. External implementations
+of custom DDSes are not supported. These exports have been moved to internal and are
+no longer available in the public API.
+
+Applications should use SharedTree or another existing DDS type (SharedMap, SharedCell, etc.)
+rather than implementing custom DDSes. The `SharedObjectKind` type remains public as the
+safe, sealed type for referencing DDS kinds.

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.beta.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.beta.api.md
@@ -13,82 +13,10 @@ export interface IFluidSerializer {
 }
 
 // @beta @legacy
-export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends IChannel, IEventProvider<TEvent> {
-    bindToContext(): void;
-}
-
-// @beta @legacy
-export interface ISharedObjectEvents extends IErrorEvent {
-    // @eventProperty
-    (event: "pre-op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
-    // @eventProperty
-    (event: "op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
-}
-
-// @beta @legacy
-export interface ISharedObjectKind<TSharedObject> {
-    create(runtime: IFluidDataStoreRuntime, id?: string): TSharedObject;
-    getFactory(): IChannelFactory<TSharedObject>;
-}
-
-// @beta @legacy
 export function makeHandlesSerializable(value: unknown, serializer: IFluidSerializer, bind: IFluidHandle): unknown;
 
 // @beta @legacy
 export function parseHandles(value: unknown, serializer: IFluidSerializer): unknown;
-
-// @beta @legacy
-export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends SharedObjectCore<TEvent> {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes,
-    telemetryContextPrefix: string);
-    getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    getGCData(fullGC?: boolean): IGarbageCollectionData;
-    protected processGCDataCore(serializer: IFluidSerializer): void;
-    // (undocumented)
-    protected get serializer(): IFluidSerializer;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext, fullTree?: boolean): ISummaryTreeWithStats;
-}
-
-// @beta @legacy
-export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends EventEmitterWithErrorHandling<TEvent> implements ISharedObject<TEvent> {
-    constructor(
-    id: string,
-    runtime: IFluidDataStoreRuntime,
-    attributes: IChannelAttributes);
-    protected abstract applyStashedOp(content: unknown): void;
-    readonly attributes: IChannelAttributes;
-    bindToContext(): void;
-    connect(services: IChannelServices): void;
-    get connected(): boolean;
-    protected get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    protected didAttach(): void;
-    protected dirty(): void;
-    emit(event: EventEmitterEventType, ...args: any[]): boolean;
-    abstract getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
-    readonly handle: IFluidHandleInternal;
-    id: string;
-    // (undocumented)
-    get IFluidLoadable(): this;
-    initializeLocal(): void;
-    protected initializeLocalCore(): void;
-    isAttached(): boolean;
-    load(services: IChannelServices): Promise<void>;
-    protected abstract loadCore(services: IChannelStorageService): Promise<void>;
-    protected readonly logger: ITelemetryLoggerExt;
-    protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: unknown) => void) => void): Promise<T>;
-    protected onConnect(): void;
-    protected abstract onDisconnect(): void;
-    protected abstract processMessagesCore(messagesCollection: IRuntimeMessageCollection): void;
-    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
-    protected reSubmitSquashed(content: unknown, localOpMetadata: unknown): void;
-    protected rollback(content: unknown, localOpMetadata: unknown): void;
-    protected runtime: IFluidDataStoreRuntime;
-    protected abstract get serializer(): IFluidSerializer;
-    protected submitLocalMessage(content: unknown, localOpMetadata?: unknown): void;
-    abstract summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
-}
 
 // @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -81,9 +81,7 @@ interface ProcessTelemetryProperties {
  * or if the intention is that no other implementations should exist and creating some might break things.
  * As part of this, any existing implementations of ISharedObject (via SharedObjectCore or otherwise) in use by legacy API users will need to be considered.
  *
- * TODO:
- * This class should eventually be made internal, as custom subclasses of it outside this repository are intended to be made unsupported in the future.
- * @legacy @beta
+ * @internal
  */
 export abstract class SharedObjectCore<
 		TEvent extends ISharedObjectEvents = ISharedObjectEvents,
@@ -238,7 +236,6 @@ export abstract class SharedObjectCore<
 	 * @param error - error object that is thrown whenever an attempt is made to modify this object
 	 */
 	private closeWithError(error: IFluidErrorBase | undefined): void {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.closeError === undefined) {
 			this.closeError = error;
 		}
@@ -736,9 +733,9 @@ export abstract class SharedObjectCore<
  * @privateRemarks
  * TODO:
  * This class is badly named.
- * Once it becomes `@internal` "SharedObjectCore" should probably become "SharedObject"
+ * "SharedObjectCore" should probably become "SharedObject"
  * and this class should be renamed to something like "SharedObjectSynchronous".
- * @legacy @beta
+ * @internal
  */
 export abstract class SharedObject<
 	TEvent extends ISharedObjectEvents = ISharedObjectEvents,
@@ -927,7 +924,7 @@ export abstract class SharedObject<
  * This does not extend {@link SharedObjectKind} since doing so would prevent implementing this interface in type safe code.
  * Any implementation of this can safely be used as a {@link SharedObjectKind} with an explicit type conversion,
  * but doing so is typically not needed as {@link createSharedObjectKind} is used to produce values that are both types simultaneously.
- * @legacy @beta
+ * @internal
  */
 export interface ISharedObjectKind<TSharedObject> {
 	/**

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -13,7 +13,7 @@ import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitio
 
 /**
  * Events emitted by {@link ISharedObject}.
- * @legacy @beta
+ * @internal
  */
 export interface ISharedObjectEvents extends IErrorEvent {
 	/**
@@ -53,9 +53,6 @@ export interface ISharedObjectEvents extends IErrorEvent {
 
 /**
  * Base interface for shared objects from which other interfaces extend.
- * @remarks
- * This interface is not intended to be implemented outside this repository:
- * implementers should migrate to using an existing implementation instead.
  * @privateRemarks
  * Implemented by {@link SharedObjectCore}.
  *
@@ -65,7 +62,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
  * Additionally the docs here need to define what a shared object is, not just claim this interface is for them.
  * If the intention is that the "shared object" concept `IFluidLoadable` mentions is only ever implemented by this interface then even more concept unification should be done.
  * If not then more clarity is needed on what this interface specifically is, what the other "shared object" concept means and how they relate.
- * @legacy @beta
+ * @internal
  */
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents>
 	extends IChannel,

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
@@ -24,14 +24,6 @@ export interface IChannelAttributes {
 }
 
 // @beta @legacy
-export interface IChannelFactory<out TChannel = unknown> {
-    readonly attributes: IChannelAttributes;
-    create(runtime: IFluidDataStoreRuntime, id: string): TChannel & IChannel;
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<TChannel & IChannel>;
-    readonly type: string;
-}
-
-// @beta @legacy
 export interface IChannelServices {
     // (undocumented)
     deltaConnection: IDeltaConnection;

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.beta.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.beta.api.md
@@ -24,14 +24,6 @@ export interface IChannelAttributes {
 }
 
 // @beta @legacy
-export interface IChannelFactory<out TChannel = unknown> {
-    readonly attributes: IChannelAttributes;
-    create(runtime: IFluidDataStoreRuntime, id: string): TChannel & IChannel;
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<TChannel & IChannel>;
-    readonly type: string;
-}
-
-// @beta @legacy
 export interface IChannelServices {
     // (undocumented)
     deltaConnection: IDeltaConnection;

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -289,7 +289,7 @@ export interface IChannelServices {
  * This approach (not requiring TChannel to extend IChannel) also makes it possible for SharedObject's public interfaces to not include IChannel if desired
  * (while still requiring the implementation to implement it).
  *
- * @legacy @beta
+ * @internal
  */
 export interface IChannelFactory<out TChannel = unknown> {
 	/**


### PR DESCRIPTION
## Summary

This PR extracts the API changes from #26184 that make custom DDS-related APIs internal:

- `SharedObject`, `SharedObjectCore` → `@internal`
- `ISharedObject`, `ISharedObjectEvents` → `@internal`
- `ISharedObjectKind` → `@internal`
- `IChannelFactory` → `@internal`

These changes target the **2.90.0** release.

## Background

The planning document and full context remain in #26184. This PR contains only the implementation changes to facilitate review and release targeting.

## Test plan

- [ ] Build succeeds (`pnpm build`)
- [ ] Tests pass (`pnpm test`)
- [ ] API reports are correctly updated
- [ ] No public packages depend on these internal types