### PR TITLE
ci: increase pnpm cache timeout from 3 to 5 minutes

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -35,7 +35,10 @@ steps:
 - ${{ if eq(parameters.enableCache, true) }}:
   - task: Cache@2
     displayName: Cache pnpm store
-    timeoutInMinutes: 3
+    # The timeout applies to both the pre-job restore and post-job save operations.
+    # 3 minutes was insufficient for the post-job cache upload of the pnpm store, causing
+    # intermittent "The task has timed out" errors that mark builds as Partially Succeeded.
+    timeoutInMinutes: 5
     continueOnError: true
     inputs:
       # Caches are already scoped to individual pipelines, so no need to include the release group name or tag


### PR DESCRIPTION
## Summary

- Increase `Cache@2` task timeout from 3 to 5 minutes in `include-install-pnpm.yml`
- Addresses intermittent "The task has timed out" errors on the post-job cache save step

## Context

The `Cache@2` task `timeoutInMinutes` applies to both the pre-job cache restore and the post-job cache save. The pnpm store cache upload intermittently exceeds the 3-minute limit during the post-job phase, especially when the cache key changes and a full upload is needed. This causes the task to timeout and marks the build as "Partially Succeeded" despite the build itself completing fine.

The task already has `continueOnError: true` so even with the increased timeout, a timeout will not block the build. The pnpm store prune step runs before caching to minimize the cache size.

## Test plan

- [ ] Monitor post-job cache save timing across builds
- [ ] Verify cache timeout warnings decrease in frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code)