### PR TITLE
build(client): add explicit build deps

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -115,6 +115,7 @@ module.exports = {
 		},
 		"depcruise": [],
 		"check:exports": ["api"],
+		"check:exports:bundle-release-tags": ["build:esnext"],
 		// The package's local 'api-extractor-lint.json' may use the entrypoint from either CJS or ESM,
 		// therefore we need to require both before running api-extractor.
 		"check:release-tags": ["tsc", "build:esnext"],

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -169,9 +169,6 @@
 				"^build:esnext",
 				"build:genver"
 			],
-			"check:exports:bundle-release-tags": [
-				"build:esnext"
-			],
 			"eslint": [
 				"api-extractor:esnext",
 				"^build:test:esm"

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -78,10 +78,6 @@
 			"check:exports:esm:index": [
 				"...",
 				"build:esnext"
-			],
-			"check:exports:bundle-release-tags": [
-				"...",
-				"build:esnext"
 			]
 		}
 	},

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -133,6 +133,13 @@
 		"webpack": "^5.94.0",
 		"webpack-cli": "^5.1.4"
 	},
+	"fluidBuild": {
+		"tasks": {
+			"check:exports:index": [
+				"build:esnext"
+			]
+		}
+	},
 	"typeValidation": {
 		"disabled": true
 	}


### PR DESCRIPTION
- "check:exports:bundle-release-tags" by default uses ./lib/index.d.ts generated (usually) by "build:esnext"
   - remove explicit config from presence and test-loader-utils
- "check:exports:index" in test-version-utils depends on "build:esnext"