### PR TITLE
chore: trigger server-gitssh pipeline to clear stale CG alerts

### DIFF
--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -3,6 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
+# Trigger CG re-scan to clear stale alerts.
 # Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
 # That version of the base image must also be baked into the CI build agent by a repo maintainer.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.


### PR DESCRIPTION
## Summary

- Adds a no-op comment to `server/gitssh/Dockerfile` to trigger the server-gitssh pipeline, which hasn't run since Feb 25
- This allows Component Governance to re-scan the pipeline and clear stale vulnerability alerts

## Test plan

- [ ] server-gitssh pipeline runs and CG re-scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)