### PR TITLE
Sanitize user display names in dice roller example 

### DIFF
--- a/examples/service-clients/azure-client/external-controller/src/view.ts
+++ b/examples/service-clients/azure-client/external-controller/src/view.ts
@@ -73,10 +73,11 @@ function makeAudienceView(audience?: IAzureAudience): HTMLDivElement {
 			}
 		}
 
-		audienceDiv.innerHTML = `
-            Current User: ${self?.name} <br />
-            Other Users: ${memberStrings.join(", ")}
-        `;
+		const currentUserDiv = document.createElement("div");
+		currentUserDiv.textContent = `Current User: ${self?.name}`;
+		const otherUsersDiv = document.createElement("div");
+		otherUsersDiv.textContent = `Other Users: ${memberStrings.join(", ")}`;
+		audienceDiv.replaceChildren(currentUserDiv, otherUsersDiv);
 	};
 
 	onAudienceChanged();


### PR DESCRIPTION
Instead of rendering the display names as HTML (which leaves the application vulnerable to injection attacks), render them as plain text. 