### PR TITLE
ci: suppress dotenv warning in devtools test webpack config

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/webpack.test.cjs
+++ b/packages/tools/devtools/devtools-browser-extension/webpack.test.cjs
@@ -55,6 +55,8 @@ module.exports = (env) => {
 			new Dotenv({
 				path: "./.env",
 				systemvars: true,
+				// Suppress missing .env warning in CI; keep it locally so devs know to create .env.
+				silent: Boolean(process.env.CI || process.env.TF_BUILD),
 			}),
 			new HtmlWebpackPlugin({
 				template: "./e2e-tests/app/index.html",


### PR DESCRIPTION
## Summary

- Add `silent: Boolean(process.env.CI || process.env.TF_BUILD)` to the Dotenv plugin in `packages/tools/devtools/devtools-browser-extension/webpack.test.cjs`
- PR #26545 added this CI-aware silent flag to `webpack.config.cjs` in the same package but missed `webpack.test.cjs`, which still produces a ".env file not found" warning in CI builds

## Test plan

- [x] Verified the change matches the exact pattern already used in `webpack.config.cjs` in the same directory
- [ ] CI build should no longer show ".env file not found" warning from this config

🤖 Generated with [Claude Code](https://claude.com/claude-code)