### PR TITLE
refactor(experimental-tree): extract ISharedTree interface, hide class from API

### DIFF
--- a/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
@@ -420,6 +420,35 @@ export interface IRevertible {
 }
 
 // @alpha
+export interface ISharedTree extends ISharedObject<ISharedTreeEvents>, NodeIdContext {
+    applyEdit(...changes: readonly Change[]): Edit<InternalizedChange>;
+    // (undocumented)
+    applyEdit(changes: readonly Change[]): Edit<InternalizedChange>;
+    applyEditInternal(editOrChanges: Edit<ChangeInternal> | readonly ChangeInternal[]): Edit<ChangeInternal>;
+    attributeNodeId(id: NodeId): AttributionId;
+    readonly attributionId: AttributionId;
+    // (undocumented)
+    readonly currentView: RevisionView;
+    // (undocumented)
+    readonly edits: OrderedEditSet<InternalizedChange>;
+    equals(sharedTree: ISharedTree): boolean;
+    getRuntime(): IFluidDataStoreRuntime;
+    getWriteFormat(): WriteFormat;
+    internalizeChange(change: Change): ChangeInternal;
+    loadSerializedSummary(blobData: string): ITelemetryBaseProperties;
+    loadSummary(summary: SharedTreeSummaryBase): void;
+    readonly logger: ITelemetryLoggerExt;
+    readonly logViewer: LogViewer;
+    mergeEditsFrom(other: ISharedTree, edits: Iterable<Edit<InternalizedChange>>, stableIdRemapper?: (id: StableNodeId) => StableNodeId): EditId[];
+    revert(editId: EditId): EditId | undefined;
+    revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined;
+    saveSerializedSummary(options?: {
+        serializer?: IFluidSerializer;
+    }): string;
+    saveSummary(): SharedTreeSummaryBase;
+}
+
+// @alpha
 export interface ISharedTreeEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: 'committedEdit', listener: EditCommittedHandler): any;

--- a/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
@@ -147,7 +147,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
     openEdit(): void;
     rebaseCurrentEdit(): EditValidationResult.Valid | EditValidationResult.Invalid;
     revert(editId: EditId): void;
-    readonly tree: SharedTree;
+    readonly tree: ISharedTree;
     protected tryApplyChangesInternal(changes: readonly ChangeInternal[]): EditStatus;
     // (undocumented)
     protected tryApplyChangesInternal(...changes: readonly ChangeInternal[]): EditStatus;
@@ -922,8 +922,7 @@ export class Transaction extends TypedEventEmitter<TransactionEvents> {
     get isOpen(): boolean;
     readonly startingView: TreeView;
     get status(): EditStatus;
-    // (undocumented)
-    readonly tree: SharedTree;
+    readonly tree: ISharedTree;
 }
 
 // @alpha

--- a/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.alpha.api.md
@@ -286,7 +286,7 @@ export interface EditBase<TChange> {
 export interface EditCommittedEventArguments {
     readonly editId: EditId;
     readonly local: boolean;
-    readonly tree: SharedTree;
+    readonly tree: ISharedTree;
 }
 
 // @alpha
@@ -453,7 +453,7 @@ export interface ISharedTreeEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: 'committedEdit', listener: EditCommittedHandler): any;
     // (undocumented)
-    (event: 'appliedSequencedEdit', listener: SequencedEditAppliedHandler): any;
+    (event: 'sequencedEditApplied', listener: SequencedEditAppliedHandler): any;
 }
 
 // @alpha
@@ -618,7 +618,7 @@ export interface SequencedEditAppliedEventArguments {
     readonly logger: ITelemetryLoggerExt;
     readonly outcome: EditApplicationOutcome;
     readonly reconciliationPath: ReconciliationPath;
-    readonly tree: SharedTree;
+    readonly tree: ISharedTree;
     readonly wasLocal: boolean;
 }
 
