### PR TITLE
fix(build-tools): allow `generate entrypoints` using "import" resolution

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -288,31 +288,36 @@ Generates type declaration entrypoints for Fluid Framework API levels (/alpha, /
 
 ```
 USAGE
-  $ flub generate entrypoints [-v | --quiet] [--mainEntrypoint <value>] [--outDir <value>] [--outFilePrefix <value>]
-    [--outFileAlpha <value>] [--outFileBeta <value>] [--outFilePublic <value>] [--outFileLegacyAlpha <value>]
-    [--outFileLegacyBeta <value>] [--outFileLegacyPublic <value>] [--outFileSuffix <value>] [--node10TypeCompat]
+  $ flub generate entrypoints [-v | --quiet] [--mainEntrypoint <value>] [--resolutionConditions <value>...] [--outDir
+    <value>] [--outFilePrefix <value>] [--outFileAlpha <value>] [--outFileBeta <value>] [--outFilePublic <value>]
+    [--outFileLegacyAlpha <value>] [--outFileLegacyBeta <value>] [--outFileLegacyPublic <value>] [--outFileSuffix
+    <value>] [--node10TypeCompat]
 
 FLAGS
-  --mainEntrypoint=<value>       [default: ./src/index.ts] Main entrypoint file containing all untrimmed exports.
-  --node10TypeCompat             Optional generation of Node10 resolution compatible type entrypoints matching others.
-  --outDir=<value>               [default: ./lib] Directory to emit entrypoint declaration files.
-  --outFileAlpha=<value>         [default: alpha] Base file name for alpha entrypoint declaration files. To opt out of
-                                 generating this entrypoint, set to `none`.
-  --outFileBeta=<value>          [default: beta] Base file name for beta entrypoint declaration files. To opt out of
-                                 generating this entrypoint, set to `none`.
-  --outFileLegacyAlpha=<value>   Base file name for legacyAlpha entrypoint declaration files. To opt into generating
-                                 this entrypoint, set to a value other than `none`.
-  --outFileLegacyBeta=<value>    Base file name for legacyBeta entrypoint declaration files. To opt into generating this
-                                 entrypoint, set to a value other than `none`.
-  --outFileLegacyPublic=<value>  Base file name for legacyPublic entrypoint declaration files. To opt into generating
-                                 this entrypoint, set to a value other than `none`.
-  --outFilePrefix=<value>        File name prefix for emitting entrypoint declaration files. Pattern of
-                                 '{@unscopedPackageName}' within value will be replaced with the unscoped name of this
-                                 package.
-  --outFilePublic=<value>        [default: public] Base file name for public entrypoint declaration files. To opt out of
-                                 generating this entrypoint, set to `none`.
-  --outFileSuffix=<value>        [default: .d.ts] File name suffix including extension for emitting entrypoint
-                                 declaration files.
+  --mainEntrypoint=<value>           [default: ./src/index.ts] Main entrypoint file containing all untrimmed exports.
+  --node10TypeCompat                 Optional generation of Node10 resolution compatible type entrypoints matching
+                                     others.
+  --outDir=<value>                   [default: ./lib] Directory to emit entrypoint declaration files.
+  --outFileAlpha=<value>             [default: alpha] Base file name for alpha entrypoint declaration files. To opt out
+                                     of generating this entrypoint, set to `none`.
+  --outFileBeta=<value>              [default: beta] Base file name for beta entrypoint declaration files. To opt out of
+                                     generating this entrypoint, set to `none`.
+  --outFileLegacyAlpha=<value>       Base file name for legacyAlpha entrypoint declaration files. To opt into generating
+                                     this entrypoint, set to a value other than `none`.
+  --outFileLegacyBeta=<value>        Base file name for legacyBeta entrypoint declaration files. To opt into generating
+                                     this entrypoint, set to a value other than `none`.
+  --outFileLegacyPublic=<value>      Base file name for legacyPublic entrypoint declaration files. To opt into
+                                     generating this entrypoint, set to a value other than `none`.
+  --outFilePrefix=<value>            File name prefix for emitting entrypoint declaration files. Pattern of
+                                     '{@unscopedPackageName}' within value will be replaced with the unscoped name of
+                                     this package.
+  --outFilePublic=<value>            [default: public] Base file name for public entrypoint declaration files. To opt
+                                     out of generating this entrypoint, set to `none`.
+  --outFileSuffix=<value>            [default: .d.ts] File name suffix including extension for emitting entrypoint
+                                     declaration files.
+  --resolutionConditions=<value>...  [default: ] Import resolution conditions used while resolving imports. If neither
+                                     "import" nor "require" are specified, one of those will be inferred based on
+                                     mainEntrypoint file extension and package.json "type" field.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
@@ -670,7 +670,7 @@ class ApiLevelReader {
 		}
 		this.log.verbose(`Loading ${packageName} API data from ${internalSource.getFilePath()}`);
 
-		const exports = getApiExports(internalSource);
+		const exports = getApiExports(internalSource, "warnForMissing", this.log);
 		for (const name of exports.unknown.keys()) {
 			// Suppress any warning for EventEmitter as this export is currently a special case.
 			// See AB#7377 for replacement status upon which this can be removed.

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -447,6 +447,7 @@ export function readArgValues(
 	argQuery: Options,
 ): Pick<
 	Options,
+	// This selects only "out" prefixed keys whose values are `string | undefined`.
 	`out${string}` & keyof Options extends infer Key
 		? Options[Key & keyof Options] extends string | undefined
 			? Key
@@ -455,7 +456,7 @@ export function readArgValues(
 > {
 	const args = commandLine.split(" ");
 
-	const argValues: Record<string, string | undefined> = {};
+	const argValues: Record<`out${string}`, string> = {};
 	for (const argName of Object.keys(argQuery).filter(
 		(key): key is `out${string}` =>
 			key.startsWith("out") &&

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -21,6 +21,7 @@ import { unscopedPackageNameString } from "./constants.js";
 
 interface Options {
 	readonly mainEntrypoint: string;
+	readonly resolutionConditions: string[];
 	readonly outDir: string;
 	readonly outFilePrefix: string;
 
@@ -71,6 +72,7 @@ interface Options {
  */
 export const optionDefaults = {
 	mainEntrypoint: "./src/index.ts",
+	resolutionConditions: [],
 	outDir: "./lib",
 	outFilePrefix: "",
 	outFileAlpha: "alpha",
@@ -96,6 +98,11 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 			description: "Main entrypoint file containing all untrimmed exports.",
 			default: optionDefaults.mainEntrypoint,
 			exists: true,
+		}),
+		resolutionConditions: Flags.string({
+			description: `Import resolution conditions used while resolving imports. If neither "import" nor "require" are specified, one of those will be inferred based on mainEntrypoint file extension and package.json "type" field.`,
+			multiple: true,
+			default: optionDefaults.resolutionConditions,
 		}),
 		outDir: Flags.directory({
 			description: "Directory to emit entrypoint declaration files.",
@@ -148,7 +155,7 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 	};
 
 	public async run(): Promise<void> {
-		const { mainEntrypoint, node10TypeCompat } = this.flags;
+		const { mainEntrypoint, resolutionConditions, node10TypeCompat } = this.flags;
 
 		const packageJson = await readPackageJson();
 
@@ -186,9 +193,32 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 			);
 		}
 
+		const customConditions = [...resolutionConditions];
+		const conditionsPresent =
+			(customConditions.includes("import") ? 1 : 0) +
+			(customConditions.includes("require") ? 2 : 0);
+		if (conditionsPresent === 3) {
+			this.logger.warning(
+				'warning: both "import" and "require" --resolutionConditions flags given; results may be unstable',
+			);
+		} else if (conditionsPresent === 0) {
+			const inferredImportCondition = inferImportConditionFromFilePath(
+				mainEntrypoint,
+				packageJson,
+			);
+			this.logger.info(`Inferred import resolution condition "${inferredImportCondition}"`);
+			customConditions.push(inferredImportCondition);
+		}
+
 		const commandLine = `flub generate entrypoints${this.commandLineArgs()}`;
 		promises.push(
-			generateEntrypoints(mainEntrypoint, mapApiTagLevelToOutput, commandLine, this.logger),
+			generateEntrypoints(
+				mainEntrypoint,
+				customConditions,
+				mapApiTagLevelToOutput,
+				commandLine,
+				this.logger,
+			),
 		);
 
 		if (node10TypeCompat) {
@@ -211,6 +241,21 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 async function readPackageJson(): Promise<PackageJson> {
 	const packageJson = await fs.readFile("./package.json", { encoding: "utf8" });
 	return JSON.parse(packageJson) as PackageJson;
+}
+
+function inferImportConditionFromFilePath(
+	filePath: string,
+	packageJson: PackageJson,
+): "import" | "require" {
+	const ext = path.extname(filePath);
+	if (ext.match(/^\.m[jt]s/i) !== null) {
+		return "import";
+	}
+	if (ext.match(/^\.c[jt]s/i) !== null) {
+		return "require";
+	}
+
+	return packageJson.type === "module" ? "import" : "require";
 }
 
 /**
@@ -443,11 +488,16 @@ function generatedHeader(commandLine: string): string {
  * Generate "rollup" entrypoints for the given main entrypoint file.
  *
  * @param mainEntrypoint - path to main entrypoint file
+ * @param customConditions - custom conditions to use for import resolution.
+ * ts-morph doesn't configure TypeScript to use import conditions in module
+ * context (https://github.com/dsherret/ts-morph/issues/1667), so, set
+ * "import" or "require" conditions explicitly.
  * @param mapApiTagLevelToOutput - level oriented ApiTag to output file mapping
  * @param log - logger
  */
 async function generateEntrypoints(
 	mainEntrypoint: string,
+	customConditions: string[],
 	mapApiTagLevelToOutput: ReadonlyMap<ApiLevel, ExportData>,
 	commandLineForContentHeader: string,
 	log: CommandLogger,
@@ -468,14 +518,14 @@ async function generateEntrypoints(
 		// part of its setting may be confusing to document and keep tidy with dual-emit.
 		compilerOptions: {
 			module: ModuleKind.Node16,
-
 			// Without this, JSX files are not properly handled by ts-morph. "React" is the
 			// value we use in our base config, so it should be a safe value.
 			jsx: 2 /* JSXEmit.React */,
+			customConditions,
 		},
 	});
 	const mainSourceFile = project.addSourceFileAtPath(mainEntrypoint);
-	const exports = getApiExports(mainSourceFile);
+	const exports = getApiExports(mainSourceFile, "throwForMissing", log);
 
 	const packageDocumentationHeader = getPackageDocumentationText(mainSourceFile);
 	const newFileHeader = `${generatedHeader(commandLineForContentHeader)}${packageDocumentationHeader}`;

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -198,8 +198,11 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 			(customConditions.includes("import") ? 1 : 0) +
 			(customConditions.includes("require") ? 2 : 0);
 		if (conditionsPresent === 3) {
+			// Someone could call using both "import" and "require" conditions,
+			// to say they just don't care and will take whatever is found.
+			// That is unlikely, so warn about this just in case.
 			this.logger.warning(
-				'warning: both "import" and "require" --resolutionConditions flags given; results may be unstable',
+				'both "import" and "require" --resolutionConditions flags given; results may be unstable',
 			);
 		} else if (conditionsPresent === 0) {
 			const inferredImportCondition = inferImportConditionFromFilePath(
@@ -248,7 +251,12 @@ function inferImportConditionFromFilePath(
 	packageJson: PackageJson,
 ): "import" | "require" {
 	const ext = path.extname(filePath);
-	if (ext.match(/^\.m[jt]s/i) !== null) {
+	// Following matches allow for the extension to be longer as in .mjsx.
+	// The import part is really the .m or .c for selecting one over the other
+	// and the [jt]s helps filter to expectations. Since this is an inference
+	// and best guess it is okay if the guess is wrong as the caller can be
+	// more prescriptive and avoid inference altogether.
+	if (ext.match(/^\.m[jt]s/) !== null) {
 		return "import";
 	}
 	if (ext.match(/^\.c[jt]s/i) !== null) {
@@ -335,7 +343,7 @@ const apiLevels: readonly Exclude<ApiLevel, typeof ApiLevel.internal>[] = [
 ] as const;
 
 function getOutputConfiguration(
-	flags: Options & { node10TypeCompat: boolean },
+	flags: Pick<Options, `out${string}` & keyof Options> & { node10TypeCompat: boolean },
 	packageJson: PackageJson,
 	logger?: CommandLogger,
 ): {
@@ -425,13 +433,34 @@ function getOutputConfiguration(
  * @param commandLine - command line to extract from
  * @param argQuery - record of arguments to read (keys) with default values
  * @returns record of argument values extracted or given default value
+ *
+ * @remarks
+ * This functionality only supports arguments that are "--flagName single-value" pairs.
+ * In practice, other values that come through argQuery are preserved (default values
+ * used), but no caller should rely on unsupported arguments. Thus the return type is
+ * trimmed to those and also only those named with "out" prefix.
+ *
  * @privateRemarks Exported for testing.
  */
-export function readArgValues(commandLine: string, argQuery: Options): Options {
+export function readArgValues(
+	commandLine: string,
+	argQuery: Options,
+): Pick<
+	Options,
+	`out${string}` & keyof Options extends infer Key
+		? Options[Key & keyof Options] extends string | undefined
+			? Key
+			: never
+		: never
+> {
 	const args = commandLine.split(" ");
 
 	const argValues: Record<string, string | undefined> = {};
-	for (const argName of Object.keys(argQuery)) {
+	for (const argName of Object.keys(argQuery).filter(
+		(key): key is `out${string}` =>
+			key.startsWith("out") &&
+			["string", "undefined"].includes(typeof argQuery[key as keyof Options]),
+	)) {
 		const indexOfArgValue = args.indexOf(`--${argName}`) + 1;
 		if (0 < indexOfArgValue && indexOfArgValue < args.length) {
 			argValues[argName] = args[indexOfArgValue];

--- a/build-tools/packages/build-cli/src/library/typescriptApi.ts
+++ b/build-tools/packages/build-cli/src/library/typescriptApi.ts
@@ -6,6 +6,7 @@
 import type { ExportDeclaration, ExportedDeclarations, JSDoc, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
+import type { CommandLogger } from "../logging.js";
 import type { ApiLevel } from "./apiLevel.js";
 import type { ReleaseLevel } from "./releaseLevel.js";
 import { isReleaseLevel } from "./releaseLevel.js";
@@ -159,7 +160,11 @@ function getNodeApiLevel(node: Node): ApiLevel | undefined {
  * Given a source file, extracts all of the named exports and associated support levels.
  * Named exports without a recognized tag are placed in unknown array.
  */
-export function getApiExports(sourceFile: SourceFile): ExportRecords {
+export function getApiExports(
+	sourceFile: SourceFile,
+	treatmentOfMissing: "throwForMissing" | "warnForMissing",
+	log: CommandLogger,
+): ExportRecords {
 	const exported = sourceFile.getExportedDeclarations();
 	const records: ExportRecords = {
 		public: [],
@@ -176,6 +181,19 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 	// share the same tag. Track and throw if there are different tags.
 	const foundNameLevels = new Map<string, ApiLevel>();
 	for (const [name, exportedDecls] of exported.entries()) {
+		// Watch for the case where we have no export declarations. This can happen
+		// for re-exports of the form `export { something } from "somewhere"` where
+		// `something` is not declared in the file. In this case we won't be able to
+		// find tags in source, so treat as error or warning depending on context.
+		if (exportedDecls.length === 0) {
+			const message = `No export declarations found for "${name}"`;
+			if (treatmentOfMissing === "throwForMissing") {
+				throw new Error(message);
+			} else {
+				log.warning(message);
+			}
+		}
+
 		for (const exportedDecl of exportedDecls) {
 			const level = getNodeApiLevel(exportedDecl);
 			const existingLevel = foundNameLevels.get(name);
@@ -224,7 +242,7 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 			const name = namespaceDecl.getName();
 			const unknownExported = records.unknown.get(name);
 			if (unknownExported !== undefined) {
-				console.log(
+				log.warning(
 					`namespace exports of the form 'export * as foo' are speculatively supported. See ${sourceFile.getFilePath()}:${namespaceDecl.getStartLineNumber()}:\n${namespaceDecl.getText()}`,
 				);
 				const namespaceLevel = getNodeApiLevel(exportDeclaration);

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -30,6 +30,18 @@ describe("generateEntrypoints", () => {
 			...optionDefaults,
 			outDir: "./lib",
 		});
+
+		// Does not support multi-args (doesn't currently need to)
+		// Takes the first arg of the first multi-arg set.
+		expect(
+			readArgValues(
+				"--resolutionConditions first second --resolutionConditions third",
+				optionDefaults,
+			),
+		).to.deep.equal({
+			...optionDefaults,
+			resolutionConditions: "first",
+		});
 	});
 
 	describe("generateNode10EntrypointFileContent", () => {

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -34,12 +34,15 @@ describe("generateEntrypoints", () => {
 		// Does not support multi-args nor args that don't start
 		// with "out" (doesn't currently need to). Instead any
 		// such options passed in are preserved.
+		const argsReadFromUnsupportedCommandLine = readArgValues(
+			"--resolutionConditions first second --resolutionConditions third --mainEntrypoint xxx",
+			optionDefaults,
+		);
+		expect(argsReadFromUnsupportedCommandLine).to.deep.equal(optionDefaults);
 		expect(
-			readArgValues(
-				"--resolutionConditions first second --resolutionConditions third --mainEntrypoint xxx",
-				optionDefaults,
-			),
-		).to.deep.equal(optionDefaults);
+			// @ts-expect-error - mainEntrypoint is not supported by readArgValues, so not in return type (though it does exist at runtime)
+			argsReadFromUnsupportedCommandLine.mainEntrypoint,
+		).to.equal(optionDefaults.mainEntrypoint);
 	});
 
 	describe("generateNode10EntrypointFileContent", () => {

--- a/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/commands/generateEntrypoints.test.ts
@@ -31,17 +31,15 @@ describe("generateEntrypoints", () => {
 			outDir: "./lib",
 		});
 
-		// Does not support multi-args (doesn't currently need to)
-		// Takes the first arg of the first multi-arg set.
+		// Does not support multi-args nor args that don't start
+		// with "out" (doesn't currently need to). Instead any
+		// such options passed in are preserved.
 		expect(
 			readArgValues(
-				"--resolutionConditions first second --resolutionConditions third",
+				"--resolutionConditions first second --resolutionConditions third --mainEntrypoint xxx",
 				optionDefaults,
 			),
-		).to.deep.equal({
-			...optionDefaults,
-			resolutionConditions: "first",
-		});
+		).to.deep.equal(optionDefaults);
 	});
 
 	describe("generateNode10EntrypointFileContent", () => {


### PR DESCRIPTION
ts-morph does not infer import conditions when parsing sources and will have underlying typescript use CommonJS "require" even though a package has type "module". See [ts-morph issue #1667](https://github.com/dsherret/ts-morph/issues/1667).

Add option to specify project's `customConditions` through new argument `resolutionConditions`. Any arguments may be specified to allow supporting generating entrypoints that require custom conditions. When neither "import" nor "require" is given, mainEntrypoint extension and package.json "type" will be used to infer one of those.

Additionally add an error when using `generate entrypoints` and some export has no source instead of silently skipping. This was the case when entrypoints were generated for a package that reexported from another and that other packages CommonJS build was not done. `modify fluid-imports` is more conservative if export is not sourced and just emits a warning.