### PR TITLE
improvement(client-presence): consumable aliases for state factory return types

### DIFF
--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -179,6 +179,9 @@ export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = P
 }
 
 // @beta @sealed
+export type LatestConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+
+// @beta @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
@@ -196,8 +199,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, Key>;
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, Key>;
 }
 
 // @beta @sealed
@@ -232,6 +235,9 @@ export interface LatestMapClientData<T, Keys extends string, TValueAccessor exte
 }
 
 // @beta @sealed
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+
+// @beta @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -252,8 +258,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKey>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
 }
 
 // @beta @sealed
@@ -272,6 +278,9 @@ export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAcces
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
 // @beta @sealed
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+
+// @beta @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
 // @beta @sealed
@@ -282,6 +291,9 @@ export interface LatestMetadata {
 
 // @beta @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
+
+// @beta @sealed
+export type LatestRawConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
 // @beta @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
@@ -299,10 +311,13 @@ export interface NotificationListenable<TListeners extends InternalPresenceUtili
 }
 
 // @alpha
-export function Notifications<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
+export function Notifications<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): NotificationsConfiguration<T, Key>;
 
 // @alpha
-export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
+export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): NotificationsWithSubscriptionsConfiguration<TSubscriptions, Key>;
+
+// @alpha @sealed
+export type NotificationsConfiguration<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha @sealed
 export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
@@ -322,6 +337,9 @@ export interface NotificationsManagerEvents {
 export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> = {
     [K in keyof InternalPresenceUtilityTypes.NotificationListeners<E>]: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
 };
+
+// @alpha @sealed
+export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
@@ -381,8 +399,8 @@ export interface RawValueAccessor<T> {
 
 // @beta
 export const StateFactory: {
-    latest: LatestFactory_2;
-    latestMap: LatestMapFactory_2;
+    readonly latest: LatestFactory_2;
+    readonly latestMap: LatestMapFactory_2;
 };
 
 // @beta @sealed
@@ -403,7 +421,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -342,17 +342,16 @@ export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTy
 export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
-export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
+export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly notifications: StatesWorkspaceEntries<TSchema>;
     readonly presence: PresenceWithNotifications;
 }
 
 // @alpha
-export interface NotificationsWorkspaceSchema {
-    // (undocumented)
-    [key: string]: InternalPresenceTypes.ManagerFactory<typeof key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
-}
+export type NotificationsWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
+};
 
 // @beta @sealed
 export interface Presence {
@@ -364,7 +363,7 @@ export interface Presence {
     };
     readonly events: Listenable<PresenceEvents>;
     readonly states: {
-        getWorkspace<StatesSchema extends StatesWorkspaceSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+        getWorkspace<StatesSchema extends StatesWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
     };
 }
 
@@ -377,7 +376,7 @@ export interface PresenceEvents {
 export interface PresenceWithNotifications extends Presence {
     // (undocumented)
     readonly notifications: {
-        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
+        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof NotificationsSchema = string & keyof NotificationsSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
     };
 }
 
@@ -420,7 +419,7 @@ export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
-export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
+export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
@@ -428,7 +427,7 @@ export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManager
 }
 
 // @beta @sealed
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
     */
@@ -439,9 +438,9 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @beta
-export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
-}
+export type StatesWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+};
 
 // @beta @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -179,7 +179,7 @@ export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = P
 }
 
 // @beta @sealed
-export type LatestConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
 // @beta @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
@@ -199,8 +199,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, Key>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, Key>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
 // @beta @sealed
@@ -235,7 +235,7 @@ export interface LatestMapClientData<T, Keys extends string, TValueAccessor exte
 }
 
 // @beta @sealed
-export type LatestMapConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
 // @beta @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
@@ -258,8 +258,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKey>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
 // @beta @sealed
@@ -278,7 +278,7 @@ export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAcces
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
 // @beta @sealed
-export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
 // @beta @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
@@ -293,7 +293,7 @@ export interface LatestMetadata {
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
 // @beta @sealed
-export type LatestRawConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
 // @beta @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
@@ -317,7 +317,7 @@ export function Notifications<T extends InternalPresenceUtilityTypes.Notificatio
 export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): NotificationsWithSubscriptionsConfiguration<TSubscriptions, Key>;
 
 // @alpha @sealed
-export type NotificationsConfiguration<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
+export type NotificationsConfiguration<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha @sealed
 export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
@@ -339,7 +339,7 @@ export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTy
 };
 
 // @alpha @sealed
-export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
+export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -342,9 +342,9 @@ export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTy
 export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
-export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+export interface NotificationsWorkspace<TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
-    readonly notifications: StatesWorkspaceEntries<TSchema>;
+    readonly notifications: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
     readonly presence: PresenceWithNotifications;
 }
 
@@ -363,7 +363,7 @@ export interface Presence {
     };
     readonly events: Listenable<PresenceEvents>;
     readonly states: {
-        getWorkspace<StatesSchema extends StatesWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+        getWorkspace<StatesSchema extends Partial<StatesWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema, unknown, SchemaKeys>;
     };
 }
 
@@ -376,7 +376,7 @@ export interface PresenceEvents {
 export interface PresenceWithNotifications extends Presence {
     // (undocumented)
     readonly notifications: {
-        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof NotificationsSchema = string & keyof NotificationsSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
+        getWorkspace<NotificationsSchema extends Partial<NotificationsWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof NotificationsSchema = string & keyof NotificationsSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema, SchemaKeys>;
     };
 }
 
@@ -419,19 +419,19 @@ export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
-export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
-    readonly states: StatesWorkspaceEntries<TSchema>;
+    readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
 // @beta @sealed
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
+export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
     */
-    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @beta

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -150,6 +150,9 @@ export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = P
 }
 
 // @beta @sealed
+export type LatestConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+
+// @beta @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
@@ -167,8 +170,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, Key>;
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, Key>;
 }
 
 // @beta @sealed
