### PR TITLE
fix(devcontainer): fix AI codespace postCreateCommand failure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,4 +31,8 @@ RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Optionally install Playwright CLI for AI agent workflows
+ARG INSTALL_PLAYWRIGHT_CLI=false
+RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
+
 USER node

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -22,6 +22,9 @@
 			]
 		}
 	},
+	"containerEnv": {
+		"NODE_VERSION_OVERRIDE": "24"
+	},
 	"postCreateCommand": "bash scripts/codespace-setup/post-create.sh && bash scripts/codespace-setup/ai-setup.sh",
 	"remoteUser": "node",
 	"features": {

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -4,7 +4,8 @@
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {
-			"NODE_VERSION": "24"
+			"NODE_VERSION": "24",
+			"INSTALL_PLAYWRIGHT_CLI": "true"
 		}
 	},
 	"runArgs": ["--init"],

--- a/scripts/codespace-setup/playwright-setup.sh
+++ b/scripts/codespace-setup/playwright-setup.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Setting up playwright CLI..."
-npm install -g @playwright/cli@latest
-echo "Playwright CLI installed."
-
 echo "Installing playwright skills..."
 playwright-cli install --skills
 echo "Playwright skills installed."

--- a/scripts/codespace-setup/post-create.sh
+++ b/scripts/codespace-setup/post-create.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
-# located at the root of the ${workspaceFolder}.
+# Determine which Node version to install. NODE_VERSION_OVERRIDE (set via
+# containerEnv in devcontainer.json) takes precedence over .nvmrc.
+NODE_VERSION="${NODE_VERSION_OVERRIDE:-}"
+
 # nvm's internal functions use 'return N' for control flow which conflicts with
 # set -e, so we source and invoke nvm in a subshell without -e.
 (
   set +ex
   . /usr/local/share/nvm/nvm.sh
-  nvm install
+  nvm install ${NODE_VERSION}
 ) || { echo "nvm install failed"; exit 1; }
 
 # Enable corepack to allow node to download and use the right version of pnpm
 # (as specified by the packageManager field in package.json).
 # Source nvm again in the current shell so the installed node is on PATH.
 . /usr/local/share/nvm/nvm.sh
-nvm use
+nvm use ${NODE_VERSION}
 corepack enable

--- a/scripts/codespace-setup/post-create.sh
+++ b/scripts/codespace-setup/post-create.sh
@@ -3,9 +3,17 @@ set -euo pipefail
 
 # Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
 # located at the root of the ${workspaceFolder}.
-. /usr/local/share/nvm/nvm.sh
-nvm install
+# nvm's internal functions use 'return N' for control flow which conflicts with
+# set -e, so we source and invoke nvm in a subshell without -e.
+(
+  set +ex
+  . /usr/local/share/nvm/nvm.sh
+  nvm install
+) || { echo "nvm install failed"; exit 1; }
 
 # Enable corepack to allow node to download and use the right version of pnpm
 # (as specified by the packageManager field in package.json).
+# Source nvm again in the current shell so the installed node is on PATH.
+. /usr/local/share/nvm/nvm.sh
+nvm use
 corepack enable


### PR DESCRIPTION
## Summary

- Fix `postCreateCommand` failing with exit code 3 in the AI-enabled codespace profile. The root cause is `nvm install` using `return 3` for internal control flow, which conflicts with `set -e` in the calling script. Resolved by running nvm in a subshell with `set -e` disabled.
- Move `@playwright/cli` global installation from the postCreate script into the Docker image via an `INSTALL_PLAYWRIGHT_CLI` build arg (defaults to `false`, set to `true` only for the ai-agent config). This ensures the CLI is available before `pnpm install` runs and keeps the base image unchanged for other devcontainer profiles.