### PR TITLE
build(client): remove unused lint disables

### DIFF
--- a/examples/apps/task-selection/src/oldestClientDiceRoller.ts
+++ b/examples/apps/task-selection/src/oldestClientDiceRoller.ts
@@ -82,7 +82,7 @@ export class OldestClientDiceRoller extends DataObject implements IDiceRoller {
 
 	private startAutoRollTask(): void {
 		console.log("Starting autoroll from OldestClientDiceRoller");
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
+
 		if (this.autoRollInterval === undefined) {
 			this.autoRollInterval = setInterval(() => {
 				this.roll();

--- a/examples/apps/task-selection/src/taskManagerDiceRoller.ts
+++ b/examples/apps/task-selection/src/taskManagerDiceRoller.ts
@@ -91,7 +91,7 @@ export class TaskManagerDiceRoller extends DataObject implements IDiceRoller {
 
 	private startAutoRollTask(): void {
 		console.log("Starting autoroll from TaskManagerDiceRoller");
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
+
 		if (this.autoRollInterval === undefined) {
 			this.autoRollInterval = setInterval(() => {
 				this.roll();

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/src/fetchApp.ts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/src/fetchApp.ts
@@ -6,7 +6,6 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import { prefetchLatestSnapshot } from "@fluidframework/odsp-driver/internal";
 import { FluidAppOdspUrlResolver } from "@fluidframework/odsp-urlresolver/internal";
-// eslint-disable-next-line import-x/no-deprecated
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { OdspSampleCache } from "./odspPersistantCache.js";
@@ -55,7 +54,7 @@ export function start(div: HTMLDivElement, odspAccessToken: string): void {
 	fetchButton1.onclick = async () => {
 		const resolvedUrl = await urlResolver.resolve({ url: text1.value });
 		assert(resolvedUrl !== undefined, "resolvedUrl should be defined");
-		// eslint-disable-next-line import-x/no-deprecated
+
 		const mockLogger = new MockLogger();
 		for (let i = 0; i < 5; ++i) {
 			await prefetchLatestSnapshot(
@@ -73,7 +72,7 @@ export function start(div: HTMLDivElement, odspAccessToken: string): void {
 	fetchButton2.onclick = async () => {
 		const resolvedUrl = await urlResolver.resolve({ url: text2.value });
 		assert(resolvedUrl !== undefined, 0x31a /* resolvedUrl is undefined */);
-		// eslint-disable-next-line import-x/no-deprecated
+
 		const mockLogger = new MockLogger();
 		for (let i = 0; i < 5; ++i) {
 			await prefetchLatestSnapshot(
@@ -89,7 +88,6 @@ export function start(div: HTMLDivElement, odspAccessToken: string): void {
 	};
 }
 
-// eslint-disable-next-line import-x/no-deprecated
 function fetchButtonClick(mockLogger: MockLogger, div: HTMLDivElement): void {
 	const fields = new Set([
 		"eventName",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/src/odspPersistantCache.ts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/src/odspPersistantCache.ts
@@ -16,7 +16,6 @@ export class OdspSampleCache implements IPersistedCache {
 	public constructor() {}
 
 	async get(entry: ICacheEntry): Promise<any> {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return this.cache.get(getKeyForCacheEntry(entry));
 	}
 

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -105,7 +105,6 @@ export interface ClickerState {
 	value: number;
 }
 
-/* eslint-disable react/prop-types -- TypeScript interfaces provide compile-time prop validation */
 export class ClickerReactView extends React.Component<ClickerProps, ClickerState> {
 	constructor(props: ClickerProps) {
 		super(props);
@@ -138,7 +137,6 @@ export class ClickerReactView extends React.Component<ClickerProps, ClickerState
 		);
 	}
 }
-/* eslint-enable react/prop-types -- TypeScript interfaces provide compile-time prop validation */
 
 // ----- FACTORY SETUP -----
 

--- a/examples/data-objects/codemirror/src/codeMirrorView.tsx
+++ b/examples/data-objects/codemirror/src/codeMirrorView.tsx
@@ -58,7 +58,7 @@ class CodeMirrorView {
 
 	public render(elm: HTMLElement): void {
 		// Create base textarea
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
+
 		if (!this.textArea) {
 			this.textArea = document.createElement("textarea");
 		}

--- a/examples/data-objects/codemirror/src/codeMirrorView.tsx
+++ b/examples/data-objects/codemirror/src/codeMirrorView.tsx
@@ -58,7 +58,6 @@ class CodeMirrorView {
 
 	public render(elm: HTMLElement): void {
 		// Create base textarea
-
 		if (!this.textArea) {
 			this.textArea = document.createElement("textarea");
 		}

--- a/examples/data-objects/monaco/loaders/compile.js
+++ b/examples/data-objects/monaco/loaders/compile.js
@@ -26,7 +26,6 @@ module.exports.pitch = function pitch(remainingRequest) {
 
 	const { filename, options = {} } = getOutputFilename(output, { target });
 
-	// eslint-disable-next-line no-underscore-dangle
 	const currentCompilation = this._compilation;
 
 	const outputFilename = loaderUtils.interpolateName(this, filename, {

--- a/examples/data-objects/multiview/container/src/container.tsx
+++ b/examples/data-objects/multiview/container/src/container.tsx
@@ -72,7 +72,7 @@ export class CoordinateContainerRuntimeFactory extends BaseContainerRuntimeFacto
 					containerRuntime,
 					constellationComponentName,
 				);
-				/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/explicit-function-return-type */
+				/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 				const view = (
 					<DefaultView
 						simpleCoordinate={simpleCoordinate}
@@ -93,7 +93,7 @@ export class CoordinateContainerRuntimeFactory extends BaseContainerRuntimeFacto
 					getDefaultDataObject: async (): Promise<FluidObject> => ({}),
 					getMountableDefaultView,
 				};
-				/* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/explicit-function-return-type */
+				/* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 			},
 		});
 	}

--- a/examples/data-objects/prosemirror/src/fluidBridge.ts
+++ b/examples/data-objects/prosemirror/src/fluidBridge.ts
@@ -450,7 +450,6 @@ function sliceToGroupOpsInternal(
 	if (value.marks) {
 		props = {};
 		for (const mark of value.marks) {
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior if attrs is falsy but defined
 			props[mark.type] = mark.attrs || true;
 		}
 	}

--- a/examples/data-objects/prosemirror/src/fluidCollabManager.ts
+++ b/examples/data-objects/prosemirror/src/fluidCollabManager.ts
@@ -8,7 +8,6 @@
 import { EventEmitter } from "@fluid-example/example-utils";
 import { assert } from "@fluidframework/core-utils/legacy";
 import {
-	// eslint-disable-next-line import-x/no-deprecated
 	createGroupOp,
 	createRemoveRangeOp,
 	// eslint-disable-next-line import-x/no-internal-modules -- #26905: `merge-tree` internals used in examples
@@ -281,7 +280,6 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 						operations = operations.concat(sliceOperations);
 					}
 
-					// eslint-disable-next-line import-x/no-deprecated
 					const groupOp = createGroupOp(...operations);
 					this.text.groupOperation(groupOp);
 
@@ -346,7 +344,6 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 						operations = operations.concat(sliceOperations);
 					}
 
-					// eslint-disable-next-line import-x/no-deprecated
 					const groupOp = createGroupOp(...operations);
 					this.text.groupOperation(groupOp);
 
@@ -354,7 +351,6 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 				}
 
 				case "addMark": {
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior if attrs is falsy but defined
 					const attrs = stepAsJson.mark.attrs || true;
 
 					this.text.annotateRange(stepAsJson.from, stepAsJson.to, {

--- a/examples/data-objects/prosemirror/src/index.ts
+++ b/examples/data-objects/prosemirror/src/index.ts
@@ -56,7 +56,7 @@ class ProseMirrorRuntimeFactory extends RuntimeFactoryHelper {
 						collabManager: proseMirror.collabManager,
 					}),
 				) as any;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
 				let getMountableDefaultView = async (): Promise<any> => view;
 				if (MountableView.canMount(view)) {
 					getMountableDefaultView = async (): Promise<MountableView> =>

--- a/examples/data-objects/prosemirror/src/prosemirror.tsx
+++ b/examples/data-objects/prosemirror/src/prosemirror.tsx
@@ -153,7 +153,7 @@ class ProseMirrorView {
 
 	public render(elm: HTMLElement): void {
 		// Create base textarea
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- intentional behavior
+
 		if (!this.textArea) {
 			this.textArea = document.createElement("div");
 			this.textArea.classList.add("editor");
@@ -170,7 +170,6 @@ class ProseMirrorView {
 			elm.appendChild(this.content!);
 		}
 
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 		if (!this.editorView) {
 			this.editorView = this.collabManager.setupEditor(this.textArea);
 		}

--- a/examples/data-objects/prosemirror/src/prosemirror.tsx
+++ b/examples/data-objects/prosemirror/src/prosemirror.tsx
@@ -153,7 +153,6 @@ class ProseMirrorView {
 
 	public render(elm: HTMLElement): void {
 		// Create base textarea
-
 		if (!this.textArea) {
 			this.textArea = document.createElement("div");
 			this.textArea.classList.add("editor");

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -24,7 +24,6 @@ import "simplemde/dist/simplemde.min.css";
  * Data object storing the data to back a SimpleMDE editor.  Primarily just a SharedString.
  */
 export class SmdeDataObject extends EventEmitter implements IFluidLoadable {
-	// eslint-disable-next-line @typescript-eslint/await-thenable -- known limitation
 	public static async load(
 		runtime: IFluidDataStoreRuntime,
 		existing: boolean,

--- a/examples/data-objects/smde/src/smdeView.tsx
+++ b/examples/data-objects/smde/src/smdeView.tsx
@@ -27,7 +27,6 @@ class SmdeView {
 
 	public render(elm: HTMLElement): void {
 		// Create base textarea
-
 		if (!this.textArea) {
 			this.textArea = document.createElement("textarea");
 		}

--- a/examples/data-objects/smde/src/smdeView.tsx
+++ b/examples/data-objects/smde/src/smdeView.tsx
@@ -27,7 +27,7 @@ class SmdeView {
 
 	public render(elm: HTMLElement): void {
 		// Create base textarea
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (!this.textArea) {
 			this.textArea = document.createElement("textarea");
 		}

--- a/examples/data-objects/table-document/src/test/table.spec.ts
+++ b/examples/data-objects/table-document/src/test/table.spec.ts
@@ -160,12 +160,11 @@ describeCompat("TableDocument", "LoaderCompat", (getTestObjectProvider) => {
 				2,
 				2,
 			);
-			/* eslint-disable @typescript-eslint/no-unsafe-return */
+
 			assert.throws(() => slice.getCellValue(-1, 0));
 			assert.throws(() => slice.getCellValue(3, 0));
 			assert.throws(() => slice.getCellValue(0, -1));
 			assert.throws(() => slice.getCellValue(0, 3));
-			/* eslint-enable @typescript-eslint/no-unsafe-return */
 		});
 
 		it("Annotations work when proxied through table slice", async () => {

--- a/examples/data-objects/webflow/src/clipboard/paste.ts
+++ b/examples/data-objects/webflow/src/clipboard/paste.ts
@@ -16,7 +16,6 @@ const enum ClipboardFormat {
 export function paste(doc: FlowDocument, data: DataTransfer, position: number): void {
 	let content: string;
 
-	/* eslint-disable no-cond-assign */
 	if ((content = data.getData(ClipboardFormat.html))) {
 		debug("paste('text/html'): %s", content);
 		const root = document.createElement("span");
@@ -30,7 +29,6 @@ export function paste(doc: FlowDocument, data: DataTransfer, position: number): 
 	} else {
 		debug("paste(%o): Unhandled clipboard type", data.types);
 	}
-	/* eslint-enable no-cond-assign */
 }
 
 const ignoredTags = [TagName.meta];

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -322,7 +322,6 @@ export class FlowDocument extends DataObject {
 
 		// Perform removals in descending order, otherwise earlier deletions will shift the positions
 		// of later ops.  Because each effected interval is non-overlapping, a simple sort suffices.
-
 		ops.sort((left, right) => right.pos1 - left.pos1);
 
 		this.sharedString.groupOperation({

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -197,7 +197,6 @@ export class FlowDocument extends DataObject {
 	}
 
 	public async getComponentFromMarker(marker: Marker): Promise<unknown> {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return marker.properties.handle.get();
 	}
 
@@ -323,7 +322,7 @@ export class FlowDocument extends DataObject {
 
 		// Perform removals in descending order, otherwise earlier deletions will shift the positions
 		// of later ops.  Because each effected interval is non-overlapping, a simple sort suffices.
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- intentional comparison
+
 		ops.sort((left, right) => right.pos1 - left.pos1);
 
 		this.sharedString.groupOperation({

--- a/examples/data-objects/webflow/src/util/dom.ts
+++ b/examples/data-objects/webflow/src/util/dom.ts
@@ -9,7 +9,7 @@ const isElement = (node: Node): node is Element => node.nodeType === Node.ELEMEN
 export class Dom {
 	public static removeAllChildren(parent: Node): void {
 		// External library uses `null`
-		// eslint-disable-next-line @rushstack/no-new-null
+
 		let firstChild: ChildNode | null;
 		while ((firstChild = parent.firstChild) !== null) {
 			firstChild.remove();

--- a/examples/data-objects/webflow/src/util/dom.ts
+++ b/examples/data-objects/webflow/src/util/dom.ts
@@ -8,7 +8,6 @@ const isElement = (node: Node): node is Element => node.nodeType === Node.ELEMEN
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Dom {
 	public static removeAllChildren(parent: Node): void {
-		// External library uses `null`
 
 		let firstChild: ChildNode | null;
 		while ((firstChild = parent.firstChild) !== null) {

--- a/examples/data-objects/webflow/src/view/formatter.ts
+++ b/examples/data-objects/webflow/src/view/formatter.ts
@@ -9,7 +9,7 @@ import { emptyObject } from "../util/index.js";
 
 import { Layout } from "./layout.js";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IFormatterState {}
 
 export abstract class Formatter<TState extends IFormatterState> {

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -222,7 +222,6 @@ export class Layout extends EventEmitter {
 			doc.visitRange((position, segment, startOffset, endOffset) => {
 				this.beginSegment(position, segment, startOffset, endOffset);
 
-				// eslint-disable-next-line no-constant-condition
 				while (true) {
 					const index = this.formatStack.length - 1;
 					const formatInfo = this.format;
@@ -321,9 +320,9 @@ export class Layout extends EventEmitter {
 		const candidate = stack?.[this.formatStack.length];
 
 		// If we find the same kind of formatter at the expected depth, pass the previous output state.
-		const prevOut =
-			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
-			(candidate && candidate.formatter === formatter ? candidate.state : undefined) as TState;
+		const prevOut = (
+			candidate && candidate.formatter === formatter ? candidate.state : undefined
+		) as TState;
 
 		const state = formatter.begin(this, init, prevOut);
 

--- a/examples/external-data/src/model-interface/index.ts
+++ b/examples/external-data/src/model-interface/index.ts
@@ -20,7 +20,7 @@ export interface ExternalSnapshotTask {
 /**
  * Events emitted by {@link IAppModel}.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IAppModelEvents extends IEvent {}
 
 /**

--- a/examples/external-data/src/view/debugView.tsx
+++ b/examples/external-data/src/view/debugView.tsx
@@ -61,7 +61,7 @@ export const DebugView: React.FC = () => {
 	);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface IExternalDataDebugViewProps {}
 
 const ExternalDataDebugView: React.FC<IExternalDataDebugViewProps> = (

--- a/examples/utils/bundle-size-tests/src/sharedTreeAttributes.ts
+++ b/examples/utils/bundle-size-tests/src/sharedTreeAttributes.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import-x/no-internal-modules
 import { SharedTreeAttributes } from "@fluidframework/tree/legacy";
 
 export function apisToBundle(): typeof SharedTreeAttributes {

--- a/examples/utils/example-utils/src/reactInputs/CollaborativeInput.tsx
+++ b/examples/utils/example-utils/src/reactInputs/CollaborativeInput.tsx
@@ -46,7 +46,7 @@ export interface ICollaborativeInputState {
  * Given a {@link @fluidframework/sequence#SharedString}, will produce a collaborative input element.
  * @internal
  */
-/* eslint-disable react/prop-types -- TypeScript interfaces provide compile-time prop validation */
+
 export class CollaborativeInput extends React.Component<
 	ICollaborativeInputProps,
 	ICollaborativeInputState
@@ -153,4 +153,3 @@ export class CollaborativeInput extends React.Component<
 		this.setState({ selectionEnd, selectionStart });
 	};
 }
-/* eslint-enable react/prop-types */

--- a/examples/utils/example-utils/src/reactInputs/CollaborativeInput.tsx
+++ b/examples/utils/example-utils/src/reactInputs/CollaborativeInput.tsx
@@ -46,7 +46,6 @@ export interface ICollaborativeInputState {
  * Given a {@link @fluidframework/sequence#SharedString}, will produce a collaborative input element.
  * @internal
  */
-
 export class CollaborativeInput extends React.Component<
 	ICollaborativeInputProps,
 	ICollaborativeInputState

--- a/examples/utils/webpack-fluid-loader/src/odspPersistantCache.ts
+++ b/examples/utils/webpack-fluid-loader/src/odspPersistantCache.ts
@@ -16,7 +16,6 @@ export class OdspPersistentCache implements IPersistedCache {
 	public constructor() {}
 
 	async get(entry: ICacheEntry): Promise<any> {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return this.cache.get(getKeyForCacheEntry(entry));
 	}
 

--- a/examples/utils/webpack-fluid-loader/src/routes.ts
+++ b/examples/utils/webpack-fluid-loader/src/routes.ts
@@ -380,7 +380,7 @@ const fluid = (
 	options: RouteOptions,
 ): void => {
 	const documentId = req.params.id;
-	// eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	const packageJson = require(path.join(baseDir, "./package.json")) as IFluidPackage;
 
 	const umd = packageJson.fluid.browser?.umd;

--- a/examples/version-migration/same-container/src/modelInterfaces.ts
+++ b/examples/version-migration/same-container/src/modelInterfaces.ts
@@ -11,7 +11,7 @@ import type {
 import type { IEventProvider } from "@fluidframework/core-interfaces";
 import { SharedString } from "@fluidframework/sequence/legacy";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IInventoryListAppModelEvents extends ISameContainerMigratableModelEvents {}
 
 /**

--- a/experimental/PropertyDDS/packages/property-changeset/src/ajvFactory.cts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/ajvFactory.cts
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
-
 import Ajv from "ajv";
 import ajvKeywords from "ajv-keywords";
 

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/schemaValidator.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/schemaValidator.ts
@@ -117,7 +117,7 @@ export class SchemaValidator {
 		in_skipSemver?: boolean,
 		in_allowDraft?: boolean,
 	): SchemaValidationResult;
-	// eslint-disable-next-line @typescript-eslint/promise-function-async
+
 	validate(
 		in_schema: PropertySchema,
 		in_previousSchema?: PropertySchema,

--- a/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
@@ -1869,7 +1869,6 @@ export namespace Utils {
 				in_options.escapeLeadingDoubleUnderscore &&
 				k &&
 				k.length > 2 &&
-				// eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
 				k[0] === "_" &&
 				k[1] === "_" &&
 				k[2] !== "_"

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -278,7 +278,6 @@ export class SharedPropertyTree extends SharedObject {
 		}
 
 		if (doSubmit || !isEmpty(changes)) {
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 			this.applyChangeSet(changes, metadata || {});
 			this.root.cleanDirty();
 		}
@@ -645,7 +644,6 @@ export class SharedPropertyTree extends SharedObject {
 					throw new Error("Invalid Snapshot.");
 				}
 
-				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 				if (snapshotSummary.remoteHeadGuid === undefined) {
 					// The summary does not contain a remoteHeadGuid. This means the summary has
 					// been created by an old version of PropertyDDS, that did not yet have this patch.

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
@@ -2212,7 +2212,6 @@ class PropertyFactory {
 	async initializeSchemaStore(in_options) {
 		// https://regex101.com/r/TlgGJp/2
 		var regexBaseUrl =
-			// eslint-disable-next-line unicorn/no-unsafe-regex
 			/^(https?:)?\/\/((.[-a-zA-Z0-9@:%_+~#=.]{2,256}){1,2}\.[a-z]{2,6}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(:\d{1,5})?(\/[-a-zA-Z0-9@:%_+.~#?&/=]*)*$/;
 
 		if (

--- a/experimental/PropertyDDS/packages/property-properties/src/test/propertyFactory.spec.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/test/propertyFactory.spec.js
@@ -3927,7 +3927,6 @@ describe("Async validation", function () {
 				try {
 					resolve(PropertyFactory.inheritsFrom(child, ancestor));
 				} catch (error) {
-					// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
 					reject(error);
 				}
 			}, 0);

--- a/experimental/dds/ot/ot/src/test/ot.stress.spec.ts
+++ b/experimental/dds/ot/ot/src/test/ot.stress.spec.ts
@@ -234,7 +234,6 @@ describe("SharedOT", () => {
 			const start = Date.now();
 			let lastStatus = start;
 
-			// eslint-disable-next-line no-constant-condition
 			while (true) {
 				await stress(
 					/* numClients: */ 2,

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -153,7 +153,6 @@ export class RunSegment extends SubSequence<SparseMatrixItem> {
 	}
 
 	public getTag(pos: number): any {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return this.tags[pos];
 	}
 
@@ -286,7 +285,6 @@ export class SparseMatrixClass extends SharedSegmentSequence<MatrixSegment> {
 	public getTag(row: number, col: number): any {
 		const { segment, offset } = this.getSegment(row, col);
 		if (segment && RunSegment.is(segment)) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return segment.getTag(offset ?? 0);
 		}
 		return undefined;

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -545,7 +545,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	public constructor(
 		runtime: IFluidDataStoreRuntime,
 		id: string,
-
 		private writeFormat: WriteFormat,
 		options: SharedTreeOptions<typeof writeFormat> = {}
 	) {

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -545,7 +545,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	public constructor(
 		runtime: IFluidDataStoreRuntime,
 		id: string,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly -- false positive; modified in changeWriteFormat()
+
 		private writeFormat: WriteFormat,
 		options: SharedTreeOptions<typeof writeFormat> = {}
 	) {

--- a/experimental/dds/tree/src/migration-shim/migrationShim.ts
+++ b/experimental/dds/tree/src/migration-shim/migrationShim.ts
@@ -155,7 +155,6 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.closeWithError}
 	 */
 	private closeWithError(error: ReturnType<typeof DataProcessingError.wrapIfUnrecognized>): void {
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 		if (this.closeError === undefined) {
 			this.closeError = error;
 		}

--- a/experimental/framework/last-edited/src/setup.ts
+++ b/experimental/framework/last-edited/src/setup.ts
@@ -31,7 +31,6 @@ function getLastEditDetailsFromMessage(
 	quorum: IQuorumClients,
 ): ILastEditDetails | undefined {
 	// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-
 	const sequencedClient = quorum.getMember(message.clientId as string);
 	const user = sequencedClient?.client.user;
 	if (user !== undefined) {

--- a/experimental/framework/last-edited/src/setup.ts
+++ b/experimental/framework/last-edited/src/setup.ts
@@ -31,7 +31,7 @@ function getLastEditDetailsFromMessage(
 	quorum: IQuorumClients,
 ): ILastEditDetails | undefined {
 	// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 	const sequencedClient = quorum.getMember(message.clientId as string);
 	const user = sequencedClient?.client.user;
 	if (user !== undefined) {

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -223,5 +223,5 @@ export interface IFluidHandle<out T = unknown> {
  * Created from {@link IFluidHandleInternal} using {@link toFluidHandleErased}.
  * @sealed @public
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {}

--- a/packages/common/core-interfaces/src/jsonString.ts
+++ b/packages/common/core-interfaces/src/jsonString.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- incorrect rule: misunderstands `declare`d types.
 import type { BrandedType } from "./brandedType.js";
 import type { InternalUtilityTypes } from "./exposedInternalUtilityTypes.js";
 import type { JsonDeserialized } from "./jsonDeserialized.js";

--- a/packages/common/core-interfaces/src/test/brandedType.spec.ts
+++ b/packages/common/core-interfaces/src/test/brandedType.spec.ts
@@ -14,8 +14,6 @@ import {
 	brandedObjectWithString,
 } from "./testValues.js";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- incorrect rule: misunderstands `declare`d types.
-
 function parameterAcceptedAs<T>(_t: T): void {
 	// Do nothing.  Used to verify type compatibility.
 }

--- a/packages/common/core-interfaces/src/test/testValues.ts
+++ b/packages/common/core-interfaces/src/test/testValues.ts
@@ -747,7 +747,7 @@ export const objectWithFluidHandle = {
 	handle: fluidHandleToNumber,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface TestErasedType<T> extends ErasedType<readonly ["TestCustomType", T]> {}
 
 export const erasedType = 0 as unknown as TestErasedType<number>;

--- a/packages/common/core-utils/src/lazy.ts
+++ b/packages/common/core-utils/src/lazy.ts
@@ -81,7 +81,6 @@ export class LazyPromise<T> implements Promise<T> {
 	}
 
 	private async getPromise(): Promise<T> {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if result is a falsy value
 		if (this.result === undefined) {
 			this.result = this.execute();
 		}

--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -98,6 +98,6 @@ declare module "@fluidframework/core-interfaces" {
 	 * For example, caller can use this to pass on various loader options in the container
 	 * load request.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 	export interface IRequestHeader extends Partial<IDriverHeader> {}
 }

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -175,7 +175,6 @@ export class SharedCounter
 				const messageId = messageContent.localOpMetadata;
 				assert(typeof messageId === "number", 0xc8e /* localOpMetadata should be a number */);
 				assert(
-					// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 					pendingOp !== undefined &&
 						pendingOp.messageId === messageId &&
 						pendingOp.type === op.type &&
@@ -222,7 +221,6 @@ export class SharedCounter
 		);
 		const pendingOp = this.pendingOps.pop();
 		assert(
-			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 			pendingOp !== undefined &&
 				pendingOp.messageId === localOpMetadata &&
 				pendingOp.type === content.type &&

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// TODO: Fix prefer-nullish-coalescing and prefer-optional-chain lint violations
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -4,7 +4,6 @@
  */
 
 // TODO: Fix prefer-nullish-coalescing and prefer-optional-chain lint violations
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/prefer-optional-chain */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -641,7 +641,6 @@ export class MapKernel {
 			// A pending clear will be last in the list, since it terminates all prior lifetimes.
 			const pendingClear = this.pendingData.pop();
 			assert(
-				// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 				pendingClear !== undefined &&
 					pendingClear.type === "clear" &&
 					pendingClear === typedLocalOpMetadata,
@@ -715,7 +714,6 @@ export class MapKernel {
 					this.sequencedData.clear();
 					const pendingClear = this.pendingData.shift();
 					assert(
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 						pendingClear !== undefined &&
 							pendingClear.type === "clear" &&
 							pendingClear === localOpMetadata,
@@ -772,7 +770,6 @@ export class MapKernel {
 					);
 					const pendingEntry = this.pendingData[pendingEntryIndex];
 					assert(
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 						pendingEntry !== undefined &&
 							pendingEntry.type === "delete" &&
 							pendingEntry === localOpMetadata,
@@ -813,7 +810,6 @@ export class MapKernel {
 					);
 					const pendingEntry = this.pendingData[pendingEntryIndex];
 					assert(
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 						pendingEntry !== undefined && pendingEntry.type === "lifetime",
 						0xbf8 /* Couldn't match local set message to pending lifetime */,
 					);

--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -651,7 +651,6 @@ for (const isSetCellPolicyFWW of [0, 2]) {
 				let iterations = 0;
 				const start = Date.now();
 
-				// eslint-disable-next-line no-constant-condition
 				while (true) {
 					await stress(
 						/* numClients: */ 3,

--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -393,7 +393,7 @@ export class AttributionCollection implements IAttributionCollection<Attribution
 		const { channels } = summary;
 		assert(
 			// Destructuring here would require renaming the variables, since seqs is declared below
-			// eslint-disable-next-line unicorn/consistent-destructuring
+
 			summary.seqs.length === summary.posBreakpoints.length,
 			0x445 /* Invalid attribution summary blob provided */,
 		);

--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -392,7 +392,6 @@ export class AttributionCollection implements IAttributionCollection<Attribution
 	): void {
 		const { channels } = summary;
 		assert(
-			// Destructuring here would require renaming the variables, since seqs is declared below
 
 			summary.seqs.length === summary.posBreakpoints.length,
 			0x445 /* Invalid attribution summary blob provided */,

--- a/packages/dds/merge-tree/src/collections/rbTree.ts
+++ b/packages/dds/merge-tree/src/collections/rbTree.ts
@@ -695,11 +695,11 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
 		if (!node) {
 			return true;
 		}
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (_start === undefined) {
 			_start = this.nodeMin(node).key;
 		}
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (_end === undefined) {
 			_end = this.nodeMax(node).key;
 		}

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -232,7 +232,6 @@ export function setValidateRefCount(
 export class LocalReferenceCollection {
 	public static append(seg1: ISegmentInternal, seg2: ISegmentInternal): void {
 		if (seg2.localRefs && !seg2.localRefs.empty) {
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 			if (!seg1.localRefs) {
 				seg1.localRefs = new LocalReferenceCollection(seg1);
 			}

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -151,7 +151,7 @@ export type MergeTreeDeltaCallback = (
 /**
  * @legacy @beta
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IMergeTreeMaintenanceCallbackArgs
 	extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> {}
 

--- a/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
@@ -53,7 +53,6 @@ export function depthFirstNodeWalk(
 	let childCount = block.childCount;
 	let start: IMergeNode | undefined = startChild;
 
-	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		// go down to the leaf level
 		let blockResult: NodeAction;

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -861,7 +861,7 @@ export class PartialSequenceLengths {
 		// eslint-disable-next-line unicorn/no-array-for-each
 		this.perClientAdjustments.forEach((clientAdjustments) => {
 			const leqPartial = clientAdjustments.latestLeq(seq);
-			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 			if (leqPartial && leqPartial.seq === seq) {
 				this.addClientAdjustment(clientId, seq, -leqPartial.seglen);
 			}
@@ -929,7 +929,7 @@ export class PartialSequenceLengths {
 				}
 				const partialLengths = branchPartialLengths.partialLengths;
 				const leqPartial = partialLengths.latestLeq(seq);
-				// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 				if (leqPartial && leqPartial.seq === seq) {
 					seqSeglen += leqPartial.seglen;
 				}
@@ -939,7 +939,7 @@ export class PartialSequenceLengths {
 				// eslint-disable-next-line unicorn/no-array-for-each
 				branchPartialLengths.perClientAdjustments.forEach((clientAdjustments) => {
 					const leqBranchPartial = clientAdjustments.latestLeq(seq);
-					// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 					if (leqBranchPartial && leqBranchPartial.seq === seq) {
 						this.addClientAdjustment(clientId, seq, leqBranchPartial.seglen);
 					}

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -118,7 +118,6 @@ export function extendIfUndefined<T>(
 ): MapLike<T> {
 	if (extension !== undefined) {
 		for (const [key, value] of Object.entries(extension)) {
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 			if (base[key] === undefined) {
 				base[key] = value;
 			}

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -86,7 +86,7 @@ export type PropsOrAdjust =
 
 const opToChanges = (op: PropsOrAdjust, seq: number): [string, PropertyChange][] => [
 	...Object.entries(op.props ?? {})
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
 		.map<[string, PropertyChange]>(([k, raw]) => [k, { raw, seq }])
 		.filter(([_, v]) => v.raw !== undefined),
 	...Object.entries(op.adjust ?? {}).map<[string, PropertyChange]>(([k, adjust]) => [

--- a/packages/dds/merge-tree/src/test/beastTest.spec.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.spec.ts
@@ -72,11 +72,10 @@ function LinearDictionary<TKey, TData>(
 			return;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (_start === undefined) {
 			_start = min()!.key;
 		}
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (_end === undefined) {
 			_end = max()!.key;
 		}

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -4,7 +4,6 @@
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-// TODO: Fix prefer-optional-chain lint violations
 
 import { strict as assert } from "node:assert";
 

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 // TODO: Fix prefer-optional-chain lint violations
-/* eslint-disable @typescript-eslint/prefer-optional-chain */
 
 import { strict as assert } from "node:assert";
 

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -295,7 +295,6 @@ export class ConsensusRegisterCollection<T>
 				case "write": {
 					// backward compatibility: File at rest written with runtime <= 0.13 do not have refSeq
 					// when the refSeq property didn't exist
-
 					if (op.refSeq === undefined) {
 						op.refSeq = messageEnvelope.referenceSequenceNumber;
 					}

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -295,7 +295,7 @@ export class ConsensusRegisterCollection<T>
 				case "write": {
 					// backward compatibility: File at rest written with runtime <= 0.13 do not have refSeq
 					// when the refSeq property didn't exist
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 					if (op.refSeq === undefined) {
 						op.refSeq = messageEnvelope.referenceSequenceNumber;
 					}

--- a/packages/dds/register-collection/src/test/dirname.cts
+++ b/packages/dds/register-collection/src/test/dirname.cts
@@ -10,5 +10,4 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-
 export const _dirname = __dirname;

--- a/packages/dds/register-collection/src/test/dirname.cts
+++ b/packages/dds/register-collection/src/test/dirname.cts
@@ -10,5 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line jsdoc/require-jsdoc
+
 export const _dirname = __dirname;

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -171,7 +171,6 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
 		this.walkSegments(
 			(segment: ISegment) => {
 				if (SubSequence.is(segment)) {
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 					if (firstSegment === undefined) {
 						firstSegment = segment;
 					}

--- a/packages/dds/sequence/src/test/subSequence.spec.ts
+++ b/packages/dds/sequence/src/test/subSequence.spec.ts
@@ -46,7 +46,6 @@ class SubSequenceTestClient extends TestClient {
 		this.walkSegments(
 			(s) => {
 				if (SubSequence.is(s)) {
-					// eslint-disable-next-line @typescript-eslint/no-base-to-string -- known limitation
 					items += s.items.toString();
 				}
 				return true;

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -238,7 +238,6 @@ export abstract class SharedObjectCore<
 	 * @param error - error object that is thrown whenever an attempt is made to modify this object
 	 */
 	private closeWithError(error: IFluidErrorBase | undefined): void {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.closeError === undefined) {
 			this.closeError = error;
 		}

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -906,7 +906,6 @@ export class TaskManagerClass
 		assert(latestPendingOps !== undefined, 0xc46 /* No pending ops when trying to rollback */);
 		const pendingOpToRollback = latestPendingOps.pop();
 		assert(
-			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 			pendingOpToRollback !== undefined && pendingOpToRollback.messageId === localOpMetadata,
 			0xc47 /* pending op mismatch */,
 		);

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1089,7 +1089,6 @@ export function setupClientContext(
 	random.handle = () => new DDSFuzzHandle(random.pick(handles), client.dataStoreRuntime);
 	return () => {
 		state.client = oldClient;
-
 		state.random.handle = oldHandle;
 	};
 }

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1089,7 +1089,7 @@ export function setupClientContext(
 	random.handle = () => new DDSFuzzHandle(random.pick(handles), client.dataStoreRuntime);
 	return () => {
 		state.client = oldClient;
-		// eslint-disable-next-line unicorn/consistent-destructuring
+
 		state.random.handle = oldHandle;
 	};
 }

--- a/packages/dds/test-dds-utils/src/utils.ts
+++ b/packages/dds/test-dds-utils/src/utils.ts
@@ -6,7 +6,6 @@
 import type {
 	MockContainerRuntimeForReconnection,
 	MockFluidDataStoreRuntime,
-	// eslint-disable-next-line import-x/no-internal-modules
 } from "@fluidframework/test-runtime-utils/legacy";
 
 export function makeUnreachableCodePathProxy<T extends object>(name: string): T {

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -1210,7 +1210,7 @@ class PathNode extends ReferenceCountedBase implements AnchorNode {
 function binaryFind(sorted: readonly PathNode[], index: number): PathNode | undefined {
 	// Try guessing the list is not sparse as a starter:
 	const guess = sorted[index];
-	// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 	if (guess !== undefined && guess.parentIndex === index) {
 		return guess;
 	}

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -206,7 +206,7 @@ function transferRoots(
 				delayed.push({ oldId, newId });
 				continue;
 			}
-			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- intentional behavior
+
 			newRootId = detachedFieldIndex.createEntry(newId, revision);
 			const fields = mapToUpdate.get(oldRootId);
 			if (fields !== undefined) {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -590,7 +590,6 @@ class LazyFieldEncoder implements FieldEncoder {
 	}
 
 	private get encoder(): FieldEncoder {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.encoderLazy === undefined) {
 			this.encoderLazy = this.fieldEncoderFromPolicy(this.nodeBuilder, this.fieldSchema);
 		}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -97,7 +97,6 @@ function rebaseGenericChange(
 	const rebased: GenericChangeset = new BTree();
 	let nextIndex = 0;
 
-	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		const newEntry = change.getPairOrNextHigher(nextIndex);
 		const baseEntry = over.getPairOrNextHigher(nextIndex);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -481,7 +481,6 @@ export class ModularChangeFamily
 				setInChangeAtomIdMap(composedNodes, nodeId, nodeChangeset);
 			}
 
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 			if (nodeChangeset.fieldChanges === undefined) {
 				nodeChangeset.fieldChanges = new Map();
 			}
@@ -3161,7 +3160,6 @@ export function normalizeFieldId(
 function normalizeNodeId(nodeId: NodeId, nodeAliases: ChangeAtomIdBTree<NodeId>): NodeId {
 	let currentId = nodeId;
 
-	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		const dealiased = getFromChangeAtomIdMap(nodeAliases, currentId);
 		if (dealiased === undefined) {

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -182,7 +182,7 @@ export function decodeSharedBranch<TChangeset>(
 		trunk: trunk.map(
 			(commit): SequencedCommit<TChangeset> =>
 				// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
 				decodeCommit(changeCodec, revisionTagCodec, commit, {
 					originatorId: commit.sessionId,
 					idCompressor: context.idCompressor,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -182,7 +182,6 @@ export function decodeSharedBranch<TChangeset>(
 		trunk: trunk.map(
 			(commit): SequencedCommit<TChangeset> =>
 				// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
-
 				decodeCommit(changeCodec, revisionTagCodec, commit, {
 					originatorId: commit.sessionId,
 					idCompressor: context.idCompressor,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -549,7 +549,7 @@ export function getBranch<T extends ImplicitFieldSchema | UnsafeUnknownSchema>(
  * Once an entry is defined and used in production, it cannot be changed.
  * This is because the format for SharedTree changes are not explicitly versioned.
  */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- intentional comparison
+
 export const changeFormatVersionForEditManager = DependentFormatVersion.fromPairs([
 	[
 		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v3),

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -549,7 +549,6 @@ export function getBranch<T extends ImplicitFieldSchema | UnsafeUnknownSchema>(
  * Once an entry is defined and used in production, it cannot be changed.
  * This is because the format for SharedTree changes are not explicitly versioned.
  */
-
 export const changeFormatVersionForEditManager = DependentFormatVersion.fromPairs([
 	[
 		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v3),

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -11,7 +11,6 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { TreeValue } from "../../core/index.js";
 // This import is required for intellisense in @link doc comments on mouseover in VSCode.
-// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
 import type { FlexTreeHydratedContextMinimal } from "../../feature-libraries/index.js";
 import {
 	type JsonCompatibleReadOnlyObject,

--- a/packages/dds/tree/src/simple-tree/core/treeNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNode.ts
@@ -72,7 +72,6 @@ export abstract class TreeNode implements WithType {
 	 * someone could manually (or via Intellisense auto-implement completion, or in response to a type error)
 	 * make an object literal with the [type] field and pass it off as a node: this private brand prevents that.
 	 */
-
 	readonly #brand!: unknown;
 
 	/**

--- a/packages/dds/tree/src/simple-tree/core/treeNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNode.ts
@@ -72,7 +72,7 @@ export abstract class TreeNode implements WithType {
 	 * someone could manually (or via Intellisense auto-implement completion, or in response to a type error)
 	 * make an object literal with the [type] field and pass it off as a node: this private brand prevents that.
 	 */
-	// eslint-disable-next-line no-unused-private-class-members
+
 	readonly #brand!: unknown;
 
 	/**

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -99,8 +99,7 @@ import type {
  */
 export type ObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> =
 	RestrictiveStringRecord<ImplicitFieldSchema> extends T
-		? // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-			{}
+		? {}
 		: {
 				-readonly [Property in keyof T]: Property extends string
 					? TreeFieldFromImplicitField<T[Property]>

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -8,7 +8,6 @@ import { strict as assert, fail } from "node:assert";
 import { type Static, Type } from "@sinclair/typebox";
 
 import { DiscriminatedUnionDispatcher, unionOptions } from "../../../../codec/index.js";
-// eslint-disable-next-line import-x/no-internal-modules
 import type { ChunkedCursor } from "../../../../core/index.js";
 import {
 	type ChunkDecoder,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -118,7 +118,6 @@ const singleNodeRebaser: FieldChangeRebaser<SingleNodeChangeset> = {
 	rebase: (change, base, rebaseChild) => rebaseChild(change, base),
 	prune: (change, pruneChild) => (change === undefined ? undefined : pruneChild(change)),
 	replaceRevisions: (change, replacer) =>
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- replacer type inference issue
 		change === undefined ? undefined : replacer.getUpdatedAtomId(change),
 };
 

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -103,7 +103,6 @@ export function testForest(config: ForestTestConfiguration): void {
 
 	// Use Json Cursor to insert and extract some Json data
 	describe("insert and extract json", () => {
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 		const testCases: [string, {} | number][] = [
 			["primitive", 5],
 			["array", [1, 2, 3]],

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -292,7 +292,7 @@ export function runUnitTestScenario(
 				switch (type) {
 					case "Push": {
 						let seq = step.seq;
-						// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 						if (seq === undefined) {
 							seq =
 								iNextAck < acks.length

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -292,7 +292,6 @@ export function runUnitTestScenario(
 				switch (type) {
 					case "Push": {
 						let seq = step.seq;
-
 						if (seq === undefined) {
 							seq =
 								iNextAck < acks.length

--- a/packages/dds/tree/src/test/shared-tree-core/editManagerSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/editManagerSummarizer.spec.ts
@@ -14,7 +14,6 @@ import {
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import { MockStorage, validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-// eslint-disable-next-line import-x/no-internal-modules
 import { DependentFormatVersion, FluidClientVersion } from "../../codec/index.js";
 import { RevisionTagCodec } from "../../core/index.js";
 import { FormatValidatorBasic } from "../../external-utilities/index.js";
@@ -36,7 +35,6 @@ import {
 	summarizablesMetadataKey,
 	type SharedTreeSummarizableMetadata,
 } from "../../shared-tree-core/index.js";
-// eslint-disable-next-line import-x/no-internal-modules
 import { testChangeFamilyFactory } from "../testChange.js";
 import { testIdCompressor } from "../utils.js";
 

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -38,7 +38,6 @@ import {
 } from "../../simple-tree/index.js";
 import type { Mutable } from "../../util/index.js";
 import { brand } from "../../util/index.js";
-// eslint-disable-next-line import-x/no-internal-modules
 import { fieldJsonCursor } from "../json/index.js";
 import { insert, makeTreeFromJsonSequence } from "../sequenceRootUtils.js";
 import { testDocumentIndependentView } from "../testTrees.js";

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -1192,7 +1192,6 @@ describe("sharedTreeView", () => {
 				const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
 					assert(getRevertible !== undefined, "Expected commit to be revertible.");
 					// Only save off the first revertible, as it's the only one we'll use.
-
 					if (revertible === undefined) {
 						revertible = getRevertible();
 					}

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -1192,7 +1192,7 @@ describe("sharedTreeView", () => {
 				const unsubscribe = view.events.on("changed", ({ getRevertible }) => {
 					assert(getRevertible !== undefined, "Expected commit to be revertible.");
 					// Only save off the first revertible, as it's the only one we'll use.
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 					if (revertible === undefined) {
 						revertible = getRevertible();
 					}

--- a/packages/dds/tree/src/test/simple-tree/api/discrepancies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/discrepancies.spec.ts
@@ -36,7 +36,6 @@ import {
 // eslint-disable-next-line import-x/no-internal-modules
 import { LeafNodeSchema } from "../../../simple-tree/leafNodeSchema.js";
 import { brand } from "../../../util/index.js";
-// eslint-disable-next-line import-x/no-internal-modules
 import { fieldSchema } from "../../utils.js";
 
 // Arbitrary schema name used in tests

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -76,7 +76,6 @@ import { hydrate } from "../utils.js";
 	class NodeMap extends schema.map("Notes", Note) {}
 	class NodeList extends schema.array("Notes", Note) {}
 
-	// eslint-disable-next-line no-inner-declarations
 	function f(n: NodeMap): void {
 		const item = n.get("x");
 	}

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -1046,7 +1046,6 @@ describe("SchemaFactory Recursive methods", () => {
 				// Check constructor
 				type TBuild = NodeBuilderData<typeof RecordRecursive>;
 				type _check2 = requireAssignableTo<RecordRecursive, TBuild>;
-
 				type _check3 = requireAssignableTo<{}, TBuild>;
 				type _check4 = requireAssignableTo<{ a: RecordRecursive }, TBuild>;
 				type _check5 = requireAssignableTo<Record<string, TInsert>, TBuild>;

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -1046,7 +1046,7 @@ describe("SchemaFactory Recursive methods", () => {
 				// Check constructor
 				type TBuild = NodeBuilderData<typeof RecordRecursive>;
 				type _check2 = requireAssignableTo<RecordRecursive, TBuild>;
-				// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+
 				type _check3 = requireAssignableTo<{}, TBuild>;
 				type _check4 = requireAssignableTo<{ a: RecordRecursive }, TBuild>;
 				type _check5 = requireAssignableTo<Record<string, TInsert>, TBuild>;

--- a/packages/dds/tree/src/test/simple-tree/fieldSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/fieldSchema.spec.ts
@@ -81,7 +81,6 @@ describe("fieldSchema", () => {
 			type _check7 = requireTrue<areSafelyAssignable<I9, never>>;
 			type _check8 = requireTrue<areSafelyAssignable<I10, never>>;
 
-			// eslint-disable-next-line no-inner-declarations
 			function _generic<T extends ImplicitAllowedTypes>() {
 				type I14 = InsertableTreeFieldFromImplicitField<T>;
 				type IOptional = InsertableTreeFieldFromImplicitField<
@@ -118,7 +117,6 @@ describe("fieldSchema", () => {
 			type I13 = InsertableField<typeof booleanSchema>;
 			type _check13 = requireTrue<areSafelyAssignable<I13, boolean>>;
 
-			// eslint-disable-next-line no-inner-declarations
 			function _generic<T extends ImplicitAllowedTypes>() {
 				type I14 = InsertableField<T>;
 				type IOptional = InsertableField<FieldSchema<FieldKind.Optional, T>>;

--- a/packages/dds/tree/src/test/simple-tree/list.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/list.spec.ts
@@ -31,7 +31,6 @@ describe("List", () => {
 		return result;
 	}
 
-	// eslint-disable-next-line @fluid-internal/fluid/no-markdown-links-in-jsdoc -- false positive AB#51719
 	/** Creates test case titles that resemble function calls:`<array>.[name](..args..) -> <expected>` */
 	function prettyCall(
 		name: string,

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
@@ -93,7 +93,6 @@ const schemaFactory = new SchemaFactory("Test");
 
 	// Empty case
 	{
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 		type result = InsertableObjectFromSchemaRecord<{}>;
 		type _check = requireAssignableTo<result, Record<string, never>>;
 	}
@@ -174,7 +173,7 @@ const schemaFactory = new SchemaFactory("Test");
 	// Generic case
 	{
 		type result = ObjectFromSchemaRecord<RestrictiveStringRecord<ImplicitFieldSchema>>;
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+
 		type _check = requireTrue<areSafelyAssignable<{}, result>>;
 
 		type _check3 = requireTrue<isAssignableTo<{ x: unknown }, result>>;
@@ -182,9 +181,8 @@ const schemaFactory = new SchemaFactory("Test");
 
 	// Empty case
 	{
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 		type result = ObjectFromSchemaRecord<{}>;
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+
 		type _check = requireTrue<areSafelyAssignable<{}, result>>;
 		type _check2 = requireFalse<isAssignableTo<result, { x: unknown }>>;
 
@@ -642,9 +640,9 @@ describeHydration(
 				type Create<T extends RecordX> = (data: RecordX extends T ? never : T) => unknown;
 
 				// Two identical interfaces
-				// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+
 				interface X1<T extends RecordX = RecordX> extends Create<T> {}
-				// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+
 				interface X2<T extends RecordX = RecordX> extends Create<T> {}
 
 				// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -697,7 +695,7 @@ describeHydration(
 				}) {
 					// Since fields are own properties, we expect inherited properties (like this) to be shadowed by fields.
 					// However in TypeScript they work like inherited properties, so the types don't make the runtime behavior.
-					// eslint-disable-next-line @typescript-eslint/class-literal-property-style
+
 					public override get foo(): 5 {
 						return 5;
 					}

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
@@ -173,7 +173,6 @@ const schemaFactory = new SchemaFactory("Test");
 	// Generic case
 	{
 		type result = ObjectFromSchemaRecord<RestrictiveStringRecord<ImplicitFieldSchema>>;
-
 		type _check = requireTrue<areSafelyAssignable<{}, result>>;
 
 		type _check3 = requireTrue<isAssignableTo<{ x: unknown }, result>>;
@@ -182,7 +181,6 @@ const schemaFactory = new SchemaFactory("Test");
 	// Empty case
 	{
 		type result = ObjectFromSchemaRecord<{}>;
-
 		type _check = requireTrue<areSafelyAssignable<{}, result>>;
 		type _check2 = requireFalse<isAssignableTo<result, { x: unknown }>>;
 
@@ -640,7 +638,6 @@ describeHydration(
 				type Create<T extends RecordX> = (data: RecordX extends T ? never : T) => unknown;
 
 				// Two identical interfaces
-
 				interface X1<T extends RecordX = RecordX> extends Create<T> {}
 
 				interface X2<T extends RecordX = RecordX> extends Create<T> {}
@@ -695,7 +692,6 @@ describeHydration(
 				}) {
 					// Since fields are own properties, we expect inherited properties (like this) to be shadowed by fields.
 					// However in TypeScript they work like inherited properties, so the types don't make the runtime behavior.
-
 					public override get foo(): 5 {
 						return 5;
 					}

--- a/packages/dds/tree/src/test/simple-tree/object.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/object.spec.ts
@@ -211,7 +211,6 @@ function testObjectLike(testCases: TestCaseErased[]) {
 			test1((subject) => {
 				const all = Object.getOwnPropertyDescriptors(subject);
 				return Object.fromEntries(
-					// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- intentional behavior
 					Object.entries(all).filter(([key, descriptor]) => descriptor.enumerable),
 				);
 			});

--- a/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
@@ -31,7 +31,6 @@ import {
 	TreeNodeValid,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../simple-tree/core/treeNodeValid.js";
-// eslint-disable-next-line import-x/no-internal-modules
 import {
 	getTreeNodeSchemaInitializedData,
 	getUnhydratedContext,

--- a/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
+++ b/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import-x/no-internal-modules
 import { strict as assert } from "node:assert";
 
 import { AttachState } from "@fluidframework/container-definitions";

--- a/packages/dds/tree/src/test/util/brand.spec.ts
+++ b/packages/dds/tree/src/test/util/brand.spec.ts
@@ -96,7 +96,6 @@ type _check1 = requireFalse<isAssignableTo<E4, E5>> | requireFalse<isAssignableT
 	allowUnused<requireAssignableTo<typeof TestA.a, 1>>();
 
 	// Switch using the actual constants works fine
-
 	function switchLiterals(x: TestA) {
 		switch (x) {
 			case 1: {
@@ -129,7 +128,6 @@ type _check1 = requireFalse<isAssignableTo<E4, E5>> | requireFalse<isAssignableT
 	}
 
 	// Switch using the enum members does narrow with unbrand
-
 	function switchUnbrand(x: TestA) {
 		switch (x) {
 			case unbrand(TestA.a): {

--- a/packages/dds/tree/src/test/util/brand.spec.ts
+++ b/packages/dds/tree/src/test/util/brand.spec.ts
@@ -96,7 +96,7 @@ type _check1 = requireFalse<isAssignableTo<E4, E5>> | requireFalse<isAssignableT
 	allowUnused<requireAssignableTo<typeof TestA.a, 1>>();
 
 	// Switch using the actual constants works fine
-	// eslint-disable-next-line no-inner-declarations
+
 	function switchLiterals(x: TestA) {
 		switch (x) {
 			case 1: {
@@ -112,7 +112,7 @@ type _check1 = requireFalse<isAssignableTo<E4, E5>> | requireFalse<isAssignableT
 	}
 
 	// Switch using the enum members does not narrow without unbrand
-	// eslint-disable-next-line no-inner-declarations
+
 	function switchConstants(x: TestA) {
 		switch (x) {
 			case TestA.a: {
@@ -129,7 +129,7 @@ type _check1 = requireFalse<isAssignableTo<E4, E5>> | requireFalse<isAssignableT
 	}
 
 	// Switch using the enum members does narrow with unbrand
-	// eslint-disable-next-line no-inner-declarations
+
 	function switchUnbrand(x: TestA) {
 		switch (x) {
 			case unbrand(TestA.a): {

--- a/packages/dds/tree/src/util/referenceCounting.ts
+++ b/packages/dds/tree/src/util/referenceCounting.ts
@@ -39,7 +39,6 @@ export interface ReferenceCounted {
  * Base class to assist with implementing ReferenceCounted.
  */
 export abstract class ReferenceCountedBase implements ReferenceCounted {
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly -- false positive; modified in multiple places
 	protected constructor(private refCount: number = 1) {}
 
 	public referenceAdded(count = 1): void {

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -321,7 +321,6 @@ export class DebugReplayController extends ReplayController implements IDebugger
 		fetchedOps: ISequencedDocumentMessage[],
 	): Promise<void> {
 		let _fetchedOps = fetchedOps;
-
 		while (true) {
 			if (_fetchedOps.length === 0) {
 				this.ui.updateNextOpText([]);

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -321,7 +321,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
 		fetchedOps: ISequencedDocumentMessage[],
 	): Promise<void> {
 		let _fetchedOps = fetchedOps;
-		// eslint-disable-next-line no-constant-condition
+
 		while (true) {
 			if (_fetchedOps.length === 0) {
 				this.ui.updateNextOpText([]);

--- a/packages/drivers/debugger/src/sanitizer.ts
+++ b/packages/drivers/debugger/src/sanitizer.ts
@@ -376,7 +376,6 @@ export class Sanitizer {
 		if (typeof input === "string") {
 			return this.replaceText(input);
 		} else if (Array.isArray(input)) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return this.replaceArray(input);
 		} else if (typeof input === "object") {
 			return this.replaceObject(input, excludedKeys);

--- a/packages/drivers/driver-web-cache/src/FluidCache.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCache.ts
@@ -280,7 +280,7 @@ export class FluidCache implements IPersistedCache {
 		});
 
 		// Value will contain metadata like the expiry time, we just want to return the object we were asked to cache
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
 		return cachedItem?.cachedObject;
 	}
 

--- a/packages/drivers/driver-web-cache/src/FluidCache.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCache.ts
@@ -280,7 +280,6 @@ export class FluidCache implements IPersistedCache {
 		});
 
 		// Value will contain metadata like the expiry time, we just want to return the object we were asked to cache
-
 		return cachedItem?.cachedObject;
 	}
 

--- a/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
@@ -74,7 +74,7 @@ function getMockCacheEntry(itemKey: string, options?: { docId: string }): ICache
 	describe(`Fluid Cache tests: immediateClose: ${immediateClose}`, () => {
 		beforeEach(() => {
 			// Reset the indexed db before each test so that it starts off in an empty state
-			// eslint-disable-next-line import-x/no-internal-modules, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+			// eslint-disable-next-line import-x/no-internal-modules, @typescript-eslint/no-require-imports
 			const FDBFactory = require("fake-indexeddb/lib/FDBFactory");
 			(window.indexedDB as any) = new FDBFactory();
 		});

--- a/packages/drivers/driver-web-cache/src/test/FluidCacheIndexedDb.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCacheIndexedDb.test.ts
@@ -40,7 +40,7 @@ const upgradeTestCases = getUpgradeTestCases(versions);
 describe("getFluidCacheIndexedDbInstance", () => {
 	beforeEach(() => {
 		// Reset the indexed db before each test so that it starts off in an empty state
-		// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import-x/no-internal-modules
+		// eslint-disable-next-line @typescript-eslint/no-require-imports, import-x/no-internal-modules
 		const FDBFactory = require("fake-indexeddb/lib/FDBFactory");
 		(window.indexedDB as any) = new FDBFactory();
 	});

--- a/packages/drivers/driver-web-cache/src/test/FluidCacheTimer.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCacheTimer.test.ts
@@ -75,7 +75,7 @@ function getMockCacheEntry(itemKey: string, options?: { docId: string }): ICache
 describe("FluidCacheTimer tests", () => {
 	beforeEach(() => {
 		// Reset the indexed db before each test so that it starts off in an empty state
-		// eslint-disable-next-line import-x/no-internal-modules, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+		// eslint-disable-next-line import-x/no-internal-modules, @typescript-eslint/no-require-imports
 		const FDBFactory = require("fake-indexeddb/lib/FDBFactory");
 		(window.indexedDB as any) = new FDBFactory();
 	});

--- a/packages/drivers/file-driver/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDeltaStorageService.ts
@@ -24,7 +24,6 @@ export class FileDeltaStorageService implements IDocumentDeltaStorageService {
 	constructor(private readonly path: string) {
 		this.messages = [];
 		let counter = 0;
-
 		while (true) {
 			const filename = `${this.path}//messages${counter === 0 ? "" : counter}.json`;
 			if (!fs.existsSync(filename)) {

--- a/packages/drivers/file-driver/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDeltaStorageService.ts
@@ -24,7 +24,7 @@ export class FileDeltaStorageService implements IDocumentDeltaStorageService {
 	constructor(private readonly path: string) {
 		this.messages = [];
 		let counter = 0;
-		// eslint-disable-next-line no-constant-condition
+
 		while (true) {
 			const filename = `${this.path}//messages${counter === 0 ? "" : counter}.json`;
 			if (!fs.existsSync(filename)) {

--- a/packages/drivers/local-driver/src/auth.ts
+++ b/packages/drivers/local-driver/src/auth.ts
@@ -21,7 +21,6 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver: string = "1.0",
 ): string {
-	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
 	let userClaim = user ? user : generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();

--- a/packages/drivers/local-driver/src/localDocumentStorageService.ts
+++ b/packages/drivers/local-driver/src/localDocumentStorageService.ts
@@ -57,7 +57,6 @@ export class LocalDocumentStorageService implements IDocumentStorageService {
 	}
 
 	public async getVersions(versionId: string | null, count: number): Promise<IVersion[]> {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
 		const id = versionId ? versionId : this.id;
 		const commits = await this.manager.getCommits(id, count);
 		return commits.map((commit) => ({

--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -47,7 +47,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
 			keys.forEach((splitKey) => {
 				value = value[splitKey];
 			});
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
 			return value;
 		}
 
@@ -77,7 +77,6 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
 		});
 
 		if (sort && Object.keys(sort).length === 1) {
-			// eslint-disable-next-line no-inner-declarations
 			function compare(a, b): number {
 				// Non null asserting here because of the length check above
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -89,7 +88,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
 
 			filteredCollection = filteredCollection.sort(compare);
 		}
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
 		return filteredCollection;
 	}
 
@@ -97,7 +96,6 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
 	 * {@inheritDoc @fluidframework/server-services-core#ICollection.findAll}
 	 */
 	public async findAll(): Promise<any[]> {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return this.getAllInternal();
 	}
 
@@ -108,7 +106,6 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
 	 * Query is expected to have a member "_id" which is a string used to find value in the database.
 	 */
 	public async findOne(query: any): Promise<any> {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return this.findOneInternal(query);
 	}
 
@@ -241,7 +238,6 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
 	private insertInternal(...values: any[]): void {
 		for (const value of values) {
 			if (value) {
-				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 				if (!value._id) {
 					value._id = uuid();
 				}

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -159,7 +159,6 @@ export function convertToCompactSnapshot(snapshotContents: ISnapshot): Uint8Arra
 	);
 
 	let latestSequenceNumber = snapshotContents.latestSequenceNumber;
-
 	if (latestSequenceNumber === undefined) {
 		latestSequenceNumber =
 			snapshotContents.ops.length > 0

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -159,7 +159,7 @@ export function convertToCompactSnapshot(snapshotContents: ISnapshot): Uint8Arra
 	);
 
 	let latestSequenceNumber = snapshotContents.latestSequenceNumber;
-	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 	if (latestSequenceNumber === undefined) {
 		latestSequenceNumber =
 			snapshotContents.ops.length > 0

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -139,7 +139,7 @@ export class EpochTracker implements IPersistedFileCache {
 			)) as IVersionedValueWithEpoch;
 			// Version mismatch between what the runtime expects and what it recieved.
 			// The cached value should not be used
-			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 			if (value === undefined || value.version !== persistedCacheValueVersion) {
 				return undefined;
 			}
@@ -170,7 +170,7 @@ export class EpochTracker implements IPersistedFileCache {
 					return undefined;
 				}
 			}
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
 			return value.value;
 		} catch (error) {
 			this.logger.sendErrorEvent({ eventName: "cacheFetchError", type: entry.type }, error);
@@ -295,7 +295,7 @@ export class EpochTracker implements IPersistedFileCache {
 			.catch(async (error) => {
 				// Get the server epoch from error in case we don't have it as if undefined we won't be able
 				// to mark it as epoch error.
-				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 				if (epochFromResponse === undefined) {
 					epochFromResponse = (error as IOdspError).serverEpoch;
 				}

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -139,7 +139,6 @@ export class EpochTracker implements IPersistedFileCache {
 			)) as IVersionedValueWithEpoch;
 			// Version mismatch between what the runtime expects and what it recieved.
 			// The cached value should not be used
-
 			if (value === undefined || value.version !== persistedCacheValueVersion) {
 				return undefined;
 			}
@@ -295,7 +294,6 @@ export class EpochTracker implements IPersistedFileCache {
 			.catch(async (error) => {
 				// Get the server epoch from error in case we don't have it as if undefined we won't be able
 				// to mark it as epoch error.
-
 				if (epochFromResponse === undefined) {
 					epochFromResponse = (error as IOdspError).serverEpoch;
 				}

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -749,7 +749,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	public get disposed(): boolean {
 		if (!(this._disposed || this.socket.connected)) {
 			// Send error event if this connection is not yet disposed after socket is disconnected for 15s.
-			// eslint-disable-next-line unicorn/no-lonely-if, @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+			// eslint-disable-next-line unicorn/no-lonely-if -- using ??= could change behavior if value is falsy
 			if (this.connectionNotYetDisposedTimeout === undefined) {
 				this.connectionNotYetDisposedTimeout = setTimeout(() => {
 					if (!this._disposed) {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -172,7 +172,6 @@ export class OdspDocumentService
 	 * @returns returns the document storage service for sharepoint driver.
 	 */
 	public async connectToStorage(): Promise<IDocumentStorageService> {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (!this.storageManager) {
 			this.storageManager = new OdspDocumentStorageService(
 				this.odspResolvedUrl,
@@ -248,7 +247,6 @@ export class OdspDocumentService
 	 * @returns returns the document delta stream service for onedrive/sharepoint driver.
 	 */
 	public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.socketModuleP === undefined) {
 			this.socketModuleP = this.getDelayLoadedDeltaStream();
 		}

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -724,7 +724,6 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		this.checkSnapshotUrl();
 
 		// Set the module promise right away, so as to not call it twice.
-
 		if (this.summaryModuleP === undefined) {
 			this.summaryModuleP = this.getDelayLoadedSummaryManager();
 		}

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -724,7 +724,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		this.checkSnapshotUrl();
 
 		// Set the module promise right away, so as to not call it twice.
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (this.summaryModuleP === undefined) {
 			this.summaryModuleP = this.getDelayLoadedSummaryManager();
 		}
@@ -761,7 +761,6 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 			}
 		}
 
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (!this.odspSummaryUploadManager) {
 			this.odspSummaryUploadManager = await this.summaryModuleP
 				.then(async (m) => {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -241,7 +241,7 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 
 	private async readTree(id: string, scenarioName?: string): Promise<ISnapshotTree | null> {
 		let tree = this.commitCache.get(id);
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (!tree) {
 			tree = await this.fetchTreeFromSnapshot(id, scenarioName);
 		}

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -241,7 +241,6 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 
 	private async readTree(id: string, scenarioName?: string): Promise<ISnapshotTree | null> {
 		let tree = this.commitCache.get(id);
-
 		if (!tree) {
 			tree = await this.fetchTreeFromSnapshot(id, scenarioName);
 		}

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -112,7 +112,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 			const driveID = searchParams.get("driveId");
 			const filePath = searchParams.get("path");
 			const packageName = searchParams.get("containerPackageName");
-			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- false positive
+
 			if (!(fileName && siteURL && driveID && filePath !== null && filePath !== undefined)) {
 				throw new NonRetryableError(
 					"Proper new file params should be there",

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -112,7 +112,6 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 			const driveID = searchParams.get("driveId");
 			const filePath = searchParams.get("path");
 			const packageName = searchParams.get("containerPackageName");
-
 			if (!(fileName && siteURL && driveID && filePath !== null && filePath !== undefined)) {
 				throw new NonRetryableError(
 					"Proper new file params should be there",

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -139,7 +139,7 @@ export class OpsCache {
 	private async getCore(from: number, to?: number): Promise<IMessage[]> {
 		const messages: IMessage[] = [];
 		let batchNumber = this.getBatchNumber(from);
-		// eslint-disable-next-line no-constant-condition
+
 		while (true) {
 			const res = await this.cache.read(`${this.batchSize}_${batchNumber}`);
 			if (res === undefined) {

--- a/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
@@ -103,7 +103,6 @@ describe("Local Odsp driver", () => {
 			stream: IStream<ISequencedDocumentMessage[]>,
 		): Promise<ISequencedDocumentMessage[]> {
 			const ops: ISequencedDocumentMessage[] = [];
-
 			while (true) {
 				const result = await stream.read();
 				if (result.done) {

--- a/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
@@ -103,7 +103,7 @@ describe("Local Odsp driver", () => {
 			stream: IStream<ISequencedDocumentMessage[]>,
 		): Promise<ISequencedDocumentMessage[]> {
 			const ops: ISequencedDocumentMessage[] = [];
-			// eslint-disable-next-line no-constant-condition
+
 			while (true) {
 				const result = await stream.read();
 				if (result.done) {

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -402,7 +402,6 @@ describe("OdspDeltaStorageWithCache", () => {
 		stream: IStream<ISequencedDocumentMessage[]>,
 	): Promise<ISequencedDocumentMessage[]> {
 		const ops: ISequencedDocumentMessage[] = [];
-
 		while (true) {
 			const result = await stream.read();
 			if (result.done) {

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -402,7 +402,7 @@ describe("OdspDeltaStorageWithCache", () => {
 		stream: IStream<ISequencedDocumentMessage[]>,
 	): Promise<ISequencedDocumentMessage[]> {
 		const ops: ISequencedDocumentMessage[] = [];
-		// eslint-disable-next-line no-constant-condition
+
 		while (true) {
 			const result = await stream.read();
 			if (result.done) {

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -103,7 +103,6 @@ export class ReplayControllerStatic extends ReplayController {
 		if (this.unitIsTime === true) {
 			for (const [i, { timestamp }] of fetchedOps.entries()) {
 				if (timestamp !== undefined) {
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 					if (this.firstTimeStamp === undefined) {
 						this.firstTimeStamp = timestamp;
 					}

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -131,7 +131,6 @@ class RouterliciousRestWrapper extends RestWrapper {
 		private readonly getAuthorizationHeader: AuthorizationHeaderGetter,
 		private readonly useRestLess: boolean,
 		baseurl?: string,
-
 		private tokenP?: Promise<ITokenResponse>,
 		defaultQueryString: QueryStringType = {},
 	) {

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -131,7 +131,7 @@ class RouterliciousRestWrapper extends RestWrapper {
 		private readonly getAuthorizationHeader: AuthorizationHeaderGetter,
 		private readonly useRestLess: boolean,
 		baseurl?: string,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly -- false positive, modified in getToken()
+
 		private tokenP?: Promise<ITokenResponse>,
 		defaultQueryString: QueryStringType = {},
 	) {

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -76,7 +76,6 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
 	}
 
 	public async getVersions(versionId: string | null, count: number): Promise<IVersion[]> {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
 		const id = versionId ? versionId : this.id;
 		const commits = await PerformanceEvent.timedExecAsync(
 			this.logger,

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -142,7 +142,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		}
 
 		// Otherwise, get the latest version of the document as normal.
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
+
 		const id = versionId ? versionId : this.id;
 		const commits = await PerformanceEvent.timedExecAsync(
 			this.logger,

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -142,7 +142,6 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		}
 
 		// Otherwise, get the latest version of the document as normal.
-
 		const id = versionId ? versionId : this.id;
 		const commits = await PerformanceEvent.timedExecAsync(
 			this.logger,

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
@@ -44,7 +44,7 @@ export class InsecureTinyliciousUrlResolver implements IUrlResolver {
 		let finalDocumentId: string = documentIdFromRequest;
 
 		// Special handling if the request is to create a new container
-		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 		if (request.headers && request.headers[DriverHeader.createNew] === true) {
 			// Use the document ID passed by the application via the create request;
 			// if none was passed, use the reserved keyword to let the driver generate the ID.

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
@@ -44,7 +44,6 @@ export class InsecureTinyliciousUrlResolver implements IUrlResolver {
 		let finalDocumentId: string = documentIdFromRequest;
 
 		// Special handling if the request is to create a new container
-
 		if (request.headers && request.headers[DriverHeader.createNew] === true) {
 			// Use the document ID passed by the application via the create request;
 			// if none was passed, use the reserved keyword to let the driver generate the ID.

--- a/packages/framework/client-logger/fluid-telemetry/src/container/telemetryManager.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/container/telemetryManager.ts
@@ -58,7 +58,6 @@ export class ContainerTelemetryManager {
 	 */
 	private setupHeartbeatTelemetryEmission(): void {
 		setInterval(() => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- container.connectionState may not be typed precisely
 			if (this.container.connectionState === ConnectionState.Connected) {
 				const telemetry = this.telemetryProducer.produceHeartbeatTelemetry();
 				for (const consumer of this.telemetryConsumers) {

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -130,7 +130,6 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
 				);
 	};
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return subDirectoryWithInterception;
 }
 

--- a/packages/framework/react/src/propNode.ts
+++ b/packages/framework/react/src/propNode.ts
@@ -16,7 +16,7 @@ import type { TreeNode, TreeLeafValue } from "@fluidframework/tree";
  * To convert a TreeNode to this type use {@link toPropTreeNode} or {@link toPropTreeRecord}.
  * @alpha
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface PropTreeNode<T extends TreeNode> extends ErasedType<[T, "PropTreeNode"]> {}
 
 /**

--- a/packages/framework/react/src/test/useObservation.spec.tsx
+++ b/packages/framework/react/src/test/useObservation.spec.tsx
@@ -44,7 +44,6 @@ describe("useObservation", () => {
 					 *
 					 * @remarks When in StrictMode, React may double render, so that case is not checked for an exact match.
 					 */
-
 					function checkRenderLog(log: string[], expected: readonly string[]): void {
 						if (reactStrictMode) {
 							assert.deepEqual(new Set(log), new Set(expected));

--- a/packages/framework/react/src/test/useObservation.spec.tsx
+++ b/packages/framework/react/src/test/useObservation.spec.tsx
@@ -44,7 +44,7 @@ describe("useObservation", () => {
 					 *
 					 * @remarks When in StrictMode, React may double render, so that case is not checked for an exact match.
 					 */
-					// eslint-disable-next-line no-inner-declarations
+
 					function checkRenderLog(log: string[], expected: readonly string[]): void {
 						if (reactStrictMode) {
 							assert.deepEqual(new Set(log), new Set(expected));

--- a/packages/framework/react/src/test/useTree.spec.tsx
+++ b/packages/framework/react/src/test/useTree.spec.tsx
@@ -59,7 +59,7 @@ describe("useTree", () => {
 			 *
 			 * When in StrictMode, React may double render, so that case is not checked for an exact match.
 			 */
-			// eslint-disable-next-line no-inner-declarations
+
 			function checkRenderLog(log: string[], expected: readonly string[]): void {
 				if (reactStrictMode) {
 					assert.deepEqual(new Set(log), new Set(expected));

--- a/packages/framework/react/src/test/useTree.spec.tsx
+++ b/packages/framework/react/src/test/useTree.spec.tsx
@@ -59,7 +59,6 @@ describe("useTree", () => {
 			 *
 			 * When in StrictMode, React may double render, so that case is not checked for an exact match.
 			 */
-
 			function checkRenderLog(log: string[], expected: readonly string[]): void {
 				if (reactStrictMode) {
 					assert.deepEqual(new Set(log), new Set(expected));

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -107,7 +107,7 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
 					return parent.getProvider(provider);
 				} else {
 					// older implementations of the IFluidDependencySynthesizer exposed getProvider
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
 					const maybeGetProvider = parent as { getProvider?(provider: string & keyof TMap) };
 					if (maybeGetProvider?.getProvider !== undefined) {
 						return maybeGetProvider.getProvider(provider);

--- a/packages/framework/tree-agent/src/test/typeFactoryRendering.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeFactoryRendering.spec.ts
@@ -513,7 +513,6 @@ describe("renderTypeFactoryTypeScript", () => {
 			// Create an empty lookup that doesn't have the type
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-arguments
 			const emptyLookup = new WeakMap<any, any>();
-
 			assert.throws(
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 				() => renderTypeFactoryTypeScript(instanceOfType, () => "", emptyLookup),
@@ -524,7 +523,6 @@ describe("renderTypeFactoryTypeScript", () => {
 		it("throws UsageError for unsupported type kind", () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
 			const invalidType = { _kind: "invalid" } as any;
-
 			assert.throws(
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 				() => renderTypeFactoryTypeScript(invalidType, () => "", instanceOfsTypeFactory),

--- a/packages/framework/tree-agent/src/test/typeFactoryRendering.spec.ts
+++ b/packages/framework/tree-agent/src/test/typeFactoryRendering.spec.ts
@@ -513,7 +513,7 @@ describe("renderTypeFactoryTypeScript", () => {
 			// Create an empty lookup that doesn't have the type
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-arguments
 			const emptyLookup = new WeakMap<any, any>();
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+
 			assert.throws(
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 				() => renderTypeFactoryTypeScript(instanceOfType, () => "", emptyLookup),
@@ -524,7 +524,7 @@ describe("renderTypeFactoryTypeScript", () => {
 		it("throws UsageError for unsupported type kind", () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
 			const invalidType = { _kind: "invalid" } as any;
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+
 			assert.throws(
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 				() => renderTypeFactoryTypeScript(invalidType, () => "", instanceOfsTypeFactory),
@@ -539,7 +539,7 @@ describe("renderTypeFactoryTypeScript", () => {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 				renderTypeFactoryTypeScript(invalidType, () => "", instanceOfsTypeFactory);
 				assert.fail("Expected error to be thrown");
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} catch (error: any) {
 				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 				assert(error.message.includes("Expected one of:"));

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -564,7 +564,7 @@ export class ConnectionManager implements IConnectionManager {
 				this.logger.sendTelemetryEvent(
 					{
 						eventName: "ConnectionReceived",
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 						connected: connection !== undefined && connection.disposed === false,
 					},
 					undefined,
@@ -574,7 +574,7 @@ export class ConnectionManager implements IConnectionManager {
 				this.logger.sendTelemetryEvent(
 					{
 						eventName: "ConnectToDeltaStreamException",
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 						connected: connection !== undefined && connection.disposed === false,
 					},
 					undefined,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -564,7 +564,6 @@ export class ConnectionManager implements IConnectionManager {
 				this.logger.sendTelemetryEvent(
 					{
 						eventName: "ConnectionReceived",
-
 						connected: connection !== undefined && connection.disposed === false,
 					},
 					undefined,
@@ -574,7 +573,6 @@ export class ConnectionManager implements IConnectionManager {
 				this.logger.sendTelemetryEvent(
 					{
 						eventName: "ConnectToDeltaStreamException",
-
 						connected: connection !== undefined && connection.disposed === false,
 					},
 					undefined,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable unicorn/consistent-function-scoping, @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/prefer-optional-chain */
+/* eslint-disable unicorn/consistent-function-scoping */
 
 import {
 	TypedEventEmitter,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -668,7 +668,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			throw new Error("Delta manager is not attached");
 		}
 
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.deltaStorage === undefined) {
 			this.deltaStorage = await docService.connectToDeltaStorage();
 		}
@@ -737,7 +736,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				fetchReason,
 			);
 
-			// eslint-disable-next-line no-constant-condition
 			while (true) {
 				const result = await stream.read();
 				if (result.done) {
@@ -965,7 +963,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 					duplicate++;
 				} else if (message.sequenceNumber !== prev + 1) {
 					gap++;
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 					if (firstMissing === undefined) {
 						firstMissing = prev + 1;
 					}

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -963,7 +963,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 					duplicate++;
 				} else if (message.sequenceNumber !== prev + 1) {
 					gap++;
-
 					if (firstMissing === undefined) {
 						firstMissing = prev + 1;
 					}

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -53,7 +53,7 @@ export function tryInitializeMemoryDetachedBlobStorage(
  * It also provides methods for serialization and initialization with attachment blobs.
  * @returns A new `MemoryDetachedBlobStorage` instance.
  */
-// eslint-disable-next-line import-x/no-deprecated
+
 export function createMemoryDetachedBlobStorage(): MemoryDetachedBlobStorage {
 	const blobs: ArrayBufferLike[] = [];
 	const storage: MemoryDetachedBlobStorage = {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1684,12 +1684,11 @@ export class ContainerRuntime
 		this.clientDetails = clientDetails;
 		this.isSummarizerClient = this.clientDetails.type === summarizerClientType;
 		this.loadedFromVersionId = context.getLoadedFromVersion()?.id;
-		// eslint-disable-next-line unicorn/consistent-destructuring
+
 		this._getClientId = () => context.clientId;
-		// eslint-disable-next-line unicorn/consistent-destructuring
+
 		this._getAttachState = () => context.attachState;
 		this.getAbsoluteUrl = async (relativeUrl: string) => {
-			// eslint-disable-next-line unicorn/consistent-destructuring
 			if (context.getAbsoluteUrl === undefined) {
 				throw new Error("Driver does not implement getAbsoluteUrl");
 			}
@@ -1870,7 +1869,6 @@ export class ContainerRuntime
 			this.duplicateBatchDetector = new DuplicateBatchDetector(recentBatchInfo);
 		}
 
-		// eslint-disable-next-line unicorn/consistent-destructuring
 		if (context.attachState === AttachState.Attached) {
 			const maxSnapshotCacheDurationMs = this._storage?.policies?.maximumCacheDurationMs;
 			if (
@@ -5467,7 +5465,7 @@ export class ContainerRuntime
 					entry = factory.resolvePriorInstantiation(entry);
 				}
 			}
-			// eslint-disable-next-line unicorn/consistent-destructuring -- 'entry' may have been update and thus use of 'extension' would be incorrect
+
 			entry.extension.onNewUse(...useContext);
 		}
 		return entry.interface as T;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -580,7 +580,7 @@ export abstract class FluidDataStoreContext
 			!this.detachedRuntimeCreation,
 			0x13d /* "Detached runtime creation on realize()" */,
 		);
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (!this.channelP) {
 			this.channelP = this.realizeCore(this.existing).catch((error) => {
 				const errorWrapped = DataProcessingError.wrapIfUnrecognized(

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -69,7 +69,6 @@ export class DeltaScheduler {
 	}
 
 	private readonly batchBegin = (message: ISequencedDocumentMessage): void => {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.processingStartTime === undefined) {
 			this.processingStartTime = performanceNow();
 		}

--- a/packages/runtime/container-runtime/src/gc/gcHelpers.ts
+++ b/packages/runtime/container-runtime/src/gc/gcHelpers.ts
@@ -251,7 +251,7 @@ export function unpackChildNodesGCDetails(
 		}
 
 		let childGCDetails = childGCDetailsMap.get(childId);
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (childGCDetails === undefined) {
 			childGCDetails = { gcData: { gcNodes: {} }, usedRoutes: [] };
 		}

--- a/packages/runtime/container-runtime/src/gc/gcHelpers.ts
+++ b/packages/runtime/container-runtime/src/gc/gcHelpers.ts
@@ -251,7 +251,6 @@ export function unpackChildNodesGCDetails(
 		}
 
 		let childGCDetails = childGCDetailsMap.get(childId);
-
 		if (childGCDetails === undefined) {
 			childGCDetails = { gcData: { gcNodes: {} }, usedRoutes: [] };
 		}

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -104,7 +104,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 		 * Encoded handle or path to the node
 		 */
 		private readonly _summaryHandleId: string,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly
+
 		private _changeSequenceNumber: number,
 		/**
 		 * Summary reference sequence number, i.e. last sequence number seen when last successful summary was created

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -415,7 +415,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			// If the child route used routes are not defined, initialize it now and it can be used for all child nodes
 			// created until this summarization process is completed. This is an optimization to unpack the used routes
 			// only when needed.
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 			if (this.wipChildNodesUsedRoutes === undefined) {
 				this.wipChildNodesUsedRoutes = unpackChildNodesUsedRoutes(this.usedRoutes);
 			}

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -415,7 +415,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			// If the child route used routes are not defined, initialize it now and it can be used for all child nodes
 			// created until this summarization process is completed. This is an optimization to unpack the used routes
 			// only when needed.
-
 			if (this.wipChildNodesUsedRoutes === undefined) {
 				this.wipChildNodesUsedRoutes = unpackChildNodesUsedRoutes(this.usedRoutes);
 			}

--- a/packages/runtime/id-compressor/src/sessions.ts
+++ b/packages/runtime/id-compressor/src/sessions.ts
@@ -107,7 +107,7 @@ export class Sessions {
 		// the next lower session (which is B) and erroneously determine we do not collide
 		// with any other session, but this situation is impossible to get into as B would
 		// have detected that it collided with A (or the other way around, depending on ordering).
-		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 		while (closestMatch !== undefined && closestMatch[1] === owningSession) {
 			closestMatch = this.uuidSpace.nextLowerPair(closestMatch[0]);
 		}

--- a/packages/runtime/id-compressor/src/sessions.ts
+++ b/packages/runtime/id-compressor/src/sessions.ts
@@ -107,7 +107,6 @@ export class Sessions {
 		// the next lower session (which is B) and erroneously determine we do not collide
 		// with any other session, but this situation is impossible to get into as B would
 		// have detected that it collided with A (or the other way around, depending on ordering).
-
 		while (closestMatch !== undefined && closestMatch[1] === owningSession) {
 			closestMatch = this.uuidSpace.nextLowerPair(closestMatch[0]);
 		}

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -538,7 +538,6 @@ export class IdCompressorTestNetwork {
 				assert(range.sessionId === compressor.localSessionId);
 				if (range.ids !== undefined) {
 					// initialize firstGenCount if not set
-
 					if (firstGenCount === undefined) {
 						firstGenCount = range.ids.firstGenCount;
 					}

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -538,7 +538,7 @@ export class IdCompressorTestNetwork {
 				assert(range.sessionId === compressor.localSessionId);
 				if (range.ids !== undefined) {
 					// initialize firstGenCount if not set
-					// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 					if (firstGenCount === undefined) {
 						firstGenCount = range.ids.firstGenCount;
 					}

--- a/packages/runtime/id-compressor/src/test/snapshots/dirname.cts
+++ b/packages/runtime/id-compressor/src/test/snapshots/dirname.cts
@@ -10,5 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line unicorn/prefer-module
+
 export const _dirname = __dirname;

--- a/packages/runtime/id-compressor/src/test/snapshots/dirname.cts
+++ b/packages/runtime/id-compressor/src/test/snapshots/dirname.cts
@@ -10,5 +10,4 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-
 export const _dirname = __dirname;

--- a/packages/runtime/runtime-utils/src/requestParser.ts
+++ b/packages/runtime/runtime-utils/src/requestParser.ts
@@ -57,7 +57,6 @@ export class RequestParser implements IRequest {
 	 * Returns the decoded path parts of the request's url
 	 */
 	public get pathParts(): readonly string[] {
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 		if (this.requestPathParts === undefined) {
 			this.requestPathParts = RequestParser.getPathParts(this.url);
 		}

--- a/packages/runtime/test-runtime-utils/src/generateToken.ts
+++ b/packages/runtime/test-runtime-utils/src/generateToken.ts
@@ -59,7 +59,6 @@ export function generateToken(
 	lifetime: number = 60 * 60,
 	ver: string = "1.0",
 ): string {
-	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
 	let userClaim = user ? user : generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
 		userClaim = generateUser();

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -141,7 +141,7 @@ export class AzureClient {
 	 * @param compatibilityMode - Compatibility mode the container should run in.
 	 * @returns New detached container instance along with associated services.
 	 */
-	// eslint-disable-next-line @typescript-eslint/await-thenable -- known limitation
+
 	public async createContainer<const TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
 		compatibilityMode: CompatibilityMode,
@@ -176,7 +176,7 @@ export class AzureClient {
 	 * @param compatibilityMode - Compatibility mode the container should run in.
 	 * @returns Existing container instance along with associated services.
 	 */
-	// eslint-disable-next-line @typescript-eslint/await-thenable -- known limitation
+
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
@@ -201,7 +201,7 @@ export class AzureClient {
 		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
 		});
-		// eslint-disable-next-line @typescript-eslint/await-thenable -- known limitation
+
 		const services = this.getContainerServices(container);
 		return { container: fluidContainer, services };
 	}

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -176,7 +176,6 @@ export class AzureClient {
 	 * @param compatibilityMode - Compatibility mode the container should run in.
 	 * @returns Existing container instance along with associated services.
 	 */
-
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,

--- a/packages/service-clients/azure-client/src/AzureUrlResolver.ts
+++ b/packages/service-clients/azure-client/src/AzureUrlResolver.ts
@@ -24,7 +24,6 @@ export class AzureUrlResolver implements IUrlResolver {
 		const { ordererUrl, storageUrl, tenantId, containerId } = decodeAzureUrl(request.url);
 		// determine whether the request is for creating of a new container.
 		// such request has the `createNew` header set to true and doesn't have a container ID.
-
 		if (request.headers && request.headers[DriverHeader.createNew] === true) {
 			return {
 				endpoints: {

--- a/packages/service-clients/azure-client/src/AzureUrlResolver.ts
+++ b/packages/service-clients/azure-client/src/AzureUrlResolver.ts
@@ -24,7 +24,7 @@ export class AzureUrlResolver implements IUrlResolver {
 		const { ordererUrl, storageUrl, tenantId, containerId } = decodeAzureUrl(request.url);
 		// determine whether the request is for creating of a new container.
 		// such request has the `createNew` header set to true and doesn't have a container ID.
-		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
+
 		if (request.headers && request.headers[DriverHeader.createNew] === true) {
 			return {
 				endpoints: {

--- a/packages/service-clients/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/service-clients/azure-client/src/test/AzureClient.spec.ts
@@ -141,7 +141,6 @@ for (const compatibilityMode of ["1", "2"] as const) {
 			const { container } = await client.createContainer(schema, compatibilityMode);
 			const containerId = await container.attach();
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- container.connectionState is typed as ConnectionState but test doesn't type it precisely
 			if (container.connectionState !== ConnectionState.Connected) {
 				await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
 					durationMs: connectTimeoutMs,
@@ -167,7 +166,6 @@ for (const compatibilityMode of ["1", "2"] as const) {
 			const { container } = await client.createContainer(schema, compatibilityMode);
 			const containerId = await container.attach();
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- container.connectionState is typed as ConnectionState but test doesn't type it precisely
 			if (container.connectionState !== ConnectionState.Connected) {
 				await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
 					durationMs: connectTimeoutMs,
@@ -201,7 +199,6 @@ for (const compatibilityMode of ["1", "2"] as const) {
 			);
 			const containerId = await newContainer.attach();
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- container.connectionState is typed as ConnectionState but test doesn't type it precisely
 			if (newContainer.connectionState !== ConnectionState.Connected) {
 				await timeoutPromise((resolve) => newContainer.once("connected", () => resolve()), {
 					durationMs: connectTimeoutMs,

--- a/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
@@ -896,9 +896,7 @@ async function synchronizeClients(connectedClients: Client[]): Promise<void> {
 	return timeoutPromise((resolve, reject) => {
 		let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
 
-		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 		const rejectHandler = (error?: IErrorBase | undefined): void => {
-			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- nullable boolean in array predicate
 			const client = connectedClients.find((c) => c.container.closed || c.container.disposed);
 			if (client !== undefined) {
 				reject(

--- a/packages/test/stochastic-test-utils/src/markovChain.ts
+++ b/packages/test/stochastic-test-utils/src/markovChain.ts
@@ -82,7 +82,7 @@ export class SpaceEfficientWordMarkovChain extends MarkovChain<string, string> {
 
 	constructor(random: IRandom = makeRandom(1), chain?: Record<string, [string, number][]>) {
 		super();
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
+
 		this.chain = chain ? chain : {};
 
 		this.random = random;
@@ -98,7 +98,7 @@ export class SpaceEfficientWordMarkovChain extends MarkovChain<string, string> {
 			let prevWord: string | null = null;
 			for (let i = 0; i < sentence.length; i++) {
 				const word = sentence[i];
-				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 				if (initialChain[word] === undefined) {
 					initialChain[word] = {};
 				}
@@ -222,7 +222,7 @@ export class PerformanceWordMarkovChain extends MarkovChain<string, string> {
 
 	constructor(random: IRandom = makeRandom(1), chain?: Record<string, string[]>) {
 		super();
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ?? could change behavior for falsy values
+
 		this.chain = chain ? chain : {};
 		this.random = random;
 	}
@@ -236,7 +236,7 @@ export class PerformanceWordMarkovChain extends MarkovChain<string, string> {
 			let prevWord: string | null = null;
 			for (let i = 0; i < sentence.length; i++) {
 				const word = sentence[i];
-				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 				if (this.chain[word] === undefined) {
 					this.chain[word] = [];
 				}

--- a/packages/test/test-end-to-end-tests/src/mocking.ts
+++ b/packages/test/test-end-to-end-tests/src/mocking.ts
@@ -27,7 +27,6 @@ export function wrapObjectAndOverride<T extends Record<string, any>>(
 				// check if the override is a function, which means it is factory
 				// in which case we called the factory to generate the property
 				if (typeof override === "function") {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 					return override(target);
 				}
 
@@ -48,7 +47,6 @@ export function wrapObjectAndOverride<T extends Record<string, any>>(
 							return res.then((v: any) => wrapObjectAndOverride(v, override));
 						}
 
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 						return wrapObjectAndOverride(res, override);
 					};
 				}

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -195,7 +195,6 @@ describeCompat(
 			);
 
 			// Channel should get attached as it was registered to its dataStore
-
 			assert.strictEqual(
 				channel.handle.isAttached,
 				true,
@@ -226,7 +225,6 @@ describeCompat(
 			toFluidHandleInternal(channel.handle).attachGraph();
 
 			// Channel should get attached as it was registered to its dataStore
-
 			assert.strictEqual(
 				channel.handle.isAttached,
 				true,

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -195,7 +195,7 @@ describeCompat(
 			);
 
 			// Channel should get attached as it was registered to its dataStore
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- intentional comparison
+
 			assert.strictEqual(
 				channel.handle.isAttached,
 				true,
@@ -226,7 +226,7 @@ describeCompat(
 			toFluidHandleInternal(channel.handle).attachGraph();
 
 			// Channel should get attached as it was registered to its dataStore
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- intentional comparison
+
 			assert.strictEqual(
 				channel.handle.isAttached,
 				true,

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -209,7 +209,6 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 											...newMessages[batchStartIndex],
 											metadata: {
 												// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to undefined.
-
 												...(newMessages[batchStartIndex].metadata as any),
 												batch: undefined,
 											},
@@ -251,7 +250,6 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 										...newMessages[batchEndIndex],
 										metadata: {
 											// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to undefined.
-
 											...(newMessages[batchEndIndex].metadata as any),
 											batch: undefined,
 										},

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-
 import { strict as assert } from "assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
@@ -211,7 +209,7 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 											...newMessages[batchStartIndex],
 											metadata: {
 												// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to undefined.
-												// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 												...(newMessages[batchStartIndex].metadata as any),
 												batch: undefined,
 											},
@@ -253,7 +251,7 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 										...newMessages[batchEndIndex],
 										metadata: {
 											// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to undefined.
-											// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 											...(newMessages[batchEndIndex].metadata as any),
 											batch: undefined,
 										},

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -17,8 +17,6 @@ import {
 	type IContainerRuntimeOptions,
 	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
-// TODO:AB#6558: This should be provided based on the compatibility configuration.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -10,8 +10,6 @@ import {
 	describeInstallVersions,
 	getVersionedTestObjectProvider,
 } from "@fluid-private/test-version-utils";
-// TODO:AB#6558: describeInstallVersions doesn't support dynamically providing package APIs.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import {
 	ContainerRuntimeFactoryWithDefaultDataStore,
 	DataObject,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -13,7 +13,6 @@ import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 // This test doesn't care to test compat of the Fluid handle implementation, it's just used for convenience
 // to simulate an unknown object.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
 import { FluidHandleBase } from "@fluidframework/runtime-utils/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -298,7 +298,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 						string.annotateRange(0, 1, { B: handle });
 					},
 					async readHandle(): Promise<unknown> {
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 						return string.getPropertiesAtPosition(0)?.B;
 					},
 					handle: string.handle,

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -11,8 +11,6 @@ import {
 	getDataRuntimeApi,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-// TODO:AB#6558: This should be provided based on the compatibility configuration.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -227,7 +227,6 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 			if (i >= 2 && i < 5) {
 				assert.equal(props?.foo, "old");
 			} else {
-				// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 				assert(props === undefined || props.foo === undefined);
 			}
 		}

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -197,14 +197,14 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 					}
 				};
 
-				/* eslint-disable @typescript-eslint/await-thenable -- Promise.all wrapping awaited values is intentional pattern */
+				 
 				await Promise.all([
 					await createAliasedDataStore(),
 					await createAliasedDataStore(),
 					await createAliasedDataStore(),
 					await createAliasedDataStore(),
 				]);
-				/* eslint-enable @typescript-eslint/await-thenable */
+				 
 
 				assert.equal(datastores.length, 1);
 			},

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -197,7 +197,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 					}
 				};
 
-				 
 				await Promise.all([
 					await createAliasedDataStore(),
 					await createAliasedDataStore(),

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -9,7 +9,6 @@ import {
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
 import {
-	// eslint-disable-next-line import-x/no-deprecated
 	IOnDemandSummarizeOptions,
 	ISummarizer,
 	ISummaryRuntimeOptions,

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -228,7 +228,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
 		const resumed = this.resumeProcessing(...containers);
 
 		let waitingSequenceNumberSynchronized: string | undefined;
-
 		while (true) {
 			// yield a turn to allow side effect of resuming or the ops we just processed execute before we check
 			await new Promise<void>((resolve) => {

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -228,7 +228,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 		const resumed = this.resumeProcessing(...containers);
 
 		let waitingSequenceNumberSynchronized: string | undefined;
-		// eslint-disable-next-line no-constant-condition
+
 		while (true) {
 			// yield a turn to allow side effect of resuming or the ops we just processed execute before we check
 			await new Promise<void>((resolve) => {
@@ -515,7 +515,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
 		for (const container of containersToApply) {
 			const record = this.containers.get(container);
 			if (record !== undefined && !record.paused) {
-				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 				if (record.pauseP === undefined) {
 					record.pauseP = this.pauseContainer(container, record);
 				}

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -503,7 +503,6 @@ export class TestObjectProvider implements ITestObjectProvider {
 	 * {@inheritDoc ITestObjectProvider.documentServiceFactory}
 	 */
 	public get documentServiceFactory(): IDocumentServiceFactory {
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 		if (!this._documentServiceFactory) {
 			this._documentServiceFactory = this.driver.createDocumentServiceFactory();
 		}
@@ -514,7 +513,6 @@ export class TestObjectProvider implements ITestObjectProvider {
 	 * {@inheritDoc ITestObjectProvider.urlResolver}
 	 */
 	public get urlResolver(): IUrlResolver {
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 		if (!this._urlResolver) {
 			this._urlResolver = this.driver.createUrlResolver();
 		}
@@ -821,7 +819,6 @@ export class TestObjectProviderWithVersionedLoad implements ITestObjectProvider 
 	 * {@inheritDoc ITestObjectProvider.documentServiceFactory}
 	 */
 	public get documentServiceFactory(): IDocumentServiceFactory {
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 		if (!this._documentServiceFactory) {
 			this._documentServiceFactory = this.driverForCreating.createDocumentServiceFactory();
 		}
@@ -832,7 +829,6 @@ export class TestObjectProviderWithVersionedLoad implements ITestObjectProvider 
 	 * {@inheritDoc ITestObjectProvider.urlResolver}
 	 */
 	public get urlResolver(): IUrlResolver {
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 		if (!this._urlResolver) {
 			this._urlResolver = this.driverForCreating.createUrlResolver();
 		}

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -308,7 +308,6 @@ function createE2EDocsDescribe(docTypes?: DescribeE2EDocInfo[]): DescribeE2EDocS
 
 	const d: DescribeE2EDocSuite = (title, tests, testType) => {
 		describe(
-			// eslint-disable-next-line @typescript-eslint/no-base-to-string -- testType toString is expected to return meaningful string
 			`${testType} -`,
 			createE2EDocCompatSuite(
 				title,

--- a/packages/test/test-version-utils/src/itExpects.ts
+++ b/packages/test/test-version-utils/src/itExpects.ts
@@ -10,9 +10,8 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import {
 	getUnexpectedLogErrorException,
-	TestObjectProvider,
+	type TestObjectProvider,
 } from "@fluidframework/test-utils/internal";
-// eslint-disable-next-line import-x/no-extraneous-dependencies
 import { Context } from "mocha";
 
 /**

--- a/packages/test/test-version-utils/src/itSkipsOnFailure.ts
+++ b/packages/test/test-version-utils/src/itSkipsOnFailure.ts
@@ -6,7 +6,6 @@
 import { TestDriverTypes } from "@fluid-internal/test-driver-definitions";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { TestObjectProvider, timeoutAwait } from "@fluidframework/test-utils/internal";
-// eslint-disable-next-line import-x/no-extraneous-dependencies
 import { Context } from "mocha";
 
 import { ExpectedEvents, createExpectsTest } from "./itExpects.js";

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -304,7 +304,7 @@ export async function ensureInstalled(
 								error instanceof Error
 									? `${error.message}\n${error.stack}`
 									: JSON.stringify(error);
-							// eslint-disable-next-line @typescript-eslint/no-base-to-string -- known limitation
+
 							reject(
 								new Error(
 									`Failed to install in ${modulePath}\nError:${errorString}\nStdOut:${stdout}\nStdErr:${stderr}`,

--- a/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
+++ b/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
@@ -33,7 +33,7 @@ import {
  * @sealed
  * @beta
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IDevtoolsLogger extends ITelemetryBaseLogger {}
 
 /**

--- a/packages/tools/devtools/devtools-test-app/src/ClientUtilities.ts
+++ b/packages/tools/devtools/devtools-test-app/src/ClientUtilities.ts
@@ -96,7 +96,6 @@ export async function loadExistingContainer(
 	console.log("Container loaded!");
 	const container = model.container;
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- intentional comparison
 	if (container.connectionState !== ConnectionState.Connected) {
 		console.log("Connecting to container...");
 		await new Promise<void>((resolve) => {

--- a/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
@@ -743,7 +743,7 @@ function calcChannelStats(
 	const channelStats = new Map<string, [number, number]>();
 	for (const [objectId, type] of dataType) {
 		let value = objectStats.get(objectId);
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (value === undefined) {
 			value = [0, 0];
 		}

--- a/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
@@ -743,7 +743,6 @@ function calcChannelStats(
 	const channelStats = new Map<string, [number, number]>();
 	for (const [objectId, type] of dataType) {
 		let value = objectStats.get(objectId);
-
 		if (value === undefined) {
 			value = [0, 0];
 		}

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -155,7 +155,6 @@ export async function getSharepointFiles(
 		files.push(fileInfo);
 	}
 
-	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		const folderInfo = pendingFolder.shift();
 		if (!folderInfo) {

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -385,7 +385,6 @@ export async function fluidFetchSnapshot(
 		if (version === undefined) {
 			console.log("No snapshot tree");
 		} else {
-			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing -- intentional behavior
 			if (blobsToDump === undefined) {
 				blobsToDump = await fetchBlobsFromVersion(storage, version);
 			}

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -573,7 +573,7 @@ export class ReplayTool {
 			? this.mainDocument.originalSummarySequenceNumbers.filter((s) => s >= this.args.from)
 			: [];
 		let nextSnapPoint = -1;
-		// eslint-disable-next-line no-constant-condition
+
 		while (true) {
 			const currentOp = this.mainDocument.currentOp;
 			if (nextSnapPoint <= currentOp) {

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -194,7 +194,6 @@ export function generateErrorWithStack(stackTraceLimit?: number): Error {
 	}
 	const err = new Error("<<generated stack>>");
 
-	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
 	if (stackPopulatedOnCreation === undefined) {
 		stackPopulatedOnCreation = err.stack !== undefined;
 	}

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -378,7 +378,6 @@ export const odspTokensCache: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens
 	},
 	async save(key: IOdspTokenManagerCacheKey, tokens: IOdspTokens): Promise<void> {
 		const rc = await loadAndPatchRC();
-
 		if (!rc.tokens) {
 			rc.tokens = {
 				version: 1,

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -378,7 +378,7 @@ export const odspTokensCache: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens
 	},
 	async save(key: IOdspTokenManagerCacheKey, tokens: IOdspTokens): Promise<void> {
 		const rc = await loadAndPatchRC();
-		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- using ??= could change behavior if value is falsy
+
 		if (!rc.tokens) {
 			rc.tokens = {
 				version: 1,


### PR DESCRIPTION
Ran the following command on all packages:

`eslint --fix --fix-type directive --report-unused-disable-directives-severity=error`

That produced some incorrect removals which I believe are caused by not properly using the projectService, which will be addressed by #26239. I reverted those changes as needed until lint passed.
