### PR TITLE
Checkout implements TreeBranchAlpha

### DIFF
--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -31,7 +31,6 @@ export {
 	TreeCheckout,
 	type ITreeCheckout,
 	type CheckoutEvents,
-	type ITreeCheckoutFork,
 	type BranchableTree,
 	type TreeBranchFork,
 } from "./treeCheckout.js";

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -9,7 +9,7 @@ import type {
 	IEmitter,
 	Listenable,
 } from "@fluidframework/core-interfaces/internal";
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { anchorSlot, rootFieldKey } from "../core/index.js";
@@ -17,7 +17,6 @@ import {
 	type NodeIdentifierManager,
 	defaultSchemaPolicy,
 	cursorForMapTreeField,
-	TreeStatus,
 	Context,
 	combineChunks,
 	type FlexTreeOptionalField,
@@ -41,16 +40,12 @@ import {
 	type ReadableField,
 	type ReadSchema,
 	type UnsafeUnknownSchema,
-	type TreeBranch,
 	type TreeBranchEvents,
-	getInnerNode,
-	getKernel,
 	type VoidTransactionCallbackStatus,
 	type TransactionCallbackStatus,
 	type TransactionResult,
 	type TransactionResultExt,
 	type RunTransactionParams,
-	type TransactionConstraintAlpha,
 	HydratedContext,
 	SimpleContextSlot,
 	areImplicitFieldSchemaEqual,
@@ -72,7 +67,7 @@ import {
 } from "../util/index.js";
 
 import { canInitialize, initialize, initializerFromChunk } from "./schematizeTree.js";
-import type { ITreeCheckout, TreeCheckout } from "./treeCheckout.js";
+import type { TreeCheckout } from "./treeCheckout.js";
 
 /**
  * Creating multiple tree views from the same checkout is not supported. This slot is used to detect if one already
@@ -276,16 +271,10 @@ export class SchematizingSimpleTreeView<
 		return this.flexTreeContext;
 	}
 
-	/**
-	 * {@inheritDoc @fluidframework/shared-tree#TreeViewAlpha.runTransaction}
-	 */
 	public runTransaction<TSuccessValue, TFailureValue>(
 		transaction: () => TransactionCallbackStatus<TSuccessValue, TFailureValue>,
 		params?: RunTransactionParams,
 	): TransactionResultExt<TSuccessValue, TFailureValue>;
-	/**
-	 * {@inheritDoc @fluidframework/shared-tree#TreeViewAlpha.runTransaction}
-	 */
 	public runTransaction(
 		transaction: () => VoidTransactionCallbackStatus | void,
 		params?: RunTransactionParams,
@@ -297,21 +286,14 @@ export class SchematizingSimpleTreeView<
 			| void,
 		params?: RunTransactionParams,
 	): TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult {
-		this.mountTransaction(params, false);
-		const transactionCallbackStatus = transaction();
-		return this.unmountTransaction(transactionCallbackStatus, params);
+		this.ensureUndisposed();
+		return this.checkout.runTransaction(transaction, params);
 	}
 
-	/**
-	 * {@inheritDoc @fluidframework/shared-tree#TreeViewAlpha.runTransactionAsync}
-	 */
 	public runTransactionAsync<TSuccessValue, TFailureValue>(
 		transaction: () => Promise<TransactionCallbackStatus<TSuccessValue, TFailureValue>>,
 		params?: RunTransactionParams,
 	): Promise<TransactionResultExt<TSuccessValue, TFailureValue>>;
-	/**
-	 * {@inheritDoc @fluidframework/shared-tree#TreeViewAlpha.runTransactionAsync}
-	 */
 	public runTransactionAsync(
 		transaction: () => Promise<VoidTransactionCallbackStatus | void>,
 		params?: RunTransactionParams,
@@ -324,66 +306,8 @@ export class SchematizingSimpleTreeView<
 		>,
 		params: RunTransactionParams | undefined,
 	): Promise<TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult> {
-		this.mountTransaction(params, true);
-		const transactionCallbackStatus = await transaction();
-		return this.unmountTransaction(transactionCallbackStatus, params);
-	}
-
-	private mountTransaction(params: RunTransactionParams | undefined, isAsync: boolean): void {
 		this.ensureUndisposed();
-		const { checkout } = this;
-		if (isAsync && checkout.transaction.size > 0) {
-			throw new UsageError(
-				"An asynchronous transaction cannot be started while another transaction is already in progress.",
-			);
-		}
-		checkout.pushLabelFrame(params?.label);
-		checkout.transaction.start();
-
-		// Validate preconditions before running the transaction callback.
-		addConstraintsToTransaction(
-			checkout,
-			false /* constraintsOnRevert */,
-			params?.preconditions,
-		);
-	}
-
-	private unmountTransaction<TSuccessValue, TFailureValue>(
-		transactionCallbackStatus:
-			| TransactionCallbackStatus<TSuccessValue, TFailureValue>
-			| VoidTransactionCallbackStatus
-			| void,
-		params: RunTransactionParams | undefined,
-	): TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult {
-		this.ensureUndisposed();
-		const { checkout } = this;
-		const rollback = transactionCallbackStatus?.rollback;
-		const value = (
-			transactionCallbackStatus as TransactionCallbackStatus<TSuccessValue, TFailureValue>
-		)?.value;
-
-		if (rollback === true) {
-			checkout.popLabelFrame(true);
-			checkout.transaction.abort();
-			return value === undefined
-				? { success: false }
-				: { success: false, value: value as TFailureValue };
-		}
-
-		// Validate preconditions on revert after running the transaction callback and was successful.
-		addConstraintsToTransaction(
-			checkout,
-			true /* constraintsOnRevert */,
-			transactionCallbackStatus?.preconditionsOnRevert,
-		);
-
-		checkout.popLabelFrame(false);
-		checkout.runWithTransactionLabel(() => {
-			checkout.transaction.commit();
-		}, params?.label);
-		return value === undefined
-			? { success: true }
-			: { success: true, value: value as TSuccessValue };
+		return this.checkout.runTransactionAsync(transaction, params);
 	}
 
 	private ensureUndisposed(): void {
@@ -585,95 +509,12 @@ export class SchematizingSimpleTreeView<
 	}
 
 	public merge(context: TreeBranchAlpha, disposeMerged = true): void {
-		this.checkout.merge(getCheckout(context), disposeMerged);
+		this.checkout.merge(context, disposeMerged);
 	}
 
 	public rebaseOnto(context: TreeBranchAlpha): void {
-		getCheckout(context).rebase(this.checkout);
+		this.checkout.rebaseOnto(context);
 	}
 
 	// #endregion Branching
-}
-
-/**
- * Get the {@link TreeCheckout} associated with a given {@link TreeBranch}.
- * @remarks Currently, all contexts are also {@link SchematizingSimpleTreeView}s.
- * Other checkout implementations (e.g. not associated with a view) may be supported in the future.
- */
-export function getCheckout(context: TreeBranch): TreeCheckout {
-	if (context instanceof SchematizingSimpleTreeView) {
-		return context.checkout;
-	}
-	throw new UsageError("Unsupported context implementation");
-}
-
-/**
- * Adds constraints to a `checkout`'s pending transaction.
- *
- * @param checkout - The checkout's who's transaction will have the constraints added to it.
- * @param constraintsOnRevert - If true, use {@link ISharedTreeEditor.addNodeExistsConstraintOnRevert}.
- * @param constraints - The constraints to add to the transaction.
- *
- * @see {@link RunTransactionParams.preconditions}.
- */
-export function addConstraintsToTransaction(
-	checkout: ITreeCheckout,
-	constraintsOnRevert: boolean,
-	constraints: readonly TransactionConstraintAlpha[] = [],
-): void {
-	for (const constraint of constraints) {
-		assertValidConstraint(constraint, constraintsOnRevert);
-		const constraintType = constraint.type;
-		switch (constraintType) {
-			case "nodeInDocument": {
-				const node = getInnerNode(constraint.node);
-				assert(node.isHydrated(), 0xbc2 /* In document node must be hydrated. */);
-				if (constraintsOnRevert) {
-					checkout.editor.addNodeExistsConstraintOnRevert(node.anchorNode);
-				} else {
-					checkout.editor.addNodeExistsConstraint(node.anchorNode);
-				}
-				break;
-			}
-			case "noChange": {
-				if (constraintsOnRevert) {
-					checkout.editor.addNoChangeConstraintOnRevert();
-				} else {
-					checkout.editor.addNoChangeConstraint();
-				}
-				break;
-			}
-			default: {
-				unreachableCase(constraintType);
-			}
-		}
-	}
-}
-
-/**
- * Throws if the given {@link TransactionConstraintAlpha | transaction constraint} is not currently satisfied.
- */
-export function assertValidConstraint(
-	constraint: TransactionConstraintAlpha,
-	onRevert: boolean,
-): void {
-	switch (constraint.type) {
-		case "nodeInDocument": {
-			const nodeStatus = getKernel(constraint.node).getStatus();
-			if (nodeStatus !== TreeStatus.InDocument) {
-				const revertText = onRevert ? " on revert" : "";
-				throw new UsageError(
-					`Attempted to add a "nodeInDocument" constraint${revertText}, but the node is not currently in the document. Node status: ${nodeStatus}`,
-				);
-			}
-			break;
-		}
-		case "noChange": {
-			// This constraint is always satisfied at the time of checking, since it just requires that no changes have been made since the transaction callback returned.
-			break;
-		}
-		default: {
-			unreachableCase(constraint);
-		}
-	}
 }

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -307,6 +307,19 @@ export class SchematizingSimpleTreeView<
 		params: RunTransactionParams | undefined,
 	): Promise<TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult> {
 		this.ensureUndisposed();
+		if (this.checkout.transaction.size > 0) {
+			// breaker.break() sets brokenBy synchronously before throwing.
+			// A plain `throw` inside an async function would be captured as a rejected Promise
+			// before @breakingClass could set brokenBy. By setting it here first, the
+			// subsequent call to unmountTransaction (also @breakingClass-wrapped) will see the
+			// broken state and throw synchronously, propagating out of the outer runTransaction
+			// to its caller.
+			this.breaker.break(
+				new UsageError(
+					"An asynchronous transaction cannot be started while another transaction is already in progress.",
+				),
+			);
+		}
 		return this.checkout.runTransactionAsync(transaction, params);
 	}
 

