### PR TITLE
Add 5 minute cache control header to package manifests

### DIFF
--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -54,7 +54,11 @@ jobs:
         scriptLocation: inlineScript
         inlineScript: |
           for file in upload_release_reports/*; do
-              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite true --verbose
+              # Use 5 minute TTL for manifest files. This could be lengthened significantly
+              # for manifest files for a particular build (immutable) or for those for a particular
+              # release (updates with our release cycle), but using a shorter TTL for all risks only small
+              # perf losses while remaining simple.
+              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
           done
           # Delete generate_release_reports and upload_release_reports folder
           rm -r generate_release_reports upload_release_reports


### PR DESCRIPTION
## Description

Adds a 5 minute TTL for our manifest files. We were seeing issues with our internal pipelines picking up older versions of FF for integration purposes for no apparent reason. The root cause is likely that the Azure front door in front of the storage account we upload these manifests to has caching enabled (which helps with static images on fluidframework.com).

I verified this approach should work with a [test run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=377098&view=logs&j=23d5d7b0-162c-5ef6-5d70-654cbfcb6ff6&t=a251c111-74d2-5617-9d2d-a617c63944cd). The uploaded blob has the expected header:

<img width="460" height="534" alt="image" src="https://github.com/user-attachments/assets/38df112a-8217-42b2-8c76-7b10ae17e89a" />

whereas an arbitrary manifest file I looked at from before the change has no header. AFD documents its caching behavior as being on the order of days in this case.
