### PR TITLE
Pin "@rushstack/node-core-library": "5.19.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -361,7 +361,8 @@
 			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed.",
 			"oclif includes some AWS-related features, but we don't use them, so we override those dependencies with empty packages. This helps reduce lockfile churn since the deps release very frequently.",
 			"axios pre-1.0 needs an override to stay current on a version with no reported CVEs. Caret dependencies aren't enough on a pre-1.0 package.",
-			"Security overrides: tar is overridden to address path traversal CVEs (GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w, GHSA-34x7-hfp2-rc4v). The existing axios@<0.30.0 override resolves to 0.30.2 which is also affected by GHSA-43fc-jf86-j433 (DoS via __proto__), but updating that pre-1.0 override is out of scope here."
+			"Security overrides: tar is overridden to address path traversal CVEs (GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w, GHSA-34x7-hfp2-rc4v). The existing axios@<0.30.0 override resolves to 0.30.2 which is also affected by GHSA-43fc-jf86-j433 (DoS via __proto__), but updating that pre-1.0 override is out of scope here.",
+			"@rushstack/node-core-library is pinned to 5.19.1 due to an issue in the 5.20.0 release."
 		],
 		"overrides": {
 			"@biomejs/biome": "~2.3.11",
@@ -374,7 +375,8 @@
 			"oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
 			"oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0",
 			"axios@<0.30.0": "^0.30.0",
-			"tar": ">=7.5.7"
+			"tar": ">=7.5.7",
+			"@rushstack/node-core-library": "5.19.1"
 		},
 		"peerDependencyComments": [
 			"The react-split-pane package used by devtools-view has a peer dependency on React 16, but it doesn't seem to be maintained and it works fine with React 18. TODO: AB#18876",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   axios@<0.30.0: ^0.30.0
   tar: '>=7.5.7'
+  '@rushstack/node-core-library': 5.19.1
 
 pnpmfileChecksum: sha256-UgK94jvekjDphs6M2itZJZ9CcCzYY0xcxZhNXJw7D28=
 
@@ -17120,8 +17121,8 @@ importers:
   tools/markdown-magic:
     dependencies:
       '@rushstack/node-core-library':
-        specifier: ^3.61.0
-        version: 3.66.1(@types/node@20.19.30)
+        specifier: 5.19.1
+        version: 5.19.1(@types/node@20.19.30)
       '@tylerbu/markdown-magic':
         specifier: 2.4.0-tylerbu-1
         version: 2.4.0-tylerbu-1
@@ -19681,24 +19682,8 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  '@rushstack/node-core-library@3.66.1':
-    resolution: {integrity: sha512-ker69cVKAoar7MMtDFZC4CzcDxjwqIhFzqEnYI5NRN/8M3om6saWCVx/A7vL2t/jFCJsnzQplRDqA7c78pytng==}
-    peerDependencies:
-      '@types/node': ~20.19.30
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/node-core-library@5.14.0':
-    resolution: {integrity: sha512-eRong84/rwQUlATGFW3TMTYVyqL1vfW9Lf10PH+mVGfIb9HzU3h5AASNIw+axnBLjnD0n3rT5uQBwu9fvzATrg==}
-    peerDependencies:
-      '@types/node': ~20.19.30
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/node-core-library@5.19.0':
-    resolution: {integrity: sha512-BxAopbeWBvNJ6VGiUL+5lbJXywTdsnMeOS8j57Cn/xY10r6sV/gbsTlfYKjzVCUBZATX2eRzJHSMCchsMTGN6A==}
+  '@rushstack/node-core-library@5.19.1':
+    resolution: {integrity: sha512-ESpb2Tajlatgbmzzukg6zyAhH+sICqJR2CNXNhXcEbz6UGCQfrKCtkxOpJTftWc8RGouroHG0Nud1SJAszvpmA==}
     peerDependencies:
       '@types/node': ~20.19.30
     peerDependenciesMeta:
@@ -21584,10 +21569,6 @@ packages:
 
   colors@0.6.2:
     resolution: {integrity: sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==}
-    engines: {node: '>=0.1.90'}
-
-  colors@1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
     engines: {node: '>=0.1.90'}
 
   colors@1.4.0:
@@ -27906,10 +27887,6 @@ packages:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  validator@13.15.26:
-    resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
-    engines: {node: '>= 0.10'}
-
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -28342,11 +28319,6 @@ packages:
 
   yoga-wasm-web@0.3.3:
     resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
-
-  z-schema@5.0.5:
-    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
 
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
@@ -30359,7 +30331,7 @@ snapshots:
       '@oclif/plugin-not-found': 3.2.73(@types/node@20.19.30)
       '@octokit/core': 7.0.6
       '@octokit/rest': 22.0.1
-      '@rushstack/node-core-library': 5.19.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
       async: 3.2.6
       azure-devops-node-api: 11.2.0
       change-case: 5.4.4
@@ -32593,7 +32565,7 @@ snapshots:
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -32601,7 +32573,7 @@ snapshots:
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.0
-      '@rushstack/node-core-library': 5.19.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -32610,7 +32582,7 @@ snapshots:
       '@microsoft/api-extractor-model': 7.30.7(@types/node@20.19.30)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.15.4(@types/node@20.19.30)
       '@rushstack/ts-command-line': 5.0.2(@types/node@20.19.30)
@@ -32628,7 +32600,7 @@ snapshots:
       '@microsoft/api-extractor-model': 7.32.1(@types/node@20.19.30)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.0
-      '@rushstack/node-core-library': 5.19.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
       '@rushstack/rig-package': 0.6.0
       '@rushstack/terminal': 0.19.4(@types/node@20.19.30)
       '@rushstack/ts-command-line': 5.1.4(@types/node@20.19.30)
@@ -33173,32 +33145,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rushstack/node-core-library@3.66.1(@types/node@20.19.30)':
-    dependencies:
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
-      z-schema: 5.0.5
-    optionalDependencies:
-      '@types/node': 20.19.30
-
-  '@rushstack/node-core-library@5.14.0(@types/node@20.19.30)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.2
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 20.19.30
-
-  '@rushstack/node-core-library@5.19.0(@types/node@20.19.30)':
+  '@rushstack/node-core-library@5.19.1(@types/node@20.19.30)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -33227,14 +33174,14 @@ snapshots:
 
   '@rushstack/terminal@0.15.4(@types/node@20.19.30)':
     dependencies:
-      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.19.30
 
   '@rushstack/terminal@0.19.4(@types/node@20.19.30)':
     dependencies:
-      '@rushstack/node-core-library': 5.19.0(@types/node@20.19.30)
+      '@rushstack/node-core-library': 5.19.1(@types/node@20.19.30)
       '@rushstack/problem-matcher': 0.1.1(@types/node@20.19.30)
       supports-color: 8.1.1
     optionalDependencies:
@@ -35336,8 +35283,6 @@ snapshots:
   colorette@2.0.20: {}
 
   colors@0.6.2: {}
-
-  colors@1.2.5: {}
 
   colors@1.4.0: {}
 
@@ -43126,8 +43071,6 @@ snapshots:
 
   validate-npm-package-name@6.0.2: {}
 
-  validator@13.15.26: {}
-
   vary@1.1.2: {}
 
   vfile-message@2.0.4:
@@ -43744,14 +43687,6 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoga-wasm-web@0.3.3: {}
-
-  z-schema@5.0.5:
-    dependencies:
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 13.15.26
-    optionalDependencies:
-      commander: 9.5.0
 
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -25,7 +25,7 @@
 		"test": "node src/index.cjs --files \"test/**/*.md\" !test/README.md"
 	},
 	"dependencies": {
-		"@rushstack/node-core-library": "^3.61.0",
+		"@rushstack/node-core-library": "^5.19.1",
 		"@tylerbu/markdown-magic": "2.4.0-tylerbu-1",
 		"chalk": "^4.1.2",
 		"markdown-magic-package-scripts": "^1.2.2",


### PR DESCRIPTION
## Description

The 5.20.0 release of Client RG: Pin `@rushstack/node-core-library` changed how their build outputs are structured which broke our internal build pipelines.

## Reviewer Guidance

This branch so far only updates the Client ReleaseGroup since that's the most impactful.  Others are coming.
