### PR TITLE
Fix forest codec version validation in schema

### DIFF
--- a/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
@@ -9,6 +9,7 @@ import {
 	getConfigForMinVersionForCollab,
 	lowestMinVersionForCollab,
 } from "@fluidframework/runtime-utils/internal";
+import { Type } from "@sinclair/typebox";
 
 import {
 	type CodecTree,
@@ -21,12 +22,9 @@ import type { FieldKey, ITreeCursorSynchronous } from "../../core/index.js";
 import { brand, type JsonCompatibleReadOnly } from "../../util/index.js";
 import type { FieldBatchCodec, FieldBatchEncodingContext } from "../chunked-forest/index.js";
 
-import {
-	ForestFormatVersion,
-	validVersions,
-	type Format,
-	FormatCommon,
-} from "./formatCommon.js";
+import { ForestFormatVersion, validVersions, type Format } from "./formatCommon.js";
+import { FormatV1 } from "./formatV1.js";
+import { FormatV2 } from "./formatV2.js";
 
 /**
  * Uses field cursors
@@ -61,7 +59,10 @@ export function makeForestSummarizerCodec(
 ): ForestCodec {
 	const inner = fieldBatchCodec;
 	const writeVersion = clientVersionToForestFormatVersion(options.minVersionForCollab);
-	const formatSchema = FormatCommon(writeVersion);
+	const formatSchema = Type.Union([FormatV1, FormatV2]);
+	// Both the encode and decode logic here support both v1 and v2, as does `validVersions` and `formatSchema`.
+	// This makes this use of makeVersionedValidatedCodec atypical as it is a single call being used to make a codec that supports all versions,
+	// instead of one call per version, then using another utility to select between them based on version.
 	return makeVersionedValidatedCodec(options, validVersions, formatSchema, {
 		encode: (data: FieldSet, context: FieldBatchEncodingContext): Format => {
 			const keys: FieldKey[] = [];

--- a/packages/dds/tree/src/feature-libraries/forest-summary/formatCommon.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/formatCommon.ts
@@ -20,8 +20,8 @@ export type ForestFormatVersion = Values<typeof ForestFormatVersion>;
 
 export const validVersions = new Set([...Object.values(ForestFormatVersion)]);
 
-export const FormatCommon = (
-	version: ForestFormatVersion,
+export const FormatCommon = <const TVersion extends ForestFormatVersion>(
+	version: TVersion,
 	// Return type is intentionally derived.
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 ) =>
@@ -33,4 +33,6 @@ export const FormatCommon = (
 		},
 		{ additionalProperties: false },
 	);
-export type Format = Static<ReturnType<typeof FormatCommon>>;
+export type Format<TVersion extends ForestFormatVersion = ForestFormatVersion> = Static<
+	ReturnType<typeof FormatCommon<TVersion>>
+>;

--- a/packages/dds/tree/src/feature-libraries/forest-summary/formatV1.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/formatV1.ts
@@ -5,9 +5,7 @@
 
 import type { Static } from "@sinclair/typebox";
 
-import { brand } from "../../util/index.js";
-
 import { FormatCommon, ForestFormatVersion } from "./formatCommon.js";
 
-export const FormatV1 = FormatCommon(brand<ForestFormatVersion>(ForestFormatVersion.v1));
+export const FormatV1 = FormatCommon(ForestFormatVersion.v1);
 export type FormatV1 = Static<typeof FormatV1>;

--- a/packages/dds/tree/src/feature-libraries/forest-summary/formatV2.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/formatV2.ts
@@ -5,9 +5,7 @@
 
 import type { Static } from "@sinclair/typebox";
 
-import { brand } from "../../util/index.js";
-
 import { FormatCommon, ForestFormatVersion } from "./formatCommon.js";
 
-export const FormatV2 = FormatCommon(brand<ForestFormatVersion>(ForestFormatVersion.v2));
+export const FormatV2 = FormatCommon(ForestFormatVersion.v2);
 export type FormatV2 = Static<typeof FormatV2>;

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -244,7 +244,7 @@ describe("ForestSummarizerCodec", () => {
 						},
 						context,
 					),
-				validateUsageError(/Unsupported version 2.5 encountered while decoding data/),
+				validateUsageError(/Unsupported version 2\.5 encountered while decoding data/),
 			);
 		});
 

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -219,7 +219,7 @@ describe("ForestSummarizerCodec", () => {
 						context,
 					),
 				validateUsageError(
-					/Unsupported version 2.5 encountered while decoding data. Supported versions for this data are: 1, 2./,
+					/Unsupported version 2\.5 encountered while decoding data. Supported versions for this data are: 1, 2\./,
 				),
 			);
 		});

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -33,6 +33,8 @@ import {
 import { ForestFormatVersion } from "../../../feature-libraries/forest-summary/formatCommon.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { FormatV1 } from "../../../feature-libraries/forest-summary/formatV1.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import type { FormatV2 } from "../../../feature-libraries/forest-summary/formatV2.js";
 import {
 	FieldBatchFormatVersion,
 	TreeCompressionStrategy,
@@ -78,90 +80,121 @@ const malformedData: [string, unknown][] = [
 	],
 	["incorrect data type", ["incorrect data type"]],
 ];
-const validDataOld: [string, FieldSet, FormatV1 | undefined][] = [
-	[
-		"no entry",
-		new Map(),
-		{
-			version: brand(ForestFormatVersion.v1),
-			keys: [],
-			fields: fieldBatchCodecOld.encode([], context),
-		},
-	],
-	[
-		"single entry",
-		new Map([[rootFieldKey, testFieldChunk.cursor()]]),
-		{
-			version: brand(ForestFormatVersion.v1),
-			keys: [rootFieldKey],
-			fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
-		},
-	],
-	[
-		"multiple entries",
-		new Map([
-			[rootFieldKey, testFieldChunk.cursor()],
-			[brand("X"), testFieldChunk.cursor()],
-		]),
-		undefined,
-	],
-];
 
-const validDataCurrent: [string, FieldSet, FormatV1 | undefined][] = [
+/**
+ * [
+ * name,
+ * data to encode,
+ * data to decode,
+ * which coded version is expected to encode to this exact data (if any)
+ * ][]
+ */
+const validData: [string, FieldSet, FormatV2 | undefined, ForestFormatVersion | undefined][] =
 	[
-		"no entry",
-		new Map(),
-		{
-			version: brand(ForestFormatVersion.v2),
-			keys: [],
-			fields: fieldBatchCodecCurrent.encode([], context),
-		},
-	],
-	[
-		"single entry",
-		new Map([[rootFieldKey, testFieldChunk.cursor()]]),
-		{
-			version: brand(ForestFormatVersion.v2),
-			keys: [rootFieldKey],
-			fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
-		},
-	],
-	[
-		"multiple entries",
-		new Map([
-			[rootFieldKey, testFieldChunk.cursor()],
-			[brand("X"), testFieldChunk.cursor()],
-		]),
-		undefined,
-	],
-];
+		[
+			"no entry v1",
+			new Map(),
+			{
+				version: ForestFormatVersion.v1,
+				keys: [],
+				fields: fieldBatchCodecOld.encode([], context),
+			},
+			ForestFormatVersion.v1,
+		],
+		[
+			"single entry v1",
+			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+			{
+				version: ForestFormatVersion.v1,
+				keys: [rootFieldKey],
+				fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
+			},
+			ForestFormatVersion.v1,
+		],
+		[
+			"new field batch in v1",
+			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+			{
+				version: ForestFormatVersion.v1,
+				keys: [rootFieldKey],
+				fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
+			},
+			undefined,
+		],
+		[
+			"multiple entries v1",
+			new Map([
+				[rootFieldKey, testFieldChunk.cursor()],
+				[brand("X"), testFieldChunk.cursor()],
+			]),
+			undefined,
+			ForestFormatVersion.v1,
+		],
+		[
+			"no entry v2",
+			new Map(),
+			{
+				version: ForestFormatVersion.v2,
+				keys: [],
+				fields: fieldBatchCodecCurrent.encode([], context),
+			},
+			ForestFormatVersion.v2,
+		],
+		[
+			"single entry v2",
+			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+			{
+				version: ForestFormatVersion.v2,
+				keys: [rootFieldKey],
+				fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
+			},
+			ForestFormatVersion.v2,
+		],
+		[
+			"old field batch in v2",
+			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+			{
+				version: ForestFormatVersion.v2,
+				keys: [rootFieldKey],
+				fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
+			},
+			undefined,
+		],
+		[
+			"multiple entries v2",
+			new Map([
+				[rootFieldKey, testFieldChunk.cursor()],
+				[brand("X"), testFieldChunk.cursor()],
+			]),
+			undefined,
+			ForestFormatVersion.v2,
+		],
+	];
 
 describe("ForestSummarizerCodec", () => {
-	describe("encodes and decodes valid old data.", () => {
-		for (const [name, data, expected] of validDataOld) {
-			it(name, () => {
-				const encodedData = codecOld.encode(data, context);
-				if (expected !== undefined) {
-					assert.deepEqual(encodedData, expected);
-				}
+	describe("encodes and decodes valid data.", () => {
+		for (const [codec, codecVersion] of [
+			[codecOld, ForestFormatVersion.v1],
+			[codecCurrent, ForestFormatVersion.v2],
+		] as const) {
+			for (const [name, data, expected, encoderVersion] of validData) {
+				it(`${name} with codec version ${codecVersion}`, () => {
+					const encodedData = codec.encode(data, context);
+					if (expected !== undefined) {
+						if (encoderVersion === codecVersion) {
+							assert.deepEqual(encodedData, expected);
+						} else {
+							// Should be able to decode the expected data with either codec,
+							// since codec should be able to decode all formats, not just the one it encodes.
+							const decodedData2 = codec.decode(expected, context);
+							assert.deepEqual(decodedData2, data);
+						}
+					}
 
-				const decodedData = codecOld.decode(encodedData, context);
-				assert.deepEqual(decodedData, data);
-			});
-		}
-	});
-
-	describe("encodes and decodes valid current data.", () => {
-		for (const [name, data, expected] of validDataCurrent) {
-			it(name, () => {
-				const encodedData = codecCurrent.encode(data, context);
-				if (expected !== undefined) {
-					assert.deepEqual(encodedData, expected);
-				}
-
-				const decodedData = codecCurrent.decode(encodedData, context);
-				assert.deepEqual(decodedData, data);
-			});
+					const decodedData = codec.decode(encodedData, context);
+					assert.deepEqual(decodedData, data);
+				});
+			}
 		}
 	});
 
@@ -179,38 +212,35 @@ describe("ForestSummarizerCodec", () => {
 				() =>
 					codecCurrent.decode(
 						{
-							version: 2.5 as ForestFormatVersion,
-							fields: {
-								version: FieldBatchFormatVersion.v1,
-								identifiers: [],
-								shapes: [],
-								data: [],
-							},
+							version: 2.5,
+							fields: fieldBatchCodecOld.encode([], context),
 							keys: [],
 						},
 						context,
 					),
-				validateUsageError(/Unsupported version 2.5 encountered while decoding data/),
+				validateUsageError(
+					/Unsupported version 2.5 encountered while decoding data. Supported versions for this data are: 1, 2./,
+				),
 			);
 		});
 
 		it("invalid nested version", () => {
+			// Create a properly encoded forest, then modify the nested version to be invalid
+			const encoded = fieldBatchCodecOld.encode([], context);
+			assert(typeof encoded === "object" && encoded !== null);
+			const invalidFields = { ...encoded, version: 2.5 };
+
 			assert.throws(
 				() =>
 					codecCurrent.decode(
 						{
-							version: ForestFormatVersion.v1,
-							fields: {
-								version: 2.5 as FieldBatchFormatVersion,
-								identifiers: [],
-								shapes: [],
-								data: [],
-							},
+							version: 1,
 							keys: [],
+							fields: invalidFields,
 						},
 						context,
 					),
-				validateAssertionError("Encoded schema should validate"),
+				validateUsageError(/Unsupported version 2.5 encountered while decoding data/),
 			);
 		});
 

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -89,87 +89,91 @@ const malformedData: [string, unknown][] = [
  * which coded version is expected to encode to this exact data (if any)
  * ][]
  */
-const validData: [string, FieldSet, FormatV2 | undefined, ForestFormatVersion | undefined][] =
+const validData: [
+	string,
+	FieldSet,
+	FormatV1 | FormatV2 | undefined,
+	ForestFormatVersion | undefined,
+][] = [
 	[
-		[
-			"no entry v1",
-			new Map(),
-			{
-				version: ForestFormatVersion.v1,
-				keys: [],
-				fields: fieldBatchCodecOld.encode([], context),
-			},
-			ForestFormatVersion.v1,
-		],
-		[
-			"single entry v1",
-			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
-			{
-				version: ForestFormatVersion.v1,
-				keys: [rootFieldKey],
-				fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
-			},
-			ForestFormatVersion.v1,
-		],
-		[
-			"new field batch in v1",
-			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
-			{
-				version: ForestFormatVersion.v1,
-				keys: [rootFieldKey],
-				fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
-			},
-			undefined,
-		],
-		[
-			"multiple entries v1",
-			new Map([
-				[rootFieldKey, testFieldChunk.cursor()],
-				[brand("X"), testFieldChunk.cursor()],
-			]),
-			undefined,
-			ForestFormatVersion.v1,
-		],
-		[
-			"no entry v2",
-			new Map(),
-			{
-				version: ForestFormatVersion.v2,
-				keys: [],
-				fields: fieldBatchCodecCurrent.encode([], context),
-			},
-			ForestFormatVersion.v2,
-		],
-		[
-			"single entry v2",
-			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
-			{
-				version: ForestFormatVersion.v2,
-				keys: [rootFieldKey],
-				fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
-			},
-			ForestFormatVersion.v2,
-		],
-		[
-			"old field batch in v2",
-			new Map([[rootFieldKey, testFieldChunk.cursor()]]),
-			{
-				version: ForestFormatVersion.v2,
-				keys: [rootFieldKey],
-				fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
-			},
-			undefined,
-		],
-		[
-			"multiple entries v2",
-			new Map([
-				[rootFieldKey, testFieldChunk.cursor()],
-				[brand("X"), testFieldChunk.cursor()],
-			]),
-			undefined,
-			ForestFormatVersion.v2,
-		],
-	];
+		"no entry v1",
+		new Map(),
+		{
+			version: ForestFormatVersion.v1,
+			keys: [],
+			fields: fieldBatchCodecOld.encode([], context),
+		},
+		ForestFormatVersion.v1,
+	],
+	[
+		"single entry v1",
+		new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+		{
+			version: ForestFormatVersion.v1,
+			keys: [rootFieldKey],
+			fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
+		},
+		ForestFormatVersion.v1,
+	],
+	[
+		"new field batch in v1",
+		new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+		{
+			version: ForestFormatVersion.v1,
+			keys: [rootFieldKey],
+			fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
+		},
+		undefined,
+	],
+	[
+		"multiple entries v1",
+		new Map([
+			[rootFieldKey, testFieldChunk.cursor()],
+			[brand("X"), testFieldChunk.cursor()],
+		]),
+		undefined,
+		ForestFormatVersion.v1,
+	],
+	[
+		"no entry v2",
+		new Map(),
+		{
+			version: ForestFormatVersion.v2,
+			keys: [],
+			fields: fieldBatchCodecCurrent.encode([], context),
+		},
+		ForestFormatVersion.v2,
+	],
+	[
+		"single entry v2",
+		new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+		{
+			version: ForestFormatVersion.v2,
+			keys: [rootFieldKey],
+			fields: fieldBatchCodecCurrent.encode([testFieldChunk.cursor()], context),
+		},
+		ForestFormatVersion.v2,
+	],
+	[
+		"old field batch in v2",
+		new Map([[rootFieldKey, testFieldChunk.cursor()]]),
+		{
+			version: ForestFormatVersion.v2,
+			keys: [rootFieldKey],
+			fields: fieldBatchCodecOld.encode([testFieldChunk.cursor()], context),
+		},
+		undefined,
+	],
+	[
+		"multiple entries v2",
+		new Map([
+			[rootFieldKey, testFieldChunk.cursor()],
+			[brand("X"), testFieldChunk.cursor()],
+		]),
+		undefined,
+		ForestFormatVersion.v2,
+	],
+];
 
 describe("ForestSummarizerCodec", () => {
 	describe("encodes and decodes valid data.", () => {


### PR DESCRIPTION
## Description

Fixes the same bug that was fixed in https://github.com/microsoft/FluidFramework/pull/26372, except this time for the forest codec.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