@@ -203,6 +206,9 @@ export interface LatestMapClientData<T, Keys extends string, TValueAccessor exte
 }
 
 // @beta @sealed
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+
+// @beta @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -223,8 +229,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKey>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
 }
 
 // @beta @sealed
@@ -243,6 +249,9 @@ export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAcces
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
 // @beta @sealed
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+
+// @beta @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
 // @beta @sealed
@@ -253,6 +262,9 @@ export interface LatestMetadata {
 
 // @beta @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
+
+// @beta @sealed
+export type LatestRawConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
 // @beta @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
@@ -294,8 +306,8 @@ export interface RawValueAccessor<T> {
 
 // @beta
 export const StateFactory: {
-    latest: LatestFactory_2;
-    latestMap: LatestMapFactory_2;
+    readonly latest: LatestFactory_2;
+    readonly latestMap: LatestMapFactory_2;
 };
 
 // @beta @sealed
@@ -316,7 +328,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -279,7 +279,7 @@ export interface Presence {
     };
     readonly events: Listenable<PresenceEvents>;
     readonly states: {
-        getWorkspace<StatesSchema extends StatesWorkspaceSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+        getWorkspace<StatesSchema extends StatesWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
     };
 }
 
@@ -327,7 +327,7 @@ export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
-export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
+export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
@@ -335,7 +335,7 @@ export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManager
 }
 
 // @beta @sealed
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
     */
@@ -346,9 +346,9 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @beta
-export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
-}
+export type StatesWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+};
 
 // @beta @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -150,7 +150,7 @@ export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = P
 }
 
 // @beta @sealed
-export type LatestConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
 // @beta @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
@@ -170,8 +170,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, Key>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, Key>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
 // @beta @sealed
@@ -206,7 +206,7 @@ export interface LatestMapClientData<T, Keys extends string, TValueAccessor exte
 }
 
 // @beta @sealed
-export type LatestMapConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
 // @beta @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
@@ -229,8 +229,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKey>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
 // @beta @sealed
@@ -249,7 +249,7 @@ export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAcces
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
 // @beta @sealed
-export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
 // @beta @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
@@ -264,7 +264,7 @@ export interface LatestMetadata {
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
 // @beta @sealed
-export type LatestRawConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
 // @beta @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -279,7 +279,7 @@ export interface Presence {
     };
     readonly events: Listenable<PresenceEvents>;
     readonly states: {
-        getWorkspace<StatesSchema extends StatesWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+        getWorkspace<StatesSchema extends Partial<StatesWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema, unknown, SchemaKeys>;
     };
 }
 
@@ -327,19 +327,19 @@ export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
-export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
-    readonly states: StatesWorkspaceEntries<TSchema>;
+    readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
 // @beta @sealed
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
+export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
     */
-    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @beta

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -182,6 +182,9 @@ export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = P
 }
 
 // @beta @sealed
+export type LatestConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+
+// @beta @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
@@ -199,8 +202,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, Key>;
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, Key>;
 }
 
 // @beta @sealed
@@ -235,6 +238,9 @@ export interface LatestMapClientData<T, Keys extends string, TValueAccessor exte
 }
 
 // @beta @sealed
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+
+// @beta @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -255,8 +261,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKey>;
+    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
 }
 
 // @beta @sealed
@@ -275,6 +281,9 @@ export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAcces
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
 // @beta @sealed
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+
+// @beta @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
 // @beta @sealed
@@ -285,6 +294,9 @@ export interface LatestMetadata {
 
 // @beta @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
+
+// @beta @sealed
+export type LatestRawConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
 // @beta @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
@@ -302,10 +314,13 @@ export interface NotificationListenable<TListeners extends InternalPresenceUtili
 }
 
 // @alpha
-export function Notifications<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
+export function Notifications<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string = string>(initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>): NotificationsConfiguration<T, Key>;
 
 // @alpha
-export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
+export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): NotificationsWithSubscriptionsConfiguration<TSubscriptions, Key>;
+
+// @alpha @sealed
+export type NotificationsConfiguration<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha @sealed
 export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
@@ -325,6 +340,9 @@ export interface NotificationsManagerEvents {
 export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTypes.NotificationListeners<E>> = {
     [K in keyof InternalPresenceUtilityTypes.NotificationListeners<E>]: (sender: Attendee, ...args: InternalPresenceUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
 };
+
+// @alpha @sealed
+export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
@@ -384,8 +402,8 @@ export interface RawValueAccessor<T> {
 
 // @beta
 export const StateFactory: {
-    latest: LatestFactory_2;
-    latestMap: LatestMapFactory_2;
+    readonly latest: LatestFactory_2;
+    readonly latestMap: LatestMapFactory_2;
 };
 
 // @beta @sealed
@@ -406,7 +424,7 @@ unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
 export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
-    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
     readonly states: StatesWorkspaceEntries<TSchema>;

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -345,17 +345,16 @@ export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTy
 export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
-export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
+export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly notifications: StatesWorkspaceEntries<TSchema>;
     readonly presence: PresenceWithNotifications;
 }
 
 // @alpha
-export interface NotificationsWorkspaceSchema {
-    // (undocumented)
-    [key: string]: InternalPresenceTypes.ManagerFactory<typeof key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
-}
+export type NotificationsWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
+};
 
 // @beta @sealed
 export interface Presence {
@@ -367,7 +366,7 @@ export interface Presence {
     };
     readonly events: Listenable<PresenceEvents>;
     readonly states: {
-        getWorkspace<StatesSchema extends StatesWorkspaceSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+        getWorkspace<StatesSchema extends StatesWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
     };
 }
 
@@ -380,7 +379,7 @@ export interface PresenceEvents {
 export interface PresenceWithNotifications extends Presence {
     // (undocumented)
     readonly notifications: {
-        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
+        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof NotificationsSchema = string & keyof NotificationsSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
     };
 }
 
@@ -423,7 +422,7 @@ export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
-export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManagerConstraints = unknown> {
+export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
@@ -431,7 +430,7 @@ export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManager
 }
 
 // @beta @sealed
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
     */
@@ -442,9 +441,9 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @beta
-export interface StatesWorkspaceSchema {
-    [key: string]: StatesWorkspaceEntry<typeof key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
-}
+export type StatesWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+};
 
 // @beta @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -345,9 +345,9 @@ export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTy
 export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
-export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+export interface NotificationsWorkspace<TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>(key: TKey, manager: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>>;
-    readonly notifications: StatesWorkspaceEntries<TSchema>;
+    readonly notifications: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
     readonly presence: PresenceWithNotifications;
 }
 
@@ -366,7 +366,7 @@ export interface Presence {
     };
     readonly events: Listenable<PresenceEvents>;
     readonly states: {
-        getWorkspace<StatesSchema extends StatesWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema>;
+        getWorkspace<StatesSchema extends Partial<StatesWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema, unknown, SchemaKeys>;
     };
 }
 
