### PR TITLE
test: skip failing tests

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -131,6 +131,10 @@ describe(`Presence with AzureClient`, () => {
 			const allAttendeesFullyJoinedTimeoutMs = (2000 + 300 * numClients) * timeoutMultiplier;
 
 			for (const writeClients of [numClients, 1]) {
+				/**
+				 * Note: This test is currently skipped because it is flaky in the Service Clients End to End tests pipelines.
+				 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
+				 */
 				it.skip(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
 					setTestTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
 
@@ -154,6 +158,10 @@ describe(`Presence with AzureClient`, () => {
 					);
 				});
 
+				/**
+				 * Note: This test is currently skipped because it is flaky in the Service Clients End to End tests pipelines.
+				 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
+				 */
 				it.skip(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
 					if (useAzure && numClients > 50) {
 						// Even with increased timeouts, more than 50 clients can be too large for AFR.

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -131,7 +131,7 @@ describe(`Presence with AzureClient`, () => {
 			const allAttendeesFullyJoinedTimeoutMs = (2000 + 300 * numClients) * timeoutMultiplier;
 
 			for (const writeClients of [numClients, 1]) {
-				it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
+				it.skip(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
 					setTestTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
 
 					// Setup
@@ -154,7 +154,7 @@ describe(`Presence with AzureClient`, () => {
 					);
 				});
 
-				it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
+				it.skip(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
 					if (useAzure && numClients > 50) {
 						// Even with increased timeouts, more than 50 clients can be too large for AFR.
 						// This may be due to slow responses/inactivity from the clients that are

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -133,13 +133,10 @@ describe(`Presence with AzureClient`, () => {
 			for (const writeClients of [numClients, 1]) {
 				it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
 					/**
-					 * Note: This test is currently skipped in the AFR driver because it is flaky in the Service Clients End to End tests pipelines.
-					 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
+					 * Note: This test is currently skipped in the AFR driver due to General Network Errors in the Service Clients End to End tests pipelines.
+					 * For more context, see AB#59980.
 					 */
 					if (useAzure && numClients > 50) {
-						// Even with increased timeouts, more than 50 clients can be too large for AFR.
-						// This may be due to slow responses/inactivity from the clients that are
-						// creating pressure on ADO agent.
 						this.skip();
 					}
 					setTestTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
@@ -166,8 +163,8 @@ describe(`Presence with AzureClient`, () => {
 
 				it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
 					/**
-					 * Note: This test is currently skipped in the AFR driver because it is flaky in the Service Clients End to End tests pipelines.
-					 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
+					 * Note: This test is currently skipped in the AFR driver due to General Network Errors in the Service Clients End to End tests pipelines.
+					 * For more context, see AB#59980.
 					 */
 					if (useAzure && numClients > 50) {
 						// Even with increased timeouts, more than 50 clients can be too large for AFR.

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -131,11 +131,17 @@ describe(`Presence with AzureClient`, () => {
 			const allAttendeesFullyJoinedTimeoutMs = (2000 + 300 * numClients) * timeoutMultiplier;
 
 			for (const writeClients of [numClients, 1]) {
-				/**
-				 * Note: This test is currently skipped because it is flaky in the Service Clients End to End tests pipelines.
-				 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
-				 */
-				it.skip(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
+				it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {
+					/**
+					 * Note: This test is currently skipped in the AFR driver because it is flaky in the Service Clients End to End tests pipelines.
+					 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
+					 */
+					if (useAzure && numClients > 50) {
+						// Even with increased timeouts, more than 50 clients can be too large for AFR.
+						// This may be due to slow responses/inactivity from the clients that are
+						// creating pressure on ADO agent.
+						this.skip();
+					}
 					setTestTimeout(this, childConnectTimeoutMs + allAttendeesJoinedTimeoutMs + 1000);
 
 					// Setup
@@ -158,11 +164,11 @@ describe(`Presence with AzureClient`, () => {
 					);
 				});
 
-				/**
-				 * Note: This test is currently skipped because it is flaky in the Service Clients End to End tests pipelines.
-				 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
-				 */
-				it.skip(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
+				it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
+					/**
+					 * Note: This test is currently skipped in the AFR driver because it is flaky in the Service Clients End to End tests pipelines.
+					 * See AB#59980 for tracking and re-enabling once the flakiness is resolved.
+					 */
 					if (useAzure && numClients > 50) {
 						// Even with increased timeouts, more than 50 clients can be too large for AFR.
 						// This may be due to slow responses/inactivity from the clients that are

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -162,10 +162,6 @@ describe(`Presence with AzureClient`, () => {
 				});
 
 				it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeDisconnected() {
-					/**
-					 * Note: This test is currently skipped in the AFR driver due to General Network Errors in the Service Clients End to End tests pipelines.
-					 * For more context, see AB#59980.
-					 */
 					if (useAzure && numClients > 50) {
 						// Even with increased timeouts, more than 50 clients can be too large for AFR.
 						// This may be due to slow responses/inactivity from the clients that are


### PR DESCRIPTION
## Description

These tests are "flaky" in the Service Clients pipelines due to network or service instability, so for now we should skip them.

The bug tracking the flakiness is [AB#59980](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/59980) 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
