### PR TITLE
Parallelize coverage tests in client build pipeline

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -682,6 +682,7 @@ extends:
               - build
               - ${{ each test in parameters.coverageTests }}:
                 - Coverage_${{ test.jobName }}
+            condition: succeededOrFailed()
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -751,10 +752,18 @@ extends:
                   mkdir -p nyc/.nyc_output
                   for dir in nyc/.nyc_output_*/; do
                     if [ -d "$dir" ]; then
-                      echo "Merging coverage data from $dir"
-                      cp -r "$dir"* nyc/.nyc_output/ 2>/dev/null || true
+                      if compgen -G "$dir"/* > /dev/null; then
+                        echo "Merging coverage data from $dir"
+                        cp -r "$dir"/* nyc/.nyc_output/
+                      else
+                        echo "No coverage files found in $dir; skipping."
+                      fi
                     fi
                   done
+                  if ! compgen -G "nyc/.nyc_output/*" > /dev/null; then
+                    echo "Error: No coverage files were merged into nyc/.nyc_output."
+                    exit 1
+                  fi
                   echo "Merged coverage files:"
                   ls -la nyc/.nyc_output/ | head -20
                 displayName: Merge coverage data

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -742,6 +742,7 @@ extends:
               - ${{ each test in parameters.coverageTests }}:
                 - task: DownloadPipelineArtifact@2
                   displayName: 'Download coverage data (${{ test.jobName }})'
+                  continueOnError: true
                   inputs:
                     artifact: 'coverage_data_${{ test.jobName }}'
                     targetPath: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/nyc/.nyc_output_${{ test.jobName }}'
@@ -772,7 +773,7 @@ extends:
               # Generate combined coverage report
               - script: |
                   set -eu -o pipefail
-                  npx c8 report
+                  npx c8 report --temp-directory nyc/.nyc_output --report-dir nyc/report
                 displayName: Generate combined coverage report
                 workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
 

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -585,9 +585,103 @@ extends:
                       sbomEnabled: false
                       publishLocation: pipeline
 
-          - job: Coverage_tests
-            displayName: "Coverage tests"
-            dependsOn: build
+          # Parallel jobs for coverage tests
+          - ${{ each test in parameters.coverageTests }}:
+            - job: Coverage_${{ test.jobName }}
+              displayName: "Coverage ${{ test.jobName }}"
+              dependsOn: build
+              variables:
+                - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+                  - name: targetBranchName
+                    value: $(System.PullRequest.TargetBranch)
+                # Absolute path to the folder that contains the source code for the telemetry-generator package, which is
+                # used in a few places in the pipeline to push custom telemetry to Kusto.
+                - name: absolutePathToTelemetryGenerator
+                  value: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/tools/telemetry-generator
+                  readonly: true
+                # We already run CodeQL in the main build job, so we don't need to run it again here.
+                # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
+                - name: ONEES_ENFORCED_CODEQL_ENABLED
+                  value: 'false'
+                - name: COMMIT_SHA
+                  value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+
+              steps:
+                # Setup
+                - checkout: self
+                  path: $(FluidFrameworkDirectory)
+                  clean: true
+                  lfs: '${{ parameters.checkoutSubmodules }}'
+                  submodules: '${{ parameters.checkoutSubmodules }}'
+
+                - script: |
+                    echo "commit: $(COMMIT_SHA)"
+                    git fetch origin $(COMMIT_SHA)
+                    git checkout $(COMMIT_SHA)
+                  displayName: "Checkout build commit"
+
+                - template: /tools/pipelines/templates/include-use-node-version.yml@self
+
+                - template: /tools/pipelines/templates/include-install.yml@self
+                  parameters:
+                    packageManager: '${{ parameters.packageManager }}'
+                    buildDirectory: '${{ parameters.buildDirectory }}'
+                    packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
+
+                - task: DownloadPipelineArtifact@2
+                  inputs:
+                    artifact: build_output_archive
+                    targetPath: $(Build.StagingDirectory)
+
+                - script: |
+                    echo "Extracting build output archive contents..."
+                    tar --extract --gzip --file $(Build.StagingDirectory)/build_output_archive.tar.gz --directory $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+                  displayName: Extract Build Output Contents
+
+                # Set variable startTest if everything is good so far and we'll start running tests,
+                # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
+                - script: |
+                    echo "##vso[task.setvariable variable=startTest]true"
+                  displayName: Start Test
+
+                - template: /tools/pipelines/templates/include-test-task.yml@self
+                  parameters:
+                    taskTestStep: '${{ test.name }}'
+                    buildDirectory: '${{ parameters.buildDirectory }}'
+                    testCoverage: '${{ parameters.testCoverage }}'
+
+                - task: Npm@1
+                  displayName: 'npm run test:copyresults'
+                  condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                  inputs:
+                    command: custom
+                    workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                    customCommand: 'run test:copyresults'
+
+                # Process test result, include publishing and logging
+                - template: /tools/pipelines/templates/include-process-test-results.yml@self
+                  parameters:
+                    buildDirectory: '${{ parameters.buildDirectory }}'
+                    testResultDirs: '${{ parameters.testResultDirs }}'
+
+              templateContext:
+                outputs:
+                  # Publish raw coverage data for merge job
+                  - output: pipelineArtifact
+                    displayName: Publish Artifact - coverage data (${{ test.jobName }})
+                    condition: succeededOrFailed()
+                    targetPath: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/nyc/.nyc_output
+                    artifactName: 'coverage_data_${{ test.jobName }}'
+                    sbomEnabled: false
+                    publishLocation: pipeline
+
+          # Merge coverage data from parallel jobs and generate combined report
+          - job: Merge_coverage
+            displayName: "Merge Coverage Reports"
+            dependsOn:
+              - build
+              - ${{ each test in parameters.coverageTests }}:
+                - Coverage_${{ test.jobName }}
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -643,26 +737,35 @@ extends:
                   tar --extract --gzip --file $(Build.StagingDirectory)/build_output_archive.tar.gz --directory $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
                 displayName: Extract Build Output Contents
 
-              # Set variable startTest if everything is good so far and we'll start running tests,
-              # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
-              - script: |
-                  echo "##vso[task.setvariable variable=startTest]true"
-                displayName: Start Test
-
+              # Download raw coverage data from each parallel job
               - ${{ each test in parameters.coverageTests }}:
-                - template: /tools/pipelines/templates/include-test-task.yml@self
-                  parameters:
-                    taskTestStep: '${{ test.name }}'
-                    buildDirectory: '${{ parameters.buildDirectory }}'
-                    testCoverage: '${{ parameters.testCoverage }}'
+                - task: DownloadPipelineArtifact@2
+                  displayName: 'Download coverage data (${{ test.jobName }})'
+                  inputs:
+                    artifact: 'coverage_data_${{ test.jobName }}'
+                    targetPath: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/nyc/.nyc_output_${{ test.jobName }}'
 
-              - task: Npm@1
-                displayName: 'npm run test:copyresults'
-                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-                inputs:
-                  command: custom
-                  workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                  customCommand: 'run test:copyresults'
+              # Merge all coverage data into single .nyc_output directory
+              - script: |
+                  set -eu -o pipefail
+                  mkdir -p nyc/.nyc_output
+                  for dir in nyc/.nyc_output_*/; do
+                    if [ -d "$dir" ]; then
+                      echo "Merging coverage data from $dir"
+                      cp -r "$dir"* nyc/.nyc_output/ 2>/dev/null || true
+                    fi
+                  done
+                  echo "Merged coverage files:"
+                  ls -la nyc/.nyc_output/ | head -20
+                displayName: Merge coverage data
+                workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+
+              # Generate combined coverage report
+              - script: |
+                  set -eu -o pipefail
+                  npx c8 report
+                displayName: Generate combined coverage report
+                workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
 
               # Test - Upload coverage results
               # Some webpacked file using externals introduce file name with quotes in them
