### PR TITLE
Git-ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ build_output_archive
 # Claude Code
 # Local settings contain author-specific information and should not be shared.
 **/.claude/**/*.local.*
+CLAUDE.local.md
 # Session-specific task tracking
 **/.claude/todos/
 # Git worktrees created by Claude Code


### PR DESCRIPTION
## Description

`CLAUDE.local.md` goes outside the `.claude/` folder so we needed another entry for it