### PR TITLE
Use GET verb instead of POST when calling GetSharingInformation API endpoint

### DIFF
--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -194,7 +194,7 @@ async function getFileLinkCore(
 				}/_api/web/GetFileById(@a1)/ListItemAllFields/GetSharingInformation?@a1=guid${encodeURIComponent(
 					`'${fileItem.sharepointIds.listItemUniqueId}'`,
 				)}`;
-				const method = "POST";
+				const method = "GET";
 				const authHeader = await getAuthHeader(
 					{ ...options, request: { url, method } },
 					"GetFileLinkCore",


### PR DESCRIPTION
## Description

odsp-driver historically have used POST verb when calling GetSharingInformation because we used to support putting access token into request body instead of Authorization header. It was used as optimization technique to avoid OPTIONS call by making request adhere to 'simple request' definition. That optimization has been removed long time ago but we continued using POST as the end result was the same.

Recently we added support for app-only flows resulting in GSI call being made with app only token. Such call is subject to logical permissions and our flows have been preauthorized only for Read logical permissions. Apparently, POST is treated as mutating verb and requires Write logical permissions.

This change should be functionally equivalent but has advantage of requiring only Red logical permissions.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
