### PR TITLE
Remove Transactor.isInProgress

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -332,7 +332,7 @@ export class SchematizingSimpleTreeView<
 	private mountTransaction(params: RunTransactionParams | undefined, isAsync: boolean): void {
 		this.ensureUndisposed();
 		const { checkout } = this;
-		if (isAsync && checkout.transaction.isInProgress()) {
+		if (isAsync && checkout.transaction.size > 0) {
 			throw new UsageError(
 				"An asynchronous transaction cannot be started while another transaction is already in progress.",
 			);

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -420,7 +420,7 @@ export class SharedTreeKernel
 
 	public override didAttach(): void {
 		for (const checkout of this.checkouts.values()) {
-			if (checkout.transaction.isInProgress()) {
+			if (checkout.transaction.size > 0) {
 				// Attaching during a transaction is not currently supported.
 				// At least part of of the system is known to not handle this case correctly - commit enrichment - and there may be others.
 				throw new UsageError(
@@ -438,7 +438,7 @@ export class SharedTreeKernel
 	): void {
 		for (const checkout of this.checkouts.values()) {
 			assert(
-				!checkout.transaction.isInProgress(),
+				checkout.transaction.size === 0,
 				0x674 /* Unexpected transaction is open while applying stashed ops */,
 			);
 		}
@@ -453,7 +453,7 @@ export class SharedTreeKernel
 	): void {
 		const checkout = this.getCheckout(branchId);
 		assert(
-			!checkout.transaction.isInProgress(),
+			checkout.transaction.size === 0,
 			0xaa6 /* Cannot submit a commit while a transaction is in progress */,
 		);
 		if (isResubmit) {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -514,7 +514,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 						if (viewUpdate !== undefined) {
 							this.applyChange(viewUpdate, newHead.revision);
 						}
-						if (!this.transaction.isInProgress()) {
+						if (this.transaction.size === 0) {
 							// The changes in a transaction squash commit have already applied to the checkout and are known to be valid, so we can validate the squash commit automatically.
 							this.validateCommit(newHead);
 						}
@@ -870,7 +870,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			"The parent branch has already been disposed and can no longer create new branches.",
 		);
 		// Branching after an unfinished transaction would expose the application to a state where its invariants may be violated.
-		if (this.transaction.isInProgress()) {
+		if (this.transaction.size > 0) {
 			throw new UsageError("A view cannot be forked while it has a pending transaction.");
 		}
 
@@ -902,7 +902,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	): void {
 		// TODO: Dispose old branch, if necessary
 		assert(
-			!this.#transaction.isInProgress(),
+			this.#transaction.size === 0,
 			0xc55 /* Cannot switch branches during a transaction */,
 		);
 		const diff = diffHistories(
@@ -932,12 +932,12 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		);
 		this.editLock.checkUnlocked("Rebasing");
 
-		if (this.transaction.isInProgress()) {
+		if (this.transaction.size > 0) {
 			throw new UsageError(
 				"Views cannot be rebased onto a view that has a pending transaction.",
 			);
 		}
-		if (checkout.transaction.isInProgress()) {
+		if (checkout.transaction.size > 0) {
 			throw new UsageError("A view cannot be rebased while it has a pending transaction.");
 		}
 
@@ -966,12 +966,12 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			"The source of the branch merge has been disposed and cannot be merged.",
 		);
 		this.editLock.checkUnlocked("Merging");
-		if (this.transaction.isInProgress()) {
+		if (this.transaction.size > 0) {
 			throw new UsageError(
 				"Views cannot be merged into a view while it has a pending transaction.",
 			);
 		}
-		if (checkout.transaction.isInProgress()) {
+		if (checkout.transaction.size > 0) {
 			throw new UsageError(
 				"Views with an open transaction cannot be merged into another view.",
 			);
@@ -1057,7 +1057,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 
 	private revertRevertible(revision: RevisionTag, kind: CommitKind): RevertMetrics {
 		this.editLock.checkUnlocked("Reverting a commit");
-		if (this.transaction.isInProgress()) {
+		if (this.transaction.size > 0) {
 			throw new UsageError("Undo is not yet supported during transactions.");
 		}
 

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -33,7 +33,7 @@ describe("TransactionStacks", () => {
 		const transaction = new TransactionStack();
 		let started = false;
 		transaction.events.on("started", () => {
-			assert.equal(transaction.isInProgress(), true);
+			assert.equal(transaction.size, 1);
 			started = true;
 		});
 		transaction.start();
@@ -44,7 +44,7 @@ describe("TransactionStacks", () => {
 		const transaction = new TransactionStack();
 		let aborting = false;
 		transaction.events.on("aborting", () => {
-			assert.equal(transaction.isInProgress(), true);
+			assert.equal(transaction.size, 1);
 			aborting = true;
 		});
 		transaction.start();
@@ -56,7 +56,7 @@ describe("TransactionStacks", () => {
 		const transaction = new TransactionStack();
 		let committing = false;
 		transaction.events.on("committing", () => {
-			assert.equal(transaction.isInProgress(), true);
+			assert.equal(transaction.size, 1);
 			committing = true;
 		});
 		transaction.start();
@@ -66,39 +66,39 @@ describe("TransactionStacks", () => {
 
 	it("report whether or not a transaction is in progress", () => {
 		const transaction = new TransactionStack();
-		assert.equal(transaction.isInProgress(), false);
+		assert.equal(transaction.size, 0);
 		transaction.start();
-		assert.equal(transaction.isInProgress(), true);
+		assert.equal(transaction.size, 1);
 		transaction.start();
-		assert.equal(transaction.isInProgress(), true);
+		assert.equal(transaction.size, 2);
 		transaction.commit();
-		assert.equal(transaction.isInProgress(), true);
+		assert.equal(transaction.size, 1);
 		transaction.abort();
-		assert.equal(transaction.isInProgress(), false);
+		assert.equal(transaction.size, 0);
 	});
 
 	it("report the number of transactions in progress", () => {
 		const transaction = new TransactionStack();
-		assert.equal(transaction.size(), 0);
+		assert.equal(transaction.size, 0);
 		transaction.start();
-		assert.equal(transaction.size(), 1);
+		assert.equal(transaction.size, 1);
 		transaction.start();
-		assert.equal(transaction.size(), 2);
+		assert.equal(transaction.size, 2);
 		transaction.start();
-		assert.equal(transaction.size(), 3);
+		assert.equal(transaction.size, 3);
 		transaction.commit();
-		assert.equal(transaction.size(), 2);
+		assert.equal(transaction.size, 2);
 		transaction.abort();
-		assert.equal(transaction.size(), 1);
+		assert.equal(transaction.size, 1);
 		transaction.commit();
-		assert.equal(transaction.size(), 0);
+		assert.equal(transaction.size, 0);
 	});
 
 	it("run a function when a transaction begins", () => {
 		let invoked = 0;
 		const transaction = new TransactionStack((): void => {
 			invoked += 1;
-			assert.equal(transaction.isInProgress(), false);
+			assert.equal(transaction.size, 0);
 		});
 		transaction.start();
 		assert.equal(invoked, 1);
@@ -108,7 +108,7 @@ describe("TransactionStacks", () => {
 		let invoked = 0;
 		const transaction = new TransactionStack((): void => {
 			invoked += 1;
-			assert.equal(transaction.isInProgress(), invoked > 1);
+			assert.equal(transaction.size, invoked - 1);
 		});
 		transaction.start();
 		assert.equal(invoked, 1);
@@ -124,15 +124,15 @@ describe("TransactionStacks", () => {
 		let invokedInner2 = 0;
 		const transaction: TransactionStack = new TransactionStack(() => {
 			invokedOuter += 1;
-			assert.equal(transaction.isInProgress(), false);
+			assert.equal(transaction.size, 0);
 			return {
 				onPush: () => {
 					invokedInner1 += 1;
-					assert.equal(transaction.isInProgress(), true);
+					assert.equal(transaction.size, 1);
 					return {
 						onPush: () => {
 							invokedInner2 += 1;
-							assert.equal(transaction.isInProgress(), true);
+							assert.equal(transaction.size, invokedInner2 + 1);
 						},
 					};
 				},
@@ -164,19 +164,19 @@ describe("TransactionStacks", () => {
 			return {
 				onPop: () => {
 					invokedOuter += 1;
-					assert.equal(transaction.isInProgress(), false);
+					assert.equal(transaction.size, 0);
 				},
 				onPush: () => {
 					return {
 						onPop: () => {
 							invokedInner1 += 1;
-							assert.equal(transaction.isInProgress(), true);
+							assert.equal(transaction.size, 1);
 						},
 						onPush: () => {
 							return {
 								onPop: () => {
 									invokedInner2 += 1;
-									assert.equal(transaction.isInProgress(), true);
+									assert.equal(transaction.size, 2);
 								},
 							};
 						},
@@ -208,7 +208,7 @@ describe("TransactionStacks", () => {
 				onPop: (result) => {
 					invoked += 1;
 					assert.equal(result, TransactionResult.Abort);
-					assert.equal(transaction.isInProgress(), false);
+					assert.equal(transaction.size, 0);
 				},
 			};
 		});
@@ -225,7 +225,7 @@ describe("TransactionStacks", () => {
 				onPop: (result) => {
 					invoked += 1;
 					assert.equal(result, TransactionResult.Commit);
-					assert.equal(transaction.isInProgress(), false);
+					assert.equal(transaction.size, 0);
 				},
 			};
 		});
@@ -256,11 +256,7 @@ describe("TransactionStacks", () => {
 		assert.equal(transaction.disposed, false);
 		transaction.dispose();
 		assert.equal(transaction.disposed, true);
-		assert.throws(
-			() => transaction.isInProgress(),
-			validateAssertionError("Transactor is disposed"),
-		);
-		assert.throws(() => transaction.size(), validateAssertionError("Transactor is disposed"));
+		assert.throws(() => transaction.size, validateAssertionError("Transactor is disposed"));
 		assert.throws(() => transaction.start(), validateAssertionError("Transactor is disposed"));
 		assert.throws(
 			() => transaction.commit(),

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -576,7 +576,7 @@ export const makeTransactionEditGenerator = (
 				boundary: "commit",
 			},
 			opWeights.commit,
-			(state) => viewFromState(state).checkout.transaction.isInProgress(),
+			(state) => viewFromState(state).checkout.transaction.size > 0,
 		],
 		[
 			{
@@ -584,7 +584,7 @@ export const makeTransactionEditGenerator = (
 				boundary: "abort",
 			},
 			opWeights.abort,
-			(state) => viewFromState(state).checkout.transaction.isInProgress(),
+			(state) => viewFromState(state).checkout.transaction.size > 0,
 		],
 	]);
 };
@@ -756,7 +756,7 @@ export function makeOpGenerator(
 				[
 					() => makeConstraintEditGenerator(weights),
 					constraintWeight,
-					(state: FuzzTestState) => viewFromState(state).checkout.transaction.isInProgress(),
+					(state: FuzzTestState) => viewFromState(state).checkout.transaction.size > 0,
 				],
 				[
 					() => makeBranchEditGenerator(weights),

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -230,7 +230,7 @@ export function applyForkMergeOperation(
 					: clientForkedViews[branchEdit.contents.baseBranch];
 			assert(forkBranchIndex !== undefined);
 			const forkedBranch = clientForkedViews[forkBranchIndex];
-			if (baseBranch.checkout.transaction.isInProgress() === true) {
+			if (baseBranch.checkout.transaction.size > 0) {
 				return;
 			}
 
@@ -415,7 +415,7 @@ export function applyTransactionBoundary(
 		}
 	}
 
-	if (!checkout.transaction.isInProgress()) {
+	if (checkout.transaction.size === 0) {
 		// Transaction is complete, so merge the changes into the root view and clean up the fork from the state.
 		state.transactionViews.delete(state.client.channel);
 		const rootView = viewFromState(state);

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -773,16 +773,16 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("statuses are reported correctly", ({ view }) => {
-			assert.equal(view.checkout.transaction.isInProgress(), false);
+			assert.equal(view.checkout.transaction.size, 0);
 			view.runTransaction(() => {
-				assert.equal(view.checkout.transaction.isInProgress(), true);
+				assert.equal(view.checkout.transaction.size, 1);
 				view.runTransaction(() => {
-					assert.equal(view.checkout.transaction.isInProgress(), true);
+					assert.equal(view.checkout.transaction.size, 2);
 				});
-				assert.equal(view.checkout.transaction.isInProgress(), true);
+				assert.equal(view.checkout.transaction.size, 1);
 				return { rollback: true };
 			});
-			assert.equal(view.checkout.transaction.isInProgress(), false);
+			assert.equal(view.checkout.transaction.size, 0);
 		});
 
 		it("rejects async transactions within existing transactions", async () => {


### PR DESCRIPTION
Cleanup PR that replaces the now-redundant `isInProgress` with checks against `size`. `Transactor.size` has also been made a property rather than a method.