### PR TITLE
chore(lint): remove obsolete eslint-disable comments (devtools)

### DIFF
--- a/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
+++ b/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
@@ -33,7 +33,7 @@ import {
  * @sealed
  * @beta
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IDevtoolsLogger extends ITelemetryBaseLogger {}
 
 /**


### PR DESCRIPTION
## Summary

Remove obsolete `eslint-disable` comment from devtools-core package.


These rules correctly no longer trigger because the CLI and VSCode both use `projectService`

**CODEOWNERS:** @microsoft/fluid-cr-devtools

## Packages affected
- `@fluidframework/devtools-core`

Split from #26240