@@ -379,7 +379,7 @@ export interface PresenceEvents {
 export interface PresenceWithNotifications extends Presence {
     // (undocumented)
     readonly notifications: {
-        getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema<SchemaKeys>, SchemaKeys extends string & keyof NotificationsSchema = string & keyof NotificationsSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema>;
+        getWorkspace<NotificationsSchema extends Partial<NotificationsWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof NotificationsSchema = string & keyof NotificationsSchema>(notificationsId: WorkspaceAddress, requestedNotifications: NotificationsSchema): NotificationsWorkspace<NotificationsSchema, SchemaKeys>;
     };
 }
 
@@ -422,19 +422,19 @@ export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
 // @beta @sealed
-export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
-    readonly states: StatesWorkspaceEntries<TSchema>;
+    readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
 // @beta @sealed
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema<TSchemaKeys>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
+export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
     */
-    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @beta

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -182,7 +182,7 @@ export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = P
 }
 
 // @beta @sealed
-export type LatestConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
 // @beta @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
@@ -202,8 +202,8 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 
 // @beta @sealed
 export interface LatestFactory {
-    <T extends object | null, Key extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, Key>;
-    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, Key>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
 // @beta @sealed
@@ -238,7 +238,7 @@ export interface LatestMapClientData<T, Keys extends string, TValueAccessor exte
 }
 
 // @beta @sealed
-export type LatestMapConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
 // @beta @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
