### PR TITLE
fix(eslint-config-fluid): add tsconfigRootDir to all package eslint configs

### DIFF
--- a/azure/packages/azure-local-service/eslint.config.mts
+++ b/azure/packages/azure-local-service/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/azure/packages/azure-service-utils/eslint.config.mts
+++ b/azure/packages/azure-service-utils/eslint.config.mts
@@ -28,6 +28,13 @@ const config: Linter.Config[] = [
 			"unicorn/prevent-abbreviations": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/apps/blobs/eslint.config.mts
+++ b/examples/apps/blobs/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/apps/collaborative-textarea/eslint.config.mts
+++ b/examples/apps/collaborative-textarea/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/apps/contact-collection/eslint.config.mts
+++ b/examples/apps/contact-collection/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/apps/data-object-grid/eslint.config.mts
+++ b/examples/apps/data-object-grid/eslint.config.mts
@@ -17,6 +17,13 @@ const config: Linter.Config[] = [
 			"import-x/no-unassigned-import": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/apps/diceroller/eslint.config.mts
+++ b/examples/apps/diceroller/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/apps/presence-tracker/eslint.config.mts
+++ b/examples/apps/presence-tracker/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/unbound-method": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/apps/staging/eslint.config.mts
+++ b/examples/apps/staging/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/apps/task-selection/eslint.config.mts
+++ b/examples/apps/task-selection/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/apps/tree-cli-app/eslint.config.mts
+++ b/examples/apps/tree-cli-app/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...strict, ...sharedConfig];
+const config: Linter.Config[] = [
+	...strict,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/apps/tree-comparison/eslint.config.mts
+++ b/examples/apps/tree-comparison/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/benchmarks/bubblebench/baseline/eslint.config.mts
+++ b/examples/benchmarks/bubblebench/baseline/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/benchmarks/bubblebench/common/eslint.config.mts
+++ b/examples/benchmarks/bubblebench/common/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/benchmarks/bubblebench/experimental-tree/eslint.config.mts
+++ b/examples/benchmarks/bubblebench/experimental-tree/eslint.config.mts
@@ -22,6 +22,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/benchmarks/bubblebench/ot/eslint.config.mts
+++ b/examples/benchmarks/bubblebench/ot/eslint.config.mts
@@ -21,6 +21,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/benchmarks/bubblebench/shared-tree/eslint.config.mts
+++ b/examples/benchmarks/bubblebench/shared-tree/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/eslint.config.mts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"import-x/no-extraneous-dependencies": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/benchmarks/tablebench/eslint.config.mts
+++ b/examples/benchmarks/tablebench/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/unbound-method": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/client-logger/app-insights-logger/eslint.config.mts
+++ b/examples/client-logger/app-insights-logger/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/canvas/eslint.config.mts
+++ b/examples/data-objects/canvas/eslint.config.mts
@@ -21,6 +21,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/clicker/eslint.config.mts
+++ b/examples/data-objects/clicker/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/codemirror/eslint.config.mts
+++ b/examples/data-objects/codemirror/eslint.config.mts
@@ -20,6 +20,13 @@ const config: Linter.Config[] = [
 	{
 		ignores: ["*.spec.ts"],
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/inventory-app/eslint.config.mts
+++ b/examples/data-objects/inventory-app/eslint.config.mts
@@ -44,6 +44,13 @@ const config: Linter.Config[] = [
 			"react/prop-types": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/monaco/eslint.config.mts
+++ b/examples/data-objects/monaco/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"no-bitwise": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/multiview/constellation-model/eslint.config.mts
+++ b/examples/data-objects/multiview/constellation-model/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/multiview/constellation-view/eslint.config.mts
+++ b/examples/data-objects/multiview/constellation-view/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated, ...sharedConfig];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/multiview/container/eslint.config.mts
+++ b/examples/data-objects/multiview/container/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/multiview/coordinate-model/eslint.config.mts
+++ b/examples/data-objects/multiview/coordinate-model/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/multiview/interface/eslint.config.mts
+++ b/examples/data-objects/multiview/interface/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated, ...sharedConfig];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/multiview/plot-coordinate-view/eslint.config.mts
+++ b/examples/data-objects/multiview/plot-coordinate-view/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/multiview/slider-coordinate-view/eslint.config.mts
+++ b/examples/data-objects/multiview/slider-coordinate-view/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/multiview/triangle-view/eslint.config.mts
+++ b/examples/data-objects/multiview/triangle-view/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/data-objects/prosemirror/eslint.config.mts
+++ b/examples/data-objects/prosemirror/eslint.config.mts
@@ -23,6 +23,13 @@ const config: Linter.Config[] = [
 	{
 		ignores: ["*.spec.ts"],
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/smde/eslint.config.mts
+++ b/examples/data-objects/smde/eslint.config.mts
@@ -24,6 +24,13 @@ const config: Linter.Config[] = [
 	{
 		ignores: ["*.spec.ts"],
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/table-document/eslint.config.mts
+++ b/examples/data-objects/table-document/eslint.config.mts
@@ -18,6 +18,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/unbound-method": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/table-tree/eslint.config.mts
+++ b/examples/data-objects/table-tree/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/text-editor/eslint.config.mts
+++ b/examples/data-objects/text-editor/eslint.config.mts
@@ -44,6 +44,13 @@ const config: Linter.Config[] = [
 			"react/prop-types": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/todo/eslint.config.mts
+++ b/examples/data-objects/todo/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/data-objects/webflow/eslint.config.mts
+++ b/examples/data-objects/webflow/eslint.config.mts
@@ -41,6 +41,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/external-data/eslint.config.mts
+++ b/examples/external-data/eslint.config.mts
@@ -55,6 +55,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/service-clients/azure-client/external-controller/eslint.config.mts
+++ b/examples/service-clients/azure-client/external-controller/eslint.config.mts
@@ -17,6 +17,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/brace-style": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/service-clients/azure-client/todo-list/eslint.config.mts
+++ b/examples/service-clients/azure-client/todo-list/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"import-x/no-extraneous-dependencies": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/service-clients/odsp-client/shared-tree-demo/eslint.config.mts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/utils/bundle-size-tests/eslint.config.mts
+++ b/examples/utils/bundle-size-tests/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/utils/example-driver/eslint.config.mts
+++ b/examples/utils/example-driver/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/utils/example-utils/eslint.config.mts
+++ b/examples/utils/example-utils/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/utils/example-webpack-integration/eslint.config.mts
+++ b/examples/utils/example-webpack-integration/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/utils/import-testing/eslint.config.mts
+++ b/examples/utils/import-testing/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...strict, ...sharedConfig];
+const config: Linter.Config[] = [
+	...strict,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/utils/migration-tools/eslint.config.mts
+++ b/examples/utils/migration-tools/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/utils/webpack-fluid-loader/eslint.config.mts
+++ b/examples/utils/webpack-fluid-loader/eslint.config.mts
@@ -17,6 +17,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/version-migration/live-schema-upgrade/eslint.config.mts
+++ b/examples/version-migration/live-schema-upgrade/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated, ...sharedConfig];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/version-migration/same-container/eslint.config.mts
+++ b/examples/version-migration/same-container/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated, ...sharedConfig];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/version-migration/separate-container/eslint.config.mts
+++ b/examples/version-migration/separate-container/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/version-migration/tree-shim/eslint.config.mts
+++ b/examples/version-migration/tree-shim/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/examples/view-integration/container-views/eslint.config.mts
+++ b/examples/view-integration/container-views/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated, ...sharedConfig];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/view-integration/external-views/eslint.config.mts
+++ b/examples/view-integration/external-views/eslint.config.mts
@@ -7,6 +7,16 @@ import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 import sharedConfig from "../../eslint.config.data.mts";
 
-const config: Linter.Config[] = [...recommended, ...sharedConfig];
+const config: Linter.Config[] = [
+	...recommended,
+	...sharedConfig,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/examples/view-integration/view-framework-sampler/eslint.config.mts
+++ b/examples/view-integration/view-framework-sampler/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"react/no-deprecated": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/PropertyDDS/packages/property-changeset/eslint.config.mts
+++ b/experimental/PropertyDDS/packages/property-changeset/eslint.config.mts
@@ -61,6 +61,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/PropertyDDS/packages/property-common/eslint.config.mts
+++ b/experimental/PropertyDDS/packages/property-common/eslint.config.mts
@@ -22,6 +22,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/PropertyDDS/packages/property-dds/eslint.config.mts
+++ b/experimental/PropertyDDS/packages/property-dds/eslint.config.mts
@@ -22,6 +22,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/PropertyDDS/packages/property-properties/eslint.config.mts
+++ b/experimental/PropertyDDS/packages/property-properties/eslint.config.mts
@@ -67,6 +67,13 @@ const config: Linter.Config[] = [
 	{
 		ignores: ["src/index.d.ts"],
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/dds/ot/ot/eslint.config.mts
+++ b/experimental/dds/ot/ot/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/experimental/dds/ot/sharejs/json1/eslint.config.mts
+++ b/experimental/dds/ot/sharejs/json1/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/experimental/dds/sequence-deprecated/eslint.config.mts
+++ b/experimental/dds/sequence-deprecated/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/dds/tree/eslint.config.mts
+++ b/experimental/dds/tree/eslint.config.mts
@@ -37,6 +37,13 @@ const config: Linter.Config[] = [
 			'import-x/no-unused-modules': 'off',
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/framework/data-objects/eslint.config.mts
+++ b/experimental/framework/data-objects/eslint.config.mts
@@ -24,6 +24,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/experimental/framework/last-edited/eslint.config.mts
+++ b/experimental/framework/last-edited/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/common/client-utils/eslint.config.mts
+++ b/packages/common/client-utils/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/common/container-definitions/eslint.config.mts
+++ b/packages/common/container-definitions/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/common/core-interfaces/eslint.config.mts
+++ b/packages/common/core-interfaces/eslint.config.mts
@@ -41,6 +41,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/common/core-utils/eslint.config.mts
+++ b/packages/common/core-utils/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			"unicorn/consistent-function-scoping": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/common/driver-definitions/eslint.config.mts
+++ b/packages/common/driver-definitions/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/consistent-indexed-object-style": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/cell/eslint.config.mts
+++ b/packages/dds/cell/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"unicorn/numeric-separators-style": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/counter/eslint.config.mts
+++ b/packages/dds/counter/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/ink/eslint.config.mts
+++ b/packages/dds/ink/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/legacy-dds/eslint.config.mts
+++ b/packages/dds/legacy-dds/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/map/eslint.config.mts
+++ b/packages/dds/map/eslint.config.mts
@@ -22,6 +22,13 @@ const config: Linter.Config[] = [
 			"unicorn/prefer-module": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/matrix/eslint.config.mts
+++ b/packages/dds/matrix/eslint.config.mts
@@ -24,6 +24,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/merge-tree/eslint.config.mts
+++ b/packages/dds/merge-tree/eslint.config.mts
@@ -18,6 +18,13 @@ const config: Linter.Config[] = [
 			"unicorn/no-useless-spread": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/ordered-collection/eslint.config.mts
+++ b/packages/dds/ordered-collection/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/pact-map/eslint.config.mts
+++ b/packages/dds/pact-map/eslint.config.mts
@@ -19,6 +19,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/register-collection/eslint.config.mts
+++ b/packages/dds/register-collection/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/sequence/eslint.config.mts
+++ b/packages/dds/sequence/eslint.config.mts
@@ -17,6 +17,13 @@ const config: Linter.Config[] = [
 			"prefer-arrow-callback": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/shared-object-base/eslint.config.mts
+++ b/packages/dds/shared-object-base/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/shared-summary-block/eslint.config.mts
+++ b/packages/dds/shared-summary-block/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/dds/task-manager/eslint.config.mts
+++ b/packages/dds/task-manager/eslint.config.mts
@@ -19,6 +19,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/test-dds-utils/eslint.config.mts
+++ b/packages/dds/test-dds-utils/eslint.config.mts
@@ -20,6 +20,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -41,6 +41,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-unsafe-member-access": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/debugger/eslint.config.mts
+++ b/packages/drivers/debugger/eslint.config.mts
@@ -17,6 +17,13 @@ const config: Linter.Config[] = [
 			"no-inner-declarations": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/driver-base/eslint.config.mts
+++ b/packages/drivers/driver-base/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/driver-web-cache/eslint.config.mts
+++ b/packages/drivers/driver-web-cache/eslint.config.mts
@@ -18,6 +18,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/unbound-method": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/file-driver/eslint.config.mts
+++ b/packages/drivers/file-driver/eslint.config.mts
@@ -19,6 +19,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/local-driver/eslint.config.mts
+++ b/packages/drivers/local-driver/eslint.config.mts
@@ -24,6 +24,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/odsp-driver-definitions/eslint.config.mts
+++ b/packages/drivers/odsp-driver-definitions/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/drivers/odsp-driver/eslint.config.mts
+++ b/packages/drivers/odsp-driver/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			"unicorn/prefer-module": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/odsp-urlResolver/eslint.config.mts
+++ b/packages/drivers/odsp-urlResolver/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/replay-driver/eslint.config.mts
+++ b/packages/drivers/replay-driver/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/routerlicious-driver/eslint.config.mts
+++ b/packages/drivers/routerlicious-driver/eslint.config.mts
@@ -17,6 +17,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/unbound-method": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/routerlicious-urlResolver/eslint.config.mts
+++ b/packages/drivers/routerlicious-urlResolver/eslint.config.mts
@@ -35,6 +35,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/drivers/tinylicious-driver/eslint.config.mts
+++ b/packages/drivers/tinylicious-driver/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/agent-scheduler/eslint.config.mts
+++ b/packages/framework/agent-scheduler/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/aqueduct/eslint.config.mts
+++ b/packages/framework/aqueduct/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/attributor/eslint.config.mts
+++ b/packages/framework/attributor/eslint.config.mts
@@ -20,6 +20,13 @@ const config: Linter.Config[] = [
 			"unicorn/prefer-module": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/client-logger/app-insights-logger/eslint.config.mts
+++ b/packages/framework/client-logger/app-insights-logger/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/client-logger/fluid-telemetry/eslint.config.mts
+++ b/packages/framework/client-logger/fluid-telemetry/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/data-object-base/eslint.config.mts
+++ b/packages/framework/data-object-base/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/dds-interceptions/eslint.config.mts
+++ b/packages/framework/dds-interceptions/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/fluid-framework/eslint.config.mts
+++ b/packages/framework/fluid-framework/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/fluid-static/eslint.config.mts
+++ b/packages/framework/fluid-static/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/oldest-client-observer/eslint.config.mts
+++ b/packages/framework/oldest-client-observer/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/presence/eslint.config.mts
+++ b/packages/framework/presence/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/react/eslint.config.mts
+++ b/packages/framework/react/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/request-handler/eslint.config.mts
+++ b/packages/framework/request-handler/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/synthesize/eslint.config.mts
+++ b/packages/framework/synthesize/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/tree-agent-langchain/eslint.config.mts
+++ b/packages/framework/tree-agent-langchain/eslint.config.mts
@@ -47,6 +47,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/tree-agent-ses/eslint.config.mts
+++ b/packages/framework/tree-agent-ses/eslint.config.mts
@@ -47,6 +47,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/strict-boolean-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/tree-agent/eslint.config.mts
+++ b/packages/framework/tree-agent/eslint.config.mts
@@ -40,6 +40,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/framework/undo-redo/eslint.config.mts
+++ b/packages/framework/undo-redo/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/loader/container-loader/eslint.config.mts
+++ b/packages/loader/container-loader/eslint.config.mts
@@ -24,6 +24,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/loader/driver-utils/eslint.config.mts
+++ b/packages/loader/driver-utils/eslint.config.mts
@@ -21,6 +21,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/loader/test-loader-utils/eslint.config.mts
+++ b/packages/loader/test-loader-utils/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/runtime/container-runtime-definitions/eslint.config.mts
+++ b/packages/runtime/container-runtime-definitions/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/runtime/container-runtime/eslint.config.mts
+++ b/packages/runtime/container-runtime/eslint.config.mts
@@ -26,6 +26,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/runtime/datastore-definitions/eslint.config.mts
+++ b/packages/runtime/datastore-definitions/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/runtime/datastore/eslint.config.mts
+++ b/packages/runtime/datastore/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { recommended } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...recommended];
+const config: Linter.Config[] = [
+	...recommended,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/runtime/id-compressor/eslint.config.mts
+++ b/packages/runtime/id-compressor/eslint.config.mts
@@ -24,6 +24,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/runtime/runtime-definitions/eslint.config.mts
+++ b/packages/runtime/runtime-definitions/eslint.config.mts
@@ -12,6 +12,13 @@ const config: Linter.Config[] = [
 	{
 		ignores: ["test-d"],
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/runtime/runtime-utils/eslint.config.mts
+++ b/packages/runtime/runtime-utils/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/runtime/test-runtime-utils/eslint.config.mts
+++ b/packages/runtime/test-runtime-utils/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/service-clients/azure-client/eslint.config.mts
+++ b/packages/service-clients/azure-client/eslint.config.mts
@@ -33,6 +33,13 @@ const config: Linter.Config[] = [
 			"prefer-arrow-callback": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/service-clients/end-to-end-tests/azure-client/eslint.config.mts
+++ b/packages/service-clients/end-to-end-tests/azure-client/eslint.config.mts
@@ -65,6 +65,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/service-clients/end-to-end-tests/odsp-client/eslint.config.mts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/eslint.config.mts
@@ -46,6 +46,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/service-clients/odsp-client/eslint.config.mts
+++ b/packages/service-clients/odsp-client/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/service-clients/tinylicious-client/eslint.config.mts
+++ b/packages/service-clients/tinylicious-client/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"prefer-arrow-callback": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/functional-tests/eslint.config.mts
+++ b/packages/test/functional-tests/eslint.config.mts
@@ -19,6 +19,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/local-server-stress-tests/eslint.config.mts
+++ b/packages/test/local-server-stress-tests/eslint.config.mts
@@ -25,6 +25,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/local-server-tests/eslint.config.mts
+++ b/packages/test/local-server-tests/eslint.config.mts
@@ -32,6 +32,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/mocha-test-setup/eslint.config.mts
+++ b/packages/test/mocha-test-setup/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { minimalDeprecated } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...minimalDeprecated];
+const config: Linter.Config[] = [
+	...minimalDeprecated,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/test/snapshots/eslint.config.mts
+++ b/packages/test/snapshots/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/stochastic-test-utils/eslint.config.mts
+++ b/packages/test/stochastic-test-utils/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-driver-definitions/eslint.config.mts
+++ b/packages/test/test-driver-definitions/eslint.config.mts
@@ -12,6 +12,13 @@ const config: Linter.Config[] = [
 		files: ["*.spec.ts", "src/test/**"],
 		rules: {},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-drivers/eslint.config.mts
+++ b/packages/test/test-drivers/eslint.config.mts
@@ -14,6 +14,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/unbound-method": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-end-to-end-tests/eslint.config.mts
+++ b/packages/test/test-end-to-end-tests/eslint.config.mts
@@ -114,6 +114,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-pairwise-generator/eslint.config.mts
+++ b/packages/test/test-pairwise-generator/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-service-load/eslint.config.mts
+++ b/packages/test/test-service-load/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-utils/eslint.config.mts
+++ b/packages/test/test-utils/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/test/test-version-utils/eslint.config.mts
+++ b/packages/test/test-version-utils/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/changelog-generator-wrapper/eslint.config.mts
+++ b/packages/tools/changelog-generator-wrapper/eslint.config.mts
@@ -16,6 +16,13 @@ const config: Linter.Config[] = [
 			"unicorn/prefer-module": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/devtools/devtools-browser-extension/eslint.config.mts
+++ b/packages/tools/devtools/devtools-browser-extension/eslint.config.mts
@@ -28,6 +28,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-unused-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/devtools/devtools-core/eslint.config.mts
+++ b/packages/tools/devtools/devtools-core/eslint.config.mts
@@ -22,6 +22,13 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-unused-expressions": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/devtools/devtools-test-app/eslint.config.mts
+++ b/packages/tools/devtools/devtools-test-app/eslint.config.mts
@@ -34,6 +34,13 @@ const config: Linter.Config[] = [
 			"unicorn/prefer-module": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/devtools/devtools-view/eslint.config.mts
+++ b/packages/tools/devtools/devtools-view/eslint.config.mts
@@ -61,6 +61,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/devtools/devtools/eslint.config.mts
+++ b/packages/tools/devtools/devtools/eslint.config.mts
@@ -21,6 +21,13 @@ const config: Linter.Config[] = [
 			"unicorn/prefer-module": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/fetch-tool/eslint.config.mts
+++ b/packages/tools/fetch-tool/eslint.config.mts
@@ -37,6 +37,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/fluid-runner/eslint.config.mts
+++ b/packages/tools/fluid-runner/eslint.config.mts
@@ -63,6 +63,13 @@ const config: Linter.Config[] = [
 			},
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/tools/replay-tool/eslint.config.mts
+++ b/packages/tools/replay-tool/eslint.config.mts
@@ -36,6 +36,13 @@ const config: Linter.Config[] = [
 			],
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/utils/odsp-doclib-utils/eslint.config.mts
+++ b/packages/utils/odsp-doclib-utils/eslint.config.mts
@@ -15,6 +15,13 @@ const config: Linter.Config[] = [
 			"no-case-declarations": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;

--- a/packages/utils/telemetry-utils/eslint.config.mts
+++ b/packages/utils/telemetry-utils/eslint.config.mts
@@ -6,6 +6,15 @@
 import type { Linter } from "eslint";
 import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
+];
 
 export default config;

--- a/packages/utils/tool-utils/eslint.config.mts
+++ b/packages/utils/tool-utils/eslint.config.mts
@@ -13,6 +13,13 @@ const config: Linter.Config[] = [
 			"import-x/no-nodejs-modules": "off",
 		},
 	},
+	{
+		languageOptions: {
+			parserOptions: {
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 ];
 
 export default config;


### PR DESCRIPTION
## Summary

- Adds `tsconfigRootDir: import.meta.dirname` to the `parserOptions` in every package-level `eslint.config.mts` across the monorepo (160 files).
- Fixes the "No tsconfigRootDir was set" error from typescript-eslint's parser, which occurs in the monorepo when the parser encounters multiple candidate `tsconfig.json` roots and cannot resolve the correct one automatically.
- For configs that used a single-line array spread (e.g. `[...strict]`), the array is expanded to multi-line with the new config object appended. For configs that already had a multi-line array, the new config object is appended as the last entry.