### PR TITLE
tree(fix): remove spurious MCF codec version numbers

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -39,11 +39,8 @@ export function makeModularChangeCodecFamily(
 	return makeCodecFamily(
 		Array.from(fieldKindConfigurations.entries(), ([version, fieldKinds]) => {
 			switch (version) {
-				case 1:
-				case 2:
 				case 3:
-				case 4:
-				case 6: {
+				case 4: {
 					return [
 						version,
 						makeModularChangeCodecV1(

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -57,6 +57,7 @@ import {
 	jsonableTreeFromFieldCursor,
 	DefaultRevisionReplacer,
 	type ChangeAtomIdBTree,
+	fieldKindConfigurations,
 } from "../../../feature-libraries/index.js";
 import type {
 	EncodedModularChangesetV1,
@@ -190,14 +191,9 @@ const codecOptions: CodecWriteOptions = {
 };
 
 const codec = makeModularChangeCodecFamily(
-	new Map([
-		[1, fieldKindConfiguration],
-		[2, fieldKindConfiguration],
-		[3, fieldKindConfiguration],
-		[4, fieldKindConfiguration],
-		[5, fieldKindConfiguration],
-		[6, fieldKindConfiguration],
-	]),
+	new Map(
+		[...fieldKindConfigurations.keys()].map((version) => [version, fieldKindConfiguration]),
+	),
 	testRevisionTagCodec,
 	makeFieldBatchCodec(codecOptions),
 	codecOptions,
@@ -1506,7 +1502,7 @@ describe("ModularChangeFamily", () => {
 			family.codecs,
 			encodingTestDataForAllVersions,
 			assertEquivalent,
-			[1, 2, 3, 4, 6],
+			[3, 4],
 		);
 		makeEncodingTestSuite(family.codecs, encodingTestDataV5Only, assertEquivalent, [5]);
 	});


### PR DESCRIPTION
## Description

Removes references to `ModularChangeFamily` codec version numbers that are not supported.

The numbers will be replaced with a `strictEnum` in a future PR to prevent this kind of problem in the future.

## Breaking Changes

None