### PR TITLE
Bump manifest version for publishing

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
+++ b/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <!-- Enumerate unpublished changes here. They can be merged into release sections when the next release is published. -->
 
+# 1.1.1
+
+Fix accessibility issues in the Refresh buttons
+
 # 1.1.0
 
 Adds support for `DataObject` and `TreeDataObject` visualization.

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Fluid Framework Developer Tools",
 	"description": "Devtools extension for viewing live data about your Fluid application.",
 	"author": "Microsoft",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"action": {
 		"default_icon": {
 			"16": "icons/icon_16.png",


### PR DESCRIPTION
Bumps the extension manifest to 1.1.1 for accessibility fixes.