### PR TITLE
fix(devcontainer): add bubblewrap package

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get -y install --no-install-recommends \
+        bubblewrap \
         fd-find \
         jq \
         sqlite3 \


### PR DESCRIPTION
## Summary

- Adds `bubblewrap` (`bwrap`) to the devcontainer Dockerfile's apt package list, making it available in the development environment.