### PR TITLE
Skip odsp client stage

### DIFF
--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -82,6 +82,7 @@ stages:
     parameters:
       stageId: e2e_odsp_client_odsp_server
       stageDisplayName: e2e - odsp-client with ODSP service
+      condition: false
       poolBuild: Small-eastus2
       testPackage: ${{ variables.testOdspPackage }}
       testCommand: test:realsvc:odsp

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -82,6 +82,7 @@ stages:
     parameters:
       stageId: e2e_odsp_client_odsp_server
       stageDisplayName: e2e - odsp-client with ODSP service
+      # TODO: Remove condition to re-enable ODSP client tests. ADO#58239
       condition: false
       poolBuild: Small-eastus2
       testPackage: ${{ variables.testOdspPackage }}


### PR DESCRIPTION
The service client e2e tests for odsp client have been failing since December. MFA is required for this stage and the user accounts should be updated to account for this same. Till then, skipping the odsp client stage to avoid CI runs and alerts being fired for OCE.

[ADO#58239](https://dev.azure.com/fluidframework/internal/_workitems/edit/58239)

Test pipeline run skipping odsp client stage: https://dev.azure.com/fluidframework/internal/_build/results?buildId=376317&view=results