### PR TITLE
SiteMove/Geo move not handled properly during container load

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -189,12 +189,31 @@ export async function fetchSnapshotWithRedeem(
 					putInCache,
 					loadingGroupIds,
 				);
-			} else if (isLocationRedirectionError(error)) {
-				const redirectedResolvedUrl: IOdspResolvedUrl = {
-					...getOdspResolvedUrl(error.redirectUrl),
-					shareLinkInfo: odspResolvedUrl.shareLinkInfo,
-				};
-				await redeemSharingLink(redirectedResolvedUrl, storageTokenFetcher, logger);
+			} else if (
+				isLocationRedirectionError(error) &&
+				odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem !== undefined
+			) {
+				try {
+					// The redirect itself is handled earlier, but we need to redeem the sharing link
+					// now against the redirected URL rather than waiting until the next API call retries
+					// with the redirect URL applied. After this point the sharing link is removed from
+					// the resolved URL, so we wouldn't be able to redeem during a later failure.
+					const redirectedResolvedUrl: IOdspResolvedUrl = {
+						...getOdspResolvedUrl(error.redirectUrl),
+						shareLinkInfo: odspResolvedUrl.shareLinkInfo,
+					};
+
+					await redeemSharingLink(redirectedResolvedUrl, storageTokenFetcher, logger);
+					logger.sendTelemetryEvent(
+						{
+							eventName: "RedirectRedeemFallback",
+							errorType: error.errorType,
+						},
+						error,
+					);
+				} catch (redeemError) {
+					logger.sendErrorEvent({ eventName: "RedirectRedeemFallbackError" }, redeemError);
+				}
 				throw error;
 			} else {
 				throw error;
@@ -808,8 +827,8 @@ function isLocationRedirectionError(error: unknown): error is ILocationRedirecti
 	return (
 		typeof error === "object" &&
 		error !== null &&
-		(error as Partial<ILocationRedirectionError>).errorType ===
-			DriverErrorTypes.locationRedirection
+		(error as Partial<IOdspError>).errorType === DriverErrorTypes.locationRedirection &&
+		(error as Partial<ILocationRedirectionError>).redirectUrl !== undefined
 	);
 }
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -6,7 +6,12 @@
 import { fromUtf8ToBase64 } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
 import { getW3CData } from "@fluidframework/driver-base/internal";
-import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import {
+	DriverErrorTypes,
+	type ILocationRedirectionError,
+	type ISnapshot,
+	type ISnapshotTree,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	type DriverErrorTelemetryProps,
 	NonRetryableError,
@@ -54,6 +59,7 @@ import {
 	fetchAndParseAsJSONHelper,
 	fetchHelper,
 	getWithRetryForTokenRefresh,
+	getOdspResolvedUrl,
 	getWithRetryForTokenRefreshRepeat,
 	isSnapshotFetchForLoadingGroup,
 	measure,
@@ -183,6 +189,13 @@ export async function fetchSnapshotWithRedeem(
 					putInCache,
 					loadingGroupIds,
 				);
+			} else if (isLocationRedirectionError(error)) {
+				const redirectedResolvedUrl: IOdspResolvedUrl = {
+					...getOdspResolvedUrl(error.redirectUrl),
+					shareLinkInfo: odspResolvedUrl.shareLinkInfo,
+				};
+				await redeemSharingLink(redirectedResolvedUrl, storageTokenFetcher, logger);
+				throw error;
 			} else {
 				throw error;
 			}
@@ -790,6 +803,15 @@ export const downloadSnapshot = mockify(
 		};
 	},
 );
