### PR TITLE
fix: Protection against infinite loops in tree-agent

### DIFF
--- a/packages/framework/tree-agent/src/agent.ts
+++ b/packages/framework/tree-agent/src/agent.ts
@@ -408,9 +408,9 @@ class TreeAgentImpl<TSchema extends ImplicitFieldSchema> implements TreeAgent {
 		try {
 			while (true) {
 				editLoopTurns++;
-				// Allow for one extra turn to allow for a final assistant response after the last edit.
-				if (editLoopTurns > this.#maxEditCount + 1) {
-					const cutoffMessage = `The model failed to produce a response within ${editLoopTurns} turns.`;
+				// Allow for two extra turns: one for a last tool error message, and one for a final response from the llm.
+				if (editLoopTurns > this.#maxEditCount + 2) {
+					const cutoffMessage = `The model failed to produce a response within ${this.#maxEditCount} edits.`;
 					this.#history.push({ role: "assistant", content: cutoffMessage });
 					this.#options?.logger?.log(`## Cancel\n\n${cutoffMessage}\n\n`);
 					queryTree.branch.dispose();
@@ -448,7 +448,7 @@ class TreeAgentImpl<TSchema extends ImplicitFieldSchema> implements TreeAgent {
 					continue;
 				}
 
-				// It's fair to assume that every loop turn corresponds to one edit attempt, since the only way for the model to take multiple turns without making progress on the task is to make multiple attempts at editing the tree.
+				// Every loop turn roughly corresponds to one edit attempt, since the loop terminates when the llm produces a non-tool response.
 				if (editLoopTurns > this.#maxEditCount) {
 					rollbackEdits = true;
 					const errorMessage = `The maximum number of edits (${this.#maxEditCount}) for this query has been exceeded.`;

--- a/packages/framework/tree-agent/src/agent.ts
+++ b/packages/framework/tree-agent/src/agent.ts
@@ -404,9 +404,15 @@ class TreeAgentImpl<TSchema extends ImplicitFieldSchema> implements TreeAgent {
 		const queryTree = this.#outerTree.fork();
 		let editCount = 0;
 		let rollbackEdits = false;
+		const maxModelCalls = this.#maxEditCount + 2;
+		let modelCalls = 0;
 
 		try {
 			while (true) {
+				if (++modelCalls > maxModelCalls) {
+					queryTree.branch.dispose();
+					return `The model failed to produce a response within ${maxModelCalls} calls.`;
+				}
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const response = await this.#model.invoke!(this.#history);
 

--- a/packages/framework/tree-agent/src/agent.ts
+++ b/packages/framework/tree-agent/src/agent.ts
@@ -402,16 +402,15 @@ class TreeAgentImpl<TSchema extends ImplicitFieldSchema> implements TreeAgent {
 
 		// Fork a branch for this edit session
 		const queryTree = this.#outerTree.fork();
-		let editCount = 0;
+		let editLoopTurns = 0;
 		let rollbackEdits = false;
-		// Allow for one extra call to allow for a final assistant response after the last edit.
-		const maxModelCalls = this.#maxEditCount + 1;
-		let modelCalls = 0;
 
 		try {
 			while (true) {
-				if (++modelCalls >= maxModelCalls) {
-					const cutoffMessage = `The model failed to produce a response within ${maxModelCalls} calls.`;
+				editLoopTurns++;
+				// Allow for one extra turn to allow for a final assistant response after the last edit.
+				if (editLoopTurns > this.#maxEditCount + 1) {
+					const cutoffMessage = `The model failed to produce a response within ${editLoopTurns} turns.`;
 					this.#history.push({ role: "assistant", content: cutoffMessage });
 					this.#options?.logger?.log(`## Cancel\n\n${cutoffMessage}\n\n`);
 					queryTree.branch.dispose();
@@ -449,8 +448,8 @@ class TreeAgentImpl<TSchema extends ImplicitFieldSchema> implements TreeAgent {
 					continue;
 				}
 
-				editCount++;
-				if (editCount > this.#maxEditCount) {
+				// It's fair to assume that every loop turn corresponds to one edit attempt, since the only way for the model to take multiple turns without making progress on the task is to make multiple attempts at editing the tree.
+				if (editLoopTurns > this.#maxEditCount) {
 					rollbackEdits = true;
 					const errorMessage = `The maximum number of edits (${this.#maxEditCount}) for this query has been exceeded.`;
 					this.#history.push({

--- a/packages/framework/tree-agent/src/agent.ts
+++ b/packages/framework/tree-agent/src/agent.ts
@@ -404,14 +404,18 @@ class TreeAgentImpl<TSchema extends ImplicitFieldSchema> implements TreeAgent {
 		const queryTree = this.#outerTree.fork();
 		let editCount = 0;
 		let rollbackEdits = false;
-		const maxModelCalls = this.#maxEditCount + 2;
+		// Allow for one extra call to allow for a final assistant response after the last edit.
+		const maxModelCalls = this.#maxEditCount + 1;
 		let modelCalls = 0;
 
 		try {
 			while (true) {
-				if (++modelCalls > maxModelCalls) {
+				if (++modelCalls >= maxModelCalls) {
+					const cutoffMessage = `The model failed to produce a response within ${maxModelCalls} calls.`;
+					this.#history.push({ role: "assistant", content: cutoffMessage });
+					this.#options?.logger?.log(`## Cancel\n\n${cutoffMessage}\n\n`);
 					queryTree.branch.dispose();
-					return `The model failed to produce a response within ${maxModelCalls} calls.`;
+					return cutoffMessage;
 				}
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const response = await this.#model.invoke!(this.#history);

--- a/packages/framework/tree-agent/src/test/agent.spec.ts
+++ b/packages/framework/tree-agent/src/test/agent.spec.ts
@@ -717,13 +717,12 @@ describe("createTreeAgent", () => {
 	it("terminates if the model never returns an assistant response", async () => {
 		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");
-		// Create many tool_call responses with malformed args (no string property).
-		// With maximumSequentialEdits: 2, maxModelCalls = 4. The model should be cut off.
+		// Create many valid tool_call responses. The agent should terminate after exceeding the edit limit.
 		const badResponses = Array.from({ length: 20 }, (_, i) => ({
 			role: "tool_call" as const,
 			toolCallId: `c${i}`,
 			toolName: editToolName,
-			toolArgs: {},
+			toolArgs: { js: `context.root = "Edit ${i}";` },
 		}));
 		const model = createMockInvokeModel(badResponses);
 		const agent = createTreeAgent(model, view, { maximumSequentialEdits: 2 });

--- a/packages/framework/tree-agent/src/test/agent.spec.ts
+++ b/packages/framework/tree-agent/src/test/agent.spec.ts
@@ -714,6 +714,25 @@ describe("createTreeAgent", () => {
 		agent.dispose();
 	});
 
+	it("terminates if the model never returns an assistant response", async () => {
+		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
+		view.initialize("Initial");
+		// Create many tool_call responses with malformed args (no string property).
+		// With maximumSequentialEdits: 2, maxModelCalls = 4. The model should be cut off.
+		const badResponses = Array.from({ length: 20 }, (_, i) => ({
+			role: "tool_call" as const,
+			toolCallId: `c${i}`,
+			toolName: editToolName,
+			toolArgs: {},
+		}));
+		const model = createMockInvokeModel(badResponses);
+		const agent = createTreeAgent(model, view, { maximumSequentialEdits: 2 });
+		const result = await agent.message("Do something");
+		assert(result.includes("failed to produce a response"));
+		assert.equal(view.root, "Initial");
+		agent.dispose();
+	});
+
 	it("merges on success, rolls back on failure", async () => {
 		const view = independentView(new TreeViewConfiguration({ schema: sf.string }));
 		view.initialize("Initial");


### PR DESCRIPTION
## Description

Adds a protection against infinite loops in tree-agent, for the situation that the model always returns a tool call.

## Breaking Changes

None.

## Reviewer Guidance

Unit test is added.