### PR TITLE
build: Drop unnecessary deps with a better approach

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -147,7 +147,7 @@
 		},
 		"overrideComments": [
 			"eslint: jssm-viz-cli brings in ESLint 8.x as a transitive dependency. Force ESLint 9.x to ensure consistent version across the workspace.",
-			"oclif includes some AWS-related features, but we don't use them, so we override those dependencies with empty packages. This helps reduce lockfile churn since the deps release very frequently.",
+			"oclif includes some AWS-related features, but we don't use them, so we drop those dependencies. This helps reduce lockfile churn since the deps release very frequently.",
 			"@types/node: To avoid duplicating the oclif package and adding a bunch of dependencies, force @types/node to a single version. For some reason version 22.8.0 can't be overridden, so use that to ensure a single version",
 			"@types/minimatch: @types/glob@7.x uses minimatch.IOptions and minimatch.IMinimatch interfaces. Force @types/minimatch@5 which includes these legacy type definitions.",
 			"mdast-util-gfm-footnote: mdast-util-gfm@3.1.0 has a type definition bug where it imports ToMarkdownOptions from mdast-util-gfm-footnote, but version 2.0.0 doesn't export it. Override to 2.1.0 which includes the missing export."
@@ -159,8 +159,8 @@
 			"json5@<1.0.2": "^1.0.2",
 			"json5@>=2.0.0 <2.2.2": "^2.2.2",
 			"mdast-util-gfm-footnote": "^2.1.0",
-			"oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
-			"oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0",
+			"oclif>@aws-sdk/client-cloudfront": "-",
+			"oclif>@aws-sdk/client-s3": "-",
 			"qs": "^6.14.0",
 			"sharp": "^0.34.5"
 		},

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -11,8 +11,8 @@ overrides:
   json5@<1.0.2: ^1.0.2
   json5@>=2.0.0 <2.2.2: ^2.2.2
   mdast-util-gfm-footnote: ^2.1.0
-  oclif>@aws-sdk/client-cloudfront: npm:empty-npm-package@1.0.0
-  oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
+  oclif>@aws-sdk/client-cloudfront: '-'
+  oclif>@aws-sdk/client-s3: '-'
   qs: ^6.14.0
   sharp: ^0.34.5
 
