### PR TITLE
Run RefreshSerializerLifeCycle.spec.ts tests s only in local server

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
@@ -114,10 +114,7 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 			testConfig ?? "undefined",
 		)}`, async () => {
 			const provider: ITestObjectProvider = getTestObjectProvider();
-			if (
-				testConfig.useLoadingGroupIdForSnapshotFetch === true &&
-				provider.driver.type !== "local"
-			) {
+			if (provider.driver.type !== "local") {
 				return;
 			}
 			let snapshotRefreshTimeoutMs;


### PR DESCRIPTION
RefreshSerializerLifeCycle.spec.ts tests are still flaky running in different servers due to timeouts. I still find useful to run this tests locally. Unit tests were added after SnapshotRefresher creation to mitigate some of the missing coverage when we skipped this test suite.