### PR TITLE
improvement(eslint-config-fluid): const configs and exact typing

### DIFF
--- a/common/build/eslint-config-fluid/flat.mts
+++ b/common/build/eslint-config-fluid/flat.mts
@@ -18,15 +18,15 @@
  */
 
 import {
-	createMinimalDeprecatedConfig,
-	createRecommendedConfig,
-	createStrictConfig,
-	createStrictBiomeConfig,
+	fullMinimalDeprecatedConfig,
+	fullRecommendedConfig,
+	fullStrictBiomeConfig,
+	fullStrictConfig,
 } from "./library/configs/factory.mjs";
 
-const minimalDeprecated = createMinimalDeprecatedConfig();
-const recommended = createRecommendedConfig();
-const strict = createStrictConfig();
-const strictBiome = createStrictBiomeConfig();
+const minimalDeprecated = [...fullMinimalDeprecatedConfig] as const;
+const recommended = [...fullRecommendedConfig] as const;
+const strict = [...fullStrictConfig] as const;
+const strictBiome = [...fullStrictBiomeConfig] as const;
 
 export { recommended, strict, minimalDeprecated, strictBiome };

--- a/common/build/eslint-config-fluid/library/configs/factory.mts
+++ b/common/build/eslint-config-fluid/library/configs/factory.mts
@@ -29,14 +29,14 @@ import { strictRules, strictTsRules } from "../rules/strict.mjs";
 import {
 	dependConfig,
 	reactRecommendedOverride,
+	sharedConfigs,
 	testRecommendedOverride,
-	addSharedConfigs,
 } from "./overrides.mjs";
 
 /**
  * Minimal-deprecated configuration.
  */
-export const minimalDeprecatedConfig: FlatConfigArray = [
+export const minimalDeprecatedConfig = [
 	...baseConfig,
 	{
 		rules: minimalDeprecatedRules,
@@ -55,12 +55,12 @@ export const minimalDeprecatedConfig: FlatConfigArray = [
 		},
 	},
 	dependConfig,
-];
+] as const satisfies FlatConfigArray;
 
 /**
  * Recommended configuration.
  */
