### PR TITLE
Stage removal of URL-based DDS types

### DIFF
--- a/packages/dds/cell/src/cellFactory.ts
+++ b/packages/dds/cell/src/cellFactory.ts
@@ -26,6 +26,9 @@ export class CellFactory implements IChannelFactory<ISharedCell> {
 	/**
 	 * {@inheritDoc CellFactory."type"}
 	 */
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "SharedCell";
 	public static readonly Type = "https://graph.microsoft.com/types/cell";
 
 	/**

--- a/packages/dds/cell/src/cellFactory.ts
+++ b/packages/dds/cell/src/cellFactory.ts
@@ -27,8 +27,8 @@ export class CellFactory implements IChannelFactory<ISharedCell> {
 	 * {@inheritDoc CellFactory."type"}
 	 */
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "SharedCell";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "cell";
 	public static readonly Type = "https://graph.microsoft.com/types/cell";
 
 	/**

--- a/packages/dds/counter/src/counterFactory.ts
+++ b/packages/dds/counter/src/counterFactory.ts
@@ -25,8 +25,8 @@ export class CounterFactory implements IChannelFactory<ISharedCounter> {
 	 * Static value for {@link CounterFactory."type"}.
 	 */
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "SharedCounter";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "counter";
 	public static readonly Type = "https://graph.microsoft.com/types/counter";
 
 	/**

--- a/packages/dds/counter/src/counterFactory.ts
+++ b/packages/dds/counter/src/counterFactory.ts
@@ -24,6 +24,9 @@ export class CounterFactory implements IChannelFactory<ISharedCounter> {
 	/**
 	 * Static value for {@link CounterFactory."type"}.
 	 */
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "SharedCounter";
 	public static readonly Type = "https://graph.microsoft.com/types/counter";
 
 	/**

--- a/packages/dds/ink/src/inkFactory.ts
+++ b/packages/dds/ink/src/inkFactory.ts
@@ -23,6 +23,9 @@ export class InkFactory implements IChannelFactory {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static Type = "Ink";
 	public static Type = "https://graph.microsoft.com/types/ink";
 
 	/**

--- a/packages/dds/ink/src/inkFactory.ts
+++ b/packages/dds/ink/src/inkFactory.ts
@@ -24,8 +24,8 @@ export class InkFactory implements IChannelFactory {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static Type = "Ink";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static Type = "ink";
 	public static Type = "https://graph.microsoft.com/types/ink";
 
 	/**

--- a/packages/dds/legacy-dds/src/array/sharedArrayFactory.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArrayFactory.ts
@@ -26,6 +26,9 @@ import { SharedArrayClass } from "./sharedArray.js";
 export class SharedArrayFactory<T extends SerializableTypeForSharedArray>
 	implements IChannelFactory
 {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "SharedArray";
 	public static readonly Type = "https://graph.microsoft.com/types/SharedArray";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/legacy-dds/src/array/sharedArrayFactory.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArrayFactory.ts
@@ -27,7 +27,7 @@ export class SharedArrayFactory<T extends SerializableTypeForSharedArray>
 	implements IChannelFactory
 {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
 	// public static readonly Type = "SharedArray";
 	public static readonly Type = "https://graph.microsoft.com/types/SharedArray";
 

--- a/packages/dds/legacy-dds/src/signal/sharedSignalFactory.ts
+++ b/packages/dds/legacy-dds/src/signal/sharedSignalFactory.ts
@@ -21,8 +21,8 @@ import { SharedSignalClass } from "./sharedSignal.js";
  */
 export class SharedSignalFactory implements IChannelFactory<ISharedSignal> {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type: string = "SharedSignal";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type: string = "signal";
 	public static readonly Type: string = "https://graph.microsoft.com/types/signal";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/legacy-dds/src/signal/sharedSignalFactory.ts
+++ b/packages/dds/legacy-dds/src/signal/sharedSignalFactory.ts
@@ -20,6 +20,9 @@ import { SharedSignalClass } from "./sharedSignal.js";
  * @internal
  */
 export class SharedSignalFactory implements IChannelFactory<ISharedSignal> {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type: string = "SharedSignal";
 	public static readonly Type: string = "https://graph.microsoft.com/types/signal";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -27,8 +27,8 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "SharedDirectory";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "directory";
 	public static readonly Type = "https://graph.microsoft.com/types/directory";
 
 	/**

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -26,6 +26,9 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "SharedDirectory";
 	public static readonly Type = "https://graph.microsoft.com/types/directory";
 
 	/**

--- a/packages/dds/map/src/mapFactory.ts
+++ b/packages/dds/map/src/mapFactory.ts
@@ -27,8 +27,8 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "SharedMap";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "map";
 	public static readonly Type = "https://graph.microsoft.com/types/map";
 
 	/**

--- a/packages/dds/map/src/mapFactory.ts
+++ b/packages/dds/map/src/mapFactory.ts
@@ -26,6 +26,9 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "SharedMap";
 	public static readonly Type = "https://graph.microsoft.com/types/map";
 
 	/**

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -22,8 +22,8 @@ import { pkgVersion } from "./packageVersion.js";
  */
 export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static Type = "SharedMatrix";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static Type = "sharedmatrix";
 	public static Type = "https://graph.microsoft.com/types/sharedmatrix";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -21,6 +21,9 @@ import { pkgVersion } from "./packageVersion.js";
  * @deprecated Use `SharedMatrix.getFactory` instead.
  */
 export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static Type = "SharedMatrix";
 	public static Type = "https://graph.microsoft.com/types/sharedmatrix";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -25,8 +25,8 @@ import { pkgVersion } from "./packageVersion.js";
  */
 export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static Type = "ConsensusQueue";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static Type = "consensus-queue";
 	public static Type = "https://graph.microsoft.com/types/consensus-queue";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -24,6 +24,9 @@ import { pkgVersion } from "./packageVersion.js";
  * @internal
  */
 export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static Type = "ConsensusQueue";
 	public static Type = "https://graph.microsoft.com/types/consensus-queue";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/pact-map/src/pactMapFactory.ts
+++ b/packages/dds/pact-map/src/pactMapFactory.ts
@@ -19,6 +19,9 @@ import { PactMapClass } from "./pactMap.js";
  * The factory that produces the PactMap
  */
 export class PactMapFactory implements IChannelFactory<IPactMap> {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "PactMap";
 	public static readonly Type = "https://graph.microsoft.com/types/pact-map";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/pact-map/src/pactMapFactory.ts
+++ b/packages/dds/pact-map/src/pactMapFactory.ts
@@ -20,8 +20,8 @@ import { PactMapClass } from "./pactMap.js";
  */
 export class PactMapFactory implements IChannelFactory<IPactMap> {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "PactMap";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "pact-map";
 	public static readonly Type = "https://graph.microsoft.com/types/pact-map";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -23,6 +23,9 @@ import { pkgVersion } from "./packageVersion.js";
 export class ConsensusRegisterCollectionFactory
 	implements IChannelFactory<IConsensusRegisterCollection>
 {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static Type = "ConsensusRegisterCollection";
 	public static Type = "https://graph.microsoft.com/types/consensus-register-collection";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -24,8 +24,8 @@ export class ConsensusRegisterCollectionFactory
 	implements IChannelFactory<IConsensusRegisterCollection>
 {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static Type = "ConsensusRegisterCollection";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static Type = "consensus-register-collection";
 	public static Type = "https://graph.microsoft.com/types/consensus-register-collection";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -16,8 +16,6 @@ import { pkgVersion } from "./packageVersion.js";
 import { SharedStringClass, SharedStringSegment, type ISharedString } from "./sharedString.js";
 
 export class SharedStringFactory implements IChannelFactory<ISharedString> {
-	// TODO rename back to https://graph.microsoft.com/types/mergeTree/string once paparazzi is able to dynamically
-	// load code (UPDATE: paparazzi is gone... anything to do here?)
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
 	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
 	// public static Type = "mergeTree";

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -18,6 +18,9 @@ import { SharedStringClass, SharedStringSegment, type ISharedString } from "./sh
 export class SharedStringFactory implements IChannelFactory<ISharedString> {
 	// TODO rename back to https://graph.microsoft.com/types/mergeTree/string once paparazzi is able to dynamically
 	// load code (UPDATE: paparazzi is gone... anything to do here?)
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static Type = "SharedString";
 	public static Type = "https://graph.microsoft.com/types/mergeTree";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -19,8 +19,8 @@ export class SharedStringFactory implements IChannelFactory<ISharedString> {
 	// TODO rename back to https://graph.microsoft.com/types/mergeTree/string once paparazzi is able to dynamically
 	// load code (UPDATE: paparazzi is gone... anything to do here?)
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static Type = "SharedString";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static Type = "mergeTree";
 	public static Type = "https://graph.microsoft.com/types/mergeTree";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
@@ -22,6 +22,9 @@ export class SharedSummaryBlockFactory implements IChannelFactory<ISharedSummary
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "SharedSummaryBlock";
 	public static readonly Type = "https://graph.microsoft.com/types/shared-summary-block";
 
 	/**

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
@@ -23,8 +23,8 @@ export class SharedSummaryBlockFactory implements IChannelFactory<ISharedSummary
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
 	 */
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "SharedSummaryBlock";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "shared-summary-block";
 	public static readonly Type = "https://graph.microsoft.com/types/shared-summary-block";
 
 	/**

--- a/packages/dds/task-manager/src/taskManagerFactory.ts
+++ b/packages/dds/task-manager/src/taskManagerFactory.ts
@@ -19,6 +19,9 @@ import { TaskManagerClass } from "./taskManager.js";
  * The factory that defines the task queue
  */
 export class TaskManagerFactory implements IChannelFactory<ITaskManager> {
+	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+	// public static readonly Type = "TaskManager";
 	public static readonly Type = "https://graph.microsoft.com/types/task-manager";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/task-manager/src/taskManagerFactory.ts
+++ b/packages/dds/task-manager/src/taskManagerFactory.ts
@@ -20,8 +20,8 @@ import { TaskManagerClass } from "./taskManager.js";
  */
 export class TaskManagerFactory implements IChannelFactory<ITaskManager> {
 	// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-	// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-	// public static readonly Type = "TaskManager";
+	// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+	// public static readonly Type = "task-manager";
 	public static readonly Type = "https://graph.microsoft.com/types/task-manager";
 
 	public static readonly Attributes: IChannelAttributes = {

--- a/packages/dds/tree/src/sharedTreeAttributes.ts
+++ b/packages/dds/tree/src/sharedTreeAttributes.ts
@@ -12,6 +12,11 @@ import { pkgVersion } from "./packageVersion.js";
  * @beta
  * @legacy
  */
+// New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
+// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
+// IMPORTANT: "SharedTree" cannot be used here because experimental/dds/tree already uses that string
+// as its live type.
+// export const SharedTreeFactoryType = "SharedTree2";
 export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
 
 /**

--- a/packages/dds/tree/src/sharedTreeAttributes.ts
+++ b/packages/dds/tree/src/sharedTreeAttributes.ts
@@ -13,10 +13,8 @@ import { pkgVersion } from "./packageVersion.js";
  * @legacy
  */
 // New type string, to be activated once the migration has been fully shipped dark and is safe to flip.
-// See legacyTypeRedirects in packages/runtime/datastore/src/channelContext.ts.
-// IMPORTANT: "SharedTree" cannot be used here because experimental/dds/tree already uses that string
-// as its live type.
-// export const SharedTreeFactoryType = "SharedTree2";
+// See LegacyTypeAwareRegistry in packages/runtime/datastore/src/dataStoreRuntime.ts.
+// export const SharedTreeFactoryType = "tree";
 export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
 
 /**

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -34,35 +34,6 @@ import type { ISharedObjectRegistry } from "./dataStoreRuntime.js";
 
 export const attributesBlobKey = ".attributes";
 
-/**
- * Maps legacy URL-based DDS type strings to their replacement short-name types.
- *
- * Documents created before the type migration store URL-based type strings in their summaries.
- * When loading such a document, the stored type is looked up against the registry. If not found,
- * this table is consulted to translate the legacy type to the new short name for a second lookup.
- *
- * This allows registries built with the new short-name factory types to transparently load
- * documents that were summarized with the old URL-based types.
- */
-const legacyTypeRedirects: Readonly<Record<string, string>> = {
-	"https://graph.microsoft.com/types/directory": "SharedDirectory",
-	"https://graph.microsoft.com/types/map": "SharedMap",
-	"https://graph.microsoft.com/types/counter": "SharedCounter",
-	"https://graph.microsoft.com/types/cell": "SharedCell",
-	"https://graph.microsoft.com/types/mergeTree": "SharedString",
-	"https://graph.microsoft.com/types/sharedmatrix": "SharedMatrix",
-	"https://graph.microsoft.com/types/tree": "SharedTree2",
-	"https://graph.microsoft.com/types/ink": "Ink",
-	"https://graph.microsoft.com/types/pact-map": "PactMap",
-	"https://graph.microsoft.com/types/task-manager": "TaskManager",
-	"https://graph.microsoft.com/types/consensus-queue": "ConsensusQueue",
-	"https://graph.microsoft.com/types/consensus-register-collection":
-		"ConsensusRegisterCollection",
-	"https://graph.microsoft.com/types/shared-summary-block": "SharedSummaryBlock",
-	"https://graph.microsoft.com/types/SharedArray": "SharedArray",
-	"https://graph.microsoft.com/types/signal": "SharedSignal",
-};
-
 export interface IChannelContext {
 	getChannel(): Promise<IChannel>;
 
@@ -197,14 +168,7 @@ export async function loadChannelFactoryAndAttributes(
 			}),
 		);
 	}
-	let factory = registry.get(channelFactoryType);
-	if (factory === undefined) {
-		// Fall back to the redirect table for legacy URL-based type strings from old documents.
-		const redirectedType = legacyTypeRedirects[channelFactoryType];
-		if (redirectedType !== undefined) {
-			factory = registry.get(redirectedType);
-		}
-	}
+	const factory = registry.get(channelFactoryType);
 	if (factory === undefined) {
 		throw new DataCorruptionError(
 			"channelFactoryNotRegisteredForGivenType",

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -34,6 +34,35 @@ import type { ISharedObjectRegistry } from "./dataStoreRuntime.js";
 
 export const attributesBlobKey = ".attributes";
 
+/**
+ * Maps legacy URL-based DDS type strings to their replacement short-name types.
+ *
+ * Documents created before the type migration store URL-based type strings in their summaries.
+ * When loading such a document, the stored type is looked up against the registry. If not found,
+ * this table is consulted to translate the legacy type to the new short name for a second lookup.
+ *
+ * This allows registries built with the new short-name factory types to transparently load
+ * documents that were summarized with the old URL-based types.
+ */
+const legacyTypeRedirects: Readonly<Record<string, string>> = {
+	"https://graph.microsoft.com/types/directory": "SharedDirectory",
+	"https://graph.microsoft.com/types/map": "SharedMap",
+	"https://graph.microsoft.com/types/counter": "SharedCounter",
+	"https://graph.microsoft.com/types/cell": "SharedCell",
+	"https://graph.microsoft.com/types/mergeTree": "SharedString",
+	"https://graph.microsoft.com/types/sharedmatrix": "SharedMatrix",
+	"https://graph.microsoft.com/types/tree": "SharedTree2",
+	"https://graph.microsoft.com/types/ink": "Ink",
+	"https://graph.microsoft.com/types/pact-map": "PactMap",
+	"https://graph.microsoft.com/types/task-manager": "TaskManager",
+	"https://graph.microsoft.com/types/consensus-queue": "ConsensusQueue",
+	"https://graph.microsoft.com/types/consensus-register-collection":
+		"ConsensusRegisterCollection",
+	"https://graph.microsoft.com/types/shared-summary-block": "SharedSummaryBlock",
+	"https://graph.microsoft.com/types/SharedArray": "SharedArray",
+	"https://graph.microsoft.com/types/signal": "SharedSignal",
+};
+
 export interface IChannelContext {
 	getChannel(): Promise<IChannel>;
 
@@ -168,7 +197,14 @@ export async function loadChannelFactoryAndAttributes(
 			}),
 		);
 	}
-	const factory = registry.get(channelFactoryType);
+	let factory = registry.get(channelFactoryType);
+	if (factory === undefined) {
+		// Fall back to the redirect table for legacy URL-based type strings from old documents.
+		const redirectedType = legacyTypeRedirects[channelFactoryType];
+		if (redirectedType !== undefined) {
+			factory = registry.get(redirectedType);
+		}
+	}
 	if (factory === undefined) {
 		throw new DataCorruptionError(
 			"channelFactoryNotRegisteredForGivenType",

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -157,6 +157,76 @@ export interface ISharedObjectRegistry {
 	get(name: string): IChannelFactory | undefined;
 }
 
+/**
+ * The common URL prefix used by legacy DDS type strings.
+ * Factories originally used full URLs (e.g. `"https://graph.microsoft.com/types/map"`);
+ * new factories use only the trailing path segment (e.g. `"map"`).
+ *
+ * @remarks
+ * This is encoded using base64 to avoid replacement of URL-like values that we have seen some reverse proxies perform.
+ * The value at runtime is "https://graph.microsoft.com/types/".
+ */
+const legacyTypeUrlPrefix = atob("aHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3R5cGVzLw==");
+
+/**
+ * Wraps an {@link ISharedObjectRegistry} to transparently redirect legacy URL-based DDS type
+ * strings to the factories registered under the corresponding short-name path segment.
+ *
+ * When a lookup by the full URL fails, this wrapper retries using only the portion of the URL
+ * after `"https://graph.microsoft.com/types/"`. This allows old documents whose summaries
+ * contain URL-based type strings to be loaded against a registry built with the current
+ * short-name factory types.
+ *
+ * @remarks
+ * See {@link legacyTypeUrlPrefix} for details on old vs. new formats
+ */
+class LegacyTypeAwareRegistry implements ISharedObjectRegistry {
+	public constructor(private readonly base: ISharedObjectRegistry) {}
+
+	public get(name: string): IChannelFactory | undefined {
+		let factory = this.base.get(name);
+		if (factory !== undefined) {
+			return factory;
+		}
+
+		// Back-compat: if the name is a legacy URL-based type string, retry with just the trailing path segment.
+		if (name.startsWith(legacyTypeUrlPrefix)) {
+			factory = this.base.get(name.slice(legacyTypeUrlPrefix.length));
+		} else {
+			// Temporary compat: if the name is *not* a legacy URL-based type string and we haven't found a match yet, check if we have a match with the
+			// corresponding legacy scheme. This ensures that if a client containing an older code version with the legacy attribute types loads a document
+			// written by a newer code version, they are still able to find the correct factories. This block can be removed once collaboration between clients
+			// with legacy vs. new attribute types in their code is no longer supported.
+			factory = this.base.get(`${legacyTypeUrlPrefix}${name}`);
+		}
+
+		if (factory !== undefined) {
+			return factory;
+		}
+
+		if (isURL(name) && name.includes("graph.microsoft")) {
+			// Reasonably strong signal that this the document refers to a DDS type string that is using the legacy URL format, but
+			// the base URL was likely changed by a reverse proxy or similar. Assume that its final segment is still the short (modern) name of
+			// a valid DDS type and look it up as such.
+			const finalSegment = name.split("/").slice(-1)[0];
+			if (finalSegment) {
+				return (
+					this.base.get(finalSegment) ?? this.base.get(`${legacyTypeUrlPrefix}${finalSegment}`)
+				);
+			}
+		}
+	}
+}
+
+function isURL(str: string): boolean {
+	try {
+		new URL(str);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 const defaultPolicies: IFluidDataStorePolicies = {
 	readonlyInStagingMode: false,
 };
@@ -277,6 +347,7 @@ export class FluidDataStoreRuntime
 		ISequencedDocumentMessage,
 		IDocumentMessage
 	>;
+	private readonly sharedObjectRegistry: ISharedObjectRegistry;
 	private readonly quorum: IQuorumClients;
 	private readonly audience: IAudience;
 	private readonly mc: MonitoringContext;
@@ -327,12 +398,13 @@ export class FluidDataStoreRuntime
 	 */
 	public constructor(
 		private readonly dataStoreContext: IFluidDataStoreContext,
-		private readonly sharedObjectRegistry: ISharedObjectRegistry,
+		sharedObjectRegistry: ISharedObjectRegistry,
 		existing: boolean,
 		provideEntryPoint: (runtime: IFluidDataStoreRuntime) => Promise<FluidObject>,
 		policies?: Partial<IFluidDataStorePolicies>,
 	) {
 		super();
+		this.sharedObjectRegistry = new LegacyTypeAwareRegistry(sharedObjectRegistry);
 
 		assert(
 			!dataStoreContext.id.includes("/"),

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -189,8 +189,9 @@ export class LegacyTypeAwareRegistry implements ISharedObjectRegistry {
 			return factory;
 		}
 
-		// Back-compat: if the name is a legacy URL-based type string, retry with just the trailing path segment.
+		// eslint-disable-next-line unicorn/prefer-ternary -- This is more readable as an if statement to clearly delineate which logic can be later removed vs. which needs to stay.
 		if (name.startsWith(legacyTypeUrlPrefix)) {
+			// Back-compat: if the name is a legacy URL-based type string, retry with just the trailing path segment.
 			factory = this.base.get(name.slice(legacyTypeUrlPrefix.length));
 		} else {
 			// Temporary compat: if the name is *not* a legacy URL-based type string and we haven't found a match yet, check if we have a match with the
@@ -209,7 +210,7 @@ export class LegacyTypeAwareRegistry implements ISharedObjectRegistry {
 			// the base URL was likely changed by a reverse proxy or similar. Assume that its final segment is still the short (modern) name of
 			// a valid DDS type and look it up as such.
 			const finalSegment = name.split("/").slice(-1)[0];
-			if (finalSegment) {
+			if (finalSegment !== undefined) {
 				return (
 					this.base.get(finalSegment) ?? this.base.get(`${legacyTypeUrlPrefix}${finalSegment}`)
 				);

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -162,6 +162,7 @@ export interface ISharedObjectRegistry {
  * Factories originally used full URLs (e.g. `"https://graph.microsoft.com/types/map"`);
  * new factories use only the trailing path segment (e.g. `"map"`).
  *
+ * Support for reading both formats was added in 2.92.0.
  * @remarks
  * This is encoded using base64 to avoid replacement of URL-like values that we have seen some reverse proxies perform.
  * The value at runtime is "https://graph.microsoft.com/types/".

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -180,7 +180,7 @@ const legacyTypeUrlPrefix = atob("aHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3R5cGVzLw
  * @remarks
  * See {@link legacyTypeUrlPrefix} for details on old vs. new formats
  */
-class LegacyTypeAwareRegistry implements ISharedObjectRegistry {
+export class LegacyTypeAwareRegistry implements ISharedObjectRegistry {
 	public constructor(private readonly base: ISharedObjectRegistry) {}
 
 	public get(name: string): IChannelFactory | undefined {

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -532,7 +532,7 @@ describe("LegacyTypeAwareRegistry", () => {
 		});
 
 		it("returns undefined for a URL whose final path segment is empty", () => {
-			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ "": "empty" }));
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ map: "map" }));
 			assert.strictEqual(r.get("https://graph.microsoft.proxy.contoso.com/"), undefined);
 		});
 	});

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -31,6 +31,7 @@ import sinon from "sinon";
 import {
 	DataStoreMessageType,
 	FluidDataStoreRuntime,
+	LegacyTypeAwareRegistry,
 	type ISharedObjectRegistry,
 } from "../dataStoreRuntime.js";
 
@@ -438,6 +439,102 @@ describe("FluidDataStoreRuntime.isDirty tracking", () => {
 		);
 
 		assert.strictEqual(runtime.isDirty, false, "Runtime should be clean after rollback");
+	});
+});
+
+describe("LegacyTypeAwareRegistry", () => {
+	/**
+	 * Returns a simple registry backed by a plain-object map.
+	 * Each value is used as the `type` property on the returned stub factory,
+	 * which is sufficient for asserting which factory was found.
+	 */
+	function makeBaseRegistry(entries: Record<string, string>): ISharedObjectRegistry {
+		return {
+			get(name) {
+				const type = entries[name];
+				if (type === undefined) return undefined;
+				return {
+					type,
+					attributes: { type, snapshotFormatVersion: "0" },
+					create: () => {
+						throw new Error("not implemented");
+					},
+					load: async () => {
+						throw new Error("not implemented");
+					},
+				};
+			},
+		};
+	}
+
+	// The expected decoded value of legacyTypeUrlPrefix.
+	const prefix = "https://graph.microsoft.com/types/";
+
+	it("returns factory when name matches directly", () => {
+		const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ map: "map" }));
+		assert.strictEqual(r.get("map")?.type, "map");
+	});
+
+	it("returns undefined for a completely unknown name", () => {
+		const r = new LegacyTypeAwareRegistry(makeBaseRegistry({}));
+		assert.strictEqual(r.get("unknownType"), undefined);
+	});
+
+	describe("back-compat: old URL in document, new short name in registry", () => {
+		it("strips the URL prefix and finds the factory by path segment", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ map: "map" }));
+			assert.strictEqual(r.get(`${prefix}map`)?.type, "map");
+		});
+
+		it("returns undefined when the path segment is also unregistered", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ other: "other" }));
+			assert.strictEqual(r.get(`${prefix}unknown`), undefined);
+		});
+
+		it("works for a multi-word path segment (e.g. consensus-queue)", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ "consensus-queue": "cq" }));
+			assert.strictEqual(r.get(`${prefix}consensus-queue`)?.type, "cq");
+		});
+	});
+
+	describe("temporary compat: new short name in document, old URL in registry", () => {
+		it("prepends the URL prefix and finds the factory", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ [`${prefix}map`]: "map-url" }));
+			assert.strictEqual(r.get("map")?.type, "map-url");
+		});
+
+		it("returns undefined when neither the short name nor the prefixed form is registered", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ other: "other" }));
+			assert.strictEqual(r.get("unknownType"), undefined);
+		});
+	});
+
+	describe("reverse-proxy compat: mangled graph.microsoft URL in document", () => {
+		it("extracts the final path segment and finds the factory by short name", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ map: "map" }));
+			assert.strictEqual(
+				r.get("https://graph.microsoft.proxy.contoso.com/types/map")?.type,
+				"map",
+			);
+		});
+
+		it("extracts the final path segment and finds the factory by legacy URL", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ [`${prefix}map`]: "map-url" }));
+			assert.strictEqual(
+				r.get("https://graph.microsoft.proxy.contoso.com/types/map")?.type,
+				"map-url",
+			);
+		});
+
+		it("returns undefined for a URL that does not contain 'graph.microsoft'", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ map: "map" }));
+			assert.strictEqual(r.get("https://otherdds.contoso.com/types/map"), undefined);
+		});
+
+		it("returns undefined for a URL whose final path segment is empty", () => {
+			const r = new LegacyTypeAwareRegistry(makeBaseRegistry({ "": "empty" }));
+			assert.strictEqual(r.get("https://graph.microsoft.proxy.contoso.com/"), undefined);
+		});
 	});
 });
 