@@ -670,7 +773,7 @@ extends:
               # A quick fix to patch the file with sed. (See https://github.com/bcoe/c8/issues/302)
               - task: Bash@3
                 displayName: Check for nyc/report directory
-                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                condition: succeededOrFailed()
                 inputs:
                   targetType: 'inline'
                   workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
@@ -726,12 +829,6 @@ extends:
                     echo "ADO CI BUILD_DEFINITION_ID for PR: $ADO_CI_BUILD_DEFINITION_ID_PR"
                     echo "Running code coverage comparison"
                     flub report codeCoverage --verbose
-
-            # Process test result, include publishing and logging
-              - template: /tools/pipelines/templates/include-process-test-results.yml@self
-                parameters:
-                  buildDirectory: '${{ parameters.buildDirectory }}'
-                  testResultDirs: '${{ parameters.testResultDirs }}'
 
             templateContext:
               outputParentDirectory: $(Build.ArtifactStagingDirectory)/codeCoverageAnalysis

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -766,7 +766,7 @@ extends:
                     exit 1
                   fi
                   echo "Merged coverage files:"
-                  ls -la nyc/.nyc_output/ | head -20
+                  ls nyc/.nyc_output/ | wc -l | xargs -I{} echo "{} coverage files merged"
                 displayName: Merge coverage data
                 workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
 


### PR DESCRIPTION
## Summary

