### PR TITLE
feat(devcontainer): add agency installation and update host requirements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,24 +33,31 @@ RUN apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Optionally configure agency PATH for all shells (must run as root, before USER node).
-# /etc/profile.d/ covers bash/sh login shells; /etc/zsh/zshenv covers zsh (all invocation types).
-# Also hook into bash interactive shells via /etc/bash/bashrc.d or /etc/bash.bashrc as a fallback.
-# Use POSIX case syntax to avoid duplicate PATH entries.
+# /etc/profile.d/ covers bash/sh login shells; /etc/zsh/zshrc.d or /etc/zsh/zshrc covers
+# interactive zsh shells; /etc/bash/bashrc.d or /etc/bash.bashrc covers interactive bash shells.
+# The -d guard ensures PATH is only modified when agency is actually installed.
 ARG INSTALL_AGENCY=false
 RUN if [ "$INSTALL_AGENCY" = "true" ]; then printf '%s\n' \
-    'case ":${PATH}:" in' \
-    '    *":$HOME/.config/agency/CurrentVersion:"*) ;;' \
-    '    *) export PATH="$HOME/.config/agency/CurrentVersion:${PATH}" ;;' \
-    'esac' \
+    'if [ -d "$HOME/.config/agency/CurrentVersion" ]; then' \
+    '    case ":${PATH}:" in' \
+    '        *":$HOME/.config/agency/CurrentVersion:"*) ;;' \
+    '        *) export PATH="$HOME/.config/agency/CurrentVersion:${PATH}" ;;' \
+    '    esac' \
+    'fi' \
     > /etc/profile.d/agency.sh \
     && chmod +x /etc/profile.d/agency.sh \
-    && mkdir -p /etc/zsh \
-    && cp /etc/profile.d/agency.sh /etc/zsh/zshenv \
     && if [ -d /etc/bash/bashrc.d ]; then \
            cp /etc/profile.d/agency.sh /etc/bash/bashrc.d/agency.sh; \
        elif [ -f /etc/bash.bashrc ]; then \
            if ! grep -q 'agency/CurrentVersion' /etc/bash.bashrc; then \
                { printf '\n# Add agency to PATH if installed\n'; cat /etc/profile.d/agency.sh; } >> /etc/bash.bashrc; \
+           fi; \
+       fi \
+    && if [ -d /etc/zsh/zshrc.d ]; then \
+           cp /etc/profile.d/agency.sh /etc/zsh/zshrc.d/agency.sh; \
+       elif [ -f /etc/zsh/zshrc ]; then \
+           if ! grep -q 'agency/CurrentVersion' /etc/zsh/zshrc; then \
+               { printf '\n'; cat /etc/profile.d/agency.sh; } >> /etc/zsh/zshrc; \
            fi; \
        fi; \
     fi
@@ -65,8 +72,7 @@ ARG INSTALL_PLAYWRIGHT_CLI=false
 RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
 
 # Optionally install agency (installs to $HOME/.config/agency, must run as node user)
-ARG INSTALL_AGENCY
-RUN if [ "$INSTALL_AGENCY" = "true" ]; then curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency; fi
+RUN if [ "$INSTALL_AGENCY" = "true" ]; then curl --proto '=https' --tlsv1.2 -fsSL https://aka.ms/InstallTool.sh | sh -s agency; fi
 
 # Optionally install repoverlay
 ARG INSTALL_REPOVERLAY=false

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,31 @@ RUN apt-get autoremove -y \
 ARG INSTALL_PLAYWRIGHT_CLI=false
 RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
 
