### PR TITLE
Use session cache in broadcast-signal to skip DB lookups

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -476,7 +476,7 @@ async function handleBroadcastSignal(
 	}
 
 	// Cache miss: fall back to DB lookup.
-	if (sessionOrdererUrl === undefined) {
+	if (!cacheHit) {
 		const document = await storage.getDocument(tenantId, documentId);
 		sessionOrdererUrl = document?.session?.ordererUrl;
 		// A document with a scheduled deletion time should be treated as not found.

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -91,6 +91,7 @@ export function create(
 		revokedTokenChecker,
 		collaborationSessionEventEmitter,
 		fluidAccessTokenGenerator,
+		redisCacheForGetSession,
 		denyList,
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -7,5 +7,10 @@ export { Constants } from "./constants";
 export { createDocumentRouter, type IPlugin } from "./documentRouter";
 export { catch404, handleError } from "./middleware";
 export { getIdFromRequest, getTenantIdFromRequest } from "./params";
-export { getSession, generateCacheKey, setGetSessionResultInCache } from "./sessionHelper";
+export {
+	getSession,
+	generateCacheKey,
+	getSessionFromCache,
+	setGetSessionResultInCache,
+} from "./sessionHelper";
 export { configureThrottler } from "./throttling";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -284,7 +284,7 @@ export function generateCacheKey(tenantId: string, documentId: string): string {
  * If the document is deleted, we store a session object with empty URLs and isSessionAlive=false.
  * @internal
  */
-async function getSessionFromCache(
+export async function getSessionFromCache(
 	tenantId: string,
 	documentId: string,
 	redisCacheForGetSession: ICache,


### PR DESCRIPTION
## Description

Add Redis session cache support to the broadcast-signal endpoint. The cache is populated by the session discovery endpoint (GET /documents/:tenantId/session/:id) which clients call before connecting, so it will be warm for any active session.

- Read from getSessionFromCache before falling back to DB
- Export getSessionFromCache from sessionHelper for reuse
- Add cacheHit telemetry to success and 404 logs
- Add tests for cache hit, miss, redirect, and deleted sentinel