### PR TITLE
deprecate(dds): mark DDS implementation classes as deprecated

### DIFF
--- a/.changeset/deprecate-dds-impl-classes.md
+++ b/.changeset/deprecate-dds-impl-classes.md
@@ -1,0 +1,13 @@
+---
+"@fluidframework/register-collection": minor
+"@fluidframework/ordered-collection": minor
+"__section": deprecation
+---
+
+Deprecated DDS implementation classes
+
+The following DDS implementation classes are now deprecated and will be removed in a future release:
+
+- `ConsensusRegisterCollectionClass` — use `ConsensusRegisterCollectionFactory` to create instances and `IConsensusRegisterCollection` for typing
+- `ConsensusOrderedCollection` — use `IConsensusOrderedCollection` for typing
+- `ConsensusQueueClass` — use the `ConsensusQueue` singleton to create instances and `IConsensusOrderedCollection` for typing

--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
@@ -38,7 +38,7 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensus
 // @beta @legacy
 export const ConsensusQueue: ISharedObjectKind<IConsensusOrderedCollection<any>> & SharedObjectKind<IConsensusOrderedCollection<any>>;
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export type ConsensusQueue<T = any> = ConsensusQueueClass<T>;
 
 // @beta @deprecated @legacy

--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
@@ -7,7 +7,7 @@
 // @beta @legacy
 export type ConsensusCallback<T> = (value: T) => Promise<ConsensusResult>;
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensusOrderedCollectionEvents<T>> implements IConsensusOrderedCollection<T> {
     protected constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, data: IOrderedCollection<T>);
     acquire(callback: ConsensusCallback<T>): Promise<boolean>;
@@ -41,7 +41,7 @@ export const ConsensusQueue: ISharedObjectKind<IConsensusOrderedCollection<any>>
 // @beta @legacy
 export type ConsensusQueue<T = any> = ConsensusQueueClass<T>;
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export class ConsensusQueueClass<T = any> extends ConsensusOrderedCollection<T> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
 }

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -102,6 +102,7 @@ const idForLocalUnattachedClient = undefined;
  *
  * Generally not used directly. A derived type will pass in a backing data type
  * IOrderedCollection that will define the deterministic add/acquire order and snapshot ability.
+ * @deprecated Use {@link IConsensusOrderedCollection} for typing and the appropriate factory to create instances. This implementation class will be removed in a future release.
  * @legacy @beta
  */
 

