### PR TITLE
Fix telemetry upload pnpm install

### DIFF
--- a/tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+++ b/tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
@@ -48,7 +48,7 @@ stages:
 
     - template: /tools/pipelines/templates/include-install-pnpm.yml@self
       parameters:
-        buildDirectory: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)
+        buildDirectory: $(FFPipelineHostDirectory)
         primaryRegistry: $(ado-feeds-ff-download-only)
 
     - task: Bash@3


### PR DESCRIPTION
One more fix, telemetry upload also needs to use a relative path for the pnpm install.