### PR TITLE
Run slow test suites in parallel

### DIFF
--- a/packages/dds/merge-tree/.mocharc.cjs
+++ b/packages/dds/merge-tree/.mocharc.cjs
@@ -8,4 +8,6 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
+config.parallel = true;
+config.jobs = 4;
 module.exports = config;

--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
@@ -56,4 +56,8 @@ if (runningAgainstInternalRouterliciousCluster) {
 
 // TODO: ADO#34589: These tests leak memory and sometimes crash on CI. This is a workaround to increase the memory limit.
 config["node-option"] = [...config["node-option"], "max-old-space-size=8000"];
+
+config.parallel = true;
+config.jobs = 4;
+
 module.exports = config;


### PR DESCRIPTION
## Description

Make the two slowest test suites run tests in parallel for faster CI times.

Since these two suites take much longer than the others, splitting them up for aprallel running should better utalize the CPU time on CI after the other test suites have finished.

The job count is kept somehat low (at 4) since to avoid way too many processes and memory use when CI runs multiple suites in parallel.

## Local testing showed:

### For merge-tree:

real    7m6.237s
user    9m21.428s
sys     0m7.807s

to 

real    2m47.996s
user    9m43.899s
sys     0m4.306s

### For end-to-end:

real    8m8.765s
user    4m21.356s
sys     0m17.529s

to 

real    2m3.571s
user    6m21.392s
sys     0m42.993s


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
