### PR TITLE
Use federated credentials in end-to-end tests 

### DIFF
--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -98,7 +98,7 @@ export const mochaHooks = {
 	async beforeAll() {
 		// Code in our tests will call the global `getTestLogger` function to get a logger to use.
 
-		// First we call the version of that function that was (potentially) injected dynamicaly to get the logger that it
+		// First we call the version of that function that was (potentially) injected dynamically to get the logger that it
 		// provides and wrap it with a more intelligent logger which adds test-run-related context to all events logged
 		// through it. See the documentation on `FluidTestRunLogger` for details.
 		let originalLogger: ITelemetryBufferedLogger;

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -396,7 +396,9 @@ export class OdspTestDriver implements ITestDriver {
 
 	private static async getStorageToken(
 		options: OdspResourceTokenFetchOptions & { useBrowserAuth?: boolean },
-		config: TokenConfig & { getNewToken?: () => Promise<{ GUID: string; UserPrincipalName: string; Token: string }> },
+		config: TokenConfig & {
+			getNewToken?: () => Promise<{ GUID: string; UserPrincipalName: string; Token: string }>;
+		},
 	): Promise<string> {
 		const host = new URL(options.siteUrl).host;
 

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -26,7 +26,7 @@ import {
 
 const cellId = "cellKey";
 
-describeCompat("SharedCell", "FullCompat", (getTestObjectProvider, apis) => {
+describeCompat.only("SharedCell", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedCell } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -15,7 +15,7 @@ import { unauthPostAsync } from "./odspRequest.js";
  */
 export interface IOdspTokens {
 	readonly accessToken: string;
-	readonly refreshToken: string;
+	readonly refreshToken?: string; // Optional - not needed for bearer token flows
 	readonly receivedAt?: number; // Unix timestamp in seconds
 	readonly expiresIn?: number; // Seconds from reception until the token expires
 }
@@ -167,7 +167,7 @@ export async function fetchTokens(
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 	const refreshToken = parsedResponse.refresh_token;
 
-	if (accessToken === undefined || refreshToken === undefined) {
+	if (accessToken === undefined) {
 		try {
 			throwOdspNetworkError(
 				// pre-0.58 error message: unableToGetAccessToken
@@ -239,7 +239,10 @@ export async function refreshTokens(
 ): Promise<IOdspTokens> {
 	// Clear out the old tokens while awaiting the new tokens
 	const refresh_token = tokens.refreshToken;
-	assert(refresh_token.length > 0, 0x1ec /* "No refresh token provided." */);
+	assert(
+		refresh_token !== undefined && refresh_token.length > 0,
+		0x1ec /* "No refresh token provided." */,
+	);
 
 	const credentials: TokenRequestCredentials = {
 		grant_type: "refresh_token",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -131,7 +131,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_OdspTokenConfig": {
+				"backCompat": false
+			},
+			"Interface_IResources": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "internal"
 	}
 }

--- a/packages/utils/tool-utils/src/test/types/validateToolUtilsPrevious.generated.ts
+++ b/packages/utils/tool-utils/src/test/types/validateToolUtilsPrevious.generated.ts
@@ -132,6 +132,7 @@ declare type old_as_current_for_Interface_IResources = requireAssignableTo<TypeO
  * typeValidation.broken:
  * "Interface_IResources": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IResources = requireAssignableTo<TypeOnly<current.IResources>, TypeOnly<old.IResources>>
 
 /*
@@ -168,6 +169,7 @@ declare type old_as_current_for_TypeAlias_OdspTokenConfig = requireAssignableTo<
  * typeValidation.broken:
  * "TypeAlias_OdspTokenConfig": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_OdspTokenConfig = requireAssignableTo<TypeOnly<current.OdspTokenConfig>, TypeOnly<old.OdspTokenConfig>>
 
 /*

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -416,6 +416,19 @@ stages:
               key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}" | "$(compatVersionCacheKey)"'
               path: $(compatVersionInstallsPath)
 
+        # Install @ff-internal/trips-setup to provide the getFicToken function for ODSP tests.
+        # The ado-feeds-ff-download-only variable (from the ado-feeds group, set up in
+        # include-setup-npmrc-for-download.yml) provides authenticated access to the ADO feed.
+        - ${{ if ne(parameters.odspTenantType, 'none') }}:
+          - task: Bash@3
+            displayName: Install @ff-internal/trips-setup
+            inputs:
+              targetType: 'inline'
+              workingDirectory: ${{ variables.pipelineHostPath }}
+              script: |
+                set -eu -o pipefail
+                pnpm add @ff-internal/trips-setup
+
         # Only check out tenants from the tenant pool if we are running tests against ODSP
         - ${{ if ne(parameters.odspTenantType, 'none') }}:
           # Retrieve a tenant from the tenant pool
@@ -460,6 +473,10 @@ stages:
             ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
               login__microsoft__clientId: $(appClientId)
               login__odsp__test__tenants: $(tenantCreds)
+            # Provide the package that exports getFicToken, used by the ODSP test driver
+            # to refresh FIC bearer tokens without an OAuth refresh token.
+            ${{ if ne(parameters.odspTenantType, 'none') }}:
+              token__package__specifier: '@ff-internal/trips-setup'
           inputs:
             command: 'custom'
             workingDir: ${{ variables.pipelineHostPath }}/node_modules/${{ parameters.testPackage }}


### PR DESCRIPTION
[AB#52057](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/52057)