### PR TITLE
build: disable formatWithErrors in biome

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -139,7 +139,9 @@
 	"formatter": {
 		"enabled": true,
 		"includes": ["**", "!**/dist/**", "!**/lib/**"],
-		"formatWithErrors": true,
+		// Enabling this will cause Biome to format code that is not valid, which can sometimes make the code even wosrse
+		// syntactically. This is especially annoying when using format-on-save, so we disable it by default.
+		"formatWithErrors": false,
 		"indentStyle": "tab",
 		"lineWidth": 95,
 		"lineEnding": "lf"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -139,7 +139,7 @@
 	"formatter": {
 		"enabled": true,
 		"includes": ["**", "!**/dist/**", "!**/lib/**"],
-		// Enabling this will cause Biome to format code that is not valid, which can sometimes make the code even wosrse
+		// Enabling this will cause Biome to format code that is not valid, which can sometimes make the code even worse
 		// syntactically. This is especially annoying when using format-on-save, so we disable it by default.
 		"formatWithErrors": false,
 		"indentStyle": "tab",


### PR DESCRIPTION
Disable the `formatWithErrors` setting in biome, which should address the problem folks have reported where biome further "corrupts" a file with a parser error, especially when using format-on-save.