### PR TITLE
feat(devcontainer): add agency installation and update CPU allocation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get -y install --no-install-recommends \
+        bubblewrap \
         fd-find \
         jq \
         sqlite3 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,11 +38,12 @@ RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/c
 
 ARG INSTALL_AGENCY=false
 RUN if [ "$INSTALL_AGENCY" = "true" ]; then \
-        curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency; \
+        su node -c 'export HOME=/home/node; curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency'; \
     fi
 
 # Add agency to PATH for all shells; use POSIX case syntax to avoid duplicate entries.
 # /etc/profile.d/ covers bash/sh login shells; /etc/zsh/zshenv covers zsh (all invocation types).
+# Also hook into bash interactive shells via /etc/bash/bashrc.d or /etc/bash.bashrc as a fallback.
 RUN printf '%s\n' \
     'case ":${PATH}:" in' \
     '    *":$HOME/.config/agency/CurrentVersion:"*) ;;' \
@@ -51,6 +52,13 @@ RUN printf '%s\n' \
     > /etc/profile.d/agency.sh \
     && chmod +x /etc/profile.d/agency.sh \
     && mkdir -p /etc/zsh \
-    && cp /etc/profile.d/agency.sh /etc/zsh/zshenv
+    && cp /etc/profile.d/agency.sh /etc/zsh/zshenv \
+    && if [ -d /etc/bash/bashrc.d ]; then \
+           cp /etc/profile.d/agency.sh /etc/bash/bashrc.d/agency.sh; \
+       elif [ -f /etc/bash.bashrc ]; then \
+           if ! grep -q 'agency/CurrentVersion' /etc/bash.bashrc; then \
+               { printf '\n# Add agency to PATH if installed\n'; cat /etc/profile.d/agency.sh; } >> /etc/bash.bashrc; \
+           fi; \
+       fi
 
 USER node

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,4 +36,21 @@ RUN apt-get autoremove -y \
 ARG INSTALL_PLAYWRIGHT_CLI=false
 RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
 
+ARG INSTALL_AGENCY=false
+RUN if [ "$INSTALL_AGENCY" = "true" ]; then \
+        curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency; \
+    fi
+
+# Add agency to PATH for all shells; use POSIX case syntax to avoid duplicate entries.
+# /etc/profile.d/ covers bash/sh login shells; /etc/zsh/zshenv covers zsh (all invocation types).
+RUN printf '%s\n' \
+    'case ":${PATH}:" in' \
+    '    *":$HOME/.config/agency/CurrentVersion:"*) ;;' \
+    '    *) export PATH="$HOME/.config/agency/CurrentVersion:${PATH}" ;;' \
+    'esac' \
+    > /etc/profile.d/agency.sh \
+    && chmod +x /etc/profile.d/agency.sh \
+    && mkdir -p /etc/zsh \
+    && cp /etc/profile.d/agency.sh /etc/zsh/zshenv
+
 USER node

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -37,7 +37,7 @@
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
 	// can be lengthy enough that it's convenient.
 	"hostRequirements": {
-		"cpus": 16,
+		"cpus": 32,
 		"memory": "64gb"
 	}
 }

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -5,6 +5,7 @@
 		"dockerfile": "../Dockerfile",
 		"args": {
 			"NODE_VERSION": "24",
+			"INSTALL_AGENCY": "true",
 			"INSTALL_PLAYWRIGHT_CLI": "true"
 		}
 	},


### PR DESCRIPTION
## Summary

- Installs `bubblewrap` (`bwrap`) in the devcontainer base image, which is a dependency for sandboxed execution environments.
- Adds an optional `INSTALL_AGENCY` build arg to install the [agency](https://aka.ms/InstallTool.sh) CLI tool, with PATH configuration for both bash and zsh shells.
- Increases the ai-agent devcontainer CPU requirement from 16 to 32 cores.