### PR TITLE
ci: move npm pack to a parallel job to unblock tests earlier

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -385,22 +385,6 @@ extends:
                   sourceFolder: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/build_output_archive
                   targetFolder: $(Build.ArtifactStagingDirectory)/build_output_archive
 
-              # Pack
-              - ${{ if ne(parameters.taskPack, false) }}:
-                  - task: Bash@3
-                    displayName: npm pack
-                    env:
-                      PACKAGE_MANAGER: '${{ parameters.packageManager }}'
-                      RELEASE_GROUP: '${{ parameters.tagName }}'
-                      STAGING_PATH: $(Build.ArtifactStagingDirectory)
-                    inputs:
-                      targetType: filePath
-                      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      filePath: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/scripts/pack-packages.sh
-
-                  # At this point we want to publish the artifact with npm-packed packages, and the one with test files,
-                  # but as part of 1ES migration that's now part of templateContext.outputs below.
-
               # Collect/publish/run bundle analysis
               - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
                   - task: Npm@1
@@ -554,20 +538,6 @@ extends:
                   artifactName: build_output_archive
                   publishLocation: pipeline
 
-                - ${{ if ne(parameters.taskPack, false) }}:
-                    - output: pipelineArtifact
-                      displayName: Publish Artifact - pack
-                      targetPath: $(Build.ArtifactStagingDirectory)/pack
-                      artifactName: pack
-                      publishLocation: pipeline
-
-                    - output: pipelineArtifact
-                      displayName: Publish Artifact - Test Files
-                      targetPath: $(Build.ArtifactStagingDirectory)/test-files
-                      artifactName: test-files
-                      publishLocation: pipeline
-                      sbomEnabled: false
-
                 - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
                     - output: pipelineArtifact
                       displayName: Publish Artifacts - bundle-analysis
@@ -584,6 +554,87 @@ extends:
                       artifactName: _api-extractor-temp
                       sbomEnabled: false
                       publishLocation: pipeline
+
+          - ${{ if ne(parameters.taskPack, false) }}:
+            - job: pack
+              displayName: Pack
+              dependsOn: build
+              variables:
+                - name: COMMIT_SHA
+                  value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                - name: ONEES_ENFORCED_CODEQL_ENABLED
+                  value: 'false'
+              steps:
+                # Setup (same pattern as test jobs)
+                - checkout: self
+                  path: $(FluidFrameworkDirectory)
+                  clean: true
+                  lfs: '${{ parameters.checkoutSubmodules }}'
+                  submodules: '${{ parameters.checkoutSubmodules }}'
+
+                - script: |
+                    echo "commit: $(COMMIT_SHA)"
+                    git fetch origin $(COMMIT_SHA)
+                    git checkout $(COMMIT_SHA)
+                  displayName: "Checkout build commit"
+
+                - template: /tools/pipelines/templates/include-use-node-version.yml@self
+
+                - template: /tools/pipelines/templates/include-install.yml@self
+                  parameters:
+                    packageManager: '${{ parameters.packageManager }}'
+                    buildDirectory: '${{ parameters.buildDirectory }}'
+                    packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
+
+                # Re-run Set Package Version so package.json has correct versions for packing
+                - ${{ if eq(parameters.taskPublishBundleSizeArtifacts, false) }}:
+                    - template: /tools/pipelines/templates/include-set-package-version.yml@self
+                      parameters:
+                        buildDirectory: '${{ parameters.buildDirectory }}'
+                        buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+                        buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
+                        tagName: '${{ parameters.tagName }}'
+                        interdependencyRange: '${{ parameters.interdependencyRange }}'
+                        packageTypesOverride: '${{ parameters.packageTypesOverride }}'
+
+                # Download and extract build outputs (compiled JS, .d.ts, etc.)
+                - task: DownloadPipelineArtifact@2
+                  inputs:
+                    artifact: build_output_archive
+                    targetPath: $(Build.StagingDirectory)
+
+                - script: |
+                    echo "Extracting build output archive contents..."
+                    tar --extract --gzip --file $(Build.StagingDirectory)/build_output_archive.tar.gz --directory $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+                  displayName: Extract Build Output Contents
+
+                # Pack
+                - task: Bash@3
+                  displayName: npm pack
+                  env:
+                    PACKAGE_MANAGER: '${{ parameters.packageManager }}'
+                    RELEASE_GROUP: '${{ parameters.tagName }}'
+                    STAGING_PATH: $(Build.ArtifactStagingDirectory)
+                  inputs:
+                    targetType: filePath
+                    workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                    filePath: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/scripts/pack-packages.sh
+
+              templateContext:
+                outputParentDirectory: $(Build.ArtifactStagingDirectory)
+                outputs:
+                  - output: pipelineArtifact
+                    displayName: Publish Artifact - pack
+                    targetPath: $(Build.ArtifactStagingDirectory)/pack
+                    artifactName: pack
+                    publishLocation: pipeline
+
+                  - output: pipelineArtifact
+                    displayName: Publish Artifact - Test Files
+                    targetPath: $(Build.ArtifactStagingDirectory)/test-files
+                    artifactName: test-files
+                    publishLocation: pipeline
+                    sbomEnabled: false
 
           - job: Coverage_tests
             displayName: "Coverage tests"


### PR DESCRIPTION
## Summary

- Moves `npm pack` (~1.4 min) from the `build` job into its own `pack` job that runs in parallel with test jobs
- Tests no longer wait for npm pack to finish before starting, reducing pipeline wall-clock time by ~1.4 min
- The pack job re-runs "Set Package Version" because the build_output_archive only contains untracked build outputs (lib/, dist/, .d.ts), not version-bumped package.json files

## How it works

**Before:**
```
build: checkout → install → set-version → ci:build → archive → npm pack (1.4m) → bundle-analysis → docs → publish artifacts
                                                                    ↑ tests wait for entire build job
```

**After:**
```
build: checkout → install → set-version → ci:build → archive → bundle-analysis → docs → publish artifacts
                                                        ↓ (tests start ~1.4m earlier)
pack (parallel with tests):                             ↓
  checkout → install → set-version → download archive → extract → npm pack → publish pack + test-files artifacts
```

Publish stages depend on the build **stage** (not job), so they automatically wait for all jobs including the new pack job. No changes needed to publish dependencies.

## Test plan

- [ ] CI pipeline runs successfully on this branch
- [ ] 3+ parallel jobs appear after build completes: pack + Coverage_tests + Test_* running concurrently
- [ ] `pack` and `test-files` artifacts are published successfully by the pack job
- [ ] Build job duration is ~1.4 min shorter than before
- [ ] Overall pipeline wall-clock time is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)