### PR TITLE
ci: Upload all tinylicious.log files correctly

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -817,11 +817,20 @@ extends:
                     displayName: Upload tinylicious log
                     condition: always()
                     continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
+                    env:
+                      TEST_NAME: '${{ test.name }}'
                     inputs:
                       targetType: inline
                       script: |
                         set -eu -o pipefail
-                        PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/packages/test/test-end-to-end-tests/tinylicious.log;
+                        # Determine package path based on test type
+                        if [[ "$TEST_NAME" == *"stress"* ]]; then
+                          PACKAGE_PATH="packages/test/test-service-load"
+                        else
+                          PACKAGE_PATH="packages/test/test-end-to-end-tests"
+                        fi
+
+                        PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/$PACKAGE_PATH/tinylicious.log;
                         if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                           echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
                           echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -830,8 +830,8 @@ extends:
                           PACKAGE_PATH="packages/test/test-end-to-end-tests"
                         fi
 
-                        PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/$PACKAGE_PATH/tinylicious.log;
-                        if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
+                        PATH_TO_TINYLICIOUS_LOG="$(Build.SourcesDirectory)/$PACKAGE_PATH/tinylicious.log";
+                        if [ -f "$PATH_TO_TINYLICIOUS_LOG" ] ; then
                           echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
                           echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
                         else

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -813,6 +813,12 @@ extends:
                     customCommand: 'run test:copyresults'
 
                 - ${{ if contains(test.name, 'tinylicious') }}:
+                  # We upload the log file for the tinylicious server as a preventive troubleshooting mechanism.
+                  # It's not really too relevant unless tests fail, but when they do it's helpful to have it available
+                  # so we can investigate if there were issues on the server side.
+                  # It's also slightly tricky to only upload it conditionally based on things like whether the tests
+                  # failed, because in some scenarios (stress tests in particular) the pipeline steps might not actually fail.
+                  # Since the log files are not extremely huge (they average ~150Mb), we can afford to upload them unconditionally.
                   - task: Bash@3
                     displayName: Upload tinylicious log(s)
                     condition: always()

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -814,28 +814,43 @@ extends:
 
                 - ${{ if contains(test.name, 'tinylicious') }}:
                   - task: Bash@3
-                    displayName: Upload tinylicious log
+                    displayName: Upload tinylicious log(s)
                     condition: always()
                     continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
-                    env:
-                      TEST_NAME: '${{ test.name }}'
                     inputs:
                       targetType: inline
                       script: |
                         set -eu -o pipefail
-                        # Determine package path based on test type
-                        if [[ "$TEST_NAME" == *"stress"* ]]; then
-                          PACKAGE_PATH="packages/test/test-service-load"
-                        else
-                          PACKAGE_PATH="packages/test/test-end-to-end-tests"
-                        fi
+                        FOUND=0
 
-                        PATH_TO_TINYLICIOUS_LOG="$(Build.SourcesDirectory)/$PACKAGE_PATH/tinylicious.log";
-                        if [ -f "$PATH_TO_TINYLICIOUS_LOG" ] ; then
-                          echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
-                          echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
-                        else
-                          echo "##vso[task.logissue type=warning]Failed to upload tinylicious log file ('$PATH_TO_TINYLICIOUS_LOG' not found).";
+                        # Process each tinylicious.log file found in the repo
+                        # Uses process substitution (< <(...)) to avoid creating a subshell, which would prevent
+                        # the FOUND variable from being updated properly
+                        while IFS= read -r LOG; do
+                          # Extract the relative path by removing the source directory prefix
+                          # Example: /build/source/packages/test/foo/tinylicious.log -> packages/test/foo/tinylicious.log
+                          RELATIVE_PATH="${LOG#$(Build.SourcesDirectory)/}"
+
+                          # Extract the directory path and filename separately
+                          DIR_PATH=$(dirname "$RELATIVE_PATH")
+                          FILENAME=$(basename "$RELATIVE_PATH")
+
+                          # Note: Azure DevOps only preserves the filename when uploading, not the directory structure,
+                          # so multiple files named "tinylicious.log" would overwrite each other.
+                          # Thus we create a unique name for each log file by using a safe version of its directory path.
+                          # Example: packages/test/foo/tinylicious.log -> packages_test_foo-tinylicious.log
+                          SAFE_NAME="${DIR_PATH//\//_}-${FILENAME}"
+
+                          TEMP_LOG="$(Build.SourcesDirectory)/$SAFE_NAME"
+                          cp "$LOG" "$TEMP_LOG"
+
+                          echo "Found tinylicious log at '$LOG'. Uploading as '$SAFE_NAME'.";
+                          echo "##vso[task.uploadfile]$TEMP_LOG";
+                          FOUND=1
+                        done < <(find "$(Build.SourcesDirectory)" -maxdepth 5 -name "tinylicious.log" -type f 2>/dev/null)
+
+                        if [ "$FOUND" -eq 0 ]; then
+                          echo "##vso[task.logissue type=warning]No tinylicious log files found.";
                         fi
 
                 # Process test result, include publishing and logging

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -823,6 +823,11 @@ extends:
                         set -eu -o pipefail
                         FOUND=0
 
+                        # Sanitize the test name by removing colons and replacing other problematic characters
+                        TEST_NAME="${{ test.name }}"
+                        SAFE_TEST_NAME="${TEST_NAME//:/}"
+                        SAFE_TEST_NAME="${SAFE_TEST_NAME// /_}"
+
                         # Process each tinylicious.log file found in the repo
                         # Uses process substitution (< <(...)) to avoid creating a subshell, which would prevent
                         # the FOUND variable from being updated properly
@@ -837,9 +842,10 @@ extends:
 
                           # Note: Azure DevOps only preserves the filename when uploading, not the directory structure,
                           # so multiple files named "tinylicious.log" would overwrite each other.
-                          # Thus we create a unique name for each log file by using a safe version of its directory path.
-                          # Example: packages/test/foo/tinylicious.log -> packages_test_foo-tinylicious.log
-                          SAFE_NAME="${DIR_PATH//\//_}-${FILENAME}"
+                          # Thus we create a unique name for each log file by using the test name and a safe version of its directory path.
+                          # Example: packages/test/foo/tinylicious.log -> test_tinylicious-packages_test_foo-tinylicious.log
+                          SAFE_DIR="${DIR_PATH//\//_}"
+                          SAFE_NAME="${SAFE_TEST_NAME}-${SAFE_DIR}-${FILENAME}"
 
                           TEMP_LOG="$(Build.SourcesDirectory)/$SAFE_NAME"
                           cp "$LOG" "$TEMP_LOG"


### PR DESCRIPTION
## Description

Currently when we run the stress tests against tinylicious (in the build pipeline, not in the separate pipeline for stress tests), the step to upload the tinylicious log to the pipeline artifacts [logs a warning](https://dev.azure.com/fluidframework/public/public%20Team/_build/results?buildId=377020&view=logs&j=6bb09b85-9174-5850-be23-a20013a777c6&t=aad6019f-4142-5ba1-d2ba-152116590ec5&l=12) because it's looking for the log file in the wrong place (the path where the file ends up in when the real-svc tests run, but not when the stress tests run).

Also, we're not uploading the tinylicious.log files from other tests that also produce them.

This adds logic to look for all the relevant log files produced in the repo and upload them no matter where they are.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
