### PR TITLE
fix: Clear snapshot cache if possible in case of redirection

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -301,7 +301,7 @@ export class EpochTracker implements IPersistedFileCache {
 				await this.checkForEpochError(error, epochFromResponse, fetchType);
 				throw error;
 			})
-			.catch((error) => {
+			.catch(async (error) => {
 				// If the error is about location redirection, then we need to generate new resolved url with correct
 				// location info.
 				if (
@@ -320,6 +320,9 @@ export class EpochTracker implements IPersistedFileCache {
 							{ driverVersion, redirectLocation },
 						);
 						locationRedirectionError.addTelemetryProperties(error.getTelemetryProperties());
+						// Clear the cache for this file entry since the site/geo has moved.
+						// The cached snapshot was stored under the old siteUrl and is no longer valid.
+						await this.removeEntries();
 						throw locationRedirectionError;
 					}
 				}

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -371,9 +371,21 @@ describe("Tests for Epoch Tracker", () => {
 		);
 	});
 
-	it("Check for resolved url on LocationRedirection error", async () => {
-		let success: boolean = true;
+	it("LocationRedirection error should have correct resolved url and clear cache", async () => {
+		const cacheEntry: IEntry = {
+			key: "key1",
+			type: "snapshot",
+		};
+		epochTracker.setEpoch("epoch1", true, "test");
+		await epochTracker.put(cacheEntry, { val: "val1" });
+
+		assert(
+			(await epochTracker.get(cacheEntry)) !== undefined,
+			"Entry should exist in cache before redirect",
+		);
+
 		const newSiteUrl = "https://microsoft.sharepoint.com/siteUrl";
+		let success: boolean = true;
 		try {
 			await mockFetchSingle(
 				async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "test"),
@@ -402,5 +414,9 @@ describe("Tests for Epoch Tracker", () => {
 			assert.strictEqual(newResolvedUrl.driveId, driveId, "driveId should remain same");
 		}
 		assert.strictEqual(success, false, "Fetching should not succeed!!");
+		assert(
+			(await epochTracker.get(cacheEntry)) === undefined,
+			"Cache entry should be cleared after site/geo move redirect",
+		);
 	});
 });


### PR DESCRIPTION
## Description

* Update epochTracker.ts to clear cache when we are in the scenario where a redirect error is about to be thrown.
* Prior to this fix, cache is kept even if the page was redirected therefore it would be stale the next time it's loaded.
* fixes https://dev.azure.com/fluidframework/internal/_workitems/edit/58855

## Reviewer Guidance

* Updated a unit test that is already going through this scenario and adds some additional validation to confirm the cache is indeed cleared.
