### PR TITLE
fix: update mongodb to 5.x in server-services

### DIFF
--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -69,7 +69,7 @@
 		"ioredis": "^5.6.1",
 		"lodash": "^4.17.21",
 		"lru-cache": "^6.0.0",
-		"mongodb": "4.17.1",
+		"mongodb": "^5.9.2",
 		"nconf": "^0.12.0",
 		"socket.io": "^4.8.0",
 		"telegrafjs": "^0.1.3",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1051,8 +1051,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       mongodb:
-        specifier: 4.17.1
-        version: 4.17.1
+        specifier: ^5.9.2
+        version: 5.9.2(@aws-sdk/credential-providers@3.470.0)
       nconf:
         specifier: ^0.12.0
         version: 0.12.0
@@ -4469,6 +4469,10 @@ packages:
     resolution: {integrity: sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==}
     engines: {node: '>=6.9.0'}
 
+  bson@5.5.1:
+    resolution: {integrity: sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==}
+    engines: {node: '>=14.20.1'}
+
   buffer-alloc-unsafe@1.1.0:
     resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
 
@@ -7082,6 +7086,27 @@ packages:
   mongodb@4.17.1:
     resolution: {integrity: sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==}
     engines: {node: '>=12.9.0'}
+
+  mongodb@5.9.2:
+    resolution: {integrity: sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==}
+    engines: {node: '>=14.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.0.0
+      kerberos: ^1.0.0 || ^2.0.0
+      mongodb-client-encryption: '>=2.3.0 <3'
+      snappy: ^7.2.2
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
 
   morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
@@ -13020,6 +13045,8 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
+  bson@5.5.1: {}
+
   buffer-alloc-unsafe@1.1.0: {}
 
   buffer-alloc@1.2.0:
@@ -16085,6 +16112,15 @@ snapshots:
       '@mongodb-js/saslprep': 1.1.1
     transitivePeerDependencies:
       - aws-crt
+
+  mongodb@5.9.2(@aws-sdk/credential-providers@3.470.0):
+    dependencies:
+      bson: 5.5.1
+      mongodb-connection-string-url: 2.6.0
+      socks: 2.8.3
+    optionalDependencies:
+      '@aws-sdk/credential-providers': 3.470.0
+      '@mongodb-js/saslprep': 1.1.1
 
   morgan@1.10.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Updates `mongodb` from `4.17.1` to `^5.9.2` in `@fluidframework/server-services`
- MongoDB 5.x moves `@aws-sdk/credential-providers` from a direct optional dependency to an optional peer dependency, reducing the transitive dependency footprint
- All existing MongoDB usage in the codebase is promise-based (no callbacks), which is the main breaking change in the 4.x to 5.x migration

## Test plan

- [ ] Server build passes (routerlicious)
- [ ] Server integration tests pass
- [ ] Verify no callback-based MongoDB usage exists (confirmed — all async/await)

🤖 Generated with [Claude Code](https://claude.com/claude-code)