--- a/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -71,6 +71,7 @@ export const ConsensusQueue = createSharedObjectKind(ConsensusQueueFactory);
 
 /**
  * {@inheritDoc ConsensusQueueClass}
+ * @deprecated Use {@link IConsensusOrderedCollection} for typing instead. This type alias will be removed in a future release.
  * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)

--- a/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -10,6 +10,7 @@ import type {
 } from "@fluidframework/datastore-definitions/internal";
 import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
+// eslint-disable-next-line import-x/no-deprecated -- Internal usage of deprecated class in factory
 import { ConsensusQueueClass } from "./consensusQueue.js";
 import type {
 	IConsensusOrderedCollection,
@@ -48,12 +49,14 @@ export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<IConsensusOrderedCollection> {
+		// eslint-disable-next-line import-x/no-deprecated -- Internal usage of deprecated class
 		const collection = new ConsensusQueueClass(id, runtime, attributes);
 		await collection.load(services);
 		return collection;
 	}
 
 	public create(document: IFluidDataStoreRuntime, id: string): IConsensusOrderedCollection {
+		// eslint-disable-next-line import-x/no-deprecated -- Internal usage of deprecated class
 		const collection = new ConsensusQueueClass(id, document, this.attributes);
 		collection.initializeLocal();
 		return collection;
@@ -71,5 +74,5 @@ export const ConsensusQueue = createSharedObjectKind(ConsensusQueueFactory);
  * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, import-x/no-deprecated
 export type ConsensusQueue<T = any> = ConsensusQueueClass<T>;

--- a/packages/dds/ordered-collection/src/consensusQueue.ts
+++ b/packages/dds/ordered-collection/src/consensusQueue.ts
@@ -8,6 +8,7 @@ import type {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
 
+// eslint-disable-next-line import-x/no-deprecated -- Subclass of deprecated class
 import { ConsensusOrderedCollection } from "./consensusOrderedCollection.js";
 import type { IOrderedCollection } from "./interfaces.js";
 import { SnapshotableArray } from "./snapshotableArray.js";
@@ -32,10 +33,11 @@ class SnapshotableQueue<T> extends SnapshotableArray<T> implements IOrderedColle
  * Implementation of a consensus stack
  *
  * An derived type of ConsensusOrderedCollection with a queue as the backing data and order.
+ * @deprecated Use the `ConsensusQueue` singleton and {@link IConsensusOrderedCollection} for typing. This implementation class will be removed in a future release.
  * @legacy @beta
  */
 // TODO: #22835 Use undefined instead of any (breaking change)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, import-x/no-deprecated
 export class ConsensusQueueClass<T = any> extends ConsensusOrderedCollection<T> {
 	/**
 	 * Constructs a new consensus queue. If the object is non-local an id and service interfaces will

--- a/packages/dds/register-collection/api-report/register-collection.legacy.beta.api.md
+++ b/packages/dds/register-collection/api-report/register-collection.legacy.beta.api.md
@@ -10,7 +10,7 @@ export const ConsensusRegisterCollection: ISharedObjectKind<IConsensusRegisterCo
 // @beta @legacy
 export type ConsensusRegisterCollection<T> = IConsensusRegisterCollection<T>;
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export class ConsensusRegisterCollectionClass<T> extends SharedObject<IConsensusRegisterCollectionEvents> implements IConsensusRegisterCollection<T> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // (undocumented)

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -122,6 +122,7 @@ interface IConsensusRegisterCollectionInternalEvents {
 
 /**
  * {@inheritDoc IConsensusRegisterCollection}
+ * @deprecated Use {@link IConsensusRegisterCollection} for typing and {@link ConsensusRegisterCollectionFactory} to create instances. This implementation class will be removed in a future release.
  * @legacy @beta
  */
 export class ConsensusRegisterCollection<T>

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -11,6 +11,7 @@ import {
 } from "@fluidframework/datastore-definitions/internal";
 import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
+// eslint-disable-next-line import-x/no-deprecated -- Internal usage of deprecated class in factory
 import { ConsensusRegisterCollection as ConsensusRegisterCollectionClass } from "./consensusRegisterCollection.js";
 import { IConsensusRegisterCollection } from "./interfaces.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -47,12 +48,14 @@ export class ConsensusRegisterCollectionFactory
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<IConsensusRegisterCollection> {
+		// eslint-disable-next-line import-x/no-deprecated -- Internal usage of deprecated class
 		const collection = new ConsensusRegisterCollectionClass(id, runtime, attributes);
 		await collection.load(services);
 		return collection;
 	}
 
 	public create(document: IFluidDataStoreRuntime, id: string): IConsensusRegisterCollection {
+		// eslint-disable-next-line import-x/no-deprecated -- Internal usage of deprecated class
 		const collection = new ConsensusRegisterCollectionClass(
 			id,
 			document,


### PR DESCRIPTION
## Summary

Deprecate DDS implementation classes on the legacy API surface as part of the custom DDS removal effort:

- `ConsensusRegisterCollectionClass` in `@fluidframework/register-collection`
- `ConsensusOrderedCollection` in `@fluidframework/ordered-collection`
- `ConsensusQueueClass` in `@fluidframework/ordered-collection`

These classes expose internal implementation details that consumers should not depend on. Consumers should use the corresponding interfaces (`IConsensusRegisterCollection`, `IConsensusOrderedCollection`) for typing and factory/singleton patterns for instance creation.

## What changed

- Added `@deprecated` TSDoc tags to all three implementation classes
- Added `eslint-disable` comments for `import-x/no-deprecated` on internal usages (factories and subclasses)
- Regenerated API reports reflecting the `@deprecated` annotations
- Added changeset

## Test plan

- [x] Both packages build successfully (tsc, api-extractor, eslint)
- [x] API reports updated to show `@deprecated` annotations