### PR TITLE
ci: Use pnpm with an override to install build-tools in the publish stage

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,35 +58,27 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
-          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
-            parameters:
-              buildDirectory: $(Pipeline.Workspace)
-              enableCache: false
-
           # We can use this step to add overrides that might be necessary to allow for a correct
           # installation of build-tools from the tarball artifacts produced by the build stage.
           # Since this is a lockfile-less install (ideally we should figure out how to change that),
-          # pnpm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
+          # npm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
           # Current overrides:
           # - @rushstack/node-core-library 5.19.1: version 5.20.0 broke ESM module resolution in Node.
           #   https://github.com/microsoft/rushstack/issues/5644
           - task: Bash@3
             name: CreatePackageJsonForOverrides
-            displayName: Create package.json with pnpm overrides
+            displayName: Create package.json with npm overrides
             inputs:
               targetType: 'inline'
               workingDirectory: '$(Pipeline.Workspace)/buildTools-zip/tarballs'
               script: |
                 set -eu -o pipefail
-                echo "Creating package.json with pnpm overrides"
+                echo "Creating package.json with npm overrides"
                 cat > package.json << 'EOF'
                 {
                   "name": "build-tools-install",
-                  "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
-                  "pnpm": {
-                    "overrides": {
-                      "@rushstack/node-core-library": "5.19.1"
-                    }
+                  "overrides": {
+                    "@rushstack/node-core-library": "5.19.1"
                   }
                 }
                 EOF
@@ -103,7 +95,7 @@ jobs:
                 echo "Listing files in directory: $(pwd)"
                 ls -la
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                pnpm add ./*.tgz
+                npm i -g ./*.tgz
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -77,6 +77,7 @@ jobs:
                 cat > package.json << 'EOF'
                 {
                   "name": "build-tools-install",
+                  "packageManager": "npm@8.3",
                   "overrides": {
                     "@rushstack/node-core-library": "5.19.1"
                   }

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -94,6 +94,7 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
+                pnpm setup
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
                 pnpm add -g ./*.tgz
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -63,6 +63,13 @@ jobs:
               buildDirectory: $(Pipeline.Workspace)
               enableCache: false
 
+          # We can use this step to add overrides that might be necessary to allow for a correct
+          # installation of build-tools from the tarball artifacts produced by the build stage.
+          # Since this is a lockfile-less install (ideally we should figure out how to change that),
+          # pnpm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
+          # Current overrides:
+          # - @rushstack/node-core-library 5.19.1: version 5.20.0 broke ESM module resolution in Node.
+          #   https://github.com/microsoft/rushstack/issues/5644
           - task: Bash@3
             name: CreatePackageJsonForOverrides
             displayName: Create package.json with pnpm overrides

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,6 +58,32 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
+          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+            parameters:
+              buildDirectory: $(Pipeline.Workspace)
+              enableCache: false
+
+          - task: Bash@3
+            name: CreatePackageJsonForOverrides
+            displayName: Create package.json with pnpm overrides
+            inputs:
+              targetType: 'inline'
+              workingDirectory: '$(Pipeline.Workspace)/buildTools-zip/tarballs'
+              script: |
+                set -eu -o pipefail
+                echo "Creating package.json with pnpm overrides"
+                cat > package.json << 'EOF'
+                {
+                  "name": "build-tools-install",
+                  "pnpm": {
+                    "overrides": {
+                      "@rushstack/node-core-library": "5.19.1"
+                    }
+                  }
+                }
+                EOF
+                cat package.json
+
           - task: Bash@3
             name: InstallBuildToolsFromTarball
             displayName: Install Fluid Build Tools from artifact tarball
@@ -69,7 +95,7 @@ jobs:
                 echo "Listing files in directory: $(pwd)"
                 ls -la
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                npm i -g ./*.tgz
+                pnpm add -g ./*.tgz
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -102,9 +102,8 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
-                pnpm setup
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                pnpm add -g ./*.tgz
+                pnpm add ./*.tgz
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -95,6 +95,7 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
+                npm --version
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
                 npm i -g ./*.tgz
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -82,6 +82,7 @@ jobs:
                 cat > package.json << 'EOF'
                 {
                   "name": "build-tools-install",
+                  "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
                   "pnpm": {
                     "overrides": {
                       "@rushstack/node-core-library": "5.19.1"


### PR DESCRIPTION
## Description

A release of a transitive dependency of build-tools (`@rushstack/node-core-library`) is broken and that is causing the installation of build-tools in the publishing stage of our pipeline to fail.

This changes the way we do that install in the pipeline stage so we can leverage pnpm overrides to pin to a working version of the dependency.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#59774](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/59774)