### PR TITLE
fix: add --fail-zero to shared mocha config to catch silently empty test runs

### DIFF
--- a/packages/framework/aqueduct/.mocharc.cjs
+++ b/packages/framework/aqueduct/.mocharc.cjs
@@ -8,4 +8,6 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
+// This package has no tests; disable fail-zero so the empty placeholder spec doesn't fail the run.
+config["fail-zero"] = false;
 module.exports = config;

--- a/packages/framework/request-handler/.mocharc.cjs
+++ b/packages/framework/request-handler/.mocharc.cjs
@@ -8,4 +8,6 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
+// This package has no tests; disable fail-zero so the empty placeholder spec doesn't fail the run.
+config["fail-zero"] = false;
 module.exports = config;

--- a/packages/test/mocha-test-setup/mocharc-common.cjs
+++ b/packages/test/mocha-test-setup/mocharc-common.cjs
@@ -72,6 +72,10 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		"recursive": true,
 		"require": requiredModulePaths,
 		"unhandled-rejections": "strict",
+		// Fail the test run if no tests are found/run. This catches cases where test files fail to
+		// load silently (e.g. due to broken imports), which would otherwise produce a green "0 passing"
+		// result with exit code 0.
+		"fail-zero": true,
 		ignore: [
 			// Ignore "tools" which are scripts intended to be run, not part of the test suite.
 			"**/*.tool.{js,cjs,mjs}",


### PR DESCRIPTION
## Summary

- Adds `"fail-zero": true` to the shared mocha config in `mocharc-common.cjs`
- This makes mocha exit with code 1 whenever 0 tests are found/run, rather than silently passing with exit code 0

## Background

Broken tests can silently produce a green CI result in certain scenarios. The one that prompted this goes like this:

1. **The trigger**: a test file imports (transitively) a browser-only package that accesses `document` at module evaluation time (e.g. `quill` via `@fluidframework/react/alpha` in `inventory-app`). In Node.js without a DOM, this throws `ReferenceError: document is not defined`.

2. **The silent swallow**: On Node.js ≥ v20.19 (where `require(esm)` is available), mocha's `requireModule()` tries `require(file)` first. When that throws, it catches the error and falls back to `import()`. Due to a quirk in how Node.js caches ESM module records after a `require(esm)` failure, the subsequent `import()` call "succeeds" — returning an empty module with no exports, because the module's top-level code (the `describe()`/`it()` calls) never ran.

3. **The result**: 0 tests are registered, mocha runs, reports `0 passing`, and exits with **code 0**. `--unhandled-rejections strict` doesn't help because the error is explicitly caught by mocha's try/catch.

`--fail-zero` is the correct mitigation: mocha already has this flag specifically for catching empty test runs (added as `runner.js:1086`: `if (!this.total && this._opts.failZero) this.failures = 1`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)