+
+function isLocationRedirectionError(error: unknown): error is ILocationRedirectionError {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		(error as Partial<ILocationRedirectionError>).errorType ===
+			DriverErrorTypes.locationRedirection
+	);
+}
 
 function isRedeemSharingLinkError(
 	odspResolvedUrl: IOdspResolvedUrl,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -198,12 +198,6 @@ export async function fetchSnapshotWithRedeem(
 					// now against the redirected URL rather than waiting until the next API call retries
 					// with the redirect URL applied. After this point the sharing link is removed from
 					// the resolved URL, so we wouldn't be able to redeem during a later failure.
-					const redirectedResolvedUrl: IOdspResolvedUrl = {
-						...getOdspResolvedUrl(error.redirectUrl),
-						shareLinkInfo: odspResolvedUrl.shareLinkInfo,
-					};
-
-					await redeemSharingLink(redirectedResolvedUrl, storageTokenFetcher, logger);
 					logger.sendTelemetryEvent(
 						{
 							eventName: "RedirectRedeemFallback",
@@ -211,6 +205,11 @@ export async function fetchSnapshotWithRedeem(
 						},
 						error,
 					);
+					const redirectedResolvedUrl: IOdspResolvedUrl = {
+						...getOdspResolvedUrl(error.redirectUrl),
+						shareLinkInfo: odspResolvedUrl.shareLinkInfo,
+					};
+					await redeemSharingLink(redirectedResolvedUrl, storageTokenFetcher, logger);
 				} catch (redeemError) {
 					logger.sendErrorEvent({ eventName: "RedirectRedeemFallbackError" }, redeemError);
 				}
@@ -827,8 +826,7 @@ function isLocationRedirectionError(error: unknown): error is ILocationRedirecti
 	return (
 		typeof error === "object" &&
 		error !== null &&
-		(error as Partial<IOdspError>).errorType === DriverErrorTypes.locationRedirection &&
-		(error as Partial<ILocationRedirectionError>).redirectUrl !== undefined
+		(error as Partial<IOdspError>).errorType === DriverErrorTypes.locationRedirection
 	);
 }
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -195,9 +195,9 @@ export async function fetchSnapshotWithRedeem(
 			) {
 				try {
 					// The redirect itself is handled earlier, but we need to redeem the sharing link
-					// now against the redirected URL rather than waiting until the next API call retries
-					// with the redirect URL applied. After this point the sharing link is removed from
-					// the resolved URL, so we wouldn't be able to redeem during a later failure.
+					// now against the redirected URL rather than waiting until the error reaches the
+					// resolveWithLocationRedirectionHandling handler as it will call getAbsoluteURL
+					// and would fail due to permission issues since it will not attempt to redeem.
 					logger.sendTelemetryEvent(
 						{
 							eventName: "RedirectRedeemFallback",

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -8,7 +8,11 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import {
+	DriverErrorTypes,
+	type ISnapshot,
+	type ISnapshotTree,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	type IOdspResolvedUrl,
 	OdspErrorTypes,
@@ -626,6 +630,54 @@ describe("Tests1 for snapshot fetch", () => {
 				{ eventName: "RedeemFallback", errorType: "fileNotFoundOrAccessDeniedError" },
 				{ eventName: "TreesLatest_end" },
 			]),
+		);
+	});
+
+	it("Redeem sharing link on location redirection error", async () => {
+		resolved.shareLinkInfo = {
+			sharingLinkToRedeem: "https://microsoft.sharepoint-df.com/sharelink",
+		};
+
+		const newSiteUrl = "https://microsoft.sharepoint.com/siteUrl";
+
+		try {
+			await mockFetchMultiple(
+				async () => service.getSnapshot({}),
+				[
+					// First fetch (trees/latest) returns 404 with redirectLocation
+					async (): Promise<MockResponse> =>
+						createResponse(
+							{ "x-fluid-epoch": "epoch1" },
+							{
+								error: {
+									"message": "locationMoved",
+									"@error.redirectLocation": newSiteUrl,
+								},
+							},
+							404,
+						),
+					// Second fetch is the redeem /shares API call
+					async (): Promise<MockResponse> => okResponse({}, {}),
+				],
+			);
+			assert.fail("Should have thrown a locationRedirection error");
+		} catch (error: unknown) {
+			assert.strictEqual(
+				(error as Partial<IFluidErrorBase>).errorType,
+				DriverErrorTypes.locationRedirection,
+				"Error should be a locationRedirection error",
+			);
+		}
+		assert(
+			mockLogger.matchEvents([
+				{ eventName: "TreesLatest_cancel" },
+				{
+					eventName: "RedeemShareLink_end",
+					details:
+						'{"shareLinkUrlLength":45,"queryParamsLength":0,"useHeaders":true,"isRedemptionNonDurable":false}',
+				},
+			]),
+			"Should have redeemed sharing link before re-throwing the redirection error",
 		);
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -676,8 +676,92 @@ describe("Tests1 for snapshot fetch", () => {
 					details:
 						'{"shareLinkUrlLength":45,"queryParamsLength":0,"useHeaders":true,"isRedemptionNonDurable":false}',
 				},
+				{ eventName: "RedirectRedeemFallback" },
 			]),
 			"Should have redeemed sharing link before re-throwing the redirection error",
+		);
+	});
+
+	it("Location redirection error without shareLink skips redeem", async () => {
+		// No shareLinkInfo set on resolved URL
+		resolved.shareLinkInfo = undefined;
+
+		const newSiteUrl = "https://microsoft.sharepoint.com/siteUrl";
+
+		try {
+			await mockFetchMultiple(
+				async () => service.getSnapshot({}),
+				[
+					async (): Promise<MockResponse> =>
+						createResponse(
+							{ "x-fluid-epoch": "epoch1" },
+							{
+								error: {
+									"message": "locationMoved",
+									"@error.redirectLocation": newSiteUrl,
+								},
+							},
+							404,
+						),
+				],
+			);
+			assert.fail("Should have thrown a locationRedirection error");
+		} catch (error: unknown) {
+			assert.strictEqual(
+				(error as Partial<IFluidErrorBase>).errorType,
+				DriverErrorTypes.locationRedirection,
+				"Error should be a locationRedirection error",
+			);
+		}
+		assert(
+			!mockLogger.matchAnyEvent([{ eventName: "RedeemShareLink_end" }]),
+			"Should not have attempted redeem without a shareLink",
+		);
+		assert(
+			!mockLogger.matchAnyEvent([{ eventName: "RedirectRedeemFallback" }]),
+			"Should not have logged redirect redeem fallback without a shareLink",
+		);
+	});
+
+	it("Location redirection error still throws when redeem fails", async () => {
+		resolved.shareLinkInfo = {
+			sharingLinkToRedeem: "https://microsoft.sharepoint-df.com/sharelink",
+		};
+
+		const newSiteUrl = "https://microsoft.sharepoint.com/siteUrl";
+
+		try {
+			await mockFetchMultiple(
+				async () => service.getSnapshot({}),
+				[
+					// First fetch (trees/latest) returns 404 with redirectLocation
+					async (): Promise<MockResponse> =>
+						createResponse(
+							{ "x-fluid-epoch": "epoch1" },
+							{
+								error: {
+									"message": "locationMoved",
+									"@error.redirectLocation": newSiteUrl,
+								},
+							},
+							404,
+						),
+					// Second fetch is the redeem /shares API call - returns failure
+					async (): Promise<MockResponse> =>
+						createResponse({}, { error: "redeemFailed" }, 500),
+				],
+			);
+			assert.fail("Should have thrown a locationRedirection error");
+		} catch (error: unknown) {
+			assert.strictEqual(
+				(error as Partial<IFluidErrorBase>).errorType,
+				DriverErrorTypes.locationRedirection,
+				"Original redirection error should be thrown even when redeem fails",
+			);
+		}
+		assert(
+			mockLogger.matchAnyEvent([{ eventName: "RedirectRedeemFallbackError" }]),
+			"Should have logged redeem failure telemetry",
 		);
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -671,12 +671,12 @@ describe("Tests1 for snapshot fetch", () => {
 		assert(
 			mockLogger.matchEvents([
 				{ eventName: "TreesLatest_cancel" },
+				{ eventName: "RedirectRedeemFallback" },
 				{
 					eventName: "RedeemShareLink_end",
 					details:
 						'{"shareLinkUrlLength":45,"queryParamsLength":0,"useHeaders":true,"isRedemptionNonDurable":false}',
 				},
-				{ eventName: "RedirectRedeemFallback" },
 			]),
 			"Should have redeemed sharing link before re-throwing the redirection error",
 		);


### PR DESCRIPTION
## Description

When a site move or geo move triggers a location redirection during container load, the sharing link was not being redeemed against the new (redirected) URL. The redirect itself is handled earlier in the flow, but after the redirect the sharing link is not part of the resolved URL. This means on the subsequent retry at the new location, the sharing link can no longer be redeemed — causing the container load to fail for users who accessed via a sharing link.

fixes https://dev.azure.com/fluidframework/internal/_workitems/edit/58231

## Solution 
* On a location redirection error, redeem the sharing link against the redirected URL before re-throwing, so it's already redeemed when the retry happens at the new location.
* Only attempt redeem if a sharing link is actually present.
* Treat redeem as best-effort — catch failures and log telemetry (RedirectRedeemFallback / RedirectRedeemFallbackError), always re-throwing the original redirection error so the normal redirect flow continues.
* Add tests for the no-shareLink and redeem-failure paths.