### PR TITLE
Use relative path for install in perf benchmarks pipeline

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -57,7 +57,7 @@ steps:
 - template: /tools/pipelines/templates/include-install.yml@self
   parameters:
     packageManager: pnpm
-    buildDirectory: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)
+    buildDirectory: $(FFPipelineHostDirectory)
     packageManagerInstallCommand: pnpm install
     primaryRegistry: $(ado-feeds-ff-download-only)
     userNpmrcPath: ${{ parameters.userNpmrcDirectory }}/.npmrc


### PR DESCRIPTION
Currently breaking install step for perf benchmarks pipeline