### PR TITLE
build: add MAI extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,10 @@
 				"biomejs.biome",
 				"dbaeumer.vscode-eslint",
 				"esbenp.prettier-vscode",
+				"MAI-EngineeringSystems.mai-ai-telemetry",
 				"ms-azure-devops.azure-pipelines",
 				"ms-azuretools.vscode-docker",
-				"mutantdino.resourcemonitor"
+				"mutantdino.resourcemonitor",
 			]
 		}
 	},

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,9 +6,10 @@
 		"biomejs.biome",
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
+		"MAI-EngineeringSystems.mai-ai-telemetry",
 		"ms-azure-devops.azure-pipelines",
-		"xyc.vscode-mdx-preview",
 		"unifiedjs.vscode-mdx",
+		"xyc.vscode-mdx-preview",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [],


### PR DESCRIPTION
Adds the MAI extension to the codespace image and suggests it for non-codespace users.