### PR TITLE
Prototype: feat(container-runtime): Add Document Schema "Preflight" API

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -45,6 +45,7 @@ export interface ContainerRuntimeOptions {
     readonly gcOptions: IGCRuntimeOptions;
     readonly loadSequenceNumberVerification: "close" | "log" | "bypass";
     readonly maxBatchSizeInBytes: number;
+    readonly onBeforeSchemaChange?: (result: ISchemaPreflightResult) => boolean;
     // (undocumented)
     readonly summaryOptions: ISummaryRuntimeOptions;
 }
@@ -202,6 +203,18 @@ export interface IOnDemandSummarizeOptions extends ISummarizeOptions {
 export interface IRetriableFailureError extends Error {
     // (undocumented)
     readonly retryAfterSeconds?: number;
+}
+
+// @beta @legacy
+export interface ISchemaPreflightResult {
+    readonly incompatibleProperty?: string;
+    readonly incompatibleValue?: string | string[] | true | number | undefined;
+    readonly isCompatible: boolean;
+    readonly proposedSchema: {
+        readonly version: number;
+        readonly refSeq: number;
+        readonly runtime: Record<string, unknown>;
+    };
 }
 
 // @beta @legacy

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -43,6 +43,7 @@ export type RuntimeOptionsAffectingDocSchema = Omit<
 	| "maxBatchSizeInBytes"
 	| "loadSequenceNumberVerification"
 	| "summaryOptions"
+	| "onBeforeSchemaChange"
 >;
 
 /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -287,6 +287,7 @@ import {
 	type IDocumentSchemaChangeMessageIncoming,
 	type IDocumentSchemaCurrent,
 	type IDocumentSchemaFeatures,
+	type ISchemaPreflightResult,
 	type IEnqueueSummarizeOptions,
 	type IGeneratedSummaryStats,
 	type IGenerateSummaryTreeResult,
@@ -476,6 +477,15 @@ export interface ContainerRuntimeOptions {
 	 * When enabled (`true`), createBlob will return a handle before the blob upload completes.
 	 */
 	readonly createBlobPayloadPending: true | undefined;
+
+	/**
+	 * Optional callback invoked before processing a batch that contains a DocumentSchemaChange op.
+	 * The callback receives an {@link ISchemaPreflightResult} indicating whether the proposed schema
+	 * change is compatible with this client's runtime.
+	 *
+	 * @returns `true` to continue processing normally, `false` to abort processing and close the container.
+	 */
+	readonly onBeforeSchemaChange?: (result: ISchemaPreflightResult) => boolean;
 }
 
 /**
@@ -962,6 +972,7 @@ export class ContainerRuntime
 			loadSequenceNumberVerification: "close",
 			maxBatchSizeInBytes: defaultMaxBatchSizeInBytes,
 			chunkSizeInBytes: defaultChunkSizeInBytes,
+			onBeforeSchemaChange: undefined,
 		};
 
 		const defaultConfigs = {
@@ -987,6 +998,7 @@ export class ContainerRuntime
 				? disabledCompressionConfig
 				: defaultConfigs.compressionOptions,
 			createBlobPayloadPending = defaultConfigs.createBlobPayloadPending,
+			onBeforeSchemaChange = defaultConfigs.onBeforeSchemaChange,
 		}: IContainerRuntimeOptionsInternal = runtimeOptions;
 
 		// If explicitSchemaControl is off, ensure that options which require explicitSchemaControl are not enabled.
@@ -1215,6 +1227,7 @@ export class ContainerRuntime
 			enableGroupedBatching,
 			explicitSchemaControl,
 			createBlobPayloadPending,
+			onBeforeSchemaChange,
 		};
 
 		validateMinimumVersionForCollab(updatedMinVersionForCollab);
@@ -3145,6 +3158,30 @@ export class ContainerRuntime
 				runtimeBatch = false;
 			}
 
+			// Scan the batch for DocumentSchemaChange ops and run the preflight check before processing.
+			// This allows the host to detect incompatible schema changes and switch to a different
+			// co-authoring stack before the runtime throws an error.
+			if (runtimeBatch) {
+				const schemaChangeContents: IDocumentSchemaChangeMessageIncoming[] = [];
+				for (const { message } of messagesWithPendingState) {
+					if (
+						(message as InboundSequencedContainerRuntimeMessage).type ===
+						ContainerMessageType.DocumentSchemaChange
+					) {
+						schemaChangeContents.push(
+							message.contents as IDocumentSchemaChangeMessageIncoming,
+						);
+					}
+				}
+				const shouldContinue = this.preflightSchemaChangeCheck(schemaChangeContents);
+				// If the callback returned false, the host wants to abort processing and close
+				// the container.
+				if (!shouldContinue) {
+					this.closeFn();
+					return;
+				}
+			}
+
 			const locationInBatch: { batchStart: boolean; batchEnd: boolean } =
 				inboundResult.type === "fullBatch"
 					? { batchStart: true, batchEnd: true }
@@ -3163,6 +3200,18 @@ export class ContainerRuntime
 					: false /* groupedBatch */,
 			);
 		} else {
+			// Preflight check for non-modern path
+			if (runtimeBatch && messageCopy.type === ContainerMessageType.DocumentSchemaChange) {
+				const shouldContinue = this.preflightSchemaChangeCheck([
+					messageCopy.contents as IDocumentSchemaChangeMessageIncoming,
+				]);
+				// If the callback returned false, the host wants to abort processing and close
+				// the container.
+				if (!shouldContinue) {
+					this.closeFn();
+					return;
+				}
+			}
 			this.processInboundMessages(
 				[{ message: messageCopy, localOpMetadata: undefined }],
 				{ batchStart: true, batchEnd: true }, // Single message
@@ -3179,6 +3228,26 @@ export class ContainerRuntime
 			// we have consecutively replayed the pending states
 			this.resetReconnectCount();
 		}
+	}
+
+	/**
+	 * Runs the preflight schema check for the given schema change contents and invokes the
+	 * host's onBeforeSchemaChange callback.
+	 * @param contents - The incoming schema change message contents to check.
+	 * @returns `true` to continue processing, `false` to abort (based on callback return value).
+	 */
+	private preflightSchemaChangeCheck(
+		contents: IDocumentSchemaChangeMessageIncoming[],
+	): boolean {
+		if (contents.length === 0) {
+			return true;
+		}
+		if (this.runtimeOptions.onBeforeSchemaChange === undefined) {
+			return true;
+		}
+		const preflightResult = this.documentsSchemaController.preflightSchemaCheck(contents);
+		const shouldContinue = this.runtimeOptions.onBeforeSchemaChange(preflightResult);
+		return shouldContinue;
 	}
 
 	private _processedClientSequenceNumber: number | undefined;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3245,9 +3245,16 @@ export class ContainerRuntime
 		if (this.runtimeOptions.onBeforeSchemaChange === undefined) {
 			return true;
 		}
