### PR TITLE
build: set base api-extractor config to do nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ legacy.d.ts
 # Temporary api-extractor build artifacts
 **/_api-extractor-temp/**
 
+# api-extractor metadata artifact
+# This should not be generically ignored nor checked in. If found, examine settings
+# to see if file is meant to be generated in that location.
+# tsdoc-metadata.json
+
 # Bundle analysis artifacts
 bundleAnalysis
 
@@ -38,9 +43,6 @@ bundleAnalysis
 artifacts
 
 docs/resources/_gen/
-
-# documentation tool artifact
-tsdoc-metadata.json
 
 # PNPM store (when mounting host file system in docker container)
 .pnpm-store/

--- a/common/build/build-common/api-extractor-base.cjs.no-legacy.json
+++ b/common/build/build-common/api-extractor-base.cjs.no-legacy.json
@@ -5,6 +5,9 @@
 	"apiReport": {
 		"enabled": true
 	},
+	"docModel": {
+		"enabled": true
+	},
 	// API-Extractor uses the presence of this file in an npm package to determine whether or not its API members
 	// should be considered when making decisions about reports and rollups in consuming packages.
 	// This includes determining whether or not release tags on external members should be respected when

--- a/common/build/build-common/api-extractor-base.esm.json
+++ b/common/build/build-common/api-extractor-base.esm.json
@@ -5,6 +5,9 @@
 	"apiReport": {
 		"enabled": true
 	},
+	"docModel": {
+		"enabled": true
+	},
 	// API-Extractor uses the presence of this file in an npm package to determine whether or not its API members
 	// should be considered when making decisions about reports and rollups in consuming packages.
 	// This includes determining whether or not release tags on external members should be respected when

--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -10,12 +10,14 @@
 	 * Can be overridden as necessary for packages with different build structures.
 	 *
 	 * See: <https://api-extractor.com/pages/configs/api-extractor_json/#mainentrypointfilepath>
+	 *
+	 * Usually should be `<projectFolder>/lib/index.d.ts` or `<projectFolder>/dist/index.d.ts`.
 	 */
-	"mainEntryPointFilePath": "INVALID - specify in derived config - likely: <projectFolder>/lib/index.d.ts or <projectFolder>/dist/index.d.ts",
+	"mainEntryPointFilePath": "INVALID - specify in derived config",
 
 	// All of the outputs are disabled (`"enabled": false`) by default in the base config.
 	// Derived configs should enable the outputs that they need.  This ensures that we
-	// don't accidentally generate outputs with more explicit intent.
+	// don't accidentally generate outputs without more explicit intent.
 
 	/**
 	 * Configures how the API report file (*.api.md) will be generated.

--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -11,13 +11,17 @@
 	 *
 	 * See: <https://api-extractor.com/pages/configs/api-extractor_json/#mainentrypointfilepath>
 	 */
-	"mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts",
+	"mainEntryPointFilePath": "INVALID - specify in derived config - likely: <projectFolder>/lib/index.d.ts or <projectFolder>/dist/index.d.ts",
+
+	// All of the outputs are disabled (`"enabled": false`) by default in the base config.
+	// Derived configs should enable the outputs that they need.  This ensures that we
+	// don't accidentally generate outputs with more explicit intent.
 
 	/**
 	 * Configures how the API report file (*.api.md) will be generated.
 	 */
 	"apiReport": {
-		"enabled": true,
+		"enabled": false,
 		"reportFileName": "<unscopedPackageName>",
 		"reportFolder": "<projectFolder>/api-report/",
 		"reportTempFolder": "<projectFolder>/_api-extractor-temp/",
@@ -36,7 +40,7 @@
 	 * Configures how the doc model file (*.api.json) will be generated.
 	 */
 	"docModel": {
-		"enabled": true,
+		"enabled": false,
 		"apiJsonFilePath": "<projectFolder>/_api-extractor-temp/doc-models/<unscopedPackageName>.api.json"
 	},
 
@@ -51,7 +55,7 @@
 	 * Configures how the tsdoc-metadata.json file will be generated.
 	 */
 	"tsdocMetadata": {
-		"enabled": true
+		"enabled": false
 	},
 
 	/**

--- a/common/lib/common-utils/api-extractor-lint.json
+++ b/common/lib/common-utils/api-extractor-lint.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../build/build-common/api-extractor-lint.json"
+	"extends": "../../build/build-common/api-extractor-lint.json",
+	"mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts"
 }

--- a/server/routerlicious/api-extractor-lint-base.json
+++ b/server/routerlicious/api-extractor-lint-base.json
@@ -44,7 +44,7 @@
 			"ae-missing-release-tag": {
 				"logLevel": "none"
 			},
-			// Links with implicit (unanotated) package name specifiers don't currently resolve correctly
+			// Links with implicit (unannotated) package name specifiers don't currently resolve correctly
 			// when their members are bundled.
 			// See https://github.com/microsoft/rushstack/issues/3521
 			// Omit this check from the cross-package lint step.

--- a/server/routerlicious/api-extractor-lint-base.json
+++ b/server/routerlicious/api-extractor-lint-base.json
@@ -7,6 +7,15 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "@fluidframework/build-common/api-extractor-base.json",
+
+	/**
+	 * Specifies the .d.ts file to be used as the starting point for analysis. API Extractor analyzes the symbols exported by this module.
+	 * Can be overridden as necessary for packages with different build structures.
+	 *
+	 * See: <https://api-extractor.com/pages/configs/api-extractor_json/#mainentrypointfilepath>
+	 */
+	"mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts",
+
 	"apiReport": {
 		// Don't generate API report in lint pass
 		"enabled": false

--- a/tools/benchmark/api-extractor-lint.json
+++ b/tools/benchmark/api-extractor-lint.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../common/build/build-common/api-extractor-lint.json",
+	"mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts"
 }

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -36,6 +36,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - common/build/build-common
     - tools/benchmark
     - tools/pipelines/build-benchmark-tool.yml
     - tools/pipelines/templates/build-npm-package.yml
@@ -61,6 +62,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - common/build/build-common
     - tools/benchmark
     - tools/pipelines/build-benchmark-tool.yml
     - tools/pipelines/templates/build-npm-package.yml


### PR DESCRIPTION
Derived configs must specify which sections to explicitly enable and select main entrypoint path.

This prevents unexpected actions when setting up new configs.

In api-extractor-base.json:
- default all action options to false.
- set entrypoint path to invalid
Fix up derivatives to preserve their original (and not explicit) settings.

Remove tsdoc-metadata.json from .gitignore as it already should be ignored structurally.

Additionally, make sure benchmark build is triggered for common/build/build-common changes.

Future suggestion: replace `api-extractor-base.json` and `api-extractor-lint.json` with the other configs that match uses where possible.