### PR TITLE
Make assert tagging more strict about what it allows

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
@@ -341,11 +341,6 @@ The format of the configuration is specified by the "AssertTaggingPackageConfig"
 						templateErrors.push(msg);
 						break;
 					}
-					case SyntaxKind.BinaryExpression:
-					case SyntaxKind.CallExpression: {
-						// TODO: why are CallExpression and BinaryExpression silently allowed?
-						break;
-					}
 					default: {
 						otherErrors.push(msg);
 						break;


### PR DESCRIPTION
## Description

Assert tagging has for as long as I have worked on it, allowed call and binary expressions where the message should go, and just ignored such cases in tagging.

I never found out why this was, but our current code does not hit these cases and it seems like they should be errors as they can't be tagged so I removed the special case allowing them so they fall through and produce errors. If I manually add a violation to the codebase, it produces an error like:

```
ERROR: Unsupported argument kind:
BinaryExpression: /home/craig/Work/FluidFramework.git/1/packages/dds/tree/src/shared-tree/tree.ts:456
```

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

