### PR TITLE
fix(devcontainer): remove overrideCommand to fix codespace prebuilds

### DIFF
--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -9,7 +9,6 @@
 		}
 	},
 	"runArgs": ["--init"],
-	"overrideCommand": false,
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
 			"NODE_VERSION": "24"
 		}
 	},
-	"overrideCommand": false,
 	"runArgs": ["--init"],
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/lightweight/devcontainer.json
+++ b/.devcontainer/lightweight/devcontainer.json
@@ -8,7 +8,6 @@
 		}
 	},
 	"runArgs": ["--init"],
-	"overrideCommand": false,
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
## Summary

- Removes `"overrideCommand": false` from `.devcontainer/devcontainer.json` to fix Codespace prebuilds that have been failing since #26678

## Problem

Codespace prebuilds have been failing consistently since commit 43c5f67 (PR #26678) with `Error code: 1300 (UnifiedContainersGeneralError)`. The container builds and starts successfully, but exits immediately before the Codespaces agent can run its second `devcontainer up --expect-existing-container --prebuild` step.

### Root cause

With `overrideCommand: false`, the devcontainer CLI preserves the base image's original CMD (`docker-entrypoint.sh node`) as positional arguments in the container's keep-alive script:

```bash
echo Container started
trap "exit 0" 15
/usr/local/share/docker-init.sh
exec "$@"                          # <-- exec "docker-entrypoint.sh" "node"
while sleep 1 & wait $!; do :; done  # <-- never reached
```

`exec "$@"` replaces the shell with Node.js, which has no script to run and exits immediately. The `while sleep` keep-alive loop never executes, the container dies, and the prebuild fails.

Without `overrideCommand: false` (defaults to `true`), no original CMD args are passed, so `exec "$@"` is a no-op and the keep-alive loop runs as intended.

This wasn't an issue with the old Dockerfile which had an explicit `ENTRYPOINT ["/usr/local/share/docker-init.sh"]` and `CMD ["sleep", "infinity"]`. The PR #26678 refactored to use the `docker-outside-of-docker` feature instead, but `overrideCommand: false` was carried over when it's no longer needed.

## Test plan

Tested locally using the `devcontainer` CLI to simulate the prebuild lifecycle:

**Before (with `overrideCommand: false`):**
```
$ devcontainer up --workspace-folder .
Container started
Error response from daemon: container dff3253e... is not running
```
`docker inspect` confirmed CMD included `"docker-entrypoint.sh", "node"` as positional args — container exited immediately (exit code 0).

**After (removing `overrideCommand: false`):**
```
$ devcontainer up --workspace-folder .
Container started
Fetching git lfs artifacts...
Git LFS initialized.
```
`docker ps` confirmed container stays running. `docker inspect` confirmed CMD positional args are just `"-"` (no original CMD), so the keep-alive loop executes.
