### PR TITLE
tool: ignore Claude personal and temporary files/folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ build_output_archive
 
 # Claude Code
 # Local settings contain author-specific information and should not be shared.
-**/.claude/settings.local.json
+**/.claude/**/*.local.*
 # Session-specific task tracking
 **/.claude/todos/
 # Git worktrees created by Claude Code

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ UPCOMING.md
 build_output_archive
 
 # Claude Code
-# This is a local file that likely contains author specific information and
-# should not be shared generally.
-.claude/settings.local.json
+# Local settings contain author-specific information and should not be shared.
+**/.claude/settings.local.json
+# Session-specific task tracking
+**/.claude/todos/
+# Git worktrees created by Claude Code
+**/.claude/worktrees/


### PR DESCRIPTION
This configuration provided by Claude and revised to apply to all subdirectories in case Claude is invoked in a narrow scope.