### PR TITLE
build: revert "build: streamline by removing unneeded build deps (#25733)"

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -49,7 +49,9 @@ module.exports = {
 			script: false,
 		},
 		"compile": {
-			dependsOn: ["commonjs", "build:esnext", "^api", "build:test", "build:copy"],
+			// Note that "api" is included as "compile" intends to build a complete package
+			// and "api" generates package entrypoint files.
+			dependsOn: ["commonjs", "build:esnext", "api", "build:test", "build:copy"],
 			script: false,
 		},
 		"commonjs": {


### PR DESCRIPTION
This reverts commit ee07c7525607eb4cd61fb279ec23a58f6da1dc7c except for a comment removal. That commit was previously partially reverted by 46c21a3d8781782d74576a4fea4bfdea68d8e6b7.

Adds note of why "api" should be a part of "compile".