### PR TITLE
Updated `ITelemetryBaseLogger` comment and made minLogLevel readonly

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
@@ -298,7 +298,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -400,7 +400,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
@@ -387,7 +387,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.public.api.md
@@ -298,7 +298,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
@@ -298,7 +298,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -68,7 +68,7 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 
 /**
  * Interface to output telemetry events.
- * Implemented by hosting app / loader
+ * Implemented by hosting app / loader. The host should implement this interface but not directly call it.
  * @public
  */
 export interface ITelemetryBaseLogger {
@@ -83,7 +83,7 @@ export interface ITelemetryBaseLogger {
 	 * Minimum log level to be logged.
 	 * @defaultValue {@link (LogLevel:variable).default}
 	 */
-	minLogLevel?: LogLevel;
+	readonly minLogLevel?: LogLevel;
 }
 
 /**

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -89,7 +89,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
@@ -89,7 +89,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -89,7 +89,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -89,7 +89,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    readonly minLogLevel?: LogLevel;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 


### PR DESCRIPTION
## Description

Made more specific the comment for the `ITelemetryBaseLogger ` interface to ensure there's no misuse and changed the `minLogLevel` property to readonly to narrow the implementation requirements.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
