### PR TITLE
Fix explicit sources directory breaks

### DIFF
--- a/tools/pipelines/deploy-website.yml
+++ b/tools/pipelines/deploy-website.yml
@@ -196,6 +196,7 @@ stages:
       displayName: Guardian tasks
       steps:
         - checkout: self
+          path: ${{ variables.FluidFrameworkDirectory }}
           submodules: false
           clean: true
 

--- a/tools/pipelines/deploy-website.yml
+++ b/tools/pipelines/deploy-website.yml
@@ -62,6 +62,18 @@ variables:
     value: true
   - name: pnpmStorePath
     value: $(Pipeline.Workspace)/.pnpm-store
+  # ADO changes the value of Build.SourcesDirectory depending on whether 1 vs. many repositories are checked out.
+  # Using 's' is consistent with the behavior when multiple repositories are checked out and allows for more
+  # consistent build scripts. See this documentation for more details:
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
+  # A relative path is required in some places (like "checkout" steps). To get the absolute path, concatenate it
+  # with the predefined variable "Pipeline.Workspace", e.g.: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}'
+  - name: consistentSourcesDirectory
+    value: 's'
+  - name: FluidFrameworkDirectory
+    value: '${{ variables.consistentSourcesDirectory }}/FluidFramework'
+  - name: FFPipelineHostDirectory
+    value: '${{ variables.consistentSourcesDirectory }}/ff_pipeline_host'
 
 trigger:
   branches:
@@ -89,6 +101,9 @@ stages:
             echo repoToTrigger ${{ variables.repoToTrigger }}
             echo shouldRetainGuardianAssets ${{ variables.shouldRetainGuardianAssets }}
             echo publishGuardianBaselines ${{ variables.publishGuardianBaselines }}
+            echo consistentSourcesDirectory ${{ variables.consistentSourcesDirectory }}
+            echo FluidFrameworkDirectory ${{ variables.FluidFrameworkDirectory }}
+            echo FFPipelineHostDirectory ${{ variables.FFPipelineHostDirectory }}
           displayName: Show Variables
 
     - job: component_detection
@@ -109,7 +124,7 @@ stages:
       pool: Large-eastus2
       steps:
         - checkout: self
-          path: $(FluidFrameworkDirectory)
+          path: ${{ variables.FluidFrameworkDirectory }}
           submodules: false
           clean: true
 
@@ -117,14 +132,14 @@ stages:
 
         - template: /tools/pipelines/templates/include-install-pnpm.yml@self
           parameters:
-            buildDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            buildDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
 
         - task: Bash@3
           displayName: Install dependencies
           retryCountOnTaskFailure: 4
           inputs:
             targetType: 'inline'
-            workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            workingDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
             script: |
               set -eu -o pipefail
               # Ensure it's easy to tell which workspace this is running in by inspecting the logs
@@ -135,7 +150,7 @@ stages:
           displayName: npm run build
           inputs:
             command: 'custom'
-            workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            workingDir: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
             customCommand: 'run build'
           env:
             INSTRUMENTATION_KEY: $(INSTRUMENTATION_KEY)
@@ -146,28 +161,28 @@ stages:
           displayName: 'Check inline script hashes correctness'
           inputs:
             targetType: 'filePath'
-            workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
-            filePath: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs/validateHashes.sh'
+            workingDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
+            filePath: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs/validateHashes.sh'
 
         # Run the tests
         - task: Npm@1
           displayName: Run tests
           inputs:
             command: 'custom'
-            workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            workingDir: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
             customCommand: 'run test'
 
         - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
           displayName: 'Generate SBOM'
           inputs:
-            BuildDropPath: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs/build
+            BuildDropPath: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs/build
             PackageName: 'fluidframework-docs'
             PackageVersion: '$(Build.BuildId)'
 
         - task: PublishPipelineArtifact@1
           displayName: 'Publish site build artifact'
           inputs:
-            targetPath: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs/build'
+            targetPath: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs/build'
             artifactName: 'fluidframework-docs'
             publishLocation: 'pipeline'
 
@@ -220,7 +235,7 @@ stages:
           inputs:
             GdnBreakPolicyMinSev: Warning
             GdnBreakAllTools: true
