### PR TITLE
ci: suppress baseline-browser-mapping warnings in webpack steps

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -365,6 +365,9 @@ extends:
 
               - task: Npm@1
                 displayName: 'npm run webpack'
+                env:
+                  # Suppress baseline-browser-mapping staleness warnings during webpack.
+                  BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA: 1
                 inputs:
                   command: custom
                   workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
@@ -533,6 +536,9 @@ extends:
 
               - task: Npm@1
                 displayName: Build devtools
+                env:
+                  # Suppress baseline-browser-mapping staleness warnings during webpack.
+                  BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA: 1
                 inputs:
                   command: 'custom'
                   workingDir: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/packages/tools/devtools/devtools-browser-extension/


### PR DESCRIPTION
## Summary

- PR #26544 added `BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA=1` to the build and lint steps in `include-build-lint.yml` to suppress the 100+ "data is over two months old" warnings from the `baseline-browser-mapping` transitive dependency of `browserslist`.
- That PR missed the two webpack `Npm@1` steps in `build-npm-client-package.yml` — the main `npm run webpack` step and the devtools `Build devtools` step — which also invoke browserslist and produce the same warnings.
- This PR adds the same `env` block to both webpack tasks, matching the pattern already established in `include-build-lint.yml`.

## Test plan

- [ ] Verify the YAML is syntactically valid (CI pipeline validation on PR)
- [ ] Confirm webpack steps no longer emit baseline-browser-mapping staleness warnings in build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)