### PR TITLE
Support pnpm 10.28.1 and higher

### DIFF
--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -533,7 +533,9 @@ export async function setVersion(
 				],
 				options,
 			],
-			["pnpm", ["-r", "run", "build:genver"], options],
+			// If no packages use `packageVersion.ts` then none will have the build:genver script,
+			// so use --if-present to avoid errors in that case in versions of pnpm where this is an error (versions >= 10.28.1).
+			["pnpm", ["-r", "--if-present", "run", "build:genver"], options],
 		);
 	} else {
 		options = {


### PR DESCRIPTION
## Description

Suppress warning which becomes an error in [pnpm 10.28.1](https://github.com/pnpm/pnpm/releases/tag/v10.28.1).

This fixes an error when running most release groups other than client throuhg our CI tooling if they use the latest pnpm.

This should resolve the errors hit by https://github.com/microsoft/FluidFramework/pull/26398 once the updated build tools are integrated into the relevant release groups.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

