### PR TITLE
ci: Ensure explicit pnpm version is used when activating pnpm in publish steps in the pipelines (fix break from pnpm 10.31)

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -61,10 +61,6 @@ steps:
       set -eu -o pipefail
       echo "Using node $(node --version)"
       sudo corepack enable
-      # pnpm 10.31 seems to have a change that breaks the 'npmAuthenticate' task below for some reason.
-      # Trying this as a mitigation while we figure out the problem.
-      sudo corepack install --global pnpm@10.30.3
-      sudo corepack use pnpm@10.30.3
       echo "Using pnpm $(pnpm -v)"
       # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -64,6 +64,7 @@ steps:
       # pnpm 10.31 seems to have a change that breaks the 'npmAuthenticate' task below for some reason.
       # Trying this as a mitigation while we figure out the problem.
       sudo corepack install --global pnpm@10.30.3
+      sudo corepack use pnpm@10.30.3
       echo "Using pnpm $(pnpm -v)"
       # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -61,6 +61,9 @@ steps:
       set -eu -o pipefail
       echo "Using node $(node --version)"
       sudo corepack enable
+      # pnpm 10.31 seems to have a change that breaks the 'npmAuthenticate' task below for some reason.
+      # Trying this as a mitigation while we figure out the problem.
+      sudo corepack use pnpm@10.30.3
       echo "Using pnpm $(pnpm -v)"
       # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -81,6 +81,7 @@ steps:
   env:
     NPM_REGISTRY: ${{ parameters.primaryRegistry }}
     NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath}}
+    CI: true
     # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
     # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
     # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -63,7 +63,7 @@ steps:
       sudo corepack enable
       # pnpm 10.31 seems to have a change that breaks the 'npmAuthenticate' task below for some reason.
       # Trying this as a mitigation while we figure out the problem.
-      sudo corepack use pnpm@10.30.3
+      sudo corepack use pnpm@10.30.3 --force
       echo "Using pnpm $(pnpm -v)"
       # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"
@@ -81,7 +81,6 @@ steps:
   env:
     NPM_REGISTRY: ${{ parameters.primaryRegistry }}
     NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath}}
-    CI: true
     # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
     # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
     # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -63,7 +63,7 @@ steps:
       sudo corepack enable
       # pnpm 10.31 seems to have a change that breaks the 'npmAuthenticate' task below for some reason.
       # Trying this as a mitigation while we figure out the problem.
-      sudo corepack use pnpm@10.30.3 --force
+      sudo corepack install --global pnpm@10.30.3
       echo "Using pnpm $(pnpm -v)"
       # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,6 +58,28 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
+          # In pipeline jobs that don't check out the repo, we sometimes want a stub package.json file to be able to
+          # control certain things about dependency installs during a pipeline run.
+          # In this case we need to pin the version of pnpm, just like we do in the package.json files in the repo,
+          # because version 10.31 introduced a break.
+          - task: Bash@3
+            name: PrepareBuildToolsZipDirectory
+            displayName: Prepare buildTools-zip directory and package.json
+            inputs:
+              targetType: 'inline'
+              workingDirectory: '$(Pipeline.Workspace)'
+              script: |
+                set -eu -o pipefail
+                mkdir -p buildTools-zip
+                cat > buildTools-zip/package.json <<'EOF'
+                {
+                  "name": "build-tools-zip",
+                  "private": true,
+                  "packageManager": "pnpm@10.30.3"
+                }
+                EOF
+
+
           - template: /tools/pipelines/templates/include-install-pnpm.yml@self
             parameters:
               buildDirectory: buildTools-zip

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,37 +58,15 @@ jobs:
           steps:
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
-          # In pipeline jobs that don't check out the repo, we sometimes want a stub package.json file to be able to
-          # control certain things about dependency installs during a pipeline run.
-          # In this case we need to pin the version of pnpm, just like we do in the package.json files in the repo,
-          # because version 10.31 introduced a break.
-          - task: Bash@3
-            name: PrepareBuildToolsZipDirectory
-            displayName: Prepare buildTools-zip directory and package.json
-            inputs:
-              targetType: 'inline'
-              workingDirectory: '$(Pipeline.Workspace)'
-              script: |
-                set -eu -o pipefail
-                mkdir -p buildTools-zip
-                cat > buildTools-zip/package.json <<'EOF'
-                {
-                  "name": "build-tools-zip",
-                  "private": true,
-                  "packageManager": "pnpm@10.30.3"
-                }
-                EOF
-
-
-          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
-            parameters:
-              buildDirectory: buildTools-zip
-              enableCache: false
-
-          # We can use this step to add overrides that might be necessary to allow for a correct
-          # installation of build-tools from the tarball artifacts produced by the build stage.
-          # Since this is a lockfile-less install (ideally we should figure out how to change that),
-          # overrides is one recourse when a dependency releases a new version that causes build-tools installation to break.
+          # We can use this step for two things:
+          # - Pin pnpm to a specific version (usually keep it in line with the one we use in the package.json files
+          #   in the repo), to prevent breaks in a freshly release version from affecting us (like 10.31 did).
+          # - Add overrides that might be necessary to allow for a correct installation of build-tools
+          #   from the tarball artifacts produced by the build stage.
+          #   Since this is a lockfile-less install (ideally we should figure out how to change that),
+          #   overrides is one recourse when a dependency releases a new version that causes build-tools installation to break.
+          # Note that this step needs to run before we install + configure pnpm so the package.json with overrides
+          # is in place before we install/activate pnpm, or we try to install the packages from the tarballs.
           # Current overrides:
           # - Build-tools packages: map all versions to local tarballs so interdependencies resolve correctly.
           - task: Bash@3
@@ -125,6 +103,11 @@ jobs:
                   }' > package.json
 
                 cat package.json
+
+          - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+            parameters:
+              buildDirectory: buildTools-zip/tarballs
+              enableCache: false
 
           - task: Bash@3
             name: InstallBuildToolsFromTarball


### PR DESCRIPTION
## Description

[pnpm 10.31](https://github.com/pnpm/pnpm/releases/tag/v10.31.0) released two days ago and seems to have broken something in our pipelines. I suspect it has to do with this line from the release notes:

> Explicitly tell npm the path to the global rc config file.

While we investigate or wait for a fix, this is an attempt to unblock publishing packages from our CI pipeline runs. In essence just ensuring that the stub `package.json` file we create in the publishing steps of the pipeline exists before we try to install pnpm, so the version specified in the file is respected.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Other issues have been reported to the pnpm repo already related to auth ([example](https://github.com/pnpm/pnpm/issues/10926)), so I think this is a bug on their end.