### PR TITLE
Add unordered list and header support to formatted text editor

### DIFF
--- a/packages/framework/react/src/test/text/textEditor.test.tsx
+++ b/packages/framework/react/src/test/text/textEditor.test.tsx
@@ -21,6 +21,8 @@ import {
 	type FormattedEditorHandle,
 	parseCssFontFamily,
 	parseCssFontSize,
+	parseLineTag,
+	buildDeltaFromTree,
 	// Allow import of files being tested
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../text/formatted/quillFormattedView.js";
@@ -962,132 +964,69 @@ describe("textEditor", () => {
 				});
 			}
 		});
-	});
-
-	// Line-level formatting tests: exercises the tree operations that the Quill
-	// delta handler performs (swap newline → line atom, insert implicit trailing
-	// newline, clear header). Quill always ends documents with a trailing \n,
-	// so tests start with that state.
-	describe("line tag round-trip through rendering", () => {
-		function createPlainFormat(): FormattedTextAsTree.CharacterFormat {
-			return new FormattedTextAsTree.CharacterFormat({
-				bold: false,
-				italic: false,
-				underline: false,
-				size: 12,
-				font: "Arial",
+		describe("parseLineTag", () => {
+			it("return lineTag for valid header", () => {
+				const result = parseLineTag({ header: 1 });
+				assert.ok(result, "Expected a line tag for header 1");
+				assert.equal(result.value, "h1", "Expected tag to be h1");
 			});
-		}
-
-		for (const reactStrictMode of [false, true]) {
-			describe(`StrictMode: ${reactStrictMode}`, () => {
-				it("swap trailing newline to h1 line atom", () => {
-					// Quill starts with "Hello\n". Applying header 1 retains to the \n
-					// then swaps it to a StringLineAtom — removeRange + insertWithFormattingAt.
-					const { tree: text } = createFormattedTreeView("Hello\n");
-					const content = <FormattedMainView root={toPropTreeNode(text)} />;
-					const rendered = render(content, { reactStrictMode });
-
-					text.removeRange(5, 6);
-					text.insertWithFormattingAt(5, [
-						new FormattedTextAsTree.StringAtom({
-							content: new FormattedTextAsTree.StringLineAtom({
-								tag: FormattedTextAsTree.LineTag("h1"),
-							}),
-							format: createPlainFormat(),
-						}),
-					]);
-
-					rendered.rerender(content);
-					const el = rendered.container.querySelector("h1");
-					assert.ok(el, "Expected <h1> tag");
-					assert.match(el.textContent ?? "", /Hello/);
-				});
-
-				it("insert line atom at end for implicit trailing newline", () => {
-					// Tree has no trailing \n. Quill retains past end with { list: "bullet" },
-					// so the delta handler inserts a new StringLineAtom.
-					const { tree: text } = createFormattedTreeView("Item");
-					const content = <FormattedMainView root={toPropTreeNode(text)} />;
-					const rendered = render(content, { reactStrictMode });
-
-					text.insertWithFormattingAt(4, [
-						new FormattedTextAsTree.StringAtom({
-							content: new FormattedTextAsTree.StringLineAtom({
-								tag: FormattedTextAsTree.LineTag("li"),
-							}),
-							format: createPlainFormat(),
-						}),
-					]);
-
-					rendered.rerender(content);
-					const el = rendered.container.querySelector("li");
-					assert.ok(el, "Expected <li> tag");
-					assert.match(el.textContent ?? "", /Item/);
-				});
-
-				it("insert newline with line tag creates new header line", () => {
-					// Pressing Enter at the end of a header line in Quill sends
-					// { insert: "\n", attributes: { header: 1 } }. The delta handler
-					// calls insertWithFormattingAt with a StringLineAtom.
-					const { tree: text } = createFormattedTreeView("Hello\nWorld");
-					const content = <FormattedMainView root={toPropTreeNode(text)} />;
-					const rendered = render(content, { reactStrictMode });
-
-					// Insert a \n with h1 line tag after "Hello" (index 5)
-					text.insertWithFormattingAt(5, [
-						new FormattedTextAsTree.StringAtom({
-							content: new FormattedTextAsTree.StringLineAtom({
-								tag: FormattedTextAsTree.LineTag("h1"),
-							}),
-							format: createPlainFormat(),
-						}),
-					]);
-
-					rendered.rerender(content);
-					const el = rendered.container.querySelector("h1");
-					assert.ok(el, "Expected <h1> tag");
-					assert.match(el.textContent ?? "", /Hello/);
-					assert.match(rendered.baseElement.textContent ?? "", /World/);
-				});
-				it("clear header swaps line atom back to plain newline", () => {
-					// Quill clears a header by sending { retain: N }, { retain: 1, attributes: { header: null } }.
-					// parseLineTag returns undefined for { header: null }, so the delta handler
-					// detects the existing StringLineAtom and swaps it back to a plain \n.
-					const { tree: text } = createFormattedTreeView("Hello\n");
-					const content = <FormattedMainView root={toPropTreeNode(text)} />;
-
-					// Swap trailing \n to h1 line atom (simulates applying header)
-					text.removeRange(5, 6);
-					text.insertWithFormattingAt(5, [
-						new FormattedTextAsTree.StringAtom({
-							content: new FormattedTextAsTree.StringLineAtom({
-								tag: FormattedTextAsTree.LineTag("h1"),
-							}),
-							format: createPlainFormat(),
-						}),
-					]);
-
-					const rendered = render(content, { reactStrictMode });
-					assert.ok(rendered.container.querySelector("h1"), "Initially: has <h1>");
-
-					// Simulate clearing: remove the StringLineAtom and insert a plain \n
-					// (what the delta handler now does for { retain: 1, attributes: { header: null } })
-					text.removeRange(5, 6);
-					text.insertAt(5, "\n");
-
-					const atom = text.charactersWithFormatting()[5];
-					assert.ok(atom, "Expected atom at index 5");
-					assert(
-						atom.content instanceof FormattedTextAsTree.StringTextAtom,
-						"After clear: atom should be StringTextAtom, not StringLineAtom",
-					);
-
-					rendered.rerender(content);
-					assert.ok(!rendered.container.querySelector("h1"), "After clear: no <h1>");
-					assert.match(rendered.baseElement.textContent ?? "", /Hello/);
-				});
+			it("returns lineTag for valid bullet list", () => {
+				const result = parseLineTag({ list: "bullet" });
+				assert.ok(result, "Expected a line tag for bullet list");
+				assert.equal(result.value, "li", "Expected tag to be li)");
 			});
-		}
+			// Tests for unsupported parameters - should return undefined, not throw an error.
+			// Also used for when formatting is stripped from a newline and it becomes a default newline
+			it("returns undefined for unsupported parameter", () => {
+				assert.equal(
+					parseLineTag({ header: 7 }),
+					undefined,
+					"Expected undefined for unsupported lineTag",
+				);
+			});
+		});
+		// tests quillFormattedview conversion that feeds into quill delta generation,
+		// specifically for line atoms which have special handling for headers and lists.
+		// Quill always has a trailing newline, so these tests set up the string with a newline,
+		// then replace it with a line atom with the appropriate tag.
+		describe("buildDeltaFromTree with line Atoms", () => {
+			it("emits header attribute for h1 line atom", () => {
+				const { tree } = createFormattedTreeView("Hello\n");
+				tree.removeRange(5, 6);
+				tree.insertWithFormattingAt(5, [
+					new FormattedTextAsTree.StringAtom({
+						content: new FormattedTextAsTree.StringLineAtom({
+							tag: FormattedTextAsTree.LineTag("h1"),
+						}),
+						format: createPlainFormat(),
+					}),
+				]);
+
+				const ops = buildDeltaFromTree(tree);
+				const lineOp = ops.find((op) => op.insert === "\n" && op.attributes?.header === 1);
+				assert.ok(lineOp, "Expected { insert : `\\n`, attributes: { header: 1 } } in delta");
+			});
+			it("emits header attribute for li line atom", () => {
+				const { tree } = createFormattedTreeView("item\n");
+				tree.removeRange(4, 5);
+				tree.insertWithFormattingAt(4, [
+					new FormattedTextAsTree.StringAtom({
+						content: new FormattedTextAsTree.StringLineAtom({
+							tag: FormattedTextAsTree.LineTag("li"),
+						}),
+						format: createPlainFormat(),
+					}),
+				]);
+
+				const ops = buildDeltaFromTree(tree);
+				const lineOp = ops.find(
+					(op) => op.insert === "\n" && op.attributes?.list === "bullet",
+				);
+				assert.ok(
+					lineOp,
+					"Expected { insert : `\\n`, attributes: { list: 'bullet' } } in delta",
+				);
+			});
+		});
 	});
 });

--- a/packages/framework/react/src/test/text/textEditor.test.tsx
+++ b/packages/framework/react/src/test/text/textEditor.test.tsx
@@ -962,5 +962,102 @@ describe("textEditor", () => {
 				});
 			}
 		});
