### PR TITLE
feat(build-cli): add check mode to assertTags command

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -22,12 +22,15 @@ Tags asserts by replacing their message with a unique numerical value.
 
 ```
 USAGE
-  $ flub generate assertTags [-v | --quiet] [--disableConfig] [--concurrency <value>] [--branch <value> [--changed |
-    [--all | --dir <value>... | --packages | -g client|server|azure|build-tools|gitrest|historian|all... |
+  $ flub generate assertTags [-v | --quiet] [--disableConfig] [--check] [--concurrency <value>] [--branch <value>
+    [--changed | [--all | --dir <value>... | --packages | -g client|server|azure|build-tools|gitrest|historian|all... |
     --releaseGroupRoot client|server|azure|build-tools|gitrest|historian|all...]]] [--private] [--scope <value>... |
     --skipScope <value>...]
 
 FLAGS
+  --check                Check mode: validate assert usage without modifying files. Exits with code 0 if all asserts are
+                         valid and tagged, 1 if there are validation errors (invalid usage), or 2 if there are untagged
+                         asserts.
   --concurrency=<value>  [default: 25] The number of tasks to execute concurrently.
 
 PACKAGE SELECTION FLAGS


### PR DESCRIPTION
## Summary

Adds a `--check` flag to the `flub generate:assertTags` command that validates assert usage without modifying any files.

- **Exit 0**: All asserts are valid and tagged
- **Exit 1**: Validation errors found (invalid assert usage like non-hex short codes, duplicates, or template expressions)
- **Exit 2**: Untagged asserts found that need tagging

This enables CI validation of assert tagging status without requiring the command to actually modify source files.