### PR TITLE
(compat) Logic to enable layer compatibility enforcement as per new policies

### DIFF
--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -92,9 +92,12 @@ Layer compatibility policy describes specific **support windows** between layers
 
 | Layer Boundary | Support Window | What This Means |
 | -------------- | -------------- | --------------- |
-| **Driver ↔ Loader** | 12 months | Driver and Loader remain compatible when up to 12 months apart |
-| **Loader ↔ Runtime** | 12 months | Loader and Runtime remain compatible when up to 12 months apart |
-| **Runtime ↔ DataStore** | 3 months | Runtime and DataStore remain compatible when up to 3 months apart |
+| **Driver → Loader** | 12 months | Driver is compatible with Loader versions up to 12 months older |
+| **Loader → Driver** | 3 months | Loader is compatible with Driver versions up to 3 months older |
+| **Loader → Runtime** | 3 months | Loader is compatible with Runtime versions up to 3 months older |
+| **Runtime → Loader** | 12 months | Runtime is compatible with Loader versions up to 12 months older |
+| **Runtime → DataStore** | 3 months | Runtime is compatible with DataStore versions up to 3 months older |
+| **DataStore → Runtime** | 3 months | DataStore is compatible with Runtime versions up to 3 months older |
 
 ### What This Means for An Application
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -103,6 +103,10 @@ Layer compatibility policy describes specific **support windows** between layers
 
 These support windows determine how much version drift is acceptable between layers in your application. Applications should use this to plan their upgrade strategy and ensure layers remain compatible. They should coordinate updates across repositories and deployment boundaries to stay within the support windows.
 
