### PR TITLE
fix(devcontainer): replace legacy docker-debian.sh with docker-outside-of-docker feature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-ARG NODE_VERSION=18
+ARG NODE_VERSION=24
 FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_VERSION}
 
 # Install Chromium to get .so libraries required for Puppeteer tests.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,45 +1,14 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-# Fluid Development Container based on "docker-from-docker" template:
-# https://github.com/microsoft/vscode-dev-containers/blob/master/containers/docker-from-docker/.devcontainer/Dockerfile
-
 ARG NODE_VERSION=18
-
-# 'node:${VARIANT}' base image includes the following:
-#
-#    eslint (global), node/npm, nvm, yarn
-#
-# Debian base image includes the following:
-#
-#    ca-certificates, curl, g++, git, gnupg, libxss1, make, procps, python, wget
-#
-# (See https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node/.devcontainer)
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_VERSION}
 
 # Install Chromium to get .so libraries required for Puppeteer tests.
 # (Note that Puppeteer bundles its own version of Chromium, we just need OS dependencies.)
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get -y install --no-install-recommends chromium libxss1
-
-# Install Docker CLI / Docker-Compose and create '/usr/local/share/docker-init.sh' to proxy the
-# docker socket.  (We retrieve the script from the 'docker-from-docker' dev container template)
-
-# [Option] Enable non-root Docker access in container
-ARG ENABLE_NONROOT_DOCKER="true"
-# [Option] Use the OSS Moby CLI instead of the licensed Docker CLI
-ARG USE_MOBY="true"
-
-# A user of "automatic" attempts to reuse an user ID if one already exists.
-ARG USERNAME=automatic
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN mkdir /tmp/library-scripts
-RUN wget -O /tmp/library-scripts/docker-debian.sh https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
-RUN /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" "${USE_MOBY}"
-RUN rm -rf /tmp/library-scripts/
 
 # Install additional desired packages here
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -69,7 +38,3 @@ RUN if [ "$AI_READY" = "true" ]; then \
     fi
 
 USER node
-
-# Set '/usr/local/share/docker-init.sh' as entrypoint to proxy Docker socket on start.
-ENTRYPOINT ["/usr/local/share/docker-init.sh"]
-CMD ["sleep", "infinity"]

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -26,8 +26,9 @@
 	"postCreateCommand": "bash -lc \"scripts/codespace-setup/post-create.sh && . scripts/codespace-setup/ai-setup.sh\"",
 	"remoteUser": "node",
 	"features": {
-		"github-cli": "latest",
-		"git-lfs": "latest"
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/git-lfs:1": {}
 	},
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
 	// can be lengthy enough that it's convenient.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 		}
 	},
 	"overrideCommand": false,
+	"runArgs": ["--init"],
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,3 @@
-// Fluid Development Container based on "docker-from-docker" template:
-// https://github.com/microsoft/vscode-dev-containers/blob/master/containers/docker-from-docker/.devcontainer/devcontainer.json
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
 	"name": "Standard",
@@ -10,8 +8,6 @@
 			"NODE_VERSION": "24"
 		}
 	},
-	"runArgs": ["--init"],
-	"mounts": ["source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"],
 	"overrideCommand": false,
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -36,12 +32,13 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"git-lfs": "latest"
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/git-lfs:1": {}
 		// We do not install Azure CLI and Github CLI because of security considerations
 		// when creating Github Codespaces instances. It's ok to install them manually if
 		// using this file to develop in a local container.
-		// "azure-cli": "latest",  // DO NOT UNCOMMENT
-		// "github-cli": "latest", // DO NOT UNCOMMENT
+		// "ghcr.io/devcontainers/features/azure-cli:1": {},  // DO NOT UNCOMMENT
+		// "ghcr.io/devcontainers/features/github-cli:1": {},  // DO NOT UNCOMMENT
 	},
 
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build

--- a/.devcontainer/lightweight/devcontainer.json
+++ b/.devcontainer/lightweight/devcontainer.json
@@ -25,7 +25,8 @@
 	"postCreateCommand": "bash scripts/codespace-setup/post-create.sh",
 	"remoteUser": "node",
 	"features": {
-		"git-lfs": "latest"
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/git-lfs:1": {}
 	},
 	"hostRequirements": {
 		"cpus": 4,


### PR DESCRIPTION
## Summary

The Codespaces prebuild CI was failing because the `docker-debian.sh` script downloaded from the deprecated `microsoft/vscode-dev-containers` repo doesn't support Debian 13 (trixie), which is the base OS in the Node 24 devcontainer image. The script crashes with `err: command not found` when it can't match the OS codename.

- Remove manual Docker-in-Docker setup from Dockerfile (script download, socket proxy entrypoint, related ARGs)
- Replace with the modern `ghcr.io/devcontainers/features/docker-outside-of-docker:1` devcontainer feature across all three profiles (Standard, AI-enabled, Lightweight)
- Update base image from deprecated `mcr.microsoft.com/vscode/devcontainers/javascript-node` to `mcr.microsoft.com/devcontainers/javascript-node`
- Migrate feature references from shorthand format to fully qualified OCI references
- Remove now-unnecessary `runArgs` and `mounts` from the Standard profile (handled by the feature)