### PR TITLE
ESLint flat config migration: diff review

### DIFF
--- a/scripts/generate-baseline-eslint-configs.mjs
+++ b/scripts/generate-baseline-eslint-configs.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Generates a "baseline" set of eslint configs for diff review purposes.
+ *
+ * For each eslint.config.mts (and eslint.config.data.mts) on the current branch,
+ * this script finds the corresponding old .eslintrc.cjs (or .eslintrc.data.cjs)
+ * content from the commit just before the flat-config migration PR landed, and
+ * overwrites the new file with the old content.
+ *
+ * This creates a branch where the only diff vs the real branch is the actual
+ * content change from old → new config format, making review much easier.
+ *
+ * Usage:
+ *   node scripts/generate-baseline-eslint-configs.mjs
+ *
+ * Regeneration workflow (after preserve-eslint-comments is updated):
+ *   git checkout lint/baseline-flat-config-migration
+ *   git reset --hard preserve-eslint-comments
+ *   node scripts/generate-baseline-eslint-configs.mjs
+ *   git add -A && git commit -m "chore: regenerate baseline eslint configs"
+ *   git push --force-with-lease
+ */
+
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+// Parent commit of PR #26054's merge — the last commit with old .eslintrc.cjs files
+const BASELINE_COMMIT = "7a050c953e944c0ea0db8c1fe9b92e693dbd743e";
+
+/**
+ * Maps a new eslint flat config filename to its old legacy config filename.
+ *
+ * @param {string} newPath - relative path like "packages/dds/tree/eslint.config.mts"
+ * @returns {string} relative path like "packages/dds/tree/.eslintrc.cjs"
+ */
+function mapNewToOld(newPath) {
+	const dir = dirname(newPath);
+	const filename = newPath.split("/").pop();
+
+	if (filename === "eslint.config.data.mts") {
+		// Special case: eslint.config.data.mts → .eslintrc.data.cjs
+		return dir === "." ? ".eslintrc.data.cjs" : `${dir}/.eslintrc.data.cjs`;
+	}
+
+	// Standard case: eslint.config.mts → .eslintrc.cjs
+	return dir === "." ? ".eslintrc.cjs" : `${dir}/.eslintrc.cjs`;
+}
+
+/**
+ * Reads a file from a specific git commit.
+ *
+ * @param {string} commit
+ * @param {string} relativePath
+ * @returns {string | null} file content, or null if the file doesn't exist at that commit
+ */
+function gitShowFile(commit, relativePath) {
+	try {
+		return execFileSync("git", ["show", `${commit}:${relativePath}`], {
+			cwd: repoRoot,
+			encoding: "utf8",
+			maxBuffer: 1024 * 1024,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Finds all eslint.config.mts and eslint.config.data.mts files tracked by git.
+ *
+ * @returns {string[]} relative paths
+ */
+function findNewConfigs() {
+	const output = execFileSync(
+		"git",
+		["ls-files", "--", "**/eslint.config.mts", "**/eslint.config.data.mts"],
+		{ cwd: repoRoot, encoding: "utf8" },
+	);
+	return output
+		.trim()
+		.split("\n")
+		.filter((line) => line.length > 0);
+}
+
+function main() {
+	const newConfigs = findNewConfigs();
+	console.log(`Found ${newConfigs.length} eslint flat config files on current branch.\n`);
+
+	let replaced = 0;
+	let skipped = 0;
+	const skippedFiles = [];
+
+	for (const newPath of newConfigs) {
+		const oldPath = mapNewToOld(newPath);
+		const oldContent = gitShowFile(BASELINE_COMMIT, oldPath);
+
+		if (oldContent === null) {
+			skipped++;
+			skippedFiles.push(newPath);
+			continue;
+		}
+
+		const absPath = resolve(repoRoot, newPath);
+		writeFileSync(absPath, oldContent, "utf8");
+		replaced++;
+	}
+
+	console.log(`Replaced ${replaced} file(s) with old .eslintrc.cjs content.`);
+
+	if (skippedFiles.length > 0) {
+		console.log(`\nSkipped ${skipped} file(s) with no old equivalent:`);
+		for (const f of skippedFiles) {
+			console.log(`  - ${f}`);
+		}
+	}
+
+	console.log("\nDone.");
+}
+
+main();


### PR DESCRIPTION
## Summary

**Dummy PR for reviewing the ESLint 8 → 9 flat config migration.**

The base branch (`lint/baseline-flat-config-migration`) starts from the merge-base of `main` and `preserve-eslint-comments`, then has a single commit with the full `preserve-eslint-comments` tree but with each `eslint.config.mts` file replaced by its corresponding old `.eslintrc.cjs` content from before the migration.

The **Files Changed** tab shows all changes from `preserve-eslint-comments` relative to `main`, which are almost exclusively eslint config file modifications. The base branch provides context about the old config content.

Related to PR #26211 (`preserve-eslint-comments`).

> [!CAUTION]
> **DO NOT MERGE** — this PR exists only for diff review purposes.

## How this works

- `scripts/generate-baseline-eslint-configs.mjs` reads old `.eslintrc.cjs` content from commit `7a050c95` (before the migration) and writes it into the new `eslint.config.mts` filenames.
- 189 files have a 1:1 old→new mapping; 1 new file (`examples/data-objects/text-editor/eslint.config.mts`) has no old equivalent and is skipped.

## Regeneration workflow

When `preserve-eslint-comments` is updated:

```bash
git checkout lint/baseline-flat-config-migration
git reset --hard $(git merge-base main preserve-eslint-comments)
git checkout preserve-eslint-comments -- .
node scripts/generate-baseline-eslint-configs.mjs
git add -A && git commit -m "chore: regenerate baseline eslint configs"
git push --force-with-lease upstream lint/baseline-flat-config-migration
```

## Review notes

- Comments/feedback on this PR should be applied to the `preserve-eslint-comments` branch, then this PR regenerated.
- This PR should **not** be merged.