### PR TITLE
build: update client-utils layer compatibility generation to 5

### DIFF
--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -261,9 +261,9 @@
 		}
 	},
 	"fluidCompatMetadata": {
-		"generation": 4,
-		"releaseDate": "2026-01-20",
-		"releasePkgVersion": "2.81.0"
+		"generation": 5,
+		"releaseDate": "2026-03-01",
+		"releasePkgVersion": "2.90.0"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/common/client-utils/src/layerGenerationState.ts
+++ b/packages/common/client-utils/src/layerGenerationState.ts
@@ -9,4 +9,4 @@
  * The generation number for Fluid layer compatibility.
  * @internal
  */
-export const generation = 4;
+export const generation = 5;


### PR DESCRIPTION
- Bump `client-utils` layer generation from 4 to 5
- Update release date and package version in compatibility metadata
- Preparation for the 2.90.0 release