### PR TITLE
Tinylicous readme instructions update

### DIFF
--- a/examples/apps/blobs/README.md
+++ b/examples/apps/blobs/README.md
@@ -17,7 +17,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/blobs`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -16,7 +16,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/collaborative-textarea`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/contact-collection/README.md
+++ b/examples/apps/contact-collection/README.md
@@ -28,7 +28,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/contact-collection`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/data-object-grid/README.md
+++ b/examples/apps/data-object-grid/README.md
@@ -15,7 +15,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/data-object-grid`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/diceroller/README.md
+++ b/examples/apps/diceroller/README.md
@@ -17,7 +17,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/diceroller`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/staging/README.md
+++ b/examples/apps/staging/README.md
@@ -15,7 +15,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/staging`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/task-selection/README.md
+++ b/examples/apps/task-selection/README.md
@@ -15,7 +15,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/task-selection`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/apps/tree-comparison/README.md
+++ b/examples/apps/tree-comparison/README.md
@@ -15,7 +15,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/tree-comparison`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/data-objects/text-editor/README.md
+++ b/examples/data-objects/text-editor/README.md
@@ -15,7 +15,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/text-editor`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/version-migration/live-schema-upgrade/README.md
+++ b/examples/version-migration/live-schema-upgrade/README.md
@@ -40,7 +40,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/app-integration-live-schema-upgrade`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/version-migration/same-container/README.md
+++ b/examples/version-migration/same-container/README.md
@@ -61,7 +61,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/version-migration-same-container`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/version-migration/separate-container/README.md
+++ b/examples/version-migration/separate-container/README.md
@@ -57,7 +57,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/version-migration-separate-container`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/version-migration/tree-shim/README.md
+++ b/examples/version-migration/tree-shim/README.md
@@ -19,7 +19,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/tree-shim`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/view-integration/container-views/README.md
+++ b/examples/view-integration/container-views/README.md
@@ -19,7 +19,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/app-integration-container-views`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/view-integration/external-views/README.md
+++ b/examples/view-integration/external-views/README.md
@@ -19,7 +19,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/app-integration-external-views`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/examples/view-integration/view-framework-sampler/README.md
+++ b/examples/view-integration/view-framework-sampler/README.md
@@ -15,7 +15,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/view-framework-sampler`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/tools/markdown-magic/src/transforms/exampleGettingStartedTransform.cjs
+++ b/tools/markdown-magic/src/transforms/exampleGettingStartedTransform.cjs
@@ -40,7 +40,7 @@ const generateExampleGettingStartedSection = (
 
 	if (includeTinyliciousStep) {
 		sectionBody.push(
-			`1. In a separate terminal, start a Tinylicious server by running \`pnpm Tinylicious\` in this directory.`,
+			`1. In a separate terminal, start a Tinylicious server by running \`pnpm tinylicious\` in this directory.`,
 		);
 
 		sectionBody.push(

--- a/tools/markdown-magic/test/example-getting-started.md
+++ b/tools/markdown-magic/test/example-getting-started.md
@@ -11,7 +11,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluidframework/test-package`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.

--- a/tools/markdown-magic/test/example-readme-header.md
+++ b/tools/markdown-magic/test/example-readme-header.md
@@ -11,7 +11,7 @@ You can run this example using the following steps:
 1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluidframework/test-package`
-1. In a separate terminal, start a Tinylicious server by running `pnpm Tinylicious` in this directory.
+1. In a separate terminal, start a Tinylicious server by running `pnpm tinylicious` in this directory.
 1. If using codespaces in a browser, set tinylicious (port 7070) visibility to "public". "Private to Organization" will not work. See [sharing a port](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port) for how to do this.
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.


### PR DESCRIPTION
## Summary

Updated `exampleGettingStartedTransform.cjs` to have proper casing for the instruction `pnpm tinylicious`.