### PR TITLE
Update .gitignore for Claude Code folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,8 @@ build_output_archive
 # Claude Code
 # Exclude the root .claude folder to minimize automatically loaded context,
 # but allow reusable skills to be checked in and shared.
-.claude/
-!.claude/skills/
-# Nested packages control their own .claude folders, but exclude local files
-# (e.g. settings.local.json) which contain author-specific configuration.
+/.claude/
+!/.claude/skills/
+# Exclude author-specific local files in any .claude folder across the repo.
+# Nested packages can check in their own .claude folders freely.
 **/.claude/*.local.*

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ UPCOMING.md
 build_output_archive
 
 # Claude Code
-# This is a local file that likely contains author specific information and
-# should not be shared generally.
-.claude/settings.local.json
+# Exclude the root .claude folder to minimize automatically loaded context,
+# but allow reusable skills to be checked in and shared.
+.claude/
+!.claude/skills/
+# Nested packages control their own .claude folders, but exclude local files
+# (e.g. settings.local.json) which contain author-specific configuration.
+**/.claude/*.local.*


### PR DESCRIPTION
## Summary

Updates the Claude Code section of the root `.gitignore` to better control what gets checked in across the repo.

## What changed

Previously, only `.claude/settings.local.json` was ignored. This PR replaces that with:

| Rule | Purpose |
|---|---|
| `/.claude/` | Exclude the root `.claude` folder (anchored to repo root) |
| `!/.claude/skills/` | Re-include the `skills/` subfolder |
| `**/.claude/*.local.*` | Exclude local files in any `.claude` folder across the repo |

## Why

- **Root `/.claude/` is excluded** — The root `.claude` folder contains project-level settings (`settings.json`, hooks, etc.) that tend to be author-specific and shouldn't be imposed on the whole team.
- **`/.claude/skills/` is re-included** — Skills are reusable, shareable prompt templates. Checking them in lets the team build a shared library of Claude Code skills that anyone can invoke.
- **Nested packages work out of the box** — The rules are anchored with a leading `/`, so they only apply at the repo root. Individual packages can freely check in their own `.claude/` folders (e.g. a `CLAUDE.md` with build instructions) without needing per-package gitignore exceptions. Only `*.local.*` files are excluded everywhere, keeping author-specific config out of source control.