### PR TITLE
test: increase ReconnectFarm timeout from 30s to 60s

### DIFF
--- a/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -120,7 +120,7 @@ function runReconnectFarmTests(opts: IReconnectFarmConfig, extraSeed?: number): 
 				testOpts,
 				applyMessagesWithReconnect,
 			);
-		}).timeout(30 * 1000);
+		}).timeout(60 * 1000);
 	});
 }
 


### PR DESCRIPTION
## Summary

Increases the timeout for the `ReconnectFarm` stress tests from 30s to 60s. These tests run randomized merge-tree operations with reconnection and can intermittently exceed the 30s timeout on CI machines under load, causing flaky `Timeout of 30000ms exceeded` failures.

Observed in build 379358: `MergeTree.Client > ReconnectFarm_2_0` timed out with 1554 other tests passing.

## Coverage audit

No change to what the test validates — same operations, same assertions, same seed-based determinism. Only the timeout threshold changed.

## Test plan

- [x] Change is a single constant: `30 * 1000` → `60 * 1000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)