@@ -261,8 +261,8 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
 
 // @beta @sealed
 export interface LatestMapFactory {
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKey>;
-    <T, Keys extends string = string, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
 // @beta @sealed
@@ -281,7 +281,7 @@ export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAcces
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
 // @beta @sealed
-export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKey extends string> = InternalPresenceTypes.ManagerFactory<RegistrationKey, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
 // @beta @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
@@ -296,7 +296,7 @@ export interface LatestMetadata {
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
 // @beta @sealed
-export type LatestRawConfiguration<T extends object | null, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
 // @beta @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
@@ -320,7 +320,7 @@ export function Notifications<T extends InternalPresenceUtilityTypes.Notificatio
 export function Notifications<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string = string>(initialSubscriptions: Partial<TSubscriptions>): NotificationsWithSubscriptionsConfiguration<TSubscriptions, Key>;
 
 // @alpha @sealed
-export type NotificationsConfiguration<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
+export type NotificationsConfiguration<T extends InternalPresenceUtilityTypes.NotificationListeners<T>, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha @sealed
 export interface NotificationsManager<T extends InternalPresenceUtilityTypes.NotificationListeners<T>> {
@@ -342,7 +342,7 @@ export type NotificationSubscriberSignatures<E extends InternalPresenceUtilityTy
 };
 
 // @alpha @sealed
-export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, Key extends string> = InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
+export type NotificationsWithSubscriptionsConfiguration<TSubscriptions extends InternalPresenceUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>>>;
 
 // @alpha @sealed
 export interface NotificationsWorkspace<TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {

--- a/packages/framework/presence/src/exposedInternalTypes.ts
+++ b/packages/framework/presence/src/exposedInternalTypes.ts
@@ -140,6 +140,11 @@ export namespace InternalTypes {
 	/**
 	 * Package internal function declaration for state and notification instantiation.
 	 *
+	 * @remarks
+	 * Direct use of this type is discouraged. If in need, try to use the type
+	 * returned by the factory functions instead, as those are more specific and
+	 * stable.
+	 *
 	 * @system
 	 */
 	export type ManagerFactory<

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -50,11 +50,13 @@ export type {
 	LatestMapArguments,
 	LatestMapArgumentsRaw,
 	LatestMapClientData,
+	LatestMapConfiguration,
 	LatestMapEvents,
 	LatestMapFactory,
 	LatestMapItemRemovedClientData,
 	LatestMapItemUpdatedClientData,
 	LatestMapRaw,
+	LatestMapRawConfiguration,
 	LatestMapRawEvents,
 	StateMap,
 } from "./latestMapTypes.js";
@@ -62,9 +64,11 @@ export type {
 	Latest,
 	LatestArguments,
 	LatestArgumentsRaw,
+	LatestConfiguration,
 	LatestEvents,
 	LatestFactory,
 	LatestRaw,
+	LatestRawConfiguration,
 	LatestRawEvents,
 } from "./latestTypes.js";
 export type {
@@ -82,9 +86,11 @@ export { Notifications } from "./notificationsManager.js";
 export type {
 	NotificationEmitter,
 	NotificationListenable,
+	NotificationsConfiguration,
 	NotificationSubscriberSignatures,
 	NotificationsManager,
 	NotificationsManagerEvents,
+	NotificationsWithSubscriptionsConfiguration,
 } from "./notificationsManagerTypes.js";
 
 export { StateFactory } from "./stateFactory.js";

--- a/packages/framework/presence/src/latestMapTypes.ts
+++ b/packages/framework/presence/src/latestMapTypes.ts
@@ -378,6 +378,48 @@ export interface LatestMapArguments<T, Keys extends string = string>
 // Overloads should be ordered from most specific to least specific when combined.
 
 /**
+ * Type alias for the return type of {@link LatestMapFactory} when called with
+ * {@link LatestMapArguments}.
+ *
+ * @remarks
+ * Use this type instead of any InternalPresenceTypes that may be revealed from
+ * examining factory return type.
+ *
+ * @beta
+ * @sealed
+ */
+export type LatestMapConfiguration<
+	T,
+	Keys extends string,
+	RegistrationKey extends string,
+> = InternalTypes.ManagerFactory<
+	RegistrationKey,
+	InternalTypes.MapValueState<T, Keys>,
+	LatestMap<T, Keys>
+>;
+
+/**
+ * Type alias for the return type of {@link LatestMapFactory} when called with
+ * {@link LatestMapArgumentsRaw}.
+ *
+ * @remarks
+ * Use this type instead of any InternalPresenceTypes that may be revealed from
+ * examining factory return type.
+ *
+ * @beta
+ * @sealed
+ */
+export type LatestMapRawConfiguration<
+	T,
+	Keys extends string,
+	RegistrationKey extends string,
+> = InternalTypes.ManagerFactory<
+	RegistrationKey,
+	InternalTypes.MapValueState<T, Keys>,
+	LatestMapRaw<T, Keys>
+>;
+
+/**
  * Factory for creating a {@link LatestMap} or {@link LatestMapRaw} State object.
  *
  * @beta
@@ -393,11 +435,7 @@ export interface LatestMapFactory {
 	 */
 	<T, Keys extends string = string, RegistrationKey extends string = string>(
 		args: LatestMapArguments<T, Keys>,
-	): InternalTypes.ManagerFactory<
-		RegistrationKey,
-		InternalTypes.MapValueState<T, Keys>,
-		LatestMap<T, Keys>
-	>;
+	): LatestMapConfiguration<T, Keys, RegistrationKey>;
 
 	/**
 	 * Factory for creating a {@link LatestMapRaw} State object.
@@ -408,11 +446,7 @@ export interface LatestMapFactory {
 	 */
 	<T, Keys extends string = string, RegistrationKey extends string = string>(
 		args?: LatestMapArgumentsRaw<T, Keys>,
-	): InternalTypes.ManagerFactory<
-		RegistrationKey,
-		InternalTypes.MapValueState<T, Keys>,
-		LatestMapRaw<T, Keys>
-	>;
+	): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
 }
 
 // #endregion

--- a/packages/framework/presence/src/latestMapTypes.ts
+++ b/packages/framework/presence/src/latestMapTypes.ts
@@ -374,9 +374,6 @@ export interface LatestMapArguments<T, Keys extends string = string>
 	keyValidator?: KeySchemaValidator<Keys>;
 }
 
-// #region factory function overloads
-// Overloads should be ordered from most specific to least specific when combined.
-
 /**
  * Type alias for the return type of {@link LatestMapFactory} when called with
  * {@link LatestMapArguments}.
@@ -385,15 +382,20 @@ export interface LatestMapArguments<T, Keys extends string = string>
  * Use this type instead of any InternalPresenceTypes that may be revealed from
  * examining factory return type.
  *
+ * @typeparam RegistrationKeyRestrictions - Optional type parameter to constrain
+ * allowed registration keys for this State object within a workspace.
+ * Specification is recommended to highlight connection between schema and
+ * factory when spread across modules.
+ *
  * @beta
  * @sealed
  */
 export type LatestMapConfiguration<
 	T,
 	Keys extends string,
-	RegistrationKey extends string,
+	RegistrationKeyRestrictions extends string = string,
 > = InternalTypes.ManagerFactory<
-	RegistrationKey,
+	RegistrationKeyRestrictions,
 	InternalTypes.MapValueState<T, Keys>,
 	LatestMap<T, Keys>
 >;
@@ -406,15 +408,20 @@ export type LatestMapConfiguration<
  * Use this type instead of any InternalPresenceTypes that may be revealed from
  * examining factory return type.
  *
+ * @typeparam RegistrationKeyRestrictions - Optional type parameter to constrain
+ * allowed registration keys for this State object within a workspace.
+ * Specification is recommended to highlight connection between schema and
+ * factory when spread across modules.
+ *
  * @beta
  * @sealed
  */
 export type LatestMapRawConfiguration<
 	T,
 	Keys extends string,
-	RegistrationKey extends string,
+	RegistrationKeyRestrictions extends string = string,
 > = InternalTypes.ManagerFactory<
-	RegistrationKey,
+	RegistrationKeyRestrictions,
 	InternalTypes.MapValueState<T, Keys>,
 	LatestMapRaw<T, Keys>
 >;
@@ -433,9 +440,9 @@ export interface LatestMapFactory {
 	 * This overload is used when called with {@link LatestMapArguments}.
 	 * That is, if a validator function is provided.
 	 */
-	<T, Keys extends string = string, RegistrationKey extends string = string>(
+	<T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(
 		args: LatestMapArguments<T, Keys>,
-	): LatestMapConfiguration<T, Keys, RegistrationKey>;
+	): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
 
 	/**
 	 * Factory for creating a {@link LatestMapRaw} State object.
@@ -444,9 +451,7 @@ export interface LatestMapFactory {
 	 * This overload is used when called with {@link LatestMapArgumentsRaw}.
 	 * That is, if a validator function is _not_ provided.
 	 */
-	<T, Keys extends string = string, RegistrationKey extends string = string>(
+	<T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(
 		args?: LatestMapArgumentsRaw<T, Keys>,
-	): LatestMapRawConfiguration<T, Keys, RegistrationKey>;
+	): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
-
-// #endregion

--- a/packages/framework/presence/src/latestTypes.ts
+++ b/packages/framework/presence/src/latestTypes.ts
@@ -155,6 +155,40 @@ export interface LatestArguments<T extends object | null> extends LatestArgument
 }
 
 /**
+ * Type alias for the return type of {@link LatestFactory} when called with
+ * {@link LatestArguments}.
+ *
+ * @remarks
+ * Use this type instead of any InternalPresenceTypes that may be revealed from
+ * examining factory return type.
+ *
+ * @beta
+ * @sealed
+ */
+export type LatestConfiguration<
+	// eslint-disable-next-line @rushstack/no-new-null -- undefined is not a valid replacement for null
+	T extends object | null,
+	Key extends string,
+> = InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
+
+/**
+ * Type alias for the return type of {@link LatestFactory} when called with
+ * {@link LatestArgumentsRaw}.
+ *
+ * @remarks
+ * Use this type instead of any InternalPresenceTypes that may be revealed from
+ * examining factory return type.
+ *
+ * @beta
+ * @sealed
+ */
+export type LatestRawConfiguration<
+	// eslint-disable-next-line @rushstack/no-new-null -- undefined is not a valid replacement for null
+	T extends object | null,
+	Key extends string,
+> = InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+
+/**
  * Factory for creating a {@link Latest} or {@link LatestRaw} State object.
  *
  * @beta
@@ -170,7 +204,7 @@ export interface LatestFactory {
 	 */
 	<T extends object | null, Key extends string = string>(
 		args: LatestArguments<T>,
-	): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
+	): LatestConfiguration<T, Key>;
 
 	/**
 	 * Factory for creating a {@link LatestRaw} State object.
@@ -181,5 +215,5 @@ export interface LatestFactory {
 	 */
 	<T extends object | null, Key extends string = string>(
 		args: LatestArgumentsRaw<T>,
-	): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+	): LatestRawConfiguration<T, Key>;
 }

