### PR TITLE
Add observeNodeDeep

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/observer.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/observer.ts
@@ -22,8 +22,25 @@ import type { FlexTreeNode } from "./flexTreeTypes.js";
  * See {@link withObservation} and {@link currentObserver}.
  */
 export interface Observer {
+	/**
+	 * Arbitrary content in `node` subtree might be observed.
+	 */
+	observeNodeDeep(node: FlexTreeNode): void;
+	/**
+	 * Which fields exist (as non-empty) on `node` is being observed.
+	 * @remarks
+	 * The set of fields should be considered order independent.
+	 */
 	observeNodeFields(node: FlexTreeNode): void;
+	/**
+	 * The the contents of the `key` field of `node` is being observed.
+	 * @remarks
+	 * Any (shallow) change to which children exist in this field, or in what order should invalidate this observation.
+	 */
 	observeNodeField(node: FlexTreeNode, key: FieldKey): void;
+	/**
+	 * The parent of `node` is being observed.
+	 */
 	observeParentOf(node: FlexTreeNode): void;
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/observer.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/observer.ts
@@ -33,7 +33,7 @@ export interface Observer {
 	 */
 	observeNodeFields(node: FlexTreeNode): void;
 	/**
-	 * The the contents of the `key` field of `node` is being observed.
+	 * The contents of the `key` field of `node` are being observed.
 	 * @remarks
 	 * Any (shallow) change to which children exist in this field, or in what order should invalidate this observation.
 	 */

--- a/packages/dds/tree/src/shared-tree/treeAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeAlpha.ts
@@ -672,12 +672,12 @@ class NodeSubscription {
 					subscriptions.set(flexNode, newSubscription);
 				} else {
 					// Already subscribed to this node.
-					subscription.keys = "deep"; // Now subscribed to all keys.
+					subscription.keys = "deep"; // Now subscribed to subtree changes (deep observation).
 				}
 			},
 			observeNodeFields(flexNode: FlexTreeNode): void {
 				if (flexNode.value !== undefined) {
-					// Leaf value: the set of fields is always empty, can cannot change, so no need to subscribe.
+					// Leaf value: the set of fields is always empty, and cannot change, so no need to subscribe.
 					return;
 				}
 

--- a/packages/dds/tree/src/shared-tree/treeAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeAlpha.ts
@@ -661,7 +661,7 @@ class NodeSubscription {
 		const observer: Observer = {
 			observeNodeDeep(flexNode: FlexTreeNode): void {
 				if (flexNode.value !== undefined) {
-					// Leaf value: the set of fields is always empty, can cannot change, so no need to subscribe.
+					// Leaf value: the set of fields (and thus their content) is always empty, and cannot change, so no need to subscribe.
 					return;
 				}
 

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -15,6 +15,7 @@ import {
 import { FluidClientVersion } from "../../../codec/index.js";
 import { type NormalizedUpPath, rootFieldKey } from "../../../core/index.js";
 import {
+	currentObserver,
 	defaultSchemaPolicy,
 	jsonableTreeFromFieldCursor,
 	MockNodeIdentifierManager,
@@ -286,6 +287,11 @@ describe("treeNodeApi", () => {
 					() => Tree.parent(y),
 				);
 
+				TreeAlpha.trackObservations(
+					() => log.push("deep"),
+					() => currentObserver?.observeNodeDeep(getInnerNode(node)),
+				);
+
 				log.push("change: x.value");
 				node.x.value = 3;
 
@@ -296,10 +302,12 @@ describe("treeNodeApi", () => {
 					"change: x.value",
 					"node.x.value",
 					"x.value",
+					"deep",
 					"change: y",
 					"node.y",
 					"node.y.value",
 					"y.parent",
+					"deep",
 				]);
 			});
 


### PR DESCRIPTION
## Description

Add observeNodeDeep, which can be used when reading contents out of a tree using lower level APIs like cursor as an optimization. This will be used by text.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
