### PR TITLE
Install fluid-build to a local pnpm project in publish jobs

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -121,32 +121,17 @@ jobs:
                 ls -la
                 pnpm --version
 
-                # Set up pnpm global bin directory explicitly
-                export PNPM_HOME="$HOME/.local/share/pnpm"
-                mkdir -p "$PNPM_HOME"
-                export PATH="$PNPM_HOME:$PATH"
-                pnpm config set global-bin-dir "$PNPM_HOME"
-
                 echo "Installing build tools from tarballs (uses overrides from package.json)"
                 pnpm install ./*.tgz
 
-                echo "Linking build tools globally"
-                for tgz in *.tgz; do
-                  pkg_name=$(tar -xzf "$tgz" --to-stdout package/package.json | jq -r '.name')
-                  # Check if the package has a bin field (i.e., provides CLI commands)
-                  has_bin=$(tar -xzf "$tgz" --to-stdout package/package.json | jq -e '.bin' > /dev/null 2>&1 && echo "yes" || echo "no")
-                  if [ "$has_bin" = "yes" ]; then
-                    echo "Linking $pkg_name globally"
-                    pnpm link --global "node_modules/$pkg_name"
-                  fi
-                done
+                # Add the local node_modules/.bin to PATH for subsequent pipeline steps
+                BIN_DIR="$(pwd)/node_modules/.bin"
+                echo "Adding $BIN_DIR to PATH for subsequent steps"
+                echo "##vso[task.prependpath]$BIN_DIR"
 
                 # Verify the tools are available
-                echo "Global bin directory contents:"
-                ls -la "$PNPM_HOME"
-            env:
-              PNPM_HOME: $(HOME)/.local/share/pnpm
-              PATH: $(HOME)/.local/share/pnpm:$(PATH)
+                echo "Installed binaries:"
+                ls -la "$BIN_DIR"
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,6 +58,11 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
+          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+            parameters:
+              buildDirectory: $(Pipeline.Workspace)
+              enableCache: false
+
           # We can use this step to add overrides that might be necessary to allow for a correct
           # installation of build-tools from the tarball artifacts produced by the build stage.
           # Since this is a lockfile-less install (ideally we should figure out how to change that),

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -66,10 +66,8 @@ jobs:
           # We can use this step to add overrides that might be necessary to allow for a correct
           # installation of build-tools from the tarball artifacts produced by the build stage.
           # Since this is a lockfile-less install (ideally we should figure out how to change that),
-          # npm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
+          # overrides is one recourse when a dependency releases a new version that causes build-tools installation to break.
           # Current overrides:
-          # - @rushstack/node-core-library 5.19.1: version 5.20.0 broke ESM module resolution in Node.
-          #   https://github.com/microsoft/rushstack/issues/5644
           # - Build-tools packages: map all versions to local tarballs so interdependencies resolve correctly.
           - task: Bash@3
             name: CreatePackageJsonForOverrides
@@ -81,9 +79,9 @@ jobs:
                 set -eu -o pipefail
                 echo "Creating package.json with npm overrides"
 
-                # Manual overrides - add new entries here as needed
+                # Manual overrides - add new entries here as needed, using same syntax supported by the pnpm overrides field
                 manual_overrides='{
-                  "@rushstack/node-core-library": "5.19.1"
+
                 }'
 
                 # Build overrides for local tarballs so interdependencies resolve correctly

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,35 +58,27 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
-          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
-            parameters:
-              buildDirectory: $(Pipeline.Workspace)
-              enableCache: false
-
           # We can use this step to add overrides that might be necessary to allow for a correct
           # installation of build-tools from the tarball artifacts produced by the build stage.
           # Since this is a lockfile-less install (ideally we should figure out how to change that),
-          # pnpm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
+          # npm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
           # Current overrides:
           # - @rushstack/node-core-library 5.19.1: version 5.20.0 broke ESM module resolution in Node.
           #   https://github.com/microsoft/rushstack/issues/5644
           - task: Bash@3
             name: CreatePackageJsonForOverrides
-            displayName: Create package.json with pnpm overrides
+            displayName: Create package.json with npm overrides
             inputs:
               targetType: 'inline'
               workingDirectory: '$(Pipeline.Workspace)/buildTools-zip/tarballs'
               script: |
                 set -eu -o pipefail
-                echo "Creating package.json with pnpm overrides"
+                echo "Creating package.json with npm overrides"
                 cat > package.json << 'EOF'
                 {
                   "name": "build-tools-install",
-                  "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
-                  "pnpm": {
-                    "overrides": {
-                      "@rushstack/node-core-library": "5.19.1"
-                    }
+                  "overrides": {
+                    "@rushstack/node-core-library": "5.19.1"
                   }
                 }
                 EOF
@@ -103,7 +95,7 @@ jobs:
                 echo "Listing files in directory: $(pwd)"
                 ls -la
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                pnpm add ./*.tgz
+                npm i -g ./*.tgz
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -121,6 +121,7 @@ jobs:
                 ls -la
                 pnpm --version
 
+                pnpm setup
                 echo "Installing build tools from tarballs (uses overrides from package.json)"
                 pnpm install ./*.tgz
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -77,6 +77,7 @@ jobs:
                 cat > package.json << 'EOF'
                 {
                   "name": "build-tools-install",
+                  "packageManager": "npm@8.3",
                   "overrides": {
                     "@rushstack/node-core-library": "5.19.1"
                   }

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -94,6 +94,7 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
+                pnpm setup
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
                 pnpm add -g ./*.tgz
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -63,6 +63,13 @@ jobs:
               buildDirectory: $(Pipeline.Workspace)
               enableCache: false
 
+          # We can use this step to add overrides that might be necessary to allow for a correct
+          # installation of build-tools from the tarball artifacts produced by the build stage.
+          # Since this is a lockfile-less install (ideally we should figure out how to change that),
+          # pnpm overrides is our recourse when a dependency releases a new version that causes build-tools installation to break.
+          # Current overrides:
+          # - @rushstack/node-core-library 5.19.1: version 5.20.0 broke ESM module resolution in Node.
+          #   https://github.com/microsoft/rushstack/issues/5644
           - task: Bash@3
             name: CreatePackageJsonForOverrides
             displayName: Create package.json with pnpm overrides

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -80,10 +80,7 @@ jobs:
                 echo "Creating package.json with npm overrides"
 
                 # Manual overrides - add new entries here as needed, using same syntax supported by the pnpm overrides field
-                manual_overrides='{
-
-                }'
-
+                manual_overrides='{}'
                 # Build overrides for local tarballs so interdependencies resolve correctly
                 tarball_overrides='{}'
                 for tgz in *.tgz; do

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,6 +58,32 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
+          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+            parameters:
+              buildDirectory: $(Pipeline.Workspace)
+              enableCache: false
+
+          - task: Bash@3
+            name: CreatePackageJsonForOverrides
+            displayName: Create package.json with pnpm overrides
+            inputs:
+              targetType: 'inline'
+              workingDirectory: '$(Pipeline.Workspace)/buildTools-zip/tarballs'
+              script: |
+                set -eu -o pipefail
+                echo "Creating package.json with pnpm overrides"
+                cat > package.json << 'EOF'
+                {
+                  "name": "build-tools-install",
+                  "pnpm": {
+                    "overrides": {
+                      "@rushstack/node-core-library": "5.19.1"
+                    }
+                  }
+                }
+                EOF
+                cat package.json
+
           - task: Bash@3
             name: InstallBuildToolsFromTarball
             displayName: Install Fluid Build Tools from artifact tarball
@@ -69,7 +95,7 @@ jobs:
                 echo "Listing files in directory: $(pwd)"
                 ls -la
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                npm i -g ./*.tgz
+                pnpm add -g ./*.tgz
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -102,9 +102,8 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
-                pnpm setup
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                pnpm add -g ./*.tgz
+                pnpm add ./*.tgz
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -117,7 +117,12 @@ jobs:
                 pnpm --version
 
                 echo "Installing build tools from tarballs (uses overrides from package.json)"
-                pnpm install ./*.tgz
+                if ls ./*.tgz > /dev/null 2>&1; then
+                  pnpm install ./*.tgz
+                else
+                  echo "Error: No .tgz files found in $(pwd)"
+                  exit 1
+                fi
 
                 # Add the local node_modules/.bin to PATH for subsequent pipeline steps
                 BIN_DIR="$(pwd)/node_modules/.bin"

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -112,9 +112,21 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
-                npm --version
-                echo "Attempting install of build tools from build tools pipeline artifact tarball"
-                npm i -g ./*.tgz
+                pnpm --version
+
+                echo "Installing build tools from tarballs (uses overrides from package.json)"
+                pnpm install ./*.tgz
+
+                echo "Linking build tools globally"
+                for tgz in *.tgz; do
+                  pkg_name=$(tar -xzf "$tgz" --to-stdout package/package.json | jq -r '.name')
+                  # Check if the package has a bin field (i.e., provides CLI commands)
+                  has_bin=$(tar -xzf "$tgz" --to-stdout package/package.json | jq -e '.bin' > /dev/null 2>&1 && echo "yes" || echo "no")
+                  if [ "$has_bin" = "yes" ]; then
+                    echo "Linking $pkg_name globally"
+                    pnpm link --global "node_modules/$pkg_name"
+                  fi
+                done
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -121,7 +121,7 @@ jobs:
                 ls -la
                 pnpm --version
 
-                pnpm setup
+                SHELL=$SHELL pnpm setup
                 echo "Installing build tools from tarballs (uses overrides from package.json)"
                 pnpm install ./*.tgz
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -102,7 +102,9 @@ jobs:
                   '{
                     "name": "build-tools-install",
                     "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
-                    "overrides": ($manual + $tarballs)
+                    "pnpm": {
+                      "overrides": ($manual + $tarballs)
+                    }
                   }' > package.json
 
                 cat package.json

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -71,7 +71,7 @@ jobs:
           # - Build-tools packages: map all versions to local tarballs so interdependencies resolve correctly.
           - task: Bash@3
             name: CreatePackageJsonForOverrides
-            displayName: Create package.json with npm overrides
+            displayName: Create package.json with pnpm overrides
             inputs:
               targetType: 'inline'
               workingDirectory: '$(Pipeline.Workspace)/buildTools-zip/tarballs'

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -121,7 +121,12 @@ jobs:
                 ls -la
                 pnpm --version
 
-                SHELL=$SHELL pnpm setup
+                # Set up pnpm global bin directory explicitly
+                export PNPM_HOME="$HOME/.local/share/pnpm"
+                mkdir -p "$PNPM_HOME"
+                export PATH="$PNPM_HOME:$PATH"
+                pnpm config set global-bin-dir "$PNPM_HOME"
+
                 echo "Installing build tools from tarballs (uses overrides from package.json)"
                 pnpm install ./*.tgz
 
@@ -135,6 +140,13 @@ jobs:
                     pnpm link --global "node_modules/$pkg_name"
                   fi
                 done
+
+                # Verify the tools are available
+                echo "Global bin directory contents:"
+                ls -la "$PNPM_HOME"
+            env:
+              PNPM_HOME: $(HOME)/.local/share/pnpm
+              PATH: $(HOME)/.local/share/pnpm:$(PATH)
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -95,6 +95,7 @@ jobs:
                 set -eu -o pipefail
                 echo "Listing files in directory: $(pwd)"
                 ls -la
+                npm --version
                 echo "Attempting install of build tools from build tools pipeline artifact tarball"
                 npm i -g ./*.tgz
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -125,8 +125,13 @@ jobs:
                 echo "##vso[task.prependpath]$BIN_DIR"
 
                 # Verify the tools are available
-                echo "Installed binaries:"
-                ls -la "$BIN_DIR"
+                if [ -d "$BIN_DIR" ]; then
+                  echo "Installed binaries:"
+                  ls -la "$BIN_DIR"
+                else
+                  echo "Error: $BIN_DIR does not exist; expected installed binaries to be present."
+                  exit 1
+                fi
 
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -101,7 +101,7 @@ jobs:
                   --argjson tarballs "$tarball_overrides" \
                   '{
                     "name": "build-tools-install",
-                    "packageManager": "npm@8.3",
+                    "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
                     "overrides": ($manual + $tarballs)
                   }' > package.json
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -82,6 +82,7 @@ jobs:
                 cat > package.json << 'EOF'
                 {
                   "name": "build-tools-install",
+                  "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
                   "pnpm": {
                     "overrides": {
                       "@rushstack/node-core-library": "5.19.1"

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -65,6 +65,7 @@ jobs:
           # Current overrides:
           # - @rushstack/node-core-library 5.19.1: version 5.20.0 broke ESM module resolution in Node.
           #   https://github.com/microsoft/rushstack/issues/5644
+          # - Build-tools packages: map all versions to local tarballs so interdependencies resolve correctly.
           - task: Bash@3
             name: CreatePackageJsonForOverrides
             displayName: Create package.json with npm overrides
@@ -74,15 +75,31 @@ jobs:
               script: |
                 set -eu -o pipefail
                 echo "Creating package.json with npm overrides"
-                cat > package.json << 'EOF'
-                {
-                  "name": "build-tools-install",
-                  "packageManager": "npm@8.3",
-                  "overrides": {
-                    "@rushstack/node-core-library": "5.19.1"
-                  }
-                }
-                EOF
+
+                # Manual overrides - add new entries here as needed
+                manual_overrides='{
+                  "@rushstack/node-core-library": "5.19.1"
+                }'
+
+                # Build overrides for local tarballs so interdependencies resolve correctly
+                tarball_overrides='{}'
+                for tgz in *.tgz; do
+                  # Extract package.json from tarball and get the package name
+                  pkg_name=$(tar -xzf "$tgz" --to-stdout package/package.json | jq -r '.name')
+                  echo "Adding override for $pkg_name -> file:$tgz"
+                  tarball_overrides=$(echo "$tarball_overrides" | jq --arg name "$pkg_name" --arg file "file:$tgz" '. + {($name): $file}')
+                done
+
+                # Merge manual overrides with tarball overrides and create package.json
+                jq -n \
+                  --argjson manual "$manual_overrides" \
+                  --argjson tarballs "$tarball_overrides" \
+                  '{
+                    "name": "build-tools-install",
+                    "packageManager": "npm@8.3",
+                    "overrides": ($manual + $tarballs)
+                  }' > package.json
+
                 cat package.json
 
           - task: Bash@3


### PR DESCRIPTION
## Description

A recent bad publish of the \@rushstack libraries (see https://github.com/microsoft/rushstack/issues/5644) made us realize that problems caused by new releases of the (transitive) dependencies of build-tools can block us from releasing as well. This is because our publish step currently installs Fluid's build-tools (to run the publish command) from a fresh context without a lock file.

This PR implements a relatively self-contained mitigation mechanism: it moves the global installation of fluid-build via npm to instead be a locally spun up project installation via `pnpm` that is then added to the PATH. This allows leveraging pnpm's overrides mechanism, which is how we would address similar sorts of dependency issues.

Test run can be found [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=378885&view=results)
