### PR TITLE
Replace hydrateUnsafe with a simpler and safer hydrateNode, and cleanup simpleTreeBench

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -115,7 +115,7 @@ describe("SimpleTree benchmarks", () => {
 						},
 						benchmarkFn: () => {
 							readNumber = treeReadingFunction(
-								tree ?? fail("Expected unhydratedTree to be set"),
+								tree ?? fail("Expected tree to be set"),
 							);
 						},
 						after: () => {

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -114,9 +114,7 @@ describe("SimpleTree benchmarks", () => {
 							}
 						},
 						benchmarkFn: () => {
-							readNumber = treeReadingFunction(
-								tree ?? fail("Expected tree to be set"),
-							);
+							readNumber = treeReadingFunction(tree ?? fail("Expected tree to be set"));
 						},
 						after: () => {
 							assert.equal(readNumber, expectedValue);


### PR DESCRIPTION
## Description

Replace hydrateUnsafe with a simpler and safer hydrateNode.

Refactor simpleTreeBench to reduce duplicated code, and fix incorrect references to hydrated trees as flex trees (flex trees are a lower level of abstraction which we might want to compare to, but these tests do not compare to).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

