### PR TITLE
ci: parallelize merge-tree mocha tests (skip in perf mode)

### DIFF
--- a/packages/dds/merge-tree/.mocharc.cjs
+++ b/packages/dds/merge-tree/.mocharc.cjs
@@ -8,4 +8,12 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
+// Parallelize tests to speed up CI, but not in perf mode where parallel execution
+// breaks the benchmark reporter and degrades measurement quality.
+if (!process.argv.includes("--perfMode")) {
+	config.parallel = true;
+	// Keep job count limited to avoid excessive memory use and thread overhead in CI.
+	// 4 jobs was measured to give most of the speed up while not slowing down CI.
+	config.jobs = 4;
+}
 module.exports = config;

--- a/packages/dds/merge-tree/src/test/client.applyStashedOpFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyStashedOpFarm.spec.ts
@@ -209,7 +209,9 @@ function runApplyStashedOpFarmTests(
 				opts,
 				(s, m, c) => applyMessagesWithReconnect(s, m, c, stashClients),
 			);
-		}).timeout(30 * 1000);
+			// Matches the timeout convention used by other farm tests (conflictFarm, obliterateFarm,
+			// rollbackFarm). Tests complete in ~15-20s normally, but need headroom under parallel execution.
+		}).timeout(30 * 10000);
 	});
 }
 

--- a/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -120,7 +120,9 @@ function runReconnectFarmTests(opts: IReconnectFarmConfig, extraSeed?: number): 
 				testOpts,
 				applyMessagesWithReconnect,
 			);
-		}).timeout(30 * 1000);
+			// Matches the timeout convention used by other farm tests (conflictFarm, obliterateFarm,
+			// rollbackFarm). Tests complete in ~15-20s normally, but need headroom under parallel execution.
+		}).timeout(30 * 10000);
 	});
 }
 


### PR DESCRIPTION
## Summary

Re-applies the parallelization from #26624 (reverted in #26653) with a fix for the Performance Benchmarks pipeline failure.

- Enables `parallel: true` with `jobs: 4` for merge-tree mocha tests, **except** when running in perf mode (`--perfMode`)
- Perf mode is excluded because Mocha's parallel worker serialization strips methods from Hook objects (like `hook.error()`), which the benchmark reporter depends on. Sequential execution is also needed for measurement quality.
- Bumps timeouts in `applyStashedOpFarm` and `reconnectFarm` to match other farm tests

## Changes

- `packages/dds/merge-tree/.mocharc.cjs` — conditional parallel config
- `packages/dds/merge-tree/src/test/client.applyStashedOpFarm.spec.ts` — timeout bump
- `packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts` — timeout bump

## Verification

**Without fix** (parallel enabled unconditionally) — perf tests fail with the reported error:
```
TypeError: hook.error is not a function
Test Uncaught error outside test suite failed with error:  TypeError: hook.error is not a function
```

**With fix** (`--perfMode` guard) — both pass:
- `npm run perf` — all benchmarks pass (sequential mode, benchmark reporter works)
- `npm run test:mocha` — 1555 passing, 2 pending (parallel mode, ~2 min)

## Test plan

- [x] Reproduce `hook.error is not a function` failure without the fix
- [x] `npm run perf` passes with the fix (sequential mode)
- [x] `npm run test:mocha` passes with the fix (parallel mode)
- [ ] Performance Benchmarks pipeline passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)