### PR TITLE
Fix biome formatting error in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 				"MAI-EngineeringSystems.mai-ai-telemetry",
 				"ms-azure-devops.azure-pipelines",
 				"ms-azuretools.vscode-docker",
-				"mutantdino.resourcemonitor",
+				"mutantdino.resourcemonitor"
 			]
 		}
 	},


### PR DESCRIPTION
## Summary

- Removes trailing comma after last extension entry in `.devcontainer/devcontainer.json` that biome 2.x flags as a formatting error
- Introduced in #26547 — currently causing `biome check` failures across all PR builds

## Test plan

- [ ] `biome check .` passes (no formatting errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)