### PR TITLE
(test) Rename and update the LTS version used for compatibility testing

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -321,7 +321,6 @@ function genCompatConfig(versionDetails: {
  * The delta versions will be:
  * - N-1 and N-2, for "fast train" customers (i.e. \>=2.10.0 \<2.20.0, \>=2.20.0 \<2.30.0, etc.)
  * - N-1 and N-2, for "slow train" customers (i.e. ^1.0.0, ^2.0.0, etc.)
- * - OCV (Oldest Compatible Version)
  *
  * @remarks
  * Fast/slow trains refer to the different velocities that customers adopt new releases.
@@ -342,8 +341,6 @@ export const genCrossClientCompatConfig = (): CompatConfig[] => {
 	// We build a map of all the versions we want to test the current version against.
 	// The key is the version and the value is a string describing the delta from the current version.
 	// We will not add any versions below 1.0.0 (only >1.0.0 is supported by our cross-client compat policy).
-	// If there is a duplicate version (i.e. the N-1 public major version is the same as the OCV),
-	// then we will append the delta description to the existing delta description for that version.
 	const deltaVersions: Map<string, string> = new Map();
 
 	// N-1 and N-2 for "fast train" releases

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -63,13 +63,22 @@ export interface CompatConfig {
 	loadVersion?: string;
 }
 
-const defaultCompatVersions = {
+/**
+ * The default versions to be used for generating configurations for layer compat testing.
+ */
+const defaultVersionsForLayerCompat = {
 	// N and N - 1
 	currentVersionDeltas: [0, -1],
+	// This is the oldest compatible version (OCV) for Loader and Driver layers.
+	oldestCompatibleVersion: [resolveVersion("2.0.0-internal.5.4.2", false)],
+};
+
+/**
+ * The default versions to be used for generating configurations for cross-client compat testing.
+ */
+const defaultVersionsForCrossClientCompat = {
 	// N, N-1, and N-2 for cross-client compat
-	currentCrossClientVersionDeltas: [0, -1, -2],
-	// This is the oldest supported version (OSV) for Loader and Driver layers.
-	oldestSupportedVersions: [resolveVersion("2.0.0-internal.5.4.2", false)],
+	currentVersionDeltas: [0, -1, -2],
 };
 
 // This indicates the number of versions above 2.0.0.internal.1.y.z that we want to support for back compat.
@@ -155,16 +164,16 @@ function genConfig(compatVersion: number | string): CompatConfig[] {
 	];
 }
 
-const genOldestSupportedConfig = (compatVersion: number | string): CompatConfig[] => {
+const genOldestCompatibleConfig = (compatVersion: number | string): CompatConfig[] => {
 	return [
 		{
-			name: `compat OSV ${compatVersion} - old loader`,
+			name: `compat OCV ${compatVersion} - old loader`,
 			kind: CompatKind.Loader,
 			compatVersion,
 			loader: compatVersion,
 		},
 		{
-			name: `compat OSV ${compatVersion} - old loader + old driver`,
+			name: `compat OCV ${compatVersion} - old loader + old driver`,
 			kind: CompatKind.LoaderDriver,
 			compatVersion,
 			driver: compatVersion,
@@ -213,7 +222,7 @@ const getNumberOfVersionsToGoBack = (numOfVersionsAboveV2Int1: number = 0): numb
 	// We want to generate back compat configs for all of them because they are all considered major releases.
 	// RCs can be thought of as internal 9 through 13 for this purpose, so just add them.
 	const numOfInternalMajorsBeforePublic2dot0 = 8 + 5;
-	// This allows us to increase our oldest supported version (OSV) support for certain versions above
+	// This allows us to increase our oldest compatible version (OCV) support for certain versions above
 	// 2.0.0.internal.1.y.z, where we don't want to go that far.
 	return numOfInternalMajorsBeforePublic2dot0 - numOfVersionsAboveV2Int1;
 };
@@ -312,7 +321,7 @@ function genCompatConfig(versionDetails: {
  * The delta versions will be:
  * - N-1 and N-2, for "fast train" customers (i.e. \>=2.10.0 \<2.20.0, \>=2.20.0 \<2.30.0, etc.)
  * - N-1 and N-2, for "slow train" customers (i.e. ^1.0.0, ^2.0.0, etc.)
- * - OSV (Oldest Supported Version)
+ * - OCV (Oldest Compatible Version)
  *
  * @remarks
  * Fast/slow trains refer to the different velocities that customers adopt new releases.
@@ -333,12 +342,12 @@ export const genCrossClientCompatConfig = (): CompatConfig[] => {
 	// We build a map of all the versions we want to test the current version against.
 	// The key is the version and the value is a string describing the delta from the current version.
 	// We will not add any versions below 1.0.0 (only >1.0.0 is supported by our cross-client compat policy).
-	// If there is a duplicate version (i.e. the N-1 public major version is the same as the OSV),
+	// If there is a duplicate version (i.e. the N-1 public major version is the same as the OCV),
 	// then we will append the delta description to the existing delta description for that version.
 	const deltaVersions: Map<string, string> = new Map();
 
 	// N-1 and N-2 for "fast train" releases
-	defaultCompatVersions.currentCrossClientVersionDeltas
+	defaultVersionsForCrossClientCompat.currentVersionDeltas
 		.filter((delta) => delta !== 0) // skip current build
 		.forEach((delta) => {
 			const v = getRequestedVersion(pkgVersion, delta, false /* adjustMajorPublic */);
@@ -348,8 +357,8 @@ export const genCrossClientCompatConfig = (): CompatConfig[] => {
 		});
 
 	// N-1 and N-2 for "slow train" releases
-	// Note: We add these in a separate for loop to maintain the order of tests (minor, major, then OSV).
-	defaultCompatVersions.currentCrossClientVersionDeltas
+	// Note: We add these in a separate for loop to maintain the order of tests (minor, then major)
+	defaultVersionsForCrossClientCompat.currentVersionDeltas
 		.filter((delta) => delta !== 0) // skip current build
 		.forEach((delta) => {
 			const v = getRequestedVersion(pkgVersion, delta, true /* adjustMajorPublic */);
@@ -361,17 +370,6 @@ export const genCrossClientCompatConfig = (): CompatConfig[] => {
 				}
 			}
 		});
-
-	// Oldest supported versions
-	for (const v of defaultCompatVersions.oldestSupportedVersions) {
-		if (semver.gte(v, "1.0.0")) {
-			if (deltaVersions.has(v)) {
-				deltaVersions.set(v, `${deltaVersions.get(v)}/OSV`);
-			} else {
-				deltaVersions.set(v, "OSV");
-			}
-		}
-	}
 
 	// Build all combos of (current version, prior version) & (prior version, current version)
 	const configs: CompatConfig[] = [];
@@ -417,12 +415,12 @@ export const configList = new Lazy<readonly CompatConfig[]>(() => {
 
 	// CompatVersions is set via pipeline flags. If not set, use default scenarios.
 	if (!compatVersions || compatVersions.length === 0) {
-		// By default run currentVersionDeltas (N/N-1), OSV, and cross-client compat tests
-		defaultCompatVersions.currentVersionDeltas.forEach((value) => {
+		// By default run currentVersionDeltas (N/N-1), OCV, and cross-client compat tests
+		defaultVersionsForLayerCompat.currentVersionDeltas.forEach((value) => {
 			_configList.push(...genConfig(value));
 		});
-		defaultCompatVersions.oldestSupportedVersions.forEach((value) => {
-			_configList.push(...genOldestSupportedConfig(value));
+		defaultVersionsForLayerCompat.oldestCompatibleVersion.forEach((value) => {
+			_configList.push(...genOldestCompatibleConfig(value));
 		});
 		_configList.push(...genCrossClientCompatConfig());
 		// If fluid__test__backCompat=FULL is enabled, run full back compat tests
@@ -435,9 +433,9 @@ export const configList = new Lazy<readonly CompatConfig[]>(() => {
 	} else {
 		compatVersions.forEach((value) => {
 			switch (value) {
-				case "OSV": {
-					defaultCompatVersions.oldestSupportedVersions.forEach((osv) => {
-						_configList.push(...genOldestSupportedConfig(osv));
+				case "OCV": {
+					defaultVersionsForLayerCompat.oldestCompatibleVersion.forEach((ocv) => {
+						_configList.push(...genOldestCompatibleConfig(ocv));
 					});
 					break;
 				}

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -105,8 +105,8 @@ stages:
           flags: --compatVersion=0
         - name: N-1
           flags: --compatVersion=-1
-        - name: oldestSupportedVersion
-          flags: --compatVersion=OSV
+        - name: oldestCompatibleVersion
+          flags: --compatVersion=OCV
         - name: Cross-Client
           flags: --compatVersion=CROSS_CLIENT
       cacheCompatVersionsInstalls: true
@@ -146,8 +146,8 @@ stages:
           flags: --compatVersion=0
         - name: N-1
           flags: --compatVersion=-1
-        - name: oldestSupportedVersion
-          flags: --compatVersion=OSV
+        - name: oldestCompatibleVersion
+          flags: --compatVersion=OCV
         - name: Cross-Client
           flags: --compatVersion=CROSS_CLIENT
       cacheCompatVersionsInstalls: true

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -105,7 +105,7 @@ stages:
           flags: --compatVersion=0
         - name: N-1
           flags: --compatVersion=-1
-        - name: oldestCompatibleVersion
+        - name: Oldest-Compatible-Version
           flags: --compatVersion=OCV
         - name: Cross-Client
           flags: --compatVersion=CROSS_CLIENT
@@ -146,7 +146,7 @@ stages:
           flags: --compatVersion=0
         - name: N-1
           flags: --compatVersion=-1
-        - name: oldestCompatibleVersion
+        - name: Oldest-Compatible-Version
           flags: --compatVersion=OCV
         - name: Cross-Client
           flags: --compatVersion=CROSS_CLIENT

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -105,8 +105,8 @@ stages:
           flags: --compatVersion=0
         - name: N-1
           flags: --compatVersion=-1
-        - name: LTS
-          flags: --compatVersion=LTS
+        - name: oldestSupportedVersion
+          flags: --compatVersion=OSV
         - name: Cross-Client
           flags: --compatVersion=CROSS_CLIENT
       cacheCompatVersionsInstalls: true
@@ -146,8 +146,8 @@ stages:
           flags: --compatVersion=0
         - name: N-1
           flags: --compatVersion=-1
-        - name: LTS
-          flags: --compatVersion=LTS
+        - name: oldestSupportedVersion
+          flags: --compatVersion=OSV
         - name: Cross-Client
           flags: --compatVersion=CROSS_CLIENT
       cacheCompatVersionsInstalls: true


### PR DESCRIPTION
This PR does two things:
1. Renames the LTS versions used in tests to OSV - Oldest Supported Version. This should avoid confusing it with the LTS branch (and corresponding package version) that is supported. This is purely for testing and is used to determine which is the oldest version that we should be testing in compatibility mode.
2. Updates the OSV version to "2.0.0-internal.5.4.2". The latest data shows that this version is 100% saturated for runtime, 99.993% for driver and 99.997% for loader. This is enough saturation to move to testing this version as the oldest. Note that this does change what we support in code - it only changes what we test. These are separate as of now.