--- a/packages/dds/tree/src/shared-tree/tree.ts
+++ b/packages/dds/tree/src/shared-tree/tree.ts
@@ -18,11 +18,8 @@ import {
 	type TransactionConstraint,
 } from "../simple-tree/index.js";
 
-import {
-	addConstraintsToTransaction,
-	SchematizingSimpleTreeView,
-} from "./schematizingTreeView.js";
-import type { ITreeCheckout } from "./treeCheckout.js";
+import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
+import { addConstraintsToTransaction, type ITreeCheckout } from "./treeCheckout.js";
 
 /**
  * Provides various functions for interacting with {@link TreeNode}s.

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -107,9 +107,11 @@ import {
 } from "../simple-tree/index.js";
 import {
 	Breakable,
+	breakingMethod,
 	disposeSymbol,
 	getOrCreate,
 	hasSome,
+	throwIfBroken,
 	type JsonCompatibleReadOnly,
 	type WithBreakable,
 } from "../util/index.js";
@@ -732,6 +734,7 @@ export class TreeCheckout implements ITreeCheckout {
 		});
 	}
 
+	@throwIfBroken
 	public exportVerbose(): VerboseTree | undefined {
 		const cursor = this.forest.allocateCursor("contentSnapshot");
 		try {
@@ -854,6 +857,7 @@ export class TreeCheckout implements ITreeCheckout {
 	/**
 	 * Applies the given serialized change (as was produced via a `"changed"` event of another checkout) to this checkout.
 	 */
