### PR TITLE
fix(devcontainer): fix AI-enabled postCreateCommand and load agent aliases system-wide

### DIFF
--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -22,7 +22,7 @@
 			]
 		}
 	},
-	"postCreateCommand": "bash -lc \"scripts/codespace-setup/post-create.sh && . scripts/codespace-setup/ai-setup.sh\"",
+	"postCreateCommand": "bash scripts/codespace-setup/post-create.sh && bash scripts/codespace-setup/ai-setup.sh",
 	"remoteUser": "node",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -8,4 +8,5 @@ alias opus="agency claude --model opus"
 
 alias copilot="agency copilot"
 alias copilot-ado="agency copilot --mcp 'ado --org fluidframework'"
+alias copilot-kusto="agency copilot --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'"
 alias copilot-work="agency copilot --mcp 'workiq'"

--- a/scripts/codespace-setup/ai-setup.sh
+++ b/scripts/codespace-setup/ai-setup.sh
@@ -8,12 +8,30 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 #
 # Two hooks are needed because shells load different init files:
 #   - /etc/profile.d/*.sh  → sourced by login shells (ssh, `bash -l`)
-#   - /etc/bash.bashrc     → sourced by interactive non-login shells (VS Code terminal)
+#   - /etc/bash/bashrc.d/  → sourced by interactive non-login shells (VS Code terminal)
 #
-# VS Code / Codespaces terminals are non-login interactive shells, so
-# /etc/profile.d/ alone isn't enough — the /etc/bash.bashrc append covers that case.
-sudo cp "$SCRIPT_DIR/agent-aliases.sh" /etc/profile.d/agent-aliases.sh
-echo "source /etc/profile.d/agent-aliases.sh" | sudo tee -a /etc/bash.bashrc > /dev/null
+# The aliases script uses bash-specific features (shopt, aliases), so
+# /etc/profile.d/ gets a wrapper with a $BASH_VERSION guard to avoid
+# errors when sourced by non-bash shells (e.g. /bin/sh via /etc/profile).
+
+# Place the actual aliases in a neutral location
+sudo install -Dm644 "$SCRIPT_DIR/agent-aliases.sh" /usr/local/lib/agent-aliases.sh
+
+# Login shells: guarded wrapper in /etc/profile.d/
+sudo tee /etc/profile.d/agent-aliases.sh > /dev/null <<'EOF'
+# Guard against being sourced by non-bash shells (e.g., /bin/sh via /etc/profile).
+[ -n "$BASH_VERSION" ] || return 0
+# shellcheck disable=SC1091
+. /usr/local/lib/agent-aliases.sh
+EOF
+
+# Interactive non-login shells (VS Code / Codespaces terminals):
+# prefer /etc/bash/bashrc.d/ for symmetry; fall back to /etc/bash.bashrc.
+if [ -d /etc/bash/bashrc.d ]; then
+  sudo ln -sf /usr/local/lib/agent-aliases.sh /etc/bash/bashrc.d/agent-aliases.sh
+elif ! sudo grep -qxF 'source /usr/local/lib/agent-aliases.sh' /etc/bash.bashrc 2>/dev/null; then
+  echo "source /usr/local/lib/agent-aliases.sh" | sudo tee -a /etc/bash.bashrc > /dev/null
+fi
 
 bash "$SCRIPT_DIR/playwright-setup.sh"
 

--- a/scripts/codespace-setup/ai-setup.sh
+++ b/scripts/codespace-setup/ai-setup.sh
@@ -2,7 +2,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-source "$SCRIPT_DIR/agent-aliases.sh"
+
+# Install agent aliases system-wide so they're available in all shell sessions
+# without modifying any user dotfiles (~/.bashrc, ~/.profile, etc.).
+#
+# Two hooks are needed because shells load different init files:
+#   - /etc/profile.d/*.sh  → sourced by login shells (ssh, `bash -l`)
+#   - /etc/bash.bashrc     → sourced by interactive non-login shells (VS Code terminal)
+#
+# VS Code / Codespaces terminals are non-login interactive shells, so
+# /etc/profile.d/ alone isn't enough — the /etc/bash.bashrc append covers that case.
+sudo cp "$SCRIPT_DIR/agent-aliases.sh" /etc/profile.d/agent-aliases.sh
+echo "source /etc/profile.d/agent-aliases.sh" | sudo tee -a /etc/bash.bashrc > /dev/null
 
 bash "$SCRIPT_DIR/playwright-setup.sh"
 


### PR DESCRIPTION
## Summary

- Fixes the AI-enabled devcontainer `postCreateCommand` which wrapped commands in `bash -lc "..."` — scripts are 644 (not executable), so this silently failed. Switches to explicit `bash script.sh` invocations matching the other devcontainer configs.
- Loads agent aliases system-wide via `/etc/profile.d/` and `/etc/bash.bashrc` so they're available in all shell session types (login and interactive non-login) without modifying user dotfiles.
- Adds `copilot-kusto` alias for Kusto MCP integration.