### PR TITLE
Recommend snapshotSchemaCompatibility

### DIFF
--- a/docs/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
@@ -10,6 +10,9 @@ This guide shows how to safely add a new [TreeNodeSchema](../../../api/fluid-fra
 Directly adding a new node type to an existing field would cause old clients to be unable to load documents whose schema contain the new type, breaking them immediately.
 The following process stages changes to introduce a new allowed type in a non-breaking way.
 
+Writing a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) is recommended to help ensure this process is followed correctly,
+and that all required versions of the application or library can collaborate through the rollout.
+
 ## Step-by-Step Guide
 
 The example below walks through the process of adding string support to a field that previously only supported numbers.

--- a/docs/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 8
 
 As your application (or library) grows and evolves, you may need to modify the structure of your [SharedTree](../index.mdx) data.
 SharedTree makes it possible to update your [schemas](../schema-definition.mdx) in ways that allow an app to load or upgrade documents created or edited by earlier versions of the app (see [understanding compatibility](./index.mdx#understanding-compatibility)).
-To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions use, write a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function).
+To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions, write a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function).
 
 :::note
 For detailed information about which types of changes are safe versus breaking, see [types of schema changes](./types-of-changes).

--- a/docs/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/index.mdx
@@ -5,8 +5,9 @@ sidebar_position: 8
 
 # Schema Evolution
 
-As your application grows and evolves, you may need to modify the structure of your [SharedTree](../index.mdx) data.
+As your application (or library) grows and evolves, you may need to modify the structure of your [SharedTree](../index.mdx) data.
 SharedTree makes it possible to update your [schemas](../schema-definition.mdx) in ways that allow an app to load or upgrade documents created or edited by earlier versions of the app (see [understanding compatibility](./index.mdx#understanding-compatibility)).
+To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions use, write a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function).
 
 :::note
 For detailed information about which types of changes are safe versus breaking, see [types of schema changes](./types-of-changes).

--- a/docs/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
@@ -6,6 +6,8 @@ sidebar_position: 2
 # Types of Schema Changes
 
 Understanding which types of schema changes are safe versus breaking is crucial for evolving your [SharedTree](../index.mdx) schemas without disrupting existing applications.
+Writing a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) is highly recommended to ensure any schema changes maintain your compatibility requirements.
+Knowledge of the details below will still be needed to design schemas such that the required future changes can be compatible, and to understand any errors detected by the test.
 
 All the examples below are modifying this schema:
 ```typescript

--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -53,7 +53,7 @@ API documentation for **@fluidframework/tree** is available at <https://fluidfra
 
 ## Status
 
-Notable considerations that users should be wary of:
+Notable considerations that users should be aware of:
 
 -   The persisted format is stable: documents created with released versions 2.0.0 or greater of this package are fully supported long term.
 -   All range changes are currently atomized.

--- a/packages/dds/tree/src/simple-tree/api/configuration.ts
+++ b/packages/dds/tree/src/simple-tree/api/configuration.ts
@@ -147,6 +147,10 @@ export interface ITreeViewConfiguration<
 > extends ITreeConfigurationOptions {
 	/**
 	 * The schema which the application wants to view the tree with.
+	 * @remarks
+	 * Use {@link SchemaFactory} to construct this the schema.
+	 * Changes to this schema between different versions have important compatibility implications.
+	 * See the {@link https://fluidframework.com/docs/data-structures/tree/schema-evolution | documentation on schema evolution} for more details.
 	 */
 	readonly schema: TSchema;
 }

--- a/packages/dds/tree/src/simple-tree/api/configuration.ts
+++ b/packages/dds/tree/src/simple-tree/api/configuration.ts
@@ -148,7 +148,7 @@ export interface ITreeViewConfiguration<
 	/**
 	 * The schema which the application wants to view the tree with.
 	 * @remarks
-	 * Use {@link SchemaFactory} to construct this the schema.
+	 * Use {@link SchemaFactory} to construct the schema.
 	 * Changes to this schema between different versions have important compatibility implications.
 	 * See the {@link https://fluidframework.com/docs/data-structures/tree/schema-evolution | documentation on schema evolution} for more details.
 	 */

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -226,12 +226,13 @@ export const SchemaFactory_base = classWithStatics(schemaStaticsPublic);
  * @remarks
  * For details related to inputting data constrained by schema (including via assignment), and how non-exact schema types are handled in general refer to {@link Input}.
  * For information about recursive schema support, see methods postfixed with "recursive" and {@link ValidateRecursiveSchema}.
- * To apply schema defined with this factory to a tree, see {@link ViewableTree.viewWith} and {@link TreeViewConfiguration}.
+ * To apply schema defined with this factory to a tree, see {@link TreeViewConfiguration} and {@link ViewableTree.viewWith}.
+ * See the {@link https://fluidframework.com/docs/data-structures/tree/schema-evolution | documentation on schema evolution} for how to handle changes to schema over time.
  *
  * All schema produced by this factory get a {@link TreeNodeSchemaCore.identifier|unique identifier} by combining the {@link SchemaFactory.scope} with the schema's `Name`.
  * The `Name` part may be explicitly provided as a parameter, or inferred as a structural combination of the provided types.
  * The APIs which use this second approach, structural naming, also deduplicate all equivalent calls.
- * Therefor two calls to `array(allowedTypes)` with the same allowedTypes will return the same {@link TreeNodeSchema} instance.
+ * Therefore two calls to `array(allowedTypes)` with the same allowedTypes will return the same {@link TreeNodeSchema} instance.
  * On the other hand, two calls to `array(name, allowedTypes)` will always return different {@link TreeNodeSchema} instances
  * and it is an error to use both in the same tree (since their identifiers are not unique).
  *


### PR DESCRIPTION
## Description

Now that snapshotSchemaCompatibility is beta, it shouldn't be renamed and links to it should be stable.
Since it is unchanged since last released (as alpha) the links to it are already valid, so we can add them to docs.

Use these links to recommend snapshotSchemaCompatibility in more places.

Also included are a few related docs tweaks noted while working on this.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
