### PR TITLE
fix(local-driver, container-loader): fix URL trailing slash mismatch in PendingLocalStateStore

### DIFF
--- a/packages/drivers/local-driver/src/localResolver.ts
+++ b/packages/drivers/local-driver/src/localResolver.ts
@@ -86,7 +86,9 @@ export class LocalResolver implements IUrlResolver {
 			0x09a /* "'documentId' must be a defined, non-zero length string." */,
 		);
 
-		return `http://localhost:3000/${documentId}/${url}`;
+		return url
+			? `http://localhost:3000/${documentId}/${url}`
+			: `http://localhost:3000/${documentId}`;
 	}
 
 	public createCreateNewRequest(documentId: string): IRequest {

--- a/packages/drivers/local-driver/src/test/localResolverTest.spec.ts
+++ b/packages/drivers/local-driver/src/test/localResolverTest.spec.ts
@@ -58,4 +58,34 @@ describe("Local Driver Resolver", () => {
 			assert.equal(resolvedUrl.url, expectedUrl, "The resolved container url should match");
 		});
 	});
+
+	describe("getAbsoluteUrl with empty relativeUrl", () => {
+		beforeEach(() => {
+			resolver = new LocalResolver();
+		});
+
+		it("should return container URL without trailing slash when relativeUrl is empty", async () => {
+			const request = resolver.createCreateNewRequest(documentId);
+			const resolvedUrl = await resolver.resolve(request);
+			const response = await resolver.getAbsoluteUrl(resolvedUrl, "");
+			const expectedUrl = `http://localhost:3000/${documentId}`;
+			assert.equal(
+				response,
+				expectedUrl,
+				"The requestUrl should not have a trailing slash when relativeUrl is empty",
+			);
+		});
+
+		it("should return container URL without trailing slash when relativeUrl is just a slash", async () => {
+			const request = resolver.createCreateNewRequest(documentId);
+			const resolvedUrl = await resolver.resolve(request);
+			const response = await resolver.getAbsoluteUrl(resolvedUrl, "/");
+			const expectedUrl = `http://localhost:3000/${documentId}`;
+			assert.equal(
+				response,
+				expectedUrl,
+				"The requestUrl should not have a trailing slash when relativeUrl is a single slash",
+			);
+		});
+	});
 });

--- a/packages/loader/container-loader/src/pendingLocalStateStore.ts
+++ b/packages/loader/container-loader/src/pendingLocalStateStore.ts
@@ -94,8 +94,11 @@ export class PendingLocalStateStore<TKey> {
 		const state = getAttachedContainerStateFromSerializedContainer(pendingLocalState);
 		const { savedOps, snapshotBlobs, loadedGroupIdSnapshots, url } = state;
 
+		// Normalize URL by removing trailing slash for comparison
+		const normalizedUrl = url.replace(/\/$/, "");
+		const normalizedFirstUrl = this.#firstUrl?.replace(/\/$/, "");
 		this.#firstUrl ??= url;
-		if (this.#firstUrl !== url) {
+		if (normalizedFirstUrl !== undefined && normalizedFirstUrl !== normalizedUrl) {
 			throw new UsageError("PendingLocalStateStore can only be used with a single container.");
 		}
 

--- a/packages/loader/container-loader/src/test/pendingLocalStateStore.spec.ts
+++ b/packages/loader/container-loader/src/test/pendingLocalStateStore.spec.ts
@@ -238,6 +238,30 @@ describe("PendingLocalStateStore", () => {
 				"Expected UsageError for different URLs",
 			);
 		});
+
+		it("should accept URLs that differ only by trailing slash", () => {
+			const store = new PendingLocalStateStore<string>();
+			const stateWithTrailingSlash = createMockContainerState("http://test.com/doc/");
+			const stateWithoutTrailingSlash = createMockContainerState("http://test.com/doc");
+
+			// Should not throw - URLs should be normalized and treated as equal
+			store.set("key1", JSON.stringify(stateWithTrailingSlash));
+			store.set("key2", JSON.stringify(stateWithoutTrailingSlash));
+
+			assert.strictEqual(store.size, 2);
+		});
+
+		it("should accept URLs when first has no trailing slash and second has trailing slash", () => {
+			const store = new PendingLocalStateStore<string>();
+			const stateWithoutTrailingSlash = createMockContainerState("http://test.com/doc");
+			const stateWithTrailingSlash = createMockContainerState("http://test.com/doc/");
+
+			// Should not throw - URLs should be normalized and treated as equal
+			store.set("key1", JSON.stringify(stateWithoutTrailingSlash));
+			store.set("key2", JSON.stringify(stateWithTrailingSlash));
+
+			assert.strictEqual(store.size, 2);
+		});
 	});
 
 	describe("ops deduplication", () => {


### PR DESCRIPTION
## Summary

- Fix `LocalResolver.getAbsoluteUrl` to not add trailing slash when `relativeUrl` is empty
- Add URL normalization in `PendingLocalStateStore` to strip trailing slashes before comparing

This fixes an issue where containers loaded via `getAbsoluteUrl("")` had a trailing slash in their URL, causing `PendingLocalStateStore` to incorrectly reject states from what is actually the same container.

## Test plan

- [x] Verified fix with local-server-stress-tests (previously failing seeds 69, 121, 137, 149 now pass)

related to [AB#8839](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8839)

🤖 Generated with [Claude Code](https://claude.com/claude-code)