--- a/packages/framework/presence/src/latestTypes.ts
+++ b/packages/framework/presence/src/latestTypes.ts
@@ -162,14 +162,23 @@ export interface LatestArguments<T extends object | null> extends LatestArgument
  * Use this type instead of any InternalPresenceTypes that may be revealed from
  * examining factory return type.
  *
+ * @typeparam RegistrationKeyRestrictions - Optional type parameter to constrain
+ * allowed registration keys for this State object within a workspace.
+ * Specification is recommended to highlight connection between schema and
+ * factory when spread across modules.
+ *
  * @beta
  * @sealed
  */
 export type LatestConfiguration<
 	// eslint-disable-next-line @rushstack/no-new-null -- undefined is not a valid replacement for null
 	T extends object | null,
-	Key extends string,
-> = InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
+	RegistrationKeyRestrictions extends string = string,
+> = InternalTypes.ManagerFactory<
+	RegistrationKeyRestrictions,
+	InternalTypes.ValueRequiredState<T>,
+	Latest<T>
+>;
 
 /**
  * Type alias for the return type of {@link LatestFactory} when called with
@@ -179,14 +188,23 @@ export type LatestConfiguration<
  * Use this type instead of any InternalPresenceTypes that may be revealed from
  * examining factory return type.
  *
+ * @typeparam RegistrationKeyRestrictions - Optional type parameter to constrain
+ * allowed registration keys for this State object within a workspace.
+ * Specification is recommended to highlight connection between schema and
+ * factory when spread across modules.
+ *
  * @beta
  * @sealed
  */
 export type LatestRawConfiguration<
 	// eslint-disable-next-line @rushstack/no-new-null -- undefined is not a valid replacement for null
 	T extends object | null,
-	Key extends string,
-> = InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+	RegistrationKeyRestrictions extends string = string,
+> = InternalTypes.ManagerFactory<
+	RegistrationKeyRestrictions,
+	InternalTypes.ValueRequiredState<T>,
+	LatestRaw<T>
+>;
 
 /**
  * Factory for creating a {@link Latest} or {@link LatestRaw} State object.
@@ -202,9 +220,9 @@ export interface LatestFactory {
 	 * This overload is used when called with {@link LatestArguments}.
 	 * That is, if a validator function is provided.
 	 */
-	<T extends object | null, Key extends string = string>(
+	<T extends object | null, RegistrationKeyRestrictions extends string = string>(
 		args: LatestArguments<T>,
-	): LatestConfiguration<T, Key>;
+	): LatestConfiguration<T, RegistrationKeyRestrictions>;
 
 	/**
 	 * Factory for creating a {@link LatestRaw} State object.
@@ -213,7 +231,7 @@ export interface LatestFactory {
 	 * This overload is used when called with {@link LatestArgumentsRaw}.
 	 * That is, if a validator function is _not_ provided.
 	 */
-	<T extends object | null, Key extends string = string>(
+	<T extends object | null, RegistrationKeyRestrictions extends string = string>(
 		args: LatestArgumentsRaw<T>,
-	): LatestRawConfiguration<T, Key>;
+	): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }

--- a/packages/framework/presence/src/notificationsManager.ts
+++ b/packages/framework/presence/src/notificationsManager.ts
@@ -13,9 +13,11 @@ import { revealOpaqueJson, toOpaqueJson } from "./internalUtils.js";
 import type {
 	NotificationEmitter,
 	NotificationListenable,
+	NotificationsConfiguration,
 	NotificationsManager,
 	NotificationsManagerEvents,
 	NotificationSubscriberSignatures,
+	NotificationsWithSubscriptionsConfiguration,
 } from "./notificationsManagerTypes.js";
 import type { Attendee, PresenceWithNotifications as Presence } from "./presence.js";
 import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
@@ -146,11 +148,7 @@ export function Notifications<
 	Key extends string = string,
 >(
 	initialSubscriptions: Partial<NotificationSubscriberSignatures<T>>,
-): InternalTypes.ManagerFactory<
-	Key,
-	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
-	NotificationsManager<T>
->;
+): NotificationsConfiguration<T, Key>;
 /**
  * Factory for creating a {@link NotificationsManager}.
  *
@@ -166,13 +164,7 @@ export function Notifications<
 	Key extends string = string,
 >(
 	initialSubscriptions: Partial<TSubscriptions>,
-): InternalTypes.ManagerFactory<
-	Key,
-	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
-	NotificationsManager<
-		InternalUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>
-	>
->;
+): NotificationsWithSubscriptionsConfiguration<TSubscriptions, Key>;
 
 /**
  * Factory for creating a {@link NotificationsManager}.

--- a/packages/framework/presence/src/notificationsManagerTypes.ts
+++ b/packages/framework/presence/src/notificationsManagerTypes.ts
@@ -5,6 +5,7 @@
 
 import type { Listenable, Off } from "@fluidframework/core-interfaces";
 
+import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { InternalUtilityTypes } from "./exposedUtilityTypes.js";
 import type { Attendee, PresenceWithNotifications as Presence } from "./presence.js";
 
@@ -148,3 +149,44 @@ export interface NotificationsManager<
 	 */
 	readonly notifications: NotificationListenable<T>;
 }
