### PR TITLE
Fix: Use new feature gate for setSensitivityLabelHeader after timestamp fix

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -416,8 +416,9 @@ export class OdspDelayLoadedDeltaStream {
 		const disableJoinSessionRefresh = this.mc.config.getBoolean(
 			"Fluid.Driver.Odsp.disableJoinSessionRefresh",
 		);
+		// Previous gate "Fluid.Driver.Odsp.setSensitivityLabelHeader" was removed as it was sensitive to a timestamp bug that was fixed in with commit eb4f45c.
 		const setSensitivityLabelHeader = this.mc.config.getBoolean(
-			"Fluid.Driver.Odsp.setSensitivityLabelHeader",
+			"Fluid.Driver.Odsp.setSensitivityLabelHeaderPostFix",
 		);
 		const executeFetch = async (): Promise<{
 			entryTime: number;

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -416,7 +416,7 @@ export class OdspDelayLoadedDeltaStream {
 		const disableJoinSessionRefresh = this.mc.config.getBoolean(
 			"Fluid.Driver.Odsp.disableJoinSessionRefresh",
 		);
-		// Previous gate "Fluid.Driver.Odsp.setSensitivityLabelHeader" was removed as it was sensitive to a timestamp bug that was fixed in with commit eb4f45c.
+		// Previous gate "Fluid.Driver.Odsp.setSensitivityLabelHeader" was removed because it was sensitive to a timestamp-related bug that was fixed by PR #26318; using this new gate ensures that the bug fix is present.
 		const setSensitivityLabelHeader = this.mc.config.getBoolean(
 			"Fluid.Driver.Odsp.setSensitivityLabelHeaderPostFix",
 		);


### PR DESCRIPTION
## Description

PR #26318 fixed an issue in parsing sensitivity label timestamps. Requesting sensitivity label information with a build that doesn't have this fix, results in errors. So replace the previous `Fluid.Driver.Odsp.setSensitivityLabelHeader` gate with a new gate `Fluid.Driver.Odsp.setSensitivityLabelHeaderPostFix` so that we have the guarantee that we're only setting the header on builds that have the fix.

## Breaking Changes

Dropping support for `Fluid.Driver.Odsp.setSensitivityLabelHeader` gate. The gate has been rolled back already.

## Reviewer Guidance

Note PR #26318.