### PR TITLE
ci: skip bundle-size comparison until token is rotated (AB#56981)

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -437,11 +437,11 @@ extends:
                           echo "Bundle size comparison completed successfully."
                         else
                           exit_code=$?
-                          if grep -qi "Bad credentials\|401\|authentication\|DANGER_GITHUB_API_TOKEN" /tmp/bundle-analysis.log; then
-                            echo "##[warning]Bundle size comparison failed due to GitHub authentication (exit code $exit_code). The GitHub token (githubPublicRepoSecret) may need to be rotated."
-                            echo "##[warning]Skipping bundle size comparison — this does not affect build correctness."
+                          if grep -q "Bad credentials" /tmp/bundle-analysis.log; then
+                            echo "##[warning]Bundle size comparison skipped — GitHub token (githubPublicRepoSecret) returned 'Bad credentials'. Token may need rotation."
                           else
-                            echo "##[warning]Bundle size comparison failed (exit code $exit_code). See log above for details."
+                            echo "##[error]Bundle size comparison failed (exit code $exit_code). See log above."
+                            exit 1
                           fi
                         fi
 

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -437,8 +437,8 @@ extends:
                           echo "Bundle size comparison completed successfully."
                         else
                           exit_code=$?
-                          if grep -q "Bad credentials" /tmp/bundle-analysis.log; then
-                            echo "##[warning]Bundle size comparison skipped — GitHub token (githubPublicRepoSecret) returned 'Bad credentials'. Token may need rotation."
+                          if grep -qE "Bad credentials|forbids access via a personal access token" /tmp/bundle-analysis.log; then
+                            echo "##[warning]Bundle size comparison skipped — GitHub token (githubPublicRepoSecret) was rejected. Token may need rotation or its lifetime may exceed enterprise policy limits."
                           else
                             echo "##[error]Bundle size comparison failed (exit code $exit_code). See log above."
                             exit 1

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -421,18 +421,29 @@ extends:
                   # At this point we want to publish the artifact with the bundle size analysis,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-                  - task: Npm@1
+                  - task: Bash@3
                     displayName: (PR only) Compare bundle sizes against baseline
                     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-                    continueOnError: true
                     env:
                       ADO_API_TOKEN: $(System.AccessToken)
                       DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
                       TARGET_BRANCH_NAME: '$(targetBranchName)'
                     inputs:
-                      command: custom
-                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:run'
+                      targetType: inline
+                      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                      script: |
+                        set -uo pipefail
+                        if npm run bundle-analysis:run 2>&1 | tee /tmp/bundle-analysis.log; then
+                          echo "Bundle size comparison completed successfully."
+                        else
+                          exit_code=$?
+                          if grep -qi "Bad credentials\|401\|authentication\|DANGER_GITHUB_API_TOKEN" /tmp/bundle-analysis.log; then
+                            echo "##[warning]Bundle size comparison failed due to GitHub authentication (exit code $exit_code). The GitHub token (githubPublicRepoSecret) may need to be rotated."
+                            echo "##[warning]Skipping bundle size comparison — this does not affect build correctness."
+                          else
+                            echo "##[warning]Bundle size comparison failed (exit code $exit_code). See log above for details."
+                          fi
+                        fi
 
                   - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
                       - task: Bash@3

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -423,9 +423,11 @@ extends:
 
                   # TODO(AB#56981): Re-enable once githubPublicRepoSecret is rotated in prague-key-vault.
                   # Disabled because the token is expired/rejected.
+                  # Original condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
                   - task: Npm@1
                     displayName: (PR only) Compare bundle sizes against baseline (DISABLED)
                     condition: false
+                    continueOnError: true
                     env:
                       ADO_API_TOKEN: $(System.AccessToken)
                       DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -421,8 +421,8 @@ extends:
                   # At this point we want to publish the artifact with the bundle size analysis,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-                  # Disabled: githubPublicRepoSecret token is expired/rejected (AB#56981).
-                  # Re-enable once the token is rotated in prague-key-vault.
+                  # TODO(AB#56981): Re-enable once githubPublicRepoSecret is rotated in prague-key-vault.
+                  # Disabled because the token is expired/rejected.
                   - task: Npm@1
                     displayName: (PR only) Compare bundle sizes against baseline (DISABLED)
                     condition: false

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -421,29 +421,19 @@ extends:
                   # At this point we want to publish the artifact with the bundle size analysis,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-                  - task: Bash@3
-                    displayName: (PR only) Compare bundle sizes against baseline
-                    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+                  # Disabled: githubPublicRepoSecret token is expired/rejected (AB#56981).
+                  # Re-enable once the token is rotated in prague-key-vault.
+                  - task: Npm@1
+                    displayName: (PR only) Compare bundle sizes against baseline (DISABLED)
+                    condition: false
                     env:
                       ADO_API_TOKEN: $(System.AccessToken)
                       DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
                       TARGET_BRANCH_NAME: '$(targetBranchName)'
                     inputs:
-                      targetType: inline
-                      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      script: |
-                        set -uo pipefail
-                        if npm run bundle-analysis:run 2>&1 | tee /tmp/bundle-analysis.log; then
-                          echo "Bundle size comparison completed successfully."
-                        else
-                          exit_code=$?
-                          if grep -qE "Bad credentials|forbids access via a personal access token" /tmp/bundle-analysis.log; then
-                            echo "##[warning]Bundle size comparison skipped — GitHub token (githubPublicRepoSecret) was rejected. Token may need rotation or its lifetime may exceed enterprise policy limits."
-                          else
-                            echo "##[error]Bundle size comparison failed (exit code $exit_code). See log above."
-                            exit 1
-                          fi
-                        fi
+                      command: custom
+                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                      customCommand: 'run bundle-analysis:run'
 
                   - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
                       - task: Bash@3


### PR DESCRIPTION
## Summary

Disables the bundle-size comparison step (`bundle-analysis:run`) with `condition: false` until the `githubPublicRepoSecret` token is rotated in `prague-key-vault` ([AB#56981](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/56981)).

The step was failing with 401/forbidden on every PR build, and `continueOnError: true` was masking it as `partiallySucceeded` — hiding real failures behind the same yellow status.

### What changed

- Set `condition: false` so the step is visibly skipped, not silently swallowed
- Added `(DISABLED)` to the display name
- Added `TODO([AB#56981](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/56981))` comment for re-enabling
- Preserved the original condition as a comment for easy restoration
- Kept `continueOnError: true` as a safety net for when the step is re-enabled

### Re-enabling

When the token is rotated, restore the original condition and remove `(DISABLED)` from the display name:
```yaml
# condition: false
condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
```

## Test plan

- [x] YAML is valid
- [x] PR builds should show the step as skipped (not partially succeeded)
- [x] No functional changes to any other pipeline steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)