### PR TITLE
ci: improve pnpm install resilience with network retry config

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -67,6 +67,11 @@ steps:
       echo "Primary registry: ${NPM_REGISTRY}"
       pnpm config set -g workspace-concurrency 0
       pnpm config set registry "${NPM_REGISTRY}"
+      # Increase network resilience for CI environments where transient failures are common
+      pnpm config set fetch-retries 5
+      pnpm config set fetch-retry-mintimeout 30000
+      pnpm config set fetch-retry-maxtimeout 120000
+      pnpm config set network-timeout 120000
       if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]; then
         echo "##vso[task.setvariable variable=registryType]public"
       else


### PR DESCRIPTION
## Summary

- Configure pnpm with increased fetch retries (5), longer network timeout (120s), and retry backoff settings in `include-install-pnpm.yml`
- Addresses intermittent `pnpm install --frozen-lockfile` failures observed in build-client pipeline (definition 11) where installs fail with exit code 1 after exhausting all 4 ADO-level retries

## Context

Recent builds (e.g., #377610 for PR #26444) show `pnpm install --frozen-lockfile` consistently failing across both the "Run checks" and "Build Stage" jobs. The ADO-level `retryCountOnTaskFailure: 4` retries the entire task, but pnpm's own default network settings (3 fetch retries, 60s timeout) are insufficient for transient registry issues in CI environments.

This change adds pnpm-level network resilience settings so that pnpm itself retries more aggressively before the task-level retry kicks in.

## Verification

- [x] `pnpm install` succeeds in PR build
- [x] CI build passes (all 75 checks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)