### PR TITLE
fix(inventory-app): fix test:mocha not running tests due to Quill accessing document at import time

### DIFF
--- a/examples/data-objects/inventory-app/.mocharc.cjs
+++ b/examples/data-objects/inventory-app/.mocharc.cjs
@@ -12,4 +12,7 @@ const config = getFluidTestMochaConfig(__dirname);
 // AB#7856
 config.exit = true;
 
+// Set up JSDOM before Quill is imported (Quill requires document at import time)
+config["node-option"].push("import=./lib/test/mochaHooks.js");
+
 module.exports = config;

--- a/examples/data-objects/inventory-app/.mocharc.cjs
+++ b/examples/data-objects/inventory-app/.mocharc.cjs
@@ -13,6 +13,7 @@ const config = getFluidTestMochaConfig(__dirname);
 config.exit = true;
 
 // Set up JSDOM before Quill is imported (Quill requires document at import time)
+config["node-option"] ??= [];
 config["node-option"].push("import=./lib/test/mochaHooks.js");
 
 module.exports = config;

--- a/examples/data-objects/inventory-app/src/test/mochaHooks.ts
+++ b/examples/data-objects/inventory-app/src/test/mochaHooks.ts
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import globalJsdom from "global-jsdom";
+
+// Set up JSDOM before any modules are loaded (Quill requires document at import time).
+// This file is loaded via Node's --import flag (before Mocha starts), so mocha globals
+// like before() are not available here.
+globalJsdom();

--- a/examples/data-objects/inventory-app/src/test/mochaHooks.ts
+++ b/examples/data-objects/inventory-app/src/test/mochaHooks.ts
@@ -5,7 +5,13 @@
 
 import globalJsdom from "global-jsdom";
 
-// Set up JSDOM before any modules are loaded (Quill requires document at import time).
-// This file is loaded via Node's --import flag (before Mocha starts), so mocha globals
-// like before() are not available here.
+// Set up JSDOM before any modules are loaded. Importing @fluidframework/react transitively
+// imports Quill, which requires document at import time.
+// This file is loaded via Node's --import flag (before Mocha starts) rather than being
+// discovered as a spec file, because Mocha loads spec files alphabetically and
+// "inventoryApp.test.tsx" ("i") sorts before "mochaHooks.ts" ("m") — meaning the test file
+// would be imported first and Quill would load before JSDOM is set up.
+// As a consequence, Mocha globals like before() are not available here, to follow the same
+// pattern that packages/framework/react uses (and which apparently could break if it gained
+// test files that sorted before `mochaHooks.ts` lexicographically).
 globalJsdom();


### PR DESCRIPTION
## Summary

