### PR TITLE
revert(protocol-definitions): indexed type changes

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.legacy.beta.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.legacy.beta.api.md
@@ -274,12 +274,16 @@ export interface ISignalMessageBase {
 // @beta @legacy (undocumented)
 export interface ISnapshotTree {
     // (undocumented)
-    blobs: Record<string, string>;
+    blobs: {
+        [path: string]: string;
+    };
     groupId?: string;
     // (undocumented)
     id?: string;
     // (undocumented)
-    trees: Record<string, ISnapshotTree>;
+    trees: {
+        [path: string]: ISnapshotTree;
+    };
     unreferenced?: true;
 }
 
@@ -341,7 +345,9 @@ export interface ISummaryProposal {
 // @public
 export interface ISummaryTree {
     groupId?: string;
-    tree: Record<string, SummaryObject>;
+    tree: {
+        [path: string]: SummaryObject;
+    };
     // (undocumented)
     type: SummaryType.Tree;
     unreferenced?: true;

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.legacy.public.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.legacy.public.api.md
@@ -126,7 +126,9 @@ export interface ISummaryHandle {
 // @public
 export interface ISummaryTree {
     groupId?: string;
-    tree: Record<string, SummaryObject>;
+    tree: {
+        [path: string]: SummaryObject;
+    };
     // (undocumented)
     type: SummaryType.Tree;
     unreferenced?: true;

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.public.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.public.api.md
@@ -126,7 +126,9 @@ export interface ISummaryHandle {
 // @public
 export interface ISummaryTree {
     groupId?: string;
-    tree: Record<string, SummaryObject>;
+    tree: {
+        [path: string]: SummaryObject;
+    };
     // (undocumented)
     type: SummaryType.Tree;
     unreferenced?: true;

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -132,8 +132,10 @@ export interface ITree {
  */
 export interface ISnapshotTree {
 	id?: string;
-	blobs: Record<string, string>;
-	trees: Record<string, ISnapshotTree>;
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path
+	blobs: { [path: string]: string };
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path
+	trees: { [path: string]: ISnapshotTree };
 
 	/**
 	 * Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
@@ -154,7 +156,8 @@ export interface ISnapshotTree {
  */
 export interface ISnapshotTreeEx extends ISnapshotTree {
 	id: string;
-	trees: Record<string, ISnapshotTreeEx>;
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path
+	trees: { [path: string]: ISnapshotTreeEx };
 }
 
 /**

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -132,9 +132,9 @@ export interface ITree {
  */
 export interface ISnapshotTree {
 	id?: string;
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarify that it should be a path
 	blobs: { [path: string]: string };
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarify that it should be a path
 	trees: { [path: string]: ISnapshotTree };
 
 	/**
@@ -156,7 +156,7 @@ export interface ISnapshotTree {
  */
 export interface ISnapshotTreeEx extends ISnapshotTree {
 	id: string;
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarify that it should be a path
 	trees: { [path: string]: ISnapshotTreeEx };
 }
 

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -162,7 +162,7 @@ export interface ISummaryTree {
 	 *
 	 * @param path - The key to store the SummaryObject at in the current summary tree being generated. Should not contain any "/" characters and should not change when encodeURIComponent is called on it.
 	 */
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path (also make `@param` comment meaningful).
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarify that it should be a path (also make `@param` comment meaningful).
 	tree: { [path: string]: SummaryObject };
 
 	/**

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -162,7 +162,8 @@ export interface ISummaryTree {
 	 *
 	 * @param path - The key to store the SummaryObject at in the current summary tree being generated. Should not contain any "/" characters and should not change when encodeURIComponent is called on it.
 	 */
-	tree: Record<string, SummaryObject>;
+	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- use `[path: string]` to clarity that it should be a path (also make `@param` comment meaningful).
+	tree: { [path: string]: SummaryObject };
 
 	/**
 	 * Indicates that this tree entry is unreferenced.


### PR DESCRIPTION
Revert "feat(common-utils,protocol-definitions): upgrade to ESLint 9 flat config (#26408)"

This reverts source code changes from commit 74a04e8b97364392d0ec3dd3fdd5917b3f61a2ed and the api report changes from 0f8dd82a826b4009c3a2562b39508e2cf432ab7d.

In place of `Record` to resolve lint issue, suppress.