### PR TITLE
Add ExtensibleSchemaUnion

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -270,6 +270,19 @@ export function evaluateLazySchema<T extends TreeNodeSchema>(value: LazyItem<T>)
 // @alpha
 export function exportCompatibilitySchemaSnapshot(config: Pick<TreeViewConfiguration, "schema">): JsonCompatibleReadOnly;
 
+// @alpha
+export namespace ExtensibleSchemaUnion {
+    export function extensibleSchemaUnion<const T extends readonly TreeNodeSchema[], const TScope extends string, const TName extends string>(types: T, inputSchemaFactory: SchemaFactoryBeta<TScope>, name: TName): Statics<T> & TreeNodeSchemaCore_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, false, unknown, never, unknown> & (new (data: InternalTreeNode_2) => Members<TreeNodeFromImplicitAllowedTypes<T>> & TreeNode_2 & WithType_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, unknown>);
+    export interface Members<T> {
+        // (undocumented)
+        readonly child: T | undefined;
+    }
+    export interface Statics<T extends readonly TreeNodeSchema[]> {
+        // (undocumented)
+        create<TThis extends TreeNodeSchema>(this: TThis, child: TreeNodeFromImplicitAllowedTypes<T>): TreeFieldFromImplicitField<TThis>;
+    }
+}
+
 // @public @system
 type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? Result : Item;
 

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -274,11 +274,9 @@ export function exportCompatibilitySchemaSnapshot(config: Pick<TreeViewConfigura
 export namespace ExtensibleSchemaUnion {
     export function extensibleSchemaUnion<const T extends readonly TreeNodeSchema[], const TScope extends string, const TName extends string>(types: T, inputSchemaFactory: SchemaFactoryBeta<TScope>, name: TName): Statics<T> & TreeNodeSchemaCore_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, false, unknown, never, unknown> & (new (data: InternalTreeNode_2) => Members<TreeNodeFromImplicitAllowedTypes<T>> & TreeNode_2 & WithType_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, unknown>);
     export interface Members<T> {
-        // (undocumented)
         readonly child: T | undefined;
     }
     export interface Statics<T extends readonly TreeNodeSchema[]> {
-        // (undocumented)
         create<TThis extends TreeNodeSchema>(this: TThis, child: TreeNodeFromImplicitAllowedTypes<T>): TreeFieldFromImplicitField<TThis>;
     }
 }

--- a/packages/dds/tree/src/extensibleSchemaUnion.ts
+++ b/packages/dds/tree/src/extensibleSchemaUnion.ts
@@ -28,8 +28,8 @@ import type { UnionToIntersection } from "./util/index.js";
  * This does mean however that old clients may see types they do not know about, which are simply exposed as `undefined` children.
  *
  * `staged` types are lower overhead, and might gain support for `unknown` types in the future, so prefer them when possible.
- * This is simply an alternative for when future compat with unknown types is required,
- * and is built on top of the existing {@link ObjectSchemaOptions.allowUnknownOptionalFields | allowUnknownOptionalFields} feature.
+ * This is simply an alternative for when future compatibility with unknown types is required.
+ * It is built on top of the existing {@link ObjectSchemaOptions.allowUnknownOptionalFields | allowUnknownOptionalFields} feature.
  * @alpha
  */
 export namespace ExtensibleSchemaUnion {

--- a/packages/dds/tree/src/extensibleSchemaUnion.ts
+++ b/packages/dds/tree/src/extensibleSchemaUnion.ts
@@ -38,6 +38,10 @@ export namespace ExtensibleSchemaUnion {
 	 * @alpha
 	 */
 	export interface Members<T> {
+		/**
+		 * The child wrapped by this node, which is has one of the type allowed by the union,
+		 * or `undefined` if the type is one which was added to the union by a future version of this schema.
+		 */
 		readonly child: T | undefined;
 	}
 
@@ -46,6 +50,9 @@ export namespace ExtensibleSchemaUnion {
 	 * @alpha
 	 */
 	export interface Statics<T extends readonly TreeNodeSchema[]> {
+		/**
+		 * Create a {@link TreeNode} with `this` schema which wraps the provided child to create the union.
+		 */
 		create<TThis extends TreeNodeSchema>(
 			this: TThis,
 			child: TreeNodeFromImplicitAllowedTypes<T>,

--- a/packages/dds/tree/src/extensibleSchemaUnion.ts
+++ b/packages/dds/tree/src/extensibleSchemaUnion.ts
@@ -34,7 +34,7 @@ import type { UnionToIntersection } from "./util/index.js";
  */
 export namespace ExtensibleSchemaUnion {
 	/**
-	 * Members for classes created by {@link extensibleSchemaUnion}.
+	 * Members for classes created by {@link ExtensibleSchemaUnion.extensibleSchemaUnion}.
 	 * @alpha
 	 */
 	export interface Members<T> {
@@ -42,7 +42,7 @@ export namespace ExtensibleSchemaUnion {
 	}
 
 	/**
-	 * Statics for classes created by {@link extensibleSchemaUnion}.
+	 * Statics for classes created by {@link ExtensibleSchemaUnion.extensibleSchemaUnion}.
 	 * @alpha
 	 */
 	export interface Statics<T extends readonly TreeNodeSchema[]> {

--- a/packages/dds/tree/src/extensibleSchemaUnion.ts
+++ b/packages/dds/tree/src/extensibleSchemaUnion.ts
@@ -46,7 +46,7 @@ import type { UnionToIntersection } from "./util/index.js";
  * ) {}
  * // Instances of the union are created using `create`.
  * const anyItem = AnyItem.create(new ItemA({ x: "hello" }));
- * // Reacting the content our of the union is done via `child`,
+ * // Reading the content from the union is done via `child`,
  * // which can be `undefined` to handle the case where a future version of this schema allows a type unknown to the current version.
  * const childNode: ItemA | ItemB | undefined = anyItem.child;
  * // To determine which member of the union was present, its schema can be inspected:

--- a/packages/dds/tree/src/extensibleSchemaUnion.ts
+++ b/packages/dds/tree/src/extensibleSchemaUnion.ts
@@ -1,0 +1,103 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TreeAlpha, Tree } from "./shared-tree/index.js";
+import type {
+	TreeNodeSchema,
+	TreeNodeFromImplicitAllowedTypes,
+	TreeFieldFromImplicitField,
+	ImplicitFieldSchema,
+	InsertableTreeFieldFromImplicitField,
+	SchemaFactoryBeta,
+} from "./simple-tree/index.js";
+import {
+	createCustomizedFluidFrameworkScopedFactory,
+	eraseSchemaDetailsSubclassable,
+	SchemaFactory,
+	TreeBeta,
+} from "./simple-tree/index.js";
+import type { UnionToIntersection } from "./util/index.js";
+
+/**
+ * Utilities for creating extensible schema unions.
+ * @remarks
+ * Unlike a schema union created using {@link SchemaStaticsBeta.staged | staged} allowed types, this union allows for unknown future types to exist in addition to the known types.
+ * This allows for faster roll-outs of new types without waiting for old clients to be updated to be aware of them.
+ * This does mean however that old clients may see types they do not know about, which are simply exposed as `undefined` children.
+ *
+ * `staged` types are lower overhead, and might gain support for `unknown` types in the future, so prefer them when possible.
+ * This is simply an alternative for when future compat with unknown types is required,
+ * and is built on top of the existing {@link ObjectSchemaOptions.allowUnknownOptionalFields | allowUnknownOptionalFields} feature.
+ * @alpha
+ */
+export namespace ExtensibleSchemaUnion {
+	/**
+	 * Members for classes created by {@link extensibleSchemaUnion}.
+	 * @alpha
+	 */
+	export interface Members<T> {
+		readonly child: T | undefined;
+	}
+
+	/**
+	 * Statics for classes created by {@link extensibleSchemaUnion}.
+	 * @alpha
+	 */
+	export interface Statics<T extends readonly TreeNodeSchema[]> {
+		create<TThis extends TreeNodeSchema>(
+			this: TThis,
+			child: TreeNodeFromImplicitAllowedTypes<T>,
+		): TreeFieldFromImplicitField<TThis>;
+	}
+
+	/**
+	 * Create an extensible schema union which currently supports the types in `types`,
+	 * but tolerates collaboration with future versions that may include additional types.
+	 * @alpha
+	 */
+	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+	export function extensibleSchemaUnion<
+		const T extends readonly TreeNodeSchema[],
+		const TScope extends string,
+		const TName extends string,
+	>(types: T, inputSchemaFactory: SchemaFactoryBeta<TScope>, name: TName) {
+		const record: Record<string, ImplicitFieldSchema> = {};
+		for (const type of types) {
+			record[`_${type.identifier}`] = SchemaFactory.optional(type, { key: type.identifier });
+		}
+		const schemaFactory = createCustomizedFluidFrameworkScopedFactory(
+			inputSchemaFactory,
+			"extensibleSchemaUnion",
+		);
+		class Union
+			extends schemaFactory.object(name, record, { allowUnknownOptionalFields: true })
+			implements Members<TreeNodeFromImplicitAllowedTypes<T>>
+		{
+			public get child(): TreeNodeFromImplicitAllowedTypes<T> | undefined {
+				for (const [_key, child] of TreeAlpha.children(this)) {
+					return child as TreeNodeFromImplicitAllowedTypes<T>;
+				}
+				return undefined;
+			}
+
+			public static create<TThis extends TreeNodeSchema>(
+				this: TThis,
+				child: TreeNodeFromImplicitAllowedTypes<T>,
+			): TreeFieldFromImplicitField<TThis> {
+				const schema = Tree.schema(child);
+				return TreeBeta.create(this, {
+					[`_${schema.identifier}`]: child,
+				} as unknown as InsertableTreeFieldFromImplicitField<
+					TThis,
+					UnionToIntersection<TThis>
+				>);
+			}
+		}
+		return eraseSchemaDetailsSubclassable<
+			Members<TreeNodeFromImplicitAllowedTypes<T>>,
+			Statics<T>
+		>()(Union);
+	}
+}

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -370,3 +370,4 @@ export { TableSchema, type System_TableSchema } from "./tableSchema.js";
 export { asAlpha, asBeta } from "./api.js";
 
 export { TextAsTree, FormattedTextAsTree } from "./text/index.js";
+export { ExtensibleSchemaUnion } from "./extensibleSchemaUnion.js";

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -53,6 +53,7 @@ export {
 	adaptEnum,
 	enumFromStrings,
 	singletonSchema,
+	createCustomizedFluidFrameworkScopedFactory,
 } from "./schemaCreationUtilities.js";
 export {
 	getIdentifierFromNode,

--- a/packages/dds/tree/src/simple-tree/api/schemaCreationUtilities.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCreationUtilities.ts
@@ -17,6 +17,7 @@ import type {
 } from "../core/index.js";
 
 import type { SchemaFactory, ScopedSchemaName } from "./schemaFactory.js";
+import { SchemaFactoryBeta } from "./schemaFactoryBeta.js";
 
 /*
  * This file does two things:
@@ -312,4 +313,27 @@ function _enumFromStrings2<TScope extends string, const Members extends readonly
 	}
 
 	return adaptEnum(factory, enumObject);
+}
+
+function createCustomizedScopedFactory<
+	TUserScope extends string,
+	TCreatorDomain extends string,
+>(
+	inputSchemaFactory: SchemaFactoryBeta<TUserScope>,
+	creatorDomain: TCreatorDomain,
+): SchemaFactoryBeta<`${TCreatorDomain}<${TUserScope}>`> {
+	return new SchemaFactoryBeta(`${creatorDomain}<${inputSchemaFactory.scope}>`);
+}
+
+export function createCustomizedFluidFrameworkScopedFactory<
+	TUserScope extends string,
+	TCreatorDomain extends string,
+>(
+	inputSchemaFactory: SchemaFactoryBeta<TUserScope>,
+	fluidDomainSuffix: TCreatorDomain,
+): SchemaFactoryBeta<`com.fluidframework.${TCreatorDomain}<${TUserScope}>`> {
+	return createCustomizedScopedFactory(
+		inputSchemaFactory,
+		`com.fluidframework.${fluidDomainSuffix}` as const,
+	);
 }

--- a/packages/dds/tree/src/simple-tree/api/schemaCreationUtilities.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCreationUtilities.ts
@@ -325,6 +325,13 @@ function createCustomizedScopedFactory<
 	return new SchemaFactoryBeta(`${creatorDomain}<${inputSchemaFactory.scope}>`);
 }
 
+/**
+ * Declare a SchemaFactory for use in cases where the Fluid Framework's code creates the schema and owns its schema compatibility (and thus scope)
+ * but it is parameterized by user provided data, the `TUserScope`.
+ * @remarks
+ * This should allow future logic in {@link generateSchemaFromSimpleSchema} to recognize these schema as ones defined by Fluid Framework,
+ * and special case them to provide better APIs and maintain data invariants.
+ */
 export function createCustomizedFluidFrameworkScopedFactory<
 	TUserScope extends string,
 	TCreatorDomain extends string,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -200,6 +200,7 @@ export {
 	checkSchemaCompatibilitySnapshots,
 	type SnapshotFileSystem,
 	type SchemaCompatibilitySnapshotsOptions,
+	createCustomizedFluidFrameworkScopedFactory,
 } from "./api/index.js";
 export type {
 	SimpleTreeSchema,

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -10,13 +10,13 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { EmptyKey } from "./core/index.js";
 import { TreeAlpha } from "./shared-tree/index.js";
+import type { SchemaFactoryBeta } from "./simple-tree/index.js";
 import {
 	type FieldHasDefault,
 	type ImplicitAllowedTypes,
 	type InsertableObjectFromSchemaRecord,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type NodeKind,
-	SchemaFactoryBeta,
 	type ScopedSchemaName,
 	TreeArrayNode,
 	type TreeNode,
@@ -37,6 +37,7 @@ import {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports -- This makes the API report slightly cleaner.
 	TreeNodeSchemaCore,
 	type TransactionConstraintAlpha,
+	createCustomizedFluidFrameworkScopedFactory,
 } from "./simple-tree/index.js";
 import { validateIndex, validateIndexRange } from "./util/index.js";
 
@@ -47,12 +48,6 @@ import { validateIndex, validateIndexRange } from "./util/index.js";
 
 // Longer-term work:
 // - Use more focused constraint APIs to protect against leaked cells
-
-/**
- * Scope for table schema built-in types.
- * @remarks User-provided factory scoping will be applied as `com.fluidframework.table<user-scope>`.
- */
-const baseSchemaScope = "com.fluidframework.table";
 
 /**
  * A private symbol put on table schema to help identify them.
@@ -1302,10 +1297,15 @@ export namespace System_TableSchema {
 	// #endregion
 }
 
+/**
+ * Sets up scope for table schema built-in types.
+ * @remarks User-provided factory scoping will be applied as `com.fluidframework.table<user-scope>`.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function createTableScopedFactory<TUserScope extends string>(
 	inputSchemaFactory: SchemaFactoryBeta<TUserScope>,
-): SchemaFactoryBeta<`${typeof baseSchemaScope}<${TUserScope}>`> {
-	return new SchemaFactoryBeta(`${baseSchemaScope}<${inputSchemaFactory.scope}>`);
+) {
+	return createCustomizedFluidFrameworkScopedFactory(inputSchemaFactory, "table");
 }
 
 /**

--- a/packages/dds/tree/src/test/domain-schema-compatibility-snapshots/extensibleSchemaUnion-example/2.82.0.json
+++ b/packages/dds/tree/src/test/domain-schema-compatibility-snapshots/extensibleSchemaUnion-example/2.82.0.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "root": {
+    "kind": 1,
+    "simpleAllowedTypes": {
+      "com.fluidframework.extensibleSchemaUnion<extensibleSchemaUnion-example>.ExtensibleUnion": {
+        "isStaged": false
+      }
+    }
+  },
+  "definitions": {
+    "com.fluidframework.leaf.number": {
+      "leaf": {
+        "kind": 3,
+        "leafKind": 0
+      }
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": {
+        "kind": 3,
+        "leafKind": 1
+      }
+    },
+    "com.fluidframework.extensibleSchemaUnion<extensibleSchemaUnion-example>.ExtensibleUnion": {
+      "object": {
+        "kind": 2,
+        "fields": {
+          "_com.fluidframework.leaf.number": {
+            "kind": 0,
+            "simpleAllowedTypes": {
+              "com.fluidframework.leaf.number": {
+                "isStaged": false
+              }
+            },
+            "storedKey": "com.fluidframework.leaf.number"
+          },
+          "_com.fluidframework.leaf.string": {
+            "kind": 0,
+            "simpleAllowedTypes": {
+              "com.fluidframework.leaf.string": {
+                "isStaged": false
+              }
+            },
+            "storedKey": "com.fluidframework.leaf.string"
+          }
+        },
+        "allowUnknownOptionalFields": true
+      }
+    }
+  }
+}

--- a/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
+++ b/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "../simple-tree/index.js";
 
 import { testSchemaCompatibilitySnapshots } from "./snapshots/index.js";
-import { mapFileSystem } from "./utils.js";
+import { inMemorySnapshotFileSystem } from "./utils.js";
 
 describe("extensibleSchemaUnion", () => {
 	it("examples", () => {
@@ -33,6 +33,7 @@ describe("extensibleSchemaUnion", () => {
 		assert.equal(aSchema, A);
 	});
 
+	// Test that this packages doesn't make any schema changes.
 	it("compatibility", () => {
 		// Test schema compatibility for an example schema using extensibleSchemaUnion.
 		const currentViewSchema = new TreeViewConfiguration({
@@ -49,25 +50,10 @@ describe("extensibleSchemaUnion", () => {
 		);
 	});
 
-	it("compatibility over time", () => {
-		// Test schema compatibility for an example schema using extensibleSchemaUnion.
-		const currentViewSchema = new TreeViewConfiguration({
-			schema: ExtensibleSchemaUnion.extensibleSchemaUnion(
-				[SchemaFactoryBeta.number, SchemaFactoryBeta.string],
-				new SchemaFactoryBeta("extensibleSchemaUnion-example"),
-				"ExtensibleUnion",
-			),
-		});
-		testSchemaCompatibilitySnapshots(
-			currentViewSchema,
-			"2.82.0",
-			"extensibleSchemaUnion-example",
-		);
-	});
-
+	// Test that users of ExtensibleSchemaUnion can evolve their schema over time.
 	it("workflow over time", () => {
 		const snapshotDirectory = "dir";
-		const [fileSystem, snapshots] = mapFileSystem();
+		const [fileSystem] = inMemorySnapshotFileSystem();
 
 		const factory = new SchemaFactoryBeta("test");
 

--- a/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
+++ b/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
@@ -1,0 +1,126 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { ExtensibleSchemaUnion } from "../extensibleSchemaUnion.js";
+import { Tree } from "../shared-tree/index.js";
+import {
+	checkSchemaCompatibilitySnapshots,
+	SchemaFactoryBeta,
+	TreeViewConfiguration,
+} from "../simple-tree/index.js";
+
+import { testSchemaCompatibilitySnapshots } from "./snapshots/index.js";
+import { mapFileSystem } from "./utils.js";
+
+describe("extensibleSchemaUnion", () => {
+	it("examples", () => {
+		const sf = new SchemaFactoryBeta("extensibleSchemaUnionExample");
+		class A extends sf.object("A", { x: sf.string }) {}
+		class B extends sf.object("B", { x: sf.number }) {}
+
+		class AnyPage extends ExtensibleSchemaUnion.extensibleSchemaUnion(
+			[A, B],
+			sf,
+			"ExtensibleUnion",
+		) {}
+		const aNode = AnyPage.create(new A({ x: "hello" }));
+		const childNode: A | B | undefined = aNode.child;
+		const aSchema = Tree.schema(childNode ?? assert.fail("No child"));
+		assert.equal(aSchema, A);
+	});
+
+	it("compatibility", () => {
+		// Test schema compatibility for an example schema using extensibleSchemaUnion.
+		const currentViewSchema = new TreeViewConfiguration({
+			schema: ExtensibleSchemaUnion.extensibleSchemaUnion(
+				[SchemaFactoryBeta.number, SchemaFactoryBeta.string],
+				new SchemaFactoryBeta("extensibleSchemaUnion-example"),
+				"ExtensibleUnion",
+			),
+		});
+		testSchemaCompatibilitySnapshots(
+			currentViewSchema,
+			"2.82.0",
+			"extensibleSchemaUnion-example",
+		);
+	});
+
+	it("compatibility over time", () => {
+		// Test schema compatibility for an example schema using extensibleSchemaUnion.
+		const currentViewSchema = new TreeViewConfiguration({
+			schema: ExtensibleSchemaUnion.extensibleSchemaUnion(
+				[SchemaFactoryBeta.number, SchemaFactoryBeta.string],
+				new SchemaFactoryBeta("extensibleSchemaUnion-example"),
+				"ExtensibleUnion",
+			),
+		});
+		testSchemaCompatibilitySnapshots(
+			currentViewSchema,
+			"2.82.0",
+			"extensibleSchemaUnion-example",
+		);
+	});
+
+	it("workflow over time", () => {
+		const snapshotDirectory = "dir";
+		const [fileSystem, snapshots] = mapFileSystem();
+
+		const factory = new SchemaFactoryBeta("test");
+
+		class A extends factory.object("A", {}) {}
+		class B extends factory.object("B", {}) {}
+		class C extends factory.object("C", {}) {}
+
+		const a = ExtensibleSchemaUnion.extensibleSchemaUnion([A], factory, "ExtensibleUnion");
+
+		// Create the initial snapshot.
+		checkSchemaCompatibilitySnapshots({
+			version: "1.0.0",
+			schema: new TreeViewConfiguration({ schema: a }),
+			fileSystem,
+			minVersionForCollaboration: "1.0.0",
+			mode: "update",
+			snapshotDirectory,
+		});
+
+		const b = ExtensibleSchemaUnion.extensibleSchemaUnion([A, B], factory, "ExtensibleUnion");
+
+		checkSchemaCompatibilitySnapshots({
+			version: "2.0.0",
+			schema: new TreeViewConfiguration({ schema: b }),
+			fileSystem,
+			minVersionForCollaboration: "1.0.0",
+			mode: "update",
+			snapshotDirectory,
+		});
+
+		const c = ExtensibleSchemaUnion.extensibleSchemaUnion(
+			[A, B, C],
+			factory,
+			"ExtensibleUnion",
+		);
+
+		checkSchemaCompatibilitySnapshots({
+			version: "3.0.0",
+			schema: new TreeViewConfiguration({ schema: c }),
+			fileSystem,
+			minVersionForCollaboration: "1.0.0",
+			mode: "update",
+			snapshotDirectory,
+		});
+
+		// c is compatible to collaborate with 1 and 2.
+		checkSchemaCompatibilitySnapshots({
+			version: "3.0.0",
+			schema: new TreeViewConfiguration({ schema: c }),
+			fileSystem,
+			minVersionForCollaboration: "1.0.0",
+			mode: "test",
+			snapshotDirectory,
+		});
+	});
+});

--- a/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
+++ b/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
@@ -18,19 +18,23 @@ import { inMemorySnapshotFileSystem } from "./utils.js";
 
 describe("extensibleSchemaUnion", () => {
 	it("examples", () => {
-		const sf = new SchemaFactoryBeta("extensibleSchemaUnionExample");
-		class A extends sf.object("A", { x: sf.string }) {}
-		class B extends sf.object("B", { x: sf.number }) {}
+		const sf = new SchemaFactoryBeta("extensibleSchemaUnionExample.items");
+		class ItemA extends sf.object("A", { x: sf.string }) {}
+		class ItemB extends sf.object("B", { x: sf.number }) {}
 
-		class AnyPage extends ExtensibleSchemaUnion.extensibleSchemaUnion(
-			[A, B],
+		class AnyItem extends ExtensibleSchemaUnion.extensibleSchemaUnion(
+			[ItemA, ItemB], // Future versions may add more members here
 			sf,
 			"ExtensibleUnion",
 		) {}
-		const aNode = AnyPage.create(new A({ x: "hello" }));
-		const childNode: A | B | undefined = aNode.child;
+		// Instances of the union are created using `create`.
+		const anyItem = AnyItem.create(new ItemA({ x: "hello" }));
+		// Reacting the content our of the union is done via `child`,
+		// which can be `undefined` to handle the case where a future version of this schema allows a type unknown to the current version.
+		const childNode: ItemA | ItemB | undefined = anyItem.child;
+		// To determine which member of the union was present, its schema can be inspected:
 		const aSchema = Tree.schema(childNode ?? assert.fail("No child"));
-		assert.equal(aSchema, A);
+		assert.equal(aSchema, ItemA);
 	});
 
 	// Test that this packages doesn't make any schema changes.

--- a/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
+++ b/packages/dds/tree/src/test/extensibleSchemaUnion.spec.ts
@@ -29,7 +29,7 @@ describe("extensibleSchemaUnion", () => {
 		) {}
 		// Instances of the union are created using `create`.
 		const anyItem = AnyItem.create(new ItemA({ x: "hello" }));
-		// Reacting the content our of the union is done via `child`,
+		// Reading the content from the union is done via `child`,
 		// which can be `undefined` to handle the case where a future version of this schema allows a type unknown to the current version.
 		const childNode: ItemA | ItemB | undefined = anyItem.child;
 		// To determine which member of the union was present, its schema can be inspected:

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -34,6 +34,7 @@ import {
 	allowUnused,
 } from "../../../simple-tree/index.js";
 import { testSrcPath } from "../../testSrcPath.cjs";
+import { mapFileSystem } from "../../utils.js";
 
 const nodeFileSystem = {
 	...fs,
@@ -280,31 +281,6 @@ describe("snapshotCompatibilityChecker", () => {
 				snapshotDirectory,
 			});
 		});
-
-		/**
-		 * Trivial in-memory file system for testing.
-		 * Ignores the directory and stores files by filename.
-		 */
-		function mapFileSystem(): [SnapshotFileSystem, Map<string, string>] {
-			const snapshots = new Map<string, string>();
-
-			const fileSystem: SnapshotFileSystem = {
-				writeFileSync(file: string, data: string, options: { encoding: "utf8" }): void {
-					snapshots.set(file, data);
-				},
-				readFileSync(file: string, encoding: "utf8"): string {
-					return snapshots.get(file) ?? assert.fail(`File not found: ${file}`);
-				},
-				mkdirSync(dir: string, options: { recursive: true }): void {},
-				readdirSync(dir: string): readonly string[] {
-					return [...snapshots.keys()];
-				},
-				join(parentPath: string, childPath: string): string {
-					return childPath;
-				},
-			};
-			return [fileSystem, snapshots];
-		}
 
 		// Tests the various operations a user of the checkSchemaCompatibilitySnapshots function might perform across various versions of their codebase.
 		it("workflow over time", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -34,7 +34,7 @@ import {
 	allowUnused,
 } from "../../../simple-tree/index.js";
 import { testSrcPath } from "../../testSrcPath.cjs";
-import { mapFileSystem } from "../../utils.js";
+import { inMemorySnapshotFileSystem } from "../../utils.js";
 
 const nodeFileSystem = {
 	...fs,
@@ -285,7 +285,7 @@ describe("snapshotCompatibilityChecker", () => {
 		// Tests the various operations a user of the checkSchemaCompatibilitySnapshots function might perform across various versions of their codebase.
 		it("workflow over time", () => {
 			const snapshotDirectory = "dir";
-			const [fileSystem, snapshots] = mapFileSystem();
+			const [fileSystem, snapshots] = inMemorySnapshotFileSystem();
 
 			const factory = new SchemaFactoryBeta("test");
 
@@ -516,7 +516,7 @@ describe("snapshotCompatibilityChecker", () => {
 
 		it("invalid versions", () => {
 			const snapshotDirectory = "dir";
-			const [fileSystem] = mapFileSystem();
+			const [fileSystem] = inMemorySnapshotFileSystem();
 
 			assert.throws(
 				() =>

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -152,7 +152,7 @@ assert(existsSync(schemaCompatibilitySnapshotsFolder));
  * This is used to select the subdirectory within {@link schemaCompatibilitySnapshotsFolder} to use for snapshots.
  * @param forceUpdate - If true, forces updating snapshots even if not in regenerate mode.
  * Handy when initially writing a test to generate the snapshots.
- * This fails the test to ensure its never checked in unnoticed.
+ * This fails the test to ensure it's never checked in unnoticed.
  * @remarks
  * Snapshots are stored in a subdirectory of {@link schemaCompatibilitySnapshotsFolder} based on the provided `domainName`.
  */

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -146,6 +146,13 @@ assert(existsSync(schemaCompatibilitySnapshotsFolder));
 
 /**
  * Test schema snapshots for shared tree components which are part of this package.
+ * @param currentViewSchema - The current schema to test.
+ * @param minVersionForCollaboration - The minimum version which is required to be able to collaborate with `currentViewSchema`.
+ * @param domainName - The name of the domain for which snapshots are being tested.
+ * This is used to select the subdirectory within {@link schemaCompatibilitySnapshotsFolder} to use for snapshots.
+ * @param forceUpdate - If true, forces updating snapshots even if not in regenerate mode.
+ * Handy when initially writing a test to generate the snapshots.
+ * This fails the test to ensure its never checked in unnoticed.
  * @remarks
  * Snapshots are stored in a subdirectory of {@link schemaCompatibilitySnapshotsFolder} based on the provided `domainName`.
  */
@@ -153,6 +160,7 @@ export function testSchemaCompatibilitySnapshots(
 	currentViewSchema: TreeViewConfiguration,
 	minVersionForCollaboration: MinimumVersionForCollab,
 	domainName: string,
+	forceUpdate: boolean = false,
 ): void {
 	const snapshotDirectory = path.join(schemaCompatibilitySnapshotsFolder, domainName);
 	checkSchemaCompatibilitySnapshots({
@@ -161,6 +169,10 @@ export function testSchemaCompatibilitySnapshots(
 		version: cleanedPackageVersion,
 		schema: currentViewSchema,
 		minVersionForCollaboration,
-		mode: regenerateSnapshots ? "update" : "test",
+		mode: regenerateSnapshots || forceUpdate ? "update" : "test",
 	});
+	assert(
+		forceUpdate === false,
+		"Forcing update of schema compatibility snapshots should not be checked in.",
+	);
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1685,10 +1685,12 @@ export function treeChunkFromCursor(fieldCursor: ITreeCursorSynchronous): TreeCh
 }
 
 /**
- * Trivial in-memory file system for testing.
- * Ignores the directory and stores files by filename.
+ * Create a trivial in-memory {@link SnapshotFileSystem} for testing.
+ * Ignores the directory and stores files by filename in a map.
+ * @remarks
+ * This is useful for testing how schema compatibility changes over time (using {@link testSchemaCompatibilitySnapshots} when making specific schema changes.
  */
-export function mapFileSystem(): [SnapshotFileSystem, Map<string, string>] {
+export function inMemorySnapshotFileSystem(): [SnapshotFileSystem, Map<string, string>] {
 	const snapshots = new Map<string, string>();
 
 	const fileSystem: SnapshotFileSystem = {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -190,6 +190,7 @@ import {
 	restrictiveStoredSchemaGenerationOptions,
 	toInitialSchema,
 	toStoredSchema,
+	type SnapshotFileSystem,
 } from "../simple-tree/index.js";
 import {
 	configuredSharedTree,
@@ -1681,4 +1682,29 @@ export function treeChunkFromCursor(fieldCursor: ITreeCursorSynchronous): TreeCh
 		policy: defaultChunkPolicy,
 		idCompressor: testIdCompressor,
 	});
+}
+
+/**
+ * Trivial in-memory file system for testing.
+ * Ignores the directory and stores files by filename.
+ */
+export function mapFileSystem(): [SnapshotFileSystem, Map<string, string>] {
+	const snapshots = new Map<string, string>();
+
+	const fileSystem: SnapshotFileSystem = {
+		writeFileSync(file: string, data: string, options: { encoding: "utf8" }): void {
+			snapshots.set(file, data);
+		},
+		readFileSync(file: string, encoding: "utf8"): string {
+			return snapshots.get(file) ?? assert.fail(`File not found: ${file}`);
+		},
+		mkdirSync(dir: string, options: { recursive: true }): void {},
+		readdirSync(dir: string): readonly string[] {
+			return [...snapshots.keys()];
+		},
+		join(parentPath: string, childPath: string): string {
+			return childPath;
+		},
+	};
+	return [fileSystem, snapshots];
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -328,11 +328,9 @@ export function exportCompatibilitySchemaSnapshot(config: Pick<TreeViewConfigura
 export namespace ExtensibleSchemaUnion {
     export function extensibleSchemaUnion<const T extends readonly TreeNodeSchema[], const TScope extends string, const TName extends string>(types: T, inputSchemaFactory: SchemaFactoryBeta<TScope>, name: TName): Statics<T> & TreeNodeSchemaCore_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, false, unknown, never, unknown> & (new (data: InternalTreeNode_2) => Members<TreeNodeFromImplicitAllowedTypes<T>> & TreeNode_2 & WithType_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, unknown>);
     export interface Members<T> {
-        // (undocumented)
         readonly child: T | undefined;
     }
     export interface Statics<T extends readonly TreeNodeSchema[]> {
-        // (undocumented)
         create<TThis extends TreeNodeSchema>(this: TThis, child: TreeNodeFromImplicitAllowedTypes<T>): TreeFieldFromImplicitField<TThis>;
     }
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -324,6 +324,19 @@ export function evaluateLazySchema<T extends TreeNodeSchema>(value: LazyItem<T>)
 // @alpha
 export function exportCompatibilitySchemaSnapshot(config: Pick<TreeViewConfiguration, "schema">): JsonCompatibleReadOnly;
 
+// @alpha
+export namespace ExtensibleSchemaUnion {
+    export function extensibleSchemaUnion<const T extends readonly TreeNodeSchema[], const TScope extends string, const TName extends string>(types: T, inputSchemaFactory: SchemaFactoryBeta<TScope>, name: TName): Statics<T> & TreeNodeSchemaCore_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, false, unknown, never, unknown> & (new (data: InternalTreeNode_2) => Members<TreeNodeFromImplicitAllowedTypes<T>> & TreeNode_2 & WithType_2<ScopedSchemaName_2<`com.fluidframework.extensibleSchemaUnion<${TScope}>`, TName>, NodeKind_2, unknown>);
+    export interface Members<T> {
+        // (undocumented)
+        readonly child: T | undefined;
+    }
+    export interface Statics<T extends readonly TreeNodeSchema[]> {
+        // (undocumented)
+        create<TThis extends TreeNodeSchema>(this: TThis, child: TreeNodeFromImplicitAllowedTypes<T>): TreeFieldFromImplicitField<TThis>;
+    }
+}
+
 // @public @system
 type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? Result : Item;
 


### PR DESCRIPTION
## Description

Adds an alpha feature for generating schema for extensible unions which support collab with future versions that add more members.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

