### PR TITLE
improvement(eslint-config-fluid): cleanup `import-x/no-internal-modules`

### DIFF
--- a/common/build/eslint-config-fluid/library/configs/overrides.mts
+++ b/common/build/eslint-config-fluid/library/configs/overrides.mts
@@ -86,7 +86,7 @@ export const testProjectConfig = {
 		"import-x/no-internal-modules": [
 			"error",
 			{
-				// Any and all import paths are allowed in test files.
+				// Any and all `@fluid*` import paths are allowed in test files.
 				// Preferably, external (alpha/beta/public) entrypoints are used
 				// for clarity where testing is somewhat whitebox versus validating
 				// customer experience.

--- a/common/build/eslint-config-fluid/library/configs/overrides.mts
+++ b/common/build/eslint-config-fluid/library/configs/overrides.mts
@@ -90,7 +90,7 @@ export const testProjectConfig = {
 				// Preferably, external (alpha/beta/public) entrypoints are used
 				// for clarity where testing is somewhat whitebox versus validating
 				// customer experience.
-				allow: ["@fluid*/**"],
+				allow: ["@fluid*/**", ...permittedImports],
 			},
 		],
 		"import-x/no-extraneous-dependencies": ["error", { devDependencies: true }],

--- a/common/build/eslint-config-fluid/library/configs/overrides.mts
+++ b/common/build/eslint-config-fluid/library/configs/overrides.mts
@@ -86,7 +86,11 @@ export const testProjectConfig = {
 		"import-x/no-internal-modules": [
 			"error",
 			{
-				allow: ["@fluid*/*/test*", "@fluid*/*/internal/test*", ...permittedImports],
+				// Any and all import paths are allowed in test files.
+				// Preferably, external (alpha/beta/public) entrypoints are used
+				// for clarity where testing is somewhat whitebox versus validating
+				// customer experience.
+				allow: ["@fluid*/**"],
 			},
 		],
 		"import-x/no-extraneous-dependencies": ["error", { devDependencies: true }],

--- a/common/build/eslint-config-fluid/library/constants.mts
+++ b/common/build/eslint-config-fluid/library/constants.mts
@@ -19,9 +19,10 @@ import type { Linter } from "eslint";
 /**
  * Shared list of permitted imports for configuring the `import-x/no-internal-modules` rule.
  *
- * @fluid- scopes could probably allow `/**` as entrypoint structuring rules do NOT apply.
- * Currently there are no known uses of structured imports from these scopes; so no
- * allowances are stated.
+ * @remarks
+ * All `@fluid-` scopes could probably allow `/**` as entrypoint structuring rules do
+ * NOT apply. Currently there are no known uses of structured imports from these scopes;
+ * so, no broad allowances are stated.
  */
 export const permittedImports = [
 	// Within Fluid Framework allow import of '/internal' from other FF packages.

--- a/common/build/eslint-config-fluid/library/constants.mts
+++ b/common/build/eslint-config-fluid/library/constants.mts
@@ -19,28 +19,15 @@ import type { Linter } from "eslint";
 /**
  * Shared list of permitted imports for configuring the `import-x/no-internal-modules` rule.
  *
- * NOTE: The `/legacy` patterns below are an intentional enhancement over the legacy CJS config
- * (minimal-deprecated.js). They were added during the ESLint 9 flat config migration to support
- * backwards compatibility during API transitions. Many packages in the codebase import from
- * `/legacy` entry points (e.g., `@fluidframework/map/legacy`).
+ * @fluid- scopes could probably allow `/**` as entrypoint structuring rules do NOT apply.
+ * Currently there are no known uses of structured imports from these scopes; so no
+ * allowances are stated.
  */
 export const permittedImports = [
 	// Within Fluid Framework allow import of '/internal' from other FF packages.
-	"@fluid-example/*/internal",
-	"@fluid-experimental/*/internal",
-	"@fluid-internal/*/internal",
-	"@fluid-private/*/internal",
-	"@fluid-tools/*/internal",
-	"@fluidframework/*/internal",
-
-	// Allow /legacy imports for backwards compatibility during API transition.
-	// This is an intentional enhancement over the legacy CJS config.
-	"@fluid-example/*/legacy",
-	"@fluid-experimental/*/legacy",
-	"@fluid-internal/*/legacy",
-	"@fluid-private/*/legacy",
-	"@fluid-tools/*/legacy",
-	"@fluidframework/*/legacy",
+	// Note that `/internal/test**` is still restricted (disallowed) but uses
+	// customCondition of "allow-ff-test-exports" for enforcement.
+	"@fluidframework/*/internal{,/**}",
 
 	// Experimental package APIs and exports are unknown, so allow any imports from them.
 	"@fluid-experimental/**",

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1208,18 +1208,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
+                    "@fluidframework/*/internal{,/**}",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -1208,18 +1208,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
+                    "@fluidframework/*/internal{,/**}",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -1210,18 +1210,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
+                    "@fluidframework/*/internal{,/**}",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1208,18 +1208,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
+                    "@fluidframework/*/internal{,/**}",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -1218,18 +1218,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
+                    "@fluidframework/*/internal{,/**}",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1218,18 +1218,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
+                    "@fluidframework/*/internal{,/**}",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1202,22 +1202,7 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/*/test*",
-                    "@fluid*/*/internal/test*",
-                    "@fluid-example/*/internal",
-                    "@fluid-experimental/*/internal",
-                    "@fluid-internal/*/internal",
-                    "@fluid-private/*/internal",
-                    "@fluid-tools/*/internal",
-                    "@fluidframework/*/internal",
-                    "@fluid-example/*/legacy",
-                    "@fluid-experimental/*/legacy",
-                    "@fluid-internal/*/legacy",
-                    "@fluid-private/*/legacy",
-                    "@fluid-tools/*/legacy",
-                    "@fluidframework/*/legacy",
-                    "@fluid-experimental/**",
-                    "*/index.js"
+                    "@fluid*/**"
                 ]
             }
         ],

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1202,7 +1202,10 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/**"
+                    "@fluid*/**",
+                    "@fluidframework/*/internal{,/**}",
+                    "@fluid-experimental/**",
+                    "*/index.js"
                 ]
             }
         ],

--- a/packages/framework/presence/eslint.config.mts
+++ b/packages/framework/presence/eslint.config.mts
@@ -11,17 +11,6 @@ const config: Linter.Config[] = [
 	{
 		rules: {
 			"@typescript-eslint/consistent-indexed-object-style": "off",
-			"import-x/no-internal-modules": [
-				"error",
-				{
-					"allow": [
-						"@fluidframework/*/internal{,/**}",
-						"*/index.js",
-						"@fluidframework/presence/alpha",
-						"@fluidframework/presence/beta",
-					],
-				},
-			],
 		},
 	},
 	{


### PR DESCRIPTION
1. Entrypoint structuring only applies to `@fluidframework` scope so limit special allowances to it.
  - This includes removing the unused /legacy allowances.
  - Imports within tests are fully unrestricted.
2. Permit `/internal` entrypoints to have substructure other than just `/internal/test`.

The special casing in presence package can now be removed.