+### Enforcement
+
+These support windows are enforced through the compatibility validation system described in [Layer Boundaries and Validation](#layer-boundaries-and-validation) section. If any incompatibility is detected, an error will be thrown as described in the [Error Handling](#error-handling) section.
+
 ### Implementation Details
 
 These support windows are enforced through the compatibility validation system described in earlier sections. The specific policy values are defined in `LayerCompatibilityPolicyWindowMonths` in

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -84,6 +84,30 @@ When incompatibility is detected, an error of type `FluidErrorTypes.layerIncompa
 In all layer validations except at the Runtime ↔ DataStore boundary, the error causes the container to close. This prevents any potential data corruption that could occur from incompatible operations.
 In case of the Runtime ↔ DataStore boundary, the data store creation / load will fail to prevent corruption of the data store from incompatible operations. The container may also close, e.g. if the data store is created / loaded during container create / load.
 
+## Layer Compatibility Policy
+
+Layer compatibility policy describes specific **support windows** between layers to ensure reliable interoperability while allowing independent upgrades. These windows define how far apart (in months) two adjacent layers can be before they become incompatible.
+
+### Support Window by Layer Boundary
+
+| Layer Boundary | Support Window | What This Means |
+| -------------- | -------------- | --------------- |
+| **Driver → Loader** | 12 months | Driver can work with Loader versions up to 12 months older |
+| **Loader → Driver** | 6 months | Loader can work with Driver versions up to 6 months older |
+| **Loader → Runtime** | 6 months | Loader can work with Runtime versions up to 6 months older |
+| **Runtime → Loader** | 12 months | Runtime can work with Loader versions up to 12 months older |
+| **Runtime → DataStore** | 3 months | Runtime can work with DataStore versions up to 3 months older |
+| **DataStore → Runtime** | 3 months | DataStore can work with Runtime versions up to 3 months older |
+
+### What This Means for An Application
+
+These support windows determine how much version drift is acceptable between layers in your application. Applications should these windows to plan their upgrade strategy and ensure layers remain compatible. They should coordinate updates across repositories and deployment boundaries to stay within the support windows.
+
+### Implementation Details
+
+These support windows are enforced through the compatibility validation system described in earlier sections. The specific policy values are defined in `LayerCompatibilityPolicyWindowMonths` in
+[layerCompat.ts](./packages/common/client-utils/src/layerCompat.ts).
+
 ## The Four Layers
 
 ### 1. Driver Layer
@@ -102,7 +126,7 @@ In case of the Runtime ↔ DataStore boundary, the data store creation / load wi
 - Stream ops from ordering service
 - Implement service-specific protocols
 
-**Validated By:** Loader layer validates Driver compatibility
+**Validated By:** Loader layer
 
 ### 2. Loader Layer
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -92,12 +92,12 @@ Layer compatibility policy describes specific **support windows** between layers
 
 | Layer Boundary | Support Window | What This Means |
 | -------------- | -------------- | --------------- |
-| **Driver → Loader** | 12 months | Driver can work with Loader versions up to 12 months older |
-| **Loader → Driver** | 6 months | Loader can work with Driver versions up to 6 months older |
-| **Loader → Runtime** | 6 months | Loader can work with Runtime versions up to 6 months older |
-| **Runtime → Loader** | 12 months | Runtime can work with Loader versions up to 12 months older |
-| **Runtime → DataStore** | 3 months | Runtime can work with DataStore versions up to 3 months older |
-| **DataStore → Runtime** | 3 months | DataStore can work with Runtime versions up to 3 months older |
+| **Driver → Loader** | 12 months | Driver is compatible with Loader versions up to 12 months older |
+| **Loader → Driver** | 6 months | Loader is compatible with Driver versions up to 6 months older |
+| **Loader → Runtime** | 6 months | Loader is compatible with Runtime versions up to 6 months older |
+| **Runtime → Loader** | 12 months | Runtime is compatible with Loader versions up to 12 months older |
+| **Runtime → DataStore** | 3 months | Runtime is compatible with DataStore versions up to 3 months older |
+| **DataStore → Runtime** | 3 months | DataStore is compatible with Runtime versions up to 3 months older |
 
 ### What This Means for An Application
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -98,7 +98,7 @@ Layer compatibility policy describes specific **support windows** between layers
 
 ### What This Means for An Application
 
-These support windows determine how much version drift is acceptable between layers in your application. Applications should these windows to plan their upgrade strategy and ensure layers remain compatible. They should coordinate updates across repositories and deployment boundaries to stay within the support windows.
+These support windows determine how much version drift is acceptable between layers in your application. Applications should use this to plan their upgrade strategy and ensure layers remain compatible. They should coordinate updates across repositories and deployment boundaries to stay within the support windows.
 
 ### Implementation Details
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -94,8 +94,8 @@ Layer compatibility policy describes specific **support windows** between layers
 | -------------- | -------------- | --------------- |
 | **Driver → Loader** | 12 months | Driver is compatible with Loader versions up to 12 months older |
 | **Loader → Driver** | 3 months | Loader is compatible with Driver versions up to 3 months older |
-| **Loader → Runtime** | 3 months | Loader is compatible with Runtime versions up to 3 months older |
 | **Runtime → Loader** | 12 months | Runtime is compatible with Loader versions up to 12 months older |
+| **Loader → Runtime** | 3 months | Loader is compatible with Runtime versions up to 3 months older |
 | **Runtime → DataStore** | 3 months | Runtime is compatible with DataStore versions up to 3 months older |
 | **DataStore → Runtime** | 3 months | DataStore is compatible with Runtime versions up to 3 months older |
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -92,12 +92,9 @@ Layer compatibility policy describes specific **support windows** between layers
 
 | Layer Boundary | Support Window | What This Means |
 | -------------- | -------------- | --------------- |
-| **Driver → Loader** | 12 months | Driver is compatible with Loader versions up to 12 months older |
-| **Loader → Driver** | 6 months | Loader is compatible with Driver versions up to 6 months older |
-| **Loader → Runtime** | 6 months | Loader is compatible with Runtime versions up to 6 months older |
-| **Runtime → Loader** | 12 months | Runtime is compatible with Loader versions up to 12 months older |
-| **Runtime → DataStore** | 3 months | Runtime is compatible with DataStore versions up to 3 months older |
-| **DataStore → Runtime** | 3 months | DataStore is compatible with Runtime versions up to 3 months older |
+| **Driver ↔ Loader** | 12 months | Driver and Loader remain compatible when up to 12 months apart |
+| **Loader ↔ Runtime** | 12 months | Loader and Runtime remain compatible when up to 12 months apart |
+| **Runtime ↔ DataStore** | 3 months | Runtime and DataStore remain compatible when up to 3 months apart |
 
 ### What This Means for An Application
 

--- a/packages/common/client-utils/src/indexBrowser.ts
+++ b/packages/common/client-utils/src/indexBrowser.ts
@@ -35,5 +35,6 @@ export {
 	type ILayerCompatDetails,
 	type IProvideLayerCompatDetails,
 	type ILayerCompatSupportRequirements,
+	LayerCompatibilityPolicyWindowMonths,
 } from "./layerCompat.js";
 export { generation } from "./layerGenerationState.js";

--- a/packages/common/client-utils/src/indexNode.ts
+++ b/packages/common/client-utils/src/indexNode.ts
@@ -35,5 +35,6 @@ export {
 	type ILayerCompatDetails,
 	type IProvideLayerCompatDetails,
 	type ILayerCompatSupportRequirements,
+	LayerCompatibilityPolicyWindowMonths,
 } from "./layerCompat.js";
 export { generation } from "./layerGenerationState.js";

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -10,6 +10,42 @@
 export type FluidLayer = "loader" | "driver" | "runtime" | "dataStore";
 
 /**
+ * The policy for compatibility windows (in months) that a layer uses to validate compatibility with another layer.
+ * The other layer must be within this window relative to the layer to be compatible.
+ *
+ * IMPORTANT: When changing these policy values, update the documentation in "Layer Compatibility Policy" section of
+ * LayerCompatibility.md at the root of the repository.
+ *
+ * @internal
+ */
+export const LayerCompatibilityPolicyWindowMonths = {
+	/**
+	 * The Loader layer must be within this many months of the Driver layer to be compatible.
+	 */
+	DriverLoader: 12,
+	/**
+	 * The Driver layer must be within this many months of the Loader layer to be compatible.
+	 */
+	LoaderDriver: 6,
+	/**
+	 * The Runtime layer must be within this many months of the Loader layer to be compatible.
+	 */
+	LoaderRuntime: 6,
+	/**
+	 * The Loader layer must be within this many months of the Runtime layer to be compatible.
+	 */
+	RuntimeLoader: 12,
+	/**
+	 * The DataStore layer must be within this many months of the Runtime layer to be compatible.
+	 */
+	RuntimeDataStore: 3,
+	/**
+	 * The Runtime layer must be within this many months of the DataStore layer to be compatible.
+	 */
+	DataStoreRuntime: 3,
+} as const;
+
+/**
  * Result of a layer compatibility check - whether a layer is compatible with another layer.
  * @internal
  */

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -20,27 +20,27 @@ export type FluidLayer = "loader" | "driver" | "runtime" | "dataStore";
  */
 export const LayerCompatibilityPolicyWindowMonths = {
 	/**
-	 * The Driver layer supports Loader that is at most this many months older.
+	 * Driver is compatible with Loader versions up to 12 months older.
 	 */
 	DriverLoader: 12,
 	/**
-	 * The Loader layer supports Driver that is at most this many months older.
+	 * Loader is compatible with Driver versions up to 3 months older.
 	 */
-	LoaderDriver: 12,
+	LoaderDriver: 3,
 	/**
-	 * The Loader layer supports Runtime that is at most this many months older.
+	 * Loader is compatible with Runtime versions up to 3 months older.
 	 */
-	LoaderRuntime: 12,
+	LoaderRuntime: 3,
 	/**
-	 * The Runtime layer supports Loader that is at most this many months older.
+	 * Runtime is compatible with Loader versions up to 12 months older.
 	 */
 	RuntimeLoader: 12,
 	/**
-	 * The Runtime layer supports DataStore that is at most this many months older.
+	 * Runtime is compatible with DataStore versions up to 3 months older.
 	 */
 	RuntimeDataStore: 3,
 	/**
-	 * The DataStore layer supports Runtime that is at most this many months older.
+	 * DataStore is compatible with Runtime versions up to 3 months older.
 	 */
 	DataStoreRuntime: 3,
 } as const;

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -10,8 +10,11 @@
 export type FluidLayer = "loader" | "driver" | "runtime" | "dataStore";
 
 /**
- * The policy for compatibility windows (in months) that a layer uses to validate compatibility with another layer.
+ * The policy for compatibility windows that a layer uses to validate compatibility with another layer.
  * The other layer must be within this window relative to the layer to be compatible.
+ * Note that the policy is defined in terms of months, but the actual compatibility check is done using generations.
+ * Generations are updated every 1+ months depending on the release cadence so they are mostly 1-to-1 with months,
+ * but they are always higher than months since releases are not exactly every month.
  *
  * IMPORTANT: When changing these policy values, update the documentation in "Layer Compatibility Policy" section of
  * LayerCompatibility.md at the root of the repository.
@@ -20,27 +23,27 @@ export type FluidLayer = "loader" | "driver" | "runtime" | "dataStore";
  */
 export const LayerCompatibilityPolicyWindowMonths = {
 	/**
-	 * Driver is compatible with Loader versions up to 12 months older.
+	 * Driver is compatible with Loader versions up to 12 months (or generations) older.
 	 */
 	DriverLoader: 12,
 	/**
-	 * Loader is compatible with Driver versions up to 3 months older.
+	 * Loader is compatible with Driver versions up to 3 months (or generations) older.
 	 */
 	LoaderDriver: 3,
 	/**
-	 * Runtime is compatible with Loader versions up to 12 months older.
+	 * Runtime is compatible with Loader versions up to 12 months (or generations) older.
 	 */
 	RuntimeLoader: 12,
 	/**
-	 * Loader is compatible with Runtime versions up to 3 months older.
+	 * Loader is compatible with Runtime versions up to 3 months (or generations) older.
 	 */
 	LoaderRuntime: 3,
 	/**
-	 * Runtime is compatible with DataStore versions up to 3 months older.
+	 * Runtime is compatible with DataStore versions up to 3 months (or generations) older.
 	 */
 	RuntimeDataStore: 3,
 	/**
-	 * DataStore is compatible with Runtime versions up to 3 months older.
+	 * DataStore is compatible with Runtime versions up to 3 months (or generations) older.
 	 */
 	DataStoreRuntime: 3,
 } as const;

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -26,11 +26,11 @@ export const LayerCompatibilityPolicyWindowMonths = {
 	/**
 	 * The Driver layer must be within this many months of the Loader layer to be compatible.
 	 */
-	LoaderDriver: 6,
+	LoaderDriver: 12,
 	/**
 	 * The Runtime layer must be within this many months of the Loader layer to be compatible.
 	 */
-	LoaderRuntime: 6,
+	LoaderRuntime: 12,
 	/**
 	 * The Loader layer must be within this many months of the Runtime layer to be compatible.
 	 */

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -28,13 +28,13 @@ export const LayerCompatibilityPolicyWindowMonths = {
 	 */
 	LoaderDriver: 3,
 	/**
-	 * Loader is compatible with Runtime versions up to 3 months older.
-	 */
-	LoaderRuntime: 3,
-	/**
 	 * Runtime is compatible with Loader versions up to 12 months older.
 	 */
 	RuntimeLoader: 12,
+	/**
+	 * Loader is compatible with Runtime versions up to 3 months older.
+	 */
+	LoaderRuntime: 3,
 	/**
 	 * Runtime is compatible with DataStore versions up to 3 months older.
 	 */

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -20,27 +20,27 @@ export type FluidLayer = "loader" | "driver" | "runtime" | "dataStore";
  */
 export const LayerCompatibilityPolicyWindowMonths = {
 	/**
-	 * The Loader layer must be within this many months of the Driver layer to be compatible.
+	 * The Driver layer supports Loader that is at most this many months older.
 	 */
 	DriverLoader: 12,
 	/**
-	 * The Driver layer must be within this many months of the Loader layer to be compatible.
+	 * The Loader layer supports Driver that is at most this many months older.
 	 */
 	LoaderDriver: 12,
 	/**
-	 * The Runtime layer must be within this many months of the Loader layer to be compatible.
+	 * The Loader layer supports Runtime that is at most this many months older.
 	 */
 	LoaderRuntime: 12,
 	/**
-	 * The Loader layer must be within this many months of the Runtime layer to be compatible.
+	 * The Runtime layer supports Loader that is at most this many months older.
 	 */
 	RuntimeLoader: 12,
 	/**
-	 * The DataStore layer must be within this many months of the Runtime layer to be compatible.
+	 * The Runtime layer supports DataStore that is at most this many months older.
 	 */
 	RuntimeDataStore: 3,
 	/**
-	 * The Runtime layer must be within this many months of the DataStore layer to be compatible.
+	 * The DataStore layer supports Runtime that is at most this many months older.
 	 */
 	DataStoreRuntime: 3,
 } as const;

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -5,6 +5,7 @@
 
 import {
 	generation,
+	LayerCompatibilityPolicyWindowMonths,
 	type ILayerCompatDetails,
 	type ILayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
@@ -29,7 +30,7 @@ export const loaderCoreCompatDetails = {
 	 * The current generation of the Loader layer.
 	 */
 	generation,
-};
+} as const;
 
 /**
  * Loader's compatibility details that is exposed to the Runtime layer.
@@ -49,10 +50,15 @@ export const loaderCompatDetailsForRuntime: ILayerCompatDetails = {
  */
 export const runtimeSupportRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
-	 * Minimum generation that Runtime must be at to be compatible with Loader. Note that 0 is used here for
-	 * Runtime layers before the introduction of the layer compatibility enforcement.
+	 * Minimum generation that Runtime must be at to be compatible with this Loader. This is calculated
+	 * based on the LayerCompatibilityPolicyWindowMonths.LoaderRuntime value which defines how many months old can
+	 * the Runtime layer be compared to the Loader layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
 	 */
-	minSupportedGeneration: 0,
+	minSupportedGeneration: Math.max(
+		0,
+		loaderCoreCompatDetails.generation - LayerCompatibilityPolicyWindowMonths.LoaderRuntime,
+	),
 	/**
 	 * The features that the Runtime must support to be compatible with Loader.
 	 */
@@ -65,10 +71,15 @@ export const runtimeSupportRequirementsForLoader: ILayerCompatSupportRequirement
  */
 export const driverSupportRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
-	 * Minimum generation that Driver must be at to be compatible with Loader. Note that 0 is used here for
-	 * Driver layers before the introduction of the layer compatibility enforcement.
+	 * Minimum generation that Driver must be at to be compatible with this Loader. This is calculated
+	 * based on the LayerCompatibilityPolicyWindowMonths.LoaderDriver value which defines how many months old can
+	 * the Driver layer be compared to the Loader layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
 	 */
-	minSupportedGeneration: 0,
+	minSupportedGeneration: Math.max(
+		0,
+		loaderCoreCompatDetails.generation - LayerCompatibilityPolicyWindowMonths.LoaderDriver,
+	),
 	/**
 	 * The features that the Driver must support to be compatible with Loader.
 	 */

--- a/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
+++ b/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
@@ -5,6 +5,7 @@
 
 import {
 	generation,
+	LayerCompatibilityPolicyWindowMonths,
 	type ILayerCompatDetails,
 	type ILayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
@@ -59,10 +60,15 @@ export const runtimeCompatDetailsForLoader: ILayerCompatDetails = {
  */
 export const loaderSupportRequirementsForRuntime: ILayerCompatSupportRequirements = {
 	/**
-	 * Minimum generation that Loader must be at to be compatible with Runtime. Note that 0 is used here so
-	 * that Loader layers before the introduction of the layer compatibility enforcement are compatible.
+	 * Minimum generation that Loader must be at to be compatible with this Runtime. This is calculated
+	 * based on the LayerCompatibilityPolicyWindowMonths.RuntimeLoader value which defines how many months old can
+	 * the Loader layer be compared to the Runtime layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
 	 */
-	minSupportedGeneration: 0,
+	minSupportedGeneration: Math.max(
+		0,
+		runtimeCoreCompatDetails.generation - LayerCompatibilityPolicyWindowMonths.RuntimeLoader,
+	),
 	/**
 	 * The features that the Loader must support to be compatible with Runtime.
 	 */
@@ -87,10 +93,16 @@ export const runtimeCompatDetailsForDataStore: ILayerCompatDetails = {
  */
 export const dataStoreSupportRequirementsForRuntime: ILayerCompatSupportRequirements = {
 	/**
-	 * Minimum generation that DataStore must be at to be compatible with Runtime. Note that 0 is used here so
-	 * that DataStore layers before the introduction of the layer compatibility enforcement are compatible.
+	 * Minimum generation that DataStore must be at to be compatible with this Runtime. This is calculated
+	 * based on the LayerCompatibilityPolicyWindowMonths.RuntimeDataStore value which defines how many months old can
+	 * the DataStore layer be compared to the Runtime layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
 	 */
-	minSupportedGeneration: 0,
+	minSupportedGeneration: Math.max(
+		0,
+		runtimeCoreCompatDetails.generation -
+			LayerCompatibilityPolicyWindowMonths.RuntimeDataStore,
+	),
 	/**
 	 * The features that the DataStore must support to be compatible with Runtime.
 	 */

--- a/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
+++ b/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
@@ -5,6 +5,7 @@
 
 import {
 	generation,
+	LayerCompatibilityPolicyWindowMonths,
 	type ILayerCompatDetails,
 	type ILayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
@@ -28,7 +29,7 @@ export const dataStoreCoreCompatDetails = {
 	 * The current generation of the DataStore layer.
 	 */
 	generation,
-};
+} as const;
 
 /**
  * DataStore's compatibility details that is exposed to the Runtime layer.
@@ -48,10 +49,16 @@ export const dataStoreCompatDetailsForRuntime: ILayerCompatDetails = {
  */
 export const runtimeSupportRequirementsForDataStore: ILayerCompatSupportRequirements = {
 	/**
-	 * Minimum generation that Runtime must be at to be compatible with DataStore. Note that 0 is used here so
-	 * that Runtime layers before the introduction of the layer compatibility enforcement are compatible.
+	 * Minimum generation that Runtime must be at to be compatible with this DataStore. This is calculated
+	 * based on the LayerCompatibilityPolicyWindowMonths.DataStoreRuntime value which defines how many months old can
+	 * the Runtime layer be compared to the DataStore layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
 	 */
-	minSupportedGeneration: 0,
+	minSupportedGeneration: Math.max(
+		0,
+		dataStoreCoreCompatDetails.generation -
+			LayerCompatibilityPolicyWindowMonths.DataStoreRuntime,
+	),
 	/**
 	 * The features that the Runtime must support to be compatible with DataStore.
 	 */


### PR DESCRIPTION
The policy of layer compatibility support across various layers is as per following:
| Layer Boundary | Support Window | What This Means |
| -------------- | -------------- | --------------- |
| **Driver → Loader** | 12 months | Driver is compatible with Loader versions up to 12 months older |
| **Loader → Driver** | 3 months | Loader is compatible with Driver versions up to 3 months older |
| **Runtime → Loader** | 12 months | Runtime is compatible with Loader versions up to 12 months older |
| **Loader → Runtime** | 3 months | Loader is compatible with Runtime versions up to 3 months older |
| **Runtime → DataStore** | 3 months | Runtime is compatible with DataStore versions up to 3 months older |
| **DataStore → Runtime** | 3 months | DataStore is compatible with Runtime versions up to 3 months older |


- Note that the `Loader ↔ Runtime` and `Driver ↔ Loader` validatations won't go into effect until September 2026 because the enforcement logic went in September 2025.
- This policy / support window has been added to a `LayerCompatibilityPolicyWindowMonths` const in `layerCompat.ts` file in `client-utils`.
- The validation logic at each layer boundary has been updated to use these values to determine a layer's  `minSupportedGeneration` for another layer.
- With this change, the process of updating generation and validating is fully automated and doesn't need to change manually. If the policy for a layer combination changes, only the `LayerCompatibilityPolicyWindowMonths` needs to be changed.
- There are existing tests that use the `minSupportedGeneration` value to validate layer compatibility and incompatibility so this PR doesn't need to add them.

[AB#51810](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/51810)