### PR TITLE
Move pnpm overrides from eslint-config-fluid to workspace root

### DIFF
--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -76,18 +76,6 @@
 			}
 		}
 	},
-	"pnpm": {
-		"commentsOverrides": [
-			"serialize-javascript - CVE-2024-11831 impacts version 6.0.0 which is pinned by mocha 10.4.0, which in turn comes from mocha-multi-reporters 1.5.1 (which has no updated version at this time)"
-		],
-		"overrides": {
-			"mocha>serialize-javascript@6.0.0": "^6.0.2"
-		},
-		"onlyBuiltDependencies": [
-			"esbuild",
-			"unrs-resolver"
-		]
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/package.json
+++ b/package.json
@@ -361,7 +361,8 @@
 			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed.",
 			"oclif includes some AWS-related features, but we don't use them, so we override those dependencies with empty packages. This helps reduce lockfile churn since the deps release very frequently.",
 			"axios pre-1.0 needs an override to stay current on a version with no reported CVEs. Caret dependencies aren't enough on a pre-1.0 package.",
-			"Security overrides: tar is overridden to address path traversal CVEs (GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w, GHSA-34x7-hfp2-rc4v). The existing axios@<0.30.0 override resolves to 0.30.2 which is also affected by GHSA-43fc-jf86-j433 (DoS via __proto__), but updating that pre-1.0 override is out of scope here."
+			"Security overrides: tar is overridden to address path traversal CVEs (GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w, GHSA-34x7-hfp2-rc4v). The existing axios@<0.30.0 override resolves to 0.30.2 which is also affected by GHSA-43fc-jf86-j433 (DoS via __proto__), but updating that pre-1.0 override is out of scope here.",
+			"serialize-javascript - CVE-2024-11831 impacts version 6.0.0 which is pinned by mocha 10.4.0, which in turn comes from mocha-multi-reporters 1.5.1 (which has no updated version at this time)"
 		],
 		"overrides": {
 			"@biomejs/biome": "~2.3.11",
@@ -374,7 +375,8 @@
 			"oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
 			"oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0",
 			"axios@<0.30.0": "^0.30.0",
-			"tar": ">=7.5.7"
+			"tar": ">=7.5.7",
+			"mocha>serialize-javascript@6.0.0": "^6.0.2"
 		},
 		"peerDependencyComments": [
 			"The react-split-pane package used by devtools-view has a peer dependency on React 16, but it doesn't seem to be maintained and it works fine with React 18. TODO: AB#18876",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   axios@<0.30.0: ^0.30.0
   tar: '>=7.5.7'
+  mocha>serialize-javascript@6.0.0: ^6.0.2
 
 pnpmfileChecksum: sha256-UgK94jvekjDphs6M2itZJZ9CcCzYY0xcxZhNXJw7D28=
 


### PR DESCRIPTION
## Summary
- Moves `pnpm.overrides` (`mocha>serialize-javascript` CVE fix) and its comment from `common/build/eslint-config-fluid/package.json` to the workspace root `package.json`
- Removes the entire `pnpm` section from `eslint-config-fluid/package.json` since the `onlyBuiltDependencies` entries (`esbuild`, `unrs-resolver`) are already in the root
- **Eliminates pnpm config warnings** that appear on every install and build: pnpm 10 only reads `pnpm.overrides` and `pnpm.onlyBuiltDependencies` from the workspace root

## Test plan
- [ ] `pnpm install` completes without pnpm config field warnings
- [ ] CI build passes (the `mocha>serialize-javascript` override still applies workspace-wide from the root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)