### PR TITLE
ci: fix tinylicious log upload to target realsvc tests and find all logs

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -812,21 +812,23 @@ extends:
                     workingDir: '${{ parameters.buildDirectory }}'
                     customCommand: 'run test:copyresults'
 
-                - ${{ if contains(test.name, 'tinylicious') }}:
+                - ${{ if contains(test.name, 'realsvc:tinylicious') }}:
                   - task: Bash@3
-                    displayName: Upload tinylicious log
+                    displayName: Upload tinylicious log(s)
                     condition: always()
                     continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                     inputs:
                       targetType: inline
                       script: |
                         set -eu -o pipefail
-                        PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/packages/test/test-end-to-end-tests/tinylicious.log;
-                        if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
-                          echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
-                          echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
-                        else
-                          echo "##vso[task.logissue type=warning]Failed to upload tinylicious log file ('$PATH_TO_TINYLICIOUS_LOG' not found).";
+                        FOUND=0
+                        while IFS= read -r LOG; do
+                          echo "Found tinylicious log at '$LOG'. Uploading.";
+                          echo "##vso[task.uploadfile]$LOG";
+                          FOUND=1
+                        done < <(find "$(Build.SourcesDirectory)" -maxdepth 5 -name "tinylicious.log" -type f 2>/dev/null)
+                        if [ "$FOUND" -eq 0 ]; then
+                          echo "##vso[task.logissue type=warning]No tinylicious log files found.";
                         fi
 
                 # Process test result, include publishing and logging


### PR DESCRIPTION
## Summary

- Narrow the upload condition from `contains(test.name, 'tinylicious')` to `contains(test.name, 'realsvc:tinylicious')` so the log upload step only runs for realsvc tests, not stress tests
- Replace the hardcoded path (`packages/test/test-end-to-end-tests/tinylicious.log`) with a `find`-based approach that discovers and uploads all `tinylicious.log` files across the 5 test packages that produce them
- Revert `build-npm-package.yml` to its original state (not affected by this issue)

## Context

The client build pipeline runs both `ci:test:realsvc:tinylicious` (5 packages) and `ci:test:stress:tinylicious` (1 package) as separate test jobs. Both matched the old `contains(test.name, 'tinylicious')` condition, but only the realsvc tests produce `tinylicious.log` at the hardcoded path. The stress test's log is in a different package directory.

The hardcoded path also only captured one of the 5 packages producing logs:
- `packages/test/test-end-to-end-tests` (was captured)
- `packages/service-clients/azure-client` (was missed)
- `packages/service-clients/end-to-end-tests/azure-client` (was missed)
- `packages/service-clients/tinylicious-client` (was missed)
- `packages/framework/client-logger/fluid-telemetry` (was missed)

## Verification

- [x] Confirmed `realsvc:tinylicious` condition matches only the realsvc test job, not stress
- [x] Confirmed all 5 packages with `start:tinylicious:test` scripts produce `tinylicious.log` in their directories
- [x] `find`-based approach with `maxdepth 5` covers all package locations
- [x] `build-npm-package.yml` reverted to original (reviewer confirmed not affected)
- [x] CI build passes (all checks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)