+ARG INSTALL_AGENCY=false
+RUN if [ "$INSTALL_AGENCY" = "true" ]; then \
+        su node -c 'export HOME=/home/node; curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency'; \
+    fi
+
+# Add agency to PATH for all shells; use POSIX case syntax to avoid duplicate entries.
+# /etc/profile.d/ covers bash/sh login shells; /etc/zsh/zshenv covers zsh (all invocation types).
+# Also hook into bash interactive shells via /etc/bash/bashrc.d or /etc/bash.bashrc as a fallback.
+RUN printf '%s\n' \
+    'case ":${PATH}:" in' \
+    '    *":$HOME/.config/agency/CurrentVersion:"*) ;;' \
+    '    *) export PATH="$HOME/.config/agency/CurrentVersion:${PATH}" ;;' \
+    'esac' \
+    > /etc/profile.d/agency.sh \
+    && chmod +x /etc/profile.d/agency.sh \
+    && mkdir -p /etc/zsh \
+    && cp /etc/profile.d/agency.sh /etc/zsh/zshenv \
+    && if [ -d /etc/bash/bashrc.d ]; then \
+           cp /etc/profile.d/agency.sh /etc/bash/bashrc.d/agency.sh; \
+       elif [ -f /etc/bash.bashrc ]; then \
+           if ! grep -q 'agency/CurrentVersion' /etc/bash.bashrc; then \
+               { printf '\n# Add agency to PATH if installed\n'; cat /etc/profile.d/agency.sh; } >> /etc/bash.bashrc; \
+           fi; \
+       fi
+
 USER node
 
 # Ensure user-local install paths are on PATH for tools installed below

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,19 +32,12 @@ RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Optionally install Playwright CLI for AI agent workflows
-ARG INSTALL_PLAYWRIGHT_CLI=false
-RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
-
-ARG INSTALL_AGENCY=false
-RUN if [ "$INSTALL_AGENCY" = "true" ]; then \
-        su node -c 'export HOME=/home/node; curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency'; \
-    fi
-
-# Add agency to PATH for all shells; use POSIX case syntax to avoid duplicate entries.
+# Optionally configure agency PATH for all shells (must run as root, before USER node).
 # /etc/profile.d/ covers bash/sh login shells; /etc/zsh/zshenv covers zsh (all invocation types).
 # Also hook into bash interactive shells via /etc/bash/bashrc.d or /etc/bash.bashrc as a fallback.
-RUN printf '%s\n' \
+# Use POSIX case syntax to avoid duplicate PATH entries.
+ARG INSTALL_AGENCY=false
+RUN if [ "$INSTALL_AGENCY" = "true" ]; then printf '%s\n' \
     'case ":${PATH}:" in' \
     '    *":$HOME/.config/agency/CurrentVersion:"*) ;;' \
     '    *) export PATH="$HOME/.config/agency/CurrentVersion:${PATH}" ;;' \
@@ -59,15 +52,20 @@ RUN printf '%s\n' \
            if ! grep -q 'agency/CurrentVersion' /etc/bash.bashrc; then \
                { printf '\n# Add agency to PATH if installed\n'; cat /etc/profile.d/agency.sh; } >> /etc/bash.bashrc; \
            fi; \
-       fi
+       fi; \
+    fi
 
 USER node
 
 # Ensure user-local install paths are on PATH for tools installed below
 ENV PATH="/home/node/.local/bin:/home/node/.cargo/bin:${PATH}"
 
-# Optionally install agency for AI agent workflows
-ARG INSTALL_AGENCY=false
+# Optionally install Playwright CLI
+ARG INSTALL_PLAYWRIGHT_CLI=false
+RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
+
+# Optionally install agency (installs to $HOME/.config/agency, must run as node user)
+ARG INSTALL_AGENCY
 RUN if [ "$INSTALL_AGENCY" = "true" ]; then curl -sSfL https://aka.ms/InstallTool.sh | sh -s agency; fi
 
 # Optionally install repoverlay

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -51,7 +51,7 @@
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
 	// can be lengthy enough that it's convenient.
 	"hostRequirements": {
-		"cpus": 16,
+		"cpus": 32,
 		"memory": "64gb"
 	}
 }


### PR DESCRIPTION
- Add `INSTALL_AGENCY` build arg to optionally install the Agency tool (runs as `node` user via `curl | sh`)
- Configure system-wide shell init hooks (`/etc/profile.d/`, `/etc/bash/bashrc.d/`, `/etc/zsh/zshrc.d/`) to add Agency to `PATH`, guarded by a `-d` check so PATH is only modified when Agency is actually installed
- Use strict curl transport flags (`--proto '=https' --tlsv1.2`) for the Agency installer, matching the existing repoverlay pattern
- Bump AI-agent Codespaces host CPU requirement from 16 to 32 cores