### PR TITLE
Refactor ClientVersionDispatchingCodecBuilder to support unstable and unused formats.

### DIFF
--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -470,7 +470,7 @@ function getWriteVersion<T extends CodecVersionBase>(
 			const selectedMinVersionForCollab = selected.minVersionForCollab;
 			if (selectedMinVersionForCollab === "none") {
 				throw new UsageError(
-					`Codec "${name}" does not support requested format version ${JSON.stringify(selectedFormatVersion)} because it is has minVersionForCollab "none". Use "allowPossiblyIncompatibleWriteVersionOverrides" to suppress this error if appropriate.`,
+					`Codec "${name}" does not support requested format version ${JSON.stringify(selectedFormatVersion)} because it has minVersionForCollab "none". Use "allowPossiblyIncompatibleWriteVersionOverrides" to suppress this error if appropriate.`,
 				);
 			} else if (gt(selectedMinVersionForCollab, options.minVersionForCollab)) {
 				throw new UsageError(

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -180,7 +180,7 @@ export interface CodecVersionBase<
 	TFormatVersion extends FormatVersion = FormatVersion,
 > {
 	/**
-	 * When `undefined` the codec never be selected as a write version unless via override.
+	 * When `undefined` the codec will never be selected as a write version except via override.
 	 * @remarks
 	 * This format will be used for decode if data in it needs to be decoded, regardless of `minVersionForCollab`.
 	 * `undefined` should be used for unstable codec versions (with string FormatVersions),

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
@@ -24,16 +24,18 @@ type BuildData = CodecWriteOptions & {
 
 export const detachedFieldIndexCodecBuilder = ClientVersionDispatchingCodecBuilder.build(
 	"DetachedFieldIndex",
-	{
-		[lowestMinVersionForCollab]: {
+	[
+		{
+			minVersionForCollab: lowestMinVersionForCollab,
 			formatVersion: DetachedFieldIndexFormatVersion.v1,
 			codec: (buildData: BuildData) =>
 				makeDetachedNodeToFieldCodecV1(buildData.revisionTagCodec, buildData.idCompressor),
 		},
-		[FluidClientVersion.v2_52]: {
+		{
+			minVersionForCollab: FluidClientVersion.v2_52,
 			formatVersion: DetachedFieldIndexFormatVersion.v2,
 			codec: (buildData: BuildData) =>
 				makeDetachedNodeToFieldCodecV2(buildData.revisionTagCodec, buildData.idCompressor),
 		},
-	},
+	],
 );

--- a/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
@@ -125,8 +125,9 @@ function decodeV2(f: FormatV2): TreeStoredSchema {
 /**
  * Creates a codec which performs synchronous monolithic encoding of schema content.
  */
-export const schemaCodecBuilder = ClientVersionDispatchingCodecBuilder.build("Schema", {
-	[lowestMinVersionForCollab]: {
+export const schemaCodecBuilder = ClientVersionDispatchingCodecBuilder.build("Schema", [
+	{
+		minVersionForCollab: lowestMinVersionForCollab,
 		formatVersion: SchemaFormatVersion.v1,
 		codec: {
 			encode: (data: TreeStoredSchema) => encodeRepoV1(data),
@@ -134,7 +135,8 @@ export const schemaCodecBuilder = ClientVersionDispatchingCodecBuilder.build("Sc
 			schema: FormatV1,
 		},
 	},
-	[FluidClientVersion.v2_43]: {
+	{
+		minVersionForCollab: FluidClientVersion.v2_43,
 		formatVersion: SchemaFormatVersion.v2,
 		codec: {
 			encode: (data: TreeStoredSchema) => encodeRepoV2(data),
@@ -142,4 +144,4 @@ export const schemaCodecBuilder = ClientVersionDispatchingCodecBuilder.build("Sc
 			schema: FormatV2,
 		},
 	},
-});
+]);

--- a/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
@@ -6,7 +6,10 @@
 import { strict as assert } from "node:assert";
 
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
-import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
+import {
+	validateAssertionError,
+	validateUsageError,
+} from "@fluidframework/test-runtime-utils/internal";
 
 import { FluidClientVersion, Versioned } from "../../../codec/index.js";
 import {
@@ -27,6 +30,10 @@ describe("versioned Codecs", () => {
 			version: 2;
 			value2: number;
 		}
+		interface VX {
+			version: "X";
+			valueX: number;
+		}
 		const codecV1: CodecAndSchema<number> = {
 			encode: (x) => ({ version: 1, value1: x }),
 			decode: (x) => (x as unknown as V1).value1,
@@ -37,17 +44,29 @@ describe("versioned Codecs", () => {
 			decode: (x) => (x as unknown as V2).value2,
 			schema: Versioned,
 		};
+		const codecVX: CodecAndSchema<number> = {
+			encode: (x) => ({ version: "X", valueX: x }),
+			decode: (x) => (x as unknown as VX).valueX,
+			schema: Versioned,
+		};
 
-		const builder = ClientVersionDispatchingCodecBuilder.build("Test", {
-			[lowestMinVersionForCollab]: {
+		const builder = ClientVersionDispatchingCodecBuilder.build("Test", [
+			{
+				minVersionForCollab: lowestMinVersionForCollab,
 				formatVersion: 1,
 				codec: codecV1,
 			},
-			[FluidClientVersion.v2_43]: {
+			{
+				minVersionForCollab: FluidClientVersion.v2_43,
 				formatVersion: 2,
 				codec: () => codecV2,
 			},
-		});
+			{
+				minVersionForCollab: "none",
+				formatVersion: "X",
+				codec: codecVX,
+			},
+		]);
 
 		it("round trip", () => {
 			const codec1 = builder.build({
@@ -69,8 +88,56 @@ describe("versioned Codecs", () => {
 
 			assert.throws(
 				() => codec1.decode({ version: 3, value2: 42 }),
-				validateUsageError(`Unsupported version 3 encountered while decoding Test data. Supported versions for this data are: 1, 2.
+				validateUsageError(`Unsupported version 3 encountered while decoding Test data. Supported versions for this data are: [1,2,"X"].
 The client which encoded this data likely specified an "minVersionForCollab" value which corresponds to a version newer than the version of this client ("${pkgVersion}").`),
+			);
+		});
+
+		it("unstable version", () => {
+			const codecX = builder.build({
+				minVersionForCollab: "2.0.0",
+				jsonValidator: FormatValidatorBasic,
+				allowPossiblyIncompatibleWriteVersionOverrides: true,
+				writeVersionOverrides: new Map([["Test", "X"]]),
+			});
+			const codec2 = builder.build({
+				minVersionForCollab: "2.55.0",
+				jsonValidator: FormatValidatorBasic,
+			});
+			const vx = codecX.encode(42);
+			const v2 = codec2.encode(42);
+			assert.deepEqual(vx, { version: "X", valueX: 42 });
+			assert.deepEqual(v2, { version: 2, value2: 42 });
+			assert.equal(codecX.decode(vx), 42);
+			assert.equal(codecX.decode(v2), 42);
+			assert.equal(codec2.decode(vx), 42);
+			assert.equal(codec2.decode(v2), 42);
+		});
+
+		it("bad override", () => {
+			assert.throws(
+				() =>
+					builder.build({
+						minVersionForCollab: "2.0.0",
+						jsonValidator: FormatValidatorBasic,
+						writeVersionOverrides: new Map([["Test", "X"]]),
+					}),
+				validateUsageError(
+					`Codec "Test" does not support requested format version "X" because it is has minVersionForCollab "none". Use "allowPossiblyIncompatibleWriteVersionOverrides" to suppress this error if appropriate.`,
+				),
+			);
+
+			assert.throws(
+				() =>
+					builder.build({
+						minVersionForCollab: "2.0.0",
+						jsonValidator: FormatValidatorBasic,
+						allowPossiblyIncompatibleWriteVersionOverrides: true,
+						writeVersionOverrides: new Map([["Test", "1"]]),
+					}),
+				validateUsageError(
+					`Codec "Test" does not support requested format version "1". Supported versions are: [1,2,"X"].`,
+				),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
@@ -319,7 +319,7 @@ describe("DetachedFieldIndex Codecs", () => {
 			unfinalizedIdCompressor,
 		)) {
 			describe(name, () => {
-				for (const format of detachedFieldIndexCodecBuilder.registry.values()) {
+				for (const format of detachedFieldIndexCodecBuilder.registry) {
 					const version = format.formatVersion;
 					if (validFor !== undefined && version !== undefined && !validFor.has(version)) {
 						continue;

--- a/packages/dds/tree/src/test/feature-libraries/schema-index/codec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-index/codec.spec.ts
@@ -42,7 +42,7 @@ const codecOptions: CodecWriteOptions = {
 };
 
 const schemaCodecs = makeCodecFamily(
-	schemaCodecBuilder.applyOptions(codecOptions).map(([_version, codec]) => {
+	schemaCodecBuilder.applyOptions(codecOptions).map((codec) => {
 		return [codec.formatVersion, codec.codec] as const;
 	}),
 );

--- a/packages/dds/tree/src/test/feature-libraries/schema-index/schemaSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-index/schemaSummarizer.spec.ts
@@ -50,7 +50,7 @@ describe("schemaSummarizer", () => {
 
 		for (const schemaFormat of schemaCodecBuilder.registry) {
 			const encode = (schema: TreeStoredSchema): JsonCompatibleReadOnly => {
-				assert(schemaFormat.minVersionForCollab !== "none");
+				assert(schemaFormat.minVersionForCollab !== undefined);
 				const codec = schemaFormat.codec({
 					jsonValidator: FormatValidatorBasic,
 					minVersionForCollab: schemaFormat.minVersionForCollab,

--- a/packages/dds/tree/src/test/feature-libraries/schema-index/schemaSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-index/schemaSummarizer.spec.ts
@@ -48,11 +48,12 @@ describe("schemaSummarizer", () => {
 	describe("encodeTreeSchema", () => {
 		useSnapshotDirectory("encodeTreeSchema");
 
-		for (const [minVersionForCollab, schemaFormat] of schemaCodecBuilder.registry) {
+		for (const schemaFormat of schemaCodecBuilder.registry) {
 			const encode = (schema: TreeStoredSchema): JsonCompatibleReadOnly => {
+				assert(schemaFormat.minVersionForCollab !== "none");
 				const codec = schemaFormat.codec({
 					jsonValidator: FormatValidatorBasic,
-					minVersionForCollab,
+					minVersionForCollab: schemaFormat.minVersionForCollab,
 				});
 				const result: JsonCompatibleReadOnly = codec.encode(schema);
 				return result;

--- a/packages/dds/tree/src/test/snapshots/schema.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/schema.spec.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "node:assert";
+
 import { FormatValidatorBasic } from "../../external-utilities/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { schemaCodecBuilder } from "../../feature-libraries/schema-index/codec.js";
@@ -13,11 +15,15 @@ import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshotTools.js";
 describe("schema snapshots", () => {
 	useSnapshotDirectory("schema-files");
 
-	for (const [minVersionForCollab, schemaFormat] of schemaCodecBuilder.registry) {
+	for (const schemaFormat of schemaCodecBuilder.registry) {
 		for (const { name, schemaData } of testTrees) {
 			it(`${name} - schema v${schemaFormat.formatVersion}`, () => {
+				assert(schemaFormat.minVersionForCollab !== "none");
 				const encoded = schemaFormat
-					.codec({ jsonValidator: FormatValidatorBasic, minVersionForCollab })
+					.codec({
+						jsonValidator: FormatValidatorBasic,
+						minVersionForCollab: schemaFormat.minVersionForCollab,
+					})
 					.encode(schemaData);
 				takeJsonSnapshot(encoded);
 			});

--- a/packages/dds/tree/src/test/snapshots/schema.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/schema.spec.ts
@@ -18,7 +18,7 @@ describe("schema snapshots", () => {
 	for (const schemaFormat of schemaCodecBuilder.registry) {
 		for (const { name, schemaData } of testTrees) {
 			it(`${name} - schema v${schemaFormat.formatVersion}`, () => {
-				assert(schemaFormat.minVersionForCollab !== "none");
+				assert(schemaFormat.minVersionForCollab !== undefined);
 				const encoded = schemaFormat
 					.codec({
 						jsonValidator: FormatValidatorBasic,


### PR DESCRIPTION
## Description

This generalizes ClientVersionDispatchingCodecBuilder  so it can be used in more cases, including with under development and discontinued formats.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
