### PR TITLE
ci: optimize client build pipeline with parallelization

### DIFF
--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -17,10 +17,10 @@ mkdir $STAGING_PATH/test-files/
 # Note: use of package's pack:tests is only supported for pnpm as PACKAGE_MANAGER.
 if [ -f ".releaseGroup" ]; then
   if [ "$PACKAGE_MANAGER" == "pnpm" ]; then
-    flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "pnpm --if-present pack:tests"
+    flub exec --no-private --concurrency=4 --releaseGroup $RELEASE_GROUP -- "pnpm --if-present pack:tests"
   fi
-  flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "$PACKAGE_MANAGER pack" && \
-  flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz" && \
+  flub exec --no-private --concurrency=4 --releaseGroup $RELEASE_GROUP -- "$PACKAGE_MANAGER pack" && \
+  flub exec --no-private --concurrency=4 --releaseGroup $RELEASE_GROUP -- "mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz" && \
   flub exec --no-private --releaseGroup $RELEASE_GROUP -- "[ ! -f ./*test-files.tar ] || (echo 'test files found' && mv -t $STAGING_PATH/test-files/ ./*test-files.tar)"
 
 else

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -208,13 +208,11 @@ extends:
     telemetry: ${{ eq(variables['Build.Reason'], 'IndividualCI') }}
     shouldShip: ${{ or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')) }}
     taskTest:
-    # This check must be run after the build, since it relies on built files being present. Eventually it might be moved
-    # to the "pack" stage since it can use the already-packed packages in that case. As it is the pipeline packs some
-    # packages twice.
     - { name: "ci:test:jest", jobName: "JestTest" }
     - { name: "ci:test:realsvc:tinylicious", jobName: "RealsvcTinyliciousTest" }
     - { name: "ci:test:stress:tinylicious", jobName: "StressTinyliciousTest" }
-    - { name: "ci:check:are-the-types-wrong", jobName: "AreTheTypesWrong" }
+    # AreTheTypesWrong moved to build job via taskCheckAreTheTypesWrong
+    taskCheckAreTheTypesWrong: true
     coverageTests:
     - { name: "ci:test:mocha", jobName: "MochaTest" }
     - { name: "ci:test:realsvc:local", jobName: "RealsvcLocalTest" }

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -44,6 +44,10 @@ parameters:
   type: boolean
   default: false
 
+- name: taskCheckAreTheTypesWrong
+  type: boolean
+  default: false
+
 - name: taskPublishBundleSizeArtifacts
   type: boolean
   default: false
@@ -401,88 +405,6 @@ extends:
                   # At this point we want to publish the artifact with npm-packed packages, and the one with test files,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-              # Collect/publish/run bundle analysis
-              - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                  - task: Npm@1
-                    displayName: 'Calculate bundle sizes'
-                    inputs:
-                      command: custom
-                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:collect'
-
-                  # Copy files so all artifacts we publish end up under the same parent folder.
-                  # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
-                  - task: CopyFiles@2
-                    displayName: Copy bundle size files to artifact staging directory
-                    inputs:
-                      sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
-                      targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-
-                  # At this point we want to publish the artifact with the bundle size analysis,
-                  # but as part of 1ES migration that's now part of templateContext.outputs below.
-
-                  - task: Npm@1
-                    displayName: (PR only) Compare bundle sizes against baseline
-                    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-                    continueOnError: true
-                    env:
-                      ADO_API_TOKEN: $(System.AccessToken)
-                      DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
-                      TARGET_BRANCH_NAME: '$(targetBranchName)'
-                    inputs:
-                      command: custom
-                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:run'
-
-                  - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
-                      - task: Bash@3
-                        displayName: List report.json
-                        inputs:
-                          targetType: inline
-                          workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                          script: |
-                            set -eu -o pipefail
-                            echo "Build Directory is ${{ parameters.buildDirectory }}";
-                            BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
-                            echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
-                            ls -la $BUNDLE_SIZE_TESTS_DIR;
-
-                      - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
-                        parameters:
-                          pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
-
-                      - task: Bash@3
-                        displayName: Write bundle sizes measurements to Aria/Kusto
-                        inputs:
-                          targetType: inline
-                          workingDirectory: $(pathToTelemetryGenerator)
-                          script: |
-                            set -eu -o pipefail
-                            echo "Writing the following performance tests results to Aria/Kusto"
-                            echo "Report Size:"
-                            ls -la '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
-                            npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
-
-              # Docs
-              - ${{ if ne(parameters.taskBuildDocs, false) }}:
-                  - task: Npm@1
-                    displayName: 'npm run ci:build:docs'
-                    inputs:
-                      command: custom
-                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      customCommand: 'run ci:build:docs'
-
-                  # Copy files so all artifacts we publish end up under the same parent folder.
-                  # The sourceFolder should be wherever the 'npm run ci:build:docs' task places its output.
-                  - task: CopyFiles@2
-                    displayName: Copy _api-extractor-temp files to artifact staging directory
-                    inputs:
-                      sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/_api-extractor-temp'
-                      targetFolder: $(Build.ArtifactStagingDirectory)/_api-extractor-temp
-
-                  # At this point we want to publish the artifact with the _api-extractor-temp folder,
-                  # but as part of 1ES migration that's now part of templateContext.outputs below.
-
               - ${{ if eq(parameters.packageManager, 'pnpm') }}:
                 # Reset the pnpm-lock.yaml file since it's been modified by the versioning. But for dependency caching we want
                 # the cache key (which is based on the contents of the lockfile) to be the unmodified file. So we reset the
@@ -521,29 +443,16 @@ extends:
                       exit -1;
                     fi
 
-              # Devtools
-              - task: Bash@3
-                displayName: Inject devtools telemetry logger token
-                inputs:
-                  targetType: 'inline'
-                  script: |
-                    set -eu -o pipefail
-                    echo Generating .env
-                    echo "DEVTOOLS_TELEMETRY_TOKEN=$(devtools-telemetry-key)" >> $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/.env
+              # AreTheTypesWrong check (moved from separate test job into build job)
+              - ${{ if eq(parameters.taskCheckAreTheTypesWrong, true) }}:
+                  - task: Npm@1
+                    displayName: 'npm run ci:check:are-the-types-wrong'
+                    inputs:
+                      command: 'custom'
+                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                      customCommand: 'run ci:check:are-the-types-wrong'
 
-              - task: Npm@1
-                displayName: Build devtools
-                inputs:
-                  command: 'custom'
-                  workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/
-                  customCommand: 'run webpack'
-
-              - task: 1ES.PublishPipelineArtifact@1
-                displayName: Publish Artifact - Devtools Browser Extension
-                inputs:
-                  targetPath: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/dist/bundle/'
-                  artifactName: 'devtools-extension-bundle_attempt-$(System.JobAttempt)'
-                  publishLocation: 'pipeline'
+              # Devtools, docs, and bundle analysis moved to parallel post-build jobs
 
             templateContext:
               outputParentDirectory: $(Build.ArtifactStagingDirectory)
@@ -568,22 +477,7 @@ extends:
                       publishLocation: pipeline
                       sbomEnabled: false
 
-                - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                    - output: pipelineArtifact
-                      displayName: Publish Artifacts - bundle-analysis
-                      condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
-                      targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-                      artifactName: bundleAnalysis
-                      sbomEnabled: false
-                      publishLocation: pipeline
-
-                - ${{ if or(eq(parameters.publishDocs, true), eq(parameters.taskBuildDocs, true)) }}:
-                    - output: pipelineArtifact
-                      displayName: Publish Artifact - _api-extractor-temp
-                      targetPath: $(Build.ArtifactStagingDirectory)/_api-extractor-temp
-                      artifactName: _api-extractor-temp
-                      sbomEnabled: false
-                      publishLocation: pipeline
+                # bundleAnalysis and _api-extractor-temp artifacts moved to their own parallel jobs
 
           - job: Coverage_tests
             displayName: "Coverage tests"
@@ -878,6 +772,265 @@ extends:
                   parameters:
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testResultDirs: '${{ parameters.testResultDirs }}'
+
+          # Parallel post-build jobs (docs, bundle analysis, devtools)
+          - ${{ if or(eq(parameters.publishDocs, true), ne(parameters.taskBuildDocs, false)) }}:
+            - job: Build_Docs
+              displayName: "Build Docs"
+              dependsOn: build
+              variables:
+                - name: ONEES_ENFORCED_CODEQL_ENABLED
+                  value: 'false'
+                - name: COMMIT_SHA
+                  value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+              steps:
+                # Setup
+                - checkout: self
+                  path: $(FluidFrameworkDirectory)
+                  clean: true
+                  lfs: '${{ parameters.checkoutSubmodules }}'
+                  submodules: '${{ parameters.checkoutSubmodules }}'
+
+                - script: |
+                    echo "commit: $(COMMIT_SHA)"
+                    git fetch origin $(COMMIT_SHA)
+                    git checkout $(COMMIT_SHA)
+                  displayName: "Checkout build commit"
+
+                - template: /tools/pipelines/templates/include-use-node-version.yml@self
+
+                - template: /tools/pipelines/templates/include-install.yml@self
+                  parameters:
+                    packageManager: '${{ parameters.packageManager }}'
+                    buildDirectory: '${{ parameters.buildDirectory }}'
+                    packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
+
+                - task: DownloadPipelineArtifact@2
+                  inputs:
+                    artifact: build_output_archive
+                    targetPath: $(Build.StagingDirectory)
+
+                - script: |
+                    echo "Extracting build output archive contents..."
+                    tar --extract --gzip --file $(Build.StagingDirectory)/build_output_archive.tar.gz --directory $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+                  displayName: Extract Build Output Contents
+
+                # Build docs
+                - task: Npm@1
+                  displayName: 'npm run ci:build:docs'
+                  inputs:
+                    command: custom
+                    workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                    customCommand: 'run ci:build:docs'
+
+                - task: CopyFiles@2
+                  displayName: Copy _api-extractor-temp files to artifact staging directory
+                  inputs:
+                    sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/_api-extractor-temp'
+                    targetFolder: $(Build.ArtifactStagingDirectory)/_api-extractor-temp
+
+              templateContext:
+                outputParentDirectory: $(Build.ArtifactStagingDirectory)
+                outputs:
+                  - output: pipelineArtifact
+                    displayName: Publish Artifact - _api-extractor-temp
+                    targetPath: $(Build.ArtifactStagingDirectory)/_api-extractor-temp
+                    artifactName: _api-extractor-temp
+                    sbomEnabled: false
+                    publishLocation: pipeline
+
+          - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
+            - job: Bundle_Analysis
+              displayName: "Bundle Analysis"
+              dependsOn: build
+              variables:
+                - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+                  - name: targetBranchName
+                    value: $(System.PullRequest.TargetBranch)
+                - name: ONEES_ENFORCED_CODEQL_ENABLED
+                  value: 'false'
+                - name: COMMIT_SHA
+                  value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+              steps:
+                # Setup
+                - checkout: self
+                  path: $(FluidFrameworkDirectory)
+                  clean: true
+                  lfs: '${{ parameters.checkoutSubmodules }}'
+                  submodules: '${{ parameters.checkoutSubmodules }}'
+
+                - script: |
+                    echo "commit: $(COMMIT_SHA)"
+                    git fetch origin $(COMMIT_SHA)
+                    git checkout $(COMMIT_SHA)
+                  displayName: "Checkout build commit"
+
+                - template: /tools/pipelines/templates/include-use-node-version.yml@self
+
+                - template: /tools/pipelines/templates/include-install.yml@self
+                  parameters:
+                    packageManager: '${{ parameters.packageManager }}'
+                    buildDirectory: '${{ parameters.buildDirectory }}'
+                    packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
+
+                # Bundle analysis needs flub (build-tools)
+                - template: /tools/pipelines/templates/include-install-build-tools.yml@self
+                  parameters:
+                    buildDirectory: ${{ parameters.buildDirectory }}
+                    buildToolsVersionToInstall: repo
+                    pnpmStorePath: $(Pipeline.Workspace)/.pnpm-store
+
+                - task: DownloadPipelineArtifact@2
+                  inputs:
+                    artifact: build_output_archive
+                    targetPath: $(Build.StagingDirectory)
+
+                - script: |
+                    echo "Extracting build output archive contents..."
+                    tar --extract --gzip --file $(Build.StagingDirectory)/build_output_archive.tar.gz --directory $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+                  displayName: Extract Build Output Contents
+
+                # Collect bundle sizes
+                - task: Npm@1
+                  displayName: 'Calculate bundle sizes'
+                  inputs:
+                    command: custom
+                    workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                    customCommand: 'run bundle-analysis:collect'
+
+                - task: CopyFiles@2
+                  displayName: Copy bundle size files to artifact staging directory
+                  inputs:
+                    sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
+                    targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+
+                # PR: compare bundle sizes against baseline
+                - task: Npm@1
+                  displayName: (PR only) Compare bundle sizes against baseline
+                  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+                  continueOnError: true
+                  env:
+                    ADO_API_TOKEN: $(System.AccessToken)
+                    DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
+                    TARGET_BRANCH_NAME: '$(targetBranchName)'
+                  inputs:
+                    command: custom
+                    workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                    customCommand: 'run bundle-analysis:run'
+
+                # CI: upload telemetry to Kusto
+                - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
+                    - task: Bash@3
+                      displayName: List report.json
+                      inputs:
+                        targetType: inline
+                        workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                        script: |
+                          set -eu -o pipefail
+                          echo "Build Directory is ${{ parameters.buildDirectory }}";
+                          BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
+                          echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
+                          ls -la $BUNDLE_SIZE_TESTS_DIR;
+
+                    - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
+                      parameters:
+                        pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
+
+                    - task: Bash@3
+                      displayName: Write bundle sizes measurements to Aria/Kusto
+                      inputs:
+                        targetType: inline
+                        workingDirectory: $(pathToTelemetryGenerator)
+                        script: |
+                          set -eu -o pipefail
+                          echo "Writing the following performance tests results to Aria/Kusto"
+                          echo "Report Size:"
+                          ls -la '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
+                          npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
+
+              templateContext:
+                outputParentDirectory: $(Build.ArtifactStagingDirectory)
+                outputs:
+                  - output: pipelineArtifact
+                    displayName: Publish Artifacts - bundle-analysis
+                    condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
+                    targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+                    artifactName: bundleAnalysis
+                    sbomEnabled: false
+                    publishLocation: pipeline
+
+          - job: Build_Devtools
+            displayName: "Build Devtools"
+            dependsOn: build
+            variables:
+              - group: storage-vars
+              - name: ONEES_ENFORCED_CODEQL_ENABLED
+                value: 'false'
+              - name: COMMIT_SHA
+                value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+            steps:
+              # Setup
+              - checkout: self
+                path: $(FluidFrameworkDirectory)
+                clean: true
+                lfs: '${{ parameters.checkoutSubmodules }}'
+                submodules: '${{ parameters.checkoutSubmodules }}'
+
+              - script: |
+                  echo "commit: $(COMMIT_SHA)"
+                  git fetch origin $(COMMIT_SHA)
+                  git checkout $(COMMIT_SHA)
+                displayName: "Checkout build commit"
+
+              - template: /tools/pipelines/templates/include-use-node-version.yml@self
+
+              - template: /tools/pipelines/templates/include-install.yml@self
+                parameters:
+                  packageManager: '${{ parameters.packageManager }}'
+                  buildDirectory: '${{ parameters.buildDirectory }}'
+                  packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
+
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifact: build_output_archive
+                  targetPath: $(Build.StagingDirectory)
+
+              - script: |
+                  echo "Extracting build output archive contents..."
+                  tar --extract --gzip --file $(Build.StagingDirectory)/build_output_archive.tar.gz --directory $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+                displayName: Extract Build Output Contents
+
+              # Build devtools
+              - task: Bash@3
+                displayName: Inject devtools telemetry logger token
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    set -eu -o pipefail
+                    echo Generating .env
+                    echo "DEVTOOLS_TELEMETRY_TOKEN=$(devtools-telemetry-key)" >> $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/.env
+
+              - task: Npm@1
+                displayName: Build devtools
+                inputs:
+                  command: 'custom'
+                  workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/
+                  customCommand: 'run webpack'
+
+              - task: CopyFiles@2
+                displayName: Copy devtools bundle to artifact staging directory
+                inputs:
+                  sourceFolder: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/dist/bundle/'
+                  targetFolder: $(Build.ArtifactStagingDirectory)/devtools-extension-bundle
+
+            templateContext:
+              outputParentDirectory: $(Build.ArtifactStagingDirectory)
+              outputs:
+                - output: pipelineArtifact
+                  displayName: Publish Artifact - Devtools Browser Extension
+                  targetPath: $(Build.ArtifactStagingDirectory)/devtools-extension-bundle
+                  artifactName: 'devtools-extension-bundle_attempt-$(System.JobAttempt)'
+                  publishLocation: 'pipeline'
 
       # Publish stage
       - ${{ if eq(parameters.publish, true) }}:

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -231,6 +231,12 @@ extends:
                 - name: targetBranchName
                   value: $(System.PullRequest.TargetBranch)
             steps:
+              - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                parameters:
+                  budgetMinutes: 30
+                  jobDisplayName: 'Build'
+                  step: start
+
               # Setup
               - checkout: self
                 path: $(FluidFrameworkDirectory)
@@ -454,6 +460,12 @@ extends:
 
               # Devtools, docs, and bundle analysis moved to parallel post-build jobs
 
+              - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                parameters:
+                  budgetMinutes: 30
+                  jobDisplayName: 'Build'
+                  step: check
+
             templateContext:
               outputParentDirectory: $(Build.ArtifactStagingDirectory)
               outputs:
@@ -482,6 +494,7 @@ extends:
           - job: Coverage_tests
             displayName: "Coverage tests"
             dependsOn: build
+            timeoutInMinutes: 60
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -499,6 +512,12 @@ extends:
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
 
             steps:
+              - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                parameters:
+                  budgetMinutes: 35
+                  jobDisplayName: 'Coverage tests'
+                  step: start
+
               # Setup
               - checkout: self
                 path: $(FluidFrameworkDirectory)
@@ -627,6 +646,12 @@ extends:
                   buildDirectory: '${{ parameters.buildDirectory }}'
                   testResultDirs: '${{ parameters.testResultDirs }}'
 
+              - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                parameters:
+                  budgetMinutes: 35
+                  jobDisplayName: 'Coverage tests'
+                  step: check
+
             templateContext:
               outputParentDirectory: $(Build.ArtifactStagingDirectory)/codeCoverageAnalysis
               outputs:
@@ -643,6 +668,7 @@ extends:
             - job: Test_${{ test.jobName }}
               displayName: "Run Task Test ${{ test.jobName }}"
               dependsOn: build
+              timeoutInMinutes: 45
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName
@@ -659,6 +685,12 @@ extends:
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
               steps:
+                - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                  parameters:
+                    budgetMinutes: 25
+                    jobDisplayName: 'Test ${{ test.jobName }}'
+                    step: start
+
                 # Setup
                 - checkout: self
                   path: $(FluidFrameworkDirectory)
@@ -773,17 +805,30 @@ extends:
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testResultDirs: '${{ parameters.testResultDirs }}'
 
+                - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                  parameters:
+                    budgetMinutes: 25
+                    jobDisplayName: 'Test ${{ test.jobName }}'
+                    step: check
+
           # Parallel post-build jobs (docs, bundle analysis, devtools)
           - ${{ if or(eq(parameters.publishDocs, true), ne(parameters.taskBuildDocs, false)) }}:
             - job: Build_Docs
               displayName: "Build Docs"
               dependsOn: build
+              timeoutInMinutes: 30
               variables:
                 - name: ONEES_ENFORCED_CODEQL_ENABLED
                   value: 'false'
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
               steps:
+                - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                  parameters:
+                    budgetMinutes: 12
+                    jobDisplayName: 'Build Docs'
+                    step: start
+
                 # Setup
                 - checkout: self
                   path: $(FluidFrameworkDirectory)
@@ -829,6 +874,12 @@ extends:
                     sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/_api-extractor-temp'
                     targetFolder: $(Build.ArtifactStagingDirectory)/_api-extractor-temp
 
+                - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                  parameters:
+                    budgetMinutes: 12
+                    jobDisplayName: 'Build Docs'
+                    step: check
+
               templateContext:
                 outputParentDirectory: $(Build.ArtifactStagingDirectory)
                 outputs:
@@ -843,6 +894,7 @@ extends:
             - job: Bundle_Analysis
               displayName: "Bundle Analysis"
               dependsOn: build
+              timeoutInMinutes: 30
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName
@@ -852,6 +904,12 @@ extends:
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
               steps:
+                - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                  parameters:
+                    budgetMinutes: 12
+                    jobDisplayName: 'Bundle Analysis'
+                    step: start
+
                 # Setup
                 - checkout: self
                   path: $(FluidFrameworkDirectory)
@@ -948,6 +1006,12 @@ extends:
                           ls -la '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
                           npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
 
+                - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                  parameters:
+                    budgetMinutes: 12
+                    jobDisplayName: 'Bundle Analysis'
+                    step: check
+
               templateContext:
                 outputParentDirectory: $(Build.ArtifactStagingDirectory)
                 outputs:
@@ -962,6 +1026,7 @@ extends:
           - job: Build_Devtools
             displayName: "Build Devtools"
             dependsOn: build
+            timeoutInMinutes: 30
             variables:
               - group: storage-vars
               - name: ONEES_ENFORCED_CODEQL_ENABLED
@@ -969,6 +1034,12 @@ extends:
               - name: COMMIT_SHA
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
             steps:
+              - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                parameters:
+                  budgetMinutes: 10
+                  jobDisplayName: 'Build Devtools'
+                  step: start
+
               # Setup
               - checkout: self
                 path: $(FluidFrameworkDirectory)
@@ -1022,6 +1093,12 @@ extends:
                 inputs:
                   sourceFolder: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/dist/bundle/'
                   targetFolder: $(Build.ArtifactStagingDirectory)/devtools-extension-bundle
+
+              - template: /tools/pipelines/templates/include-steps-timing-budget.yml@self
+                parameters:
+                  budgetMinutes: 10
+                  jobDisplayName: 'Build Devtools'
+                  step: check
 
             templateContext:
               outputParentDirectory: $(Build.ArtifactStagingDirectory)

--- a/tools/pipelines/templates/include-steps-timing-budget.yml
+++ b/tools/pipelines/templates/include-steps-timing-budget.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# Reusable template for timing budget enforcement.
+# Include at the beginning of a job's steps with step: start, and at the end with step: check.
+# If the job exceeds its budget, a pipeline warning is logged (visible in ADO UI).
+# This catches gradual performance regressions before they hit the hard timeoutInMinutes ceiling.
+
+parameters:
+- name: budgetMinutes
+  type: number
+
+- name: jobDisplayName
+  type: string
+
+- name: step
+  type: string
+  values:
+    - start
+    - check
+
+steps:
+- ${{ if eq(parameters.step, 'start') }}:
+    - task: Bash@3
+      displayName: 'Record job start time'
+      inputs:
+        targetType: inline
+        script: |
+          set -eu -o pipefail
+          START_TIME=`date +%s`
+          echo "##vso[task.setvariable variable=TIMING_BUDGET_START]$START_TIME"
+          echo "Timing budget for '${{ parameters.jobDisplayName }}': ${{ parameters.budgetMinutes }} minutes"
+
+- ${{ if eq(parameters.step, 'check') }}:
+    - task: Bash@3
+      displayName: 'Check timing budget'
+      condition: always()
+      inputs:
+        targetType: inline
+        script: |
+          set -eu -o pipefail
+          START=$(TIMING_BUDGET_START)
+          NOW=`date +%s`
+          ELAPSED_SECONDS=$((NOW - START))
+          ELAPSED_MINUTES=$((ELAPSED_SECONDS / 60))
+          ELAPSED_REMAINDER=$((ELAPSED_SECONDS % 60))
+          BUDGET=${{ parameters.budgetMinutes }}
+          echo "Job '${{ parameters.jobDisplayName }}' completed in ${ELAPSED_MINUTES}m ${ELAPSED_REMAINDER}s (budget: ${BUDGET}m)"
+          if [ "$ELAPSED_SECONDS" -gt "$((BUDGET * 60))" ]; then
+            echo "##vso[task.logissue type=warning]Timing budget exceeded for '${{ parameters.jobDisplayName }}': ${ELAPSED_MINUTES}m elapsed, budget was ${BUDGET}m"
+          fi

--- a/tools/pipelines/templates/include-steps-timing-budget.yml
+++ b/tools/pipelines/templates/include-steps-timing-budget.yml
@@ -5,6 +5,9 @@
 # Include at the beginning of a job's steps with step: start, and at the end with step: check.
 # If the job exceeds its budget, a pipeline warning is logged (visible in ADO UI).
 # This catches gradual performance regressions before they hit the hard timeoutInMinutes ceiling.
+#
+# IMPORTANT: budgetMinutes must match between the start and check invocations for the same job.
+# The start step records the time and logs the budget; the check step enforces it.
 
 parameters:
 - name: budgetMinutes
@@ -35,13 +38,17 @@ steps:
     - task: Bash@3
       displayName: 'Check timing budget'
       condition: always()
+      env:
+        TIMING_START: $(TIMING_BUDGET_START)
       inputs:
         targetType: inline
         script: |
-          set -eu -o pipefail
-          START=$(TIMING_BUDGET_START)
+          if [ -z "$TIMING_START" ] || ! [ "$TIMING_START" -eq "$TIMING_START" ] 2>/dev/null; then
+            echo "Timing budget check skipped: start time not recorded."
+            exit 0
+          fi
           NOW=`date +%s`
-          ELAPSED_SECONDS=$((NOW - START))
+          ELAPSED_SECONDS=$((NOW - TIMING_START))
           ELAPSED_MINUTES=$((ELAPSED_SECONDS / 60))
           ELAPSED_REMAINDER=$((ELAPSED_SECONDS % 60))
           BUDGET=${{ parameters.budgetMinutes }}


### PR DESCRIPTION
## Summary

Three combined optimizations that reduce the client build pipeline wall-clock time by **11 minutes** (55.9m → 44.7m), plus timing budget enforcement to catch regressions early. Measured on PR build [380450](https://dev.azure.com/fluidframework/public/_build/results?buildId=380450) vs baselines [380476](https://dev.azure.com/fluidframework/public/_build/results?buildId=380476)/[380482](https://dev.azure.com/fluidframework/public/_build/results?buildId=380482).

### Changes

1. **Split post-build work into parallel jobs** — Docs, bundle-analysis, and devtools are extracted from the monolithic build job into three new parallel jobs (`Build_Docs`, `Bundle_Analysis`, `Build_Devtools`) that run concurrently with test jobs.

2. **Increase npm pack concurrency** (`scripts/pack-packages.sh`) — Bumps `flub exec --concurrency` from 1 to 4. Pack creates globally unique `.tgz` filenames so no race conditions; conservative limit of 4 bounds I/O contention.

3. **Fold AreTheTypesWrong into build job** (`build-client.yml`) — Eliminates `Test_AreTheTypesWrong` as a separate job/agent by running it directly in the build job after pack. Adds ~2m to build but saves 1 agent.

4. **Timing budget enforcement** (`include-steps-timing-budget.yml`) — New reusable template that records job start time and emits a pipeline warning (`##[warning]`) if a job exceeds its budget. Catches gradual performance regressions before they hit the hard `timeoutInMinutes` ceiling. Applied to all pipeline jobs:

   | Job | Budget |
   |-----|--------|
   | Build | 30m |
   | Coverage tests | 35m |
   | Test jobs (Jest, Realsvc, Stress) | 25m |
   | Build Docs | 12m |
   | Bundle Analysis | 12m |
   | Build Devtools | 10m |

   Budgets are set ~50% above current measured times, providing headroom for normal variance while flagging real regressions.

### Measured results

| Metric | Baseline | This PR | Delta |
|--------|----------|---------|-------|
| Build job | 18.0m | 20.0m | +2.0m (ATTW folded in) |
| Pipeline wall-clock | 55.9m | 44.7m | **-11.1m (-20%)** |
| AreTheTypesWrong | 3.5-3.8m (separate agent) | eliminated | -1 agent |
| Post-build jobs | n/a | Docs 5.9m, Bundle 5.4m, Devtools 4.4m | all hidden by tests |

### Pipeline dependency graph

```
build ─┬─ Coverage_tests              (22m 14s)  ← critical path
       ├─ Test_JestTest               ( 4m 59s)
       ├─ Test_RealsvcTinyliciousTest (16m 41s)
       ├─ Test_StressTinyliciousTest  ( 6m  6s)
       ├─ Build_Docs          (NEW)   ( 5m 54s)
       ├─ Bundle_Analysis     (NEW)   ( 5m 22s)
       ├─ Build_Devtools      (NEW)   ( 4m 25s)
       └─ publish_*
```

Critical path: **Build (20m) → Coverage tests (22m)**. The three new parallel jobs finish well before the longest test, adding zero time to the critical path.

### Coverage audit

This PR does not change what gets built, tested, or checked — only how the work is structured:

- **AreTheTypesWrong**: Same `ci:check:are-the-types-wrong` command, moved from separate job into build job
- **Bundle analysis**: Same steps (`bundle-analysis:collect`, `bundle-analysis:run` for PRs, telemetry upload for CI), same conditions, same env vars
- **Docs**: Same `ci:build:docs`, same artifact (`_api-extractor-temp`)
- **Devtools**: Same `.env` token injection, same `npm run webpack`, same artifact name
- **Pack concurrency**: Same `flub exec` commands, only `--concurrency` changed from 1 to 4

One mechanical difference: Devtools artifact publishing switched from `1ES.PublishPipelineArtifact@1` to `CopyFiles@2` + `templateContext.outputs` — same content, follows 1ES best practices for standalone jobs.

### Related PRs

This PR works independently but is part of a set of pipeline optimizations:

- **#26559**: Parallelize coverage tests (structural refactoring, enables sharding)
- **#26562**: Shard mocha coverage into DDS/non-DDS (stacked on #26559, projected -13m off coverage critical path)

When all three land, the projected pipeline wall-clock is **~25-29m** (down from ~56m).

## Test plan

- [x] YAML validates locally
- [x] ADO Pipeline shows `Build_Docs`, `Bundle_Analysis`, `Build_Devtools` jobs; no `Test_AreTheTypesWrong`
- [x] Build job completes with ATTW folded in (+2m, as expected)
- [x] Three new parallel jobs succeed and publish artifacts correctly
- [x] PR bundle size comparison runs in `Bundle_Analysis` job
- [x] Publish stages unaffected (depend only on `build`)
- [x] Pack concurrency=4 causes no I/O issues
- [x] Pipeline wall-clock reduced by 11m vs baseline
- [x] Timing budget warnings appear correctly when thresholds are exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)