### PR TITLE
Parallelize webpack inside ci:build task graph

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -39,6 +39,7 @@ module.exports = {
 				"ci:build:docs",
 				"build:manifest",
 				"build:readme",
+				"webpack",
 			],
 			script: false,
 		},

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -363,13 +363,6 @@ extends:
                   taskLintName: '${{ parameters.taskLintName }}'
                   buildDirectory: '${{ parameters.buildDirectory }}'
 
-              - task: Npm@1
-                displayName: 'npm run webpack'
-                inputs:
-                  command: custom
-                  workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                  customCommand: 'run webpack'
-
               - task: Bash@3
                 displayName: Archive Build Output Content
                 env:


### PR DESCRIPTION
## Summary

- Adds `webpack` to `ci:build.dependsOn` in `fluidBuild.config.cjs` so fluid-build can schedule it in parallel with lint, api-reports, and docs
- Removes the separate sequential `npm run webpack` step from `build-npm-client-package.yml` since it's now handled by `ci:build`

Webpack only depends on `^tsc` and `^build:esnext` (defined at line 154 of `fluidBuild.config.cjs`), not on lint or api-reports, so it can start as soon as compilation finishes rather than waiting for all of `ci:build` to complete first.

**Expected savings:** ~1-2 minutes on the build job critical path.

## Test plan

- [ ] CI build passes (webpack output is identical whether run inside or outside ci:build)
- [ ] Verify webpack artifacts are still included in the build output archive
- [ ] Compare build job duration against baseline (~19 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)