### PR TITLE
Reduce unsafe implicit typing around JsonCompatibleReadOnly in codecs

### DIFF
--- a/packages/dds/tree/src/core/schema-stored/formatV1.ts
+++ b/packages/dds/tree/src/core/schema-stored/formatV1.ts
@@ -52,6 +52,7 @@ const FieldSchemaFormatBase = Type.Object({
 
 const noAdditionalProps: ObjectOptions = { additionalProperties: false };
 
+export type FieldSchemaFormat = Static<typeof FieldSchemaFormat>;
 export const FieldSchemaFormat = Type.Composite([FieldSchemaFormatBase], noAdditionalProps);
 
 /**
@@ -70,6 +71,7 @@ export enum PersistedValueSchema {
  *
  * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
  */
+export type TreeNodeSchemaDataFormat = Static<typeof TreeNodeSchemaDataFormat>;
 export const TreeNodeSchemaDataFormat = Type.Object(
 	{
 		/**
@@ -87,7 +89,3 @@ export const TreeNodeSchemaDataFormat = Type.Object(
 	},
 	unionOptions,
 );
-
-export type TreeNodeSchemaDataFormat = Static<typeof TreeNodeSchemaDataFormat>;
-
-export type FieldSchemaFormat = Static<typeof FieldSchemaFormat>;

--- a/packages/dds/tree/src/core/schema-stored/formatV2.ts
+++ b/packages/dds/tree/src/core/schema-stored/formatV2.ts
@@ -6,6 +6,7 @@
 import { type ObjectOptions, type Static, Type } from "@sinclair/typebox";
 
 import { unionOptions } from "../../codec/index.js";
+import type { JsonCompatibleReadOnlyObject } from "../../util/index.js";
 import { JsonCompatibleReadOnlySchema } from "../../util/index.js";
 
 import {
@@ -14,7 +15,12 @@ import {
 	TreeNodeSchemaIdentifierSchema,
 } from "./formatV1.js";
 
-export const PersistedMetadataFormat = Type.Optional(JsonCompatibleReadOnlySchema);
+export type PersistedMetadataFormat = Static<typeof PersistedMetadataFormat>;
+export const PersistedMetadataFormat = Type.Optional(
+	Type.Unsafe<JsonCompatibleReadOnlyObject>(
+		Type.Record(Type.String(), JsonCompatibleReadOnlySchema),
+	),
+);
 
 const FieldSchemaFormatBase = Type.Object({
 	kind: FieldKindIdentifierSchema,
@@ -24,6 +30,7 @@ const FieldSchemaFormatBase = Type.Object({
 
 const noAdditionalProps: ObjectOptions = { additionalProperties: false };
 
+export type FieldSchemaFormat = Static<typeof FieldSchemaFormat>;
 export const FieldSchemaFormat = Type.Composite([FieldSchemaFormatBase], noAdditionalProps);
 
 /**
@@ -56,6 +63,7 @@ export type TreeNodeSchemaUnionFormat = Static<typeof TreeNodeSchemaUnionFormat>
  *
  * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
  */
+export type TreeNodeSchemaDataFormat = Static<typeof TreeNodeSchemaDataFormat>;
 export const TreeNodeSchemaDataFormat = Type.Object(
 	{
 		/**
@@ -71,9 +79,3 @@ export const TreeNodeSchemaDataFormat = Type.Object(
 	},
 	noAdditionalProps,
 );
-
-export type TreeNodeSchemaDataFormat = Static<typeof TreeNodeSchemaDataFormat>;
-
-export type FieldSchemaFormat = Static<typeof FieldSchemaFormat>;
-
-export type PersistedMetadataFormat = Static<typeof PersistedMetadataFormat>;

--- a/packages/dds/tree/src/core/schema-stored/schema.ts
+++ b/packages/dds/tree/src/core/schema-stored/schema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { fail } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import { DiscriminatedUnionDispatcher } from "../../codec/index.js";
 import {
@@ -403,6 +403,11 @@ export function encodeFieldSchemaV2(schema: TreeFieldStoredSchema): FieldSchemaF
 }
 
 export function decodeFieldSchema(schema: FieldSchemaFormatV2): TreeFieldStoredSchema {
+	assert(schema.metadata !== null, "invalid null persistedMetadata");
+	assert(
+		schema.metadata === undefined || typeof schema.metadata === "object",
+		"invalid persistedMetadata type",
+	);
 	const out: TreeFieldStoredSchema = {
 		// TODO: maybe provide actual FieldKind objects here, error on unrecognized kinds.
 		kind: schema.kind,

--- a/packages/dds/tree/src/core/schema-stored/schema.ts
+++ b/packages/dds/tree/src/core/schema-stored/schema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, fail } from "@fluidframework/core-utils/internal";
+import { fail } from "@fluidframework/core-utils/internal";
 
 import { DiscriminatedUnionDispatcher } from "../../codec/index.js";
 import {
@@ -403,11 +403,6 @@ export function encodeFieldSchemaV2(schema: TreeFieldStoredSchema): FieldSchemaF
 }
 
 export function decodeFieldSchema(schema: FieldSchemaFormatV2): TreeFieldStoredSchema {
-	assert(schema.metadata !== null, "invalid null persistedMetadata");
-	assert(
-		schema.metadata === undefined || typeof schema.metadata === "object",
-		"invalid persistedMetadata type",
-	);
 	const out: TreeFieldStoredSchema = {
 		// TODO: maybe provide actual FieldKind objects here, error on unrecognized kinds.
 		kind: schema.kind,

--- a/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
@@ -18,7 +18,7 @@ import {
 	makeVersionedValidatedCodec,
 } from "../../codec/index.js";
 import type { FieldKey, ITreeCursorSynchronous } from "../../core/index.js";
-import { brand } from "../../util/index.js";
+import { brand, type JsonCompatibleReadOnly } from "../../util/index.js";
 import type { FieldBatchCodec, FieldBatchEncodingContext } from "../chunked-forest/index.js";
 
 import {
@@ -32,7 +32,12 @@ import {
  * Uses field cursors
  */
 export type FieldSet = ReadonlyMap<FieldKey, ITreeCursorSynchronous>;
-export type ForestCodec = IJsonCodec<FieldSet, Format, Format, FieldBatchEncodingContext>;
+export type ForestCodec = IJsonCodec<
+	FieldSet,
+	Format,
+	JsonCompatibleReadOnly,
+	FieldBatchEncodingContext
+>;
 
 /**
  * Convert a MinimumVersionForCollab to a ForestFormatVersion.

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -32,7 +32,11 @@ import {
 	type SummaryElementParser,
 	type SummaryElementStringifier,
 } from "../../shared-tree-core/index.js";
-import { idAllocatorFromMaxId, readAndParseSnapshotBlob } from "../../util/index.js";
+import {
+	idAllocatorFromMaxId,
+	readAndParseSnapshotBlob,
+	type JsonCompatibleReadOnly,
+} from "../../util/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { chunkFieldSingle, defaultChunkPolicy } from "../chunked-forest/chunkTree.js";
 import {
@@ -211,7 +215,12 @@ export class ForestSummarizer
 		// TODO: this code is parsing data without an optional validator, this should be defined in a typebox schema as part of the
 		// forest summary format.
 		const fields = this.codec.decode(
-			await readAndParseSnapshotBlob(forestSummaryRootContentKey, services, parse),
+			(await readAndParseSnapshotBlob(
+				forestSummaryRootContentKey,
+				services,
+				parse,
+				// TODO: this type cast assumes there are no handles, which should probably be enforced at runtime or the need for this cast should be removed altogether.
+			)) as JsonCompatibleReadOnly,
 			{
 				...this.encoderContext,
 				incrementalEncoderDecoder: this.incrementalSummaryBuilder,

--- a/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
@@ -276,9 +276,7 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 	 */
 	public async load(args: {
 		services: IChannelStorageService;
-		readAndParseChunk: <T extends JsonCompatible<IFluidHandle>>(
-			chunkBlobPath: string,
-		) => Promise<T>;
+		readAndParseChunk: (chunkBlobPath: string) => Promise<JsonCompatible<IFluidHandle>>;
 	}): Promise<void> {
 		const forestTree = args.services.getSnapshotTree?.();
 		// Snapshot tree should be available when loading forest's contents. However, it is an optional function
@@ -303,8 +301,9 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 						`SharedTree: Cannot find contents for incremental chunk ${chunkContentsPath}`,
 					);
 				}
-				const chunkContents =
-					await args.readAndParseChunk<EncodedFieldBatch>(chunkContentsPath);
+				const chunkContents = (await args.readAndParseChunk(
+					chunkContentsPath,
+				)) as EncodedFieldBatch; // TODO: this should use a codec to validate the data instead of just type casting.
 				this.loadedChunksMap.set(chunkReferenceId, {
 					encodedContents: chunkContents,
 					summaryPath: chunkSubTreePath,

--- a/packages/dds/tree/src/shared-tree-core/versionedSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/versionedSummarizer.ts
@@ -99,11 +99,12 @@ export abstract class VersionedSummarizer<TVersion extends number> implements Su
 	): Promise<void> {
 		let version: TVersion | undefined;
 		if (await services.contains(summarizablesMetadataKey)) {
-			const metadata = await readAndParseSnapshotBlob<SharedTreeSummarizableMetadata>(
+			const metadata = (await readAndParseSnapshotBlob(
 				summarizablesMetadataKey,
 				services,
 				(contents) => parse(contents),
-			);
+				// TODO: this type cast should use a codec to validate the data instead of just type casting.
+			)) as SharedTreeSummarizableMetadata;
 			version = metadata.version as TVersion;
 			if (!this.supportedVersions.has(version)) {
 				throw new UsageError(`Cannot read version ${version} of shared tree summary.`);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -37,6 +37,7 @@ import { ChunkedForest } from "../../../feature-libraries/chunked-forest/chunked
 // eslint-disable-next-line import-x/no-internal-modules
 import { decode } from "../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 import type {
+	EncodedFieldBatch,
 	FieldBatchEncodingContext,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/index.js";
@@ -208,7 +209,7 @@ describe("End to end chunked encoding", () => {
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
 		function stringify(content: unknown) {
-			const insertedChunk = decode((content as FormatV1).fields, {
+			const insertedChunk = decode((content as FormatV1).fields as EncodedFieldBatch, {
 				idCompressor,
 				originatorId: idCompressor.localSessionId,
 			});
@@ -242,7 +243,7 @@ describe("End to end chunked encoding", () => {
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
 		function stringify(content: unknown) {
-			const insertedChunk = decode((content as FormatV1).fields, {
+			const insertedChunk = decode((content as FormatV1).fields as EncodedFieldBatch, {
 				idCompressor,
 				originatorId: idCompressor.localSessionId,
 			});

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -92,7 +92,8 @@ export const valueHandler = {
 	rebaser: replaceRebaser(),
 	codecsFactory: () => {
 		const inner = makeValueCodec<TUnsafe<ValueChangeset>, FieldChangeEncodingContext>(
-			JsonCompatibleReadOnlySchema,
+			// As this is just a test rebaser, it is acceptable to not use a proper schema, and thus not detect invalid data here.
+			JsonCompatibleReadOnlySchema as TUnsafe<ValueChangeset>,
 		);
 		return makeCodecFamily([[1, eraseEncodedType(inner)]]);
 	},

--- a/packages/dds/tree/src/test/snapshots/output/files/SchemaIndexFormat - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/files/SchemaIndexFormat - schema v2.json
@@ -35,7 +35,12 @@
                             "type": "string"
                           }
                         },
-                        "metadata": {}
+                        "metadata": {
+                          "type": "object",
+                          "patternProperties": {
+                            "^(.*)$": {}
+                          }
+                        }
                       },
                       "required": [
                         "kind",
@@ -57,7 +62,12 @@
                         "type": "string"
                       }
                     },
-                    "metadata": {}
+                    "metadata": {
+                      "type": "object",
+                      "patternProperties": {
+                        "^(.*)$": {}
+                      }
+                    }
                   },
                   "required": [
                     "kind",
@@ -90,7 +100,12 @@
                 }
               }
             },
-            "metadata": {}
+            "metadata": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {}
+              }
+            }
           },
           "required": [
             "kind"
@@ -111,7 +126,12 @@
             "type": "string"
           }
         },
-        "metadata": {}
+        "metadata": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {}
+          }
+        }
       },
       "required": [
         "kind",

--- a/packages/dds/tree/src/test/testNodeId.ts
+++ b/packages/dds/tree/src/test/testNodeId.ts
@@ -96,7 +96,7 @@ function decode(encoded: JsonCompatibleReadOnly, context: ChangeEncodingContext)
 	const fieldChanges =
 		(encoded as EncodedNodeChangeset).fieldChanges ?? fail("Invalid encoded TestNodeId");
 
-	return fieldChanges[0].change as TestNodeId;
+	return fieldChanges[0].change as object as TestNodeId;
 }
 
 function tryGetTestChange(id: NodeId | undefined): TestChange | undefined {

--- a/packages/dds/tree/src/util/readSnapshotBlob.ts
+++ b/packages/dds/tree/src/util/readSnapshotBlob.ts
@@ -14,12 +14,12 @@ import type { JsonCompatible } from "./utils.js";
 /**
  * Reads and parses a snapshot blob from storage service.
  */
-export const readAndParseSnapshotBlob = async <T extends JsonCompatible<IFluidHandle>>(
+export const readAndParseSnapshotBlob = async (
 	blobPath: string,
 	service: IChannelStorageService,
 	parse: SummaryElementParser,
-): Promise<T> => {
+): Promise<JsonCompatible<IFluidHandle>> => {
 	const treeBuffer = await service.readBlob(blobPath);
 	const treeBufferString = bufferToString(treeBuffer, "utf8");
-	return parse(treeBufferString) as T;
+	return parse(treeBufferString) as JsonCompatible<IFluidHandle>;
 };

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { Type } from "@sinclair/typebox";
+import { Type, type TUnsafe } from "@sinclair/typebox";
 
 /**
  * Subset of Map interface.
@@ -376,7 +376,8 @@ export type JsonCompatibleReadOnlyObject = { readonly [P in string]?: JsonCompat
  * expressed using composition of schemas for runtime validation, even if we don't think making the types
  * generic is worth the maintenance cost.
  */
-export const JsonCompatibleReadOnlySchema = Type.Any();
+export const JsonCompatibleReadOnlySchema =
+	Type.Any() as unknown as TUnsafe<JsonCompatibleReadOnly>;
 
 /**
  * Returns if a particular json compatible value is an object.


### PR DESCRIPTION
## Description

Fix 3 cases of unsafe implicit typing related to JsonCompatibleReadOnly in codecs.

1. Make JsonCompatibleReadOnlySchema produce the type JsonCompatibleReadOnly instead of `any` when typebox schema using it derive their instance types with `Static`. This required adding some explicitly typing and come casts where this revealed unsafe typing which was previously implicit but is now explicit. This may make the code using it look less type safe, but that good since is used to be really unsafe due to any but that was hidden.
2. PersistedMetadataFormat was supposed to be restricted to JsonCompatibleReadOnlyObject based on all APIs using it, but it was actually restricted to `JsonCompatibleReadOnly` at the type box layer. Due to it using JsonCompatibleReadOnlySchema and the issue above, this was not caught by the type checker, and has been corrected by actually validating that PersistedMetadataFormat is an object.
3. readAndParseSnapshotBlob casted data to a type inferred from where it is used. This anti-pattern puts the unsafe type cast in the generic function where its impossible to do any validation that the cast is safe, and hides it from the code which is making the typing assumption so it is unclear an unsafe conversion has been done, removing that code's opportunity to do a safe validated conversion and hiding the indicators of unsafety like an as cast. This type cast has been removed, forcing users of this API to explicitly do the type conversions, making their lack of schema validation explicit, and also practical to fix in the future if desired.

## Breaking Changes

If someone somehow managed to get a non-object into a PersistedMetadataFormat in a document (which should require using our alpha APIs like `FieldPropsAlpha.persistedMetadata` and also violating their typescript typing), they would no longer be able to open those documents if they include our opt-in schema validation (also an alpha API, via `FormatValidator`). This seems like something that we do not need to accommodate it requires incorrectly typed use of alpha APIs and also seems very unlikely to have occurred, and has a workaround (don't validate).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

