### PR TITLE
Remove skips on stashed ops forking test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2229,8 +2229,7 @@ describeCompat(
 				assert.strictEqual(counter1.value, incrementValue);
 			},
 		);
-		for(let i = 0; i < 20; i++) {
-		itExpects.only(
+		itExpects(
 			`Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)`,
 			[
 				// All containers close: contianer1, container2, container3
@@ -2251,9 +2250,6 @@ describeCompat(
 				},
 			],
 			async function () {
-				// if (provider.driver.type !== "local") {
-				// 	this.skip();
-				// }
 				const incrementValue = 3;
 				const pendingLocalState = await generatePendingState(
 					testContainerConfig_noSummarizer,
@@ -2364,7 +2360,6 @@ describeCompat(
 				);
 			},
 		);
-	}
 		itExpects(
 			`Single-Threaded Forks: Closes (ForkedContainerError) when hydrating twice and submitting in serial (via Counter DDS)`,
 			[

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2229,8 +2229,8 @@ describeCompat(
 				assert.strictEqual(counter1.value, incrementValue);
 			},
 		);
-
-		itExpects(
+		for(let i = 0; i < 20; i++) {
+		itExpects.only(
 			`Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)`,
 			[
 				// All containers close: contianer1, container2, container3
@@ -2251,9 +2251,9 @@ describeCompat(
 				},
 			],
 			async function () {
-				if (provider.driver.type !== "local") {
-					this.skip();
-				}
+				// if (provider.driver.type !== "local") {
+				// 	this.skip();
+				// }
 				const incrementValue = 3;
 				const pendingLocalState = await generatePendingState(
 					testContainerConfig_noSummarizer,
@@ -2263,7 +2263,7 @@ describeCompat(
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
 						// Include an ID Allocation op to get coverage of the special logic around these ops as well
 						// AB#26984: Actually don't, because the ID Compressor is hitting "Ranges finalized out of order" for this test
-						// getIdCompressor(counter)?.generateCompressedId();
+						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
 					},
 				);
@@ -2364,7 +2364,7 @@ describeCompat(
 				);
 			},
 		);
-
+	}
 		itExpects(
 			`Single-Threaded Forks: Closes (ForkedContainerError) when hydrating twice and submitting in serial (via Counter DDS)`,
 			[

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2229,6 +2229,7 @@ describeCompat(
 				assert.strictEqual(counter1.value, incrementValue);
 			},
 		);
+
 		itExpects(
 			`Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)`,
 			[
@@ -2258,7 +2259,6 @@ describeCompat(
 					async (c, d) => {
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
 						// Include an ID Allocation op to get coverage of the special logic around these ops as well
-						// AB#26984: Actually don't, because the ID Compressor is hitting "Ranges finalized out of order" for this test
 						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
 					},


### PR DESCRIPTION
I've been testing locally and running the e2e pipeline related test and have not been able to reproduce the issue. Enabling the test fully again. I'll be monitoring in case errors resurface.