### PR TITLE
Revert "ci: parallelize merge-tree mocha tests"

### DIFF
--- a/packages/dds/merge-tree/.mocharc.cjs
+++ b/packages/dds/merge-tree/.mocharc.cjs
@@ -8,12 +8,4 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
-// This test suite is the slowest on CI if not run in parallel, so this parallelization speeds up CI significantly.
-config.parallel = true;
-// CI assumes that each package will use one thread when computing how many package's tests to run in parallel.
-// To avoid making this computation too inaccurate and slowing things down with excessive memory use
-// (and other overhead) from too many threads, we keep the number of jobs limited,
-// and only enable this parallelization for packages where doing so actually produces an improvement in CI time.
-// 4 jobs was measured to give most of the speed up, even when just running this suite, while not slowing down CI.
-config.jobs = 4;
 module.exports = config;

--- a/packages/dds/merge-tree/src/test/client.applyStashedOpFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyStashedOpFarm.spec.ts
@@ -209,9 +209,7 @@ function runApplyStashedOpFarmTests(
 				opts,
 				(s, m, c) => applyMessagesWithReconnect(s, m, c, stashClients),
 			);
-			// Matches the timeout convention used by other farm tests (conflictFarm, obliterateFarm,
-			// rollbackFarm). Tests complete in ~15-20s normally, but need headroom under parallel execution.
-		}).timeout(30 * 10000);
+		}).timeout(30 * 1000);
 	});
 }
 

--- a/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -120,9 +120,7 @@ function runReconnectFarmTests(opts: IReconnectFarmConfig, extraSeed?: number): 
 				testOpts,
 				applyMessagesWithReconnect,
 			);
-			// Matches the timeout convention used by other farm tests (conflictFarm, obliterateFarm,
-			// rollbackFarm). Tests complete in ~15-20s normally, but need headroom under parallel execution.
-		}).timeout(30 * 10000);
+		}).timeout(30 * 1000);
 	});
 }
 


### PR DESCRIPTION
Reverts microsoft/FluidFramework#26624

[Revert Reason](https://github.com/microsoft/FluidFramework/pull/26624#issuecomment-4001332988)
[Investigatation](https://github.com/microsoft/FluidFramework/pull/26624#issuecomment-4001371468)