### PR TITLE
build: tag untagged asserts for 2.91.0 release

### DIFF
--- a/packages/framework/react/src/text/formatted/quillFormattedView.tsx
+++ b/packages/framework/react/src/text/formatted/quillFormattedView.tsx
@@ -184,7 +184,7 @@ export function parseLineTag(
 	// Quill should never send both header and list attributes simultaneously.
 	assert(
 		!(typeof attributes.header === "number" && typeof attributes.list === "string"),
-		"expected at most one line tag (header or list), but received both",
+		0xce2 /* expected at most one line tag (header or list), but received both */,
 	);
 	if (typeof attributes.header === "number") {
 		const tag: LineTagValue =

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1938,5 +1938,6 @@ export const shortCodeMap = {
 	"0xcde": "Unsupported node type in text array",
 	"0xcdf": "Expected retain count to be a number",
 	"0xce0": "batchIdToSeqNum and seqNumToBatchId should be in sync for duplicate",
-	"0xce1": "seqNumToBatchId and batchIdToSeqNum should be in sync"
+	"0xce1": "seqNumToBatchId and batchIdToSeqNum should be in sync",
+	"0xce2": "expected at most one line tag (header or list), but received both"
 };


### PR DESCRIPTION
## Summary
- Tag untagged assert shortcodes ahead of the 2.91.0 release
- Updates `quillFormattedView.tsx` and `assertionShortCodesMap.ts`

Part of release prep for 2.91.0.