### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/index.mdx
@@ -10,7 +10,7 @@ SharedTree makes it possible to update your [schemas](../schema-definition.mdx) 
 To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions, write a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function).
 
 :::note
-For detailed information about which types of changes are safe versus breaking, see [types of schema changes](./types-of-changes).
+For detailed information about which types of changes are safe versus breaking, see [types of schema changes](./types-of-changes.mdx).
 :::
 
 ## Stored vs View Schema

--- a/docs/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/index.mdx
@@ -160,7 +160,7 @@ if (!view.compatibility.canView) {
 view.root.color = "#FF0000";
 ```
 
-For detailed information about which types of changes are safe versus breaking, see [Types of Schema Changes](./types-of-changes).
+For detailed information about which types of changes are safe versus breaking, see [Types of Schema Changes](./types-of-changes.mdx).
 
 ### Staged Rollouts
 
@@ -194,7 +194,7 @@ Even seemingly simple schema changes (for example, adding a new type of node to 
 
 ## See Also
 
-- [Types of Schema Changes](./types-of-changes) - Detailed guide on safe vs breaking changes
+- [Types of Schema Changes](./types-of-changes.mdx) - Detailed guide on safe vs breaking changes
 - [Rolling Out New Allowed Types](./allowed-types-rollout.mdx) - Guide on using staged to safely add new allowed types
 - [Schema Definition](../schema-definition.mdx) - How to define schemas
 - [Node Types](../node-types.mdx) - Understanding different node types


### PR DESCRIPTION
## Description

Fix broken link in docs.

The fact this got passed out link checker for 5 moths is tracked as a bug at https://dev.azure.com/fluidframework/internal/_workitems/edit/62820.

This linked to https://fluidframework.com/docs/data-structures/tree/types-of-changes which gives File not Found.

Link is in bottom of this section: https://fluidframework.com/docs/data-structures/tree/schema-evolution#schema-upgrade-process

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
