### PR TITLE
content derived id allocation batches

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -239,6 +239,7 @@ import {
 } from "./messageTypes.js";
 import type { ISavedOpMetadata } from "./metadata.js";
 import {
+	type BatchId,
 	type LocalBatchMessage,
 	type BatchStartInfo,
 	DuplicateBatchDetector,
@@ -826,6 +827,17 @@ function canStageMessageOfType(
 		// These are typically sent shortly after boot and will not be common in Staging Mode, but it's possible.
 		type === ContainerMessageType.DocumentSchemaChange
 	);
+}
+
+/**
+ * Compute a deterministic batchId for an ID Allocation batch based on the IdCreationRange content.
+ * Both forked containers rehydrating from the same stashed state will produce identical
+ * IdCreationRange objects (same sessionId, firstGenCount, count, localIdRanges), so
+ * JSON.stringify produces the same string, yielding the same batchId.
+ * This enables DuplicateBatchDetector to detect the duplicate and throw a clear fork error.
+ */
+function computeIdAllocBatchId(idRange: IdCreationRange): BatchId {
+	return `idalloc_${JSON.stringify(idRange)}`;
 }
 
 /**
@@ -4702,7 +4714,12 @@ export class ContainerRuntime
 					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
 					staged,
 				};
-				this.outbox.submitIdAllocation(idAllocationBatchMessage);
+				// Compute a deterministic batchId from the ID range content.
+				// Two forked containers rehydrating from the same stashed state will produce
+				// identical IdCreationRange objects, yielding the same batchId. This enables
+				// DuplicateBatchDetector to detect the duplicate and throw a clear fork error.
+				const batchId = computeIdAllocBatchId(idRange);
+				this.outbox.submitIdAllocation(idAllocationBatchMessage, batchId);
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -28,9 +28,11 @@ export interface IBatchManagerOptions {
 	readonly canRebase: boolean;
 
 	/**
-	 * If true, don't compare batchID of incoming batches to this. e.g. ID Allocation Batch IDs should be ignored
+	 * If true, this batch type is not directly resubmitted during replay.
+	 * Instead, the runtime handles resubmission separately
+	 * (e.g. ID Allocation ops are regenerated fresh via submitIdAllocationOpIfNeeded).
 	 */
