### PR TITLE
ci: fail builds on critical Component Governance alerts

### DIFF
--- a/tools/pipelines/build-performance-observability.yml
+++ b/tools/pipelines/build-performance-observability.yml
@@ -32,6 +32,8 @@ extends:
       name: Small-eastus2
       os: linux
     sdl:
+      componentGovernance:
+        alertWarningLevel: Critical
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -57,6 +57,8 @@ extends:
         arrow:
           # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
           serviceConnection: ff-internal-arrow-sc
+      componentGovernance:
+        alertWarningLevel: Critical
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -149,6 +149,8 @@ extends:
         arrow:
           # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
           serviceConnection: ff-internal-arrow-sc
+      componentGovernance:
+        alertWarningLevel: Critical
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -168,6 +168,8 @@ extends:
           serviceConnection: ff-internal-arrow-sc
           # This will make sure that the artifacts are published to the Arrow Service Connection if they are release or pre-release
           isShipped: ${{ parameters.shouldShip }}
+      componentGovernance:
+        alertWarningLevel: Critical
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -160,6 +160,8 @@ extends:
         arrow:
           # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
           serviceConnection: ff-internal-arrow-sc
+      componentGovernance:
+        alertWarningLevel: Critical
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022


### PR DESCRIPTION
## Summary

- Configure Component Governance to fail builds on Critical-severity alerts
- Adds `componentGovernance.alertWarningLevel: Critical` to the `sdl` config in all pipeline templates that extend the 1ES pipeline template
- Starting with Critical only — can tighten to High in a follow-up

## Affected pipelines

| Pipeline template | Path |
|---|---|
| Client package build | `tools/pipelines/templates/build-npm-client-package.yml` |
| NPM package build | `tools/pipelines/templates/build-npm-package.yml` |
| Docker service build | `tools/pipelines/templates/build-docker-service.yml` |
| Repo policy check | `tools/pipelines/repo-policy-check.yml` |
| Perf observability | `tools/pipelines/build-performance-observability.yml` |

## Test plan

- [ ] Verify pipelines still parse correctly (no YAML syntax errors)
- [ ] Confirm builds with Critical alerts now fail
- [ ] Confirm builds without Critical alerts continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)