### PR TITLE
generate server release reports

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -143,32 +143,34 @@ _See code: [src/commands/generate/bundleStats.ts](https://github.com/microsoft/F
 
 ## `flub generate changelog`
 
-Generate a changelog for packages based on changesets. Note that this process deletes the changeset files!
+Generate a changelog for packages based on changesets.
 
 ```
 USAGE
-  $ flub generate changelog -g <value> [-v | --quiet] [--version <value>]
+  $ flub generate changelog -g client|server|azure|build-tools|gitrest|historian [-v | --quiet] [--version <value>]
+    [--install]
 
 FLAGS
-  -g, --releaseGroup=<value>  (required) The name of a release group.
-      --version=<value>       The version for which to generate the changelog. If this is not provided, the version of
-                              the package according to package.json will be used.
+  -g, --releaseGroup=<option>  (required) Name of a release group.
+                               <options: client|server|azure|build-tools|gitrest|historian>
+      --[no-]install           Update lockfiles by running 'npm install' automatically.
+      --version=<value>        The version for which to generate the changelog. If this is not provided, the version of
+                               the package according to package.json will be used.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.
       --quiet    Disable all logging.
 
 DESCRIPTION
-  Generate a changelog for packages based on changesets. Note that this process deletes the changeset files!
-
-ALIASES
-  $ flub generate changelog
+  Generate a changelog for packages based on changesets.
 
 EXAMPLES
   Generate changelogs for the client release group.
 
     $ flub generate changelog --releaseGroup client
 ```
+
+_See code: [src/commands/generate/changelog.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/generate/changelog.ts)_
 
 ## `flub generate changeset`
 

--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -143,34 +143,32 @@ _See code: [src/commands/generate/bundleStats.ts](https://github.com/microsoft/F
 
 ## `flub generate changelog`
 
-Generate a changelog for packages based on changesets.
+Generate a changelog for packages based on changesets. Note that this process deletes the changeset files!
 
 ```
 USAGE
-  $ flub generate changelog -g client|server|azure|build-tools|gitrest|historian [-v | --quiet] [--version <value>]
-    [--install]
+  $ flub generate changelog -g <value> [-v | --quiet] [--version <value>]
 
 FLAGS
-  -g, --releaseGroup=<option>  (required) Name of a release group.
-                               <options: client|server|azure|build-tools|gitrest|historian>
-      --[no-]install           Update lockfiles by running 'npm install' automatically.
-      --version=<value>        The version for which to generate the changelog. If this is not provided, the version of
-                               the package according to package.json will be used.
+  -g, --releaseGroup=<value>  (required) The name of a release group.
+      --version=<value>       The version for which to generate the changelog. If this is not provided, the version of
+                              the package according to package.json will be used.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.
       --quiet    Disable all logging.
 
 DESCRIPTION
-  Generate a changelog for packages based on changesets.
+  Generate a changelog for packages based on changesets. Note that this process deletes the changeset files!
+
+ALIASES
+  $ flub generate changelog
 
 EXAMPLES
   Generate changelogs for the client release group.
 
     $ flub generate changelog --releaseGroup client
 ```
-
-_See code: [src/commands/generate/changelog.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/generate/changelog.ts)_
 
 ## `flub generate changeset`
 

--- a/build-tools/packages/build-cli/docs/release.md
+++ b/build-tools/packages/build-cli/docs/release.md
@@ -210,7 +210,7 @@ Generates a report of Fluid Framework releases.
 ```
 USAGE
   $ flub release report [--json] [-v | --quiet] [-i | -r | -s] [-g
-    client|server|azure|build-tools|gitrest|historian] [-o <value>] [--baseFileName <value>]
+    client|server|azure|build-tools|gitrest|historian] [-o <value>] [--baseFileName <value>] [--useCurrentVersion]
 
 FLAGS
   -g, --releaseGroup=<option>
@@ -240,6 +240,10 @@ FLAGS
       If provided, the output files will be named using this base name followed by the report kind (caret, simple, full,
       tilde, legacy-compat) and the .json extension. For example, if baseFileName is 'foo', the output files will be named
       'foo.caret.json', 'foo.simple.json', etc.
+
+  --useCurrentVersion
+      When selecting versions in in-repo mode, use current build versions (including unreleased in-repo versions) instead
+      of falling back to the latest released version.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -59,7 +59,7 @@ trigger:
     - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
-    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 pr:
   branches:
@@ -79,6 +79,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 
 variables:

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -59,7 +59,7 @@ trigger:
     - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
-    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 pr:
   branches:
@@ -79,6 +79,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -71,7 +71,7 @@ trigger:
     - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
-    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
     exclude:
     - server/routerlicious/kubernetes/routerlicious
 
@@ -95,6 +95,7 @@ pr:
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
     exclude:
     - server/routerlicious/kubernetes/routerlicious
 

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -18,6 +18,22 @@ parameters:
 - name: buildDirectory
   type: string
 
+- name: buildToolsVersionToInstall
+  type: string
+  default: repo
+
+- name: serverManifestPathSegment
+  type: string
+  default: prerelease
+  values:
+  - prerelease
+  - release
+
+# The path to the pnpm store.
+- name: pnpmStorePath
+  type: string
+  default: $(Pipeline.Workspace)/.pnpm-store
+
 stages:
 
 # This stage only runs for test-branch builds
@@ -89,9 +105,9 @@ stages:
       tagName: ${{ parameters.tagName }}
 
 # Only upload release manifest files for runs in the internal project (i.e. CI runs, not PR runs), for the main, test, and release branches, and
-# for the build of the client release group (we don't need manifests for anything else).
+# for builds of release groups that currently publish manifests.
 # Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branches.
-- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), or(eq(parameters.tagName, 'client'), eq(parameters.tagName, 'server'), eq(parameters.tagName, 'historian'), eq(parameters.tagName, 'gitrest')), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
   - stage: upload_manifests
     displayName: Upload release manifests
     dependsOn:
@@ -115,6 +131,22 @@ stages:
     variables:
     - group: ado-feeds
     jobs:
-    - template: /tools/pipelines/templates/upload-dev-manifest.yml@self
-      parameters:
-        buildDirectory: '${{ parameters.buildDirectory }}'
+    - ${{ if or(eq(parameters.tagName, 'server'), eq(parameters.tagName, 'historian'), eq(parameters.tagName, 'gitrest')) }}:
+      - template: /tools/pipelines/templates/upload-server-manifest.yml@self
+        parameters:
+          buildDirectory: '${{ parameters.buildDirectory }}'
+          blobPathPrefix: ${{ format('server/{0}', parameters.serverManifestPathSegment) }}
+          serverManifestPathSegment: ${{ parameters.serverManifestPathSegment }}
+          ${{ if eq(parameters.tagName, 'server') }}:
+            releaseGroup: 'server'
+            releaseReportCategory: 'routerlicious-'
+          ${{ elseif eq(parameters.tagName, 'historian') }}:
+            releaseGroup: 'historian'
+            releaseReportCategory: 'historian-'
+          ${{ else }}:
+            releaseGroup: 'gitrest'
+            releaseReportCategory: 'gitrest-'
+    - ${{ if eq(parameters.tagName, 'client') }}:
+      - template: /tools/pipelines/templates/upload-dev-manifest.yml@self
+        parameters:
+          buildDirectory: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/include-upload-release-reports.yml
+++ b/tools/pipelines/templates/include-upload-release-reports.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: buildDirectory
+  type: string
+
+- name: blobPathPrefix
+  type: string
+  default: ''
+
+steps:
+- task: CopyFiles@2
+  displayName: Copy release reports
+  inputs:
+    SourceFolder: ${{ parameters.buildDirectory }}/upload_release_reports
+    TargetFolder: $(Build.ArtifactStagingDirectory)/release_reports
+
+- task: AzureCLI@2
+  displayName: Upload release reports
+  continueOnError: true
+  inputs:
+    azureSubscription: 'fluid-docs'
+    scriptType: bash
+    workingDirectory: ${{ parameters.buildDirectory }}
+    scriptLocation: inlineScript
+    inlineScript: |
+      blobPrefix='${{ parameters.blobPathPrefix }}'
+      blobPrefix="${blobPrefix#/}"
+      blobPrefix="${blobPrefix%/}"
+      for file in upload_release_reports/*; do
+        fileName="$(basename "$file")"
+        if [ -n "$blobPrefix" ]; then
+          blobName="$blobPrefix/$fileName"
+        else
+          blobName="$fileName"
+        fi
+        # Use 5 minute TTL for manifest files. This could be lengthened significantly
+        # for manifest files for a particular build (immutable) or for those for a particular
+        # release (updates with our release cycle), but using a shorter TTL for all risks only small
+        # perf losses while remaining simple.
+        az storage blob upload -f "$file" -c 'manifest-files' -n "$blobName" --account-name $(STORAGE_ACCOUNT) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
+      done
+      # Delete generate_release_reports and upload_release_reports folder
+      rm -rf generate_release_reports upload_release_reports
+
+- task: 1ES.PublishPipelineArtifact@1
+  displayName: Publish Artifact - release_reports
+  inputs:
+    targetPath: $(Build.ArtifactStagingDirectory)/release_reports
+    artifactName: release_reports
+    publishLocation: pipeline

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -38,34 +38,6 @@ jobs:
           mkdir upload_release_reports
           flub release report-unreleased --version $(version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName '$(Build.SourceBranch)'
 
-    - task: CopyFiles@2
-      displayName: Copy release reports
-      inputs:
-        SourceFolder: ${{ parameters.buildDirectory }}/upload_release_reports
-        TargetFolder: $(Build.ArtifactStagingDirectory)/release_reports
-
-    - task: AzureCLI@2
-      displayName: Upload release reports
-      continueOnError: true
-      inputs:
-        azureSubscription: 'fluid-docs'
-        scriptType: bash
-        workingDirectory: ${{ parameters.buildDirectory }}
-        scriptLocation: inlineScript
-        inlineScript: |
-          for file in upload_release_reports/*; do
-              # Use 5 minute TTL for manifest files. This could be lengthened significantly
-              # for manifest files for a particular build (immutable) or for those for a particular
-              # release (updates with our release cycle), but using a shorter TTL for all risks only small
-              # perf losses while remaining simple.
-              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
-          done
-          # Delete generate_release_reports and upload_release_reports folder
-          rm -r generate_release_reports upload_release_reports
-
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: Publish Artifact - release_reports
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)/release_reports
-        artifactName: release_reports
-        publishLocation: pipeline
+    - template: /tools/pipelines/templates/include-upload-release-reports.yml@self
+      parameters:
+        buildDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/upload-server-manifest.yml
+++ b/tools/pipelines/templates/upload-server-manifest.yml
@@ -112,7 +112,6 @@ jobs:
                 .map(([pkgName]) => pkgName),
             );
             const reportsDir = "upload_release_reports";
-            const currentDate = new Date().toISOString().slice(0, 10);
 
             for (const file of fs.readdirSync(reportsDir)) {
               const reportPath = path.join(reportsDir, file);
@@ -122,29 +121,6 @@ jobs:
               const json = JSON.parse(fs.readFileSync(reportPath, "utf8"));
               const filtered = Object.fromEntries(Object.entries(json).filter(([pkgName]) => keep.has(pkgName)));
               fs.writeFileSync(reportPath, JSON.stringify(filtered, null, 2));
-            }
-
-            for (const baseFileName of ["simpleManifest", "manifest"]) {
-              const target = `${baseFileName}-${currentDate}.json`;
-              const matching = fs.readdirSync(reportsDir).filter(
-                (file) => file.startsWith(`${baseFileName}-`) && file.endsWith(".json"),
-              );
-
-              if (matching.length === 0) {
-                continue;
-              }
-
-              const source = matching.includes(target) ? target : matching[0];
-              if (source !== target) {
-                fs.renameSync(path.join(reportsDir, source), path.join(reportsDir, target));
-              }
-
-              for (const file of matching) {
-                if (file === source || file === target) {
-                  continue;
-                }
-                fs.rmSync(path.join(reportsDir, file), { force: true });
-              }
             }
             '
 

--- a/tools/pipelines/templates/upload-server-manifest.yml
+++ b/tools/pipelines/templates/upload-server-manifest.yml
@@ -1,0 +1,168 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: buildDirectory
+  type: string
+
+- name: releaseGroup
+  type: string
+
+- name: releaseReportCategory
+  type: string
+  default: ''
+
+- name: blobPathPrefix
+  type: string
+  default: ''
+
+- name: serverManifestPathSegment
+  type: string
+  default: prerelease
+
+jobs:
+  - job:
+    displayName: Upload Release Reports
+    variables:
+    - group: storage-vars
+    - name: version
+      value: $[stageDependencies.build.build.outputs['SetVersion.version']]
+    steps:
+    - template: /tools/pipelines/templates/include-use-node-version.yml@self
+    - template: /tools/pipelines/templates/include-install-build-tools.yml@self
+      parameters:
+        buildDirectory: ${{ parameters.buildDirectory }}
+
+    - ${{ if eq(parameters.serverManifestPathSegment, 'prerelease') }}:
+      - task: Bash@3
+        displayName: Generate latest prerelease reports
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.buildDirectory }}
+          script: |
+            set -eu -o pipefail
+            mkdir generate_release_reports
+            mkdir upload_release_reports
+            flub release report -g ${{ parameters.releaseGroup }} --useCurrentVersion -o generate_release_reports --baseFileName manifest
+            REPORT_VERSION="$(version)" RELEASE_GROUP="${{ parameters.releaseGroup }}" BUILD_SOURCEBRANCH='$(Build.SourceBranch)' node -e '
+            const fs = require("node:fs");
+            const full = JSON.parse(fs.readFileSync("generate_release_reports/manifest.full.json", "utf8"));
+            const releaseGroup = process.env.RELEASE_GROUP;
+            const version = process.env.REPORT_VERSION;
+            const buildSourceBranch = process.env.BUILD_SOURCEBRANCH ?? "";
+            const date = new Date().toISOString().slice(0, 10);
+            const manifest = {};
+            for (const [pkgName, details] of Object.entries(full)) {
+              if (details?.releaseGroup !== releaseGroup) {
+                continue;
+              }
+              manifest[pkgName] = version;
+            }
+
+            const testMatch = version.match(/^0\.0\.0-(\d+)-test(?:-.+)?$/);
+            const buildMatch = version.match(/(\d+)$/);
+            const buildNumber = testMatch?.[1] ?? buildMatch?.[1];
+            if (buildNumber === undefined) {
+              throw new Error(`Unable to determine build number from version: ${version}`);
+            }
+
+            fs.writeFileSync(`upload_release_reports/manifest-${buildNumber}.json`, JSON.stringify(manifest, null, 2));
+
+            if (buildSourceBranch === "refs/heads/main") {
+              fs.writeFileSync(`upload_release_reports/manifest-${date}.json`, JSON.stringify(manifest, null, 2));
+            }
+            '
+
+    - ${{ if eq(parameters.serverManifestPathSegment, 'release') }}:
+      - task: Bash@3
+        displayName: Generate release reports
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.buildDirectory }}
+          script: |
+            set -eu -o pipefail
+            mkdir generate_release_reports
+            flub release report -g ${{ parameters.releaseGroup }} -o generate_release_reports --baseFileName manifest
+
+      - task: Bash@3
+        displayName: Update release report version
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.buildDirectory }}
+          script: |
+            set -eu -o pipefail
+            mkdir upload_release_reports
+            flub release report-unreleased --version $(version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName '$(Build.SourceBranch)'
+
+      - task: Bash@3
+        displayName: Filter release report output packages
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.buildDirectory }}
+          script: |
+            set -eu -o pipefail
+            RELEASE_GROUP="${{ parameters.releaseGroup }}" node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const full = JSON.parse(fs.readFileSync("generate_release_reports/manifest.full.json", "utf8"));
+            const releaseGroup = process.env.RELEASE_GROUP;
+            const keep = new Set(
+              Object.entries(full)
+                .filter(([, details]) => details?.releaseGroup === releaseGroup)
+                .map(([pkgName]) => pkgName),
+            );
+            const reportsDir = "upload_release_reports";
+            const currentDate = new Date().toISOString().slice(0, 10);
+
+            for (const file of fs.readdirSync(reportsDir)) {
+              const reportPath = path.join(reportsDir, file);
+              if (!fs.statSync(reportPath).isFile()) {
+                continue;
+              }
+              const json = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+              const filtered = Object.fromEntries(Object.entries(json).filter(([pkgName]) => keep.has(pkgName)));
+              fs.writeFileSync(reportPath, JSON.stringify(filtered, null, 2));
+            }
+
+            for (const baseFileName of ["simpleManifest", "manifest"]) {
+              const target = `${baseFileName}-${currentDate}.json`;
+              const matching = fs.readdirSync(reportsDir).filter(
+                (file) => file.startsWith(`${baseFileName}-`) && file.endsWith(".json"),
+              );
+
+              if (matching.length === 0) {
+                continue;
+              }
+
+              const source = matching.includes(target) ? target : matching[0];
+              if (source !== target) {
+                fs.renameSync(path.join(reportsDir, source), path.join(reportsDir, target));
+              }
+
+              for (const file of matching) {
+                if (file === source || file === target) {
+                  continue;
+                }
+                fs.rmSync(path.join(reportsDir, file), { force: true });
+              }
+            }
+            '
+
+    - ${{ if ne(parameters.releaseReportCategory, '') }}:
+      - task: Bash@3
+        displayName: Prefix release report filenames
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.buildDirectory }}
+          script: |
+            set -eu -o pipefail
+            for file in upload_release_reports/*; do
+                if [ -f "$file" ]; then
+                    mv "$file" "upload_release_reports/${{ parameters.releaseReportCategory }}$(basename "$file")"
+                fi
+            done
+
+    - template: /tools/pipelines/templates/include-upload-release-reports.yml@self
+      parameters:
+        buildDirectory: ${{ parameters.buildDirectory }}
+        blobPathPrefix: ${{ parameters.blobPathPrefix }}


### PR DESCRIPTION
## Description

- Adds a manifest upload for server packages (historian, gitrest, routerlicious).
- Generates prerelease manifests for the server, and publishes exact version mappings for the selected release group.
- Adds a release report flag to build tools to use the current checked-out version when tag history does not yet contain that version.

## Reviewer Guidance
- Creates a shared file for the upload steps. `include-upload-release-reports.yml`.
- Server files are uploaded to blob storage with the path `manifest-files/server/prerelease/<filename>.json`
