### PR TITLE
Clear loadedChunksMap after forest load to reduce memory usage

### DIFF
--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -252,5 +252,10 @@ export class ForestSummarizer
 			this.forest,
 			makeDetachedFieldIndex("init", this.revisionTagCodec, this.idCompressor),
 		);
+
+		// Free the raw encoded chunk data that was downloaded during load.
+		// After decode and applyDelta, the decoded chunks are tracked in
+		// chunkTrackingPropertiesMap and the raw data is no longer needed.
+		this.incrementalSummaryBuilder.clearLoadedChunks();
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -256,6 +256,9 @@ export class ForestSummarizer
 		// Free the raw encoded chunk data that was downloaded during load.
 		// After decode and applyDelta, the decoded chunks are tracked in
 		// chunkTrackingPropertiesMap and the raw data is no longer needed.
+		// Note: this assumes all chunks have been decoded by this point, which is true
+		// for the current implementation. If virtualization is added in the future
+		// (lazy/on-demand chunk decoding), this will need to be revisited.
 		this.incrementalSummaryBuilder.clearLoadedChunks();
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
@@ -504,6 +504,15 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 	}
 
 	/**
+	 * Clears the loaded chunks map to free memory after all chunks have been decoded.
+	 * This should be called after the forest load is complete and `codec.decode()` has
+	 * processed all chunks, since the raw encoded data is no longer needed.
+	 */
+	public clearLoadedChunks(): void {
+		this.loadedChunksMap.clear();
+	}
+
+	/**
 	 * {@link IncrementalEncoder.decodeIncrementalChunk}
 	 */
 	public decodeIncrementalChunk(


### PR DESCRIPTION
## Summary

During incremental summary loading, `ForestIncrementalSummaryBuilder` downloads raw `EncodedFieldBatch` JSON into `loadedChunksMap` but never frees it after decoding. This keeps both the raw and decoded representations in memory. This PR clears the map after `applyDelta()` completes, since decoded chunks are already tracked separately in `chunkTrackingPropertiesMap`.

## Changes

- **`incrementalSummaryBuilder.ts`**: Add `clearLoadedChunks()` public method that calls `this.loadedChunksMap.clear()`
- **`forestSummarizer.ts`**: Call `clearLoadedChunks()` at the end of `loadInternal()` after `applyDelta()` completes

## Test plan

- [x] Existing tree tests pass (13,529 passing; 1 pre-existing unrelated failure in `prepareTreeForCompare`)
- [x] Verified `loadedChunksMap` is only read by `decodeIncrementalChunk()` during `codec.decode()`, which completes before the clear call

---

## Memory investigation: additional findings for the team

SharedTree consumes ~20x more heap memory than PropertyDDS when loading the same container (~173MB vs ~9MB increase). The `loadedChunksMap` leak above is the most straightforward fix, but the root causes are deeper. Here's a summary of the investigation findings, ranked by estimated impact.

### 1. ObjectForest (default) deep-copies all nodes — CRITICAL

`sharedTree.ts` defaults to `ForestTypeReference` (ObjectForest), not `ForestTypeOptimized` (ChunkedForest). ObjectForest creates full `MapTree` objects via `mapTreeFromCursor`, which deep-copies every node. ChunkedForest can reuse decoded `BasicChunk` references directly via the `tryGetChunk` fast path in `chunkRange()`, roughly halving peak memory during load. ObjectForest also performs O(n) `deepCopyMapTree` on every `clone()` (branch/fork), while ChunkedForest uses copy-on-write.

### 2. Edit history is never trimmed at load time — CRITICAL

`EditManager.minimumSequenceNumber` is initialized to `Number.MIN_SAFE_INTEGER` and `loadSummaryData()` never updates it. `trimHistory()` uses this value as the eviction boundary, so it cannot trim anything. `advanceMinimumSequenceNumber()` is only called during `processMessagesCore()` (when processing ops after loading). Result: after `loadCore()` returns, **all trunk commits + all peer branch commits from the summary remain in memory** until the first op is processed.

Additional gaps:
- All peer local branches are loaded unconditionally, including disconnected sessions
- The `trunkRevisionCache` temporary Map doubles references during loading
- Peer local branches are never cleaned up after load until `trimHistory()` eventually runs via incoming ops

### 3. Per-node object overhead — SIGNIFICANT

Each tree node (`BasicChunk` or `MapTree`) allocates a JS `Map` for fields, even leaf nodes with no children. V8 `Map` objects use ~100+ bytes each. For a document with 500K leaf nodes, this is ~50MB of empty Maps alone. A shared frozen empty `Map` singleton for leaf nodes would help for ObjectForest; ChunkedForest already avoids this via chunk reuse.

### 4. `defaultChunkPolicy` never uses uniform chunks — SIGNIFICANT

`defaultChunkPolicy` (line 375-385 of `chunkTree.ts`) always returns `polymorphic` from `shapeFromSchema`, so the uniform chunk fast path is never used during load. Every node goes through the slow `newBasicChunkTree` path. Both ObjectForest and ChunkedForest share this overhead.

### 5. Intermediate data structure chain during load

The forest loading path creates multiple intermediate representations:

| Step | Data Structure | Freed after? |
|------|---------------|-------------|
| 1 | Raw JSON → `EncodedFieldBatch` | **No** (this PR fixes it) |
| 2 | Decoded `BasicChunk` tree | After re-chunking |
| 3 | Re-chunked `BasicChunk` tree via `chunkFieldSingle` | After forest insert |
| 4 | Forest nodes (`MapTree` for ObjectForest, chunk refs for ChunkedForest) | Retained |

### 6. Other contributors

- **Removed roots / `DetachedFieldIndex`**: Tracks all removed nodes, only GC'd when trunk commits are trimmed. Cloned on branching.
- **`SharedTreeChangeEnricher`**: Can clone the entire forest for change enrichment.
- **`AnchorSet`**: Parallel tree of `AnchorNode` objects with reference counts, event emitters, and slots.

### Existing TODOs in codebase

- `uniformChunk.ts:100` — `positions` array allocated for every shape unnecessarily
- `uniformChunk.ts:206` — consider storing shape information in WASM
- `chunkedForest.ts:186` — optimize in-place replace for uniform chunks
- `chunkedForest.ts:236` — support in-place editing of other chunk formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)