+
+		// Line-level formatting tests (headers and lists via StringLineAtom)
+		describe("line formatting tests", () => {
+			for (const reactStrictMode of [false, true]) {
+				describe(`StrictMode: ${reactStrictMode}`, () => {
+					it("inserts h1 line atom and renders with header formatting", () => {
+						const { tree: text } = createFormattedTreeView();
+						const content = <FormattedMainView root={toPropTreeNode(text)} />;
+						const rendered = render(content, { reactStrictMode });
+
+						// Insert "Hello" followed by a StringLineAtom with h1 tag
+						text.insertAt(0, "Hello");
+						text.insertWithFormattingAt(5, [
+							new FormattedTextAsTree.StringAtom({
+								content: new FormattedTextAsTree.StringLineAtom({
+									tag: FormattedTextAsTree.LineTag("h1"),
+								}),
+								format: createPlainFormat(),
+							}),
+						]);
+
+						rendered.rerender(content);
+						const el = rendered.container.querySelector("h1");
+						assert.ok(el, "Expected <h1> tag");
+						assert.match(el.textContent ?? "", /Hello/);
+					});
+
+					it("inserts h3 line atom and renders with header formatting", () => {
+						const { tree: text } = createFormattedTreeView();
+						const content = <FormattedMainView root={toPropTreeNode(text)} />;
+						const rendered = render(content, { reactStrictMode });
+
+						text.insertAt(0, "Subheading");
+						text.insertWithFormattingAt(10, [
+							new FormattedTextAsTree.StringAtom({
+								content: new FormattedTextAsTree.StringLineAtom({
+									tag: FormattedTextAsTree.LineTag("h3"),
+								}),
+								format: createPlainFormat(),
+							}),
+						]);
+
+						rendered.rerender(content);
+						const el = rendered.container.querySelector("h3");
+						assert.ok(el, "Expected <h3> tag");
+						assert.match(el.textContent ?? "", /Subheading/);
+					});
+
+					it("inserts list line atom and renders with list formatting", () => {
+						const { tree: text } = createFormattedTreeView();
+						const content = <FormattedMainView root={toPropTreeNode(text)} />;
+						const rendered = render(content, { reactStrictMode });
+
+						text.insertAt(0, "Item");
+						text.insertWithFormattingAt(4, [
+							new FormattedTextAsTree.StringAtom({
+								content: new FormattedTextAsTree.StringLineAtom({
+									tag: FormattedTextAsTree.LineTag("li"),
+								}),
+								format: createPlainFormat(),
+							}),
+						]);
+
+						rendered.rerender(content);
+						const el = rendered.container.querySelector("li");
+						assert.ok(el, "Expected <li> tag");
+						assert.match(el.textContent ?? "", /Item/);
+					});
+
+					it("removes line atom and line formatting is removed", () => {
+						const { tree: text } = createFormattedTreeView();
+						const content = <FormattedMainView root={toPropTreeNode(text)} />;
+
+						// Insert "Hello" with h1 line atom
+						text.insertAt(0, "Hello");
+						text.insertWithFormattingAt(5, [
+							new FormattedTextAsTree.StringAtom({
+								content: new FormattedTextAsTree.StringLineAtom({
+									tag: FormattedTextAsTree.LineTag("h1"),
+								}),
+								format: createPlainFormat(),
+							}),
+						]);
+
+						const rendered = render(content, { reactStrictMode });
+						assert.ok(rendered.container.querySelector("h1"), "Initially: has <h1>");
+
+						// Remove the line atom (index 5)
+						text.removeRange(5, 6);
+						rendered.rerender(content);
+
+						assert.ok(!rendered.container.querySelector("h1"), "After delete: no <h1>");
+						assert.match(rendered.baseElement.textContent ?? "", /Hello/);
+					});
+				});
+			}
+		});
 	});
 });

--- a/packages/framework/react/src/test/text/textEditor.test.tsx
+++ b/packages/framework/react/src/test/text/textEditor.test.tsx
@@ -962,102 +962,132 @@ describe("textEditor", () => {
 				});
 			}
 		});
+	});
 
