### PR TITLE
Promote TextAsTree to alpha

### DIFF
--- a/.changeset/crisp-taxes-exist.md
+++ b/.changeset/crisp-taxes-exist.md
@@ -1,0 +1,9 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+Add alpha TextAsTree domain for collaboratively editable text
+
+A newly exported `TextAsTree` alpha namespace has been added with an initial version of collaboratively editable text.
+Users of SharedTree can add `TextAsTree.Tree` nodes to their tree to experiment with it.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1451,6 +1451,24 @@ export namespace TableSchema {
 }
 
 // @alpha
+export namespace TextAsTree {
+    export interface Members {
+        characterCount(): number;
+        characters(): Iterable<string>;
+        charactersCopy(): string[];
+        fullString(): string;
+        insertAt(index: number, additionalCharacters: string): void;
+        removeRange(startIndex: number | undefined, endIndex: number | undefined): void;
+    }
+    export interface Statics {
+        fromString(value: string): Tree;
+    }
+    const Tree: Statics & TreeNodeSchema<"com.fluidframework.text.Text", NodeKind, Members & TreeNode & WithType<"com.fluidframework.text.Text", NodeKind, unknown>, never, false>;
+    // (undocumented)
+    export type Tree = Members & TreeNode & WithType<"com.fluidframework.text.Text">;
+}
+
+// @alpha
 export function trackDirtyNodes(view: TreeViewAlpha<ImplicitFieldSchema>, dirty: DirtyTreeMap): () => void;
 
 // @alpha

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1464,7 +1464,6 @@ export namespace TextAsTree {
         fromString(value: string): Tree;
     }
     const Tree: Statics & TreeNodeSchema<"com.fluidframework.text.Text", NodeKind, Members & TreeNode & WithType<"com.fluidframework.text.Text", NodeKind, unknown>, never, false>;
-    // (undocumented)
     export type Tree = Members & TreeNode & WithType<"com.fluidframework.text.Text">;
 }
 

--- a/packages/dds/tree/src/text/textDomain.ts
+++ b/packages/dds/tree/src/text/textDomain.ts
@@ -13,7 +13,12 @@ import {
 	SchemaFactoryAlpha,
 	TreeArrayNode,
 } from "../simple-tree/index.js";
+// eslint-disable-next-line import-x/no-duplicates
 import type { TreeNode, WithType } from "../simple-tree/index.js";
+// Add some unused imports which show up in the generated d.ts file.
+// This prevents them from getting inline imports generated, cleaning up the d.ts file and API reports.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports, import-x/no-duplicates
+import type { NodeKind, TreeNodeSchema } from "../simple-tree/index.js";
 
 const sf = new SchemaFactoryAlpha("com.fluidframework.text");
 
@@ -174,12 +179,12 @@ class StringArray extends sf.array("StringArray", SchemaFactory.string) {
  *
  * Part of that work will be establishing and documenting those patterns so other components with complex encodings can follow them,
  * in addition to implementing them for text.
- * @internal
+ * @alpha
  */
 export namespace TextAsTree {
 	/**
 	 * Statics for text nodes.
-	 * @internal
+	 * @alpha
 	 */
 	export interface Statics {
 		/**
@@ -204,7 +209,7 @@ export namespace TextAsTree {
 	 *
 	 * @see {@link TextAsTree.Statics.fromString} for construction.
 	 * @see {@link TextAsTree.(Tree:type)} for schema.
-	 * @internal
+	 * @alpha
 	 */
 	export interface Members {
 		/**
@@ -260,7 +265,7 @@ export namespace TextAsTree {
 	 * @remarks
 	 * See {@link TextAsTree.Members} for the API.
 	 * See {@link TextAsTree.Statics} for static APIs on this Schema, including construction.
-	 * @internal
+	 * @alpha
 	 */
 	export const Tree = eraseSchemaDetails<Members, Statics>()(TextNode);
 	export type Tree = Members & TreeNode & WithType<"com.fluidframework.text.Text">;

--- a/packages/dds/tree/src/text/textDomain.ts
+++ b/packages/dds/tree/src/text/textDomain.ts
@@ -261,12 +261,18 @@ export namespace TextAsTree {
 	}
 
 	/**
-	 * Schema for a text node.
+	 * Schema for a {@link TextAsTree.(Tree:variable)} node.
 	 * @remarks
-	 * See {@link TextAsTree.Members} for the API.
-	 * See {@link TextAsTree.Statics} for static APIs on this Schema, including construction.
+	 * See {@link TextAsTree.Statics} for static APIs on this schema, including construction.
 	 * @alpha
 	 */
 	export const Tree = eraseSchemaDetails<Members, Statics>()(TextNode);
+
+	/**
+	 * Node for the {@link TextAsTree.(Tree:type)} schema exposing the {@link TextAsTree.Members} API.
+	 * @remarks
+	 * Create using {@link TextAsTree.Statics.fromString}.
+	 * @alpha
+	 */
 	export type Tree = Members & TreeNode & WithType<"com.fluidframework.text.Text">;
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1853,7 +1853,6 @@ export namespace TextAsTree {
         fromString(value: string): Tree;
     }
     const Tree: Statics & TreeNodeSchema<"com.fluidframework.text.Text", NodeKind, Members & TreeNode & WithType<"com.fluidframework.text.Text", NodeKind, unknown>, never, false>;
-    // (undocumented)
     export type Tree = Members & TreeNode & WithType<"com.fluidframework.text.Text">;
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1840,6 +1840,24 @@ export interface Tagged<V, T extends string = string> {
 export type TelemetryBaseEventPropertyType = string | number | boolean | undefined;
 
 // @alpha
+export namespace TextAsTree {
+    export interface Members {
+        characterCount(): number;
+        characters(): Iterable<string>;
+        charactersCopy(): string[];
+        fullString(): string;
+        insertAt(index: number, additionalCharacters: string): void;
+        removeRange(startIndex: number | undefined, endIndex: number | undefined): void;
+    }
+    export interface Statics {
+        fromString(value: string): Tree;
+    }
+    const Tree: Statics & TreeNodeSchema<"com.fluidframework.text.Text", NodeKind, Members & TreeNode & WithType<"com.fluidframework.text.Text", NodeKind, unknown>, never, false>;
+    // (undocumented)
+    export type Tree = Members & TreeNode & WithType<"com.fluidframework.text.Text">;
+}
+
+// @alpha
 export function trackDirtyNodes(view: TreeViewAlpha<ImplicitFieldSchema>, dirty: DirtyTreeMap): () => void;
 
 // @alpha


### PR DESCRIPTION
## Description

Promote TextAsTree to alpha.
The API is not final, but it is working and perforance is good enough for expirmental use.
This seems like a goot time for alpha.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