+
+/**
+ * Type alias for the return type of {@link (Notifications:1)}.
+ *
+ * @remarks
+ * Use this type instead of any InternalPresenceTypes that may be revealed from
+ * examining factory return type.
+ *
+ * @alpha
+ * @sealed
+ */
+export type NotificationsConfiguration<
+	T extends InternalUtilityTypes.NotificationListeners<T>,
+	Key extends string,
+> = InternalTypes.ManagerFactory<
+	Key,
+	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
+	NotificationsManager<T>
+>;
+
+/**
+ * Type alias for the return type of {@link (Notifications:2)}.
+ *
+ * @remarks
+ * Use this type instead of any InternalPresenceTypes that may be revealed from
+ * examining factory return type.
+ *
+ * @alpha
+ * @sealed
+ */
+export type NotificationsWithSubscriptionsConfiguration<
+	TSubscriptions extends
+		InternalUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>,
+	Key extends string,
+> = InternalTypes.ManagerFactory<
+	Key,
+	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
+	NotificationsManager<
+		InternalUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>
+	>
+>;

--- a/packages/framework/presence/src/notificationsManagerTypes.ts
+++ b/packages/framework/presence/src/notificationsManagerTypes.ts
@@ -157,14 +157,19 @@ export interface NotificationsManager<
  * Use this type instead of any InternalPresenceTypes that may be revealed from
  * examining factory return type.
  *
+ * @typeparam RegistrationKeyRestrictions - Optional type parameter to constrain
+ * allowed registration keys for this Notification within a workspace.
+ * Specification is recommended to highlight connection between schema and
+ * factory when spread across modules.
+ *
  * @alpha
  * @sealed
  */
 export type NotificationsConfiguration<
 	T extends InternalUtilityTypes.NotificationListeners<T>,
-	Key extends string,
+	RegistrationKeyRestrictions extends string = string,
 > = InternalTypes.ManagerFactory<
-	Key,
+	RegistrationKeyRestrictions,
 	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
 	NotificationsManager<T>
 >;
@@ -176,15 +181,20 @@ export type NotificationsConfiguration<
  * Use this type instead of any InternalPresenceTypes that may be revealed from
  * examining factory return type.
  *
+ * @typeparam RegistrationKeyRestrictions - Optional type parameter to constrain
+ * allowed registration keys for this Notification within a workspace.
+ * Specification is recommended to highlight connection between schema and
+ * factory when spread across modules.
+ *
  * @alpha
  * @sealed
  */
 export type NotificationsWithSubscriptionsConfiguration<
 	TSubscriptions extends
 		InternalUtilityTypes.NotificationListenersWithSubscriberSignatures<TSubscriptions>,
-	Key extends string,
+	RegistrationKeyRestrictions extends string = string,
 > = InternalTypes.ManagerFactory<