-		// Line-level formatting tests (headers and lists via StringLineAtom)
-		describe("line formatting tests", () => {
-			for (const reactStrictMode of [false, true]) {
-				describe(`StrictMode: ${reactStrictMode}`, () => {
-					it("inserts h1 line atom and renders with header formatting", () => {
-						const { tree: text } = createFormattedTreeView();
-						const content = <FormattedMainView root={toPropTreeNode(text)} />;
-						const rendered = render(content, { reactStrictMode });
+	// Line-level formatting tests: exercises the tree operations that the Quill
+	// delta handler performs (swap newline → line atom, insert implicit trailing
+	// newline, clear header). Quill always ends documents with a trailing \n,
+	// so tests start with that state.
+	describe("line tag round-trip through rendering", () => {
+		function createPlainFormat(): FormattedTextAsTree.CharacterFormat {
+			return new FormattedTextAsTree.CharacterFormat({
+				bold: false,
+				italic: false,
+				underline: false,
+				size: 12,
+				font: "Arial",
+			});
+		}
 
-						// Insert "Hello" followed by a StringLineAtom with h1 tag
-						text.insertAt(0, "Hello");
-						text.insertWithFormattingAt(5, [
-							new FormattedTextAsTree.StringAtom({
-								content: new FormattedTextAsTree.StringLineAtom({
-									tag: FormattedTextAsTree.LineTag("h1"),
-								}),
-								format: createPlainFormat(),
+		for (const reactStrictMode of [false, true]) {
+			describe(`StrictMode: ${reactStrictMode}`, () => {
+				it("swap trailing newline to h1 line atom", () => {
+					// Quill starts with "Hello\n". Applying header 1 retains to the \n
+					// then swaps it to a StringLineAtom — removeRange + insertWithFormattingAt.
+					const { tree: text } = createFormattedTreeView("Hello\n");
+					const content = <FormattedMainView root={toPropTreeNode(text)} />;
+					const rendered = render(content, { reactStrictMode });
+
+					text.removeRange(5, 6);
+					text.insertWithFormattingAt(5, [
+						new FormattedTextAsTree.StringAtom({
+							content: new FormattedTextAsTree.StringLineAtom({
+								tag: FormattedTextAsTree.LineTag("h1"),
 							}),
-						]);
+							format: createPlainFormat(),
+						}),
+					]);
 
-						rendered.rerender(content);
-						const el = rendered.container.querySelector("h1");
-						assert.ok(el, "Expected <h1> tag");
-						assert.match(el.textContent ?? "", /Hello/);
-					});
-
-					it("inserts h3 line atom and renders with header formatting", () => {
-						const { tree: text } = createFormattedTreeView();
-						const content = <FormattedMainView root={toPropTreeNode(text)} />;
-						const rendered = render(content, { reactStrictMode });
-
-						text.insertAt(0, "Subheading");
-						text.insertWithFormattingAt(10, [
-							new FormattedTextAsTree.StringAtom({
-								content: new FormattedTextAsTree.StringLineAtom({
-									tag: FormattedTextAsTree.LineTag("h3"),
-								}),
-								format: createPlainFormat(),
-							}),
-						]);
-
-						rendered.rerender(content);
-						const el = rendered.container.querySelector("h3");
-						assert.ok(el, "Expected <h3> tag");
-						assert.match(el.textContent ?? "", /Subheading/);
-					});
-
-					it("inserts list line atom and renders with list formatting", () => {
-						const { tree: text } = createFormattedTreeView();
-						const content = <FormattedMainView root={toPropTreeNode(text)} />;
-						const rendered = render(content, { reactStrictMode });
-
-						text.insertAt(0, "Item");
-						text.insertWithFormattingAt(4, [
-							new FormattedTextAsTree.StringAtom({
-								content: new FormattedTextAsTree.StringLineAtom({
-									tag: FormattedTextAsTree.LineTag("li"),
-								}),
-								format: createPlainFormat(),
-							}),
-						]);
-
-						rendered.rerender(content);
-						const el = rendered.container.querySelector("li");
-						assert.ok(el, "Expected <li> tag");
-						assert.match(el.textContent ?? "", /Item/);
-					});
-
-					it("removes line atom and line formatting is removed", () => {
-						const { tree: text } = createFormattedTreeView();
-						const content = <FormattedMainView root={toPropTreeNode(text)} />;
-
-						// Insert "Hello" with h1 line atom
-						text.insertAt(0, "Hello");
-						text.insertWithFormattingAt(5, [
-							new FormattedTextAsTree.StringAtom({
-								content: new FormattedTextAsTree.StringLineAtom({
-									tag: FormattedTextAsTree.LineTag("h1"),
-								}),
-								format: createPlainFormat(),
-							}),
-						]);
-
-						const rendered = render(content, { reactStrictMode });
-						assert.ok(rendered.container.querySelector("h1"), "Initially: has <h1>");
-
-						// Remove the line atom (index 5)
-						text.removeRange(5, 6);
-						rendered.rerender(content);
-
-						assert.ok(!rendered.container.querySelector("h1"), "After delete: no <h1>");
-						assert.match(rendered.baseElement.textContent ?? "", /Hello/);
-					});
+					rendered.rerender(content);
+					const el = rendered.container.querySelector("h1");
+					assert.ok(el, "Expected <h1> tag");
+					assert.match(el.textContent ?? "", /Hello/);
 				});
-			}
-		});
+
+				it("insert line atom at end for implicit trailing newline", () => {
+					// Tree has no trailing \n. Quill retains past end with { list: "bullet" },
+					// so the delta handler inserts a new StringLineAtom.
+					const { tree: text } = createFormattedTreeView("Item");
+					const content = <FormattedMainView root={toPropTreeNode(text)} />;
+					const rendered = render(content, { reactStrictMode });
+
+					text.insertWithFormattingAt(4, [
+						new FormattedTextAsTree.StringAtom({
+							content: new FormattedTextAsTree.StringLineAtom({
+								tag: FormattedTextAsTree.LineTag("li"),
+							}),
+							format: createPlainFormat(),
+						}),
+					]);
+
+					rendered.rerender(content);
+					const el = rendered.container.querySelector("li");
+					assert.ok(el, "Expected <li> tag");
+					assert.match(el.textContent ?? "", /Item/);
+				});
+
+				it("insert newline with line tag creates new header line", () => {
+					// Pressing Enter at the end of a header line in Quill sends
+					// { insert: "\n", attributes: { header: 1 } }. The delta handler
+					// calls insertWithFormattingAt with a StringLineAtom.
+					const { tree: text } = createFormattedTreeView("Hello\nWorld");
+					const content = <FormattedMainView root={toPropTreeNode(text)} />;
+					const rendered = render(content, { reactStrictMode });
+
+					// Insert a \n with h1 line tag after "Hello" (index 5)
+					text.insertWithFormattingAt(5, [
+						new FormattedTextAsTree.StringAtom({
+							content: new FormattedTextAsTree.StringLineAtom({
+								tag: FormattedTextAsTree.LineTag("h1"),
+							}),
+							format: createPlainFormat(),
+						}),
+					]);
+
+					rendered.rerender(content);
+					const el = rendered.container.querySelector("h1");
+					assert.ok(el, "Expected <h1> tag");
+					assert.match(el.textContent ?? "", /Hello/);
+					assert.match(rendered.baseElement.textContent ?? "", /World/);
+				});
+				it("clear header swaps line atom back to plain newline", () => {
+					// Quill clears a header by sending { retain: N }, { retain: 1, attributes: { header: null } }.
+					// parseLineTag returns undefined for { header: null }, so the delta handler
+					// detects the existing StringLineAtom and swaps it back to a plain \n.
+					const { tree: text } = createFormattedTreeView("Hello\n");
+					const content = <FormattedMainView root={toPropTreeNode(text)} />;
+
+					// Swap trailing \n to h1 line atom (simulates applying header)
+					text.removeRange(5, 6);
+					text.insertWithFormattingAt(5, [
+						new FormattedTextAsTree.StringAtom({
+							content: new FormattedTextAsTree.StringLineAtom({
+								tag: FormattedTextAsTree.LineTag("h1"),
+							}),
+							format: createPlainFormat(),
+						}),
+					]);
+
+					const rendered = render(content, { reactStrictMode });
+					assert.ok(rendered.container.querySelector("h1"), "Initially: has <h1>");
+
+					// Simulate clearing: remove the StringLineAtom and insert a plain \n
+					// (what the delta handler now does for { retain: 1, attributes: { header: null } })
+					text.removeRange(5, 6);
+					text.insertAt(5, "\n");
+
+					const atom = text.charactersWithFormatting()[5];
+					assert.ok(atom, "Expected atom at index 5");
+					assert(
+						atom.content instanceof FormattedTextAsTree.StringTextAtom,
+						"After clear: atom should be StringTextAtom, not StringLineAtom",
+					);
+
+					rendered.rerender(content);
+					assert.ok(!rendered.container.querySelector("h1"), "After clear: no <h1>");
+					assert.match(rendered.baseElement.textContent ?? "", /Hello/);
+				});
+			});
+		}
 	});
 });

--- a/packages/framework/react/src/test/text/textEditor.test.tsx
+++ b/packages/framework/react/src/test/text/textEditor.test.tsx
@@ -975,14 +975,12 @@ describe("textEditor", () => {
 				assert.ok(result, "Expected a line tag for bullet list");
 				assert.equal(result.value, "li", "Expected tag to be li)");
 			});
-			// Tests for unsupported parameters - should return undefined, not throw an error.
+			// Tests for unsupported parameters - should return default header ("h5"), not throw an error.
 			// Also used for when formatting is stripped from a newline and it becomes a default newline
 			it("returns undefined for unsupported parameter", () => {
-				assert.equal(
-					parseLineTag({ header: 7 }),
-					undefined,
-					"Expected undefined for unsupported lineTag",
-				);
+				const result = parseLineTag({ header: 7 });
+				assert.ok(result, "Expected a line tag for header 5");
+				assert.equal(result.value, "h5", "Expected tag to be h5 for unsupported header level");
 			});
 		});
 		// tests quillFormattedview conversion that feeds into quill delta generation,

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -280,7 +280,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	const ops: QuillDeltaOp[] = [];
 	// Accumulator for current run of identically-formatted text
 	let text = "";