+	@throwIfBroken
 	public applySerializedChange(serializedChange: JsonCompatibleReadOnly): void {
 		if (!isSerializedChange(serializedChange)) {
 			throw new UsageError(`Cannot apply change. Invalid serialized change format.`);
@@ -876,10 +880,12 @@ export class TreeCheckout implements ITreeCheckout {
 
 	// #region TreeBranchAlpha
 
+	@throwIfBroken
 	public applyChange(change: JsonCompatibleReadOnly): void {
 		this.applySerializedChange(change);
 	}
 
+	@throwIfBroken
 	public fork(): TreeCheckout {
 		return this.branch();
 	}
@@ -902,6 +908,7 @@ export class TreeCheckout implements ITreeCheckout {
 		transaction: () => VoidTransactionCallbackStatus | void,
 		params?: RunTransactionParams,
 	): TransactionResult;
+	@breakingMethod
 	public runTransaction<TSuccessValue, TFailureValue>(
 		transaction: () =>
 			| TransactionCallbackStatus<TSuccessValue, TFailureValue>
@@ -922,6 +929,7 @@ export class TreeCheckout implements ITreeCheckout {
 		transaction: () => Promise<VoidTransactionCallbackStatus | void>,
 		params?: RunTransactionParams,
 	): Promise<TransactionResult>;
+	@breakingMethod
 	public async runTransactionAsync<TSuccessValue, TFailureValue>(
 		transaction: () => Promise<
 			| TransactionCallbackStatus<TSuccessValue, TFailureValue>
@@ -1135,6 +1143,7 @@ export class TreeCheckout implements ITreeCheckout {
 		config: TreeViewConfiguration<TRoot>,
 	): TreeView<TRoot>;
 
+	@throwIfBroken
 	public viewWith<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema>(
 		config: TreeViewConfiguration<ReadSchema<TRoot>>,
 	): SchematizingSimpleTreeView<TRoot> {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -1249,10 +1249,10 @@ export class TreeCheckout implements ITreeCheckout {
 	private rebase(branch: TreeBranch): void {
 		const checkout = getCheckout(branch);
 		this.checkNotDisposed(
-			"The target of the branch rebase has been disposed and cannot be rebased.",
+			"The target branch of the rebase has been disposed and cannot be rebased.",
 		);
 		checkout.checkNotDisposed(
-			"The source of the branch rebase has been disposed and cannot be rebased.",
+			"The source branch of the rebase has been disposed and cannot be rebased.",
 		);
 		this.editLock.checkUnlocked("Rebasing");
 
@@ -1274,9 +1274,6 @@ export class TreeCheckout implements ITreeCheckout {
 	}
 
 	public rebaseOnto(branch: TreeBranch): void {
-		this.checkNotDisposed(
-			"The target of the branch rebase has been disposed and cannot be rebased.",
-		);
 		getCheckout(branch).rebase(this);
 	}
 
@@ -1285,10 +1282,10 @@ export class TreeCheckout implements ITreeCheckout {
 	public merge(branch: TreeBranch, disposeMerged = true): void {
 		const checkout = getCheckout(branch);
 		this.checkNotDisposed(
-			"The target of the branch merge has been disposed and cannot be merged.",
+			"The target branch of the merge has been disposed and cannot be merged.",
 		);
 		checkout.checkNotDisposed(
-			"The source of the branch merge has been disposed and cannot be merged.",
+			"The source branch of the merge has been disposed and cannot be merged.",
 		);
 		this.editLock.checkUnlocked("Merging");
 		if (this.transaction.size > 0) {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -69,13 +69,14 @@ import {
 	createNodeIdentifierManager,
 	defaultSchemaPolicy,
 	fieldBatchCodecBuilder,
+	TreeStatus,
 	intoDelta,
 	jsonableTreeFromCursor,
 } from "../feature-libraries/index.js";
 import {
 	SquashingTransactionStack,
 	SharedTreeBranch,
-	TransactionResult,
+	TransactionResult as InternalTransactionResult,
 	onForkTransitive,
 	type SharedTreeBranchChange,
 	type Transactor,
@@ -88,8 +89,18 @@ import {
 	type UnsafeUnknownSchema,
 	type ViewableTree,
 	type TreeBranch,
+	type TreeBranchAlpha,
 	type TreeChangeEvents,
 	type VerboseTree,
+	type VoidTransactionCallbackStatus,
+	type TransactionCallbackStatus,
+	type TransactionResult,
+	type TransactionResultExt,
+	type RunTransactionParams,
+	type TransactionConstraintAlpha,
+	type TreeViewAlpha,
+	getInnerNode,
+	getKernel,
 	customFromCursorStored,
 	type CustomTreeValue,
 	type CustomTreeNode,
@@ -103,7 +114,7 @@ import {
 	type WithBreakable,
 } from "../util/index.js";
 
-import { getCheckout, SchematizingSimpleTreeView } from "./schematizingTreeView.js";
+import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 import { SharedTreeChangeEnricher } from "./sharedTreeChangeEnricher.js";
 import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
@@ -241,7 +252,11 @@ export interface TreeBranchFork extends BranchableTree, IDisposable {
  * API for interacting with a {@link SharedTreeBranch}.
  * Implementations of this interface must implement the {@link branchKey} property.
  */
-export interface ITreeCheckout extends AnchorLocator, ViewableTree, WithBreakable {
+export interface ITreeCheckout
+	extends TreeBranchAlpha,
+		AnchorLocator,
+		ViewableTree,
+		WithBreakable {
 	/**
 	 * Read and Write access for schema stored in the document.
 	 *
@@ -277,13 +292,8 @@ export interface ITreeCheckout extends AnchorLocator, ViewableTree, WithBreakabl
 	 */
 	readonly transaction: Transactor;
 
-	branch(): ITreeCheckoutFork;
-
-	merge(checkout: ITreeCheckoutFork): void;
-
-	merge(checkout: ITreeCheckoutFork, disposeMerged: boolean): void;
-
-	rebase(checkout: ITreeCheckoutFork): void;
+	// TODO: rename to fork() and remove the separate fork() method on TreeCheckout.
+	branch(): ITreeCheckout;
 
 	/**
 	 * Replaces all schema with the provided schema.
@@ -389,15 +399,6 @@ export function createTreeCheckout(
 }
 
 /**
- * Branch (like in a version control system) of SharedTree.
- *
- * {@link ITreeCheckout} that has forked off of the main trunk/branch.
- */
-export interface ITreeCheckoutFork extends ITreeCheckout {
-	rebaseOnto(view: ITreeCheckout): void;
-}
-
-/**
  * Metrics derived from a revert operation.
  *
  * @see {@link TreeCheckout.revertRevertible}.
@@ -412,9 +413,93 @@ export interface RevertMetrics {
 }
 
 /**
- * An implementation of {@link ITreeCheckoutFork}.
+ * Get the {@link TreeCheckout} associated with a given {@link TreeBranch}.
  */
-export class TreeCheckout implements ITreeCheckoutFork {
+function getCheckout(context: TreeBranch): TreeCheckout {
+	if (context instanceof TreeCheckout) {
+		return context;
+	}
+	if (context instanceof SchematizingSimpleTreeView) {
+		return context.checkout;
+	}
+	throw new UsageError("Unsupported context implementation");
+}
+
+/**
+ * Adds constraints to a `checkout`'s pending transaction.
+ *
+ * @param checkout - The checkout whose transaction will have the constraints added to it.
+ * @param constraintsOnRevert - If true, use {@link ISharedTreeEditor.addNodeExistsConstraintOnRevert}.
+ * @param constraints - The constraints to add to the transaction.
+ *
+ * @see {@link RunTransactionParams.preconditions}.
+ */
+export function addConstraintsToTransaction(
+	checkout: ITreeCheckout,
+	constraintsOnRevert: boolean,
+	constraints: readonly TransactionConstraintAlpha[] = [],
+): void {
+	for (const constraint of constraints) {
+		assertValidConstraint(constraint, constraintsOnRevert);
+		const constraintType = constraint.type;
+		switch (constraintType) {
+			case "nodeInDocument": {
+				const node = getInnerNode(constraint.node);
+				assert(node.isHydrated(), 0xbc2 /* In document node must be hydrated. */);
+				if (constraintsOnRevert) {
+					checkout.editor.addNodeExistsConstraintOnRevert(node.anchorNode);
+				} else {
+					checkout.editor.addNodeExistsConstraint(node.anchorNode);
+				}
+				break;
+			}
+			case "noChange": {
+				if (constraintsOnRevert) {
+					checkout.editor.addNoChangeConstraintOnRevert();
+				} else {
+					checkout.editor.addNoChangeConstraint();
+				}
+				break;
+			}
+			default: {
+				unreachableCase(constraintType);
+			}
+		}
+	}
+}
+
+/**
+ * Throws if the given {@link TransactionConstraintAlpha | transaction constraint} is not currently satisfied.
+ */
+export function assertValidConstraint(
+	constraint: TransactionConstraintAlpha,
+	onRevert: boolean,
+): void {
+	switch (constraint.type) {
+		case "nodeInDocument": {
+			const nodeStatus = getKernel(constraint.node).getStatus();
+			if (nodeStatus !== TreeStatus.InDocument) {
+				const revertText = onRevert ? " on revert" : "";
+				throw new UsageError(
+					`Attempted to add a "nodeInDocument" constraint${revertText}, but the node is not currently in the document. Node status: ${nodeStatus}`,
+				);
+			}
+			break;
+		}
+		case "noChange": {
+			// This constraint is always satisfied at the time of checking, since it just requires that no changes have been made since the transaction callback returned.
+			break;
+		}
+		default: {
+			unreachableCase(constraint);
+		}
+	}
+}
+
+/**
+ * An implementation of {@link ITreeCheckout}.
+ */
+export class TreeCheckout implements ITreeCheckout {
 	public disposed = false;
 
 	private editLock: EditLock;
@@ -621,16 +706,16 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			return (result, viewUpdate: SharedTreeChange | undefined) => {
 				const newHead = this.#transaction.branch.getHead();
 				switch (result) {
-					case TransactionResult.Abort: {
+					case InternalTransactionResult.Abort: {
 						restoreRemovedRoots();
 						if (viewUpdate !== undefined) {
-							this.applyChange(viewUpdate, newHead.revision);
+							this.applyInternalChange(viewUpdate, newHead.revision);
 						}
 						break;
 					}
-					case TransactionResult.Commit: {
+					case InternalTransactionResult.Commit: {
 						if (viewUpdate !== undefined) {
-							this.applyChange(viewUpdate, newHead.revision);
+							this.applyInternalChange(viewUpdate, newHead.revision);
 						}
 						if (this.transaction.size === 0) {
 							// The changes in a transaction squash commit have already applied to the checkout and are known to be valid, so we can validate the squash commit automatically.
@@ -755,7 +840,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 					? this.#transaction.activeBranch.getHead().revision
 					: event.change.revision;
 
-			this.applyChange(event.change.change, revision);
+			this.applyInternalChange(event.change.change, revision);
 		}
 		this.#events.emit("afterBatch");
 		this.editLock.unlock();
@@ -789,8 +874,116 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.#transaction.branch.apply(tagChange(decodedChange, revision));
 	}
 
+	// #region TreeBranchAlpha
+
+	public applyChange(change: JsonCompatibleReadOnly): void {
+		this.applySerializedChange(change);
+	}
+
+	public fork(): TreeCheckout {
+		return this.branch();
+	}
+
+	public isBranch(): this is TreeBranchAlpha {
+		return true;
+	}
+
+	public hasRootSchema<TSchema extends ImplicitFieldSchema>(
+		_schema: TSchema,
+	): this is TreeViewAlpha<TSchema> {
+		return false;
+	}
+
+	public runTransaction<TSuccessValue, TFailureValue>(
+		transaction: () => TransactionCallbackStatus<TSuccessValue, TFailureValue>,
+		params?: RunTransactionParams,
+	): TransactionResultExt<TSuccessValue, TFailureValue>;
+	public runTransaction(
+		transaction: () => VoidTransactionCallbackStatus | void,
+		params?: RunTransactionParams,
+	): TransactionResult;
+	public runTransaction<TSuccessValue, TFailureValue>(
+		transaction: () =>
+			| TransactionCallbackStatus<TSuccessValue, TFailureValue>
+			| VoidTransactionCallbackStatus
+			| void,
+		params?: RunTransactionParams,
+	): TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult {
+		this.mountTransaction(params, false);
+		const transactionCallbackStatus = transaction();
+		return this.unmountTransaction(transactionCallbackStatus, params);
+	}
+
+	public runTransactionAsync<TSuccessValue, TFailureValue>(
+		transaction: () => Promise<TransactionCallbackStatus<TSuccessValue, TFailureValue>>,
+		params?: RunTransactionParams,
+	): Promise<TransactionResultExt<TSuccessValue, TFailureValue>>;
+	public runTransactionAsync(
+		transaction: () => Promise<VoidTransactionCallbackStatus | void>,
+		params?: RunTransactionParams,
+	): Promise<TransactionResult>;
+	public async runTransactionAsync<TSuccessValue, TFailureValue>(
+		transaction: () => Promise<
+			| TransactionCallbackStatus<TSuccessValue, TFailureValue>
+			| VoidTransactionCallbackStatus
+			| void
+		>,
+		params: RunTransactionParams | undefined,
+	): Promise<TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult> {
+		this.mountTransaction(params, true);
+		const transactionCallbackStatus = await transaction();
+		return this.unmountTransaction(transactionCallbackStatus, params);
+	}
+
+	private mountTransaction(params: RunTransactionParams | undefined, isAsync: boolean): void {
+		this.checkNotDisposed();
+		if (isAsync && this.transaction.size > 0) {
+			throw new UsageError(
+				"An asynchronous transaction cannot be started while another transaction is already in progress.",
+			);
+		}
+		this.pushLabelFrame(params?.label);
+		this.transaction.start();
+
+		addConstraintsToTransaction(this, false, params?.preconditions);
+	}
+
+	private unmountTransaction<TSuccessValue, TFailureValue>(
+		transactionCallbackStatus:
+			| TransactionCallbackStatus<TSuccessValue, TFailureValue>
+			| VoidTransactionCallbackStatus
+			| void,
+		params: RunTransactionParams | undefined,
+	): TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult {
+		this.checkNotDisposed();
+		const rollback = transactionCallbackStatus?.rollback;
+		const value = (
+			transactionCallbackStatus as TransactionCallbackStatus<TSuccessValue, TFailureValue>
+		)?.value;
+
+		if (rollback === true) {
+			this.popLabelFrame(true);
+			this.transaction.abort();
+			return value === undefined
+				? { success: false }
+				: { success: false, value: value as TFailureValue };
+		}
+
+		addConstraintsToTransaction(this, true, transactionCallbackStatus?.preconditionsOnRevert);
+
+		this.popLabelFrame(false);
+		this.runWithTransactionLabel(() => {
+			this.transaction.commit();
+		}, params?.label);
+		return value === undefined
+			? { success: true }
+			: { success: true, value: value as TSuccessValue };
+	}
+
+	// #endregion TreeBranchAlpha
+
 	// Revision is the revision of the commit, if any, which caused this change.
-	private applyChange(change: SharedTreeChange, revision?: RevisionTag): void {
+	private applyInternalChange(change: SharedTreeChange, revision?: RevisionTag): void {
 		// Conflicts due to schema will be empty and thus are not applied.
 		for (const innerChange of change.changes) {
 			if (innerChange.type === "data") {
@@ -1040,11 +1233,12 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		this.registerForBranchEvents();
 
 		// TODO: Rework eventing
-		this.applyChange(diff);
+		this.applyInternalChange(diff);
 		this.#events.emit("afterBatch");
 	}
 
-	public rebase(checkout: TreeCheckout): void {
+	private rebase(branch: TreeBranch): void {
+		const checkout = getCheckout(branch);
 		this.checkNotDisposed(
 			"The target of the branch rebase has been disposed and cannot be rebased.",
 		);
@@ -1070,16 +1264,17 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		checkout.#transaction.activeBranch.rebaseOnto(this.#transaction.activeBranch);
 	}
 
-	public rebaseOnto(checkout: ITreeCheckout): void {
+	public rebaseOnto(branch: TreeBranch): void {
 		this.checkNotDisposed(
 			"The target of the branch rebase has been disposed and cannot be rebased.",
 		);
-		checkout.rebase(this);
+		getCheckout(branch).rebase(this);
 	}
 
-	public merge(checkout: TreeCheckout): void;
-	public merge(checkout: TreeCheckout, disposeMerged: boolean): void;
-	public merge(checkout: TreeCheckout, disposeMerged = true): void {
+	public merge(branch: TreeBranch): void;
+	public merge(branch: TreeBranch, disposeMerged: boolean): void;
+	public merge(branch: TreeBranch, disposeMerged = true): void {
+		const checkout = getCheckout(branch);
 		this.checkNotDisposed(
 			"The target of the branch merge has been disposed and cannot be merged.",
 		);

--- a/packages/dds/tree/src/shared-tree/unhydratedTreeContext.ts
+++ b/packages/dds/tree/src/shared-tree/unhydratedTreeContext.ts
@@ -14,7 +14,7 @@ import type {
 	WithValue,
 } from "../simple-tree/index.js";
 
-import { assertValidConstraint } from "./schematizingTreeView.js";
+import { assertValidConstraint } from "./treeCheckout.js";
 
 /**
  * A {@link TreeContextAlpha | tree context} that can be used for e.g. unhydrated nodes.

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -25,7 +25,6 @@ import {
 } from "../../feature-libraries/index.js";
 import type {
 	ITreeCheckout,
-	ITreeCheckoutFork,
 	CheckoutEvents,
 	ISharedTreeEditor,
 } from "../../shared-tree/index.js";
@@ -174,19 +173,41 @@ describe("schematizeTree", () => {
 	function mockCheckout(InputSchema: ImplicitFieldSchema, isEmpty: boolean): ITreeCheckout {
 		const storedSchema = new TreeStoredSchemaRepository(toInitialSchema(InputSchema));
 		const checkout: ITreeCheckout = {
+			disposed: false,
 			breaker: new Breakable("mockCheckout"),
 			storedSchema,
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			forest: { isEmpty } as IForestSubscription,
 			editor: undefined as unknown as ISharedTreeEditor,
 			transaction: undefined as unknown as Transactor,
-			branch(): ITreeCheckoutFork {
+			branch(): ITreeCheckout {
 				throw new Error("Function not implemented.");
 			},
-			merge(view: ITreeCheckoutFork): void {
+			fork(): ITreeCheckout {
 				throw new Error("Function not implemented.");
 			},
-			rebase(view: ITreeCheckoutFork): void {
+			isBranch(): boolean {
+				return true;
+			},
+			hasRootSchema(): boolean {
+				return false;
+			},
+			runTransaction(): never {
+				throw new Error("Function not implemented.");
+			},
+			runTransactionAsync(): never {
+				throw new Error("Function not implemented.");
+			},
+			applyChange(): void {
+				throw new Error("Function not implemented.");
+			},
+			merge(): void {
+				throw new Error("Function not implemented.");
+			},
+			rebaseOnto(): void {
+				throw new Error("Function not implemented.");
+			},
+			dispose(): void {
 				throw new Error("Function not implemented.");
 			},
 			updateSchema(newSchema: TreeStoredSchema): void {

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -27,7 +27,6 @@ import {
 	Tree,
 	TreeCheckout,
 	type ITreeCheckout,
-	type ITreeCheckoutFork,
 	type BranchableTree,
 	createTreeCheckout,
 	type SharedTreeChange,
@@ -1040,7 +1039,7 @@ describe("sharedTreeView", () => {
 			expectSchemaEqual(toUpgradeSchema(schema3), view3.checkout.storedSchema);
 
 			// Rebase view3 onto view2.
-			(view3.checkout as ITreeCheckoutFork).rebaseOnto(view2.checkout);
+			view3.checkout.rebaseOnto(view2.checkout);
 
 			// All changes on view3 should be dropped but the schema change and edit in view2 should be preserved.
 			expectSchemaEqual(toUpgradeSchema(schema2), view2.checkout.storedSchema);

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -165,7 +165,6 @@ import {
 	type TreeCheckout,
 	createTreeCheckout,
 	type ISharedTreeEditor,
-	type ITreeCheckoutFork,
 	independentView,
 	SchematizingSimpleTreeView,
 	type ForestOptions,
@@ -180,6 +179,7 @@ import {
 	type TreeViewConfiguration,
 	SchemaFactory,
 	type TreeView,
+	type TreeBranchAlpha,
 	type TreeBranchEvents,
 	type ITree,
 	type UnsafeUnknownSchema,
@@ -191,6 +191,7 @@ import {
 	toInitialSchema,
 	toStoredSchema,
 	type SnapshotFileSystem,
+	type TreeViewAlpha,
 } from "../simple-tree/index.js";
 import {
 	configuredSharedTree,
@@ -1468,14 +1469,36 @@ export class MockTreeCheckout implements ITreeCheckout {
 		throw new Error("'rootEvents' property not implemented in MockTreeCheckout.");
 	}
 
-	public branch(): ITreeCheckoutFork {
+	public disposed = false;
+	public branch(): ITreeCheckout {
+		throw new Error("Method 'branch' not implemented in MockTreeCheckout.");
+	}
+	public fork(): TreeBranchAlpha {
 		throw new Error("Method 'fork' not implemented in MockTreeCheckout.");
+	}
+	public isBranch(): this is TreeBranchAlpha {
+		throw new Error("Method 'isBranch' not implemented in MockTreeCheckout.");
+	}
+	public hasRootSchema<TSchema extends ImplicitFieldSchema>(): this is TreeViewAlpha<TSchema> {
+		throw new Error("Method 'hasRootSchema' not implemented in MockTreeCheckout.");
+	}
+	public runTransaction(): never {
+		throw new Error("Method 'runTransaction' not implemented in MockTreeCheckout.");
+	}
+	public runTransactionAsync(): never {
+		throw new Error("Method 'runTransactionAsync' not implemented in MockTreeCheckout.");
+	}
+	public applyChange(): void {
+		throw new Error("Method 'applyChange' not implemented in MockTreeCheckout.");
 	}
 	public merge(view: unknown, disposeView?: unknown): void {
 		throw new Error("Method 'merge' not implemented in MockTreeCheckout.");
 	}
-	public rebase(view: ITreeCheckoutFork): void {
-		throw new Error("Method 'rebase' not implemented in MockTreeCheckout.");
+	public rebaseOnto(branch: unknown): void {
+		throw new Error("Method 'rebaseOnto' not implemented in MockTreeCheckout.");
+	}
+	public dispose(): void {
+		throw new Error("Method 'dispose' not implemented in MockTreeCheckout.");
 	}
 	public updateSchema(newSchema: TreeStoredSchema): void {
 		throw new Error("Method 'updateSchema' not implemented in MockTreeCheckout.");


### PR DESCRIPTION
This continues preparation for branches (as distinct from views) to be exposed as a user-facing API in the future.

* Checkout - which be exposed as the "branch" object to the user - now implements `TreeBranchAlpha` accordingly.
  * This was a fairly straightforward refactor since most functionality was already there in almost the right shape, but `runTransaction` and associated functions were moved into checkout (the view simply delegates to it now). Most of the code changes in this PR are simply the result of moving that.
  * The delegation of `merge` and `rebase`/`rebaseOnto` in the view code was simplified so that `getCheckout` now only lives in the treeCheckout.ts module.
  * All internal code uses `rebaseOnto` rather than `rebase`, which is now private.
  * Some minor renames (e.g. applyChange -> applyInternalChange) to avoid name collisions
* ITreeCheckoutFork was removed for simplicity.
* Checkout mocks were updated to "implement" `TreeBranchAlpha`