### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@ StylesPath = .vale
 
 MinAlertLevel = suggestion
 
-Packages = Microsoft, MDX, proselint, NoAnimalViolence
+Packages = Microsoft, MDX, proselint, https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
 
 Vocab = fluid
 
@@ -13,8 +13,6 @@ Microsoft.We = NO
 BasedOnStyles = Vale, Microsoft, proselint, NoAnimalViolence
 
 ; Note that only errors will be reported in GitHub PR comments.
-; This seems to be a limitation of the GitHub Action.
-; When running locally, all levels will be reported.
 Microsoft.Contractions = NO
 Microsoft.Passive = NO
 Microsoft.Terms = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@ StylesPath = .vale
 
 MinAlertLevel = suggestion
 
-Packages = Microsoft, MDX, proselint
+Packages = Microsoft, MDX, proselint, NoAnimalViolence
 
 Vocab = fluid
 
@@ -10,7 +10,7 @@ Vocab = fluid
 Microsoft.We = NO
 
 [*.{md}]
-BasedOnStyles = Vale, Microsoft, proselint
+BasedOnStyles = Vale, Microsoft, proselint, NoAnimalViolence
 
 ; Note that only errors will be reported in GitHub PR comments.
 ; This seems to be a limitation of the GitHub Action.


### PR DESCRIPTION
## Summary

Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale configuration.

FluidFramework already uses `Microsoft` and `proselint` for documentation quality. The `NoAnimalViolence` package extends this by flagging phrases that normalize violence toward animals and suggesting clearer, more precise technical alternatives:

| Phrase | Suggested alternative |
|--------|----------------------|
| "kill two birds with one stone" | "accomplish two things at once" |
| "cattle vs. pets" | "ephemeral vs. persistent" |
| "canary deployment" | "progressive rollout" |
| "monkey patch" | "runtime patch" |
| "guinea pig" | "test subject" |
| "dead cat bounce" | "temporary rebound" |
| "scapegoat" | "blame target" |

These appear in distributed systems and framework documentation. The alternatives are shorter and more universally clear, especially for non-native English speakers.

**Package source**: https://github.com/Open-Paws/vale-no-animal-violence

## Changes

- `.vale.ini`: add `NoAnimalViolence` to `Packages` and `BasedOnStyles`