### PR TITLE
refactor(experimental-tree)!: decouple ISharedTree from ISharedObject

### DIFF
--- a/experimental/dds/tree/src/ISharedTree.ts
+++ b/experimental/dds/tree/src/ISharedTree.ts
@@ -3,9 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import type { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
+import type {
+	IErrorEvent,
+	IEventProvider,
+	IFluidLoadable,
+	ITelemetryBaseProperties,
+} from '@fluidframework/core-interfaces';
 import type { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions/internal';
-import type { ISharedObject, IFluidSerializer } from '@fluidframework/shared-object-base/internal';
+import type { IFluidSerializer } from '@fluidframework/shared-object-base/internal';
 import type { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 
 import type { Change } from './ChangeTypes.js';
@@ -14,7 +19,10 @@ import type { AttributionId, EditId, NodeId, StableNodeId } from './Identifiers.
 import type { LogViewer } from './LogViewer.js';
 import type { NodeIdContext } from './NodeIdUtilities.js';
 import type { RevisionView } from './RevisionView.js';
-import type { ISharedTreeEvents } from './SharedTree.js';
+import type {
+	EditCommittedHandler,
+	SequencedEditAppliedHandler,
+} from './SharedTree.js';
 import type {
 	ChangeInternal,
 	Edit,
@@ -24,10 +32,27 @@ import type {
 } from './persisted-types/index.js';
 
 /**
+ * Events which may be emitted by {@link ISharedTree}.
+ *
+ * @remarks This is the public-facing events interface for ISharedTree. It does not extend
+ * ISharedObjectEvents to avoid exposing internal DDS infrastructure types in the alpha API surface.
+ * @alpha
+ */
+export interface ISharedTreeEvents extends IErrorEvent {
+	(event: 'committedEdit', listener: EditCommittedHandler): void;
+	(event: 'sequencedEditApplied', listener: SequencedEditAppliedHandler): void;
+}
+
+/**
  * A {@link https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree/README.md | distributed tree}.
  * @alpha
  */
-export interface ISharedTree extends ISharedObject<ISharedTreeEvents>, NodeIdContext {
+export interface ISharedTree extends IFluidLoadable, IEventProvider<ISharedTreeEvents>, NodeIdContext {
+	/**
+	 * A readonly identifier for the shared tree.
+	 */
+	readonly id: string;
+
 	/**
 	 * The UUID used for attribution of nodes created by this SharedTree.
 	 */

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -346,12 +346,13 @@ export type EditApplicationOutcome =
 	  };
 
 /**
- * Events which may be emitted by `SharedTree`. See {@link SharedTreeEvent} for documentation of event semantics.
- * @alpha
+ * Internal events interface that extends ISharedObjectEvents for use by the SharedTree class.
+ * The public-facing events interface is {@link @fluid-experimental/tree#ISharedTreeEvents} in ISharedTree.ts.
+ * @internal
  */
-export interface ISharedTreeEvents extends ISharedObjectEvents {
+export interface ISharedTreeInternalEvents extends ISharedObjectEvents {
 	(event: 'committedEdit', listener: EditCommittedHandler);
-	(event: 'appliedSequencedEdit', listener: SequencedEditAppliedHandler);
+	(event: 'sequencedEditApplied', listener: SequencedEditAppliedHandler);
 }
 
 /**
@@ -388,7 +389,7 @@ const stashedSessionId = '8477b8d5-cf6c-4673-8345-8f076a8f9bc6' as SessionId;
  * to reference tree instances instead. The class will be removed from the public API surface in a future release.
  * @alpha
  */
-export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeIdContext {
+export class SharedTree extends SharedObject<ISharedTreeInternalEvents> implements NodeIdContext {
 	/**
 	 * Create a new SharedTree. It will contain the default value (see initialTree).
 	 */

--- a/experimental/dds/tree/src/index.ts
+++ b/experimental/dds/tree/src/index.ts
@@ -141,10 +141,10 @@ export {
 	EditCommittedEventArguments,
 	SequencedEditAppliedEventArguments,
 	EditApplicationOutcome,
-	ISharedTreeEvents,
+	ISharedTreeInternalEvents,
 	StashedLocalOpMetadata,
 } from './SharedTree.js';
-export type { ISharedTree } from './ISharedTree.js';
+export type { ISharedTree, ISharedTreeEvents } from './ISharedTree.js';
 export { StringInterner } from './StringInterner.js';
 export { SharedTreeAttributes, SharedTreeFactoryType } from './publicContracts.js';
 


### PR DESCRIPTION
## Summary

**Breaking changes** to the `@fluid-experimental/tree` alpha API surface to remove DDS infrastructure types:

- **`ISharedTree`** now extends `IFluidLoadable + IEventProvider<ISharedTreeEvents>` instead of `ISharedObject<ISharedTreeEvents>`. Members from `IChannel` (`isAttached`, `getAttachSummary`, `summarize`, `connect`, `getGCData`, `attributes`, `bindToContext`) are no longer available on the interface.
- **`ISharedTreeEvents`** now extends `IErrorEvent` instead of `ISharedObjectEvents`. The `pre-op` and `op` event signatures are no longer available (these were documented as internal implementation details).
- **Event name fix**: `'appliedSequencedEdit'` renamed to `'sequencedEditApplied'` to match the actual emitted event name (`SharedTreeEvent.SequencedEditApplied`).
- Internal `ISharedTreeEvents` renamed to `ISharedTreeInternalEvents` (not part of public API).

This removes `SharedObject`, `ISharedObject`, `ISharedObjectEvents`, `IChannel`, and related DDS infrastructure types from the alpha API surface. Part of the custom DDS removal effort (#26184).

**Depends on:** #26721

## Test plan

- [ ] Build passes
- [ ] CI passes
- [ ] API reports regenerated and reviewed