-	let currentAttributes: Record<string, unknown> = {};
+	let previousAttributes: Record<string, unknown> = {};
 	// JSON key for current attributes, used for equality comparison
 	// TODO:Performance: implement faster equality check.
 	let key = "";
@@ -289,7 +289,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	const pushRun = (): void => {
 		if (!text) return;
 		const op: QuillDeltaOp = { insert: text };
-		if (Object.keys(currentAttributes).length > 0) op.attributes = currentAttributes;
+		if (Object.keys(previousAttributes).length > 0) op.attributes = previousAttributes;
 		ops.push(op);
 	};
 
@@ -297,22 +297,22 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	// TODO:Performance: Optimize this loop by adding an API to get runs to FormattedTextAsTree.Tree, and implementing that using cursors.
 	// Something like `getUniformRun(startIndex, maxLength): number` and `substring(startIndex, length): string`.
 	for (const atom of root.charactersWithFormatting()) {
-		const attributes = formatToQuillAttributes(atom.format);
+		const currentAttributes = formatToQuillAttributes(atom.format);
 
 		if (atom.content instanceof FormattedTextAsTree.StringLineAtom) {
 			// Merge line-specific attributes (header/list) into the format
 			const lineTag = atom.content.tag.value;
-			Object.assign(attributes, lineTagToQuillAttributes[lineTag]);
+			Object.assign(currentAttributes, lineTagToQuillAttributes[lineTag]);
 
 			// Line atoms always break the current run and emit a newline
 			pushRun();
 			text = "";
 			key = "";
 			const op: QuillDeltaOp = { insert: "\n" };
-			if (Object.keys(attributes).length > 0) op.attributes = attributes;
+			if (Object.keys(currentAttributes).length > 0) op.attributes = currentAttributes;
 			ops.push(op);
 		} else {
-			const stringifiedAttributes = JSON.stringify(attributes);
+			const stringifiedAttributes = JSON.stringify(currentAttributes);
 			if (stringifiedAttributes === key) {
 				// Same formatting as previous character - extend run
 				text += atom.content.content;
@@ -320,7 +320,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 				// Different formatting - push previous run and start a new one
 				pushRun();
 				text = atom.content.content;
-				currentAttributes = attributes;
+				previousAttributes = currentAttributes;
 				key = stringifiedAttributes;
 			}
 		}

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -288,31 +288,32 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	// TODO:Performance: Optimize this loop by adding an API to get runs to FormattedTextAsTree.Tree, and implementing that using cursors.
 	// Something like `getUniformRun(startIndex, maxLength): number` and `substring(startIndex, length): string`.
 	for (const atom of root.charactersWithFormatting()) {
-		const lineTag =
-			atom.content instanceof FormattedTextAsTree.StringLineAtom
-				? atom.content.tag.value
-				: undefined;
-		if (lineTag === undefined) {
-			const a = formatToQuillAttrs(atom.format);
-			const k = JSON.stringify(a);
-			if (k === key) {
-				// Same formatting as previous character - extend current run
-				text += atom.content.content;
-			} else {
-				// Different formatting - push current run and start new one
-				pushRun();
-				text = atom.content.content;
-				attrs = a;
-				key = k;
-			}
-		} else {
+		const attribute = formatToQuillAttrs(atom.format);
+
+		if (atom.content instanceof FormattedTextAsTree.StringLineAtom) {
+			// Merge line-specific attributes (header/list) into the format
+			const lineTag = atom.content.tag.value;
+			Object.assign(attribute, lineTagToQuillAttrs[lineTag as LineTagValue]);
+
+			// Line atoms always break the current run and emit a newline
 			pushRun();
 			text = "";
 			key = "";
-			ops.push({
-				insert: "\n",
-				attributes: lineTagToQuillAttrs[lineTag as LineTagValue],
-			});
+			const op: QuillDeltaOp = { insert: "\n" };
+			if (Object.keys(attribute).length > 0) op.attributes = attribute;
+			ops.push(op);
+		} else {
+			const stringifiedAttr = JSON.stringify(attribute);
+			if (stringifiedAttr === key) {
+				// Same formatting as previous character - extend run
+				text += atom.content.content;
+			} else {
+				// Different formatting - push previous run and start a new one
+				pushRun();
+				text = atom.content.content;
+				attrs = attribute;
+				key = stringifiedAttr;
+			}
 		}
 	}
 

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -152,6 +152,33 @@ function parseSize(size: unknown): number {
 	return defaultSize;
 }
 
+/** Extract a LineTagValue from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time */
+function parseLineTag(attrs?: Record<string, unknown>): LineTagValue | undefined {
+	// default no formatting on "/n", or line tag on "/n" that doesn't affect formatting
+	let tag = undefined as LineTagValue;
+
+	if (!attrs) return tag;
+	// Header formatting. Quill passes header formatting as a number
+	if (typeof attrs.header === "number") {
+		tag = `h${attrs.header}`;
+	}
+	// List formatting. Quill passes list formatting as a string
+	else if (typeof attrs.list === "string") {
+		tag = "li";
+	}
+	return tag;
+}
+
+/** Create a StringAtom containing a StringLineAtom with the given line tag. */
+function createLineAtom(lineTag: LineTagValue): FormattedTextAsTree.StringAtom {
+	return new FormattedTextAsTree.StringAtom({
+		content: new FormattedTextAsTree.StringLineAtom({
+			tag: FormattedTextAsTree.LineTag(lineTag),
+		}),
+		format: new FormattedTextAsTree.CharacterFormat(quillAttrsToFormat()),
+	});
+}
+
 /**
  * Convert Quill attributes to a complete CharacterFormat object.
  * Used when inserting new characters - all format properties must have values.
@@ -191,25 +218,6 @@ function quillAttrsToPartial(
 	if ("size" in attrs) format.size = parseSize(attrs.size);
 	if ("font" in attrs) format.font = typeof attrs.font === "string" ? attrs.font : defaultFont;
 	return format;
-}
-
-/** Extract a LineTagValue from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time */
-function getLineTag(attrs?: Record<string, unknown>): LineTagValue | undefined {
-	if (!attrs) return undefined;
-	if (typeof attrs.header === "number") return `h${attrs.header}` as LineTagValue;
-	if (typeof attrs.list === "string") return "li";
-	// no formatting on "/n", or line tag on "/n" that doesn't affect formatting
-	return undefined;
-}
-
-/** Create a StringAtom containing a StringLineAtom with the given line tag. */
-function createLineAtom(lineTag: LineTagValue): FormattedTextAsTree.StringAtom {
-	return new FormattedTextAsTree.StringAtom({
-		content: new FormattedTextAsTree.StringLineAtom({
-			tag: FormattedTextAsTree.LineTag(lineTag),
-		}),
-		format: new FormattedTextAsTree.CharacterFormat(quillAttrsToFormat()),
-	});
 }
 
 /**
@@ -405,7 +413,7 @@ const FormattedTextEditorView = React.forwardRef<
 						const cpCount = codepointCount(retainedStr);
 
 						if (op.attributes) {
-							const lineTag = getLineTag(op.attributes);
+							const lineTag = parseLineTag(op.attributes);
 							if (lineTag !== undefined && content[utf16Pos] === "\n") {
 								// Swap existing newline atom to StringLineAtom
 								root.removeRange(cpPos, cpPos + 1);
@@ -430,7 +438,7 @@ const FormattedTextEditorView = React.forwardRef<
 						content = content.slice(0, utf16Pos) + content.slice(utf16Pos + op.delete);
 						// Don't advance positions - next op starts at same position
 					} else if (typeof op.insert === "string") {
-						const lineTag = getLineTag(op.attributes);
+						const lineTag = parseLineTag(op.attributes);
 						if (lineTag !== undefined && op.insert === "\n") {
 							root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
 						} else {

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -169,7 +169,7 @@ function parseSize(size: unknown): number {
 }
 
 /** Extract a LineTag from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time. */
-function parseLineTag(
+export function parseLineTag(
 	attrs?: Record<string, unknown>,
 ): FormattedTextAsTree.LineTag | undefined {
 	if (!attrs) return undefined;
@@ -267,7 +267,7 @@ function formatToQuillAttrs(
  * This is used to sync Quill's display when the tree changes externally
  * (e.g., from a remote collaborator's edit).
  */
-function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp[] {
+export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp[] {
 	const ops: QuillDeltaOp[] = [];
 	// Accumulator for current run of identically-formatted text
 	let text = "";

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -59,25 +59,27 @@ const fontSet = new Set<string>(["monospace", "serif", "sans-serif", "Arial"]);
 const defaultSize = 12;
 /** Default font when no explicit font is specified. */
 const defaultFont = "Arial";
+/** default heading for when an unsupported header is supplied */
+const defaultHeading = "h5";
 /** The string literal values accepted by LineTag. */
-type LineTagValue = "h1" | "h2" | "h3" | "h4" | "h5" | "li";
+type LineTagValue = Parameters<typeof FormattedTextAsTree.LineTag>[0];
 /** Quill header numbers → LineTag values. */
-const headerToLineTag: Record<number, LineTagValue> = {
+const headerToLineTag = {
 	1: "h1",
 	2: "h2",
 	3: "h3",
 	4: "h4",
 	5: "h5",
-};
+} as const satisfies Readonly<Record<number, LineTagValue>>;
 /** LineTag values → Quill attributes. Used by buildDeltaFromTree (tree → Quill). */
-const lineTagToQuillAttrs: Record<LineTagValue, Record<string, unknown>> = {
+const lineTagToQuillAttributes = {
 	h1: { header: 1 },
 	h2: { header: 2 },
 	h3: { header: 3 },
 	h4: { header: 4 },
 	h5: { header: 5 },
 	li: { list: "bullet" },
-};
+} as const satisfies Readonly<Record<LineTagValue, Record<string, unknown>>>;
 /**
  * Parse CSS font-size from a pasted HTML element's inline style.
  * Returns a Quill size name if the pixel value matches a supported size, undefined otherwise.
@@ -170,14 +172,20 @@ function parseSize(size: unknown): number {
 
 /** Extract a LineTag from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time. */
 export function parseLineTag(
-	attrs?: Record<string, unknown>,
+	attributes?: Record<string, unknown>,
 ): FormattedTextAsTree.LineTag | undefined {
-	if (!attrs) return undefined;
-	if (typeof attrs.header === "number") {
-		const tag = headerToLineTag[attrs.header];
-		if (tag !== undefined) return FormattedTextAsTree.LineTag(tag);
+	if (!attributes) return undefined;
+	// Quill should never send both header and list attributes simultaneously.
+	assert(
+		!(typeof attributes.header === "number" && typeof attributes.list === "string"),
+		"expected at most one line tag (header or list), but received both",
+	);
+	if (typeof attributes.header === "number") {
+		const tag: LineTagValue =
+			headerToLineTag[attributes.header as keyof typeof headerToLineTag] ?? defaultHeading;
+		return FormattedTextAsTree.LineTag(tag);
 	}
-	if (attrs.list === "bullet") {
+	if (attributes.list === "bullet") {
 		return FormattedTextAsTree.LineTag("li");
 	}
 	return undefined;
@@ -189,7 +197,7 @@ function createLineAtom(lineTag: FormattedTextAsTree.LineTag): FormattedTextAsTr
 		content: new FormattedTextAsTree.StringLineAtom({
 			tag: lineTag,
 		}),
-		format: new FormattedTextAsTree.CharacterFormat(quillAttrsToFormat()),
+		format: new FormattedTextAsTree.CharacterFormat(quillAttributesToFormat()),
 	});
 }
 
@@ -198,7 +206,7 @@ function createLineAtom(lineTag: FormattedTextAsTree.LineTag): FormattedTextAsTr
  * Used when inserting new characters - all format properties must have values.
  * Missing attributes default to false/default values.
  */
-function quillAttrsToFormat(attrs?: Record<string, unknown>): {
+function quillAttributesToFormat(attributes?: Record<string, unknown>): {
 	bold: boolean;
 	italic: boolean;
 	underline: boolean;
@@ -206,11 +214,11 @@ function quillAttrsToFormat(attrs?: Record<string, unknown>): {
 	font: string;
 } {
 	return {
-		bold: attrs?.bold === true,
-		italic: attrs?.italic === true,
-		underline: attrs?.underline === true,
-		size: parseSize(attrs?.size),
-		font: typeof attrs?.font === "string" ? attrs.font : defaultFont,
+		bold: attributes?.bold === true,
+		italic: attributes?.italic === true,
+		underline: attributes?.underline === true,
+		size: parseSize(attributes?.size),
+		font: typeof attributes?.font === "string" ? attributes.font : defaultFont,
 	};
 }
 
@@ -220,17 +228,18 @@ function quillAttrsToFormat(attrs?: Record<string, unknown>): {
  * Only includes properties that were explicitly set in the Quill attributes,
  * allowing selective format updates without overwriting unrelated properties.
  */
-function quillAttrsToPartial(
-	attrs?: Record<string, unknown>,
+function quillAttributesToPartial(
+	attributes?: Record<string, unknown>,
 ): Partial<FormattedTextAsTree.CharacterFormat> {
-	if (!attrs) return {};
+	if (!attributes) return {};
 	const format: Partial<FormattedTextAsTree.CharacterFormat> = {};
 	// Only include attributes that are explicitly present in the Quill delta
-	if ("bold" in attrs) format.bold = attrs.bold === true;
-	if ("italic" in attrs) format.italic = attrs.italic === true;
-	if ("underline" in attrs) format.underline = attrs.underline === true;
-	if ("size" in attrs) format.size = parseSize(attrs.size);
-	if ("font" in attrs) format.font = typeof attrs.font === "string" ? attrs.font : defaultFont;
+	if ("bold" in attributes) format.bold = attributes.bold === true;
+	if ("italic" in attributes) format.italic = attributes.italic === true;
+	if ("underline" in attributes) format.underline = attributes.underline === true;
+	if ("size" in attributes) format.size = parseSize(attributes.size);
+	if ("font" in attributes)
+		format.font = typeof attributes.font === "string" ? attributes.font : defaultFont;
 	return format;
 }
 
@@ -239,23 +248,23 @@ function quillAttrsToPartial(
  * Used when building Quill deltas from tree content to sync external changes.
  * Only includes non-default values to keep deltas minimal.
  */
-function formatToQuillAttrs(
+function formatToQuillAttributes(
 	format: FormattedTextAsTree.CharacterFormat,
 ): Record<string, unknown> {
-	const attrs: Record<string, unknown> = {};
+	const attributes: Record<string, unknown> = {};
 	// Only include non-default formatting to keep Quill deltas minimal
-	if (format.bold) attrs.bold = true;
-	if (format.italic) attrs.italic = true;
-	if (format.underline) attrs.underline = true;
+	if (format.bold) attributes.bold = true;
+	if (format.italic) attributes.italic = true;
+	if (format.underline) attributes.underline = true;
 	if (format.size !== defaultSize) {
 		// Convert pixel value back to Quill size name if possible
-		attrs.size =
+		attributes.size =
 			format.size in sizeReverse
 				? sizeReverse[format.size as keyof typeof sizeReverse]
 				: `${format.size}px`;
 	}
-	if (format.font !== defaultFont) attrs.font = format.font;
-	return attrs;
+	if (format.font !== defaultFont) attributes.font = format.font;
+	return attributes;
 }
 
 /**
@@ -271,7 +280,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	const ops: QuillDeltaOp[] = [];
 	// Accumulator for current run of identically-formatted text
 	let text = "";
-	let attrs: Record<string, unknown> = {};
+	let currentAttributes: Record<string, unknown> = {};
 	// JSON key for current attributes, used for equality comparison
 	// TODO:Performance: implement faster equality check.
 	let key = "";
@@ -280,7 +289,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	const pushRun = (): void => {
 		if (!text) return;
 		const op: QuillDeltaOp = { insert: text };
-		if (Object.keys(attrs).length > 0) op.attributes = attrs;
+		if (Object.keys(currentAttributes).length > 0) op.attributes = currentAttributes;
 		ops.push(op);
 	};
 
@@ -288,31 +297,31 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 	// TODO:Performance: Optimize this loop by adding an API to get runs to FormattedTextAsTree.Tree, and implementing that using cursors.
 	// Something like `getUniformRun(startIndex, maxLength): number` and `substring(startIndex, length): string`.
 	for (const atom of root.charactersWithFormatting()) {
-		const attribute = formatToQuillAttrs(atom.format);
+		const attributes = formatToQuillAttributes(atom.format);
 
 		if (atom.content instanceof FormattedTextAsTree.StringLineAtom) {
 			// Merge line-specific attributes (header/list) into the format
 			const lineTag = atom.content.tag.value;
-			Object.assign(attribute, lineTagToQuillAttrs[lineTag as LineTagValue]);
+			Object.assign(attributes, lineTagToQuillAttributes[lineTag]);
 
 			// Line atoms always break the current run and emit a newline
 			pushRun();
 			text = "";
 			key = "";
 			const op: QuillDeltaOp = { insert: "\n" };
-			if (Object.keys(attribute).length > 0) op.attributes = attribute;
+			if (Object.keys(attributes).length > 0) op.attributes = attributes;
 			ops.push(op);
 		} else {
-			const stringifiedAttr = JSON.stringify(attribute);
-			if (stringifiedAttr === key) {
+			const stringifiedAttributes = JSON.stringify(attributes);
+			if (stringifiedAttributes === key) {
 				// Same formatting as previous character - extend run
 				text += atom.content.content;
 			} else {
 				// Different formatting - push previous run and start a new one
 				pushRun();
 				text = atom.content.content;
-				attrs = attribute;
-				key = stringifiedAttr;
+				currentAttributes = attributes;
+				key = stringifiedAttributes;
 			}
 		}
 	}
@@ -429,14 +438,18 @@ const FormattedTextEditorView = React.forwardRef<
 
 						if (op.attributes) {
 							const lineTag = parseLineTag(op.attributes);
+							// Case 1: Applying line formatting (header/list) to an existing newline in the document.
 							if (lineTag !== undefined && content[utf16Pos] === "\n") {
 								// Swap existing newline atom to StringLineAtom
 								root.removeRange(cpPos, cpPos + 1);
 								root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
+								// Case 2: Applying line formatting past the end of content. Quill's implicit trailing newline.
 							} else if (lineTag !== undefined && utf16Pos >= content.length) {
 								// Quill's implicit trailing newline — insert a new line atom
 								root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
 								content += "\n";
+								// Case 3: clearing line formatting. Deletes StringLineAtom and inserts a plain
+								// StringTextAtom("\n") in its place.
 							} else if (
 								lineTag === undefined &&
 								content[utf16Pos] === "\n" &&
@@ -449,8 +462,13 @@ const FormattedTextEditorView = React.forwardRef<
 								// StringLineAtom and insert a plain StringTextAtom("\n") in its place.
 								root.removeRange(cpPos, cpPos + 1);
 								root.insertAt(cpPos, "\n");
+								// Case 4: Normal character formatting (bold, italic, size, etc...)
 							} else {
-								root.formatRange(cpPos, cpPos + cpCount, quillAttrsToPartial(op.attributes));
+								root.formatRange(
+									cpPos,
+									cpPos + cpCount,
+									quillAttributesToPartial(op.attributes),
+								);
 							}
 						}
 						utf16Pos += op.retain;
@@ -471,7 +489,7 @@ const FormattedTextEditorView = React.forwardRef<
 						} else {
 							// Insert: add new text with formatting at current position
 							root.defaultFormat = new FormattedTextAsTree.CharacterFormat(
-								quillAttrsToFormat(op.attributes),
+								quillAttributesToFormat(op.attributes),
 							);
 							root.insertAt(cpPos, op.insert);
 						}

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -59,6 +59,25 @@ const fontSet = new Set<string>(["monospace", "serif", "sans-serif", "Arial"]);
 const defaultSize = 12;
 /** Default font when no explicit font is specified. */
 const defaultFont = "Arial";
+/** The string literal values accepted by LineTag. */
+type LineTagValue = "h1" | "h2" | "h3" | "h4" | "h5" | "li";
+/** Quill header numbers → LineTag values. */
+const headerToLineTag: Record<number, LineTagValue> = {
+	1: "h1",
+	2: "h2",
+	3: "h3",
+	4: "h4",
+	5: "h5",
+};
+/** LineTag values → Quill attributes. Used by buildDeltaFromTree (tree → Quill). */
+const lineTagToQuillAttrs: Record<LineTagValue, Record<string, unknown>> = {
+	h1: { header: 1 },
+	h2: { header: 2 },
+	h3: { header: 3 },
+	h4: { header: 4 },
+	h5: { header: 5 },
+	li: { list: "bullet" },
+};
 /**
  * Parse CSS font-size from a pasted HTML element's inline style.
  * Returns a Quill size name if the pixel value matches a supported size, undefined otherwise.
@@ -149,21 +168,15 @@ function parseSize(size: unknown): number {
 	return defaultSize;
 }
 
-/** Quill header numbers mapped to their LineTag string values. */
-const headerTags = { 1: "h1", 2: "h2", 3: "h3", 4: "h4", 5: "h5" } as const;
-
 /** Extract a LineTag from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time. */
 function parseLineTag(
 	attrs?: Record<string, unknown>,
 ): FormattedTextAsTree.LineTag | undefined {
-	// default no formatting on "\n", or line tag on "\n" that doesn't affect formatting
 	if (!attrs) return undefined;
-	// Header formatting. Quill passes header formatting as a number (1-5)
-	const header = attrs.header;
-	if (typeof header === "number" && header in headerTags) {
-		return FormattedTextAsTree.LineTag(headerTags[header as keyof typeof headerTags]);
+	if (typeof attrs.header === "number") {
+		const tag = headerToLineTag[attrs.header];
+		if (tag !== undefined) return FormattedTextAsTree.LineTag(tag);
 	}
-	// List formatting. Only treat "bullet" as an unordered list item.
 	if (attrs.list === "bullet") {
 		return FormattedTextAsTree.LineTag("li");
 	}
@@ -298,7 +311,7 @@ function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp[] {
 			key = "";
 			ops.push({
 				insert: "\n",
-				attributes: lineTag === "li" ? { list: "bullet" } : { header: Number(lineTag[1]) },
+				attributes: lineTagToQuillAttrs[lineTag as LineTagValue],
 			});
 		}
 	}
@@ -423,6 +436,18 @@ const FormattedTextEditorView = React.forwardRef<
 								// Quill's implicit trailing newline — insert a new line atom
 								root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
 								content += "\n";
+							} else if (
+								lineTag === undefined &&
+								content[utf16Pos] === "\n" &&
+								root.charactersWithFormatting()[cpPos]?.content instanceof
+									FormattedTextAsTree.StringLineAtom
+							) {
+								// Quill is clearing line formatting (e.g. { retain: 1, attributes: { header: null } }).
+								// StringLineAtom and StringTextAtom are distinct schema types in the tree,
+								// so we can't convert between them via formatRange — we must delete the
+								// StringLineAtom and insert a plain StringTextAtom("\n") in its place.
+								root.removeRange(cpPos, cpPos + 1);
+								root.insertAt(cpPos, "\n");
 							} else {
 								root.formatRange(cpPos, cpPos + cpCount, quillAttrsToPartial(op.attributes));
 							}

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -59,6 +59,9 @@ const fontSet = new Set<string>(["monospace", "serif", "sans-serif", "Arial"]);
 const defaultSize = 12;
 /** Default font when no explicit font is specified. */
 const defaultFont = "Arial";
+/** Valid LineTag string values accepted by FormattedTextAsTree.LineTag(). */
+type LineTagValue = "h1" | "h2" | "h3" | "h4" | "h5" | "li";
+
 /**
  * Parse CSS font-size from a pasted HTML element's inline style.
  * Returns a Quill size name if the pixel value matches a supported size, undefined otherwise.
@@ -190,6 +193,25 @@ function quillAttrsToPartial(
 	return format;
 }
 
+/** Extract a LineTagValue from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time */
+function getLineTag(attrs?: Record<string, unknown>): LineTagValue | undefined {
+	if (!attrs) return undefined;
+	if (typeof attrs.header === "number") return `h${attrs.header}` as LineTagValue;
+	if (typeof attrs.list === "string") return "li";
+	// no formatting on "/n", or line tag on "/n" that doesn't affect formatting
+	return undefined;
+}
+
+/** Create a StringAtom containing a StringLineAtom with the given line tag. */
+function createLineAtom(lineTag: LineTagValue): FormattedTextAsTree.StringAtom {
+	return new FormattedTextAsTree.StringAtom({
+		content: new FormattedTextAsTree.StringLineAtom({
+			tag: FormattedTextAsTree.LineTag(lineTag),
+		}),
+		format: new FormattedTextAsTree.CharacterFormat(quillAttrsToFormat()),
+	});
+}
+
 /**
  * Convert a CharacterFormat from the tree to Quill attributes.
  * Used when building Quill deltas from tree content to sync external changes.
@@ -244,19 +266,34 @@ function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp[] {
 	// TODO:Performance: Optimize this loop by adding an API to get runs to FormattedTextAsTree.Tree, and implementing that using cursors.
 	// Something like `getUniformRun(startIndex, maxLength): number` and `substring(startIndex, length): string`.
 	for (const atom of root.charactersWithFormatting()) {
-		const a = formatToQuillAttrs(atom.format);
-		const k = JSON.stringify(a);
-		if (k === key) {
-			// Same formatting as previous character - extend current run
-			text += atom.content.content;
+		const lineTag =
+			atom.content instanceof FormattedTextAsTree.StringLineAtom
+				? atom.content.tag.value
+				: undefined;
+		if (lineTag === undefined) {
+			const a = formatToQuillAttrs(atom.format);
+			const k = JSON.stringify(a);
+			if (k === key) {
+				// Same formatting as previous character - extend current run
+				text += atom.content.content;
+			} else {
+				// Different formatting - push current run and start new one
+				pushRun();
+				text = atom.content.content;
+				attrs = a;
+				key = k;
+			}
 		} else {
-			// Different formatting - push current run and start new one
 			pushRun();
-			text = atom.content.content;
-			attrs = a;
-			key = k;
+			text = "";
+			key = "";
+			ops.push({
+				insert: "\n",
+				attributes: lineTag === "li" ? { list: "bullet" } : { header: Number(lineTag[1]) },
+			});
 		}
 	}
+
 	// Push any remaining accumulated text
 	pushRun();
 
@@ -320,6 +357,8 @@ const FormattedTextEditorView = React.forwardRef<
 					["bold", "italic", "underline"],
 					[{ size: ["small", false, "large", "huge"] }],
 					[{ font: [] }],
+					[{ header: [1, 2, 3, 4, 5, false] }],
+					[{ list: "bullet" }],
 					["clean"],
 				],
 				clipboard: [Node.ELEMENT_NODE, clipboardFormatMatcher],
@@ -366,7 +405,18 @@ const FormattedTextEditorView = React.forwardRef<
 						const cpCount = codepointCount(retainedStr);
 
 						if (op.attributes) {
-							root.formatRange(cpPos, cpPos + cpCount, quillAttrsToPartial(op.attributes));
+							const lineTag = getLineTag(op.attributes);
+							if (lineTag !== undefined && content[utf16Pos] === "\n") {
+								// Swap existing newline atom to StringLineAtom
+								root.removeRange(cpPos, cpPos + 1);
+								root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
+							} else if (lineTag !== undefined && utf16Pos >= content.length) {
+								// Quill's implicit trailing newline — insert a new line atom
+								root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
+								content += "\n";
+							} else {
+								root.formatRange(cpPos, cpPos + cpCount, quillAttrsToPartial(op.attributes));
+							}
 						}
 						utf16Pos += op.retain;
 						cpPos += cpCount;
@@ -380,11 +430,16 @@ const FormattedTextEditorView = React.forwardRef<
 						content = content.slice(0, utf16Pos) + content.slice(utf16Pos + op.delete);
 						// Don't advance positions - next op starts at same position
 					} else if (typeof op.insert === "string") {
-						// Insert: add new text with formatting at current position
-						root.defaultFormat = new FormattedTextAsTree.CharacterFormat(
-							quillAttrsToFormat(op.attributes),
-						);
-						root.insertAt(cpPos, op.insert);
+						const lineTag = getLineTag(op.attributes);
+						if (lineTag !== undefined && op.insert === "\n") {
+							root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag)]);
+						} else {
+							// Insert: add new text with formatting at current position
+							root.defaultFormat = new FormattedTextAsTree.CharacterFormat(
+								quillAttrsToFormat(op.attributes),
+							);
+							root.insertAt(cpPos, op.insert);
+						}
 						// Update content to reflect insertion
 						content = content.slice(0, utf16Pos) + op.insert + content.slice(utf16Pos);
 						// Advance by inserted content length
@@ -488,6 +543,10 @@ const FormattedTextEditorView = React.forwardRef<
 				.ql-undo::after { content: "↶"; font-size: 18px; }
 				.ql-redo::after { content: "↷"; font-size: 18px; }
 				.ql-undo:disabled, .ql-redo:disabled { opacity: 0.3; cursor: not-allowed; }
+				/* Custom CSS Altering Quills default bullet point alignment. Vertically center */
+				/* bullets in list items, since Quill's bullet has no inherent height */
+				li[data-list="bullet"] { display: flex; align-items: center; }
+				li[data-list="bullet"] .ql-ui { align-self: center; }
 			`}</style>
 			<h2 style={{ margin: "10px 0" }}>Collaborative Formatted Text Editor</h2>
 			<div

--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -59,9 +59,6 @@ const fontSet = new Set<string>(["monospace", "serif", "sans-serif", "Arial"]);
 const defaultSize = 12;
 /** Default font when no explicit font is specified. */
 const defaultFont = "Arial";
-/** Valid LineTag string values accepted by FormattedTextAsTree.LineTag(). */
-type LineTagValue = "h1" | "h2" | "h3" | "h4" | "h5" | "li";
-
 /**
  * Parse CSS font-size from a pasted HTML element's inline style.
  * Returns a Quill size name if the pixel value matches a supported size, undefined otherwise.
@@ -152,28 +149,32 @@ function parseSize(size: unknown): number {
 	return defaultSize;
 }
 
-/** Extract a LineTagValue from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time */
-function parseLineTag(attrs?: Record<string, unknown>): LineTagValue | undefined {
-	// default no formatting on "/n", or line tag on "/n" that doesn't affect formatting
-	let tag = undefined as LineTagValue;
+/** Quill header numbers mapped to their LineTag string values. */
+const headerTags = { 1: "h1", 2: "h2", 3: "h3", 4: "h4", 5: "h5" } as const;
 
-	if (!attrs) return tag;
-	// Header formatting. Quill passes header formatting as a number
-	if (typeof attrs.header === "number") {
-		tag = `h${attrs.header}`;
+/** Extract a LineTag from Quill attributes, or undefined if none present. Quill only supports one LineTag at a time. */
+function parseLineTag(
+	attrs?: Record<string, unknown>,
+): FormattedTextAsTree.LineTag | undefined {
+	// default no formatting on "\n", or line tag on "\n" that doesn't affect formatting
+	if (!attrs) return undefined;
+	// Header formatting. Quill passes header formatting as a number (1-5)
+	const header = attrs.header;
+	if (typeof header === "number" && header in headerTags) {
+		return FormattedTextAsTree.LineTag(headerTags[header as keyof typeof headerTags]);
 	}
-	// List formatting. Quill passes list formatting as a string
-	else if (typeof attrs.list === "string") {
-		tag = "li";
+	// List formatting. Only treat "bullet" as an unordered list item.
+	if (attrs.list === "bullet") {
+		return FormattedTextAsTree.LineTag("li");
 	}
-	return tag;
+	return undefined;
 }
 
 /** Create a StringAtom containing a StringLineAtom with the given line tag. */
-function createLineAtom(lineTag: LineTagValue): FormattedTextAsTree.StringAtom {
+function createLineAtom(lineTag: FormattedTextAsTree.LineTag): FormattedTextAsTree.StringAtom {
 	return new FormattedTextAsTree.StringAtom({
 		content: new FormattedTextAsTree.StringLineAtom({
-			tag: FormattedTextAsTree.LineTag(lineTag),
+			tag: lineTag,
 		}),
 		format: new FormattedTextAsTree.CharacterFormat(quillAttrsToFormat()),
 	});
@@ -551,8 +552,8 @@ const FormattedTextEditorView = React.forwardRef<
 				.ql-undo::after { content: "↶"; font-size: 18px; }
 				.ql-redo::after { content: "↷"; font-size: 18px; }
 				.ql-undo:disabled, .ql-redo:disabled { opacity: 0.3; cursor: not-allowed; }
-				/* Custom CSS Altering Quills default bullet point alignment. Vertically center */
-				/* bullets in list items, since Quill's bullet has no inherent height */
+				/* custom css altering Quill's default bullet point alignment */
+				/* vertically center bullets in list items, since Quill's bullet has no inherent height */
 				li[data-list="bullet"] { display: flex; align-items: center; }
 				li[data-list="bullet"] .ql-ui { align-self: center; }
 			`}</style>


### PR DESCRIPTION
## Summary                                                                                                                              
  - Add support for header (h1-h5) and unordered list formatting in the Quill-based formatted text editor by integrating `StringLineAtom` line-level formatting                
  - Handle line tag parsing from Quill attributes (headers as numbers, lists as strings) and convert them to/from `FormattedTextAsTree` line atoms                                                                                                                              
  - Update `buildDeltaFromTree` to emit correct Quill delta ops for line-level formatting (headers and bullet lists)                      
  - Enable header and bullet list toolbar buttons in the Quill editor                                                                     
  - Add CSS fixes for Quills bullet point vertical alignment in list items
  - Add tests for mimicing Quills trailing newline and the conversion of Quill to formattedText LineTag

  ## Files changed
  - `packages/framework/react/src/text/formatted/quillFormattedView.tsx` — Add `parseLineTag`, `createLineAtom`, `LineTagValue` type; update `buildDeltaFromTree` to handle line atoms; handle line tags in insert/retain delta ops; add header/list toolbar buttons and bullet CSS.
  - `packages/framework/react/src/test/text/textEditor.test.tsx` — Add line formatting test suite covering lineTag