-		const preflightResult = this.documentsSchemaController.preflightSchemaCheck(contents);
-		const shouldContinue = this.runtimeOptions.onBeforeSchemaChange(preflightResult);
-		return shouldContinue;
+		for (const content of contents) {
+			const preflightResult = this.documentsSchemaController.preflightSchemaCheck(content);
+			const shouldContinue = this.runtimeOptions.onBeforeSchemaChange(preflightResult);
+			if (!shouldContinue) {
+				// Return false if any of the schema changes should not be processed
+				return false;
+			}
+		}
+		// Return true if all schema changes are safe to process
+		return true;
 	}
 
 	private _processedClientSequenceNumber: number | undefined;

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -103,6 +103,7 @@ export {
 	type IDocumentSchemaChangeMessageIncoming,
 	type IDocumentSchemaChangeMessageOutgoing,
 	type IDocumentSchemaFeatures,
+	type ISchemaPreflightResult,
 	type ReadFluidDataStoreAttributes,
 	type IFluidDataStoreAttributes0,
 	type IFluidDataStoreAttributes1,

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -336,9 +336,7 @@ export interface ISchemaPreflightResult {
  * Returns a result object indicating whether the schema is compatible with the current runtime.
  * Does not modify any state.
  */
-function checkCompatibilityPure(
-	proposedSchema: IDocumentSchema,
-): ISchemaPreflightResult {
+function checkCompatibilityPure(proposedSchema: IDocumentSchema): ISchemaPreflightResult {
 	if (proposedSchema.version !== currentDocumentVersionSchema) {
 		return { isCompatible: false, incompatibleProperty: "version", proposedSchema };
 	}
@@ -361,7 +359,7 @@ function checkCompatibilityPure(
 			};
 		}
 	}
-	return { isCompatible: true, proposedSchema};
+	return { isCompatible: true, proposedSchema };
 }
 
 /**

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -304,6 +304,67 @@ const documentSchemaSupportedConfigs = {
 };
 
 /**
+ * Result of a preflight schema compatibility check.
+ * Indicates whether a proposed schema is compatible with the current runtime without modifying any state.
+ * @legacy @beta
+ */
+export interface ISchemaPreflightResult {
+	/**
+	 * Whether the proposed schema is compatible with this client's runtime.
+	 */
+	readonly isCompatible: boolean;
+	/**
+	 * If not compatible, which property caused the incompatibility.
+	 */
+	readonly incompatibleProperty?: string;
+	/**
+	 * If not compatible, the value of the incompatible property.
+	 */
+	readonly incompatibleValue?: string | string[] | true | number | undefined;
+	/**
+	 * The proposed schema from the incoming op.
+	 */
+	readonly proposedSchema: {
+		readonly version: number;
+		readonly refSeq: number;
+		readonly runtime: Record<string, unknown>;
+	};
+}
+
+/**
+ * Non-throwing schema compatibility check.
+ * Returns a result object indicating whether the schema is compatible with the current runtime.
+ * Does not modify any state.
+ */
+function checkCompatibilityPure(
+	proposedSchema: IDocumentSchema,
+): ISchemaPreflightResult {
+	if (proposedSchema.version !== currentDocumentVersionSchema) {
+		return { isCompatible: false, incompatibleProperty: "version", proposedSchema };
+	}
+
+	const refSeq = proposedSchema.refSeq;
+	if (typeof refSeq !== "number" || refSeq < 0 || !Number.isInteger(refSeq)) {
+		return { isCompatible: false, incompatibleProperty: "refSeq", proposedSchema };
+	}
+	if (proposedSchema.runtime === null || typeof proposedSchema.runtime !== "object") {
+		return { isCompatible: false, incompatibleProperty: "runtime", proposedSchema };
+	}
+	for (const [name, value] of Object.entries(proposedSchema.runtime)) {
+		const validator = documentSchemaSupportedConfigs[name] as IProperty | undefined;
+		if (!(validator?.validate(value) ?? false)) {
+			return {
+				isCompatible: false,
+				incompatibleProperty: `runtime/${name}`,
+				incompatibleValue: value,
+				proposedSchema,
+			};
+		}
+	}
+	return { isCompatible: true, proposedSchema};
+}
+
+/**
  * Checks if a given schema is compatible with current code, i.e. if current code can understand all the features of that schema.
  * If schema is not compatible with current code, it throws an exception.
  * @param documentSchema - current schema
@@ -319,49 +380,21 @@ function checkRuntimeCompatibility(
 		return;
 	}
 
-	const msg = "Document can't be opened with current version of the code";
-	if (documentSchema.version !== currentDocumentVersionSchema) {
+	const result = checkCompatibilityPure(documentSchema);
+	if (!result.isCompatible) {
+		const msg = "Document can't be opened with current version of the code";
+		const codePath =
+			result.incompatibleProperty === "version"
+				? "checkRuntimeCompat1"
+				: "checkRuntimeCompat2";
 		throw DataProcessingError.create(
 			msg,
-			"checkRuntimeCompat1",
-			undefined, // message
-			{
-				runtimeSchemaVersion: documentSchema.version,
-				currentRuntimeSchemaVersion: currentDocumentVersionSchema,
-				schemaName,
-			},
-		);
-	}
-
-	let unknownProperty: string | undefined;
-
-	const regSeq = documentSchema.refSeq;
-	// defence in depth - it should not be possible to get here anything other than integer, but worth validating it.
-	if (typeof regSeq !== "number" || regSeq < 0 || !Number.isInteger(regSeq)) {
-		unknownProperty = "refSeq";
-	} else if (documentSchema.runtime === null || typeof documentSchema.runtime !== "object") {
-		unknownProperty = "runtime";
-	} else {
-		for (const [name, value] of Object.entries(documentSchema.runtime)) {
-			const validator = documentSchemaSupportedConfigs[name] as IProperty | undefined;
-			if (!(validator?.validate(value) ?? false)) {
-				unknownProperty = `runtime/${name}`;
-			}
-		}
-	}
-
-	if (unknownProperty !== undefined) {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const value = documentSchema[unknownProperty];
-		throw DataProcessingError.create(
-			msg,
-			"checkRuntimeCompat2",
+			codePath,
 			undefined, // message
 			{
 				codeVersion: currentDocumentVersionSchema,
-				property: unknownProperty,
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				value,
+				property: result.incompatibleProperty,
+				value: result.incompatibleValue,
 				schemaName,
 			},
 		);
@@ -803,6 +836,38 @@ export class DocumentsSchemaController {
 	 */
 	public pendingOpNotAcked(): void {
 		this.opPending = false;
+	}
+
+	/**
+	 * Preflight check for incoming schema change messages.
+	 * Evaluates whether the proposed schema changes are compatible with this client's runtime
+	 * without modifying any state.
+	 *
+	 * @param contents - The incoming schema change message contents to check.
+	 * @returns The preflight result indicating compatibility.
+	 */
+	public preflightSchemaCheck(
+		contents: IDocumentSchemaChangeMessageIncoming[],
+	): ISchemaPreflightResult {
+		assert(contents.length > 0, "preflightSchemaCheck expects at least one op to check");
+		for (const content of contents) {
+			const compatResult = checkCompatibilityPure(content);
+
+			if (!compatResult.isCompatible) {
+				return {
+					isCompatible: false,
+					incompatibleProperty: compatResult.incompatibleProperty,
+					incompatibleValue: compatResult.incompatibleValue,
+					proposedSchema: compatResult.proposedSchema,
+				};
+			}
+		}
+
+		const lastIndex = contents.length - 1;
+		return {
+			isCompatible: true,
+			proposedSchema: contents[lastIndex],
+		};
 	}
 }
 

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -845,27 +845,9 @@ export class DocumentsSchemaController {
 	 * @returns The preflight result indicating compatibility.
 	 */
 	public preflightSchemaCheck(
-		contents: IDocumentSchemaChangeMessageIncoming[],
+		content: IDocumentSchemaChangeMessageIncoming,
 	): ISchemaPreflightResult {
-		assert(contents.length > 0, "preflightSchemaCheck expects at least one op to check");
-		for (const content of contents) {
-			const compatResult = checkCompatibilityPure(content);
-
-			if (!compatResult.isCompatible) {
-				return {
-					isCompatible: false,
-					incompatibleProperty: compatResult.incompatibleProperty,
-					incompatibleValue: compatResult.incompatibleValue,
-					proposedSchema: compatResult.proposedSchema,
-				};
-			}
-		}
-
-		const lastIndex = contents.length - 1;
-		return {
-			isCompatible: true,
-			proposedSchema: contents[lastIndex],
-		};
+		return checkCompatibilityPure(content);
 	}
 }
 

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -381,13 +381,21 @@ function checkRuntimeCompatibility(
 	const result = checkCompatibilityPure(documentSchema);
 	if (!result.isCompatible) {
 		const msg = "Document can't be opened with current version of the code";
-		const codePath =
-			result.incompatibleProperty === "version"
-				? "checkRuntimeCompat1"
-				: "checkRuntimeCompat2";
+		if (result.incompatibleProperty === "version") {
+			throw DataProcessingError.create(
+				msg,
+				"checkRuntimeCompat1",
+				undefined, // message
+				{
+					runtimeSchemaVersion: documentSchema.version,
+					currentRuntimeSchemaVersion: currentDocumentVersionSchema,
+					schemaName,
+				},
+			);
+		}
 		throw DataProcessingError.create(
 			msg,
-			codePath,
+			"checkRuntimeCompat2",
 			undefined, // message
 			{
 				codeVersion: currentDocumentVersionSchema,

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -112,6 +112,7 @@ export {
 	type IDocumentSchemaChangeMessageIncoming,
 	type IDocumentSchemaChangeMessageOutgoing,
 	type IDocumentSchemaFeatures,
+	type ISchemaPreflightResult,
 } from "./documentSchema.js";
 export {
 	getFailMessage,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1778,6 +1778,7 @@ describe("Runtime", () => {
 				enableGroupedBatching: true, // Redundant, but makes the JSON.stringify yield the same result as the logs
 				explicitSchemaControl: false,
 				createBlobPayloadPending: undefined,
+				onBeforeSchemaChange: undefined,
 			} as const satisfies ContainerRuntimeOptionsInternal;
 			const mergedRuntimeOptions = { ...defaultRuntimeOptions, ...runtimeOptions } as const;
 

--- a/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
+++ b/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
@@ -22,6 +22,7 @@ import {
 	type IDocumentSchema,
 	type IDocumentSchemaCurrent,
 	type IDocumentSchemaFeatures,
+	type ISchemaPreflightResult,
 } from "../summary/index.js";
 
 function boolToProp(b: boolean | undefined) {
@@ -824,4 +825,137 @@ describe("Runtime", () => {
 		);
 		return resultingSchema;
 	}
+
+	describe("preflightSchemaCheck", () => {
+		it("isCompatible is true for a compatible schema change", () => {
+			const controller = createController({
+				...validConfig,
+				runtime: { ...validConfig.runtime, explicitSchemaControl: true },
+			});
+
+			const proposedSchema: IDocumentSchema = {
+				...validConfig,
+				refSeq: 0,
+				runtime: {
+					...validConfig.runtime,
+					explicitSchemaControl: true,
+					opGroupingEnabled: true,
+				},
+			};
+
+			const result: ISchemaPreflightResult = controller.preflightSchemaCheck([proposedSchema]);
+			assert.strictEqual(result.isCompatible, true, "should be compatible");
+			assert.strictEqual(
+				result.incompatibleProperty,
+				undefined,
+				"should not identify incompatible property",
+			);
+			assert.strictEqual(
+				result.incompatibleValue,
+				undefined,
+				"should not identify incompatible value",
+			);
+		});
+
+		it("isCompatible is false for an unknown runtime property", () => {
+			const controller = createController({
+				...validConfig,
+				runtime: { ...validConfig.runtime, explicitSchemaControl: true },
+			});
+
+			const proposedSchema: IDocumentSchema = {
+				...validConfig,
+				refSeq: 0,
+				runtime: { ...validConfig.runtime, unknownFeature: true },
+			};
+
+			const result = controller.preflightSchemaCheck([proposedSchema]);
+			assert.strictEqual(result.isCompatible, false, "should not be compatible");
+			assert.strictEqual(
+				result.incompatibleProperty,
+				"runtime/unknownFeature",
+				"should identify the incompatible property",
+			);
+		});
+
+		it("isCompatible is false for a different version", () => {
+			const controller = createController(validConfig);
+
+			const proposedSchema: IDocumentSchema = {
+				...validConfig,
+				version: 999,
+			};
+
+			const result = controller.preflightSchemaCheck([proposedSchema]);
+			assert.strictEqual(result.isCompatible, false, "should not be compatible");
+			assert.strictEqual(
+				result.incompatibleProperty,
+				"version",
+				"should identify version as incompatible",
+			);
+		});
+
+		it("isCompatible is false for disallowed version matching current client", () => {
+			const controller = createController(validConfig);
+
+			const proposedSchema: IDocumentSchema = {
+				...validConfig,
+				runtime: { ...validConfig.runtime, disallowedVersions: [pkgVersion] },
+			};
+
+			const result = controller.preflightSchemaCheck([proposedSchema]);
+			assert.strictEqual(result.isCompatible, false, "should not be compatible");
+			assert.strictEqual(
+				result.incompatibleProperty,
+				"runtime/disallowedVersions",
+				"should identify disallowedVersions as incompatible",
+			);
+		});
+
+		it("isCompatible is false for an existing option with an unknown value", () => {
+			const controller = createController(validConfig);
+
+			const proposedSchema: IDocumentSchema = {
+				...validConfig,
+				runtime: { ...validConfig.runtime, idCompressorMode: "unknownMode" },
+			};
+
+			const result = controller.preflightSchemaCheck([proposedSchema]);
+			assert.strictEqual(result.isCompatible, false, "should not be compatible");
+			assert.strictEqual(
+				result.incompatibleProperty,
+				"runtime/idCompressorMode",
+				"should identify idCompressorMode as incompatible",
+			);
+			assert.strictEqual(
+				result.incompatibleValue,
+				"unknownMode",
+				"should identify the unknown value",
+			);
+		});
+
+		it("does not modify controller state", () => {
+			const controller = createController({
+				...validConfig,
+				runtime: { ...validConfig.runtime, explicitSchemaControl: true },
+			});
+
+			const sessionSchemaBefore = { ...controller.sessionSchema };
+
+			const proposedSchema: IDocumentSchema = {
+				...validConfig,
+				refSeq: 0,
+				runtime: { unknownFeature: true },
+			};
+
+			controller.preflightSchemaCheck([proposedSchema]);
+
+			// Session schema should be unchanged
+			assert.deepStrictEqual(
+				controller.sessionSchema,
+				sessionSchemaBefore,
+				"preflightSchemaCheck should not modify state",
+			);
+		});
+	});
 });

--- a/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
+++ b/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
@@ -843,7 +843,7 @@ describe("Runtime", () => {
 				},
 			};
 
-			const result: ISchemaPreflightResult = controller.preflightSchemaCheck([proposedSchema]);
+			const result: ISchemaPreflightResult = controller.preflightSchemaCheck(proposedSchema);
 			assert.strictEqual(result.isCompatible, true, "should be compatible");
 			assert.strictEqual(
 				result.incompatibleProperty,
@@ -869,7 +869,7 @@ describe("Runtime", () => {
 				runtime: { ...validConfig.runtime, unknownFeature: true },
 			};
 
-			const result = controller.preflightSchemaCheck([proposedSchema]);
+			const result = controller.preflightSchemaCheck(proposedSchema);
 			assert.strictEqual(result.isCompatible, false, "should not be compatible");
 			assert.strictEqual(
 				result.incompatibleProperty,
@@ -886,7 +886,7 @@ describe("Runtime", () => {
 				version: 999,
 			};
 
-			const result = controller.preflightSchemaCheck([proposedSchema]);
+			const result = controller.preflightSchemaCheck(proposedSchema);
 			assert.strictEqual(result.isCompatible, false, "should not be compatible");
 			assert.strictEqual(
 				result.incompatibleProperty,
@@ -903,7 +903,7 @@ describe("Runtime", () => {
 				runtime: { ...validConfig.runtime, disallowedVersions: [pkgVersion] },
 			};
 
-			const result = controller.preflightSchemaCheck([proposedSchema]);
+			const result = controller.preflightSchemaCheck(proposedSchema);
 			assert.strictEqual(result.isCompatible, false, "should not be compatible");
 			assert.strictEqual(
 				result.incompatibleProperty,
@@ -920,7 +920,7 @@ describe("Runtime", () => {
 				runtime: { ...validConfig.runtime, idCompressorMode: "unknownMode" },
 			};
 
-			const result = controller.preflightSchemaCheck([proposedSchema]);
+			const result = controller.preflightSchemaCheck(proposedSchema);
 			assert.strictEqual(result.isCompatible, false, "should not be compatible");
 			assert.strictEqual(
 				result.incompatibleProperty,
@@ -948,7 +948,7 @@ describe("Runtime", () => {
 				runtime: { unknownFeature: true },
 			};
 
-			controller.preflightSchemaCheck([proposedSchema]);
+			controller.preflightSchemaCheck(proposedSchema);
 
 			// Session schema should be unchanged
 			assert.deepStrictEqual(

--- a/packages/service-clients/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/service-clients/azure-client/src/test/AzureClient.spec.ts
@@ -415,6 +415,7 @@ for (const compatibilityMode of ["1", "2"] as const) {
 					enableGroupedBatching: false,
 					explicitSchemaControl: false,
 					createBlobPayloadPending: undefined,
+					onBeforeSchemaChange: undefined,
 				} as const satisfies ContainerRuntimeOptionsInternal;
 				const expectedRuntimeOptions2 = {
 					summaryOptions: {},
@@ -431,6 +432,7 @@ for (const compatibilityMode of ["1", "2"] as const) {
 					enableGroupedBatching: true,
 					explicitSchemaControl: true,
 					createBlobPayloadPending: undefined,
+					onBeforeSchemaChange: undefined,
 				} as const satisfies ContainerRuntimeOptionsInternal;
 
 				const expectedRuntimeOptions =

--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -6,8 +6,14 @@
 import { strict as assert } from "assert";
 
 import { describeCompat, ITestDataObject } from "@fluid-private/test-version-utils";
-import { IContainer } from "@fluidframework/container-definitions/internal";
-import { CompressionAlgorithms } from "@fluidframework/container-runtime/internal";
+import {
+	IContainer,
+	type ICriticalContainerError,
+} from "@fluidframework/container-definitions/internal";
+import {
+	CompressionAlgorithms,
+	type ISchemaPreflightResult,
+} from "@fluidframework/container-runtime/internal";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -460,5 +466,143 @@ describeCompat("minVersionForCollab (NoCompat)", "NoCompat", (getTestObjectProvi
 				minVersionForCollab: "2.35.0",
 			},
 		]);
+	});
+});
+
+describeCompat.only("onBeforeSchemaChange callback", "NoCompat", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+
+	async function loadContainer(options: ITestContainerConfig): Promise<IContainer> {
+		return provider.loadTestContainer(options);
+	}
+
+	async function getEntryPoint(container: IContainer): Promise<ITestDataObject> {
+		return getContainerEntryPointBackCompat<ITestDataObject>(container);
+	}
+
+	beforeEach("getTestObjectProvider", async () => {
+		provider = getTestObjectProvider();
+	});
+
+	it("returning true continues processing", async function () {
+		const container1 = await provider.makeTestContainer({
+			runtimeOptions: {
+				explicitSchemaControl: true,
+				enableRuntimeIdCompressor: undefined,
+			},
+		});
+		const entry1 = await getEntryPoint(container1);
+		entry1._root.set("initialKey", "initialValue");
+		await provider.ensureSynchronized();
+
+		let callbackInvoked = false;
+		const container2 = await loadContainer({
+			runtimeOptions: {
+				explicitSchemaControl: true,
+				enableRuntimeIdCompressor: undefined,
+				onBeforeSchemaChange: (result: ISchemaPreflightResult) => {
+					callbackInvoked = true;
+					// Schema should not be applied yet when callback fires
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+					const mode = (entry2._context.containerRuntime as any).sessionSchema
+						.idCompressorMode;
+					assert.equal(
+						mode,
+						undefined,
+						"idCompressorMode should still be undefined before processing",
+					);
+					assert.strictEqual(result.isCompatible, true, "Schema change should be compatible");
+					return true;
+				},
+			},
+		});
+		const entry2 = await getEntryPoint(container2);
+
+		// Container 3 triggers a schema change by enabling ID compressor
+		const container3 = await loadContainer({
+			runtimeOptions: {
+				explicitSchemaControl: true,
+				enableRuntimeIdCompressor: "delayed",
+			},
+		});
+		const entry3 = await getEntryPoint(container3);
+		entry3._root.set("triggerSchemaChange", "value");
+		await provider.ensureSynchronized();
+
+		assert(callbackInvoked, "onBeforeSchemaChange callback should have been invoked");
+		// Schema should now be applied on all containers
+		for (const entry of [entry1, entry2, entry3]) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+			const mode = (entry._context.containerRuntime as any).sessionSchema.idCompressorMode;
+			assert.equal(
+				mode,
+				"delayed",
+				"idCompressorMode should be 'delayed' after schema change",
+			);
+		}
+	});
+
+	it("returning false closes container without processing", async function () {
+		const container1 = await provider.makeTestContainer({
+			runtimeOptions: {
+				explicitSchemaControl: true,
+			},
+		});
+		const entry1 = await getEntryPoint(container1);
+		entry1._root.set("key", "value");
+		await provider.ensureSynchronized();
+
+		let callbackInvoked = false;
+		const container2 = await loadContainer({
+			runtimeOptions: {
+				explicitSchemaControl: true,
+				onBeforeSchemaChange: (_result: ISchemaPreflightResult) => {
+					callbackInvoked = true;
+					// Verify schema was not applied before we return false
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+					const mode = (entry2._context.containerRuntime as any).sessionSchema
+						.idCompressorMode;
+					assert.equal(
+						mode,
+						undefined,
+						"idCompressorMode should still be undefined when callback fires",
+					);
+					return false;
+				},
+			},
+		});
+		const entry2 = await getEntryPoint(container2);
+		assert(!container2.closed, "Container 2 should be open initially");
+
+		const closedP = new Promise<ICriticalContainerError | undefined>((resolve) => {
+			container2.once("closed", (error) => resolve(error));
+		});
+
+		// Container 3 triggers a schema change
+		const container3 = await loadContainer({
+			runtimeOptions: {
+				explicitSchemaControl: true,
+				enableRuntimeIdCompressor: "delayed",
+			},
+		});
+		const entry3 = await getEntryPoint(container3);
+		entry3._root.set("trigger", "value");
+
+		// Wait for container2 to close (driven by the callback returning false)
+		const closeError = await closedP;
+
+		assert(callbackInvoked, "Callback should have been invoked");
+		assert(container2.closed, "Container 2 should be closed after returning false");
+		assert.equal(closeError, undefined, "Container 2 should have closed without error");
+
+		// Verify schema was never applied on container2
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+		const modeAfterClose = (entry2._context.containerRuntime as any).sessionSchema
+			.idCompressorMode;
+		assert.equal(
+			modeAfterClose,
+			undefined,
+			"idCompressorMode should remain undefined - schema change should never have been processed",
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -469,7 +469,7 @@ describeCompat("minVersionForCollab (NoCompat)", "NoCompat", (getTestObjectProvi
 	});
 });
 
-describeCompat.only("onBeforeSchemaChange callback", "NoCompat", (getTestObjectProvider) => {
+describeCompat("onBeforeSchemaChange callback", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 
 	async function loadContainer(options: ITestContainerConfig): Promise<IContainer> {

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -118,6 +118,7 @@ export function generateRuntimeOptions(
 		enableGroupedBatching: [true, false],
 		createBlobPayloadPending: [true, undefined],
 		explicitSchemaControl: [true, false],
+		onBeforeSchemaChange: [undefined],
 	};
 
 	const pairwiseOptions = generatePairwiseOptions<IContainerRuntimeOptionsInternal>(


### PR DESCRIPTION
## Description

Prototype/POC for an API that checks if a client will be compatible Document Schema upgrade **prior** to processing the Document Schema upgrade op. 

This would allow hosts to determine if they want to continue op processing or close the container gracefully prior to the client throwing. This gives customers to better control scenarios where a client is incompatible with an incoming schema change, allowing them to take an alternative action.

## Misc
[AB#53703](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/53703)
[Doc](https://microsoft.sharepoint-df.com/:fl:/g/contentstorage/CSP_35278ae7-2935-4dcc-a64a-054383a5d114/IQCYiXpZ8QpXSa39XRYz_mQCAZCYIMlb14KyfFcFh3oHO7g?e=r3WU6V&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF8zNTI3OGFlNy0yOTM1LTRkY2MtYTY0YS0wNTQzODNhNWQxMTQmZD1iJTIxNTRvbk5UVXB6RTJtU2dWRGc2WFJGTHRnNlU1NktKbEF1dlFQUlR5R0M3WFdWcHZ3ZndielFyc1RQRDFTNW15NCZmPTAxNEFXUVRRVVlSRjVGVDRJS0s1RTIzN0s1Q1laNzRaQUMmYz0lMkYmYT1Mb29wQXBwJnA9JTQwZmx1aWR4JTJGbG9vcC1wYWdlLWNvbnRhaW5lciZ4PSU3QiUyMnclMjIlM0ElMjJUMFJUVUh4dGFXTnliM052Wm5RdWMyaGhjbVZ3YjJsdWRDMWtaaTVqYjIxOFlpRTFORzl1VGxSVmNIcEZNbTFUWjFaRVp6WllVa1pNZEdjMlZUVTJTMHBzUVhWMlVWQlNWSGxIUXpkWVYxWndkbmRtZDJKNlVYSnpWRkJFTVZNMWJYazBmREF4TkVGWFVWUlJValkwTTBRMU5GbEpWRlpLUlV4TlUxbzFNMGxLV1ZBMVNETSUzRCUyMiUyQyUyMmklMjIlM0ElMjI3YmExY2Q0OC02MGVmLTQ4YTctOWNmZC02OWQzMDFiOGI4NTElMjIlN0Q%3D)