### PR DESCRIPTION
## Description

Deployed Fluid-based solutions can run into problems when their customers have certain reverse-proxy solutions which rewrite URLs to go through predefined endpoint (this allows routing traffic through known domains which can be used for various interception purposes). The core problem in those cases is that JS bundles containing Fluid libraries have rewritten "Type" values for DDSes pointing to the intercepted reverse proxy domain. Concretely, the problem resembles:

Customer has a reverse proxy that's configured to route https://github.com to `my-reverse-proxy.com/?path=github.com`, where the my-reverse-proxy.com domain serves assets from github.com (or whatever's in the path parameter) but replaces any links on that domain with an analogous link to my-reverse-proxy.com.

Fluid DDS types resemble URLs but they are not actually used as such, they function as registry keys. Furthermore, they are persisted in the document under the channel attributes blob. So, such auto-rewriting of URLs causes issues where documents created on a device subject to such a reverse proxy solution would only be usable as long as the reverse proxy has the exact same sort of configuration (and documents created on a device without that sort of thing would not be openable on one that does have such redirection). All of this looks effectively like document corruption to the user.

Historically, I believe URL-like values for DDSes were chosen when Fluid had more ambition for loading DDSes dynamically. We are at this point very far from that space (instead opting to close DDS development to within the repository for API reasons). There's no reason these need to be URLs.

This stages a redirect table in the DDS lookup process that will allow us to later update the type values to be non-URL based. The change cannot be performed immediately for compatibility reasons at rollout time (risk of users with newer version of the code writing documents that older versions do not understand).