### PR TITLE
refactor(tree): use strictEnum for more persisted format numbers

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -12,7 +12,6 @@ import {
 	forbiddenFieldKindIdentifier,
 	Multiplicity,
 } from "../../core/index.js";
-import { brand, type Brand } from "../../util/index.js";
 import { identifierFieldIdentifier } from "../fieldKindIdentifiers.js";
 import {
 	type FieldChangeDelta,
@@ -22,6 +21,7 @@ import {
 	type FieldKindConfigurationEntry,
 	FlexFieldKind,
 	type FullSchemaPolicy,
+	ModularChangeFormatVersion,
 	type ToDelta,
 	referenceFreeFieldChangeRebaser,
 } from "../modular-schema/index.js";
@@ -107,9 +107,9 @@ export const forbidden: Forbidden = new FlexFieldKind(
 export const fieldKindConfigurations: ReadonlyMap<
 	ModularChangeFormatVersion,
 	FieldKindConfiguration
-> = new Map([
+> = new Map<ModularChangeFormatVersion, FieldKindConfiguration>([
 	[
-		brand(3),
+		ModularChangeFormatVersion.v3,
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[required.identifier, { kind: required, formatVersion: 2 }],
 			[optional.identifier, { kind: optional, formatVersion: 2 }],
@@ -119,7 +119,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 		]),
 	],
 	[
-		brand(4),
+		ModularChangeFormatVersion.v4,
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[required.identifier, { kind: required, formatVersion: 2 }],
 			[optional.identifier, { kind: optional, formatVersion: 2 }],
@@ -129,7 +129,7 @@ export const fieldKindConfigurations: ReadonlyMap<
 		]),
 	],
 	[
-		brand(5),
+		ModularChangeFormatVersion.v5,
 		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
 			[required.identifier, { kind: required, formatVersion: 2 }],
 			[optional.identifier, { kind: optional, formatVersion: 2 }],
@@ -140,7 +140,6 @@ export const fieldKindConfigurations: ReadonlyMap<
 	],
 ]);
 