@@ -765,8 +765,8 @@ export interface SharedTreeSummaryBase {
 // @alpha
 export class SharedTreeUndoRedoHandler {
     constructor(stackManager: IUndoConsumer);
-    attachTree(tree: SharedTree): void;
-    detachTree(tree: SharedTree): void;
+    attachTree(tree: ISharedTree): void;
+    detachTree(tree: ISharedTree): void;
 }
 
 // @alpha

--- a/experimental/dds/tree/src/ISharedTree.ts
+++ b/experimental/dds/tree/src/ISharedTree.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
+import type { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions/internal';
+import type { ISharedObject, IFluidSerializer } from '@fluidframework/shared-object-base/internal';
+import type { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
+
+import type { Change } from './ChangeTypes.js';
+import type { OrderedEditSet } from './EditLog.js';
+import type { AttributionId, EditId, NodeId, StableNodeId } from './Identifiers.js';
+import type { LogViewer } from './LogViewer.js';
+import type { NodeIdContext } from './NodeIdUtilities.js';
+import type { RevisionView } from './RevisionView.js';
+import type { ISharedTreeEvents } from './SharedTree.js';
+import type {
+	ChangeInternal,
+	Edit,
+	InternalizedChange,
+	SharedTreeSummaryBase,
+	WriteFormat,
+} from './persisted-types/index.js';
+
+/**
+ * A {@link https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree/README.md | distributed tree}.
+ * @alpha
+ */
+export interface ISharedTree extends ISharedObject<ISharedTreeEvents>, NodeIdContext {
+	/**
+	 * The UUID used for attribution of nodes created by this SharedTree.
+	 */
+	readonly attributionId: AttributionId;
+
+	/**
+	 * Viewer for trees defined by the edit log. This allows access to views of the tree at different revisions.
+	 */
+	readonly logViewer: LogViewer;
+
+	/**
+	 * Logger for SharedTree events.
+	 */
+	readonly logger: ITelemetryLoggerExt;
+
+	/**
+	 * @returns the current view of the tree.
+	 */
+	readonly currentView: RevisionView;
+
+	/**
+	 * @returns the edit history of the tree.
+	 */
+	readonly edits: OrderedEditSet<InternalizedChange>;
+
+	/**
+	 * The write format version currently used by this `SharedTree`.
+	 */
+	getWriteFormat(): WriteFormat;
+
+	/**
+	 * Applies a set of changes to this tree.
+	 */
+	applyEdit(...changes: readonly Change[]): Edit<InternalizedChange>;
+	applyEdit(changes: readonly Change[]): Edit<InternalizedChange>;
+
+	/**
+	 * Applies a set of internal changes to this tree.
+	 * This is exposed for internal use only.
+	 */
+	applyEditInternal(editOrChanges: Edit<ChangeInternal> | readonly ChangeInternal[]): Edit<ChangeInternal>;
+
+	/**
+	 * Converts a public Change type to an internal representation.
+	 * This is exposed for internal use only.
+	 */
+	internalizeChange(change: Change): ChangeInternal;
+
+	/**
+	 * Merges `edits` from `other` into this SharedTree.
+	 */
+	mergeEditsFrom(
+		other: ISharedTree,
+		edits: Iterable<Edit<InternalizedChange>>,
+		stableIdRemapper?: (id: StableNodeId) => StableNodeId
+	): EditId[];
+
+	/**
+	 * Reverts a previous edit by applying a new edit containing the inverse of the original edit's changes.
+	 * @param editId - the edit to revert
+	 * @returns the id of the new edit, or undefined if the original edit could not be inverted given the current tree state.
+	 */
+	revert(editId: EditId): EditId | undefined;
+
+	/**
+	 * Revert the given changes.
+	 * @param changes - the changes to revert
+	 * @param before - the revision view before the changes were originally applied
+	 * @returns the inverse of `changes` or undefined if the changes could not be inverted for the given tree state.
+	 */
+	revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined;
+
+	/**
+	 * Returns the attribution ID associated with the SharedTree that generated the given node ID.
+	 */
+	attributeNodeId(id: NodeId): AttributionId;
+
+	/**
+	 * Compares this shared tree to another for equality.
+	 */
+	equals(sharedTree: ISharedTree): boolean;
+
+	/**
+	 * Gets the runtime associated with this SharedTree.
+	 */
+	getRuntime(): IFluidDataStoreRuntime;
+
+	/**
+	 * Saves this SharedTree into a deserialized summary.
+	 */
+	saveSummary(): SharedTreeSummaryBase;
+
+	/**
+	 * Initialize shared tree with a deserialized summary.
+	 */
+	loadSummary(summary: SharedTreeSummaryBase): void;
+
+	/**
+	 * Saves this SharedTree into a serialized summary. This is used for testing.
+	 */
+	saveSerializedSummary(options?: { serializer?: IFluidSerializer }): string;
+
+	/**
+	 * Initialize shared tree with a serialized summary. This is used for testing.
+	 * @returns Statistics about the loaded summary.
+	 */
+	loadSerializedSummary(blobData: string): ITelemetryBaseProperties;
+}

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -49,6 +49,7 @@ import {
 } from './EditUtilities.js';
 import { SharedTreeDiagnosticEvent, SharedTreeEvent } from './EventTypes.js';
 import { revert } from './HistoryEditFactory.js';
+import type { ISharedTree } from './ISharedTree.js';
 import { convertEditIds } from './IdConversion.js';
 import {
 	AttributionId,
@@ -297,7 +298,7 @@ export interface EditCommittedEventArguments {
 	/** Whether or not this is a local edit. */
 	readonly local: boolean;
 	/** The tree the edit was committed on. Required for local edit events handled by SharedTreeUndoRedoHandler. */
-	readonly tree: SharedTree;
+	readonly tree: ISharedTree;
 }
 
 /**
@@ -310,7 +311,7 @@ export interface SequencedEditAppliedEventArguments {
 	/** Whether or not this was a local edit. */
 	readonly wasLocal: boolean;
 	/** The tree the edit was applied to. */
-	readonly tree: SharedTree;
+	readonly tree: ISharedTree;
 	/** The telemetry logger associated with sequenced edit application. */
 	readonly logger: ITelemetryLoggerExt;
 	/** The reconciliation path for the edit. See {@link ReconciliationPath} for details. */
@@ -351,7 +352,7 @@ export type EditApplicationOutcome =
  */
 export interface ISharedTreeEvents extends ISharedObjectEvents {
 	(event: 'committedEdit', listener: EditCommittedHandler);
-	(event: 'appliedSequencedEdit', listener: SequencedEditAppliedHandler);
+	(event: 'sequencedEditApplied', listener: SequencedEditAppliedHandler);
 }
 
 /**

--- a/experimental/dds/tree/src/SummaryTestUtilities.ts
+++ b/experimental/dds/tree/src/SummaryTestUtilities.ts
@@ -6,7 +6,7 @@
 import { IsoBuffer } from '@fluid-internal/client-utils';
 
 import type { EditLog } from './EditLog.js';
-import type { SharedTree } from './SharedTree.js';
+import type { ISharedTree } from './ISharedTree.js';
 import type { ChangeInternal, EditChunkContents, FluidEditHandle } from './persisted-types/index.js';
 
 /**
@@ -29,7 +29,7 @@ interface UploadedEditChunkContents {
  * The contents will not be decoded from the format used in the blob.
  * @deprecated Edit virtualization is no longer supported. Do not use this.
  */
-export async function getUploadedEditChunkContents(sharedTree: SharedTree): Promise<UploadedEditChunkContents[]> {
+export async function getUploadedEditChunkContents(sharedTree: ISharedTree): Promise<UploadedEditChunkContents[]> {
 	const editChunks: UploadedEditChunkContents[] = [];
 	const { editChunks: editsOrHandles } = (sharedTree.edits as unknown as EditLog<ChangeInternal>).getEditLogSummary();
 	for (const { chunk } of editsOrHandles) {
@@ -52,6 +52,6 @@ export async function getUploadedEditChunkContents(sharedTree: SharedTree): Prom
  * @deprecated Edit virtualization is no longer supported. Do not use this.
  * @internal
  */
-export async function getSerializedUploadedEditChunkContents(sharedTree: SharedTree): Promise<string> {
+export async function getSerializedUploadedEditChunkContents(sharedTree: ISharedTree): Promise<string> {
 	return JSON.stringify(await getUploadedEditChunkContents(sharedTree));
 }

--- a/experimental/dds/tree/src/UndoRedoHandler.ts
+++ b/experimental/dds/tree/src/UndoRedoHandler.ts
@@ -5,8 +5,9 @@
 
 import { assertNotUndefined } from './Common.js';
 import { SharedTreeEvent } from './EventTypes.js';
+import type { ISharedTree } from './ISharedTree.js';
 import { EditId } from './Identifiers.js';
-import { EditCommittedEventArguments, SharedTree } from './SharedTree.js';
+import { EditCommittedEventArguments } from './SharedTree.js';
 
 // TODO: We temporarily duplicate these contracts from 'framework/undo-redo' to unblock development
 // while we decide on the correct layering for undo.
@@ -56,7 +57,7 @@ export class SharedTreeUndoRedoHandler {
 	 * Attach a shared tree to this handler. Each edit from the tree will invoke `this.stackManager`'s
 	 * {@link IUndoConsumer.pushToCurrentOperation} method with an associated {@link IRevertible}.
 	 */
-	public attachTree(tree: SharedTree): void {
+	public attachTree(tree: ISharedTree): void {
 		tree.on(SharedTreeEvent.EditCommitted, this.treeDeltaHandler);
 	}
 
@@ -64,7 +65,7 @@ export class SharedTreeUndoRedoHandler {
 	 * Detach a shared tree from this handler. Edits from the tree will no longer cause `this.stackManager`'s
 	 * {@link IUndoConsumer.pushToCurrentOperation} to be called.
 	 */
-	public detachTree(tree: SharedTree): void {
+	public detachTree(tree: ISharedTree): void {
 		tree.off(SharedTreeEvent.EditCommitted, this.treeDeltaHandler);
 	}
 
@@ -91,7 +92,7 @@ export class SharedTreeUndoRedoHandler {
 export class SharedTreeRevertible implements IRevertible {
 	constructor(
 		private readonly editId: EditId,
-		private readonly tree: SharedTree
+		private readonly tree: ISharedTree
 	) {}
 
 	public revert(): void {

--- a/experimental/dds/tree/src/index.ts
+++ b/experimental/dds/tree/src/index.ts
@@ -144,6 +144,7 @@ export {
 	ISharedTreeEvents,
 	StashedLocalOpMetadata,
 } from './SharedTree.js';
+export type { ISharedTree } from './ISharedTree.js';
 export { StringInterner } from './StringInterner.js';
 export { SharedTreeAttributes, SharedTreeFactoryType } from './publicContracts.js';
 

--- a/experimental/dds/tree/src/test/Checkout.tests.ts
+++ b/experimental/dds/tree/src/test/Checkout.tests.ts
@@ -617,9 +617,9 @@ export function checkoutTests(
 
 		it('can dispose and remove listeners', async () => {
 			const { checkout } = await setUpTestCheckout();
-			expect(checkout.tree.listenerCount(SharedTreeEvent.EditCommitted)).to.equal(1);
+			expect((checkout.tree as SharedTree).listenerCount(SharedTreeEvent.EditCommitted)).to.equal(1);
 			checkout.dispose();
-			expect(checkout.tree.listenerCount(SharedTreeEvent.EditCommitted)).to.equal(0);
+			expect((checkout.tree as SharedTree).listenerCount(SharedTreeEvent.EditCommitted)).to.equal(0);
 		});
 
 		additionalTests?.();


### PR DESCRIPTION
## Summary

Extract an `ISharedTree` interface from the `SharedTree` class in `@fluid-experimental/tree` so that the class no longer leaks `SharedObject` in the public API surface.

### Changes

- **New file `ISharedTree.ts`**: Defines the `ISharedTree` interface that extends `ISharedObject<ISharedTreeEvents>` and `NodeIdContext`, exposing only the public contract (properties like `attributionId`, `logViewer`, `currentView`, `edits`, and methods like `applyEdit`, `mergeEditsFrom`, `revert`, etc.)
- **`index.ts`**: Exports the new `ISharedTree` type
- **`SummaryTestUtilities.ts`**: Updated to use `ISharedTree` instead of the concrete `SharedTree` class
- **API report regenerated**: `experimental-tree.alpha.api.md` now includes the `ISharedTree` interface

### Why

This is part of a broader effort to stop leaking `SharedObject` (and its dependency chain including `IChannelFactory`, `IFluidDataStoreRuntime`, etc.) through the public API surface of DDS packages. By introducing an interface, external consumers interact with `ISharedTree` while internal code can continue using the concrete `SharedTree` class.

This follows the same pattern used by other DDSes in the Fluid Framework (SharedMap, SharedString, etc.).

## Test plan

- [x] Package builds successfully (`pnpm build @fluid-experimental/tree`)
- [x] API report regenerated and checked in
- [ ] CI passes all existing tests