Split the single sequential `Coverage_tests` job into parallel per-test jobs (`Coverage_MochaTest`, `Coverage_RealsvcLocalTest`) that run concurrently after the build, with a `Merge_coverage` job that combines the results.

This is a **structural refactoring that enables sharding** (#26562), not a standalone speedup. On its own, the coverage critical path grows due to per-job overhead and the sequential merge step.

### Changes

- Each parallel job publishes raw `nyc/.nyc_output/` as a pipeline artifact; the merge job combines them via file copy (V8 coverage files have unique UUIDs, so no conflicts)
- `Merge_coverage` runs with `condition: succeededOrFailed()` so coverage data is still collected even when tests fail
- `continueOnError: true` on artifact download steps so a dead agent in one coverage job doesn't block the merge
- No changes to `build-client.yml` — the `${{ each }}` loop handles any number of entries, enabling follow-up sharding (#26562)

### Pipeline structure

```
Build → Coverage_MochaTest       ─┐
      → Coverage_RealsvcLocalTest ─┤→ Merge_coverage
      → Test_*                     │
```

### Measured results

Compared PR build [380200](https://dev.azure.com/fluidframework/public/_build/results?buildId=380200) against baselines [380476](https://dev.azure.com/fluidframework/public/_build/results?buildId=380476)/[380482](https://dev.azure.com/fluidframework/public/_build/results?buildId=380482):

| Metric | Baseline | This PR | Delta |
|--------|----------|---------|-------|
| Build | 18.0m | 21.0m | +3.0m |
| Coverage critical path | 22.5m (monolithic) | 31.0m (Mocha 24.1m + Merge 6.9m) | +8.6m |
| RealsvcLocalTest | n/a (inside mono job) | 7.1m (parallel, off critical path) | — |
| Pipeline wall-clock | 51.5m | 53.0m | +1.5m |

The coverage critical path grew because MochaTest alone (24.1m) exceeds the old monolithic job (22.5m) due to per-job setup overhead (checkout, pnpm install, artifact extraction), and Merge adds 6.9m sequentially. RealsvcLocalTest (7.1m) runs in parallel — not on the critical path.

**This is expected.** The value comes from enabling DDS/non-DDS sharding (#26562), which splits the 24.1m MochaTest into DDS (~11m) + non-DDS (~3m), bringing the combined coverage critical path down to ~18m — a net improvement over the 22.5m baseline.

### Job timings (build 380200)

| Job | Duration |
|-----|----------|
| Build | 21m 0s |
| Coverage MochaTest | 24m 7s |
| Coverage RealsvcLocalTest | 7m 4s |
| Merge Coverage Reports | 6m 55s |
| RealsvcTinyliciousTest | 18m 6s |
| JestTest | 5m 12s |
| StressTinyliciousTest | 4m 6s |
| AreTheTypesWrong | 3m 36s |

### Coverage audit

This PR does not change what gets tested or built — only how the work is structured:

- **Same tests run**: Each parallel job uses the same `include-test-task.yml` template with the same `coverageTests` entries
- **Same coverage artifacts**: `Publish Code Coverage` task and `flub report codeCoverage` are identical to the old job
- **Same test results processing**: `include-process-test-results.yml` moved from end-of-monolithic-job to each per-test job (correct — each job processes its own JUnit XML)
- **c8 report**: Changed from implicit invocation to explicit `npx c8 report --temp-directory --report-dir` in the Merge job — same report, more explicit paths

Minor behavioral differences (improvements, not gaps):
- `Merge_coverage` uses `succeededOrFailed()` — coverage is now reported even when some tests fail (old job defaulted to `succeeded()`)
- The old `startTest` variable guard is replaced by the merge job's `compgen` check + `exit 1` on empty merge directory — functionally equivalent

### Related PRs

This PR is part of a set of pipeline optimizations:

- **#26562**: Shard mocha coverage into DDS/non-DDS (stacked on this PR, projected -13m off coverage critical path)
- **#26571**: Parallelize build job (docs, bundle-analysis, devtools) + fold ATTW + timing budgets (-11m pipeline wall-clock)

Projected combined impact (all three):

| State | Coverage critical path | Pipeline wall-clock |
|-------|----------------------|---------------------|
| Baseline | 22.5m | ~51m |
| + this PR | 31.0m | ~53m |
| + this PR + #26562 | ~18m | ~40m |
| + all three | ~18m | **~29m** |

## Test plan

- [x] YAML syntax validated
- [x] ADO Pipeline Preview confirms correct `${{ each }}` expansion
- [x] Two parallel coverage jobs start after Build completes
- [x] Merge_coverage starts after both coverage jobs complete
- [x] Coverage tab in ADO shows merged results
- [x] `flub report codeCoverage` runs in merge job
- [x] Coverage numbers match recent main build (no coverage loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)