### PR TITLE
Simplify text-editor/webpack.config.cjs

### DIFF
--- a/examples/data-objects/text-editor/webpack.config.cjs
+++ b/examples/data-objects/text-editor/webpack.config.cjs
@@ -57,8 +57,6 @@ module.exports = (env = {}) => {
 			static: {
 				directory: path.join(__dirname, "dist"),
 			},
-			port: 8081,
-			hot: true,
 			open: true,
 		},
 		watchOptions: {


### PR DESCRIPTION
## Description

Hot module reloading is on by default, so don't explicrily enable it.

Let port default to 8080 now that there is only one webpack config for this app.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
