### PR TITLE
Remove config allowing binding handles while detached

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1215,14 +1215,6 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		}
 		const previousOptimisticLocalValue = this.getOptimisticValue(key);
 
-		const detachedBind =
-			this.mc.config.getBoolean("Fluid.Directory.AllowDetachedResolve") ?? false;
-		if (detachedBind) {
-			// Create a local value and serialize it.
-			// AB#47081: This will be removed once we can validate that it is no longer needed.
-			bindHandles(value, this.directory.handle);
-		}
-
 		// If we are not attached, don't submit the op.
 		if (!this.directory.isAttached()) {
 			this.sequencedStorageData.set(key, value);

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -27,7 +27,6 @@ import type { IFluidSerializer } from "@fluidframework/shared-object-base/intern
 import {
 	SharedObject,
 	ValueType,
-	bindHandles,
 	parseHandles,
 } from "@fluidframework/shared-object-base/internal";
 import {


### PR DESCRIPTION
Removes config added in #25286 that staged the removal of the call to bindHandles in directory after a passing integration pipeline run.

[AB#47081](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/47081)
