### PR TITLE
Suppress repeated port mapping warnings in getTestPort

### DIFF
--- a/tools/test-tools/src/getTestPort.ts
+++ b/tools/test-tools/src/getTestPort.ts
@@ -7,27 +7,29 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
+const portMapPath = path.join(os.tmpdir(), "testportmap.json");
+
 /**
  * Get the port for the pkg from the mapping.  Use a default if the file or the entry doesn't exist
  * (e.g. an individual test is being run and the file was never generated), which should presumably
  * not lead to collisions.
  */
 export function getTestPort(pkgName: string): string {
-	let mappedPort: string;
+	if (!fs.existsSync(portMapPath)) {
+		return "8081";
+	}
 
 	try {
-		const portMapPath: string = fs
-			.readFileSync(path.join(os.tmpdir(), "testportmap.json"))
-			.toString();
+		const portMapContent: string = fs.readFileSync(portMapPath).toString();
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const testPortsJson = JSON.parse(portMapPath);
+		const testPortsJson = JSON.parse(portMapContent);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-		mappedPort = testPortsJson[pkgName];
+		const mappedPort: string | undefined = testPortsJson[pkgName];
+		return mappedPort ?? "8081";
 	} catch {
 		console.warn(
-			"Port mapping not available, using default port of 8081. If you encounter port collisions, be sure to run assign-test-ports.",
+			"Port mapping file exists but could not be read. Using default port 8081.",
 		);
-		mappedPort = "8081";
+		return "8081";
 	}
-	return mappedPort;
 }


### PR DESCRIPTION
## Summary
- Checks `fs.existsSync()` before reading `testportmap.json` and silently falls back to port 8081 when the file doesn't exist
- **Eliminates 10+ identical warnings** per CI build from `getTestPort()` when the port map hasn't been generated
- The warning now only fires when the file exists but can't be parsed, which indicates an actual problem

The file is absent whenever jest configs are loaded without a prior `assign-test-ports` run — the normal case for local single-package testing and for CI steps that evaluate jest configs outside of the `test:jest` flow.

## Bonus fix
Also fixes a latent bug: when the port map file exists but doesn't contain the requested package name, the original code returned `undefined` despite the function declaring a `string` return type. The `?? "8081"` fallback now correctly returns the default port in this case.

## Test plan
- [x] `Build - test-tools` pipeline passes
- [x] repo-policy-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)