### PR TITLE
Add policy check for ci:build script (Bug 59692, Part 2)

### DIFF
--- a/build-tools/packages/build-cli/api-report/build-cli.api.md
+++ b/build-tools/packages/build-cli/api-report/build-cli.api.md
@@ -124,6 +124,7 @@ export interface ScriptRequirement {
     body: string;
     bodyMustMatch?: boolean;
     name: string;
+    packageNames?: string[];
 }
 
 // (No @packageDocumentation comment for this package)

--- a/build-tools/packages/build-cli/src/config.ts
+++ b/build-tools/packages/build-cli/src/config.ts
@@ -325,6 +325,12 @@ export interface ScriptRequirement {
 	 * @defaultValue `false`
 	 */
 	bodyMustMatch?: boolean;
+
+	/**
+	 * When set, the requirement only applies to packages whose names are in this list.
+	 * When absent, the requirement applies to all public packages.
+	 */
+	packageNames?: string[];
 }
 
 const configName = "flub";

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -1889,6 +1889,14 @@ export const handlers: Handler[] = [
 			if (requirements.requiredScripts !== undefined) {
 				const scriptNames = Object.keys(packageJson.scripts ?? {});
 				for (const requiredScript of requirements.requiredScripts) {
+					// If the requirement is scoped to specific packages, skip packages not in the list.
+					if (
+						requiredScript.packageNames !== undefined &&
+						!requiredScript.packageNames.includes(packageJson.name)
+					) {
+						continue;
+					}
+
 					if (!scriptNames.includes(requiredScript.name)) {
 						// Enforce the script is present
 						errors.push(`Missing script: "${requiredScript.name}"`);
@@ -1934,6 +1942,14 @@ export const handlers: Handler[] = [
 				 * Updates the package.json contents to ensure the requirements of the specified script are met.
 				 */
 				function applyScriptCorrection(script: ScriptRequirement): void {
+					// If the requirement is scoped to specific packages, skip packages not in the list.
+					if (
+						script.packageNames !== undefined &&
+						!script.packageNames.includes(packageJson.name)
+					) {
+						return;
+					}
+
 					// If the script is missing, or if it exists but its body doesn't satisfy the requirement,
 					// apply the correct script configuration.
 					if (

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -587,6 +587,15 @@ module.exports = {
 				// 	name: "api",
 				// 	body: "fluid-build . --task api",
 				// },
+				{
+					name: "ci:build",
+					body: "fluid-build . --task ci:build",
+					bodyMustMatch: true,
+					packageNames: [
+						"@fluidframework/protocol-definitions",
+						"@fluidframework/common-utils",
+					],
+				},
 			],
 			requiredDevDependencies: [],
 		},


### PR DESCRIPTION
[AB#59692](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/59692)

## Summary

- Adds a `packageNames` scope to `ScriptRequirement` so the `ci:build` policy check applies only to `@fluidframework/protocol-definitions` and `@fluidframework/common-utils`
- Replaces the previous `optional` flag approach, which was semantically contradictory and couldn't catch missing scripts
- Catches both wrong script bodies and entirely missing `ci:build` scripts for scoped packages, while skipping workspace packages that don't need it

## Context

Bug 59692 reported that `protocol-definitions`' `ci:build` script was `"npm run build:compile"` instead of `"fluid-build . --task ci:build"`, silently skipping typetests:gen and API reports in CI. Part 1 (the script fix) was PR #26480. This is Part 2: a policy check to prevent future regressions.

## Test plan

- [x] Verify `fluidBuild.config.cjs` loads without errors: `node -e "require('./fluidBuild.config.cjs')"`
- [ ] Trace handler for `protocol-definitions` (in `packageNames`, has correct body → PASS)
- [ ] Trace handler for a client workspace package like `@fluidframework/container-runtime` (not in `packageNames` → SKIP)
- [ ] Confirm API report matches interface change (`packageNames?: string[]` in alphabetical position)

🤖 Generated with [Claude Code](https://claude.com/claude-code)