-export const recommendedConfig: FlatConfigArray = [
+export const recommendedConfig = [
 	...minimalDeprecatedConfig,
 	// unicorn/recommended rules (plugin already registered in base)
 	{
@@ -69,12 +69,12 @@ export const recommendedConfig: FlatConfigArray = [
 	{
 		rules: recommendedRules,
 	},
-];
+] as const satisfies FlatConfigArray;
 
 /**
  * Strict configuration.
  */
-export const strictConfig: FlatConfigArray = [
+export const strictConfig = [
 	...recommendedConfig,
 	{
 		rules: strictRules,
@@ -84,45 +84,47 @@ export const strictConfig: FlatConfigArray = [
 		files: ["**/*.ts", "**/*.tsx"],
 		rules: strictTsRules,
 	},
-];
+] as const satisfies FlatConfigArray;
 
 /**
  * Strict-biome configuration.
  */
-export const strictBiomeConfig: FlatConfigArray = [...strictConfig, biomeConfig];
+export const strictBiomeConfig = [...strictConfig, biomeConfig] as const satisfies FlatConfigArray;
 
 /**
- * Creates the final minimalDeprecated config with shared overrides.
+ * The final minimalDeprecated config with shared overrides.
  */
-export function createMinimalDeprecatedConfig(): FlatConfigArray {
-	return addSharedConfigs(minimalDeprecatedConfig);
-}
+export const fullMinimalDeprecatedConfig = [
+	...minimalDeprecatedConfig,
+	...sharedConfigs,
+] as const satisfies FlatConfigArray;
 
 /**
- * Creates the final recommended config with shared overrides.
+ * The final recommended config with shared overrides.
  */
-export function createRecommendedConfig(): FlatConfigArray {
-	return addSharedConfigs([
-		...recommendedConfig,
-		reactRecommendedOverride,
-		testRecommendedOverride,
-	]);
-}
+export const fullRecommendedConfig = [
+	...recommendedConfig,
+	reactRecommendedOverride,
+	testRecommendedOverride,
+	...sharedConfigs,
+] as const satisfies FlatConfigArray;
 
 /**
- * Creates the final strict config with shared overrides.
+ * The final strict config with shared overrides.
  */
-export function createStrictConfig(): FlatConfigArray {
-	return addSharedConfigs([...strictConfig, reactRecommendedOverride, testRecommendedOverride]);
-}
+export const fullStrictConfig = [
+	...strictConfig,
+	reactRecommendedOverride,
+	testRecommendedOverride,
+	...sharedConfigs,
+] as const satisfies FlatConfigArray;
 
 /**
- * Creates the final strictBiome config with shared overrides.
+ * The final strictBiome config with shared overrides.
  */
-export function createStrictBiomeConfig(): FlatConfigArray {
-	return addSharedConfigs([
-		...strictBiomeConfig,
-		reactRecommendedOverride,
-		testRecommendedOverride,
-	]);
-}
+export const fullStrictBiomeConfig = [
+	...strictBiomeConfig,
+	reactRecommendedOverride,
+	testRecommendedOverride,
+	...sharedConfigs,
+] as const satisfies FlatConfigArray;

--- a/common/build/eslint-config-fluid/library/configs/overrides.mts
+++ b/common/build/eslint-config-fluid/library/configs/overrides.mts
@@ -252,6 +252,12 @@ export const reactRecommendedOverride = {
  * Test file overrides for recommended config (from recommended.js).
  */
 export const testRecommendedOverride = {
+	// Use of spread operator shouldn't really be needed here. Under VS Code, a
+	// complaint is raised that
+	//   The type 'readonly [...]' is 'readonly' and cannot be assigned to the mutable type '(string | string[])[]'.ts(4104)
+	// without spread. But that doesn't appear in other uses. Use spread to pacify
+	// that environment. (Remember mutability is not well checked in TS generally.
+	// So an extra copy if safety was needed isn't a problem.)
 	files: [...testFilePatterns],
 	rules: {
 		"unicorn/consistent-function-scoping": "off",

--- a/common/build/eslint-config-fluid/library/configs/overrides.mts
+++ b/common/build/eslint-config-fluid/library/configs/overrides.mts
@@ -19,13 +19,13 @@
  * - jsTypeAwareDisable: Disables type-aware rules for JS files
  * - reactRecommendedOverride: React file overrides for recommended config
  * - testRecommendedOverride: Test file overrides for recommended config
- * - addSharedConfigs: Helper function to add all shared configs to a config array
+ * - sharedConfigs: Collection of all shared configs in a config array
  */
 
 import dependPlugin from "eslint-plugin-depend";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
-import type { Linter } from "eslint";
+import type { ESLint, Linter } from "eslint";
 
 import { permittedImports, restrictedImportPaths, testFilePatterns } from "../constants.mjs";
 import type { FlatConfigArray } from "./base.mjs";
@@ -33,7 +33,7 @@ import type { FlatConfigArray } from "./base.mjs";
 /**
  * eslint-plugin-depend configuration.
  */
-export const dependConfig: Linter.Config = {
+export const dependConfig = {
 	plugins: {
 		depend: dependPlugin,
 	},
@@ -45,24 +45,24 @@ export const dependConfig: Linter.Config = {
 			},
 		],
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * Use projectService for automatic tsconfig discovery instead of manual project configuration.
  */
-export const useProjectService: Linter.Config = {
+export const useProjectService = {
 	files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
 	languageOptions: {
 		parserOptions: {
 			projectService: true,
 		},
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * Test file configuration with explicit project paths and rule overrides.
  */
-export const testProjectConfig: Linter.Config = {
+export const testProjectConfig = {
 	files: ["src/test/**", ...testFilePatterns],
 	languageOptions: {
 		parserOptions: {
@@ -86,17 +86,17 @@ export const testProjectConfig: Linter.Config = {
 		"import-x/no-internal-modules": [
 			"error",
 			{
-				allow: ["@fluid*/*/test*", "@fluid*/*/internal/test*"].concat(permittedImports),
+				allow: ["@fluid*/*/test*", "@fluid*/*/internal/test*", ...permittedImports],
 			},
 		],
 		"import-x/no-extraneous-dependencies": ["error", { devDependencies: true }],
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * Override import-x/no-internal-modules for non-test files to include /legacy imports.
  */
-export const internalModulesConfig: Linter.Config = {
+export const internalModulesConfig = {
 	files: [
 		"**/*.ts",
 		"**/*.tsx",
@@ -116,12 +116,12 @@ export const internalModulesConfig: Linter.Config = {
 			},
 		],
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * React rules for ESLint 9 - extends react/recommended and react-hooks/recommended.
  */
-export const reactConfig: FlatConfigArray = [
+export const reactConfig = [
 	// react/flat.recommended
 	{
 		files: ["**/*.jsx", "**/*.tsx"],
@@ -131,7 +131,8 @@ export const reactConfig: FlatConfigArray = [
 	{
 		files: ["**/*.jsx", "**/*.tsx"],
 		plugins: {
-			"react-hooks": reactHooksPlugin,
+			// reactHooksPlugin.configs.flat does not conform. It is not a `ConfigObject`.
+			"react-hooks": reactHooksPlugin as ESLint.Plugin,
 		},
 		rules: reactHooksPlugin.configs.recommended.rules,
 		settings: {
@@ -151,30 +152,30 @@ export const reactConfig: FlatConfigArray = [
 			"react-hooks/static-components": "warn",
 		},
 	},
-];
+] as const satisfies FlatConfigArray;
 
 /**
  * CommonJS files can use __dirname and require.
  */
-export const cjsFileConfig: Linter.Config = {
+export const cjsFileConfig = {
 	files: ["**/*.cts", "**/*.cjs"],
 	rules: {
 		"unicorn/prefer-module": "off",
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * Disable type-aware parsing for JS files and .d.ts files.
  */
-export const jsNoProject: Linter.Config = {
+export const jsNoProject = {
 	files: ["**/*.js", "**/*.cjs", "**/*.mjs", "**/*.d.ts"],
 	languageOptions: { parserOptions: { project: null, projectService: false } },
-};
+} as const satisfies Linter.Config;
 
 /**
  * Disable type-required @typescript-eslint rules for pure JS files and .d.ts files.
  */
-export const jsTypeAwareDisable: Linter.Config = {
+export const jsTypeAwareDisable = {
 	files: ["**/*.js", "**/*.cjs", "**/*.mjs", "**/*.d.ts"],
 	rules: {
 		"@typescript-eslint/await-thenable": "off",
@@ -235,41 +236,38 @@ export const jsTypeAwareDisable: Linter.Config = {
 		"@typescript-eslint/unbound-method": "off",
 		"@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * React file overrides for recommended config (from recommended.js).
  */
-export const reactRecommendedOverride: Linter.Config = {
+export const reactRecommendedOverride = {
 	files: ["**/*.jsx", "**/*.tsx"],
 	rules: {
 		"unicorn/consistent-function-scoping": "off",
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
  * Test file overrides for recommended config (from recommended.js).
  */
-export const testRecommendedOverride: Linter.Config = {
-	files: testFilePatterns,
+export const testRecommendedOverride = {
+	files: [...testFilePatterns],
 	rules: {
 		"unicorn/consistent-function-scoping": "off",
 		"unicorn/prefer-module": "off",
 	},
-};
+} as const satisfies Linter.Config;
 
 /**
- * Adds shared configuration objects to a config array.
+ * Full set of shared configuration objects in config array.
  */
-export function addSharedConfigs(configs: FlatConfigArray): FlatConfigArray {
-	return [
-		...configs,
-		useProjectService,
-		testProjectConfig,
-		internalModulesConfig,
-		...reactConfig,
-		cjsFileConfig,
-		jsNoProject,
-		jsTypeAwareDisable,
-	];
-}
+export const sharedConfigs = [
+	useProjectService,
+	testProjectConfig,
+	internalModulesConfig,
+	...reactConfig,
+	cjsFileConfig,
+	jsNoProject,
+	jsTypeAwareDisable,
+] as const satisfies FlatConfigArray;

--- a/common/build/eslint-config-fluid/library/constants.mts
+++ b/common/build/eslint-config-fluid/library/constants.mts
@@ -49,7 +49,7 @@ export const permittedImports = [
 	// but not from cousin directories. Parent is allowed but only
 	// because there isn't a known way to deny it.
 	"*/index.js",
-];
+] as const;
 
 /**
  * Restricted import paths for all code.
@@ -67,7 +67,7 @@ export const restrictedImportPaths = [
 		importNames: ["default"],
 		message: 'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
 	},
-];
+] as const;
 
 /**
  * Restricted import patterns for production code.
@@ -80,17 +80,17 @@ export const restrictedImportPatternsForProductionCode = [
 		message:
 			"Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead.",
 	},
-];
+] as const;
 
 /**
  * Test file patterns for identifying test files.
  */
-export const testFilePatterns = ["*.spec.ts", "*.test.ts", "**/test/**", "**/tests/**"];
+export const testFilePatterns = ["*.spec.ts", "*.test.ts", "**/test/**", "**/tests/**"] as const;
 
 /**
  * Global ignore patterns for ESLint.
  */
-export const globalIgnores: Linter.Config = {
+export const globalIgnores = {
 	ignores: [
 		// Build output directories
 		"**/dist/**",
@@ -113,4 +113,4 @@ export const globalIgnores: Linter.Config = {
 		// Mocha config files (must be CommonJS, not compatible with TS-focused linting)
 		"**/.mocharc*.cjs",
 	],
-};
+} as const satisfies Linter.Config;

--- a/common/build/eslint-config-fluid/library/rules/base.mts
+++ b/common/build/eslint-config-fluid/library/rules/base.mts
@@ -19,7 +19,7 @@ import type { Linter } from "eslint";
  * Rules from eslint:recommended, @typescript-eslint/recommended-type-checked,
  * @typescript-eslint/stylistic-type-checked, import-x/recommended, import-x/typescript.
  */
-export const baseRules: Linter.RulesRecord = {
+export const baseRules = {
 	// Please keep entries alphabetized within a group
 
 	// #region Fluid Custom Rules
@@ -302,15 +302,15 @@ export const baseRules: Linter.RulesRecord = {
 	"yoda": "off",
 
 	// #endregion
-};
+} as const satisfies Linter.RulesRecord;
 
 /**
  * eslint-comments/recommended rules.
  */
-export const eslintCommentsRecommendedRules: Linter.RulesRecord = {
+export const eslintCommentsRecommendedRules = {
 	"@eslint-community/eslint-comments/disable-enable-pair": "error",
 	"@eslint-community/eslint-comments/no-aggregating-enable": "error",
 	"@eslint-community/eslint-comments/no-duplicate-disable": "error",
 	"@eslint-community/eslint-comments/no-unlimited-disable": "error",
 	"@eslint-community/eslint-comments/no-unused-enable": "error",
-};
+} as const satisfies Linter.RulesRecord;

--- a/common/build/eslint-config-fluid/library/rules/minimal-deprecated.mts
+++ b/common/build/eslint-config-fluid/library/rules/minimal-deprecated.mts
@@ -23,7 +23,7 @@ import {
 /**
  * Rules from minimal-deprecated.js.
  */
-export const minimalDeprecatedRules: Linter.RulesRecord = {
+export const minimalDeprecatedRules = {
 	/**
 	 * Disable max-len as it conflicts with biome formatting.
 	 */
@@ -386,4 +386,4 @@ export const minimalDeprecatedRules: Linter.RulesRecord = {
 			allow: permittedImports,
 		},
 	],
-};
+} as const satisfies Linter.RulesRecord;

--- a/common/build/eslint-config-fluid/library/rules/recommended.mts
+++ b/common/build/eslint-config-fluid/library/rules/recommended.mts
@@ -17,7 +17,7 @@ import type { Linter } from "eslint";
 /**
  * Rules from recommended.js.
  */
-export const recommendedRules: Linter.RulesRecord = {
+export const recommendedRules = {
 	"@rushstack/no-new-null": "error",
 	"no-void": "error",
 	"require-atomic-updates": "error",
@@ -206,4 +206,4 @@ export const recommendedRules: Linter.RulesRecord = {
 	"@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
 
 	// #endregion
-};
+} as const satisfies Linter.RulesRecord;

--- a/common/build/eslint-config-fluid/library/rules/strict.mts
+++ b/common/build/eslint-config-fluid/library/rules/strict.mts
@@ -17,7 +17,7 @@ import type { Linter } from "eslint";
 /**
  * Rules from strict.js.
  */
-export const strictRules: Linter.RulesRecord = {
+export const strictRules = {
 	/**
 	 * Require jsdoc/tsdoc comments on public/exported API items.
 	 */
@@ -54,12 +54,12 @@ export const strictRules: Linter.RulesRecord = {
 			exemptOverloadedImplementations: true,
 		},
 	],
-};
+} as const satisfies Linter.RulesRecord;
 
 /**
  * TypeScript-specific strict rules from strict.js.
  */
-export const strictTsRules: Linter.RulesRecord = {
+export const strictTsRules = {
 	"@typescript-eslint/explicit-member-accessibility": [
 		"error",
 		{
@@ -116,4 +116,4 @@ export const strictTsRules: Linter.RulesRecord = {
 	"@typescript-eslint/consistent-generic-constructors": "error",
 
 	"@typescript-eslint/no-redundant-type-constituents": "error",
-};
+} as const satisfies Linter.RulesRecord;

--- a/common/build/eslint-config-fluid/library/settings.mts
+++ b/common/build/eslint-config-fluid/library/settings.mts
@@ -40,7 +40,7 @@ export const importXSettings = {
 			],
 		},
 	},
-};
+} as const;
 
 /**
  * Settings for eslint-plugin-jsdoc.
@@ -63,4 +63,4 @@ export const jsdocSettings = {
 			},
 		},
 	},
-};
+} as const;


### PR DESCRIPTION
Use `as const satisifies Foo` pattern for exact typing and better type checking. (`eslint-plugin-react-hooks` is now detected as not conforming.)

Replace config factories with static configurations to propagate exact values.

No configuration changes.