-export type ModularChangeFormatVersion = Brand<3 | 4 | 5, "ModularChangeFormatVersion">;
 export function getCodecTreeForModularChangeFormat(
 	version: ModularChangeFormatVersion,
 ): CodecTree {

--- a/packages/dds/tree/src/feature-libraries/default-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/index.ts
@@ -8,7 +8,6 @@ export {
 	fieldKinds,
 	fieldKindConfigurations,
 	getCodecTreeForModularChangeFormat,
-	type ModularChangeFormatVersion,
 	defaultSchemaPolicy,
 } from "./defaultFieldKinds.js";
 

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -89,6 +89,7 @@ export {
 	type FieldKindConfigurationEntry,
 	isNeverTree,
 	DefaultRevisionReplacer,
+	ModularChangeFormatVersion,
 } from "./modular-schema/index.js";
 
 export { mapRootChanges } from "./deltaUtils.js";
@@ -139,7 +140,6 @@ export {
 	intoDelta,
 	relevantRemovedRoots,
 	getCodecTreeForModularChangeFormat,
-	type ModularChangeFormatVersion,
 } from "./default-schema/index.js";
 
 export {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -74,7 +74,10 @@ export {
 	relevantRemovedRoots,
 	updateRefreshers,
 } from "./modularChangeFamily.js";
-export { makeModularChangeCodecFamily } from "./modularChangeCodecs.js";
+export {
+	ModularChangeFormatVersion,
+	makeModularChangeCodecFamily,
+} from "./modularChangeCodecs.js";
 export type {
 	FieldKindConfiguration,
 	FieldKindConfigurationEntry,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -16,6 +16,7 @@ import type {
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../../core/index.js";
+import { strictEnum, type Values } from "../../util/index.js";
 import type { FieldBatchCodec } from "../chunked-forest/index.js";
 import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
 
@@ -25,7 +26,7 @@ import { makeModularChangeCodecV2 } from "./modularChangeCodecV2.js";
 import type { ModularChangeset } from "./modularChangeTypes.js";
 
 export function makeModularChangeCodecFamily(
-	fieldKindConfigurations: ReadonlyMap<number, FieldKindConfiguration>,
+	fieldKindConfigurations: ReadonlyMap<ModularChangeFormatVersion, FieldKindConfiguration>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
@@ -39,8 +40,8 @@ export function makeModularChangeCodecFamily(
 	return makeCodecFamily(
 		Array.from(fieldKindConfigurations.entries(), ([version, fieldKinds]) => {
 			switch (version) {
-				case 3:
-				case 4: {
+				case ModularChangeFormatVersion.v3:
+				case ModularChangeFormatVersion.v4: {
 					return [
 						version,
 						makeModularChangeCodecV1(
@@ -52,7 +53,7 @@ export function makeModularChangeCodecFamily(
 						),
 					];
 				}
-				case 5: {
+				case ModularChangeFormatVersion.v5: {
 					return [
 						version,
 						makeModularChangeCodecV2(
@@ -71,3 +72,30 @@ export function makeModularChangeCodecFamily(
 		}),
 	);
 }
+
+/**
+ * The format version for `ModularChangeset`.
+ */
+export const ModularChangeFormatVersion = strictEnum("ModularChangeFormatVersion", {
+	/**
+	 * Introduced prior to 2.0 and used beyond.
+	 * Reading capability must be maintained for backwards compatibility.
+	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.2.0.
+	 */
+	v3: 3,
+	/**
+	 * Introduced in 2.2.0.
+	 * Was inadvertently made usable for writing in 2.43.0 (through configuredSharedTree) and remains available.
+	 * Reading capability must be maintained for backwards compatibility.
+	 * Writing capability could be dropped in favor of {@link ModularChangeFormatVersion.v3},
+	 * but doing so would make the pattern of writable versions more complex and gain little
+	 * because the logic for this format is shared with {@link ModularChangeFormatVersion.v3}.
+	 */
+	v4: 4,
+	/**
+	 * Introduced and made available for writing in 2.80.0
+	 * Adds support for "no change" constraints.
+	 */
+	v5: 5,
+});
+export type ModularChangeFormatVersion = Values<typeof ModularChangeFormatVersion>;

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -99,7 +99,6 @@ import {
 	type SchemaType,
 } from "../simple-tree/index.js";
 import {
-	brand,
 	type Breakable,
 	breakingClass,
 	type JsonCompatible,
@@ -109,7 +108,7 @@ import {
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 import {
 	getCodecTreeForChangeFormat,
-	type SharedTreeChangeFormatVersion,
+	SharedTreeChangeFormatVersion,
 } from "./sharedTreeChangeCodecs.js";
 import { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
@@ -550,23 +549,14 @@ export function getBranch<T extends ImplicitFieldSchema | UnsafeUnknownSchema>(
  * This is because the format for SharedTree changes are not explicitly versioned.
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- intentional comparison
-export const changeFormatVersionForEditManager = DependentFormatVersion.fromPairs([
-	[
-		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v3),
-		brand<SharedTreeChangeFormatVersion>(3),
-	],
-	[
-		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v4),
-		brand<SharedTreeChangeFormatVersion>(4),
-	],
-	[
-		brand<EditManagerFormatVersion>(EditManagerFormatVersion.vSharedBranches),
-		brand<SharedTreeChangeFormatVersion>(4),
-	],
-	[
-		brand<EditManagerFormatVersion>(EditManagerFormatVersion.v6),
-		brand<SharedTreeChangeFormatVersion>(5),
-	],
+export const changeFormatVersionForEditManager = DependentFormatVersion.fromPairs<
+	EditManagerFormatVersion,
+	SharedTreeChangeFormatVersion
+>([
+	[EditManagerFormatVersion.v3, SharedTreeChangeFormatVersion.v3],
+	[EditManagerFormatVersion.v4, SharedTreeChangeFormatVersion.v4],
+	[EditManagerFormatVersion.vSharedBranches, SharedTreeChangeFormatVersion.v4],
+	[EditManagerFormatVersion.v6, SharedTreeChangeFormatVersion.v5],
 ]);
 
 /**
@@ -575,23 +565,14 @@ export const changeFormatVersionForEditManager = DependentFormatVersion.fromPair
  * Once an entry is defined and used in production, it cannot be changed.
  * This is because the format for SharedTree changes are not explicitly versioned.
  */
-export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs([
-	[
-		brand<MessageFormatVersion>(MessageFormatVersion.v3),
-		brand<SharedTreeChangeFormatVersion>(3),
-	],
-	[
-		brand<MessageFormatVersion>(MessageFormatVersion.v4),
-		brand<SharedTreeChangeFormatVersion>(4),
-	],
-	[
-		brand<MessageFormatVersion>(MessageFormatVersion.vSharedBranches),
-		brand<SharedTreeChangeFormatVersion>(4),
-	],
-	[
-		brand<MessageFormatVersion>(MessageFormatVersion.v6),
-		brand<SharedTreeChangeFormatVersion>(5),
-	],
+export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs<
+	MessageFormatVersion,
+	SharedTreeChangeFormatVersion
+>([
+	[MessageFormatVersion.v3, SharedTreeChangeFormatVersion.v3],
+	[MessageFormatVersion.v4, SharedTreeChangeFormatVersion.v4],
+	[MessageFormatVersion.vSharedBranches, SharedTreeChangeFormatVersion.v4],
+	[MessageFormatVersion.v6, SharedTreeChangeFormatVersion.v5],
 ]);
 
 function getCodecTreeForEditManagerFormat(clientVersion: MinimumVersionForCollab): CodecTree {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -23,7 +23,7 @@ import {
 	type TreeStoredSchema,
 } from "../core/index.js";
 import {
-	type ModularChangeFormatVersion,
+	ModularChangeFormatVersion,
 	type ModularChangeset,
 	type SchemaChange,
 	defaultSchemaPolicy,
@@ -32,10 +32,10 @@ import {
 	makeSchemaChangeCodecs,
 } from "../feature-libraries/index.js";
 import {
-	brand,
-	type Brand,
+	strictEnum,
 	type JsonCompatibleReadOnly,
 	type Mutable,
+	type Values,
 } from "../util/index.js";
 
 import {
@@ -75,7 +75,32 @@ interface ChangeFormatDependencies {
 	readonly schemaChange: SchemaFormatVersion;
 }
 
-export type SharedTreeChangeFormatVersion = Brand<3 | 4 | 5, "SharedTreeChangeFormatVersion">;
+/**
+ * The format version for `SharedTreeChange`.
+ */
+export const SharedTreeChangeFormatVersion = strictEnum("SharedTreeChangeFormatVersion", {
+	/**
+	 * Introduced prior to 2.0 and used beyond.
+	 * Reading capability must be maintained for backwards compatibility.
+	 * Writing capability needs to be maintained so long as {@link lowestMinVersionForCollab} is less than 2.2.0.
+	 */
+	v3: 3,
+	/**
+	 * Introduced in 2.2.0.
+	 * Was inadvertently made usable for writing in 2.43.0 (through configuredSharedTree) and remains available.
+	 * Reading capability must be maintained for backwards compatibility.
+	 * Writing capability could be dropped in favor of {@link SharedTreeChangeFormatVersion.v3},
+	 * but doing so would make the pattern of writable versions more complex and gain little
+	 * because the logic for this format is shared with {@link SharedTreeChangeFormatVersion.v3}.
+	 */
+	v4: 4,
+	/**
+	 * Introduced and made available for writing in 2.80.0
+	 * Adds support for "no change" constraints.
+	 */
+	v5: 5,
+});
+export type SharedTreeChangeFormatVersion = Values<typeof SharedTreeChangeFormatVersion>;
 
 /**
  * Defines for each SharedTree change format the corresponding dependent formats to use.
@@ -83,13 +108,22 @@ export type SharedTreeChangeFormatVersion = Brand<3 | 4 | 5, "SharedTreeChangeFo
  * Once an entry is defined and used in production, it cannot be changed.
  * This is because the format for the dependent formats are not explicitly versioned.
  */
-export const dependenciesForChangeFormat: Map<
+export const dependenciesForChangeFormat = new Map<
 	SharedTreeChangeFormatVersion,
 	ChangeFormatDependencies
-> = new Map([
-	[brand(3), { modularChange: brand(3), schemaChange: SchemaFormatVersion.v1 }],
-	[brand(4), { modularChange: brand(4), schemaChange: SchemaFormatVersion.v1 }],
-	[brand(5), { modularChange: brand(5), schemaChange: SchemaFormatVersion.v1 }],
+>([
+	[
+		SharedTreeChangeFormatVersion.v3,
+		{ modularChange: ModularChangeFormatVersion.v3, schemaChange: SchemaFormatVersion.v1 },
+	],
+	[
+		SharedTreeChangeFormatVersion.v4,
+		{ modularChange: ModularChangeFormatVersion.v4, schemaChange: SchemaFormatVersion.v1 },
+	],
+	[
+		SharedTreeChangeFormatVersion.v5,
+		{ modularChange: ModularChangeFormatVersion.v5, schemaChange: SchemaFormatVersion.v1 },
+	],
 ]);
 
 export function getCodecTreeForChangeFormat(

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -58,6 +58,7 @@ import {
 	DefaultRevisionReplacer,
 	type ChangeAtomIdBTree,
 	fieldKindConfigurations,
+	ModularChangeFormatVersion,
 } from "../../../feature-libraries/index.js";
 import type {
 	EncodedModularChangesetV1,
@@ -1498,13 +1499,13 @@ describe("ModularChangeFamily", () => {
 			],
 		};
 
-		makeEncodingTestSuite(
-			family.codecs,
-			encodingTestDataForAllVersions,
-			assertEquivalent,
-			[3, 4],
-		);
-		makeEncodingTestSuite(family.codecs, encodingTestDataV5Only, assertEquivalent, [5]);
+		makeEncodingTestSuite(family.codecs, encodingTestDataForAllVersions, assertEquivalent, [
+			ModularChangeFormatVersion.v3,
+			ModularChangeFormatVersion.v4,
+		]);
+		makeEncodingTestSuite(family.codecs, encodingTestDataV5Only, assertEquivalent, [
+			ModularChangeFormatVersion.v5,
+		]);
 	});
 
 	it("build child change", () => {


### PR DESCRIPTION
## Description

Uses `strictEnum` for `SharedTreeChangeFormatVersion` and `ModularChangeFormatVersion`. This reduces the change that invalid version numbers can be used. It also makes it easier to find the relevant documentation for each version.

## Breaking Changes

None