### PR TITLE
ci: fix FluidFrameworkDirectory variable in publish-api-model-artifact pipeline

### DIFF
--- a/tools/pipelines/publish-api-model-artifact.yml
+++ b/tools/pipelines/publish-api-model-artifact.yml
@@ -77,6 +77,16 @@ variables:
     value: true
   - name: pnpmStorePath
     value: $(Pipeline.Workspace)/.pnpm-store
+  # ADO changes the value of Build.SourcesDirectory depending on whether 1 vs. many repositories are checked out.
+  # Using 's' is consistent with the behavior when multiple repositories are checked out and allows for more
+  # consistent build scripts. See this documentation for more details:
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
+  # A relative path is required in some places (like "checkout" steps). To get the absolute path, concatenate it
+  # with the predefined variable "Pipeline.Workspace", e.g.: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}'
+  - name: consistentSourcesDirectory
+    value: 's'
+  - name: FluidFrameworkDirectory
+    value: '${{ variables.consistentSourcesDirectory }}/FluidFramework'
 
 resources:
   pipelines:
@@ -100,13 +110,13 @@ stages:
       displayName: 'Check Version Deployment Condition'
       steps:
         - checkout: self
-          path: $(FluidFrameworkDirectory)
+          path: ${{ variables.FluidFrameworkDirectory }}
           submodules: false
           clean: true
 
         - template: /tools/pipelines/templates/include-install-build-tools.yml@self
           parameters:
-            buildDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
+            buildDirectory: ${{ variables.FluidFrameworkDirectory }}
         - task: Bash@3
           name: SetVersion
           displayName: 'Set Build Version'
@@ -114,7 +124,7 @@ stages:
             VERSION_BUILDNUMBER: $(Build.BuildNumber)
           inputs:
             targetType: 'inline'
-            workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
+            workingDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
             script: |
               # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
               flub generate buildVersion
@@ -123,7 +133,7 @@ stages:
           displayName: 'Check Version Deployment Condition'
           inputs:
             targetType: 'inline'
-            workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
+            workingDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
             script: |
               # Extract version without build number suffix
               VERSION_TRIMMED=$(echo $(SetVersion.version) | sed 's/-[0-9]*//')
@@ -175,7 +185,7 @@ stages:
                 inputs:
                   SourceFolder: $(Pipeline.Workspace)
                   Contents: '**/*.api.json'
-                  TargetFolder: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/_api-extractor-temp'
+                  TargetFolder: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/_api-extractor-temp'
                   OverWrite: false
                   flattenFolders: true
                   CleanTargetFolder: true
@@ -183,13 +193,13 @@ stages:
               - task: PublishPipelineArtifact@1
                 displayName: 'Publish api-extractor JSON'
                 inputs:
-                  targetPath: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/_api-extractor-temp'
+                  targetPath: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/_api-extractor-temp'
                   artifactName: 'api-extractor-combined'
                   publishLocation: 'pipeline'
 
               - task: ArchiveFiles@2
                 inputs:
-                  rootFolderOrFile: '$(Pipeline.Workspace)/$(FluidFrameworkDirectory)/_api-extractor-temp'
+                  rootFolderOrFile: '$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}/_api-extractor-temp'
                   includeRootFolder: false
                   archiveType: 'tar' # Options: zip, 7z, tar, wim
                   tarCompression: 'gz'  # Optional. Options: gz, bz2, xz, none


### PR DESCRIPTION
## Description

The pipeline referenced `$(FluidFrameworkDirectory)` but never defined it, causing the "Check Build Tools Installation" step to fail with a path error. This PR mirrors the fix applied to `deploy-website.yml` in #26543 : define consistentSourcesDirectory and FluidFrameworkDirectory variables, and use `${{ variables.FluidFrameworkDirectory }}` syntax throughout.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Test run showing that the [step that currently fails](https://dev.azure.com/fluidframework/internal/_build/results?buildId=382346&view=logs&j=332c3c5d-33c7-5b70-ec97-9939bb462e3a&t=2de749ec-b2d5-5ca4-2ab2-34beb8e33898) now [passes after this PR](https://dev.azure.com/fluidframework/internal/_build/results?buildId=382757&view=logs&j=332c3c5d-33c7-5b70-ec97-9939bb462e3a&t=2de749ec-b2d5-5ca4-2ab2-34beb8e33898) (a different unrelated failure is encountered later).