### PR TITLE
Give each SharedTree branch its own breaker

### DIFF
--- a/packages/dds/tree/src/core/forest/forest.ts
+++ b/packages/dds/tree/src/core/forest/forest.ts
@@ -6,6 +6,7 @@
 import type { Listenable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 
+import type { Breakable } from "../../util/index.js";
 import type { FieldKey, TreeStoredSchemaSubscription } from "../schema-stored/index.js";
 import {
 	type Anchor,
@@ -77,11 +78,13 @@ export interface IForestSubscription {
 	readonly anchors: AnchorSet;
 
 	/**
-	 * Create an independent copy of this forest, that uses the provided schema and anchors.
+	 * Create an independent copy of this forest, that uses the provided schema.
 	 *
 	 * The new copy will not invalidate observers (dependents) of the old one.
+	 * @param breaker - If provided, the cloned forest will use this breaker instead of inheriting the original's.
+	 * This is useful when creating a fork that should have fault isolation from the original.
 	 */
-	clone(schema: TreeStoredSchemaSubscription, anchors: AnchorSet): IEditableForest;
+	clone(schema: TreeStoredSchemaSubscription, breaker?: Breakable): IEditableForest;
 
 	/**
 	 * Generate a TreeChunk[] for the current field (and its children) of cursor.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -41,6 +41,7 @@ import {
 	getLast,
 	getOrAddEmptyToMap,
 	hasSome,
+	type Breakable,
 } from "../../util/index.js";
 
 import { BasicChunk, BasicChunkCursor, type SiblingsOrKey } from "./basicChunk.js";
@@ -85,9 +86,9 @@ export class ChunkedForest implements IEditableForest {
 		return this.roots.fields.size === 0;
 	}
 
-	public clone(schema: TreeStoredSchemaSubscription, anchors: AnchorSet): ChunkedForest {
+	public clone(schema: TreeStoredSchemaSubscription, _breaker?: Breakable): ChunkedForest {
 		this.roots.referenceAdded();
-		return new ChunkedForest(this.roots, schema, this.chunker.clone(schema), anchors);
+		return new ChunkedForest(this.roots, schema, this.chunker.clone(schema));
 	}
 
 	public chunkField(cursor: ITreeCursorSynchronous): TreeChunk[] {

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -120,8 +120,14 @@ export class ObjectForest implements IEditableForest, WithBreakable {
 		return this.roots.fields.size === 0;
 	}
 
-	public clone(schema: TreeStoredSchemaSubscription, anchors: AnchorSet): ObjectForest {
-		return new ObjectForest(this.breaker, schema, anchors, this.additionalAsserts, this.roots);
+	public clone(schema: TreeStoredSchemaSubscription, breaker?: Breakable): ObjectForest {
+		return new ObjectForest(
+			breaker ?? this.breaker,
+			schema,
+			undefined,
+			this.additionalAsserts,
+			this.roots,
+		);
 	}
 
 	public chunkField(cursor: ITreeCursorSynchronous): TreeChunk[] {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeEnricher.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeEnricher.ts
@@ -7,7 +7,6 @@ import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 import {
-	AnchorSet,
 	type DeltaDetachedNodeId,
 	type DetachedFieldIndex,
 	type IEditableForest,
@@ -118,7 +117,7 @@ export class SharedTreeChangeEnricher {
 		if (this.owned === undefined) {
 			this.onForkState?.();
 			this.owned = {
-				forest: this.borrowed.forest.clone(this.schema, new AnchorSet()),
+				forest: this.borrowed.forest.clone(this.schema),
 				removedRoots: this.borrowed.removedRoots.clone(),
 			};
 		}

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -23,7 +23,6 @@ import {
 	type Anchor,
 	type AnchorLocator,
 	type AnchorNode,
-	AnchorSet,
 	type AnchorSetRootEvents,
 	type ChangeFamily,
 	CommitKind,
@@ -997,10 +996,10 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		}
 
 		this.editLock.checkUnlocked("Branching");
-		const anchors = new AnchorSet();
 		const branch = this.#transaction.activeBranch.fork();
 		const storedSchema = this.storedSchema.clone();
-		const forest = this.forest.clone(storedSchema, anchors);
+		const forkBreaker = new Breakable("TreeCheckout");
+		const forest = this.forest.clone(storedSchema, forkBreaker);
 		const checkout = new TreeCheckout(
 			branch,
 			false,
@@ -1012,7 +1011,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			this.idCompressor,
 			this._removedRoots.clone(),
 			this.logger,
-			this.breaker,
+			forkBreaker,
 			this.disposeForksAfterTransaction,
 		);
 		this.#events.emit("fork", checkout);

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -462,7 +462,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("an empty forest", () => {
 			const schema = new TreeStoredSchemaRepository();
 			const forest = factory(schema);
-			const clone = forest.clone(schema, forest.anchors);
+			const clone = forest.clone(schema);
 			const reader = clone.allocateCursor();
 			moveToDetachedField(clone, reader);
 			// Expect no nodes under the detached field
@@ -480,7 +480,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				testIdCompressor,
 			);
 
-			const clone = forest.clone(schema, forest.anchors);
+			const clone = forest.clone(schema);
 			const reader = clone.allocateCursor();
 			moveToDetachedField(clone, reader);
 			assert(reader.firstNode());
@@ -502,7 +502,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				testIdCompressor,
 			);
 
-			const clone = forest.clone(schema, forest.anchors);
+			const clone = forest.clone(schema);
 			const reader = clone.allocateCursor();
 			moveToDetachedField(clone, reader);
 			assert(reader.firstNode());
@@ -510,7 +510,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			assert.deepEqual(nestedContent, fromClone);
 		});
 
-		it("with anchors", () => {
+		it("clone has an independent anchor set", () => {
 			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
 			const forest = factory(schema);
 			initializeForest(
@@ -520,17 +520,20 @@ export function testForest(config: ForestTestConfiguration): void {
 				testIdCompressor,
 			);
 
-			const forestReader = forest.allocateCursor();
-			moveToDetachedField(forest, forestReader);
-			assert(forestReader.firstNode());
-			forestReader.enterField(xField);
-			assert(forestReader.firstNode());
-			const anchor = forestReader.buildAnchor();
+			const clone = forest.clone(schema);
 
-			const clone = forest.clone(schema, forest.anchors);
+			// The clone must have its own anchor set, not the original's.
+			assert.notEqual(clone.anchors, forest.anchors);
+
+			// Anchors built within the clone must resolve in the clone.
+			const cloneReader = clone.allocateCursor();
+			moveToDetachedField(clone, cloneReader);
+			assert(cloneReader.firstNode());
+			const cloneAnchor = cloneReader.buildAnchor();
+			cloneReader.free();
+
 			const reader = clone.allocateCursor();
-			clone.tryMoveCursorToNode(anchor, reader);
-			assert.equal(reader.value, undefined);
+			assert.equal(clone.tryMoveCursorToNode(cloneAnchor, reader), TreeNavigationResult.Ok);
 		});
 	});
 
@@ -549,7 +552,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			testIdCompressor,
 		);
 
-		const clone = forest.clone(schema, forest.anchors);
+		const clone = forest.clone(schema);
 		const mark: DeltaMark = { count: 1, detach: detachId };
 		const delta: DeltaFieldMap = new Map([[rootFieldKey, { marks: [mark] }]]);
 		applyTestDelta(delta, clone);

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -1782,6 +1782,75 @@ describe("sharedTreeView", () => {
 			});
 		});
 	});
+
+	describe("fork breaker isolation", () => {
+		const sf = new SchemaFactory("fork isolation test schema");
+		const config = new TreeViewConfiguration({ schema: sf.number });
+
+		it("fork has a distinct breaker from its parent", () => {
+			const view = getView(config);
+			view.initialize(5);
+			const fork = view.fork();
+			assert.notEqual(view.checkout.breaker, fork.checkout.breaker);
+			fork.dispose();
+		});
+
+		it("breaking a fork does not break its parent", () => {
+			const view = getView(config);
+			view.initialize(5);
+			const fork = view.fork();
+
+			// Break the fork by calling initialize() on an already-initialized tree.
+			assert.throws(
+				() => fork.initialize(10),
+				validateUsageError("Tree cannot be initialized more than once."),
+			);
+
+			// Fork should now be broken.
+			assert.throws(() => fork.root, validateUsageError(/invalid state/));
+
+			// Parent should still be usable.
+			assert.equal(view.root, 5);
+		});
+
+		it("breaking a fork does not break sibling forks", () => {
+			const view = getView(config);
+			view.initialize(5);
+			const fork1 = view.fork();
+			const fork2 = view.fork();
+
+			// Break fork1.
+			assert.throws(
+				() => fork1.initialize(10),
+				validateUsageError("Tree cannot be initialized more than once."),
+			);
+			assert.throws(() => fork1.root, validateUsageError(/invalid state/));
+
+			// Sibling fork should still be usable.
+			assert.equal(fork2.root, 5);
+			fork2.dispose();
+		});
+
+		it("breaking a transitive fork does not break its ancestors", () => {
+			const view = getView(config);
+			view.initialize(5);
+			const fork1 = view.fork();
+			const fork2 = fork1.checkout.branch().viewWith(config);
+
+			// Break the transitive fork.
+			assert.throws(
+				() => fork2.initialize(10),
+				validateUsageError("Tree cannot be initialized more than once."),
+			);
+			assert.throws(() => fork2.root, validateUsageError(/invalid state/));
+
+			// fork1 should still be usable.
+			assert.equal(fork1.root, 5);
+			// view should still be usable.
+			assert.equal(view.root, 5);
+			fork1.dispose();
+		});
+	});
 });
 
 const defaultSf = new SchemaFactory("Checkout and view test schema");


### PR DESCRIPTION
The upshot of this is that if a branch (or view) throws an error, only that branch will broken thereafter. Other branches will be unaffected. This allows a branch to be thrown away if it encounters an error without having to restart an entire application.

Additionally, this PR does a minor cleanup to the forest `clone` API by removing the `anchorset` parameter, which in practice was never used for anything meaningful. 