### PR TITLE
Fix spelling: Standardize plural form of DDS from DDSs to DDSes in packages/dds

### DIFF
--- a/packages/dds/cell/README.md
+++ b/packages/dds/cell/README.md
@@ -3,7 +3,7 @@
 The `SharedCell` Distributed Data Structure (DDS) stores a single, shared value that can be edited or deleted.
 
 This package is primarily intended as a minimal example of how distributed data structures work.
-For real-world scenarios, we recommend using one of our other DDSes, like [SharedTree](https://fluidframework.com./docs/data-structures/tree/).
+For real-world scenarios, we recommend using one of our other DDSes, like [SharedTree](https://fluidframework.com/docs/data-structures/tree/).
 
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_README_HEADER:) -->
 

--- a/packages/dds/cell/README.md
+++ b/packages/dds/cell/README.md
@@ -3,7 +3,7 @@
 The `SharedCell` Distributed Data Structure (DDS) stores a single, shared value that can be edited or deleted.
 
 This package is primarily intended as a minimal example of how distributed data structures work.
-For real-world scenarios, we recommend using one of our other DDSs, like [SharedTree](https://fluidframework.com./docs/data-structures/tree/).
+For real-world scenarios, we recommend using one of our other DDSes, like [SharedTree](https://fluidframework.com./docs/data-structures/tree/).
 
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_README_HEADER:) -->
 

--- a/packages/dds/legacy-dds/package.json
+++ b/packages/dds/legacy-dds/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fluidframework/legacy-dds",
 	"version": "2.91.0",
-	"description": "Legacy DDSs for the Fluid Framework. These are not intended for use in new code.",
+	"description": "Legacy DDSes for the Fluid Framework. These are not intended for use in new code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {
 		"type": "git",

--- a/packages/dds/legacy-dds/src/signal/sharedSignal.ts
+++ b/packages/dds/legacy-dds/src/signal/sharedSignal.ts
@@ -163,7 +163,7 @@ export class SharedSignalClass<T extends SerializableTypeForSharedSignal = any>
 		this.emit("notify", op.metadata, isLocal);
 	}
 
-	// Nothing to roll back. Allowing other DDSs to handle rollback if necessary.
+	// Nothing to roll back. Allowing other DDSes to handle rollback if necessary.
 	public rollback(content: unknown, _localOpMetadata: unknown): void {
 		return;
 	}

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -42,7 +42,7 @@ export type IntervalMessageLocalMetadata =
 	| IntervalChangeLocalMetadata
 	| IntervalDeleteLocalMetadata;
 /**
- * Optional flags that configure options for sequence DDSs
+ * Optional flags that configure options for sequence DDSes
  * @internal
  */
 export interface SequenceOptions

--- a/packages/dds/shared-object-base/src/sharedObjectKernel.ts
+++ b/packages/dds/shared-object-base/src/sharedObjectKernel.ts
@@ -235,7 +235,7 @@ export const thisWrap: unique symbol = Symbol("selfWrap");
  * for reading and writing data which are specific to this particular data structure.
  * @remarks
  * Output from {@link SharedKernelFactory}.
- * This is an alternative to defining DDSs by sub-classing {@link SharedObject}.
+ * This is an alternative to defining DDSes by sub-classing {@link SharedObject}.
  * @internal
  */
 export interface FactoryOut<T extends object> {
@@ -244,7 +244,7 @@ export interface FactoryOut<T extends object> {
 }
 
 /**
- * A factory for creating DDSs.
+ * A factory for creating DDSes.
  * @remarks
  * Outputs {@link FactoryOut}.
  * This is an alternative to directly implementing {@link @fluidframework/datastore-definitions#IChannelFactory}.


### PR DESCRIPTION
Updated all instances of "DDSs" to "DDSes" in packages/dds to match the predominant convention used throughout the codebase (DDSes appears 357 times vs DDSs appearing 63 times). Comments only; no functional code changes.