-	readonly ignoreBatchId?: boolean;
+	readonly skipResubmit?: boolean;
 }
 
 export interface BatchSequenceNumbers {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -196,6 +196,8 @@ export class Outbox {
 	private readonly mainBatch: BatchManager;
 	private readonly blobAttachBatch: BatchManager;
 	private readonly idAllocationBatch: BatchManager;
+	/** Content-derived batchId for the pending ID allocation batch, enabling fork detection */
+	private pendingIdAllocBatchId: BatchId | undefined;
 	private batchRebasesToReport = 5;
 	private rebasing = false;
 
@@ -215,7 +217,7 @@ export class Outbox {
 		this.blobAttachBatch = new BatchManager({ canRebase: true });
 		this.idAllocationBatch = new BatchManager({
 			canRebase: false,
-			ignoreBatchId: true,
+			skipResubmit: true,
 		});
 	}
 
@@ -340,9 +342,10 @@ export class Outbox {
 		this.addMessageToBatchManager(this.blobAttachBatch, message);
 	}
 
-	public submitIdAllocation(message: LocalBatchMessage): void {
+	public submitIdAllocation(message: LocalBatchMessage, batchId?: BatchId): void {
 		this.maybeFlushPartialBatch();
 
+		this.pendingIdAllocBatchId = batchId;
 		this.addMessageToBatchManager(this.idAllocationBatch, message);
 	}
 
@@ -397,13 +400,17 @@ export class Outbox {
 			return;
 		}
 
-		// Don't use resubmittingBatchId for idAllocationBatch.
-		// ID Allocation messages are not directly resubmitted so don't pass the resubmitInfo
+		// ID Allocation messages are not directly resubmitted, so don't pass the resubmitInfo.
+		// Instead, pass the content-derived batchId computed when the ID allocation was submitted.
+		// This enables DuplicateBatchDetector to detect forked containers that rehydrate
+		// the same stashed state and submit duplicate ID allocation ops.
 		this.flushInternal({
 			batchManager: this.idAllocationBatch,
+			batchId: this.pendingIdAllocBatchId,
 			// Note: For now, we will never stage ID Allocation messages.
 			// They won't contain personal info and no harm in extra allocations in case of discarding the staged changes
 		});
+		this.pendingIdAllocBatchId = undefined;
 		this.flushInternal({
 			batchManager: this.blobAttachBatch,
 			disableGroupedBatching: true,
@@ -448,13 +455,14 @@ export class Outbox {
 		batchManager: BatchManager;
 		disableGroupedBatching?: boolean;
 		resubmitInfo?: BatchResubmitInfo; // undefined if not resubmitting
+		batchId?: BatchId; // explicit batchId (e.g. content-derived for ID allocation batches)
 	}): void {
 		const { batchManager, disableGroupedBatching = false, resubmitInfo } = params;
 		if (batchManager.empty) {
 			return;
 		}
 
-		const rawBatch = batchManager.popBatch(resubmitInfo?.batchId);
+		const rawBatch = batchManager.popBatch(resubmitInfo?.batchId ?? params.batchId);
 
 		// On resubmit we use the original batch's staged state, so these should match as well.
 		const staged = rawBatch.staged === true;
@@ -499,7 +507,7 @@ export class Outbox {
 			rawBatch.messages,
 			clientSequenceNumber,
 			staged,
-			batchManager.options.ignoreBatchId,
+			batchManager.options.skipResubmit,
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -85,9 +85,11 @@ export interface IPendingMessage {
 		 */
 		length: number;
 		/**
-		 * If true, don't compare batchID of incoming batches to this. e.g. ID Allocation Batch IDs should be ignored
+		 * If true, this batch type is not directly resubmitted during replay.
+		 * Instead, the runtime handles resubmission separately
+		 * (e.g. ID Allocation ops are regenerated fresh via submitIdAllocationOpIfNeeded).
 		 */
-		ignoreBatchId?: boolean;
+		skipResubmit?: boolean;
 		/**
 		 * If true, this batch is staged and should not actually be submitted on replayPendingStates.
 		 */
@@ -103,11 +105,24 @@ type Patch<T, U> = U & Omit<T, keyof U>;
 type IPendingMessageV0 = Patch<IPendingMessage, { batchInfo?: undefined }>;
 
 /**
+ * Second version of the type (used ignoreBatchId instead of skipResubmit)
+ */
+type IPendingMessageV1 = Patch<
+	IPendingMessage,
+	{
+		batchInfo: Patch<
+			IPendingMessage["batchInfo"],
+			{ ignoreBatchId?: boolean; skipResubmit?: undefined }
+		>;
+	}
+>;
+
+/**
  * Union of all supported schemas for when applying stashed ops
  *
  * @remarks When the format changes, this type should update to reflect all possible schemas.
  */
-type IPendingMessageFromStash = IPendingMessageV0 | IPendingMessage;
+type IPendingMessageFromStash = IPendingMessageV0 | IPendingMessageV1 | IPendingMessage;
 
 export interface IPendingLocalState {
 	/**
@@ -403,13 +418,13 @@ export class PendingStateManager implements IDisposable {
 	 * @param clientSequenceNumber - The CSN of the first message in the batch,
 	 * or undefined if the batch was not yet sent (e.g. by the time we flushed we lost the connection)
 	 * @param staged - Indicates whether batch is staged (not to be submitted while runtime is in Staging Mode)
-	 * @param ignoreBatchId - Whether to ignore the batchId in the batchStartInfo
+	 * @param skipResubmit - Whether this batch type is not directly resubmitted during replay
 	 */
 	public onFlushBatch(
 		batch: LocalBatchMessage[] | [LocalEmptyBatchPlaceholder],
 		clientSequenceNumber: number | undefined,
 		staged: boolean,
-		ignoreBatchId?: boolean,
+		skipResubmit?: boolean,
 	): void {
 		// clientId and batchStartCsn are used for generating the batchId so we can detect container forks
 		// where this batch was submitted by two different clients rehydrating from the same local state.
@@ -443,7 +458,7 @@ export class PendingStateManager implements IDisposable {
 				localOpMetadata,
 				opMetadata,
 				// Note: We only will read this off the first message, but put it on all for simplicity
-				batchInfo: { clientId, batchStartCsn, length: batch.length, ignoreBatchId, staged },
+				batchInfo: { clientId, batchStartCsn, length: batch.length, skipResubmit, staged },
 			};
 			this.pendingMessages.push(pendingMessage);
 		}
@@ -513,7 +528,7 @@ export class PendingStateManager implements IDisposable {
 		// If there is no such message, then the incoming remote batch doesn't have a match here and we can return.
 		const firstIndexUsingBatchId = Array.from({
 			length: this.pendingMessages.length,
-		}).findIndex((_, i) => this.pendingMessages.get(i)?.batchInfo.ignoreBatchId !== true);
+		}).findIndex((_, i) => this.pendingMessages.get(i)?.batchInfo.skipResubmit !== true);
 		const pendingMessageUsingBatchId =
 			firstIndexUsingBatchId === -1
 				? undefined
@@ -803,7 +818,7 @@ export class PendingStateManager implements IDisposable {
 
 			// The next message starts a batch (possibly single-message), and we'll need its batchId.
 			const batchId =
-				pendingMessage.batchInfo.ignoreBatchId === true
+				pendingMessage.batchInfo.skipResubmit === true
 					? undefined
 					: getEffectiveBatchId(pendingMessage);
 
@@ -925,7 +940,8 @@ export class PendingStateManager implements IDisposable {
 }
 
 /**
- * For back-compat if trying to apply stashed ops that pre-date batchInfo
+ * For back-compat if trying to apply stashed ops that pre-date batchInfo,
+ * or that used the old `ignoreBatchId` field name (now `skipResubmit`).
  */
 function patchbatchInfo(
 	message: IPendingMessageFromStash,
@@ -934,6 +950,11 @@ function patchbatchInfo(
 	if (batchInfo === undefined) {
 		// Using uuid guarantees uniqueness, retaining existing behavior
 		message.batchInfo = { clientId: uuid(), batchStartCsn: -1, length: -1, staged: false };
+	} else if ("ignoreBatchId" in batchInfo && batchInfo.ignoreBatchId !== undefined) {
+		// Migrate old field name to new
+		const info = message.batchInfo as IPendingMessage["batchInfo"];
+		info.skipResubmit = batchInfo.ignoreBatchId;
+		delete (batchInfo as Record<string, unknown>).ignoreBatchId;
 	}
 }
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/duplicateBatchDetector.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/duplicateBatchDetector.spec.ts
@@ -193,6 +193,76 @@ describe("DuplicateBatchDetector", () => {
 		);
 	});
 
+	describe("ID Allocation batch fork detection", () => {
+		it("ID Allocation batches with same content-derived batchId are detected as duplicates", () => {
+			// Simulate two forked containers submitting the same ID allocation range.
+			// Both produce the same content-derived batchId.
+			const idAllocBatchId =
+				'idalloc_{"sessionId":"test-session","ids":{"firstGenCount":0,"count":5,"requestedClusterSize":128,"localIdRanges":[[0,5]]}}';
+
+			const fork1Batch = makeBatch({
+				sequenceNumber: seqNum++, // 1
+				minimumSequenceNumber: 0,
+				batchId: idAllocBatchId,
+			});
+			const fork2Batch = makeBatch({
+				sequenceNumber: seqNum++, // 2
+				minimumSequenceNumber: 0,
+				batchId: idAllocBatchId,
+			});
+
+			const result1 = detector.processInboundBatch(fork1Batch);
+			assert.deepEqual(result1, { duplicate: false });
+
+			const result2 = detector.processInboundBatch(fork2Batch);
+			assert.deepEqual(result2, { duplicate: true, otherSequenceNumber: 1 });
+		});
+
+		it("ID Allocation batches with different content-derived batchIds are not duplicates", () => {
+			// Different ID ranges produce different batchIds
+			const idAllocBatchId1 =
+				'idalloc_{"sessionId":"test-session","ids":{"firstGenCount":0,"count":5,"requestedClusterSize":128,"localIdRanges":[[0,5]]}}';
+			const idAllocBatchId2 =
+				'idalloc_{"sessionId":"test-session","ids":{"firstGenCount":5,"count":3,"requestedClusterSize":128,"localIdRanges":[[5,3]]}}';
+
+			const batch1 = makeBatch({
+				sequenceNumber: seqNum++,
+				minimumSequenceNumber: 0,
+				batchId: idAllocBatchId1,
+			});
+			const batch2 = makeBatch({
+				sequenceNumber: seqNum++,
+				minimumSequenceNumber: 0,
+				batchId: idAllocBatchId2,
+			});
+
+			detector.processInboundBatch(batch1);
+			const result = detector.processInboundBatch(batch2);
+			assert.deepEqual(result, { duplicate: false });
+		});
+
+		it("ID Allocation and data batches with different batchIds are not duplicates", () => {
+			const idAllocBatchId =
+				'idalloc_{"sessionId":"test-session","ids":{"firstGenCount":0,"count":5,"requestedClusterSize":128,"localIdRanges":[[0,5]]}}';
+			const dataBatchId = "clientId_[1]";
+
+			const idAllocBatch = makeBatch({
+				sequenceNumber: seqNum++,
+				minimumSequenceNumber: 0,
+				batchId: idAllocBatchId,
+			});
+			const dataBatch = makeBatch({
+				sequenceNumber: seqNum++,
+				minimumSequenceNumber: 0,
+				batchId: dataBatchId,
+			});
+
+			detector.processInboundBatch(idAllocBatch);
+			const result = detector.processInboundBatch(dataBatch);
+			assert.deepEqual(result, { duplicate: false });
+		});
+	});
+
 	describe("getStateForSummary", () => {
 		it("If empty, return undefined", () => {
 			assert.equal(

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -478,6 +478,72 @@ describe("Outbox", () => {
 		);
 	});
 
+	it("Content-derived batchId is stamped on ID Allocation batch", () => {
+		const outbox = getOutbox({
+			context: getMockContext(),
+			opGroupingConfig: {
+				groupedBatchingEnabled: false,
+			},
+		});
+		const idAllocBatchId = "idalloc_test-batch-id";
+
+		// Submit ID allocation with content-derived batchId
+		outbox.submitIdAllocation(
+			createMessage(ContainerMessageType.IdAllocation, "0"),
+			idAllocBatchId,
+		);
+		outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "1"));
+		outbox.flush({ batchId: "batchId-A", staged: false });
+
+		assert.deepEqual(
+			state.batchesSubmitted.map((x) => x.messages.map((m) => m.metadata?.batchId)),
+			[
+				[idAllocBatchId], // ID Allocation batch now has content-derived batchId
+				["batchId-A"], // Main batch
+			],
+			"Submitted batches have incorrect batch ID",
+		);
+
+		assert.deepEqual(
+			state.pendingOpContents.map(({ opMetadata }) => asBatchMetadata(opMetadata)?.batchId),
+			[
+				idAllocBatchId, // ID Allocation has content-derived batchId
+				"batchId-A", // Main batch
+			],
+			"Pending messages have incorrect batch ID",
+		);
+	});
+
+	it("pendingIdAllocBatchId is cleared after flush", () => {
+		const outbox = getOutbox({
+			context: getMockContext(),
+			opGroupingConfig: {
+				groupedBatchingEnabled: false,
+			},
+		});
+		const idAllocBatchId = "idalloc_test-batch-id";
+
+		// Flush 1 - ID alloc with batchId
+		outbox.submitIdAllocation(
+			createMessage(ContainerMessageType.IdAllocation, "0"),
+			idAllocBatchId,
+		);
+		outbox.flush();
+
+		// Flush 2 - ID alloc without batchId
+		outbox.submitIdAllocation(createMessage(ContainerMessageType.IdAllocation, "1"));
+		outbox.flush();
+
+		assert.deepEqual(
+			state.batchesSubmitted.map((x) => x.messages.map((m) => m.metadata?.batchId)),
+			[
+				[idAllocBatchId], // First flush has batchId
+				[undefined], // Second flush has no batchId (cleared)
+			],
+			"pendingIdAllocBatchId should be cleared after flush",
+		);
+	});
+
 	it("Will send messages only when allowed, but will store them in the pending state", () => {
 		const outbox = getOutbox({ context: getMockContext() });
 		const messages = [

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -1633,4 +1633,177 @@ describe("Pending State Manager", () => {
 			);
 		});
 	});
+
+	describe("skipResubmit (formerly ignoreBatchId)", () => {
+		it("skipResubmit batches pass batchId=undefined to reSubmitBatch during replay", () => {
+			const stubs = getStateHandlerStub();
+			const psm = newPendingStateManager(stubs);
+
+			// Simulate a flushed ID allocation batch with skipResubmit
+			psm.onFlushBatch(
+				[
+					{
+						runtimeOp: op("idalloc-content"),
+						referenceSequenceNumber: 0,
+						metadata: undefined,
+						localOpMetadata: undefined,
+					},
+				],
+				/* clientSequenceNumber: */ 1,
+				/* staged: */ false,
+				/* skipResubmit: */ true,
+			);
+
+			// Also add a normal data batch
+			psm.onFlushBatch(
+				[
+					{
+						runtimeOp: op("data-content"),
+						referenceSequenceNumber: 0,
+						metadata: undefined,
+						localOpMetadata: undefined,
+					},
+				],
+				/* clientSequenceNumber: */ 2,
+				/* staged: */ false,
+			);
+
+			// Change clientId to allow replay
+			stubs.clientId.returns("new-clientId");
+
+			psm.replayPendingStates();
+
+			// Both batches should be resubmitted
+			assert.strictEqual(stubs.reSubmitBatch.callCount, 2, "Expected 2 reSubmitBatch calls");
+
+			// First call (skipResubmit batch) should have batchId=undefined
+			const firstCallMetadata = stubs.reSubmitBatch.getCall(0).args[1];
+			assert.strictEqual(
+				firstCallMetadata.batchId,
+				undefined,
+				"skipResubmit batch should have batchId=undefined",
+			);
+
+			// Second call (normal batch) should have a real batchId
+			const secondCallMetadata = stubs.reSubmitBatch.getCall(1).args[1];
+			assert.notStrictEqual(
+				secondCallMetadata.batchId,
+				undefined,
+				"Normal batch should have a batchId",
+			);
+		});
+
+		it("remoteBatchMatchesPendingBatch skips skipResubmit messages", () => {
+			const stubs = getStateHandlerStub();
+			const psm = newPendingStateManager(stubs);
+
+			// Add a skipResubmit batch first
+			psm.onFlushBatch(
+				[
+					{
+						runtimeOp: op("idalloc-content"),
+						referenceSequenceNumber: 0,
+						metadata: undefined,
+						localOpMetadata: undefined,
+					},
+				],
+				/* clientSequenceNumber: */ 1,
+				/* staged: */ false,
+				/* skipResubmit: */ true,
+			);
+
+			// Add a normal data batch
+			psm.onFlushBatch(
+				[
+					{
+						runtimeOp: op("data-content"),
+						referenceSequenceNumber: 0,
+						metadata: undefined,
+						localOpMetadata: undefined,
+					},
+				],
+				/* clientSequenceNumber: */ 2,
+				/* staged: */ false,
+			);
+
+			// Simulate a remote batch that matches the data batch's batchId but not the idalloc batch.
+			// remoteBatchMatchesPendingBatch should skip the idalloc batch and compare against the data batch.
+			// The data batch's effective batchId is "clientId_[2]" (generated from clientId + batchStartCsn).
+			const remoteBatchMatchingData: InboundMessageResult = {
+				type: "fullBatch",
+				batchStart: {
+					batchId: undefined,
+					clientId: "clientId",
+					batchStartCsn: 2,
+					keyMessage: {
+						sequenceNumber: 10,
+						minimumSequenceNumber: 0,
+					} as ISequencedDocumentMessage,
+				},
+				messages: [
+					{
+						type: ContainerMessageType.FluidDataStoreOp,
+						contents: testAddressedDataStoreMessage,
+					} as InboundSequencedContainerRuntimeMessage,
+				],
+				length: 1,
+				groupedBatch: false,
+			};
+
+			// This should throw because the remote batch matches our pending batch (fork detected)
+			assert.throws(
+				() => psm.processInboundMessages(remoteBatchMatchingData, /* local: */ false),
+				(error: IErrorBase) => error.errorType === ContainerErrorTypes.dataProcessingError,
+				"Should detect forked container when remote batch matches pending data batch",
+			);
+		});
+
+		it("backward compat: ignoreBatchId in stashed state is migrated to skipResubmit", async () => {
+			const stubs = getStateHandlerStub();
+			stubs.isAttached.returns(true);
+			stubs.applyStashedOp.resolves(undefined);
+
+			// Create stashed state with old ignoreBatchId field
+			const stashedState: IPendingLocalState = {
+				pendingStates: [
+					{
+						type: "message",
+						referenceSequenceNumber: 0,
+						content: JSON.stringify({
+							type: ContainerMessageType.IdAllocation,
+							contents: "test-range",
+						}),
+						localOpMetadata: undefined,
+						opMetadata: undefined,
+						batchInfo: {
+							clientId: "old-client",
+							batchStartCsn: 1,
+							length: 1,
+							ignoreBatchId: true,
+							staged: false,
+						},
+					} as unknown as IPendingMessage, // Cast needed because ignoreBatchId is old field
+				],
+			};
+
+			const psm = newPendingStateManager(stubs, stashedState);
+
+			// Apply stashed ops - this should trigger patchbatchInfo migration
+			await psm.applyStashedOpsAt();
+
+			// Verify the migration: the pending message should now have skipResubmit instead of ignoreBatchId
+			const pendingMessage = psm.pendingMessages.peekFront();
+			assert(pendingMessage !== undefined, "Expected a pending message");
+			assert.strictEqual(
+				pendingMessage.batchInfo.skipResubmit,
+				true,
+				"ignoreBatchId should be migrated to skipResubmit",
+			);
+			assert.strictEqual(
+				(pendingMessage.batchInfo as Record<string, unknown>).ignoreBatchId,
+				undefined,
+				"Old ignoreBatchId field should be removed",
+			);
+		});
+	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2251,7 +2251,7 @@ describeCompat(
 				},
 			],
 			async function () {
-				if (provider.driver.type !== "local") {
+				if (provider.driver.type === "t9s" || provider.driver.type === "tinylicious") {
 					this.skip();
 				}
 				const incrementValue = 3;
@@ -2261,9 +2261,7 @@ describeCompat(
 					false, // Don't send ops from first container instance before closing
 					async (c, d) => {
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
-						// Include an ID Allocation op to get coverage of the special logic around these ops as well
-						// AB#26984: Actually don't, because the ID Compressor is hitting "Ranges finalized out of order" for this test
-						// getIdCompressor(counter)?.generateCompressedId();
+						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
 					},
 				);


### PR DESCRIPTION
### Problem
When two containers rehydrate from the same stashed state ("parallel fork"), both submit identical ID Allocation ops. DuplicateBatchDetector couldn't catch this because ID allocation batches had ignoreBatchId: true, meaning no batchId was tracked for duplicate detection.

### Solution: Content-Derived BatchId
4 source files modified, 3 test files updated with 8 new tests:

### Source Changes
[batchManager.ts](vscode-webview://0setsnuqdgpe6inajv22i20l1mo21fcect4fpqbjjmsc3q1f9bv8/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts) — Renamed ignoreBatchId → skipResubmit in IBatchManagerOptions with updated JSDoc

[containerRuntime.ts](vscode-webview://0setsnuqdgpe6inajv22i20l1mo21fcect4fpqbjjmsc3q1f9bv8/packages/runtime/container-runtime/src/containerRuntime.ts) — Added computeIdAllocBatchId(idRange) which derives a deterministic batchId from JSON.stringify(idRange). Both forked containers produce identical IdCreationRange, so the batchId matches → DuplicateBatchDetector catches it. Modified submitIdAllocationOpIfNeeded to pass this batchId to the outbox.

[outbox.ts](vscode-webview://0setsnuqdgpe6inajv22i20l1mo21fcect4fpqbjjmsc3q1f9bv8/packages/runtime/container-runtime/src/opLifecycle/outbox.ts) — Added pendingIdAllocBatchId field. submitIdAllocation now accepts an optional batchId. flushAll passes it through flushInternal → popBatch which stamps it on the op metadata. Renamed ignoreBatchId → skipResubmit.

[pendingStateManager.ts](vscode-webview://0setsnuqdgpe6inajv22i20l1mo21fcect4fpqbjjmsc3q1f9bv8/packages/runtime/container-runtime/src/pendingStateManager.ts) — Renamed ignoreBatchId → skipResubmit throughout. Added IPendingMessageV1 type for backward compat. Updated patchbatchInfo to migrate old ignoreBatchId field to skipResubmit when loading stashed state.

### Test Changes
duplicateBatchDetector.spec.ts: 3 tests verifying fork detection with content-derived batchIds
outbox.spec.ts: 2 tests verifying batchId stamping and clearing behavior
pendingStateManager.spec.ts: 3 tests verifying skipResubmit replay behavior, remote batch matching, and backward compat migration