### PR TITLE
chore: add eslint-config-fluid reformat commit to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -48,3 +48,6 @@ a33ffd0ca60351d694438281cb6879e71dcfac37
 45cd69ec472e35e4ed1a178f6fe764f0e66e9556
 be68e1b80389db0221158ff6362e75dcd895b07a
 38e1d64612ca1b65f5c1098a63b439afb53afd55
+
+# eslint-config-fluid printed config reformatting (spaces to tabs)
+dd1628e6d58424708d3bb7649d285f72f48a9b6b


### PR DESCRIPTION
## Summary

Follow-up to #26425. Adds the reformatting commit (`dd1628e6d58`) to `.git-blame-ignore-revs` so `git blame` skips the whitespace-only changes from switching printed eslint config output from spaces to tabs.