### PR TITLE
Restart timer after updating snapshot in SSM

### DIFF
--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -344,6 +344,7 @@ export class SerializedStateManager implements IDisposable {
 			});
 			this.latestSnapshot = undefined;
 			this.snapshotRefresher?.clearLatestSnapshot();
+			this.snapshotRefresher?.restartTimer();
 		} else if (snapshotSequenceNumber <= lastProcessedOpSequenceNumber) {
 			// Snapshot seq num is between the first and last processed op.
 			// Remove the ops that are already part of the snapshot
@@ -351,6 +352,7 @@ export class SerializedStateManager implements IDisposable {
 			this.snapshotInfo = this.latestSnapshot;
 			this.latestSnapshot = undefined;
 			this.snapshotRefresher?.clearLatestSnapshot();
+			this.snapshotRefresher?.restartTimer();
 			this.mc.logger.sendTelemetryEvent({
 				eventName: "SnapshotRefreshed",
 				snapshotSequenceNumber,


### PR DESCRIPTION
Fixing a bug left by most recent serialized state manager refactoring which removed the timer restart after attempting a base snapshot update. There are scenarios in which the update doesn't come from the snapshot refresher directly (e.g. after the container is saved) which won't trigger the timer restart so adding it back to where it was before the refactoring.

This fixes test "snapshot was refreshed after some time" in ODSP.