### PR TITLE
refactor(container-runtime): structured return types for serializeOp and getLocalState

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -5213,7 +5213,7 @@ export class ContainerRuntime
 				eventName: "getPendingLocalState",
 			},
 			(event) => {
-				const pending = this.pendingStateManager.getLocalState(props?.snapshotSequenceNumber);
+				const { pending } = this.pendingStateManager.getLocalState(props?.snapshotSequenceNumber);
 				const sessionExpiryTimerStarted =
 					props?.sessionExpiryTimerStarted ?? this.garbageCollector.sessionExpiryTimerStarted;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -5213,7 +5213,9 @@ export class ContainerRuntime
 				eventName: "getPendingLocalState",
 			},
 			(event) => {
-				const { pending } = this.pendingStateManager.getLocalState(props?.snapshotSequenceNumber);
+				const { pending } = this.pendingStateManager.getLocalState(
+					props?.snapshotSequenceNumber,
+				);
 				const sessionExpiryTimerStarted =
 					props?.sessionExpiryTimerStarted ?? this.garbageCollector.sessionExpiryTimerStarted;
 

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -162,7 +162,8 @@ export class BatchManager {
 					throw new LoggingError("Ops generated during rollback", {
 						count,
 						...tagData(TelemetryDataTag.UserData, {
-							ops: serializeOp(this.pendingBatch.slice(startPoint).map((b) => b.runtimeOp)),
+							ops: serializeOp(this.pendingBatch.slice(startPoint).map((b) => b.runtimeOp))
+								.content,
 						}),
 					});
 				}

--- a/packages/runtime/container-runtime/src/opLifecycle/opSerialization.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSerialization.ts
@@ -40,16 +40,18 @@ export function serializeOp(
 		| EmptyGroupedBatch
 		| LocalContainerRuntimeMessage
 		| LocalContainerRuntimeMessage[],
-): string {
-	return JSON.stringify(
-		toSerialize,
-		// replacer:
-		(key, value: unknown) => {
-			// If 'value' is an IFluidHandle return its encoded form.
-			if (isFluidHandle(value)) {
-				return encodeHandleForSerialization(toFluidHandleInternal(value));
-			}
-			return value;
-		},
-	);
+): { content: string } {
+	return {
+		content: JSON.stringify(
+			toSerialize,
+			// replacer:
+			(key, value: unknown) => {
+				// If 'value' is an IFluidHandle return its encoded form.
+				if (isFluidHandle(value)) {
+					return encodeHandleForSerialization(toFluidHandleInternal(value));
+				}
+				return value;
+			},
+		),
+	};
 }

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -142,7 +142,7 @@ export function localBatchToOutboundBatch({
 	// Shallow copy each message as we switch types
 	const outboundMessages = localBatch.messages.map<OutboundBatchMessage>(
 		({ runtimeOp, ...message }) => ({
-			contents: serializeOp(runtimeOp),
+			contents: serializeOp(runtimeOp).content,
 			...message,
 		}),
 	);

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -335,7 +335,9 @@ export class PendingStateManager implements IDisposable {
 		return this.pendingMessagesCount !== 0;
 	}
 
-	public getLocalState(snapshotSequenceNumber?: number): IPendingLocalState {
+	public getLocalState(snapshotSequenceNumber?: number): {
+		pending: IPendingLocalState;
+	} {
 		assert(
 			this.initialMessages.isEmpty(),
 			0x2e9 /* "Must call getLocalState() after applying initial states" */,
@@ -359,10 +361,12 @@ export class PendingStateManager implements IDisposable {
 			}
 		}
 		return {
-			pendingStates: [
-				...newSavedOps,
-				...this.pendingMessages.toArray().map((message) => toSerializableForm(message)),
-			],
+			pending: {
+				pendingStates: [
+					...newSavedOps,
+					...this.pendingMessages.toArray().map((message) => toSerializableForm(message)),
+				],
+			},
 		};
 	}
 
@@ -438,7 +442,7 @@ export class PendingStateManager implements IDisposable {
 			const pendingMessage: IPendingMessage = {
 				type: "message",
 				referenceSequenceNumber,
-				content: serializeOp(runtimeOp),
+				content: serializeOp(runtimeOp).content,
 				runtimeOp,
 				localOpMetadata,
 				opMetadata,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1713,10 +1713,10 @@ describe("Runtime", () => {
 				const state = pendingStateManager.getLocalState();
 
 				assert.notStrictEqual(state, undefined, "expect pending local state");
-				assert.strictEqual(state?.pendingStates.length, 1, "expect 1 pending message");
+				assert.strictEqual(state?.pending.pendingStates.length, 1, "expect 1 pending message");
 				assert.deepStrictEqual(
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-					JSON.parse(state?.pendingStates?.[0].content).contents.contents,
+					JSON.parse(state?.pending.pendingStates?.[0].content).contents.contents,
 					{
 						type: "op",
 						content: { address: "test", contents: { prop1: 1 } },

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -104,11 +104,7 @@ import type {
 	LocalBatchMessage,
 } from "../opLifecycle/index.js";
 import { pkgVersion } from "../packageVersion.js";
-import type {
-	IPendingLocalState,
-	IPendingMessage,
-	PendingStateManager,
-} from "../pendingStateManager.js";
+import type { IPendingMessage, PendingStateManager } from "../pendingStateManager.js";
 import {
 	type ISummaryCancellationToken,
 	neverCancelledSummaryToken,
@@ -2254,7 +2250,9 @@ describe("Runtime", () => {
 						get: (_t, p: keyof PendingStateManager, _r) => {
 							switch (p) {
 								case "getLocalState": {
-									return () => undefined;
+									return () => ({
+										pending: { pendingStates: [] },
+									});
 								}
 								case "pendingMessagesCount": {
 									return 0;
@@ -2300,8 +2298,8 @@ describe("Runtime", () => {
 						get: (_t, p: keyof PendingStateManager, _r) => {
 							switch (p) {
 								case "getLocalState": {
-									return (): IPendingLocalState => ({
-										pendingStates,
+									return () => ({
+										pending: { pendingStates },
 									});
 								}
 								case "pendingMessagesCount": {
@@ -2371,8 +2369,8 @@ describe("Runtime", () => {
 						get: (_t, p: keyof PendingStateManager, _r) => {
 							switch (p) {
 								case "getLocalState": {
-									return (): IPendingLocalState => ({
-										pendingStates,
+									return () => ({
+										pending: { pendingStates },
 									});
 								}
 								case "pendingMessagesCount": {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opSerialization.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opSerialization.spec.ts
@@ -58,7 +58,7 @@ describe("opSerialization", () => {
 
 			const serialized = serializeOp(op);
 
-			assert.strictEqual(serialized, JSON.stringify(op));
+			assert.strictEqual(serialized.content, JSON.stringify(op));
 		});
 
 		it("should replace Fluid handles with their encoded form", () => {
@@ -76,12 +76,12 @@ describe("opSerialization", () => {
 			const serialized = serializeOp(op);
 
 			assert(
-				!serialized.includes("foo"),
+				!serialized.content.includes("foo"),
 				"Serialized op should not include the handle's properties besides the path",
 			);
 			assert(
-				serialized.includes("__fluid_handle__") &&
-					serialized.includes(mockHandle.absolutePath),
+				serialized.content.includes("__fluid_handle__") &&
+					serialized.content.includes(mockHandle.absolutePath),
 				"Serialized op should include the handle's path and encoded form",
 			);
 		});
@@ -104,7 +104,7 @@ describe("opSerialization", () => {
 			const serializedWithFunction = serializeOp(op);
 			const serializedWithJSONStringify = JSON.stringify(op);
 
-			assert.strictEqual(serializedWithFunction, serializedWithJSONStringify);
+			assert.strictEqual(serializedWithFunction.content, serializedWithJSONStringify);
 		});
 	});
 });

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -194,7 +194,7 @@ describe("Outbox", () => {
 		batchMarker: boolean | undefined = undefined,
 	): IBatchMessage => ({
 		contents:
-			message.runtimeOp === undefined ? message.contents : serializeOp(message.runtimeOp),
+			message.runtimeOp === undefined ? message.contents : serializeOp(message.runtimeOp).content,
 		metadata:
 			batchMarker === undefined
 				? message.metadata

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -194,7 +194,9 @@ describe("Outbox", () => {
 		batchMarker: boolean | undefined = undefined,
 	): IBatchMessage => ({
 		contents:
-			message.runtimeOp === undefined ? message.contents : serializeOp(message.runtimeOp).content,
+			message.runtimeOp === undefined
+				? message.contents
+				: serializeOp(message.runtimeOp).content,
 		metadata:
 			batchMarker === undefined
 				? message.metadata

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -684,11 +684,11 @@ describe("Pending State Manager", () => {
 				}));
 				submitBatch(messages);
 				processFullBatch(messages, 0 /* batchStartCsn */, false /* groupedBatch */);
-				let pendingState = pendingStateManager.getLocalState(0).pendingStates;
+				let pendingState = pendingStateManager.getLocalState(0).pending.pendingStates;
 				assert.strictEqual(pendingState.length, 10);
-				pendingState = pendingStateManager.getLocalState(5).pendingStates;
+				pendingState = pendingStateManager.getLocalState(5).pending.pendingStates;
 				assert.strictEqual(pendingState.length, 5);
-				pendingState = pendingStateManager.getLocalState(10).pendingStates;
+				pendingState = pendingStateManager.getLocalState(10).pending.pendingStates;
 				assert.strictEqual(pendingState.length, 0);
 			});
 
@@ -702,7 +702,7 @@ describe("Pending State Manager", () => {
 				}));
 				submitBatch(messages);
 				assert.throws(() => pendingStateManager.getLocalState(1));
-				const pendingState = pendingStateManager.getLocalState(0).pendingStates;
+				const pendingState = pendingStateManager.getLocalState(0).pending.pendingStates;
 				assert.strictEqual(pendingState.length, 10);
 			});
 		});
@@ -815,7 +815,7 @@ describe("Pending State Manager", () => {
 			);
 			const { placeholderMessage } = opGroupingManager.createEmptyGroupedBatch("batchId", 0);
 			oldPsm.onFlushEmptyBatch(placeholderMessage, 0, false /* staged */);
-			const localStateWithEmptyBatch = oldPsm.getLocalState(0);
+			const localStateWithEmptyBatch = oldPsm.getLocalState(0).pending;
 
 			const applyStashedOps: string[] = [];
 			const pendingStateManager = new PendingStateManager(


### PR DESCRIPTION
## Summary
- Change `serializeOp()` to return `{ content: string }` instead of a raw string
- Change `PendingStateManager.getLocalState()` to return `{ pending: IPendingLocalState }` instead of a bare `IPendingLocalState`
- Update all callers and tests to use the new structured return types

These structured return types make it straightforward to extend these functions with additional metadata in the future without further signature changes. Specifically, the staging mode pending state work in #26475 needs to add `stagedHandleCache` to both return types — by landing the structural change first, that PR can focus on the substantive feature logic without a large mechanical diff touching many test files.

## Test plan
- [x] `build:esnext` passes for `@fluidframework/container-runtime` and all dependencies
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)