### PR TITLE
feat(build-cli): export policy handlers via ./policy subpath

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -18,6 +18,12 @@
 				"types": "./lib/index.d.ts",
 				"default": "./lib/index.js"
 			}
+		},
+		"./policy": {
+			"default": {
+				"types": "./lib/library/repoPolicyCheck/index.d.ts",
+				"default": "./lib/library/repoPolicyCheck/index.js"
+			}
 		}
 	},
 	"main": "lib/index.js",


### PR DESCRIPTION
## Summary

- Adds a `./policy` subpath export to `@fluid-tools/build-cli` that exposes `policyHandlers` and the `Handler` type
- Policy handlers are already exported from `src/library/index.ts` but aren't accessible to external consumers because the package's `exports` field only exposes the main entry point