`pnpm test:mocha` in `inventory-app` is silently failing to run any of its 9 tests (not counted as failures, just absent; see [today](https://dev.azure.com/fluidframework/public/public%20Team/_build/results?buildId=382505&view=logs&j=855df218-f14a-5111-4dba-a3c8eab6872c&t=a5446ac8-4e73-5540-487b-79110ad67165&l=3015) VS [with this PR](https://dev.azure.com/fluidframework/public/public%20Team/_build/results?buildId=382616&view=logs&j=855df218-f14a-5111-4dba-a3c8eab6872c&t=a5446ac8-4e73-5540-487b-79110ad67165&l=3884)). Locally this is what I see:

<img width="1427" height="490" alt="image" src="https://github.com/user-attachments/assets/880faf68-f0c7-4849-b11f-a1a3b1c75d58" />

- Root cause: `@fluidframework/react/alpha` re-exports quill-dependent text editor components. Quill's `emitter.js` calls `document.addEventListener()` at the **module's top level**, before any test `before()` hook can set up jsdom.
- Fix: add `src/test/mochaHooks.ts` that calls `globalJsdom()` at module level, loaded via Node's `--import` flag (`.mocharc.cjs`) so it runs before mocha evaluates any test files or modules imported (in this case, transitively) by them. This is the same pattern already used by the `text-editor` example package.

<details>
<summary>Claude investigation of why the tests silently fail to run instead of complaining more loudly</summary>

```
Why mocha silently reports 0 tests                                                                                                     
                                                                                                                                         
  There are four independent factors that all have to align for this silent failure to occur.                                            
                                                                                                                                         
  1. The actual error: quill accesses document at module evaluation time                                                                 
                                                                                                                                         
  The dependency chain is:                                                                                                               
  inventoryApp.test.js → ../view/inventoryView.js → @fluidframework/react/alpha → (transitively) → quill@2.0.3 → quill/core/emitter.js:7 
                                                                                                                                         
  That last file does this at the top level (not inside a function):                                                                     
  document.addEventListener(eventName, function () { ... })                                                                              
  This runs synchronously during module evaluation. In Node.js without a DOM, it throws ReferenceError: document is not defined before   
  any test code runs.                                                                                                                    
                                                                                                                                         
  2. Node.js v20.19 backported require(esm)                                                                                              
                                                                                                                                         
  Node.js v20.19.0 backported the require(esm) feature from v22, making process.features.require_module === true. Mocha checks this flag 
  to decide its loading strategy:

  // mocha/lib/nodejs/esm-utils.js
  if (process.features.require_module) {
    exports.requireOrImport = requireModule;   // ← you're here
  } else {
    exports.requireOrImport = tryImportAndRequire;
  }

  3. Mocha's requireModule has a silent fallback

  requireModule tries require(file) first. When that fails (with document is not defined), it catches the error and falls back to
  import():

  const requireModule = async (file, esmDecorator) => {
    try {
      return require(file);              // ← throws "document is not defined"
    } catch (requireErr) {
      debug('requireModule caught err: %O', requireErr.message);  // ← logged, swallowed
      try {
        return dealWithExports(await formattedImport(file, esmDecorator));  // ← fallback
      } catch (importErr) {
        // only re-throws for specific error codes; a ReferenceError would throw here...
        throw importErr;
      }
    }
  };

  The debug(...) line is why you see the trace mocha:esm-utils requireModule caught err: 'document is not defined' — only visible with
  DEBUG=mocha:*.

  4. Node.js leaves the ESM module in a broken cached state after require(esm) fails

  This is the crux. When require(esm) fails because a transitive dependency threw at evaluation time, Node.js caches
  inventoryApp.test.js's module record in a corrupted state — marked as "Evaluated" with no exports, rather than "EvaluateError". So when
   mocha's fallback import() runs:

  // Empirically confirmed:
  require(file)  → throws "document is not defined"
  import(fileURL) → resolves successfully with {}  (empty module!)

  The import() finds the cached (but empty) module record, "succeeds" with {}, and returns. Since the module's top-level code (the
  describe() / it() calls) never actually ran, no tests are registered.

  The silent outcome

  loadFilesAsync() completes without error → mocha runs its suite → grepTotal() returns 0 → runSuite(): bailing (meaning "nothing to do")
   → reporter prints 0 passing → exit code 0.

  No error. No non-zero exit code. CI passes.

  ---
  Why this doesn't happen in older Node.js

  On Node.js versions without require(esm) (process.features.require_module === false), mocha uses tryImportAndRequire instead — which
  tries import() first. That import() would fail with ReferenceError: document is not defined, which has no .code property and falls into
   the else { throw err } branch, propagating the error all the way to mocha's handler, which prints an exception and exits with code 1.

  The broader risk

  Any ESM package in the repo where:
  1. A test-only import pulls in a package that accesses browser globals at module level (not just quill — anything with document,
  window, navigator, etc. at top level), AND
  2. Tests are run on Node.js ≥ v20.19.0 (where require(esm) is available)

  ...would silently report 0 tests with exit code 0. The --unhandled-rejections strict mocha config option provides no protection here
  because the error is explicitly caught by mocha's requireModule try/catch — it's a handled exception.
``` 
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)