### PR TITLE
Prevent document corruption from duplicate ClientJoin messages

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1010,7 +1010,14 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
 					return signalMessage;
 				} else {
-					const isNewClient = this.clientSeqManager.upsertClient(
+					if (this.clientSeqManager.has(clientJoinMessage.clientId)) {
+						// Return if the client has already been added due to a prior join message.
+						// Do not call upsertClient here, as it would reset the client's
+						// clientSequenceNumber to 0, corrupting duplicate detection state.
+						return;
+					}
+
+					this.clientSeqManager.upsertClient(
 						clientJoinMessage.clientId,
 						0,
 						this.minimumSequenceNumber,
@@ -1020,10 +1027,6 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 						false,
 						message.operation.serverMetadata,
 					);
-					if (!isNewClient) {
-						// Return if the client has already been added due to a prior join message.
-						return;
-					}
 				}
 			}
 		}

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -712,6 +712,78 @@ describe("Routerlicious", () => {
 				it("Should remove clients after a disconnect while maintaining batches", async () => {
 					return removeClientsAfterDisconnectTest(lambdaWithBatching);
 				});
+
+				it("Should silently drop retransmitted ClientJoin and ops from Kafka producer retry", async () => {
+					// Client joins and sends 3 ops
+					const join = messageFactory.createJoin();
+					const op1 = messageFactory.create(MessageType.Operation, 1);
+					const op2 = messageFactory.create(MessageType.Operation, 2);
+					const op3 = messageFactory.create(MessageType.Operation, 3);
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(join, testId));
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op1, testId));
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op2, testId));
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op3, testId));
+					await quiesceWithClientsConnected();
+
+					// join (seq 1), op1 (seq 2), op2 (seq 3), op3 (seq 4)
+					const messageCountBefore = testKafka.getRawMessages().length;
+					assert.equal(messageCountBefore, 4);
+					assert.equal(testKafka.getLastMessage().operation.sequenceNumber, 4);
+
+					// Simulate Kafka producer retry: resend the join and first 2 ops
+					// at new Kafka offsets (as would happen with producer retransmission)
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(join, testId));
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op1, testId));
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op2, testId));
+
+					// Send a genuinely new op (CSN=4) - should be sequenced normally
+					const op4 = messageFactory.create(MessageType.Operation, 4);
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op4, testId));
+					await quiesceWithClientsConnected();
+
+					// The duplicate join and ops should be silently dropped.
+					// Only op4 should be newly sequenced (seq 5).
+					const messageCountAfter = testKafka.getRawMessages().length;
+					assert.equal(messageCountAfter, messageCountBefore + 1);
+					const lastMessage = testKafka.getLastMessage();
+					assert.equal(lastMessage.type, SequencedOperationType);
+					assert.equal(lastMessage.operation.sequenceNumber, 5);
+					assert.equal(lastMessage.operation.clientSequenceNumber, 4);
+				});
+
+				it("Should not reset client sequence number on duplicate ClientJoin", async () => {
+					// Client joins and sends several ops
+					const join = messageFactory.createJoin();
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(join, testId));
+					const op1 = messageFactory.create(MessageType.Operation, 1);
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op1, testId));
+					const op2 = messageFactory.create(MessageType.Operation, 2);
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op2, testId));
+					await quiesceWithClientsConnected();
+
+					// join (seq 1), op1 (seq 2), op2 (seq 3)
+					const msg2 = testKafka.getMessage(2);
+					assert.equal(msg2.type, SequencedOperationType);
+					assert.equal(msg2.operation.sequenceNumber, 3);
+
+					// Send a duplicate ClientJoin for the same client
+					const duplicateJoin = messageFactory.createJoin();
+					await lambda.handler(
+						kafkaMessageFactory.sequenceMessage(duplicateJoin, testId),
+					);
+
+					// Send the next op (CSN=3) - should be sequenced normally
+					const op3 = messageFactory.create(MessageType.Operation, 3);
+					await lambda.handler(kafkaMessageFactory.sequenceMessage(op3, testId));
+					await quiesceWithClientsConnected();
+
+					// The duplicate join should be silently dropped (not sequenced).
+					// op3 should be sequenced as seq 4 (not nacked as a gap).
+					const lastMessage = testKafka.getLastMessage();
+					assert.equal(lastMessage.type, SequencedOperationType);
+					assert.equal(lastMessage.operation.sequenceNumber, 4);
+					assert.equal(lastMessage.operation.clientSequenceNumber, 3);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
This change ensures a duplicate ClientJoin is rejected without mutating the existing client's CSN or nack state.

Duplicate ClientJoin messages may be sent due to Kafka producer retries / idempotency gap's. When that happens, upsertClient ends up resetting the CSN to 0, then rejecting the request. This leads to document corruption because it causes future ops to skip duplicate op detection, which may result in sequencing the same op twice.