### PR TITLE
Properly apply commit in `applySerializedChange`

### DIFF
--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -786,7 +786,8 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			revision,
 		};
 		const decodedChange = this.changeFamily.codecs.resolve(4).decode(change, context);
-		this.applyChange(decodedChange, revision);
+		// Apply the change to the branch, but _not_ the `activeBranch` - we do not support squashing serialized commits in a transaction.
+		this.#transaction.branch.apply(tagChange(decodedChange, revision));
 	}
 
 	// Revision is the revision of the commit, if any, which caused this change.

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -9,6 +9,7 @@ import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
+import type { Revertible } from "../../../core/index.js";
 import { Tree } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { UnhydratedFlexTreeNode } from "../../../simple-tree/core/index.js";
@@ -335,6 +336,75 @@ describe("simple-tree tree", () => {
 			assert.throws(() => {
 				viewA.applyChange({ invalid: "bogus" });
 			}, /cannot apply change.*invalid.*format/i);
+		});
+
+		it("can be undone", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			let revertible: Revertible | undefined;
+			viewA.events.on("changed", (metadata) => {
+				assert(metadata.isLocal);
+				revertible = metadata.getRevertible();
+			});
+			let change: JsonCompatibleReadOnly | undefined;
+			viewB.events.on("changed", (metadata) => {
+				assert(metadata.isLocal);
+				change = metadata.getChange();
+			});
+
+			viewB.root = 4;
+			assert(change !== undefined);
+			viewA.applyChange(change);
+			assert(revertible !== undefined);
+			revertible.revert();
+			assert.equal(viewA.root, 3);
+		});
+
+		it("can apply alongside a transaction", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			let change: JsonCompatibleReadOnly | undefined;
+			viewB.events.on("changed", (metadata) => {
+				assert(metadata.isLocal);
+				change = metadata.getChange();
+			});
+
+			viewB.root = 4;
+			viewA.runTransaction(() => {
+				assert(change !== undefined);
+				viewA.applyChange(change);
+			});
+			assert.equal(viewA.root, 4);
+		});
+
+		it("apply before transactions", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			let change: JsonCompatibleReadOnly | undefined;
+			viewB.events.on("changed", (metadata) => {
+				assert(metadata.isLocal);
+				change = metadata.getChange();
+			});
+
+			viewB.root = 4;
+			viewA.runTransaction(() => {
+				viewA.root = 5;
+				assert(change !== undefined);
+				// Even though the serialized change (= 4) is applied _after_ the transaction change (= 5),
+				// it is considered a change external to the transaction and so will be applied before the transaction changes,
+				// as is the general policy for external changes applied during a transaction.
+				viewA.applyChange(change);
+			});
+			assert.equal(viewA.root, 5);
 		});
 	});
 });


### PR DESCRIPTION
Prior to this, `applySerializedChange` only updated the view state, but not the commit graph. This left the view in a state that did not reflect the commit graph, which is a dramatic invariant violation. This has been fixed, and tested by adding a test that uses a revertible to undo the commit. Additionally, some more tests have been added that solidify the behavior around of applying serialized changes during transactions.