### PR TITLE
mocks: Auto-create compressor in mocks

### DIFF
--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -48,9 +48,10 @@ import {
 	type ISnapshotTree,
 } from "@fluidframework/driver-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import type {
-	IIdCompressorCore,
-	IdCreationRange,
+import {
+	createIdCompressor,
+	type IIdCompressorCore,
+	type IdCreationRange,
 } from "@fluidframework/id-compressor/internal";
 import {
 	ISummaryTreeWithStats,
@@ -887,7 +888,7 @@ export class MockFluidDataStoreRuntime
 			childLoggerProps.logger = logger;
 		}
 		this.logger = createChildLogger(childLoggerProps);
-		this.idCompressor = overrides?.idCompressor;
+		this.idCompressor = overrides?.idCompressor ?? createIdCompressor();
 		this._attachState = overrides?.attachState ?? AttachState.Attached;
 
 		const registry = overrides?.registry;

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -69,6 +69,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
+		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/shared-summary-block": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -38,6 +38,7 @@ import {
 	type IFileSnapshot,
 } from "@fluidframework/replay-driver/internal";
 import { convertToSummaryTreeWithStats } from "@fluidframework/runtime-utils/internal";
+import { FluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
 	type ITelemetryLoggerExt,
 	createChildLogger,
@@ -950,9 +951,10 @@ async function assertDdsEqual(
 
 	for (let row = 0; row < matrix1.rowCount; row++) {
 		for (let col = 0; col < matrix1.colCount; col++) {
+			const serializer = new FluidSerializer(dataStoreRuntime);
 			strict.deepStrictEqual(
-				JSON.stringify(matrix1.getCell(row, col)),
-				JSON.stringify(matrix2.getCell(row, col)),
+				serializer.stringify(matrix1.getCell(row, col), matrix1.IFluidLoadable.handle),
+				serializer.stringify(matrix2.getCell(row, col), matrix1.IFluidLoadable.handle),
 			);
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16775,6 +16775,9 @@ importers:
       '@fluidframework/sequence':
         specifier: workspace:~
         version: link:../../dds/sequence
+      '@fluidframework/shared-object-base':
+        specifier: workspace:~
+        version: link:../../dds/shared-object-base
       '@fluidframework/shared-summary-block':
         specifier: workspace:~
         version: link:../../dds/shared-summary-block


### PR DESCRIPTION
## Description

Currently, the MockFluidDataStoreRuntime ## Description

Currently, the `MockFluidDataStoreRuntime` class does not instantiate an ID compressor unless it is passed one in the overrides. This means that any customers that depend on the mock having an ID compressor, primarily those that use SharedTree, which itself has that dependency, must import the compressor creation function and pass it to the mocks. This change alleviates this by having the mock auto-create an ID compressor. This unblocks the effort to remove the compressor creation API from the legacy beta API service.

It also fixes an unrelated bug in the replay tool in which objects that contain fluid handles were serialized using the standard stringify method. This change exposed this bug, as this fails if the handle transitively has an ID compressor in it due to attempting to serialize a BigInt.