@@ -2968,9 +2968,6 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  empty-npm-package@1.0.0:
-    resolution: {integrity: sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -8542,8 +8539,6 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  empty-npm-package@1.0.0: {}
-
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
@@ -10644,8 +10639,6 @@ snapshots:
 
   oclif@4.22.50(@types/node@22.19.1):
     dependencies:
-      '@aws-sdk/client-cloudfront': empty-npm-package@1.0.0
-      '@aws-sdk/client-s3': empty-npm-package@1.0.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.2.4
       '@inquirer/select': 2.5.0

--- a/package.json
+++ b/package.json
@@ -355,22 +355,22 @@
 	"pnpm": {
 		"comments": [
 			"node types are forced to a consistent version to avoid conflicts between globals.",
-			"nodegit is replaced with an empty package here because it's currently only used by good-fences for features we do not need, and has issues building when changing node versions. See https://github.com/smikula/good-fences/issues/105 for details.",
+			"nodegit for good-fences is dropped because it's for features we do not need, and has issues building when changing node versions. See https://github.com/smikula/good-fences/issues/105 for details.",
 			"codemirror and marked overrides are because simplemde use * versions, and the fully up to date versions of its deps do not work. packageExtensions was tried to fix this, but did not work.",
 			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed.",
-			"oclif includes some AWS-related features, but we don't use them, so we override those dependencies with empty packages. This helps reduce lockfile churn since the deps release very frequently.",
+			"oclif includes some AWS-related features, but we don't use them, so we drop those dependencies. This helps reduce lockfile churn since the deps release very frequently.",
 			"axios pre-1.0 needs an override to stay current on a version with no reported CVEs. Caret dependencies aren't enough on a pre-1.0 package.",
 			"Security overrides: tar is overridden to address path traversal CVEs (GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w, GHSA-34x7-hfp2-rc4v). The existing axios@<0.30.0 override resolves to 0.30.2 which is also affected by GHSA-43fc-jf86-j433 (DoS via __proto__), but updating that pre-1.0 override is out of scope here."
 		],
 		"overrides": {
 			"@types/node": "~20.19.30",
-			"good-fences>nodegit": "npm:empty-npm-package@1.0.0",
+			"good-fences>nodegit": "-",
 			"qs": "^6.11.0",
 			"simplemde>codemirror": "^5.65.11",
 			"simplemde>marked": "^4.3.0",
 			"@fluentui/react-positioning>@floating-ui/dom": "~1.5.4",
-			"oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
-			"oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0",
+			"oclif>@aws-sdk/client-cloudfront": "-",
+			"oclif>@aws-sdk/client-s3": "-",
 			"axios@<0.30.0": "^0.30.0",
 			"tar": ">=7.5.7"
 		},

--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
 	"pnpm": {
 		"comments": [
 			"node types are forced to a consistent version to avoid conflicts between globals.",
-			"nodegit for good-fences is dropped because it's for features we do not need, and has issues building when changing node versions. See https://github.com/smikula/good-fences/issues/105 for details.",
+			"nodegit is replaced with an empty package here because it's currently only used by good-fences for features we do not need, and has issues building when changing node versions. See https://github.com/smikula/good-fences/issues/105 for details. Note that using '-' to completely drop it, results in build failures complaining about nodegit not being there.",
 			"codemirror and marked overrides are because simplemde use * versions, and the fully up to date versions of its deps do not work. packageExtensions was tried to fix this, but did not work.",
 			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed.",
 			"oclif includes some AWS-related features, but we don't use them, so we drop those dependencies. This helps reduce lockfile churn since the deps release very frequently.",
@@ -364,7 +364,7 @@
 		],
 		"overrides": {
 			"@types/node": "~20.19.30",
-			"good-fences>nodegit": "-",
+			"good-fences>nodegit": "npm:empty-npm-package@1.0.0",
 			"qs": "^6.11.0",
 			"simplemde>codemirror": "^5.65.11",
 			"simplemde>marked": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@types/node': ~20.19.30
-  good-fences>nodegit: '-'
+  good-fences>nodegit: npm:empty-npm-package@1.0.0
   qs: ^6.11.0
   simplemde>codemirror: ^5.65.11
   simplemde>marked: ^4.3.0
@@ -22366,6 +22366,9 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
+  empty-npm-package@1.0.0:
+    resolution: {integrity: sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==}
+
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
 
@@ -36158,6 +36161,8 @@ snapshots:
 
   empathic@2.0.0: {}
 
+  empty-npm-package@1.0.0: {}
+
   enabled@2.0.0: {}
 
   encodeurl@1.0.2: {}
@@ -37299,6 +37304,7 @@ snapshots:
       commander: 7.2.0
       fdir: 5.3.0(picomatch@2.3.1)
       minimatch: 3.1.2
+      nodegit: empty-npm-package@1.0.0
       picomatch: 2.3.1
       strip-json-comments: 3.1.1
       tsconfig-paths: 3.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ settings:
 
 overrides:
   '@types/node': ~20.19.30
-  good-fences>nodegit: npm:empty-npm-package@1.0.0
+  good-fences>nodegit: '-'
   qs: ^6.11.0
   simplemde>codemirror: ^5.65.11
   simplemde>marked: ^4.3.0
   '@fluentui/react-positioning>@floating-ui/dom': ~1.5.4
-  oclif>@aws-sdk/client-cloudfront: npm:empty-npm-package@1.0.0
-  oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
+  oclif>@aws-sdk/client-cloudfront: '-'
+  oclif>@aws-sdk/client-s3: '-'
   axios@<0.30.0: ^0.30.0
   tar: '>=7.5.7'
 
@@ -22366,9 +22366,6 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
-  empty-npm-package@1.0.0:
-    resolution: {integrity: sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==}
-
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
 
@@ -36161,8 +36158,6 @@ snapshots:
 
   empathic@2.0.0: {}
 
-  empty-npm-package@1.0.0: {}
-
   enabled@2.0.0: {}
 
   encodeurl@1.0.2: {}
@@ -37304,7 +37299,6 @@ snapshots:
       commander: 7.2.0
       fdir: 5.3.0(picomatch@2.3.1)
       minimatch: 3.1.2
-      nodegit: empty-npm-package@1.0.0
       picomatch: 2.3.1
       strip-json-comments: 3.1.1
       tsconfig-paths: 3.15.0
@@ -40182,8 +40176,6 @@ snapshots:
 
   oclif@4.22.52(@types/node@20.19.30):
     dependencies:
-      '@aws-sdk/client-cloudfront': empty-npm-package@1.0.0
-      '@aws-sdk/client-s3': empty-npm-package@1.0.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0


### PR DESCRIPTION
## Description

Pnpm supports the approach proposed in this PR to drop dependencies that we want completely removed from the dep graph, which seems to be better than pointing to an empty package. Both because it avoids the dep on the stub package, and because it seems to work in cases where the current approach doesn't (see https://github.com/microsoft/FluidFramework/pull/26663#issuecomment-4015194141 and [my reply right beneath it](https://github.com/microsoft/FluidFramework/pull/26663#issuecomment-4024515531)).

I'm letting https://github.com/microsoft/FluidFramework/pull/26663 apply this change to server/historian and server/routerlicious.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I had to revert the change for good-fences because somehow that does cause build failures; when good-fences is loaded, [at some point it's looking for nodegit](https://dev.azure.com/fluidframework/public/public%20Team/_build/results?buildId=382876&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bfe27d5f-9219-57c0-0d67-1b2946a32921&l=83). I don't get why the current approach doesn't break things in the same way, but will leave that investigation for later.