### PR TITLE
Remove legacy handle workaround

### DIFF
--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -177,9 +177,7 @@ export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
  * Symbol which must only be used on an {@link (IFluidHandle:interface)}, and is used to identify such objects.
  *
  * @remarks
- * To narrow arbitrary objects to handles do not simply check for this symbol:
- * instead use {@link @fluidframework/runtime-utils#isFluidHandle} which has improved compatibility
- * with older implementations of handles that may exist due to dynamic code loading of older packages.
+ * To narrow arbitrary objects to handles one can check for this symbol or use {@link @fluidframework/runtime-utils#isFluidHandle}.
  *
  * @privateRemarks
  * Normally `Symbol` would be used here instead of `Symbol.for` since just using Symbol (and avoiding the global symbol registry) removes the risk of collision, which is the main point of using a symbol for this in the first place.

--- a/packages/runtime/runtime-utils/src/handles.ts
+++ b/packages/runtime/runtime-utils/src/handles.ts
@@ -98,21 +98,7 @@ export function encodeHandleForSerialization(handle: IFluidHandleInternal): ISer
 }
 
 /**
- * Setting to opt into compatibility with handles from before {@link fluidHandleSymbol} existed (Fluid Framework client 2.0.0-rc.3.0.0 and earlier).
- *
- * Some code which uses this library might dynamically load multiple versions of it,
- * as well as old or duplicated versions of packages which produce or implement handles.
- * To correctly interoperate with this old packages and object produced by them, the old in-memory format for handles, without the symbol, are explicitly supported.
- *
- * This setting mostly exists as a way to easily find any code that only exists to provide this compatibility and clarify how to remove that compatibility.
- * At some point this might be removed or turned into an actual configuration option, but for now its really just documentation.
- */
-const enableBackwardsCompatibility = true;
-
-/**
  * Check if a value is an {@link @fluidframework/core-interfaces#IFluidHandle}.
- * @remarks
- * Objects which have a field named `IFluidHandle` can in some cases produce a false positive.
  * @public
  */
 export function isFluidHandle(value: unknown): value is IFluidHandle {
@@ -120,20 +106,7 @@ export function isFluidHandle(value: unknown): value is IFluidHandle {
 	if (typeof value !== "object" || value === null) {
 		return false;
 	}
-	if (fluidHandleSymbol in value) {
-		return true;
-	}
-	// If enableBackwardsCompatibility, run check for FluidHandles predating use of fluidHandleSymbol.
-	if (enableBackwardsCompatibility && IFluidHandle in value) {
-		// Since this check can have false positives, make it a bit more robust by checking value[IFluidHandle][IFluidHandle]
-		// Type assertion is needed for backward compatibility with old FluidHandle format
-		const inner = value[IFluidHandle] as IFluidHandle;
-		if (typeof inner !== "object" || inner === null) {
-			return false;
-		}
-		return IFluidHandle in inner;
-	}
-	return false;
+	return fluidHandleSymbol in value;
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/handles.ts
+++ b/packages/runtime/runtime-utils/src/handles.ts
@@ -8,7 +8,7 @@ import type {
 	IContainerRuntimeInternal,
 } from "@fluidframework/container-runtime-definitions/internal";
 import type { IFluidHandleErased } from "@fluidframework/core-interfaces";
-import { IFluidHandle, fluidHandleSymbol } from "@fluidframework/core-interfaces";
+import { type IFluidHandle, fluidHandleSymbol } from "@fluidframework/core-interfaces";
 import type {
 	IFluidHandleInternal,
 	IFluidHandleInternalPayloadPending,
@@ -126,18 +126,14 @@ export function compareFluidHandles(a: IFluidHandle, b: IFluidHandle): boolean {
  * @legacy @beta
  */
 export function toFluidHandleInternal<T>(handle: IFluidHandle<T>): IFluidHandleInternal<T> {
-	if (!(fluidHandleSymbol in handle) || !(fluidHandleSymbol in handle[fluidHandleSymbol])) {
-		if (enableBackwardsCompatibility && IFluidHandle in handle) {
-			// Type assertion needed for backward compatibility with old handle format
-			return handle[IFluidHandle] as IFluidHandleInternal<T>;
-		}
-		throw new TypeError("Invalid IFluidHandle");
+	if (fluidHandleSymbol in handle) {
+		// This casts the IFluidHandleErased from the symbol instead of `handle` to ensure that if someone
+		// implements their own IFluidHandle in terms of an existing handle, it won't break anything.
+		// Type assertion is safe as fluidHandleSymbol is guaranteed to contain an IFluidHandleInternal
+		return handle[fluidHandleSymbol] as unknown as IFluidHandleInternal<T>;
 	}
 
-	// This casts the IFluidHandleErased from the symbol instead of `handle` to ensure that if someone
-	// implements their own IFluidHandle in terms of an existing handle, it won't break anything.
-	// Type assertion is safe as fluidHandleSymbol is guaranteed to contain an IFluidHandleInternal
-	return handle[fluidHandleSymbol] as unknown as IFluidHandleInternal<T>;
+	throw new TypeError("Invalid IFluidHandle");
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/test/handles.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/handles.spec.ts
@@ -11,28 +11,26 @@ import { fluidHandleSymbol, type IFluidHandle } from "@fluidframework/core-inter
 import { isFluidHandle, lookupTemporaryBlobStorageId } from "../handles.js";
 
 describe("Handles", () => {
-	it("encodeCompactIdToString() with strings", () => {
-		it("isFluidHandle", () => {
-			assert(!isFluidHandle(0));
-			assert(!isFluidHandle({}));
-			assert(!isFluidHandle(undefined));
-			// eslint-disable-next-line unicorn/no-null -- We want to explicitly test for null
-			assert(!isFluidHandle(null));
-			assert(!isFluidHandle([]));
-			assert(!isFluidHandle({ get: () => {} }));
-			assert(!isFluidHandle({ IFluidHandle: 5, get: () => {} }));
+	it("isFluidHandle", () => {
+		assert(!isFluidHandle(0));
+		assert(!isFluidHandle({}));
+		assert(!isFluidHandle(undefined));
+		// eslint-disable-next-line unicorn/no-null -- We want to explicitly test for null
+		assert(!isFluidHandle(null));
+		assert(!isFluidHandle([]));
+		assert(!isFluidHandle({ get: () => {} }));
+		assert(!isFluidHandle({ IFluidHandle: 5, get: () => {} }));
 
-			const loopy = { IFluidHandle: {} };
-			loopy.IFluidHandle = loopy;
-			assert(!isFluidHandle(loopy));
-			assert(!isFluidHandle({ IFluidHandle: 5 }));
-			assert(!isFluidHandle({ IFluidHandle: {} }));
-			// eslint-disable-next-line unicorn/no-null -- We want to explicitly test for null
-			assert(!isFluidHandle({ IFluidHandle: null }));
+		const loopy = { IFluidHandle: {} };
+		loopy.IFluidHandle = loopy;
+		assert(!isFluidHandle(loopy));
+		assert(!isFluidHandle({ IFluidHandle: 5 }));
+		assert(!isFluidHandle({ IFluidHandle: {} }));
+		// eslint-disable-next-line unicorn/no-null -- We want to explicitly test for null
+		assert(!isFluidHandle({ IFluidHandle: null }));
 
-			// Symbol based:
-			assert(isFluidHandle({ [fluidHandleSymbol]: {} }));
-		});
+		// Symbol based:
+		assert(isFluidHandle({ [fluidHandleSymbol]: {} }));
 	});
 
 	describe("lookupTemporaryBlobStorageId", () => {

--- a/packages/runtime/runtime-utils/src/test/handles.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/handles.spec.ts
@@ -22,10 +22,9 @@ describe("Handles", () => {
 			assert(!isFluidHandle({ get: () => {} }));
 			assert(!isFluidHandle({ IFluidHandle: 5, get: () => {} }));
 
-			// Legacy compatibility for non symbol based handle
 			const loopy = { IFluidHandle: {} };
 			loopy.IFluidHandle = loopy;
-			assert(isFluidHandle(loopy));
+			assert(!isFluidHandle(loopy));
 			assert(!isFluidHandle({ IFluidHandle: 5 }));
 			assert(!isFluidHandle({ IFluidHandle: {} }));
 			// eslint-disable-next-line unicorn/no-null -- We want to explicitly test for null


### PR DESCRIPTION
## Description

Since https://github.com/microsoft/FluidFramework/pull/20123 we have had a back compat workaround for handles which are using an in memory representation constructed from a version of the runtime from before that change to support applications which duplicate runtime package versions and mix objects from the different versions. Its been a year since then, and the support window for such use was 3 months, so it should be fine to remove this compatibility logic. This removal makes the code slightly smaller, faster and resistant false positives on handle detection.

## Breaking Change

Any code using isFLuidHandle after this change with handles creating using runtime code predating the above linked PR (which landed in 2.0.0-rc.4.0.0) will not detect them to be handles. Since 2.0.0-rc.3.0.0 and older runtimes are way out of support (except 1.x LTS, which is now allowed to be mixed in memory with current versions), and also way outside the 3 months allowed version skew, this should not impact anyone.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
