### PR TITLE
build(client-test-utils): set mocha as devDep

### DIFF
--- a/packages/test/test-utils/README.md
+++ b/packages/test/test-utils/README.md
@@ -2,6 +2,8 @@
 
 This package contains utilities for writing end-to-end tests in Fluid Framework. It helps in the creation of a simple hosting application to test Fluid objects and other functionalities of the system.
 
+Internal note: Currently, it also has a load side-effect when loaded under mocha where `@fluid-internal/mocha-test-setup` is used. The side-effect will attempt to inject an error 15ms before a test case would otherwise timeout.
+
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_README_HEADER:devDependency=TRUE) -->
 
 <!-- prettier-ignore-start -->

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -134,7 +134,6 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"best-random": "^1.0.0",
 		"debug": "^4.3.4",
-		"mocha": "^11.7.5",
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
@@ -158,6 +157,7 @@
 		"diff": "^3.5.0",
 		"eslint": "~9.39.1",
 		"jiti": "^2.6.1",
+		"mocha": "^11.7.5",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"

--- a/packages/test/test-utils/src/eventAndErrorLogger.ts
+++ b/packages/test/test-utils/src/eventAndErrorLogger.ts
@@ -1,0 +1,160 @@
+import type {
+	ITelemetryBaseEvent,
+	ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
+import type { ITelemetryGenericEventExt } from "@fluidframework/telemetry-utils/internal";
+
+import { isNonEmptyArray } from "./nonEmptyArrayType.js";
+
+/** @internal */
+export interface IEventAndErrorTrackingLogger {
+	registerExpectedEvent: (...orderedExpectedEvents: ITelemetryGenericEventExt[]) => void;
+	reportAndClearTrackedEvents: () => {
+		expectedNotFound: { index: number; event: ITelemetryGenericEventExt }[];
+		unexpectedErrors: ITelemetryBaseEvent[];
+	};
+}
+
+/**
+ * This class tracks events. It allows specifying expected events, which will be looked for in order.
+ * It also tracks all unexpected errors.
+ * At any point you call reportAndClearTrackedEvents which will provide all unexpected errors, and
+ * any expected events that have not occurred.
+ * @internal
+ */
+export class EventAndErrorTrackingLogger
+	implements ITelemetryBaseLogger, IEventAndErrorTrackingLogger
+{
+	/**
+	 * Even if these error events are logged, tests should still be allowed to pass
+	 * Additionally, if downgrade is true, then log as generic (e.g. to avoid polluting the e2e test logs)
+	 */
+	private readonly allowedErrors: { eventName: string; downgrade?: true }[] = [
+		// This log was removed in current version as unnecessary, but it's still present in previous versions
+		{
+			eventName: "fluid:telemetry:Container:NoRealStorageInDetachedContainer",
+			downgrade: true,
+		},
+		// This log's category changes depending on the op latency. test results shouldn't be affected but if we see lots we'd like an alert from the logs.
+		{ eventName: "fluid:telemetry:OpRoundtripTime" },
+	];
+
+	constructor(private readonly baseLogger?: ITelemetryBaseLogger) {}
+
+	private readonly expectedEvents: { index: number; event: ITelemetryGenericEventExt }[] = [];
+	private readonly unexpectedErrors: ITelemetryBaseEvent[] = [];
+
+	public registerExpectedEvent(...orderedExpectedEvents: ITelemetryGenericEventExt[]): void {
+		if (this.expectedEvents.length !== 0) {
+			// we don't have to error here. just no reason not to. given the events must be
+			// ordered it could be tricky to figure out problems around multiple registrations.
+			throw new Error(
+				"Expected events already registered.\n" +
+					"Call reportAndClearTrackedEvents to clear them before registering more",
+			);
+		}
+		this.expectedEvents.push(
+			...orderedExpectedEvents.map((event, index) => ({ index, event })),
+		);
+	}
+
+	send(event: ITelemetryBaseEvent): void {
+		if (isNonEmptyArray(this.expectedEvents)) {
+			const ee = this.expectedEvents[0].event;
+			if (ee.eventName === event.eventName) {
+				let matches = true;
+				for (const key of Object.keys(ee)) {
+					if (ee[key] !== event[key]) {
+						matches = false;
+						break;
+					}
+				}
+				if (matches) {
+					// we found an expected event
+					// so remove it from the list of expected events
+					// and if it is an error, change it to generic
+					// this helps keep our telemetry clear of
+					// expected errors.
+					this.expectedEvents.shift();
+					if (event.category === "error") {
+						event.category = "generic";
+					}
+				}
+			}
+		}
+		if (event.category === "error") {
+			// Check to see if this error is allowed and if its category should be downgraded
+			const allowedError = this.allowedErrors.find(
+				({ eventName }) => eventName === event.eventName,
+			);
+
+			if (allowedError === undefined) {
+				this.unexpectedErrors.push(event);
+			} else if (allowedError.downgrade) {
+				event.category = "generic";
+			}
+		}
+
+		this.baseLogger?.send(event);
+	}
+
+	public reportAndClearTrackedEvents(): {
+		expectedNotFound: { index: number; event: ITelemetryGenericEventExt }[];
+		unexpectedErrors: ITelemetryBaseEvent[];
+	} {
+		const expectedNotFound = this.expectedEvents.splice(0, this.expectedEvents.length);
+		const unexpectedErrors = this.unexpectedErrors.splice(0, this.unexpectedErrors.length);
+		return {
+			expectedNotFound,
+			unexpectedErrors,
+		};
+	}
+}
+
+/** Summarize the event with just the primary properties, for succinct output in case of test failure */
+const primaryEventProps = ({
+	category,
+	eventName,
+	error,
+	errorType,
+}: ITelemetryBaseEvent): Partial<ITelemetryBaseEvent> => ({
+	category,
+	eventName,
+	error,
+	errorType,
+	["..."]: "*** Additional properties not shown, see full log for details ***",
+});
+
+/**
+ * Retrieves unexpected errors from a logger and returns them as an exception.
+ *
+ * @internal
+ */
+
+export function getUnexpectedLogErrorException(
+	logger: IEventAndErrorTrackingLogger | undefined,
+	prefix?: string,
+): Error | undefined {
+	if (logger === undefined) {
+		return;
+	}
+	const results = logger.reportAndClearTrackedEvents();
+	if (results.unexpectedErrors.length > 0) {
+		return new Error(
+			`${prefix ?? ""}Unexpected Errors in Logs:\n${JSON.stringify(
+				results.unexpectedErrors.map(primaryEventProps),
+				undefined,
+				2,
+			)}`,
+		);
+	}
+	if (results.expectedNotFound.length > 0) {
+		return new Error(
+			`${prefix ?? ""}Expected Events not found:\n${JSON.stringify(
+				results.expectedNotFound,
+				undefined,
+				2,
+			)}`,
+		);
+	}
+}

--- a/packages/test/test-utils/src/eventAndErrorLogger.ts
+++ b/packages/test/test-utils/src/eventAndErrorLogger.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import type {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
@@ -130,7 +135,6 @@ const primaryEventProps = ({
  *
  * @internal
  */
-
 export function getUnexpectedLogErrorException(
 	logger: IEventAndErrorTrackingLogger | undefined,
 	prefix?: string,

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -3,8 +3,12 @@
  * Licensed under the MIT License.
  */
 
+export type { IEventAndErrorTrackingLogger } from "./eventAndErrorLogger.js";
+export {
+	EventAndErrorTrackingLogger,
+	getUnexpectedLogErrorException,
+} from "./eventAndErrorLogger.js";
 export { IProvideTestFluidObject, ITestFluidObject } from "./interfaces.js";
-export { LoaderContainerTracker } from "./loaderContainerTracker.js";
 export {
 	fluidEntryPoint,
 	LocalCodeLoader,
@@ -30,25 +34,30 @@ export {
 	TestFluidObjectFactory,
 	TestDataObjectKind,
 } from "./testFluidObject.js";
-export {
-	createDocumentId,
-	DataObjectFactoryType,
-	EventAndErrorTrackingLogger,
-	type IEventAndErrorTrackingLogger,
-	getUnexpectedLogErrorException,
+
+// #region Exports with load side-effect
+// These exports transitively or directly load timeoutUtils.ts that has load
+// side effect of patching Mocha's timeout handling. For the side effect to
+// load, consumer must also load mocha-test-setup, which is pervasively used.
+export { LoaderContainerTracker } from "./loaderContainerTracker.js";
+export type {
 	IDocumentIdStrategy,
 	IOpProcessingController,
 	ITestContainerConfig,
 	ITestObjectProvider,
+} from "./testObjectProvider.js";
+export {
+	createDocumentId,
+	DataObjectFactoryType,
 	TestObjectProvider,
 	TestObjectProviderWithVersionedLoad,
 } from "./testObjectProvider.js";
+export type { SummaryInfo } from "./TestSummaryUtils.js";
 export {
 	createSummarizer,
 	createSummarizerCore,
 	createSummarizerFromFactory,
 	summarizeNow,
-	SummaryInfo,
 } from "./TestSummaryUtils.js";
 export {
 	timeoutAwait,
@@ -63,6 +72,8 @@ export {
 	getContainerEntryPointBackCompat,
 	getDataStoreEntryPointBackCompat,
 } from "./containerUtils.js";
+// #endregion
+
 export {
 	type ContainerRuntimeFactoryWithDefaultDataStoreConstructor,
 	type ContainerRuntimeFactoryWithDefaultDataStoreProps,

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -18,7 +18,6 @@ import {
 import type { IContainerRuntimeOptionsInternal } from "@fluidframework/container-runtime/internal";
 import {
 	IRequestHeader,
-	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
 	ITelemetryBaseProperties,
 	TelemetryBaseEventPropertyType,
@@ -32,7 +31,6 @@ import {
 import { isOdspResolvedUrl } from "@fluidframework/odsp-driver/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryGenericEventExt,
 	createChildLogger,
 	createMultiSinkLogger,
 	type ITelemetryLoggerPropertyBags,
@@ -41,10 +39,14 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
+import type { IEventAndErrorTrackingLogger } from "./eventAndErrorLogger.js";
+import {
+	EventAndErrorTrackingLogger,
+	getUnexpectedLogErrorException,
+} from "./eventAndErrorLogger.js";
 import { LoaderContainerTracker } from "./loaderContainerTracker.js";
 import { LocalCodeLoader, fluidEntryPoint } from "./localCodeLoader.js";
 import { createAndAttachContainer } from "./localLoader.js";
-import { isNonEmptyArray } from "./nonEmptyArrayType.js";
 import { ChannelFactoryRegistry } from "./testFluidObject.js";
 
 const defaultCodeDetails: IFluidCodeDetails = {
@@ -326,111 +328,6 @@ function getDocumentIdStrategy(type?: TestDriverTypes): IDocumentIdStrategy {
 					documentId = createDocumentId();
 				},
 			};
-	}
-}
-
-/** @internal */
-export interface IEventAndErrorTrackingLogger {
-	registerExpectedEvent: (...orderedExpectedEvents: ITelemetryGenericEventExt[]) => void;
-	reportAndClearTrackedEvents: () => {
-		expectedNotFound: { index: number; event: ITelemetryGenericEventExt }[];
-		unexpectedErrors: ITelemetryBaseEvent[];
-	};
-}
-
-/**
- * This class tracks events. It allows specifying expected events, which will be looked for in order.
- * It also tracks all unexpected errors.
- * At any point you call reportAndClearTrackedEvents which will provide all unexpected errors, and
- * any expected events that have not occurred.
- * @internal
- */
-export class EventAndErrorTrackingLogger
-	implements ITelemetryBaseLogger, IEventAndErrorTrackingLogger
-{
-	/**
-	 * Even if these error events are logged, tests should still be allowed to pass
-	 * Additionally, if downgrade is true, then log as generic (e.g. to avoid polluting the e2e test logs)
-	 */
-	private readonly allowedErrors: { eventName: string; downgrade?: true }[] = [
-		// This log was removed in current version as unnecessary, but it's still present in previous versions
-		{
-			eventName: "fluid:telemetry:Container:NoRealStorageInDetachedContainer",
-			downgrade: true,
-		},
-		// This log's category changes depending on the op latency. test results shouldn't be affected but if we see lots we'd like an alert from the logs.
-		{ eventName: "fluid:telemetry:OpRoundtripTime" },
-	];
-
-	constructor(private readonly baseLogger?: ITelemetryBaseLogger) {}
-
-	private readonly expectedEvents: { index: number; event: ITelemetryGenericEventExt }[] = [];
-	private readonly unexpectedErrors: ITelemetryBaseEvent[] = [];
-
-	public registerExpectedEvent(...orderedExpectedEvents: ITelemetryGenericEventExt[]): void {
-		if (this.expectedEvents.length !== 0) {
-			// we don't have to error here. just no reason not to. given the events must be
-			// ordered it could be tricky to figure out problems around multiple registrations.
-			throw new Error(
-				"Expected events already registered.\n" +
-					"Call reportAndClearTrackedEvents to clear them before registering more",
-			);
-		}
-		this.expectedEvents.push(
-			...orderedExpectedEvents.map((event, index) => ({ index, event })),
-		);
-	}
-
-	send(event: ITelemetryBaseEvent): void {
-		if (isNonEmptyArray(this.expectedEvents)) {
-			const ee = this.expectedEvents[0].event;
-			if (ee.eventName === event.eventName) {
-				let matches = true;
-				for (const key of Object.keys(ee)) {
-					if (ee[key] !== event[key]) {
-						matches = false;
-						break;
-					}
-				}
-				if (matches) {
-					// we found an expected event
-					// so remove it from the list of expected events
-					// and if it is an error, change it to generic
-					// this helps keep our telemetry clear of
-					// expected errors.
-					this.expectedEvents.shift();
-					if (event.category === "error") {
-						event.category = "generic";
-					}
-				}
-			}
-		}
-		if (event.category === "error") {
-			// Check to see if this error is allowed and if its category should be downgraded
-			const allowedError = this.allowedErrors.find(
-				({ eventName }) => eventName === event.eventName,
-			);
-
-			if (allowedError === undefined) {
-				this.unexpectedErrors.push(event);
-			} else if (allowedError.downgrade) {
-				event.category = "generic";
-			}
-		}
-
-		this.baseLogger?.send(event);
-	}
-
-	public reportAndClearTrackedEvents(): {
-		expectedNotFound: { index: number; event: ITelemetryGenericEventExt }[];
-		unexpectedErrors: ITelemetryBaseEvent[];
-	} {
-		const expectedNotFound = this.expectedEvents.splice(0, this.expectedEvents.length);
-		const unexpectedErrors = this.unexpectedErrors.splice(0, this.unexpectedErrors.length);
-		return {
-			expectedNotFound,
-			unexpectedErrors,
-		};
 	}
 }
 
@@ -1170,51 +1067,4 @@ function getUrlTelemetryProps(
 	}
 
 	return tagData(TelemetryDataTag.UserData, props);
-}
-
-/** Summarize the event with just the primary properties, for succinct output in case of test failure */
-const primaryEventProps = ({
-	category,
-	eventName,
-	error,
-	errorType,
-}: ITelemetryBaseEvent): Partial<ITelemetryBaseEvent> => ({
-	category,
-	eventName,
-	error,
-	errorType,
-	["..."]: "*** Additional properties not shown, see full log for details ***",
-});
-
-/**
- * Retrieves unexpected errors from a logger and returns them as an exception.
- *
- * @internal
- */
-export function getUnexpectedLogErrorException(
-	logger: IEventAndErrorTrackingLogger | undefined,
-	prefix?: string,
-): Error | undefined {
-	if (logger === undefined) {
-		return;
-	}
-	const results = logger.reportAndClearTrackedEvents();
-	if (results.unexpectedErrors.length > 0) {
-		return new Error(
-			`${prefix ?? ""}Unexpected Errors in Logs:\n${JSON.stringify(
-				results.unexpectedErrors.map(primaryEventProps),
-				undefined,
-				2,
-			)}`,
-		);
-	}
-	if (results.expectedNotFound.length > 0) {
-		return new Error(
-			`${prefix ?? ""}Expected Events not found:\n${JSON.stringify(
-				results.expectedNotFound,
-				undefined,
-				2,
-			)}`,
-		);
-	}
 }

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -3,7 +3,15 @@
  * Licensed under the MIT License.
  */
 
+// Warning: this module has load side effect of patching Mocha's timeout handling.
+// See globalThis.getMochaModule use below.
+
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
+// Note that "@types/mocha" is only a devDependency of this package.
+// None of the mocha types are exposed through exports and thus it's reasonable
+// to leave mocha as a devDependency only. Further, the underlying code is only
+// used when @fluid-internal/mocha-test-setup is used and that package dictates
+// a mocha version.
 import type * as Mocha from "mocha";
 
 const timeBuffer = 15; // leave 15 ms leeway for finish processing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15424,9 +15424,6 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.4.3(supports-color@8.1.1)
-      mocha:
-        specifier: ^11.7.5
-        version: 11.7.5
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -15491,6 +15488,9 @@ importers:
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
+      mocha:
+        specifier: ^11.7.5
+        version: 11.7.5
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@11.7.5)


### PR DESCRIPTION
test-utils does not have a runtime dependency on mocha. Only types are imported for mocha and those were already set as a devDependency.

Add notes about the test timeout conditional side-effect of loading that is present in test-utils package.

Additionally refactor event and error logger away from testObjectProvider.ts to further isolate modules that depend on the side-effect related code. Nothing strictly relies on the side-effect, but many components reference the module with the side-effect. Per the barrel pattern, any package load will enact the side-effect at this time (assuming no tree shaking).

test-utils is not uniformly used throughout the client workspace which makes it non-trivial to relocate the test timeout logic to @fluid-internal/mocha-test-setup that is broadly used.