### PR TITLE
fix(devcontainer): disable moby for docker-outside-of-docker on Debian Trixie

### DIFF
--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -26,7 +26,9 @@
 	"postCreateCommand": "bash -lc \"scripts/codespace-setup/post-create.sh && . scripts/codespace-setup/ai-setup.sh\"",
 	"remoteUser": "node",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": false
+		},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,9 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": false
+		},
 		"ghcr.io/devcontainers/features/git-lfs:1": {}
 		// We do not install Azure CLI and Github CLI because of security considerations
 		// when creating Github Codespaces instances. It's ok to install them manually if

--- a/.devcontainer/lightweight/devcontainer.json
+++ b/.devcontainer/lightweight/devcontainer.json
@@ -25,7 +25,9 @@
 	"postCreateCommand": "bash scripts/codespace-setup/post-create.sh",
 	"remoteUser": "node",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": false
+		},
 		"ghcr.io/devcontainers/features/git-lfs:1": {}
 	},
 	"hostRequirements": {


### PR DESCRIPTION
## Summary

- The `javascript-node:24` base image is now built on Debian Trixie, which removed `moby-cli` system packages
- The `docker-outside-of-docker` feature defaults to `"moby": true`, causing the prebuild to fail
- Sets `"moby": false` in all three devcontainer configs so the Docker CLI is installed from Docker's official apt repository instead

## Test plan

- [x] Verified `devcontainer build` succeeds locally with this change
- [ ] Codespaces prebuild workflow passes