-            GdnBreakBaselineFiles: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs/.gdnbaselines'
+            GdnBreakBaselineFiles: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs/.gdnbaselines'
             GdnBreakGdnToolESLint: true
             GdnBreakGdnToolESLintSeverity: Warning
             GdnBreakPolicy: M365
@@ -247,7 +262,7 @@ stages:
       continueOnError: true
       steps:
         - checkout: self
-          path: $(FluidFrameworkDirectory)
+          path: ${{ variables.FluidFrameworkDirectory }}
           submodules: false
           clean: true
 
@@ -255,14 +270,14 @@ stages:
 
         - template: /tools/pipelines/templates/include-install-pnpm.yml@self
           parameters:
-            buildDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            buildDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
 
         - task: Bash@3
           displayName: Install dependencies
           retryCountOnTaskFailure: 4
           inputs:
             targetType: 'inline'
-            workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            workingDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
             script: |
               set -eu -o pipefail
               # Ensure it's easy to tell which workspace this is running in by inspecting the logs
@@ -273,14 +288,14 @@ stages:
           displayName: Build
           inputs:
             command: 'custom'
-            workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            workingDir: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
             customCommand: 'run build'
 
         - task: Npm@1
           displayName: Validate links
           inputs:
             command: 'custom'
-            workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs
+            workingDir: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
             customCommand: 'run ci:check-links'
 
 - stage: deploy
@@ -300,7 +315,7 @@ stages:
       displayName: 'Deploy website'
       steps:
         - checkout: self
-          path: $(FluidFrameworkDirectory)
+          path: ${{ variables.FluidFrameworkDirectory }}
           submodules: false
           clean: true
 
@@ -309,14 +324,14 @@ stages:
           inputs:
             source: current
             artifact: fluidframework-docs
-            path: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/docs/build'
+            path: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs/build'
 
         - task: AzureStaticWebApp@0
           displayName: 'Deploy website to ASWA'
           inputs:
             skip_app_build: true # site was built in previous stage
             skip_api_build: true # api is written in js, no build needed
-            cwd: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
+            cwd: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
             app_location: 'docs/build'
             api_location: 'docs/api'
             output_location: ''

--- a/tools/pipelines/deploy-website.yml
+++ b/tools/pipelines/deploy-website.yml
@@ -132,7 +132,7 @@ stages:
 
         - template: /tools/pipelines/templates/include-install-pnpm.yml@self
           parameters:
-            buildDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
+            buildDirectory: ${{ variables.FluidFrameworkDirectory }}/docs
 
         - task: Bash@3
           displayName: Install dependencies
@@ -270,7 +270,7 @@ stages:
 
         - template: /tools/pipelines/templates/include-install-pnpm.yml@self
           parameters:
-            buildDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/docs
+            buildDirectory: ${{ variables.FluidFrameworkDirectory }}/docs
 
         - task: Bash@3
           displayName: Install dependencies

--- a/tools/pipelines/templates/include-generate-notice-steps.yml
+++ b/tools/pipelines/templates/include-generate-notice-steps.yml
@@ -14,7 +14,7 @@ steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection
   inputs:
-    sourceScanPath: ${{ parameters.buildDirectory }}
+    sourceScanPath: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
     verbosity: Verbose
     scanType: Register
     alertWarningLevel: High
@@ -28,4 +28,4 @@ steps:
   continueOnError: ${{ parameters.requireNotice }}
   inputs:
     artifact: NOTICE.txt
-    path: ${{ parameters.buildDirectory }}
+    path: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -60,7 +60,7 @@ jobs:
 
           - template: /tools/pipelines/templates/include-install-pnpm.yml@self
             parameters:
-              buildDirectory: $(Pipeline.Workspace)
+              buildDirectory: buildTools-zip
               enableCache: false
 
           # We can use this step to add overrides that might be necessary to allow for a correct


### PR DESCRIPTION
Fixes:
* deploy-website
    * Didn't include the variables from any other location, this change adds them directly
    * Two instances of specifying buildDirectory as an absolute path when it should be relative
    * Missed an explicit path on one of the checkout steps
* publish package step (multiple pipelines)
    * Needs a relative path for pnpm install (exact location shouldn't matter too much since caching is disabled)
* include-generate-notice-steps.yml
    * I had just missed updating this template.