### PR TITLE
ci: add missing trigger paths for biome-formatted files

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,7 +60,6 @@ trigger:
     - release/*
   paths:
     include:
-    - .devcontainer/*
     - .dockerignore
     - .gitattributes
     - .gitignore
@@ -72,7 +71,6 @@ trigger:
     - .pnpmfile.cjs
     - .prettierignore
     - .releaseGroup
-    - .vscode/*
     - _buildProject.config.cjs
     - assertTagging.config.mjs
     - azure
@@ -129,7 +127,6 @@ pr:
     - release/*
   paths:
     include:
-    - .devcontainer/*
     - .dockerignore
     - .gitattributes
     - .gitignore
@@ -141,7 +138,6 @@ pr:
     - .pnpmfile.cjs
     - .prettierignore
     - .releaseGroup
-    - .vscode/*
     - _buildProject.config.cjs
     - assertTagging.config.mjs
     - azure

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,6 +60,7 @@ trigger:
     - release/*
   paths:
     include:
+    - .devcontainer/*
     - .dockerignore
     - .gitattributes
     - .gitignore
@@ -68,8 +69,12 @@ trigger:
     - .markdownlint.json
     - .npmrc
     - .nvmrc
+    - .pnpmfile.cjs
     - .prettierignore
     - .releaseGroup
+    - .vscode/*
+    - _buildProject.config.cjs
+    - assertTagging.config.mjs
     - azure
     - biome.json
     - biome.jsonc
@@ -124,6 +129,7 @@ pr:
     - release/*
   paths:
     include:
+    - .devcontainer/*
     - .dockerignore
     - .gitattributes
     - .gitignore
@@ -132,8 +138,12 @@ pr:
     - .markdownlint.json
     - .npmrc
     - .nvmrc
+    - .pnpmfile.cjs
     - .prettierignore
     - .releaseGroup
+    - .vscode/*
+    - _buildProject.config.cjs
+    - assertTagging.config.mjs
     - azure
     - biome.json
     - biome.jsonc

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -117,10 +117,10 @@ extends:
             customCommand: 'run layer-check'
 
         - task: Npm@1
-          displayName: Format Check (repo)
+          displayName: Repo-wide checks
           inputs:
             command: 'custom'
-            customCommand: 'run check:format:repo'
+            customCommand: 'run checks'
 
         - task: Bash@3
           displayName: Prune pnpm store

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -116,6 +116,12 @@ extends:
             command: 'custom'
             customCommand: 'run layer-check'
 
+        - task: Npm@1
+          displayName: Format Check (repo)
+          inputs:
+            command: 'custom'
+            customCommand: 'run check:format:repo'
+
         - task: Bash@3
           displayName: Prune pnpm store
           inputs:

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -117,10 +117,10 @@ extends:
             customCommand: 'run layer-check'
 
         - task: Npm@1
-          displayName: Repo-wide checks
+          displayName: Format Check (repo)
           inputs:
             command: 'custom'
-            customCommand: 'run checks'
+            customCommand: 'run check:format:repo'
 
         - task: Bash@3
           displayName: Prune pnpm store


### PR DESCRIPTION
## Summary

PR #26547 changed `.devcontainer/devcontainer.json` and `.vscode/extensions.json` but no CI pipeline checked formatting, allowing a trailing comma error to merge (fixed by PR #26565).

**Root cause:** `biome check .` (run by `check:format:repo`) covers the entire repo, but no pipeline was running it on every PR. The `build-client` pipeline only triggers on specific paths, and `.devcontainer/` and `.vscode/` weren't included.

**Fix (two parts):**

1. **`repo-policy-check.yml`** — Add `check:format:repo` step (`biome check .`). This pipeline runs on every PR with no path filter, so formatting is always validated regardless of which files change. Note: `npm run checks` (the broader check) can't be used here because it depends on `fluid-build`/`flub` and full workspace deps, but this pipeline only installs root deps. `policy-check` and `layer-check` already run as separate steps.

2. **`build-client.yml`** — Add missing root-level config files that biome formats to the trigger paths:
   - `.pnpmfile.cjs`
   - `_buildProject.config.cjs`
   - `assertTagging.config.mjs`

## Test plan

- [ ] Verify the pipeline YAML is valid (no syntax errors)
- [ ] Confirm `repo-policy-check` pipeline runs `check:format:repo` on PRs touching any files

🤖 Generated with [Claude Code](https://claude.com/claude-code)