-	Key,
+	RegistrationKeyRestrictions,
 	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
 	NotificationsManager<
 		InternalUtilityTypes.NotificationListenersFromSubscriberSignatures<TSubscriptions>

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -226,7 +226,10 @@ export interface Presence {
 		 * @param controls - Optional settings for default broadcast controls
 		 * @returns A {@link StatesWorkspace}
 		 */
-		getWorkspace<StatesSchema extends StatesWorkspaceSchema>(
+		getWorkspace<
+			StatesSchema extends StatesWorkspaceSchema<SchemaKeys>,
+			SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema,
+		>(
 			workspaceAddress: WorkspaceAddress,
 			requestedStates: StatesSchema,
 			controls?: BroadcastControlSettings,
@@ -255,7 +258,11 @@ export interface PresenceWithNotifications extends Presence {
 		 * @param requestedNotifications - Requested notifications for the workspace
 		 * @returns A Notifications workspace
 		 */
-		getWorkspace<NotificationsSchema extends NotificationsWorkspaceSchema>(
+		getWorkspace<
+			NotificationsSchema extends NotificationsWorkspaceSchema<SchemaKeys>,
+			SchemaKeys extends string & keyof NotificationsSchema = string &
+				keyof NotificationsSchema,
+		>(
 			notificationsId: WorkspaceAddress,
 			requestedNotifications: NotificationsSchema,
 		): NotificationsWorkspace<NotificationsSchema>;

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -227,13 +227,13 @@ export interface Presence {
 		 * @returns A {@link StatesWorkspace}
 		 */
 		getWorkspace<
-			StatesSchema extends StatesWorkspaceSchema<SchemaKeys>,
+			StatesSchema extends Partial<StatesWorkspaceSchema<SchemaKeys>>,
 			SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema,
 		>(
 			workspaceAddress: WorkspaceAddress,
 			requestedStates: StatesSchema,
 			controls?: BroadcastControlSettings,
-		): StatesWorkspace<StatesSchema>;
+		): StatesWorkspace<StatesSchema, unknown, SchemaKeys>;
 	};
 }
 
@@ -259,12 +259,12 @@ export interface PresenceWithNotifications extends Presence {
 		 * @returns A Notifications workspace
 		 */
 		getWorkspace<
-			NotificationsSchema extends NotificationsWorkspaceSchema<SchemaKeys>,
+			NotificationsSchema extends Partial<NotificationsWorkspaceSchema<SchemaKeys>>,
 			SchemaKeys extends string & keyof NotificationsSchema = string &
 				keyof NotificationsSchema,
 		>(
 			notificationsId: WorkspaceAddress,
 			requestedNotifications: NotificationsSchema,
-		): NotificationsWorkspace<NotificationsSchema>;
+		): NotificationsWorkspace<NotificationsSchema, SchemaKeys>;
 	};
 }

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -112,12 +112,18 @@ export interface PresenceDatastoreManager {
 		alternateProvider: ClientConnectionId | undefined,
 	): void;
 	onDisconnected(): void;
-	getWorkspace<TSchema extends StatesWorkspaceSchema>(
+	getWorkspace<
+		TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+		TSchemaKeys extends string & keyof TSchema,
+	>(
 		internalWorkspaceAddress: `s:${WorkspaceAddress}`,
 		requestedContent: TSchema,
 		controls?: BroadcastControlSettings,
 	): StatesWorkspace<TSchema>;
-	getWorkspace<TSchema extends NotificationsWorkspaceSchema>(
+	getWorkspace<
+		TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>,
+		TSchemaKeys extends string & keyof TSchema,
+	>(
 		internalWorkspaceAddress: `n:${WorkspaceAddress}`,
 		requestedContent: TSchema,
 	): NotificationsWorkspace<TSchema>;

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -113,20 +113,20 @@ export interface PresenceDatastoreManager {
 	): void;
 	onDisconnected(): void;
 	getWorkspace<
-		TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+		TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>,
 		TSchemaKeys extends string & keyof TSchema,
 	>(
 		internalWorkspaceAddress: `s:${WorkspaceAddress}`,
 		requestedContent: TSchema,
 		controls?: BroadcastControlSettings,
-	): StatesWorkspace<TSchema>;
+	): StatesWorkspace<TSchema, unknown, TSchemaKeys>;
 	getWorkspace<
-		TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>,
+		TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>,
 		TSchemaKeys extends string & keyof TSchema,
 	>(
 		internalWorkspaceAddress: `n:${WorkspaceAddress}`,
 		requestedContent: TSchema,
-	): NotificationsWorkspace<TSchema>;
+	): NotificationsWorkspace<TSchema, TSchemaKeys>;
 	processSignal(
 		message: InboundExtensionMessage<SignalMessages> & { clientId: ClientConnectionId },
 		local: boolean,

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -71,7 +71,10 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 	public readonly attendees: Presence["attendees"];
 
 	public readonly states = {
-		getWorkspace: <TSchema extends StatesWorkspaceSchema>(
+		getWorkspace: <
+			TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+			TSchemaKeys extends string & keyof TSchema,
+		>(
 			workspaceAddress: WorkspaceAddress,
 			requestedContent: TSchema,
 			settings?: BroadcastControlSettings,
@@ -79,7 +82,10 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 			this.datastoreManager.getWorkspace(`s:${workspaceAddress}`, requestedContent, settings),
 	};
 	public readonly notifications = {
-		getWorkspace: <TSchema extends NotificationsWorkspaceSchema>(
+		getWorkspace: <
+			TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>,
+			TSchemaKeys extends string & keyof TSchema,
+		>(
 			workspaceAddress: WorkspaceAddress,
 			requestedContent: TSchema,
 		): NotificationsWorkspace<TSchema> =>

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -72,23 +72,23 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 
 	public readonly states = {
 		getWorkspace: <
-			TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+			TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>,
 			TSchemaKeys extends string & keyof TSchema,
 		>(
 			workspaceAddress: WorkspaceAddress,
 			requestedContent: TSchema,
 			settings?: BroadcastControlSettings,
-		): StatesWorkspace<TSchema> =>
+		): StatesWorkspace<TSchema, unknown, TSchemaKeys> =>
 			this.datastoreManager.getWorkspace(`s:${workspaceAddress}`, requestedContent, settings),
 	};
 	public readonly notifications = {
 		getWorkspace: <
-			TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>,
+			TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>,
 			TSchemaKeys extends string & keyof TSchema,
 		>(
 			workspaceAddress: WorkspaceAddress,
 			requestedContent: TSchema,
-		): NotificationsWorkspace<TSchema> =>
+		): NotificationsWorkspace<TSchema, TSchemaKeys> =>
 			this.datastoreManager.getWorkspace(`n:${workspaceAddress}`, requestedContent),
 	};
 

--- a/packages/framework/presence/src/stateFactory.ts
+++ b/packages/framework/presence/src/stateFactory.ts
@@ -29,4 +29,4 @@ import { latest } from "./latestValueManager.js";
 export const StateFactory = {
 	latest,
 	latestMap,
-};
+} as const;

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -178,8 +178,6 @@ export function checkCompiles(): void {
 		count0: latestCountAnyKeyConfiguration,
 		count1: latestCountAnyKeyConfiguration,
 		myCount: latestCountSpecificKeyConfiguration,
-		// // @ts-expect-error - df
-		// otherCount: latestCountSpecificKeyConfiguration,
 	});
 	// Workaround ts(2775): Assertions require every name in the call target to be declared with an explicit type annotation.
 	const workspace: typeof statesWorkspace = statesWorkspace;

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -47,15 +47,12 @@ export type StatesWorkspaceEntry<
  *
  * @beta
  */
-export interface StatesWorkspaceSchema {
+export type StatesWorkspaceSchema<Keys extends string = string> = {
 	/**
 	 * Key-value pairs of State objects registered with the {@link StatesWorkspace}.
 	 */
-	[key: string]: StatesWorkspaceEntry<
-		typeof key,
-		InternalTypes.ValueDirectoryOrState<unknown>
-	>;
-}
+	[Key in Keys]: StatesWorkspaceEntry<Key, InternalTypes.ValueDirectoryOrState<unknown>>;
+};
 
 /**
  * Map of State objects registered with {@link StatesWorkspace}.
@@ -63,7 +60,10 @@ export interface StatesWorkspaceSchema {
  * @sealed
  * @beta
  */
-export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
+export type StatesWorkspaceEntries<
+	TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+	TSchemaKeys extends string & keyof TSchema = string & keyof TSchema,
+> = {
 	/**
 	 * Registered State objects.
 	 */
@@ -85,8 +85,9 @@ export type StatesWorkspaceEntries<TSchema extends StatesWorkspaceSchema> = {
  * @beta
  */
 export interface StatesWorkspace<
-	TSchema extends StatesWorkspaceSchema,
+	TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
 	TManagerConstraints = unknown,
+	TSchemaKeys extends string & keyof TSchema = string & keyof TSchema,
 > {
 	/**
 	 * Registers a new State object with the {@link StatesWorkspace}.
@@ -133,13 +134,13 @@ export interface StatesWorkspace<
  *
  * @alpha
  */
-export interface NotificationsWorkspaceSchema {
-	[key: string]: InternalTypes.ManagerFactory<
-		typeof key,
+export type NotificationsWorkspaceSchema<Keys extends string = string> = {
+	[Key in Keys]: InternalTypes.ManagerFactory<
+		Key,
 		InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
 		NotificationsManager<InternalUtilityTypes.NotificationListeners<unknown>>
 	>;
-}
+};
 
 /**
  * `NotificationsWorkspace` maintains a registry of {@link NotificationsManager}s
@@ -154,7 +155,10 @@ export interface NotificationsWorkspaceSchema {
  * @sealed
  * @alpha
  */
-export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
+export interface NotificationsWorkspace<
+	TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>,
+	TSchemaKeys extends string & keyof TSchema = string & keyof TSchema,
+> {
 	/**
 	 * Registers a new `NotificationsManager` with the {@link NotificationsWorkspace}.
 	 * @param key - new unique key for the `NotificationsManager` within the workspace

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -91,7 +91,8 @@ export interface StatesWorkspace<
 	/**
 	 * Registers a new State object with the {@link StatesWorkspace}.
 	 * @param key - new unique key for the State object within the workspace
-	 * @param manager - factory for creating a State object
+	 * @param configuration - factory/settings for creating a State object. Use
+	 * {@link StateFactory} to create.
 	 */
 	add<
 		TKey extends string,
@@ -99,7 +100,7 @@ export interface StatesWorkspace<
 		TManager extends TManagerConstraints,
 	>(
 		key: TKey,
-		manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>,
+		configuration: InternalTypes.ManagerFactory<TKey, TValue, TManager>,
 	): asserts this is StatesWorkspace<
 		TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>,
 		TManagerConstraints

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -61,14 +61,14 @@ export type StatesWorkspaceSchema<Keys extends string = string> = {
  * @beta
  */
 export type StatesWorkspaceEntries<
-	TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+	TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>,
 	TSchemaKeys extends string & keyof TSchema = string & keyof TSchema,
 > = {
 	/**
 	 * Registered State objects.
 	 */
 	readonly [Key in keyof TSchema]: ReturnType<
-		TSchema[Key]
+		Exclude<TSchema[Key], undefined>
 	>["manager"] extends InternalTypes.StateValue<infer TManager>
 		? TManager
 		: never;
@@ -85,7 +85,7 @@ export type StatesWorkspaceEntries<
  * @beta
  */
 export interface StatesWorkspace<
-	TSchema extends StatesWorkspaceSchema<TSchemaKeys>,
+	TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>,
 	TManagerConstraints = unknown,
 	TSchemaKeys extends string & keyof TSchema = string & keyof TSchema,
 > {
@@ -110,7 +110,7 @@ export interface StatesWorkspace<
 	/**
 	 * Registry of State objects.
 	 */
-	readonly states: StatesWorkspaceEntries<TSchema>;
+	readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 
 	/**
 	 * Default controls for management of broadcast updates.
@@ -156,7 +156,7 @@ export type NotificationsWorkspaceSchema<Keys extends string = string> = {
  * @alpha
  */
 export interface NotificationsWorkspace<
-	TSchema extends NotificationsWorkspaceSchema<TSchemaKeys>,
+	TSchema extends Partial<NotificationsWorkspaceSchema<TSchemaKeys>>,
 	TSchemaKeys extends string & keyof TSchema = string & keyof TSchema,
 > {
 	/**
@@ -178,7 +178,7 @@ export interface NotificationsWorkspace<
 	/**
 	 * Registry of `NotificationsManager`s.
 	 */
-	readonly notifications: StatesWorkspaceEntries<TSchema>;
+	readonly notifications: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 
 	/**
 	 * Containing {@link PresenceWithNotifications}

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -220,9 +220,13 @@ function isStringOrNumberRecord(value: unknown): value is Record<string, string 
 // - Fallout: Until the above is addressed, keep the casts in place and document new usages accordingly.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type WorkspaceSchema = {
-	latest?: ReturnType<typeof StateFactory.latest<{ value: string }>>;
+	latest?: ReturnType<typeof StateFactory.latest<{ value: string }, "latest">>;
 	latestMap?: ReturnType<
-		typeof StateFactory.latestMap<{ value: Record<string, string | number> }, string>
+		typeof StateFactory.latestMap<
+			{ value: Record<string, string | number> },
+			string,
+			"latestMap"
+		>
 	>;
 };
 const WorkspaceSchema: WorkspaceSchema = {};
@@ -316,10 +320,7 @@ class MessageHandler {
 		);
 
 		if (latest && !workspace.states.latest) {
-			workspace.add(
-				"latest",
-				StateFactory.latest<{ value: string }>({ local: { value: "initial" } }),
-			);
+			workspace.add("latest", StateFactory.latest({ local: { value: "initial" } }));
 			// Cast required due to optional keys in WorkspaceSchema
 			// TODO: AB#47518
 			const latestState = workspace.states.latest as LatestRaw<{ value: string }>;


### PR DESCRIPTION
Should a consumer need to split schema definitions across files
`ReturnType<>` may not work as `Latest*` factories are overloaded and
direct use of `InternalPresenceTypes` is to be avoided. So, create
intermediary `*Configuration` aliases that are blessed for consumer use.

And fix support for `RegistrationKey` of `*Configuration` being specified
more narrowly than `string` by adding `Key` generic to
`StatesWorkspaceSchema` and `NotificationsWorkspaceSchema` and
additional generics where those types need to have the key type carried
through.