### PR TITLE
feat(eslint-plugin-fluid): Update `@fluid-internal/fluid/no-file-path-links-in-jsdoc` rule to allow file path links in `@privateRemarks` blocks

### DIFF
--- a/common/build/eslint-plugin-fluid/CHANGELOG.md
+++ b/common/build/eslint-plugin-fluid/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @fluidframework/eslint-plugin-fluid Changelog
 
+## [0.4.2](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.4.2)
+
+The `@fluid-internal/fluid/no-file-path-links-in-jsdoc` rule has been updated to allow file path links in `@privateRemarks` comment blocks, where they won't cause problems for generated API docs.
+
 ## [0.4.1](https://github.com/microsoft/FluidFramework/releases/tag/eslint-plugin-fluid_v0.4.1)
 
 Fixes false positives in the following rules:

--- a/common/build/eslint-plugin-fluid/package.json
+++ b/common/build/eslint-plugin-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/eslint-plugin-fluid",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Custom ESLint rules for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+//@ts-check
 /**
  * File path links are not portable in the context of JSDoc/TSDoc comments.
  * For this reason, we disallow them in favor of links to stable, user-accessible resources (like GitHub URLs).
@@ -10,6 +11,64 @@
  *
  * @remarks
  * Our separate rule, `no-markdown-links-in-jsdoc`, disallows Markdown link syntax in JSDoc/TSDoc comments.
+ * File path links are allowed in `@privateRemarks` blocks since those are not part of the public API documentation.
+ *
+ * @typedef {import("eslint").Rule.RuleModule} RuleModule
+ * @typedef {import('@microsoft/tsdoc').DocNode} DocNode
+ * @typedef {import('@microsoft/tsdoc').DocPlainText} DocPlainText
+ *
+ * @typedef {{
+ * 	startIndex: number;
+ * 	endIndex: number;
+ * }} FilePathLinkMatch
+ */
+
+const { DocNodeKind, TSDocParser } = require("@microsoft/tsdoc");
+
+const parser = new TSDocParser();
+
+/**
+ * Extracts the text excerpt from a DocNode and searches for file path links.
+ * @param {DocNode} node - The doc node to extract text from.
+ * @returns {FilePathLinkMatch[]} The list of found file path links.
+ */
+function findFilePathLinks(node) {
+	const links = [];
+
+	// Recursively walk the node tree
+	function walk(currentNode) {
+		// Check if this node has an excerpt that we can extract text from
+		if (currentNode.excerpt) {
+			const textRange = currentNode.excerpt.getContainingTextRange();
+			const text = currentNode.excerpt.content.toString();
+
+			// JSDoc/TSDoc link syntax: {@link target|text} or {@link target}
+			// Find links where the `target` component is a file path (starts with `/`, `./`, or `../`)
+			const matches = text.matchAll(/{@link\s+(\/|\.\/|\.\.\/).*?}/g);
+			for (const match of matches) {
+				links.push({
+					startIndex: textRange.pos + match.index,
+					endIndex: textRange.pos + match.index + match[0].length,
+				});
+			}
+		}
+
+		// Recurse into child nodes
+		const childNodes = currentNode.getChildNodes();
+		for (const childNode of childNodes) {
+			walk(childNode);
+		}
+	}
+
+	walk(node);
+	return links;
+}
+
+/**
+ * Eslint rule to disallow file path link syntax in JSDoc/TSDoc comments.
+ * File path links are allowed in `@privateRemarks` blocks.
+ *
+ * @type {RuleModule}
  */
 module.exports = {
 	meta: {
@@ -32,27 +91,63 @@ module.exports = {
 				const sourceCode = context.getSourceCode();
 				const comments = sourceCode
 					.getAllComments()
-					// Filter to only JSDoc/TSDoc style block comments
+					// Filter to only JSDoc/TSDoc style block comments.
+					// `getAllComments` returns the body of the block comments only (i.e. without the leading `/*` and trailing `*/`).
+					// To filter only to JSDoc/TSDoc style comments (which start with `/**`), we check that the body starts with "*".
 					.filter((comment) => comment.type === "Block" && comment.value.startsWith("*"));
 
 				for (const comment of comments) {
-					// +2 for the leading "/*", which is omitted by `comment.value`, but included in `comment.range`.
-					const commentStartIndex = comment.range[0] + 2;
+					if (comment.range === undefined) {
+						continue;
+					}
 
-					// JSDoc/TSDoc link syntax: {@link target|text} or {@link target}
-					// Find links where the `target` component is a file path (starts with `/`, `./`, or `../`)
-					const matches = comment.value.matchAll(/{@link\s+(\/|\.\/|\.\.\/).*}/g);
-					for (const match of matches) {
-						const startIndex = commentStartIndex + match.index;
-						const endIndex = startIndex + match[0].length;
+					const commentStartIndex = comment.range[0];
 
-						context.report({
-							loc: {
-								start: sourceCode.getLocFromIndex(startIndex),
-								end: sourceCode.getLocFromIndex(endIndex),
-							},
-							messageId: "filePathLink",
-						});
+					// TSDoc parser requires the surrounding "/**" and "*/", but eslint strips those off in `comment.value`.
+					const parserContext = parser.parseString(`/**${comment.value}*/`);
+					const parsedComment = parserContext.docComment;
+
+					// Check all blocks except privateRemarks
+					const blocksToCheck = [
+						...parsedComment.customBlocks,
+						...parsedComment.seeBlocks,
+					];
+					if (parsedComment.remarksBlock) {
+						blocksToCheck.push(parsedComment.remarksBlock);
+					}
+					// Note: we intentionally skip parsedComment.privateRemarks to allow file path links there
+					if (parsedComment.deprecatedBlock) {
+						blocksToCheck.push(parsedComment.deprecatedBlock);
+					}
+					if (parsedComment.returnsBlock) {
+						blocksToCheck.push(parsedComment.returnsBlock);
+					}
+
+					/**
+					 * Checks the provided comment block for file path links and report eslint errors for them.
+					 * @param {DocNode} node - The comment block to check.
+					 * @returns {void}
+					 */
+					function checkCommentBlock(node) {
+						const links = findFilePathLinks(node);
+						for (const link of links) {
+							const startIndex = commentStartIndex + link.startIndex - 1;
+							const endIndex = commentStartIndex + link.endIndex - 1;
+
+							context.report({
+								loc: {
+									start: sourceCode.getLocFromIndex(startIndex),
+									end: sourceCode.getLocFromIndex(endIndex),
+								},
+								messageId: "filePathLink",
+							});
+						}
+					}
+
+					// Check summary section and all blocks (except privateRemarks)
+					checkCommentBlock(parsedComment.summarySection);
+					for (const block of blocksToCheck) {
+						checkCommentBlock(block.content);
 					}
 				}
 			},

--- a/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
@@ -25,7 +25,6 @@
  * }} TextRange
  */
 
-const { fail } = require("node:assert");
 const { DocNodeKind, TSDocParser } = require("@microsoft/tsdoc");
 const { getBlockComments } = require("./tsdoc-utils");
 

--- a/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-file-path-links-in-jsdoc.js
@@ -11,7 +11,7 @@
  *
  * @remarks
  * Our separate rule, `no-markdown-links-in-jsdoc`, disallows Markdown link syntax in JSDoc/TSDoc comments.
- * File path links are allowed in `@privateRemarks` blocks since those are not part of the public API documentation.
+ * File path links are allowed in `@privateRemarks` blocks since those do not show up in public API documentation.
  *
  * @typedef {import('@microsoft/tsdoc').DocExcerpt} DocExcerpt
  * @typedef {import('@microsoft/tsdoc').DocInlineTag} DocInlineTag

--- a/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-hyphen-after-jsdoc-tag.js
@@ -17,6 +17,7 @@
 
 const { fail } = require("node:assert");
 const { DocNodeKind, TSDocParser } = require("@microsoft/tsdoc");
+const { getBlockComments } = require("./tsdoc-utils");
 
 const parser = new TSDocParser();
 
@@ -106,22 +107,7 @@ const rule = {
 					const parserContext = parser.parseString(`/**${comment.value}*/`);
 					const parsedComment = parserContext.docComment;
 
-					const blocksToCheck = [
-						...parsedComment.customBlocks,
-						...parsedComment.seeBlocks,
-					];
-					if (parsedComment.remarksBlock) {
-						blocksToCheck.push(parsedComment.remarksBlock);
-					}
-					if (parsedComment.privateRemarks) {
-						blocksToCheck.push(parsedComment.privateRemarks);
-					}
-					if (parsedComment.deprecatedBlock) {
-						blocksToCheck.push(parsedComment.deprecatedBlock);
-					}
-					if (parsedComment.returnsBlock) {
-						blocksToCheck.push(parsedComment.returnsBlock);
-					}
+					const blocksToCheck = getBlockComments(parsedComment);
 
 					// Note: the TSDoc format makes it difficult to extract the range information for the block content specifically.
 					// Instead, we just report the range for the tag itself.

--- a/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-markdown-links-in-jsdoc.js
@@ -19,6 +19,7 @@
 
 const { fail } = require("node:assert");
 const { DocNodeKind, TSDocParser } = require("@microsoft/tsdoc");
+const { getBlockComments } = require("./tsdoc-utils");
 
 const parser = new TSDocParser();
 
@@ -115,22 +116,7 @@ const rule = {
 					const parserContext = parser.parseString(`/**${comment.value}*/`);
 					const parsedComment = parserContext.docComment;
 
-					const blocksToCheck = [
-						...parsedComment.customBlocks,
-						...parsedComment.seeBlocks,
-					];
-					if (parsedComment.remarksBlock) {
-						blocksToCheck.push(parsedComment.remarksBlock);
-					}
-					if (parsedComment.privateRemarks) {
-						blocksToCheck.push(parsedComment.privateRemarks);
-					}
-					if (parsedComment.deprecatedBlock) {
-						blocksToCheck.push(parsedComment.deprecatedBlock);
-					}
-					if (parsedComment.returnsBlock) {
-						blocksToCheck.push(parsedComment.returnsBlock);
-					}
+					const blocksToCheck = getBlockComments(parsedComment);
 
 					/**
 					 * Checks the provided comment block for Markdown-syntax links and report eslint errors for them.
@@ -151,9 +137,10 @@ const rule = {
 								messageId: "markdownLink",
 								fix(fixer) {
 									const trimmedText = link.linkText.trim();
-									const tsdocLink = trimmedText.length > 0
-										? `{@link ${link.linkTarget} | ${trimmedText}}`
-										: `{@link ${link.linkTarget}}`;
+									const tsdocLink =
+										trimmedText.length > 0
+											? `{@link ${link.linkTarget} | ${trimmedText}}`
+											: `{@link ${link.linkTarget}}`;
 									return fixer.replaceTextRange(
 										[startIndex, endIndex],
 										tsdocLink,

--- a/common/build/eslint-plugin-fluid/src/rules/tsdoc-utils.js
+++ b/common/build/eslint-plugin-fluid/src/rules/tsdoc-utils.js
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//@ts-check
+/**
+ * Utilities for working with TSDoc parsed comments.
+ *
+ * @typedef {import('@microsoft/tsdoc').DocBlock} DocBlock
+ * @typedef {import('@microsoft/tsdoc').DocComment} DocComment
+ * @typedef {import('@microsoft/tsdoc').DocNode} DocNode
+ */
+
+/**
+ * Options for getting block comments from a parsed TSDoc comment.
+ * @typedef {{
+ * 	exclude?: string[];
+ * }} GetBlockCommentsOptions
+ */
+
+/**
+ * Checks if a tag name should be excluded based on the exclude list.
+ * @param {string} tagName - The tag name to check (e.g., "@privateRemarks").
+ * @param {Set<string>} excludeSet - Set of normalized tag names to exclude.
+ * @returns {boolean} True if the tag should be excluded.
+ */
+function shouldExcludeTag(tagName, excludeSet) {
+	// Normalize to uppercase for case-insensitive comparison (TSDoc convention)
+	return excludeSet.has(tagName.toUpperCase());
+}
+
+/**
+ * Gets all block nodes from a parsed TSDoc comment that should be checked.
+ * @param {DocComment} parsedComment - The parsed TSDoc comment.
+ * @param {GetBlockCommentsOptions} [options] - Options for filtering blocks. Use `exclude` to specify tag names to exclude (e.g., ['@privateRemarks']).
+ * @returns {DocBlock[]} Array of block nodes to check.
+ */
+function getBlockComments(parsedComment, options = {}) {
+	const { exclude = [] } = options;
+	// Normalize exclude list to uppercase for case-insensitive comparison (TSDoc convention)
+	const excludeSet = new Set(exclude.map((tag) => tag.toUpperCase()));
+
+	const blocksToCheck = [];
+
+	// Filter customBlocks and seeBlocks based on their tag names
+	for (const block of parsedComment.customBlocks) {
+		if (!shouldExcludeTag(block.blockTag.tagName, excludeSet)) {
+			blocksToCheck.push(block);
+		}
+	}
+
+	for (const block of parsedComment.seeBlocks) {
+		if (!shouldExcludeTag(block.blockTag.tagName, excludeSet)) {
+			blocksToCheck.push(block);
+		}
+	}
+
+	// Check standard blocks
+	if (parsedComment.remarksBlock && !shouldExcludeTag("@remarks", excludeSet)) {
+		blocksToCheck.push(parsedComment.remarksBlock);
+	}
+	if (parsedComment.privateRemarks && !shouldExcludeTag("@privateRemarks", excludeSet)) {
+		blocksToCheck.push(parsedComment.privateRemarks);
+	}
+	if (parsedComment.deprecatedBlock && !shouldExcludeTag("@deprecated", excludeSet)) {
+		blocksToCheck.push(parsedComment.deprecatedBlock);
+	}
+	if (parsedComment.returnsBlock && !shouldExcludeTag("@returns", excludeSet)) {
+		blocksToCheck.push(parsedComment.returnsBlock);
+	}
+
+	return blocksToCheck;
+}
+
+module.exports = {
+	getBlockComments,
+};

--- a/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
@@ -69,8 +69,7 @@ describe(`Do not allow file path links in JSDoc/TSDoc comments (eslint ${eslintV
 		const result = await lintFile("test.ts");
 		// All errors should be from other blocks, not from @privateRemarks
 		const privateRemarksErrors = result.messages.filter(
-			(msg) =>
-				msg.line >= 29 && msg.line <= 34, // Lines with @privateRemarks block
+			(message) => message.line >= 29 && message.line <= 34, // Lines with @privateRemarks block
 		);
 		assert.strictEqual(
 			privateRemarksErrors.length,

--- a/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
@@ -64,17 +64,4 @@ describe(`Do not allow file path links in JSDoc/TSDoc comments (eslint ${eslintV
 		assert.strictEqual(error5.column, 31); // 1-based, inclusive
 		assert.strictEqual(error5.endColumn, 53); // 1-based, exclusive
 	});
-
-	it("Should not report errors for file path links in @privateRemarks", async function () {
-		const result = await lintFile("test.ts");
-		// All errors should be from other blocks, not from @privateRemarks
-		const privateRemarksErrors = result.messages.filter(
-			(message) => message.line >= 29 && message.line <= 34, // Lines with @privateRemarks block
-		);
-		assert.strictEqual(
-			privateRemarksErrors.length,
-			0,
-			"Should not report errors for file path links in @privateRemarks",
-		);
-	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
@@ -27,34 +27,55 @@ describe(`Do not allow file path links in JSDoc/TSDoc comments (eslint ${eslintV
 
 	it("Should report errors for file path links in block comments", async function () {
 		const result = await lintFile("test.ts");
-		assert.strictEqual(result.errorCount, 4);
+		assert.strictEqual(result.errorCount, 5);
 
-		// Error 1
+		// Error 1: Summary section with relative path
 		const error1 = result.messages[0];
 		assert.strictEqual(error1.message, expectedErrorMessage);
 		assert.strictEqual(error1.line, 10);
 		assert.strictEqual(error1.column, 56); // 1-based, inclusive
 		assert.strictEqual(error1.endColumn, 84); // 1-based, exclusive
 
-		// Error 2
+		// Error 2: Summary section with relative path
 		const error2 = result.messages[1];
 		assert.strictEqual(error2.message, expectedErrorMessage);
 		assert.strictEqual(error2.line, 11);
 		assert.strictEqual(error2.column, 17); // 1-based, inclusive
 		assert.strictEqual(error2.endColumn, 41); // 1-based, exclusive
 
-		// Error 3
+		// Error 3: Summary section with absolute path
 		const error3 = result.messages[2];
 		assert.strictEqual(error3.message, expectedErrorMessage);
 		assert.strictEqual(error3.line, 16);
 		assert.strictEqual(error3.column, 57); // 1-based, inclusive
 		assert.strictEqual(error3.endColumn, 84); // 1-based, exclusive
 
-		// Error 4
+		// Error 4: Summary section with absolute path
 		const error4 = result.messages[3];
 		assert.strictEqual(error4.message, expectedErrorMessage);
 		assert.strictEqual(error4.line, 17);
 		assert.strictEqual(error4.column, 17); // 1-based, inclusive
 		assert.strictEqual(error4.endColumn, 40); // 1-based, exclusive
+
+		// Error 5: @remarks block with file path link
+		const error5 = result.messages[4];
+		assert.strictEqual(error5.message, expectedErrorMessage);
+		assert.strictEqual(error5.line, 23);
+		assert.strictEqual(error5.column, 29); // 1-based, inclusive
+		assert.strictEqual(error5.endColumn, 53); // 1-based, exclusive
+	});
+
+	it("Should not report errors for file path links in @privateRemarks", async function () {
+		const result = await lintFile("test.ts");
+		// All errors should be from other blocks, not from @privateRemarks
+		const privateRemarksErrors = result.messages.filter(
+			(msg) =>
+				msg.line >= 29 && msg.line <= 34, // Lines with @privateRemarks block
+		);
+		assert.strictEqual(
+			privateRemarksErrors.length,
+			0,
+			"Should not report errors for file path links in @privateRemarks",
+		);
 	});
 });

--- a/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-file-path-links-in-jsdoc.test.js
@@ -60,8 +60,8 @@ describe(`Do not allow file path links in JSDoc/TSDoc comments (eslint ${eslintV
 		// Error 5: @remarks block with file path link
 		const error5 = result.messages[4];
 		assert.strictEqual(error5.message, expectedErrorMessage);
-		assert.strictEqual(error5.line, 23);
-		assert.strictEqual(error5.column, 29); // 1-based, inclusive
+		assert.strictEqual(error5.line, 24);
+		assert.strictEqual(error5.column, 31); // 1-based, inclusive
 		assert.strictEqual(error5.endColumn, 53); // 1-based, exclusive
 	});
 

--- a/common/build/eslint-plugin-fluid/src/test/test-cases/no-file-path-links-in-jsdoc/test.ts
+++ b/common/build/eslint-plugin-fluid/src/test/test-cases/no-file-path-links-in-jsdoc/test.ts
@@ -18,6 +18,13 @@ const tsdocCommentWithRelativePathLinks = "invalid";
  */
 const tsdocCommentWithAbsolutePathLinks = "invalid";
 
+/**
+ * TSDoc comment with file path link in @remarks block should be flagged.
+ * @remarks
+ * This has a file path link: {@link ./some/file.ts}.
+ */
+const tsdocCommentWithFilePathLinkInRemarks = "invalid";
+
 // #endregion
 
 // #region Valid cases
@@ -44,5 +51,21 @@ const blockCommentWithRelativePathLink = "valid";
 // Line comment should not be flagged.
 // Line comment with link using a file path: {@link /absolute-path}.
 const lineCommentWithFilePathLink = "valid";
+
+// TSDoc comment with file path link in @privateRemarks should be allowed.
+/**
+ * TSDoc comment with file path link in privateRemarks.
+ * @privateRemarks
+ * This has a file path link: {@link ./some/file.ts}.
+ * And another: {@link ../relative/path|text}.
+ */
+const tsdocCommentWithFilePathLinkInPrivateRemarks = "valid";
+
+// TSDoc comment with file path link only in @privateRemarks should be allowed.
+/**
+ * @privateRemarks
+ * File path links are OK here: {@link /absolute/path}.
+ */
+const tsdocCommentWithOnlyPrivateRemarks = "valid";
 
 // #endregion


### PR DESCRIPTION
Such links in `@privateRemarks` blocks won't affect API docs we published, and are not intended for end-user consumption, so including such links in that context is safe and potentially useful.

Also factors out some common TSDoc-parsing utilities to better share code between TSDoc-related rule implementations.