### PR TITLE
fix: override jws in telemetry-generator install

### DIFF
--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -48,4 +48,8 @@ steps:
       mkdir -p ${{ parameters.pathForTelemetryGeneratorInstall }}
       cd ${{ parameters.pathForTelemetryGeneratorInstall }}
 
+      # Seed a package.json with overrides to force patched transitive dependencies.
+      # This ensures CG won't flag known vulnerabilities in the installed tree.
+      echo '{"overrides":{"jws":"^3.2.3"}}' > package.json
+
       npm install @ff-internal/telemetry-generator@${{ parameters.versionToInstall }}


### PR DESCRIPTION
## Summary

- Seeds a `package.json` with `{"overrides":{"jws":"^3.2.3"}}` in the telemetry-generator install directory before running `npm install`
- This forces npm to resolve `jws` to `^3.2.3`, fixing a CG alert in the "Upload telemetry to Kusto" pipeline step
- The telemetry-generator package (`@ff-internal/telemetry-generator`) is published to an internal ADO feed, so the transitive dependency can't be fixed via pnpm overrides in this repo — npm overrides in the install step is the correct approach

## Test plan

- [x] `repo-policy-check` passed
- [ ] After merge and a successful build on main, confirm the CG alert clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)