### PR TITLE
Add skill to trigger ADO pipelines in PRs

### DIFF
--- a/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
+++ b/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: trigger-pipelines-for-copilot-pr
+description: Trigger ADO pipelines for a Copilot-created PR by posting /azp run comments. Use when the user asks to trigger CI pipelines for a specific PR.
+allowed-tools: Bash(gh pr comment *)
+argument-hint: [pr-number-or-url]
+---
+
+Post two comments to the PR specified by the user ($ARGUMENTS).
+That will trigger all our pipelines, which is necessary for PRs that
+are created by Copilot.
+Comments need to be separate because otherwise it gets too long and
+fails to trigger correctly.
+
+Use the best technology available to you to comment on PRs.
+If you're just given the PR number, assume it's for the microsoft/FluidFramework repository on GitHub.
+
+The contents for each comment are as follows (text should be used verbatim):
+
+First comment:
+
+```
+/azp run Build - protocol-definitions,Build - test-tools,server-gitrest,server-gitssh,server-historian,server-routerlicious,Build - client packages,repo-policy-check
+```
+
+Second comment:
+
+```
+/azp run Build - api-markdown-documenter,Build - benchmark-tool,Build - build-common,Build - build-tools,Build - common-utils,Build - eslint-config-fluid,Build - eslint-plugin-fluid
+```

--- a/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
+++ b/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
@@ -11,8 +11,20 @@ are created by Copilot.
 Comments need to be separate because otherwise it gets too long and
 fails to trigger correctly.
 
-Use the best technology available to you to comment on PRs.
-If you're just given the PR number, assume it's for the microsoft/FluidFramework repository on GitHub.
+Use the GitHub CLI command `gh pr comment` to post the required comments to the PR. If `gh` is not available, but `$GITHUB_TOKEN` is, you can try the GitHub REST API directly, e.g.:
+
+\`\`\`
+curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
+  -d '{"body":"Great stuff!","commit_id":"6dcb09b5b57875f334f61aebed695e2e4193db5e","path":"file1.txt","start_line":1,"start_side":"RIGHT","line":2,"side":"RIGHT"}'
+\`\`\`
+
+If neither is available, don't do anything and tell the user you can't complete the request and why.
+If you're just given the PR number, assume it's for the microsoft/FluidFramework repository on GitHub, and ensure that any `gh pr comment` invocation includes `--repo microsoft/FluidFramework` (or an equivalent explicit repo selection) so it targets that repository when `$ARGUMENTS` is just a number.
 
 The contents for each comment are as follows (text should be used verbatim):
 

--- a/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
+++ b/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
@@ -2,31 +2,13 @@
 name: trigger-pipelines-for-copilot-pr
 description: Trigger ADO pipelines for a Copilot-created PR by posting /azp run comments. Use when the user asks to trigger CI pipelines for a specific PR.
 allowed-tools: Bash(gh pr comment *)
+context: fork
 argument-hint: [pr-number-or-url]
 ---
 
-Post two comments to the PR specified by the user ($ARGUMENTS).
-That will trigger all our pipelines, which is necessary for PRs that
-are created by Copilot.
-Comments need to be separate because otherwise it gets too long and
+Post the following two comments to the PR specified by the user ($ARGUMENTS), in the `microsoft/FluidFramework` repository on GitHub.
+They need to be posted separately because otherwise it gets too long and
 fails to trigger correctly.
-
-Use the GitHub CLI command `gh pr comment` to post the required comments to the PR. If `gh` is not available, but `$GITHUB_TOKEN` is, you can try the GitHub REST API directly, e.g.:
-
-\`\`\`
-curl -L \
-  -X POST \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
-  -d '{"body":"Great stuff!","commit_id":"6dcb09b5b57875f334f61aebed695e2e4193db5e","path":"file1.txt","start_line":1,"start_side":"RIGHT","line":2,"side":"RIGHT"}'
-\`\`\`
-
-If neither is available, don't do anything and tell the user you can't complete the request and why.
-If you're just given the PR number, assume it's for the microsoft/FluidFramework repository on GitHub, and ensure that any `gh pr comment` invocation includes `--repo microsoft/FluidFramework` (or an equivalent explicit repo selection) so it targets that repository when `$ARGUMENTS` is just a number.
-
-The contents for each comment are as follows (text should be used verbatim):
 
 First comment:
 
@@ -39,3 +21,21 @@ Second comment:
 ```
 /azp run Build - api-markdown-documenter,Build - benchmark-tool,Build - build-common,Build - build-tools,Build - common-utils,Build - eslint-config-fluid,Build - eslint-plugin-fluid
 ```
+
+Posting those comments will trigger all our pipelines, which is necessary for PRs that are created by Copilot.
+
+To post the comments first check if the GitHub CLI is available,
+and if so use `gh pr comment <PULL_REQUEST_NUMBER> --repo microsoft/FluidFramework --body "<COMMENT_TEXT>"`.
+If `gh` is not available but `$GITHUB_TOKEN` is, you can try the GitHub REST API directly, e.g.:
+
+```
+curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/microsoft/FluidFramework/issues/PULL_REQUEST_NUMBER/comments \
+  -d '{"body":"<COMMENT_TEXT>"}'
+```
+
+If neither is available, don't do anything and tell the user you can't complete the request and why.

--- a/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
+++ b/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
@@ -3,6 +3,7 @@ name: trigger-pipelines-for-copilot-pr
 description: Trigger ADO pipelines for a Copilot-created PR by posting /azp run comments. Use when the user asks to trigger CI pipelines for a specific PR.
 allowed-tools: Bash(gh pr comment *)
 context: fork
+model: claude-haiku-4-5-20251001
 argument-hint: [pr-number-or-url]
 ---
 


### PR DESCRIPTION
## Description

Adds an agent skill to trigger all pipelines in a PR. Useful for Copilot-generated PRs where a repo maintainer needs to manually trigger the pipelines. The comment bodies are taken from our internal docs. If we merge this, we probably want to update those docs to point to the skill so we have a single source of truth.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).