### PR TITLE
Remove deprecated Loader class from container-loader

### DIFF
--- a/examples/service-clients/azure-client/external-controller/tests/index.ts
+++ b/examples/service-clients/azure-client/external-controller/tests/index.ts
@@ -8,7 +8,7 @@ import {
 	IFluidModuleWithDetails,
 	IRuntimeFactory,
 } from "@fluidframework/container-definitions/legacy";
-import { Loader } from "@fluidframework/container-loader/legacy";
+import { createLoader } from "@fluidframework/container-loader/legacy";
 import {
 	createDOProviderContainerRuntimeFactory,
 	createFluidContainer,
@@ -62,7 +62,7 @@ export async function getSessionStorageContainer(
 
 	const codeLoader = { load };
 
-	const loader = new Loader({
+	const loader = createLoader({
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,

--- a/examples/service-clients/azure-client/todo-list/test/index.tsx
+++ b/examples/service-clients/azure-client/todo-list/test/index.tsx
@@ -8,7 +8,7 @@ import type {
 	IFluidModuleWithDetails,
 	IRuntimeFactory,
 } from "@fluidframework/container-definitions/legacy";
-import { Loader } from "@fluidframework/container-loader/legacy";
+import { createLoader } from "@fluidframework/container-loader/legacy";
 import {
 	createFluidContainer,
 	createTreeContainerRuntimeFactory,
@@ -64,7 +64,7 @@ export async function getSessionStorageContainer(
 
 	const codeLoader = { load };
 
-	const loader = new Loader({
+	const loader = createLoader({
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,

--- a/examples/utils/bundle-size-tests/src/loader.ts
+++ b/examples/utils/bundle-size-tests/src/loader.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 
 export function apisToBundle(): void {
-	new Loader({
+	createLoader({
 		codeLoader: {} as any,
 		documentServiceFactory: {} as any,
 		urlResolver: {} as any,

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -17,7 +17,7 @@ import {
 	ILoaderOptions,
 } from "@fluidframework/container-definitions/internal";
 import {
-	Loader as ContainerLoader,
+	createLoader,
 	loadExistingContainer,
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
@@ -101,7 +101,7 @@ describe("PropertyDDS summarizer", () => {
 		const registry = [[propertyDdsId, new PropertyTreeFactory()]] as ChannelFactoryRegistry;
 
 		objProvider = new TestObjectProvider(
-			ContainerLoader as any,
+			createLoader,
 			driver,
 			() =>
 				new TestContainerRuntimeFactory(

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -8,7 +8,7 @@ import { resolve } from 'path';
 import { LocalServerTestDriver } from '@fluid-private/test-drivers';
 import { AttachState } from '@fluidframework/container-definitions';
 import type { IContainer, IFluidCodeDetails, IHostLoader } from '@fluidframework/container-definitions/internal';
-import { asLegacyAlpha, Loader, waitContainerToCatchUp } from '@fluidframework/container-loader/internal';
+import { asLegacyAlpha, createLoader, waitContainerToCatchUp } from '@fluidframework/container-loader/internal';
 import { DefaultSummaryConfiguration, SummaryCollection } from '@fluidframework/container-runtime/internal';
 import type { ConfigTypes, IConfigProviderBase, IFluidHandle, IRequestHeader } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
@@ -376,7 +376,7 @@ export async function setUpLocalServerTestSharedTree(
 		await waitContainerToCatchUp(container);
 	} else {
 		const driver = new LocalServerTestDriver();
-		provider = new TestObjectProvider(Loader, driver, runtimeFactory);
+		provider = new TestObjectProvider(createLoader, driver, runtimeFactory);
 		testObjectProviders.push(provider);
 		// Once ILoaderOptions is specificable, this should use `provider.makeTestContainer` instead.
 		const loader = makeTestLoader(provider);

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -10,7 +10,7 @@ import type { Client } from "@fluid-private/test-dds-utils";
 import { LocalServerTestDriver } from "@fluid-private/test-drivers";
 import { isInPerformanceTestingMode } from "@fluid-tools/benchmark";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import type {
@@ -328,7 +328,7 @@ export class TestTreeProvider {
 				},
 			);
 
-		const objProvider = new TestObjectProvider(Loader, driver, containerRuntimeFactory);
+		const objProvider = new TestObjectProvider(createLoader, driver, containerRuntimeFactory);
 
 		if (summarizeType === SummarizeType.onDemand) {
 			const container = await objProvider.makeTestContainer();

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -26,9 +26,6 @@ export function createDetachedContainer(createDetachedContainerProps: ICreateDet
 // @alpha @legacy
 export function createFrozenDocumentServiceFactory(factory?: IDocumentServiceFactory | Promise<IDocumentServiceFactory>): IDocumentServiceFactory;
 
-// @beta @legacy
-export function createLoader(loaderProps: ILoaderProps): IHostLoader;
-
 // @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -157,23 +157,13 @@ export interface IScribeProtocolState {
 }
 
 // @beta @legacy
-export class Loader implements IHostLoader {
-    constructor(loaderProps: ILoaderProps);
-    // (undocumented)
-    createDetachedContainer(codeDetails: IFluidCodeDetails, createDetachedProps?: {
-        canReconnect?: boolean;
-        clientDetailsOverride?: IClientDetails;
-    }): Promise<IContainer>;
-    // (undocumented)
-    rehydrateDetachedContainerFromSnapshot(snapshot: string, createDetachedProps?: {
-        canReconnect?: boolean;
-        clientDetailsOverride?: IClientDetails;
-    }): Promise<IContainer>;
-    // (undocumented)
-    resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
-    // (undocumented)
-    readonly services: ILoaderServices;
-}
+export function createLoader(loaderProps: ILoaderProps): IHostLoader;
+
+// @beta @legacy
+export function createLoaderServices(loaderProps: ILoaderProps, scopeLoader?: ILoader): {
+    services: ILoaderServices;
+    mc: MonitoringContext;
+};
 
 // @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -26,6 +26,9 @@ export function createDetachedContainer(createDetachedContainerProps: ICreateDet
 // @alpha @legacy
 export function createFrozenDocumentServiceFactory(factory?: IDocumentServiceFactory | Promise<IDocumentServiceFactory>): IDocumentServiceFactory;
 
+// @beta @legacy
+export function createLoader(loaderProps: ILoaderProps): IHostLoader;
+
 // @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)
@@ -155,9 +158,6 @@ export interface IScribeProtocolState {
     // (undocumented)
     values: [string, ICommittedProposal][];
 }
-
-// @beta @legacy
-export function createLoader(loaderProps: ILoaderProps): IHostLoader;
 
 // @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -160,12 +160,6 @@ export interface IScribeProtocolState {
 export function createLoader(loaderProps: ILoaderProps): IHostLoader;
 
 // @beta @legacy
-export function createLoaderServices(loaderProps: ILoaderProps, scopeLoader?: ILoader): {
-    services: ILoaderServices;
-    mc: MonitoringContext;
-};
-
-// @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;
 
 // @alpha @legacy

--- a/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
@@ -141,12 +141,6 @@ export interface IScribeProtocolState {
 export function createLoader(loaderProps: ILoaderProps): IHostLoader;
 
 // @beta @legacy
-export function createLoaderServices(loaderProps: ILoaderProps, scopeLoader?: ILoader): {
-    services: ILoaderServices;
-    mc: MonitoringContext;
-};
-
-// @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;
 
 // @beta @legacy

--- a/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
@@ -15,9 +15,6 @@ export enum ConnectionState {
 // @beta @legacy
 export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
 
-// @beta @legacy
-export function createLoader(loaderProps: ILoaderProps): IHostLoader;
-
 // @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)

--- a/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
@@ -138,23 +138,13 @@ export interface IScribeProtocolState {
 }
 
 // @beta @legacy
-export class Loader implements IHostLoader {
-    constructor(loaderProps: ILoaderProps);
-    // (undocumented)
-    createDetachedContainer(codeDetails: IFluidCodeDetails, createDetachedProps?: {
-        canReconnect?: boolean;
-        clientDetailsOverride?: IClientDetails;
-    }): Promise<IContainer>;
-    // (undocumented)
-    rehydrateDetachedContainerFromSnapshot(snapshot: string, createDetachedProps?: {
-        canReconnect?: boolean;
-        clientDetailsOverride?: IClientDetails;
-    }): Promise<IContainer>;
-    // (undocumented)
-    resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
-    // (undocumented)
-    readonly services: ILoaderServices;
-}
+export function createLoader(loaderProps: ILoaderProps): IHostLoader;
+
+// @beta @legacy
+export function createLoaderServices(loaderProps: ILoaderProps, scopeLoader?: ILoader): {
+    services: ILoaderServices;
+    mc: MonitoringContext;
+};
 
 // @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;

--- a/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
@@ -15,6 +15,9 @@ export enum ConnectionState {
 // @beta @legacy
 export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
 
+// @beta @legacy
+export function createLoader(loaderProps: ILoaderProps): IHostLoader;
+
 // @beta @legacy (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)
@@ -136,9 +139,6 @@ export interface IScribeProtocolState {
     // (undocumented)
     values: [string, ICommittedProposal][];
 }
-
-// @beta @legacy
-export function createLoader(loaderProps: ILoaderProps): IHostLoader;
 
 // @beta @legacy
 export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -224,7 +224,15 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_Loader": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"ClassStatics_Loader": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -29,7 +29,8 @@ export {
 	type IFluidModuleWithDetails,
 	type ILoaderProps,
 	type ILoaderServices,
-	Loader,
+	createLoader,
+	createLoaderServices,
 } from "./loader.js";
 export {
 	driverSupportRequirementsForLoader,

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -30,7 +30,6 @@ export {
 	type ILoaderProps,
 	type ILoaderServices,
 	createLoader,
-	createLoaderServices,
 } from "./loader.js";
 export {
 	driverSupportRequirementsForLoader,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -346,10 +346,9 @@ export async function resolveAndLoadContainer(
 
 /**
  * Creates an IHostLoader instance from loader properties.
- * This is the recommended replacement for the deprecated Loader class.
  * @param loaderProps - Services and properties necessary for creating a loader
  * @returns An IHostLoader that can create, rehydrate, and load containers
- * @legacy @beta
+ * @internal
  */
 export function createLoader(loaderProps: ILoaderProps): IHostLoader {
 	// We need `loader` to exist before calling `createLoaderServices` so it can be

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -390,7 +390,12 @@ export function createLoader(loaderProps: ILoaderProps): IHostLoader {
 			);
 		},
 		resolve: async (request: IRequest, pendingLocalState?: string): Promise<IContainer> => {
-			return resolveAndLoadContainer(servicesRef.services, servicesRef.mc, request, pendingLocalState);
+			return resolveAndLoadContainer(
+				servicesRef.services,
+				servicesRef.mc,
+				request,
+				pendingLocalState,
+			);
 		},
 	};
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -391,10 +391,7 @@ export function createLoader(loaderProps: ILoaderProps): IHostLoader {
 				snapshot,
 			);
 		},
-		resolve: async (
-			request: IRequest,
-			pendingLocalState?: string,
-		): Promise<IContainer> => {
+		resolve: async (request: IRequest, pendingLocalState?: string): Promise<IContainer> => {
 			return resolveAndLoadContainer(services, mc, request, pendingLocalState);
 		},
 	};
@@ -403,4 +400,3 @@ export function createLoader(loaderProps: ILoaderProps): IHostLoader {
 
 	return loader;
 }
-

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -23,7 +23,7 @@ import {
 import { v4 as uuid } from "uuid";
 
 import { Container } from "../container.js";
-import { Loader } from "../loader.js";
+import { createLoader } from "../loader.js";
 import type { IPendingDetachedContainerState } from "../serializedStateManager.js";
 
 import { AbsentProperty, failProxy, failSometimeProxy } from "./failProxy.js";
@@ -40,7 +40,7 @@ const documentServiceFactoryFailProxy = failSometimeProxy<
 
 describe("loader unit test", () => {
 	it("rehydrateDetachedContainerFromSnapshot with invalid format", async () => {
-		const loader = new Loader({
+		const loader = createLoader({
 			codeLoader: failProxy(),
 			documentServiceFactory: documentServiceFactoryFailProxy,
 			urlResolver: failProxy(),
@@ -60,7 +60,7 @@ describe("loader unit test", () => {
 	});
 
 	it("rehydrateDetachedContainerFromSnapshot with valid format", async () => {
-		const loader = new Loader({
+		const loader = createLoader({
 			codeLoader: createTestCodeLoaderProxy(),
 			documentServiceFactory: documentServiceFactoryFailProxy,
 			urlResolver: failProxy(),
@@ -76,7 +76,7 @@ describe("loader unit test", () => {
 	});
 
 	it("rehydrateDetachedContainerFromSnapshot with valid format and attachment blobs", async () => {
-		const loader = new Loader({
+		const loader = createLoader({
 			codeLoader: createTestCodeLoaderProxy({ createDetachedBlob: true }),
 			documentServiceFactory: documentServiceFactoryFailProxy,
 			urlResolver: failProxy(),
@@ -92,7 +92,7 @@ describe("loader unit test", () => {
 	});
 
 	it("serialize and rehydrateDetachedContainerFromSnapshot while attaching", async () => {
-		const loader = new Loader({
+		const loader = createLoader({
 			codeLoader: createTestCodeLoaderProxy(),
 			documentServiceFactory: documentServiceFactoryFailProxy,
 			urlResolver: failProxy(),
@@ -128,7 +128,7 @@ describe("loader unit test", () => {
 			type: "fluid",
 			url: "none",
 		};
-		const loader = new Loader({
+		const loader = createLoader({
 			codeLoader: createTestCodeLoaderProxy({ createDetachedBlob: true }),
 			documentServiceFactory: createTestDocumentServiceFactoryProxy(resolvedUrl),
 			urlResolver: failSometimeProxy<IUrlResolver>({
@@ -202,7 +202,7 @@ describe("loader unit test", () => {
 		const urlResolver = failSometimeProxy<IUrlResolver>({
 			resolve: async () => resolvedUrl,
 		});
-		const loader = new Loader({
+		const loader = createLoader({
 			codeLoader: createTestCodeLoaderProxy({ runtimeWithout_setConnectionStatus: true }),
 			documentServiceFactory: createTestDocumentServiceFactoryProxy(resolvedUrl),
 			urlResolver,

--- a/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
+++ b/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
@@ -20,7 +20,9 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import Sinon from "sinon";
 
-import { Loader } from "../loader.js";
+import type { IHostLoader } from "@fluidframework/container-definitions/internal";
+
+import { createLoader } from "../loader.js";
 import {
 	driverSupportRequirementsForLoader,
 	loaderCoreCompatDetails,
@@ -285,7 +287,7 @@ describe("Loader Layer compatibility", () => {
 			resolve: async () => resolvedUrl,
 		});
 
-		async function createAndAttachContainer(loader: Loader): Promise<void> {
+		async function createAndAttachContainer(loader: IHostLoader): Promise<void> {
 			const container = await loader.createDetachedContainer({ package: "none" });
 			await container.attach({ url: "none" });
 		}
@@ -293,7 +295,7 @@ describe("Loader Layer compatibility", () => {
 		for (const testCase of testCases) {
 			describe(`Validate ${testCase.layerType} Compatibility`, () => {
 				it(`Older ${testCase.layerType} is compatible`, async () => {
-					const loader = new Loader({
+					const loader = createLoader({
 						codeLoader: createTestCodeLoaderProxy(),
 						documentServiceFactory: createTestDocumentServiceFactoryProxy(resolvedUrl),
 						urlResolver,
@@ -310,7 +312,7 @@ describe("Loader Layer compatibility", () => {
 						generation: testCase.layerSupportRequirements.minSupportedGeneration,
 						supportedFeatures: new Set(),
 					};
-					const loader = new Loader({
+					const loader = createLoader({
 						codeLoader: createTestCodeLoaderProxy(
 							testCase.layerType === "runtime" ? { layerCompatDetails } : {},
 						),
@@ -334,7 +336,7 @@ describe("Loader Layer compatibility", () => {
 						generation: layerGeneration,
 						supportedFeatures: new Set(),
 					};
-					const loader = new Loader({
+					const loader = createLoader({
 						codeLoader: createTestCodeLoaderProxy(
 							testCase.layerType === "runtime" ? { layerCompatDetails } : {},
 						),

--- a/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
+++ b/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
@@ -10,7 +10,10 @@ import type {
 	ILayerCompatDetails,
 	ILayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
-import type { ICriticalContainerError } from "@fluidframework/container-definitions/internal";
+import type {
+	ICriticalContainerError,
+	IHostLoader,
+} from "@fluidframework/container-definitions/internal";
 import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces/internal";
 import type { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions/internal";
 import {
@@ -19,8 +22,6 @@ import {
 	isLayerIncompatibilityError,
 } from "@fluidframework/telemetry-utils/internal";
 import Sinon from "sinon";
-
-import type { IHostLoader } from "@fluidframework/container-definitions/internal";
 
 import { createLoader } from "../loader.js";
 import {

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -24,6 +24,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_Loader": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_Loader = requireAssignableTo<TypeOnly<old.Loader>, TypeOnly<current.Loader>>
 
 /*
@@ -33,6 +34,7 @@ declare type old_as_current_for_Class_Loader = requireAssignableTo<TypeOnly<old.
  * typeValidation.broken:
  * "Class_Loader": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_Loader = requireAssignableTo<TypeOnly<current.Loader>, TypeOnly<old.Loader>>
 
 /*
@@ -42,6 +44,7 @@ declare type current_as_old_for_Class_Loader = requireAssignableTo<TypeOnly<curr
  * typeValidation.broken:
  * "ClassStatics_Loader": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_Loader = requireAssignableTo<TypeOnly<typeof current.Loader>, TypeOnly<typeof old.Loader>>
 
 /*

--- a/packages/test/local-server-tests/src/test/audience.spec.ts
+++ b/packages/test/local-server-tests/src/test/audience.spec.ts
@@ -11,7 +11,10 @@ import {
 	IContainer,
 	IFluidCodeDetails,
 } from "@fluidframework/container-definitions/internal";
-import { createLoader } from "@fluidframework/container-loader/internal";
+import {
+	createDetachedContainer,
+	loadExistingContainer,
+} from "@fluidframework/container-loader/internal";
 import {
 	LocalDocumentServiceFactory,
 	LocalResolver,
@@ -90,13 +93,17 @@ describe("Audience correctness", () => {
 		const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
 		const urlResolver = new LocalResolver();
 
-		// Create container in first client
-		const loader = createLoader({
+		const loaderProps = {
 			urlResolver,
 			documentServiceFactory,
 			codeLoader,
+		};
+
+		// Create container in first client
+		const container1 = await createDetachedContainer({
+			...loaderProps,
+			codeDetails,
 		});
-		const container1 = await loader.createDetachedContainer(codeDetails);
 		await container1.attach({
 			url: testDocumentUrl,
 			headers: {
@@ -105,8 +112,9 @@ describe("Audience correctness", () => {
 		});
 
 		// Load container from a second client
-		const container2 = await loader.resolve({
-			url: testDocumentUrl,
+		const container2 = await loadExistingContainer({
+			...loaderProps,
+			request: { url: testDocumentUrl },
 		});
 
 		await waitForContainerConnection(container1);

--- a/packages/test/local-server-tests/src/test/audience.spec.ts
+++ b/packages/test/local-server-tests/src/test/audience.spec.ts
@@ -11,7 +11,7 @@ import {
 	IContainer,
 	IFluidCodeDetails,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import {
 	LocalDocumentServiceFactory,
 	LocalResolver,
@@ -91,7 +91,7 @@ describe("Audience correctness", () => {
 		const urlResolver = new LocalResolver();
 
 		// Create container in first client
-		const loader = new Loader({
+		const loader = createLoader({
 			urlResolver,
 			documentServiceFactory,
 			codeLoader,

--- a/packages/test/local-server-tests/src/test/data-migration/basicMigration.spec.ts
+++ b/packages/test/local-server-tests/src/test/data-migration/basicMigration.spec.ts
@@ -16,7 +16,7 @@ import {
 	type IContainer,
 	type IRuntimeFactory,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
 import {
@@ -172,7 +172,7 @@ describe.skip("basicMigration", () => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		const driver = new LocalServerTestDriver();
-		provider = new TestObjectProvider(Loader, driver, createFluidEntryPoint);
+		provider = new TestObjectProvider(createLoader, driver, createFluidEntryPoint);
 	});
 
 	for (const strategy of migrationStrategies) {

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -10,8 +10,9 @@ import { AttachState } from "@fluidframework/container-definitions";
 import type {
 	IContainer,
 	IFluidCodeDetails,
+	IHostLoader,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import type { ISharedMap } from "@fluidframework/map/internal";
 import {
@@ -65,7 +66,7 @@ describeCompat(
 		const mapId2 = "mapId2";
 
 		let request: IRequest;
-		let loader: Loader;
+		let loader: IHostLoader;
 		const loaderContainerTracker = new LoaderContainerTracker();
 
 		const createTestStatementForAttachedDetached = (name: string, attached: boolean): string =>
@@ -97,7 +98,7 @@ describeCompat(
 			};
 		};
 
-		function createTestLoader(): Loader {
+		function createTestLoader(): IHostLoader {
 			const factory: TestFluidObjectFactory = new TestFluidObjectFactory([
 				[mapId1, SharedMap.getFactory()],
 				[mapId2, SharedMap.getFactory()],
@@ -105,7 +106,7 @@ describeCompat(
 			const urlResolver = provider.urlResolver;
 			const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
 			const documentServiceFactory = provider.documentServiceFactory;
-			const testLoader = new Loader({
+			const testLoader = createLoader({
 				urlResolver,
 				documentServiceFactory,
 				codeLoader,

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -7,7 +7,10 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import type { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
+import type {
+	IContainer,
+	IFluidCodeDetails,
+} from "@fluidframework/container-definitions/internal";
 import { createDetachedContainer } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import type { ISharedMap } from "@fluidframework/map/internal";

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -10,9 +10,10 @@ import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
 import {
 	IContainer,
 	IFluidCodeDetails,
+	IHostLoader,
 	ILoader,
 } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import { ILoaderProps, createLoader } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import {
@@ -27,14 +28,14 @@ const codeDetails: IFluidCodeDetails = { package: "test" };
 
 describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
-	let loader: Loader;
+	let loader: IHostLoader;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;
 
 	const loaderContainerTracker = new LoaderContainerTracker();
 
-	function createLoader(props?: Partial<ILoaderProps>): Loader {
-		return new Loader({
+	function makeLoader(props?: Partial<ILoaderProps>): IHostLoader {
+		return createLoader({
 			...props,
 			logger: provider.logger,
 			urlResolver: props?.urlResolver ?? provider.urlResolver,
@@ -47,7 +48,7 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 
 	before(async () => {
 		provider = getTestObjectProvider();
-		loader = createLoader();
+		loader = makeLoader();
 		loaderContainerTracker.add(loader);
 		const container = await loader.createDetachedContainer(codeDetails);
 
@@ -70,7 +71,7 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 			}
 
 			async run(): Promise<void> {
-				this.loader = createLoader();
+				this.loader = makeLoader();
 			}
 		})(),
 	);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
@@ -7,8 +7,8 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { benchmark } from "@fluid-tools/benchmark";
-import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import { IFluidCodeDetails, IHostLoader } from "@fluidframework/container-definitions/internal";
+import { ILoaderProps, createLoader } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import {
@@ -23,14 +23,14 @@ const codeDetails: IFluidCodeDetails = { package: "test" };
 
 describeCompat("Container - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
-	let loader: Loader;
+	let loader: IHostLoader;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;
 
 	const loaderContainerTracker = new LoaderContainerTracker();
 
-	function createLoader(props?: Partial<ILoaderProps>): Loader {
-		return new Loader({
+	function makeLoader(props?: Partial<ILoaderProps>): IHostLoader {
+		return createLoader({
 			...props,
 			logger: provider.logger,
 			urlResolver: props?.urlResolver ?? provider.urlResolver,
@@ -43,7 +43,7 @@ describeCompat("Container - runtime benchmarks", "NoCompat", (getTestObjectProvi
 
 	before(async () => {
 		provider = getTestObjectProvider();
-		loader = createLoader();
+		loader = makeLoader();
 		loaderContainerTracker.add(loader);
 		const container = await loader.createDetachedContainer(codeDetails);
 
@@ -59,7 +59,7 @@ describeCompat("Container - runtime benchmarks", "NoCompat", (getTestObjectProvi
 	benchmark({
 		title: "Create loader",
 		benchmarkFn: () => {
-			createLoader();
+			makeLoader();
 		},
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
@@ -7,7 +7,10 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { benchmark } from "@fluid-tools/benchmark";
-import { IFluidCodeDetails, IHostLoader } from "@fluidframework/container-definitions/internal";
+import {
+	IFluidCodeDetails,
+	IHostLoader,
+} from "@fluidframework/container-definitions/internal";
 import { ILoaderProps, createLoader } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -24,7 +24,7 @@ import {
 	ConnectionState,
 	type ContainerAlpha,
 	type ILoaderProps,
-	Loader,
+	createLoader,
 	waitContainerToCatchUp,
 } from "@fluidframework/container-loader/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
@@ -82,7 +82,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		}
 	});
 	before(async () => {
-		const loader = new Loader({
+		const loader = createLoader({
 			logger: provider.logger,
 			urlResolver: provider.urlResolver,
 			documentServiceFactory: provider.documentServiceFactory,
@@ -99,7 +99,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		props?: Partial<ILoaderProps>,
 		headers?: IRequestHeader,
 	): Promise<IContainer> {
-		const loader = new Loader({
+		const loader = createLoader({
 			...props,
 			logger: provider.logger,
 			urlResolver: props?.urlResolver ?? provider.urlResolver,
@@ -302,7 +302,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {});
 
 		const localTestObjectProvider = new TestObjectProvider(
-			Loader,
+			createLoader,
 			provider.driver,
 			runtimeFactory,
 		);
@@ -328,7 +328,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory());
 
 		const localTestObjectProvider = new TestObjectProvider(
-			Loader,
+			createLoader,
 			provider.driver,
 			runtimeFactory,
 		);
@@ -380,7 +380,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {});
 
 		const localTestObjectProvider = new TestObjectProvider(
-			Loader,
+			createLoader,
 			provider.driver,
 			runtimeFactory,
 		);

--- a/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
@@ -6,7 +6,7 @@
 import { LocalServerTestDriver } from "@fluid-private/test-drivers";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, IHostLoader } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import {
 	ChannelCollectionFactory,
 	ISummarizer,
@@ -103,7 +103,7 @@ describeCompat("Nested DataStores", "NoCompat", (getTestObjectProvider, apis) =>
 		const registry = [];
 		// ADO:7302 We need another test object provider
 		provider = new TestObjectProvider(
-			Loader,
+			createLoader,
 			driver,
 			() =>
 				new TestContainerRuntimeFactory(

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -8,8 +8,11 @@ import { strict as assert } from "assert";
 import type { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ISharedCell } from "@fluidframework/cell/internal";
-import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import {
+	IContainer,
+	IFluidCodeDetails,
+	IHostLoader,
+} from "@fluidframework/container-definitions/internal";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import type { SharedCounter } from "@fluidframework/counter/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
@@ -203,7 +206,7 @@ describeCompat(
 		const sharedCounterId = "sharedcounterKey";
 
 		let provider: ITestObjectProvider;
-		let loader: Loader;
+		let loader: IHostLoader;
 		let request: IRequest;
 		const loaderContainerTracker = new LoaderContainerTracker();
 
@@ -221,7 +224,7 @@ describeCompat(
 			};
 		}
 
-		function createTestLoader(): Loader {
+		function createTestLoader(): IHostLoader {
 			// It's important to use data store runtime of the same version as DDSs!
 			const factory = new apis.dataRuntime.TestFluidObjectFactory([
 				[sharedStringId, SharedString.getFactory()],
@@ -249,7 +252,7 @@ describeCompat(
 			const codeLoader = new LocalCodeLoader([[codeDetails, defaultFactory]], {});
 
 			// Use Loader supplied by test framework.
-			const testLoader = new apis.loader.Loader({
+			const testLoader = apis.loader.createLoader({
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: provider.documentServiceFactory,
 				codeLoader,

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -106,7 +106,7 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 	beforeEach("setup", function () {
 		provider = getTestObjectProvider();
 		request = provider.driver.createCreateNewRequest(provider.documentId);
-		loader = provider.makeTestLoader(testContainerConfig) as IHostLoader;
+		loader = provider.makeTestLoader(testContainerConfig);
 	});
 
 	it("Create detached container", async () => {
@@ -894,7 +894,7 @@ describeCompat("Detached Container", "NoCompat", (getTestObjectProvider, apis) =
 	beforeEach("setup", () => {
 		provider = getTestObjectProvider();
 		request = provider.driver.createCreateNewRequest(provider.documentId);
-		loader = provider.makeTestLoader(testContainerConfig) as IHostLoader;
+		loader = provider.makeTestLoader(testContainerConfig);
 	});
 
 	it("Retry attaching detached container", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -11,11 +11,12 @@ import type { ISharedCell } from "@fluidframework/cell/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import {
 	IContainer,
+	IHostLoader,
 	IRuntime,
 	IRuntimeFactory,
 } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import { ContainerMessageType } from "@fluidframework/container-runtime/internal";
 import { FluidObject, IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
@@ -100,12 +101,12 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 
 	let provider: ITestObjectProvider;
 	let request: IRequest;
-	let loader: Loader;
+	let loader: IHostLoader;
 
 	beforeEach("setup", function () {
 		provider = getTestObjectProvider();
 		request = provider.driver.createCreateNewRequest(provider.documentId);
-		loader = provider.makeTestLoader(testContainerConfig) as Loader;
+		loader = provider.makeTestLoader(testContainerConfig) as IHostLoader;
 	});
 
 	it("Create detached container", async () => {
@@ -888,12 +889,12 @@ describeCompat("Detached Container", "NoCompat", (getTestObjectProvider, apis) =
 
 	let provider: ITestObjectProvider;
 	let request: IRequest;
-	let loader: Loader;
+	let loader: IHostLoader;
 
 	beforeEach("setup", () => {
 		provider = getTestObjectProvider();
 		request = provider.driver.createCreateNewRequest(provider.documentId);
-		loader = provider.makeTestLoader(testContainerConfig) as Loader;
+		loader = provider.makeTestLoader(testContainerConfig) as IHostLoader;
 	});
 
 	it("Retry attaching detached container", async () => {
@@ -919,7 +920,7 @@ describeCompat("Detached Container", "NoCompat", (getTestObjectProvider, apis) =
 			IFluidDataStoreFactory: new TestFluidObjectFactory(registry),
 		};
 		const codeLoader = new LocalCodeLoader([[provider.defaultCodeDetails, fluidExport]]);
-		const mockLoader = new Loader({
+		const mockLoader = createLoader({
 			urlResolver: provider.urlResolver,
 			documentServiceFactory,
 			codeLoader,

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -10,7 +10,7 @@ import {
 	ContainerErrorTypes,
 	IContainer,
 } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import { ILoaderProps, createLoader } from "@fluidframework/container-loader/internal";
 import {
 	IDocumentServiceFactory,
 	IResolvedUrl,
@@ -38,7 +38,7 @@ describeCompat("Errors Types", "NoCompat", (getTestObjectProvider) => {
 	});
 
 	beforeEach("setup", async () => {
-		const loader = new Loader({
+		const loader = createLoader({
 			logger: provider.logger,
 			urlResolver: provider.urlResolver,
 			documentServiceFactory: provider.documentServiceFactory,
@@ -59,7 +59,7 @@ describeCompat("Errors Types", "NoCompat", (getTestObjectProvider) => {
 	});
 
 	async function loadContainer(props?: Partial<ILoaderProps>): Promise<IContainer> {
-		const loader = new Loader({
+		const loader = createLoader({
 			...props,
 			logger: provider.logger,
 			urlResolver: props?.urlResolver ?? provider.urlResolver,

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -18,7 +18,6 @@ import {
 	IContainer,
 	type IFluidCodeDetails,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
 import {
 	IContainerRuntimeOptions,
 	IdCompressorMode,
@@ -772,7 +771,7 @@ describeCompat(
 
 			// Create another container to test sync
 			const url: any = await container.getAbsoluteUrl("");
-			const loader2 = provider.makeTestLoader(testConfig) as Loader;
+			const loader2 = provider.makeTestLoader(testConfig);
 			const container2 = await loader2.resolve({ url });
 			const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 			const testChannel2 = await dataStore2.getSharedObject<ISharedCell>("sharedCell");

--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import {
 	ITestObjectProvider,
 	LoaderContainerTracker,
@@ -32,7 +32,7 @@ describe("Pong", () => {
 				this.skip();
 			}
 
-			const loader = new Loader({
+			const loader = createLoader({
 				logger: provider.logger,
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: provider.documentServiceFactory,

--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -6,24 +6,16 @@
 import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { createLoader } from "@fluidframework/container-loader/internal";
 import {
 	ITestObjectProvider,
-	LoaderContainerTracker,
-	LocalCodeLoader,
-	TestFluidObjectFactory,
 	timeoutPromise,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
-const codeDetails: IFluidCodeDetails = { package: "test" };
-
 describe("Pong", () => {
 	describeCompat("Pong", "NoCompat", (getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
-		const loaderContainerTracker = new LoaderContainerTracker();
 
 		beforeEach("setup", async function () {
 			provider = getTestObjectProvider();
@@ -31,18 +23,6 @@ describe("Pong", () => {
 			if (provider.driver.type === "local") {
 				this.skip();
 			}
-
-			const loader = createLoader({
-				logger: provider.logger,
-				urlResolver: provider.urlResolver,
-				documentServiceFactory: provider.documentServiceFactory,
-				codeLoader: new LocalCodeLoader([[codeDetails, new TestFluidObjectFactory([])]]),
-			});
-			loaderContainerTracker.add(loader);
-		});
-
-		afterEach(() => {
-			loaderContainerTracker.reset();
 		});
 
 		it("Delta manager receives pong event", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces/internal";
 import { IDataStore } from "@fluidframework/runtime-definitions/internal";
@@ -83,7 +82,7 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		const alias = "alias";
 
 		it("Assign multiple data stores to the same alias, first write wins, same container - detached", async function () {
-			const loader = provider.makeTestLoader(testContainerConfig) as Loader;
+			const loader = provider.makeTestLoader(testContainerConfig);
 			const container: IContainer = await loader.createDetachedContainer(
 				provider.defaultCodeDetails,
 			);

--- a/packages/test/test-end-to-end-tests/src/test/serializeAfterFailedAttach.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/serializeAfterFailedAttach.spec.ts
@@ -7,8 +7,12 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import {
+	IContainer,
+	IFluidCodeDetails,
+	IHostLoader,
+} from "@fluidframework/container-definitions/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import type { ISharedMap } from "@fluidframework/map/internal";
@@ -74,13 +78,13 @@ describeCompat(
 		function createTestLoader(
 			provider: ITestObjectProvider,
 			documentServiceFactory?: IDocumentServiceFactory,
-		): Loader {
+		): IHostLoader {
 			const factory: TestFluidObjectFactory = new TestFluidObjectFactory([
 				[sharedStringId, SharedString.getFactory()],
 				[sharedMapId, SharedMap.getFactory()],
 			]);
 			const codeLoader = new LocalCodeLoader([[codeDetails, factory]], {});
-			const testLoader = new Loader({
+			const testLoader = createLoader({
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: documentServiceFactory ?? provider.documentServiceFactory,
 				codeLoader,

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -6,7 +6,10 @@
 import { strict as assert } from "assert";
 
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
-import { createLoader } from "@fluidframework/container-loader/internal";
+import {
+	createDetachedContainer,
+	loadExistingContainer,
+} from "@fluidframework/container-loader/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IDocumentServiceFactory,
@@ -63,14 +66,13 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 				const codeDetails = { package: "no-dynamic-pkg" };
 				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-				const loader = createLoader({
+				const container = await createDetachedContainer({
 					urlResolver: provider.urlResolver,
 					documentServiceFactory: provider.documentServiceFactory,
 					codeLoader,
 					logger,
+					codeDetails,
 				});
-
-				const container = await loader.createDetachedContainer(codeDetails);
 				const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
 				const sharedString = await dataObject.root
 					.get<IFluidHandle<SharedString>>(stringId)
@@ -86,15 +88,14 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 				const codeDetails = { package: "no-dynamic-pkg" };
 				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-				const loader = createLoader({
+				const container = await loadExistingContainer({
 					urlResolver: provider.urlResolver,
 					documentServiceFactory: provider.documentServiceFactory,
 					codeLoader,
 					logger,
-				});
-
-				const container = await loader.resolve({
-					url: await provider.driver.createContainerUrl(documentId, containerUrl),
+					request: {
+						url: await provider.driver.createContainerUrl(documentId, containerUrl),
+					},
 				});
 				const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
 				const sharedString = await dataObject.root
@@ -135,15 +136,14 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 					},
 				});
 
-				const loader = createLoader({
+				const container = await loadExistingContainer({
 					urlResolver: provider.urlResolver,
 					documentServiceFactory,
 					codeLoader,
 					logger,
-				});
-
-				const container = await loader.resolve({
-					url: await provider.driver.createContainerUrl(documentId, containerUrl),
+					request: {
+						url: await provider.driver.createContainerUrl(documentId, containerUrl),
+					},
 				});
 				const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
 
@@ -170,14 +170,13 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 			const codeDetails = { package: "no-dynamic-pkg" };
 			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-			const loader = createLoader({
+			const container = await createDetachedContainer({
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: provider.documentServiceFactory,
 				codeLoader,
 				logger,
+				codeDetails,
 			});
-
-			const container = await loader.createDetachedContainer(codeDetails);
 			const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
 			const sharedString = await dataObject.root
 				.get<IFluidHandle<SharedString>>(stringId)
@@ -214,15 +213,14 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 			const codeDetails = { package: "no-dynamic-pkg" };
 			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-			const loader = createLoader({
+			const container = await loadExistingContainer({
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: provider.documentServiceFactory,
 				codeLoader,
 				logger,
-			});
-
-			const container = await loader.resolve({
-				url: await provider.driver.createContainerUrl(documentId, containerUrl),
+				request: {
+					url: await provider.driver.createContainerUrl(documentId, containerUrl),
+				},
 			});
 			const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
 			const sharedString = await dataObject.root

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IDocumentServiceFactory,
@@ -63,7 +63,7 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 				const codeDetails = { package: "no-dynamic-pkg" };
 				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-				const loader = new Loader({
+				const loader = createLoader({
 					urlResolver: provider.urlResolver,
 					documentServiceFactory: provider.documentServiceFactory,
 					codeLoader,
@@ -86,7 +86,7 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 				const codeDetails = { package: "no-dynamic-pkg" };
 				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-				const loader = new Loader({
+				const loader = createLoader({
 					urlResolver: provider.urlResolver,
 					documentServiceFactory: provider.documentServiceFactory,
 					codeLoader,
@@ -135,7 +135,7 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 					},
 				});
 
-				const loader = new Loader({
+				const loader = createLoader({
 					urlResolver: provider.urlResolver,
 					documentServiceFactory,
 					codeLoader,
@@ -170,7 +170,7 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 			const codeDetails = { package: "no-dynamic-pkg" };
 			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-			const loader = new Loader({
+			const loader = createLoader({
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: provider.documentServiceFactory,
 				codeLoader,
@@ -214,7 +214,7 @@ describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 			const codeDetails = { package: "no-dynamic-pkg" };
 			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
-			const loader = new Loader({
+			const loader = createLoader({
 				urlResolver: provider.urlResolver,
 				documentServiceFactory: provider.documentServiceFactory,
 				codeLoader,

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluidframework/container-definitions/internal";
 import {
 	createDetachedContainer,
-	Loader,
+	createLoader as createContainerLoader,
 	type ICreateDetachedContainerProps,
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
@@ -41,7 +41,7 @@ export function createLoader(
 ): IHostLoader {
 	const codeLoader: ICodeDetailsLoader = new LocalCodeLoader(packageEntries);
 
-	return new Loader({
+	return createContainerLoader({
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -211,7 +211,7 @@ export async function getVersionedTestObjectProviderFromApis(
 		);
 	};
 
-	return new TestObjectProvider(apis.loader.Loader, driver, containerFactoryFn);
+	return new TestObjectProvider(apis.loader.createLoader, driver, containerFactoryFn);
 }
 
 // eslint-disable-next-line jsdoc/require-description -- TODO: add documentation
@@ -358,8 +358,8 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 	};
 
 	return new TestObjectProviderWithVersionedLoad(
-		apis.loader.Loader,
-		apis.loaderForLoading.Loader,
+		apis.loader.createLoader,
+		apis.loaderForLoading.createLoader,
 		driverForCreating,
 		driverForLoading,
 		createContainerFactoryFn,

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -10,7 +10,7 @@ import type {
 	IContainer,
 	ILoaderOptions,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import { createLoader } from "@fluidframework/container-loader/internal";
 import type {
 	ContainerRuntime,
 	IContainerRuntimeOptions,
@@ -207,7 +207,7 @@ export async function loadContainer(
 	};
 
 	// Load the Fluid document while forcing summarizeProtocolTree option
-	const loader = new Loader({
+	const loader = createLoader({
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -10,7 +10,7 @@ import type {
 	IContainer,
 	ILoaderOptions,
 } from "@fluidframework/container-definitions/internal";
-import { createLoader } from "@fluidframework/container-loader/internal";
+import { loadExistingContainer } from "@fluidframework/container-loader/internal";
 import type {
 	ContainerRuntime,
 	IContainerRuntimeOptions,
@@ -207,16 +207,15 @@ export async function loadContainer(
 	};
 
 	// Load the Fluid document while forcing summarizeProtocolTree option
-	const loader = createLoader({
+	return loadExistingContainer({
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,
 		options: loaderOptions ? { ...loaderOptions } : {},
 		logger,
 		configProvider,
+		request: { url: resolved.url },
 	});
-
-	return loader.resolve({ url: resolved.url });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove the deprecated `Loader` class from `@fluidframework/container-loader` (closes #24450)
- Refactor direct callers to use the existing free-form functions (`createDetachedContainer`, `loadExistingContainer`, `rehydrateDetachedContainer`) instead of `createLoader()`
- Downgrade `createLoader()` from `@legacy @beta` to `@internal` — it is only needed by test infrastructure (`TestObjectProvider`), not user-facing code
- Extract `createLoaderServices()` as an internal helper for direct access to loader services and monitoring context
- Extract `resolveAndLoadContainer()` as a shared internal helper for URL resolution and container loading
- Refactor free-form functions to use `createLoaderServices()` + `Container` static methods directly, removing their internal dependency on the `Loader` class
- Update `TestObjectProvider` to accept a factory function `(props: ILoaderProps) => IHostLoader` instead of `typeof Loader`
- Update `LoaderApi` in test-version-utils to use `createLoader`, with backward-compat wrapping for older package versions
- Remove dead loader code from `pongEvent.spec.ts` (loader was created but never used)

## Breaking changes

### `Loader` class removed

Replace `new Loader(props)` with the appropriate free-form function:
- `new Loader(props)` + `loader.createDetachedContainer(codeDetails)` → `createDetachedContainer({ ...props, codeDetails })`
- `new Loader(props)` + `loader.resolve(request)` → `loadExistingContainer({ ...props, request })`
- `new Loader(props)` + `loader.rehydrateDetachedContainerFromSnapshot(snapshot)` → `rehydrateDetachedContainer({ ...props, serializedState: snapshot })`

For test infrastructure that needs a factory function, `createLoader()` remains available as an `@internal` API.

### `provideScopeLoader` behavior change for free-form functions

The free-form functions (`createDetachedContainer`, `rehydrateDetachedContainer`, `loadExistingContainer`) no longer inject an `ILoader` into the container's scope. Previously, the internally-created `Loader` instance was added to scope as `ILoader` (unless `provideScopeLoader` was `false`), but this was a throwaway instance that no external code held a reference to. If you need `ILoader` in scope, use `createLoader()` instead — it correctly injects itself as the scope loader.

## Test plan

- [x] container-loader package builds cleanly (`npm run build:compile`)
- [x] All 220 container-loader unit tests pass (`npm test`)
- [x] test-end-to-end-tests, local-server-tests build cleanly with refactored free-form function calls
- [x] API reports regenerated and match expected output
- [ ] E2E tests pass in CI
- [ ] Compat tests pass (older versions wrapped via `LoaderApi.createLoader` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)