### PR TITLE
Fix parallel forked containers causing IdCompressor "Ranges finalized out of order" 

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3445,9 +3445,7 @@ export class ContainerRuntime
 					// IdAllocation batches use ignoreBatchId, so the DuplicateBatchDetector cannot
 					// catch these duplicates — we must detect them here before finalizeCreationRange.
 					if (range.ids !== undefined) {
-						const nextExpectedGenCount = this.finalizedIdAllocationRanges.get(
-							range.sessionId,
-						);
+						const nextExpectedGenCount = this.finalizedIdAllocationRanges.get(range.sessionId);
 						if (
 							nextExpectedGenCount !== undefined &&
 							range.ids.firstGenCount < nextExpectedGenCount

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3442,7 +3442,7 @@ export class ContainerRuntime
 					// Detect duplicate (overlapping) IdAllocation ranges from forked containers.
 					// Forked containers share the same session ID but submit from different clients,
 					// producing IdAllocation ranges with the same sessionId and overlapping genCounts.
-					// IdAllocation batches use ignoreBatchId, so the DuplicateBatchDetector cannot
+					// IdAllocation batches don't have a stable batch identity over resubmit so the DuplicateBatchDetector cannot
 					// catch these duplicates — we must detect them here before finalizeCreationRange.
 					if (range.ids !== undefined) {
 						const nextExpectedGenCount = this.finalizedIdAllocationRanges.get(range.sessionId);

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -444,10 +444,7 @@ describe("Runtime", () => {
 							),
 						(error: IErrorBase) => {
 							assert(isFluidError(error));
-							assert.strictEqual(
-								error.errorType,
-								ContainerErrorTypes.dataCorruptionError,
-							);
+							assert.strictEqual(error.errorType, ContainerErrorTypes.dataCorruptionError);
 							assert(
 								error.message.includes("Duplicate IdAllocation range detected"),
 								`Unexpected error message: ${error.message}`,
@@ -505,10 +502,7 @@ describe("Runtime", () => {
 							),
 						(error: IErrorBase) => {
 							assert(isFluidError(error));
-							assert.strictEqual(
-								error.errorType,
-								ContainerErrorTypes.dataCorruptionError,
-							);
+							assert.strictEqual(error.errorType, ContainerErrorTypes.dataCorruptionError);
 							return true;
 						},
 						"Partially overlapping ranges should be detected as duplicates",

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2258,6 +2258,136 @@ describeCompat(
 					false, // Don't send ops from first container instance before closing
 					async (c, d) => {
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
+						counter.increment(incrementValue);
+					},
+				);
+
+				async function rehydrateConnectAndPause(loggingId: string): Promise<IContainer> {
+					// Rehydrate and immediately pause outbound to ensure we don't send the ops yet
+					// Container won't be connected yet, so no race here.
+					const container = await loader.resolve(
+						{
+							url,
+							headers: {
+								[LoaderHeader.loadMode]: { deltaConnection: "none" },
+							} satisfies Partial<ILoaderHeader>,
+						},
+						pendingLocalState,
+					);
+					await toIDeltaManagerFull(container.deltaManager).outbound.pause();
+					container.connect();
+
+					// Wait for the container to connect, and then pause the inbound queue
+					// This order matters - we need to process our inbound join op to finish connecting!
+					await waitForContainerConnection(container, true /* failOnContainerClose */, {
+						reject: true,
+						errorMsg: `${loggingId} didn't connect in time`,
+					});
+					await toIDeltaManagerFull(container.deltaManager).inbound.pause();
+
+					// Now this container should submit the op when we resume the outbound queue
+					return container;
+				}
+
+				// Rehydrate twice, waiting for each to connect but blocking outgoing for both, to avoid submitting any ops yet
+				const container2 = await rehydrateConnectAndPause("container2");
+				const container3 = await rehydrateConnectAndPause("container3");
+
+				// Get these before any containers close
+				const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+				const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
+				const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
+				const counter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
+
+				const container2DeltaManager = toIDeltaManagerFull(container2.deltaManager);
+				const container3DeltaManager = toIDeltaManagerFull(container3.deltaManager);
+				// Here's the "in parallel" part - resume both outbound queues at the same time,
+				// and then resume both inbound queues once the outbound queues are idle (done sending).
+				const allSentP = Promise.all([
+					timeoutPromise<unknown>(
+						(resolve) => {
+							container2DeltaManager.outbound.once("idle", resolve);
+						},
+						{ errorMsg: "container2 outbound queue never reached idle state" },
+					),
+					timeoutPromise<unknown>(
+						(resolve) => {
+							container3DeltaManager.outbound.once("idle", resolve);
+						},
+						{ errorMsg: "container3 outbound queue never reached idle state" },
+					),
+				]);
+				container2DeltaManager.outbound.resume();
+				container3DeltaManager.outbound.resume();
+				await allSentP;
+				container2DeltaManager.inbound.resume();
+				container3DeltaManager.inbound.resume();
+
+				// At this point, both rehydrated containers should have submitted the same Counter op.
+				// ContainerRuntime will use PSM and BatchTracker and it will play out like this:
+				// - One will win the race and get their op sequenced first.
+				// - Then the other will close with Forked Container Error when it sees that ack - with matching batchId but from a different client
+				// - Each other client (including the winner) will be tracking the batchId, and when it sees the duplicate from the loser, it will close.
+				await provider.ensureSynchronized();
+
+				// Both containers will close with the correct value for the counter.
+				// The container whose op is sequenced first will close with "Duplicate batch" error
+				// when it sees the other container's batch come in.
+				// The other container (that loses the race to be sequenced) will close with "Forked Container Error"
+				// when it sees the winner's batch come in.
+				assert(container2.closed, "container2 should be closed");
+				assert(container3.closed, "container3 should be closed");
+				assert.strictEqual(
+					counter2.value,
+					incrementValue,
+					"container2 should have incremented to 3 (at least locally)",
+				);
+				assert.strictEqual(
+					counter3.value,
+					incrementValue,
+					"container3 should have incremented to 3 (at least locally)",
+				);
+
+				// Container1 is not used directly in this test, but is present and observing the session,
+				// so we can double-check eventual consistency - the container should have closed when processing the duplicate (after applying the first)
+				assert(container1.closed, "container1 should be closed");
+				assert.strictEqual(
+					counter1.value,
+					incrementValue,
+					"container1 should have incremented to 3 before closing",
+				);
+			},
+		);
+
+		itExpects(
+			`Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)
+			with ID Allocation op`,
+			[
+				// All containers close: contianer1, container2, container3
+				// container2 or container3 (the loser of the race) will close with "Forked Container Error",
+				// The other two will close with "Duplicate batch"
+				// Due to the race condition, we can't specify the order of the different errors here.
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					category: "error",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					category: "error",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					category: "error",
+				},
+			],
+			async function () {
+				const incrementValue = 3;
+				const pendingLocalState = await generatePendingState(
+					testContainerConfig_noSummarizer,
+					provider,
+					false, // Don't send ops from first container instance before closing
+					async (c, d) => {
+						const counter = await d.getSharedObject<SharedCounter>(counterId);
 						// Include an ID Allocation op to get coverage of the special logic around these ops as well
 						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
@@ -2360,7 +2490,6 @@ describeCompat(
 				);
 			},
 		);
-
 		itExpects(
 			`Single-Threaded Forks: Closes (ForkedContainerError) when hydrating twice and submitting in serial (via Counter DDS)`,
 			[

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2230,267 +2230,158 @@ describeCompat(
 			},
 		);
 
+		async function parallelForksTest(
+			generateOps: (counter: SharedCounter) => void,
+		): Promise<void> {
+			const incrementValue = 3;
+			const pendingLocalState = await generatePendingState(
+				testContainerConfig_noSummarizer,
+				provider,
+				false, // Don't send ops from first container instance before closing
+				async (c, d) => {
+					const counter = await d.getSharedObject<SharedCounter>(counterId);
+					generateOps(counter);
+				},
+			);
+
+			async function rehydrateConnectAndPause(loggingId: string): Promise<IContainer> {
+				// Rehydrate and immediately pause outbound to ensure we don't send the ops yet
+				// Container won't be connected yet, so no race here.
+				const container = await loader.resolve(
+					{
+						url,
+						headers: {
+							[LoaderHeader.loadMode]: { deltaConnection: "none" },
+						} satisfies Partial<ILoaderHeader>,
+					},
+					pendingLocalState,
+				);
+				await toIDeltaManagerFull(container.deltaManager).outbound.pause();
+				container.connect();
+
+				// Wait for the container to connect, and then pause the inbound queue
+				// This order matters - we need to process our inbound join op to finish connecting!
+				await waitForContainerConnection(container, true /* failOnContainerClose */, {
+					reject: true,
+					errorMsg: `${loggingId} didn't connect in time`,
+				});
+				await toIDeltaManagerFull(container.deltaManager).inbound.pause();
+
+				// Now this container should submit the op when we resume the outbound queue
+				return container;
+			}
+
+			// Rehydrate twice, waiting for each to connect but blocking outgoing for both, to avoid submitting any ops yet
+			const container2 = await rehydrateConnectAndPause("container2");
+			const container3 = await rehydrateConnectAndPause("container3");
+
+			// Get these before any containers close
+			const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
+			const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
+			const counter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
+
+			const container2DeltaManager = toIDeltaManagerFull(container2.deltaManager);
+			const container3DeltaManager = toIDeltaManagerFull(container3.deltaManager);
+			// Here's the "in parallel" part - resume both outbound queues at the same time,
+			// and then resume both inbound queues once the outbound queues are idle (done sending).
+			const allSentP = Promise.all([
+				timeoutPromise<unknown>(
+					(resolve) => {
+						container2DeltaManager.outbound.once("idle", resolve);
+					},
+					{ errorMsg: "container2 outbound queue never reached idle state" },
+				),
+				timeoutPromise<unknown>(
+					(resolve) => {
+						container3DeltaManager.outbound.once("idle", resolve);
+					},
+					{ errorMsg: "container3 outbound queue never reached idle state" },
+				),
+			]);
+			container2DeltaManager.outbound.resume();
+			container3DeltaManager.outbound.resume();
+			await allSentP;
+			container2DeltaManager.inbound.resume();
+			container3DeltaManager.inbound.resume();
+
+			// At this point, both rehydrated containers should have submitted the same Counter op.
+			// ContainerRuntime will use PSM and BatchTracker and it will play out like this:
+			// - One will win the race and get their op sequenced first.
+			// - Then the other will close with Forked Container Error when it sees that ack - with matching batchId but from a different client
+			// - Each other client (including the winner) will be tracking the batchId, and when it sees the duplicate from the loser, it will close.
+			await provider.ensureSynchronized();
+
+			// Both containers will close with the correct value for the counter.
+			// The container whose op is sequenced first will close with "Duplicate batch" error
+			// when it sees the other container's batch come in.
+			// The other container (that loses the race to be sequenced) will close with "Forked Container Error"
+			// when it sees the winner's batch come in.
+			assert(container2.closed, "container2 should be closed");
+			assert(container3.closed, "container3 should be closed");
+			assert.strictEqual(
+				counter2.value,
+				incrementValue,
+				"container2 should have incremented to 3 (at least locally)",
+			);
+			assert.strictEqual(
+				counter3.value,
+				incrementValue,
+				"container3 should have incremented to 3 (at least locally)",
+			);
+
+			// Container1 is not used directly in this test, but is present and observing the session,
+			// so we can double-check eventual consistency - the container should have closed when processing the duplicate (after applying the first)
+			assert(container1.closed, "container1 should be closed");
+			assert.strictEqual(
+				counter1.value,
+				incrementValue,
+				"container1 should have incremented to 3 before closing",
+			);
+		}
+
+		const parallelForksExpectedErrors = [
+			// All containers close: contianer1, container2, container3
+			// container2 or container3 (the loser of the race) will close with "Forked Container Error",
+			// The other two will close with "Duplicate batch"
+			// Due to the race condition, we can't specify the order of the different errors here.
+			{
+				eventName: "fluid:telemetry:Container:ContainerClose",
+				category: "error",
+			},
+			{
+				eventName: "fluid:telemetry:Container:ContainerClose",
+				category: "error",
+			},
+			{
+				eventName: "fluid:telemetry:Container:ContainerClose",
+				category: "error",
+			},
+		] as const;
+
 		itExpects(
 			`Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)`,
-			[
-				// All containers close: contianer1, container2, container3
-				// container2 or container3 (the loser of the race) will close with "Forked Container Error",
-				// The other two will close with "Duplicate batch"
-				// Due to the race condition, we can't specify the order of the different errors here.
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					category: "error",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					category: "error",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					category: "error",
-				},
-			],
+			[...parallelForksExpectedErrors],
 			async function () {
-				const incrementValue = 3;
-				const pendingLocalState = await generatePendingState(
-					testContainerConfig_noSummarizer,
-					provider,
-					false, // Don't send ops from first container instance before closing
-					async (c, d) => {
-						const counter = await d.getSharedObject<SharedCounter>(counterId);
-						counter.increment(incrementValue);
-					},
-				);
-
-				async function rehydrateConnectAndPause(loggingId: string): Promise<IContainer> {
-					// Rehydrate and immediately pause outbound to ensure we don't send the ops yet
-					// Container won't be connected yet, so no race here.
-					const container = await loader.resolve(
-						{
-							url,
-							headers: {
-								[LoaderHeader.loadMode]: { deltaConnection: "none" },
-							} satisfies Partial<ILoaderHeader>,
-						},
-						pendingLocalState,
-					);
-					await toIDeltaManagerFull(container.deltaManager).outbound.pause();
-					container.connect();
-
-					// Wait for the container to connect, and then pause the inbound queue
-					// This order matters - we need to process our inbound join op to finish connecting!
-					await waitForContainerConnection(container, true /* failOnContainerClose */, {
-						reject: true,
-						errorMsg: `${loggingId} didn't connect in time`,
-					});
-					await toIDeltaManagerFull(container.deltaManager).inbound.pause();
-
-					// Now this container should submit the op when we resume the outbound queue
-					return container;
-				}
-
-				// Rehydrate twice, waiting for each to connect but blocking outgoing for both, to avoid submitting any ops yet
-				const container2 = await rehydrateConnectAndPause("container2");
-				const container3 = await rehydrateConnectAndPause("container3");
-
-				// Get these before any containers close
-				const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-				const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
-				const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
-				const counter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
-
-				const container2DeltaManager = toIDeltaManagerFull(container2.deltaManager);
-				const container3DeltaManager = toIDeltaManagerFull(container3.deltaManager);
-				// Here's the "in parallel" part - resume both outbound queues at the same time,
-				// and then resume both inbound queues once the outbound queues are idle (done sending).
-				const allSentP = Promise.all([
-					timeoutPromise<unknown>(
-						(resolve) => {
-							container2DeltaManager.outbound.once("idle", resolve);
-						},
-						{ errorMsg: "container2 outbound queue never reached idle state" },
-					),
-					timeoutPromise<unknown>(
-						(resolve) => {
-							container3DeltaManager.outbound.once("idle", resolve);
-						},
-						{ errorMsg: "container3 outbound queue never reached idle state" },
-					),
-				]);
-				container2DeltaManager.outbound.resume();
-				container3DeltaManager.outbound.resume();
-				await allSentP;
-				container2DeltaManager.inbound.resume();
-				container3DeltaManager.inbound.resume();
-
-				// At this point, both rehydrated containers should have submitted the same Counter op.
-				// ContainerRuntime will use PSM and BatchTracker and it will play out like this:
-				// - One will win the race and get their op sequenced first.
-				// - Then the other will close with Forked Container Error when it sees that ack - with matching batchId but from a different client
-				// - Each other client (including the winner) will be tracking the batchId, and when it sees the duplicate from the loser, it will close.
-				await provider.ensureSynchronized();
-
-				// Both containers will close with the correct value for the counter.
-				// The container whose op is sequenced first will close with "Duplicate batch" error
-				// when it sees the other container's batch come in.
-				// The other container (that loses the race to be sequenced) will close with "Forked Container Error"
-				// when it sees the winner's batch come in.
-				assert(container2.closed, "container2 should be closed");
-				assert(container3.closed, "container3 should be closed");
-				assert.strictEqual(
-					counter2.value,
-					incrementValue,
-					"container2 should have incremented to 3 (at least locally)",
-				);
-				assert.strictEqual(
-					counter3.value,
-					incrementValue,
-					"container3 should have incremented to 3 (at least locally)",
-				);
-
-				// Container1 is not used directly in this test, but is present and observing the session,
-				// so we can double-check eventual consistency - the container should have closed when processing the duplicate (after applying the first)
-				assert(container1.closed, "container1 should be closed");
-				assert.strictEqual(
-					counter1.value,
-					incrementValue,
-					"container1 should have incremented to 3 before closing",
-				);
+				await parallelForksTest((counter) => {
+					counter.increment(3);
+				});
 			},
 		);
 
 		itExpects(
 			`Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)
 			with ID Allocation op`,
-			[
-				// All containers close: contianer1, container2, container3
-				// container2 or container3 (the loser of the race) will close with "Forked Container Error",
-				// The other two will close with "Duplicate batch"
-				// Due to the race condition, we can't specify the order of the different errors here.
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					category: "error",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					category: "error",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					category: "error",
-				},
-			],
+			[...parallelForksExpectedErrors],
 			async function () {
 				if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
 					this.skip();
 				}
-				const incrementValue = 3;
-				const pendingLocalState = await generatePendingState(
-					testContainerConfig_noSummarizer,
-					provider,
-					false, // Don't send ops from first container instance before closing
-					async (c, d) => {
-						const counter = await d.getSharedObject<SharedCounter>(counterId);
-						// Include an ID Allocation op to get coverage of the special logic around these ops as well
-						getIdCompressor(counter)?.generateCompressedId();
-						counter.increment(incrementValue);
-					},
-				);
-
-				async function rehydrateConnectAndPause(loggingId: string): Promise<IContainer> {
-					// Rehydrate and immediately pause outbound to ensure we don't send the ops yet
-					// Container won't be connected yet, so no race here.
-					const container = await loader.resolve(
-						{
-							url,
-							headers: {
-								[LoaderHeader.loadMode]: { deltaConnection: "none" },
-							} satisfies Partial<ILoaderHeader>,
-						},
-						pendingLocalState,
-					);
-					await toIDeltaManagerFull(container.deltaManager).outbound.pause();
-					container.connect();
-
-					// Wait for the container to connect, and then pause the inbound queue
-					// This order matters - we need to process our inbound join op to finish connecting!
-					await waitForContainerConnection(container, true /* failOnContainerClose */, {
-						reject: true,
-						errorMsg: `${loggingId} didn't connect in time`,
-					});
-					await toIDeltaManagerFull(container.deltaManager).inbound.pause();
-
-					// Now this container should submit the op when we resume the outbound queue
-					return container;
-				}
-
-				// Rehydrate twice, waiting for each to connect but blocking outgoing for both, to avoid submitting any ops yet
-				const container2 = await rehydrateConnectAndPause("container2");
-				const container3 = await rehydrateConnectAndPause("container3");
-
-				// Get these before any containers close
-				const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-				const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
-				const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
-				const counter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
-
-				const container2DeltaManager = toIDeltaManagerFull(container2.deltaManager);
-				const container3DeltaManager = toIDeltaManagerFull(container3.deltaManager);
-				// Here's the "in parallel" part - resume both outbound queues at the same time,
-				// and then resume both inbound queues once the outbound queues are idle (done sending).
-				const allSentP = Promise.all([
-					timeoutPromise<unknown>(
-						(resolve) => {
-							container2DeltaManager.outbound.once("idle", resolve);
-						},
-						{ errorMsg: "container2 outbound queue never reached idle state" },
-					),
-					timeoutPromise<unknown>(
-						(resolve) => {
-							container3DeltaManager.outbound.once("idle", resolve);
-						},
-						{ errorMsg: "container3 outbound queue never reached idle state" },
-					),
-				]);
-				container2DeltaManager.outbound.resume();
-				container3DeltaManager.outbound.resume();
-				await allSentP;
-				container2DeltaManager.inbound.resume();
-				container3DeltaManager.inbound.resume();
-
-				// At this point, both rehydrated containers should have submitted the same Counter op.
-				// ContainerRuntime will use PSM and BatchTracker and it will play out like this:
-				// - One will win the race and get their op sequenced first.
-				// - Then the other will close with Forked Container Error when it sees that ack - with matching batchId but from a different client
-				// - Each other client (including the winner) will be tracking the batchId, and when it sees the duplicate from the loser, it will close.
-				await provider.ensureSynchronized();
-
-				// Both containers will close with the correct value for the counter.
-				// The container whose op is sequenced first will close with "Duplicate batch" error
-				// when it sees the other container's batch come in.
-				// The other container (that loses the race to be sequenced) will close with "Forked Container Error"
-				// when it sees the winner's batch come in.
-				assert(container2.closed, "container2 should be closed");
-				assert(container3.closed, "container3 should be closed");
-				assert.strictEqual(
-					counter2.value,
-					incrementValue,
-					"container2 should have incremented to 3 (at least locally)",
-				);
-				assert.strictEqual(
-					counter3.value,
-					incrementValue,
-					"container3 should have incremented to 3 (at least locally)",
-				);
-
-				// Container1 is not used directly in this test, but is present and observing the session,
-				// so we can double-check eventual consistency - the container should have closed when processing the duplicate (after applying the first)
-				assert(container1.closed, "container1 should be closed");
-				assert.strictEqual(
-					counter1.value,
-					incrementValue,
-					"container1 should have incremented to 3 before closing",
-				);
+				await parallelForksTest((counter) => {
+					// Include an ID Allocation op to get coverage of the special logic around these ops as well
+					getIdCompressor(counter)?.generateCompressedId();
+					counter.increment(3);
+				});
 			},
 		);
 		itExpects(

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2381,7 +2381,7 @@ describeCompat(
 				},
 			],
 			async function () {
-				if (provider.driver.type === "t9s") {
+				if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
 					this.skip();
 				}
 				const incrementValue = 3;

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2381,6 +2381,9 @@ describeCompat(
 				},
 			],
 			async function () {
+				if (provider.driver.type === "t9s") {
+					this.skip();
+				}
 				const incrementValue = 3;
 				const pendingLocalState = await generatePendingState(
 					testContainerConfig_noSummarizer,

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2251,9 +2251,6 @@ describeCompat(
 				},
 			],
 			async function () {
-				if (provider.driver.type !== "local") {
-					this.skip();
-				}
 				const incrementValue = 3;
 				const pendingLocalState = await generatePendingState(
 					testContainerConfig_noSummarizer,
@@ -2262,8 +2259,7 @@ describeCompat(
 					async (c, d) => {
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
 						// Include an ID Allocation op to get coverage of the special logic around these ops as well
-						// AB#26984: Actually don't, because the ID Compressor is hitting "Ranges finalized out of order" for this test
-						// getIdCompressor(counter)?.generateCompressedId();
+						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
 					},
 				);


### PR DESCRIPTION
### Bug scenario:
When a container forks (two instances load from the same stashed state), the ID Compressor in each fork has the same session ID. Both independently generate IDs and submit IdAllocation ops:
Fork 1 sends: "Session ABC claims IDs 1-10"
Fork 2 sends: "Session ABC claims IDs 1-10" (same range — they started from the same state)
When finalizeCreationRange processes both, the compressor sees overlapping ranges for the same session, hitting "Ranges finalized out of order" inside the compressor itself, which is a confusing error with no indication it's a fork.

### Fix
Detect duplicate (overlapping) IdAllocation ranges from forked containers that share the same session ID but submit from different clients. IdAllocation batches use ignoreBatchId, so the DuplicateBatchDetector cannot catch these — this adds range-level overlap detection before finalizeCreationRange.

- Add a new e2e test variant that explicitly covers parallel forks with ID allocation ops.
- Add unit tests covering: overlapping ranges (same session, different clients), sequential ranges (same session, allowed), different sessions (allowed), and partial overlap detection.