### PR TITLE
Add move support for unhydrated nodes

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -560,11 +560,6 @@ export class UnhydratedSequenceField
 		},
 		move: (sourceIndex, count, destIndex, source?): void => {
 			const sourceField = source ?? this;
-			for (let i = sourceIndex; i < sourceIndex + count; i++) {
-				const child = sourceField.children[i];
-				assert(child !== undefined, "Unexpected sparse array in move source");
-			}
-
 			if (sourceField === this) {
 				// Within-field move: do both operations in a single edit to emit only one event
 				this.edit((mapTrees) => {

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -1120,11 +1120,10 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 				);
 			}
 
-			// destinationField is unhydrated since we're in the else branch of isHydrated() check
-			if (!(destinationField instanceof UnhydratedSequenceField)) {
-				// This should never happen due to the isHydrated() check above
-				throw new UsageError("Expected unhydrated destination field");
-			}
+			assert(
+				destinationField instanceof UnhydratedSequenceField,
+				"destinationField should be unhydrated since we're in the else branch of isHydrated() check",
+			);
 
 			// Use native move which handles the operation atomically for within-field moves
 			// to ensure only a single event is emitted per affected field.

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -52,7 +52,6 @@ import {
 	createTreeNodeSchemaPrivateData,
 	type FlexContent,
 	type TreeNodeSchemaPrivateData,
-	withBufferedTreeEvents,
 	AnnotatedAllowedTypesInternal,
 } from "../../core/index.js";
 import {
@@ -1121,24 +1120,20 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 				);
 			}
 
-			// We implement move here via subsequent `remove` and `insert`.
-			// This is strictly an implementation detail and should not be observable by the user.
-			// TODO:AB#47457: Implement proper move support for unhydrated trees.
-			// As a temporary mitigation, we will pause tree events until both edits have been completed.
-			// That way, users will only see a single change event for the array instead of 2.
-			withBufferedTreeEvents(() => {
-				if (sourceField !== destinationField || destinationGap < sourceStart) {
-					destinationField.editor.insert(
-						destinationGap,
-						sourceField.editor.remove(sourceStart, movedCount),
-					);
-				} else if (destinationGap > sourceStart + movedCount) {
-					destinationField.editor.insert(
-						destinationGap - movedCount,
-						sourceField.editor.remove(sourceStart, movedCount),
-					);
-				}
-			});
+			// destinationField is unhydrated since we're in the else branch of isHydrated() check
+			if (!(destinationField instanceof UnhydratedSequenceField)) {
+				// This should never happen due to the isHydrated() check above
+				throw new UsageError("Expected unhydrated destination field");
+			}
+
+			// Use native move which handles the operation atomically for within-field moves
+			// to ensure only a single event is emitted per affected field.
+			destinationField.editor.move(
+				sourceStart,
+				movedCount,
+				destinationGap,
+				sourceField === destinationField ? undefined : sourceField,
+			);
 		}
 	}
 

--- a/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
@@ -179,5 +179,57 @@ describe("array move events", () => {
 				`treeChanged should fire exactly once, but fired ${treeChangedCount} times`,
 			);
 		});
+
+		it("cross-field move emits nodeChanged on both source and destination arrays", () => {
+			const MyParent = schemaFactory.object("myParent", {
+				array1: MyArray,
+				array2: MyArray,
+			});
+			const parent = init(MyParent, { array1: [1, 2, 3], array2: [4, 5] });
+
+			let array1NodeChangedCount = 0;
+			let array1TreeChangedCount = 0;
+			let array2NodeChangedCount = 0;
+			let array2TreeChangedCount = 0;
+
+			TreeBeta.on(parent.array1, "nodeChanged", () => {
+				array1NodeChangedCount++;
+			});
+			TreeBeta.on(parent.array1, "treeChanged", () => {
+				array1TreeChangedCount++;
+			});
+			TreeBeta.on(parent.array2, "nodeChanged", () => {
+				array2NodeChangedCount++;
+			});
+			TreeBeta.on(parent.array2, "treeChanged", () => {
+				array2TreeChangedCount++;
+			});
+
+			// Move element at index 0 from array2 to the end of array1
+			parent.array1.moveToEnd(0, parent.array2);
+
+			assert.deepEqual([...parent.array1], [1, 2, 3, 4]);
+			assert.deepEqual([...parent.array2], [5]);
+			assert.equal(
+				array1NodeChangedCount,
+				1,
+				`destination array nodeChanged should fire exactly once, but fired ${array1NodeChangedCount} times`,
+			);
+			assert.equal(
+				array1TreeChangedCount,
+				1,
+				`destination array treeChanged should fire exactly once, but fired ${array1TreeChangedCount} times`,
+			);
+			assert.equal(
+				array2NodeChangedCount,
+				1,
+				`source array nodeChanged should fire exactly once, but fired ${array2NodeChangedCount} times`,
+			);
+			assert.equal(
+				array2TreeChangedCount,
+				1,
+				`source array treeChanged should fire exactly once, but fired ${array2TreeChangedCount} times`,
+			);
+		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
@@ -144,3 +144,40 @@ describe("withBufferedTreeEvents", () => {
 		assert.equal(eventCounter, 1); // Only a single event should have been raised.
 	});
 });
+
+describe("array move events", () => {
+	const schemaFactory = new SchemaFactory("test");
+
+	describeHydration("move operations", (init) => {
+		const MyArray = schemaFactory.array("myArray", schemaFactory.number);
+
+		it("move within array emits single nodeChanged event", () => {
+			const myArray = init(MyArray, [1, 2, 3]);
+
+			let nodeChangedCount = 0;
+			let treeChangedCount = 0;
+
+			TreeBeta.on(myArray, "nodeChanged", () => {
+				nodeChangedCount++;
+			});
+			TreeBeta.on(myArray, "treeChanged", () => {
+				treeChangedCount++;
+			});
+
+			// Move element at index 0 to the end
+			myArray.moveToEnd(0);
+
+			assert.deepEqual([...myArray], [2, 3, 1]);
+			assert.equal(
+				nodeChangedCount,
+				1,
+				`nodeChanged should fire exactly once, but fired ${nodeChangedCount} times`,
+			);
+			assert.equal(
+				treeChangedCount,
+				1,
+				`treeChanged should fire exactly once, but fired ${treeChangedCount} times`,
+			);
+		});
+	});
+});

--- a/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
@@ -151,7 +151,7 @@ describe("array move events", () => {
 	describeHydration("move operations", (init) => {
 		const MyArray = schemaFactory.array("myArray", schemaFactory.number);
 
-		it("move within array emits single nodeChanged event", () => {
+		it("move within array", () => {
 			const myArray = init(MyArray, [1, 2, 3]);
 
 			let nodeChangedCount = 0;
@@ -180,7 +180,7 @@ describe("array move events", () => {
 			);
 		});
 
-		it("cross-field move emits nodeChanged on both source and destination arrays", () => {
+		it("cross-field move", () => {
 			const MyParent = schemaFactory.object("myParent", {
 				array1: MyArray,
 				array2: MyArray,


### PR DESCRIPTION
## Description

This PR adds support for native move operations for unhydrated nodes. This also allows us to no longer have to use `withBufferedTreeEvents` as a workaround for preventing events for moves triggering more than once.