### PR TITLE
Consolidate GC logs on boot into ContainerLoadStats event

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -219,7 +219,6 @@ import {
 	type IGCRuntimeOptions,
 	type IGCStats,
 	type IGarbageCollector,
-	gcGenerationOptionName,
 	type GarbageCollectionMessage,
 	type IGarbageCollectionRuntime,
 } from "./gc/index.js";
@@ -2084,11 +2083,8 @@ export class ContainerRuntime
 			summaryNumber: loadSummaryNumber,
 			summaryFormatVersion: metadata?.summaryFormatVersion,
 			disableIsolatedChannels: metadata?.disableIsolatedChannels,
-			gcDetails: JSON.stringify({
-				gcFeature: metadata?.gcFeature,
-				gcFeatureMatrix: JSON.stringify(metadata?.gcFeatureMatrix),
-				gcGeneration: runtimeOptions.gcOptions[gcGenerationOptionName],
-			}),
+			// This is useful even for interactive clients since they track unreferenced nodes and log errors.
+			gcConfigs: this.garbageCollector.serializedConfigs,
 			options: JSON.stringify(runtimeOptions),
 			idCompressorModeMetadata: metadata?.documentSchema?.runtime?.idCompressorMode,
 			idCompressorMode: this.sessionSchema.idCompressorMode,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2084,6 +2084,7 @@ export class ContainerRuntime
 			summaryFormatVersion: metadata?.summaryFormatVersion,
 			disableIsolatedChannels: metadata?.disableIsolatedChannels,
 			// This is useful even for interactive clients since they track unreferenced nodes and log errors.
+			gcVersion: metadata?.gcFeature,
 			gcConfigs: this.garbageCollector.serializedConfigs,
 			options: JSON.stringify(runtimeOptions),
 			idCompressorModeMetadata: metadata?.documentSchema?.runtime?.idCompressorMode,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1750,15 +1750,6 @@ export class ContainerRuntime
 				this.getConnectionState() === ConnectionState.CatchingUp
 			: undefined;
 
-		this.mc.logger.sendTelemetryEvent({
-			eventName: "GCFeatureMatrix",
-			metadataValue: JSON.stringify(metadata?.gcFeatureMatrix),
-			inputs: JSON.stringify({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				gcOptions_gcGeneration: runtimeOptions.gcOptions[gcGenerationOptionName],
-			}),
-		});
-
 		this.telemetryDocumentId = metadata?.telemetryDocumentId ?? uuid();
 
 		const opGroupingManager = new OpGroupingManager(
@@ -2093,7 +2084,11 @@ export class ContainerRuntime
 			summaryNumber: loadSummaryNumber,
 			summaryFormatVersion: metadata?.summaryFormatVersion,
 			disableIsolatedChannels: metadata?.disableIsolatedChannels,
-			gcVersion: metadata?.gcFeature,
+			gcDetails: JSON.stringify({
+				gcFeature: metadata?.gcFeature,
+				gcFeatureMatrix: JSON.stringify(metadata?.gcFeatureMatrix),
+				gcGeneration: runtimeOptions.gcOptions[gcGenerationOptionName],
+			}),
 			options: JSON.stringify(runtimeOptions),
 			idCompressorModeMetadata: metadata?.documentSchema?.runtime?.idCompressorMode,
 			idCompressorMode: this.sessionSchema.idCompressorMode,

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -100,7 +100,9 @@ export class GarbageCollector implements IGarbageCollector {
 
 	private readonly configs: IGarbageCollectorConfigs;
 
-	public readonly serializedConfigs: string;
+	public get serializedConfigs(): string {
+		return JSON.stringify(this.configs);
+	}
 
 	public get shouldRunGC(): boolean {
 		return this.configs.gcAllowed;
@@ -184,7 +186,6 @@ export class GarbageCollector implements IGarbageCollector {
 		});
 
 		this.configs = generateGCConfigs(this.mc, createParams);
-		this.serializedConfigs = JSON.stringify(this.configs);
 
 		// If session expiry is enabled, we need to close the container when the session expiry timeout expires.
 		if (this.configs.sessionExpiryTimeoutMs !== undefined) {

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -100,6 +100,8 @@ export class GarbageCollector implements IGarbageCollector {
 
 	private readonly configs: IGarbageCollectorConfigs;
 
+	public readonly serializedConfigs: string;
+
 	public get shouldRunGC(): boolean {
 		return this.configs.gcAllowed;
 	}
@@ -182,6 +184,7 @@ export class GarbageCollector implements IGarbageCollector {
 		});
 
 		this.configs = generateGCConfigs(this.mc, createParams);
+		this.serializedConfigs = JSON.stringify(this.configs);
 
 		// If session expiry is enabled, we need to close the container when the session expiry timeout expires.
 		if (this.configs.sessionExpiryTimeoutMs !== undefined) {
@@ -333,15 +336,6 @@ export class GarbageCollector implements IGarbageCollector {
 			const usedRoutes = runGarbageCollection(gcNodes, ["/"]).referencedNodeIds;
 
 			return { gcData: { gcNodes }, usedRoutes };
-		});
-
-		// Log all the GC options and the state determined by the garbage collector.
-		// This is useful even for interactive clients since they track unreferenced nodes and log errors.
-		this.mc.logger.sendTelemetryEvent({
-			eventName: "GarbageCollectorLoaded",
-			gcConfigs: JSON.stringify(this.configs),
-			gcOptions: JSON.stringify(createParams.gcOptions),
-			...createParams.createContainerMetadata,
 		});
 	}
 

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -374,6 +374,10 @@ export interface IGarbageCollectionRuntime {
  */
 export interface IGarbageCollector {
 	/**
+	 * The GC configurations serialized as a JSON string for telemetry.
+	 */
+	readonly serializedConfigs: string;
+	/**
 	 * Tells the time at which session expiry timer started in a previous container.
 	 * This is only set when loading from a stashed container and will be equal to the
 	 * original container's local client time when it was loaded (and started the session expiry timer).


### PR DESCRIPTION
## Description

We're trying to reduce logging overhead/noise from high event volume for consumers. These two events occur on boot and the info can be consolidated into the canonical boot event "ContainerLoadStats":

* "GCFeatureMatrix"
* "GarbageCollectorLoaded"
