### PR TITLE
feat(tree): count deleted items in RangeMap

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/rangeMap.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/rangeMap.spec.ts
@@ -142,7 +142,8 @@ describe("RangeMap", () => {
 			const map = newRangeMap();
 
 			// Delete keys 3-6 from an empty map
-			map.delete(3, 4);
+			const deletedCount = map.delete(3, 4);
+			assert.equal(deletedCount, 0);
 
 			assert.deepEqual(map.entries(), []);
 		});
@@ -154,7 +155,8 @@ describe("RangeMap", () => {
 			map.set(2, 4, "a");
 
 			// Delete keys 3-6
-			map.delete(3, 4);
+			const deletedCount = map.delete(3, 4);
+			assert.equal(deletedCount, 3);
 
 			assert.deepEqual(map.entries(), [{ start: 2, length: 1, value: "a" }]);
 		});
@@ -172,7 +174,8 @@ describe("RangeMap", () => {
 			map.set(9, 4, "c");
 
 			// Delete keys 4-8
-			map.delete(4, 5);
+			const deletedCount = map.delete(4, 5);
+			assert.equal(deletedCount, 3);
 
 			assert.deepEqual(map.entries(), [
 				{ start: 2, length: 2, value: "a" },
@@ -190,7 +193,8 @@ describe("RangeMap", () => {
 			map.set(7, 3, "b");
 
 			// Delete keys 2-5
-			map.delete(2, 4);
+			const deletedCount = map.delete(2, 4);
+			assert.equal(deletedCount, 4);
 
 			assert.deepEqual(map.entries(), [{ start: 7, length: 3, value: "b" }]);
 		});
@@ -205,7 +209,8 @@ describe("RangeMap", () => {
 			map.set(7, 3, "b");
 
 			// Delete keys 4-6
-			map.delete(4, 3);
+			const deletedCount = map.delete(4, 3);
+			assert.equal(deletedCount, 2);
 
 			assert.deepEqual(map.entries(), [
 				{ start: 2, length: 2, value: "a" },
@@ -223,7 +228,8 @@ describe("RangeMap", () => {
 			map.set(7, 3, "b");
 
 			// Delete keys 5-8
-			map.delete(5, 4);
+			const deletedCount = map.delete(5, 4);
+			assert.equal(deletedCount, 3);
 
 			assert.deepEqual(map.entries(), [
 				{ start: 2, length: 3, value: "a" },
@@ -238,7 +244,8 @@ describe("RangeMap", () => {
 			map.set(2, 6, "a");
 
 			// Delete keys 4-6
-			map.delete(4, 3);
+			const deletedCount = map.delete(4, 3);
+			assert.equal(deletedCount, 3);
 
 			assert.deepEqual(map.entries(), [
 				{ start: 2, length: 2, value: "a" },

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -171,18 +171,22 @@ export class RangeMap<K, V> {
 	 *
 	 * @param start - The start of the range to delete (inclusive).
 	 * @param length - The length of the range to delete.
+	 * @returns The number of entries deleted.
 	 */
-	public delete(start: K, length: number): void {
+	public delete(start: K, length: number): number {
+		let deleteCount = 0;
 		const lastDeleteKey = this.offsetKey(start, length - 1);
 		for (const { start: key, length: entryLength, value } of this.getIntersectingEntries(
 			start,
 			length,
 		)) {
+			deleteCount += entryLength;
 			this.tree.delete(key);
 			const lengthBefore = this.subtractKeys(start, key);
 			if (lengthBefore > 0) {
 				// A portion of this entry comes before the deletion range, so we reinsert that portion.
 				this.tree.set(key, { length: lengthBefore, value });
+				deleteCount -= lengthBefore;
 			}
 
 			const lastEntryKey = this.offsetKey(key, entryLength - 1);
@@ -195,8 +199,10 @@ export class RangeMap<K, V> {
 					length: lengthAfter,
 					value: this.offsetValue(value, difference),
 				});
+				deleteCount -= lengthAfter;
 			}
 		}
+		return deleteCount;
 	}
 
 	public clone(): RangeMap<K, V> {

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -171,7 +171,7 @@ export class RangeMap<K, V> {
 	 *
 	 * @param start - The start of the range to delete (inclusive).
 	 * @param length - The length of the range to delete.
-	 * @returns The number of entries deleted.
+	 * @returns The number of keys/value pairs deleted (integer between 0 and `length`, inclusive).
 	 */
 	public delete(start: K, length: number): number {
 		let deleteCount = 0;


### PR DESCRIPTION
## Description

Makes the delete method on `RangeMap` return the number of deleted entries.
This is needed for a future PR that enables detach-attach edits.

## Breaking Changes

None