### PR TITLE
test(build-tools): Remove unused use of ts-node, put spec in config

### DIFF
--- a/build-tools/packages/build-cli/.mocharc.json
+++ b/build-tools/packages/build-cli/.mocharc.json
@@ -1,9 +1,8 @@
 {
-	"require": ["ts-node/register"],
 	"watch-extensions": ["ts", "cts", "mts"],
 	"recursive": true,
 	"reporter": "mocha-multi-reporters",
 	"reporter-options": "configFile=mocha-multi-reporter-config.json",
 	"timeout": 60000,
-	"node-option": ["loader=ts-node/esm"]
+	"spec": "\"lib/test/**/*.test.*js\""
 }

--- a/build-tools/packages/build-cli/.mocharc.json
+++ b/build-tools/packages/build-cli/.mocharc.json
@@ -4,5 +4,5 @@
 	"reporter": "mocha-multi-reporters",
 	"reporter-options": "configFile=mocha-multi-reporter-config.json",
 	"timeout": 60000,
-	"spec": "\"lib/test/**/*.test.*js\""
+	"spec": "lib/test/**/*.test.*js"
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -56,7 +56,7 @@
 		"postpack": "npm run clean:manifest",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm run test",
-		"test:mocha": "mocha --forbid-only \"lib/test/**/*.test.*js\""
+		"test:mocha": "mocha --forbid-only"
 	},
 	"c8": {
 		"all": true,


### PR DESCRIPTION
## Description

ts-node allows node to load ts files. The spec in this mocha config points at the JS files so ts-node is not needed.

For unknown reasons the unnecessary use of ts-node caused node to segfault when I tried to debug tests so I had to remove it for debugging, and keeping it removed seems like a good idea. To also aid in debugging I moved the spec into the config so a `pnpm exec mocha` is sufficient to debug tests. This is how mocha is setup in client and works well there.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

