### PR TITLE
Don't reuse referenceId

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/incrementalSummaryBuilder.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/incrementalSummaryBuilder.spec.ts
@@ -483,12 +483,10 @@ describe("ForestIncrementalSummaryBuilder", () => {
 				builder: summaryTreeBuilder2,
 			});
 			const referenceIds2 = builder.encodeIncrementalField(testCursor, () => mockEncodedChunk);
-			// Should reuse the same reference ID
-			assert.deepEqual(referenceIds1, referenceIds2, "Reference IDs should match");
 
 			// Verify that a handle was added to the summary builder
-			assert.equal(referenceIds1.length, 1);
-			const referenceId1 = referenceIds1[0];
+			assert.equal(referenceIds2.length, 1);
+			const referenceId1 = referenceIds2[0];
 			builder.completeSummary({
 				incrementalSummaryContext: incrementalSummaryContext2,
 				forestSummaryRootContent: mockForestSummaryRootContent,
@@ -547,13 +545,12 @@ describe("ForestIncrementalSummaryBuilder", () => {
 				builder: summaryTreeBuilder3,
 			});
 
-			// Should reuse the same reference ID since the chunk hasn't changed since the last successful summary.
+			// Get the reference ID for the chunk which hasn't changed since the last successful summary.
 			const referenceIds2 = builder.encodeIncrementalField(testCursor, () => mockEncodedChunk);
-			assert.deepEqual(referenceIds1, referenceIds2, "Reference IDs should match");
 
 			// Verify that a handle was added to the summary builder
-			assert.equal(referenceIds1.length, 1);
-			const referenceId1 = referenceIds1[0];
+			assert.equal(referenceIds2.length, 1);
+			const referenceId1 = referenceIds2[0];
 			builder.completeSummary({
 				incrementalSummaryContext: incrementalSummaryContext3,
 				forestSummaryRootContent: mockForestSummaryRootContent,


### PR DESCRIPTION
## Description

Attempt to simplify and document how referenceIds are allocated and scoped.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I know this fails a test, but I'd like to know if that's the test being overly specific about testing implementation details, or a caught real bug.

Also I'd like to know if there is some reason the referenceId's work the way they do instead of the way I suggest which seems simpler.
