### PR TITLE
build(client): build:compile:esm:packages - fast production ESM build

### DIFF
--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -64,20 +64,6 @@
 			}
 		}
 	},
-	"fluidBuild": {
-		"tasks": {
-			"eslint": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"@fluid-example/multiview-slider-coordinate-view#build:esnext",
-				"^tsc"
-			],
-			"build:esnext": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"@fluid-example/multiview-slider-coordinate-view#build:esnext",
-				"^tsc"
-			]
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -63,18 +63,6 @@
 			}
 		}
 	},
-	"fluidBuild": {
-		"tasks": {
-			"eslint": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"^tsc"
-			],
-			"build:esnext": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"^tsc"
-			]
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -63,18 +63,6 @@
 			}
 		}
 	},
-	"fluidBuild": {
-		"tasks": {
-			"eslint": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"^tsc"
-			],
-			"build:esnext": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"^tsc"
-			]
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -63,18 +63,6 @@
 			}
 		}
 	},
-	"fluidBuild": {
-		"tasks": {
-			"eslint": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"^tsc"
-			],
-			"build:esnext": [
-				"@fluid-example/multiview-coordinate-interface#build:esnext",
-				"^tsc"
-			]
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -138,10 +138,15 @@
 	"fluidBuild": {
 		"_tasksComment1": "webpack-fluid-loader injects a script tag pointing at its own bundle (/code/fluid-loader.bundle.js) into the page. This bundle must remain up to date for webpack-fluid-loader users.",
 		"_tasksComment2": "Using build:esnext over something like compile guarantees that this happens, since the build:esnext target depends on all transitive dependencies' build:esnext targets.",
+		"_tasksComment3": "The webpack task is then set to depend on ^build:esnext overriding default that also include ^tsc",
 		"tasks": {
 			"build:esnext": [
 				"...",
 				"webpack"
+			],
+			"webpack": [
+				"^api-extractor:esnext",
+				"^build:esnext"
 			]
 		}
 	},

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -10,6 +10,12 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
+	"exports": {
+		".": {
+			"import": "./lib/index.js",
+			"require": "./dist/index.js"
+		}
+	},
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",

--- a/experimental/PropertyDDS/packages/property-dds/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.base.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"downlevelIteration": true,
@@ -11,6 +11,9 @@
 		"types": ["node"],
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
+		// Use "bundler" module resolution to allow for property-properties package.
+		"module": "esnext",
+		"moduleResolution": "bundler",
 	},
 	"include": ["src/**/*"],
 }

--- a/experimental/PropertyDDS/packages/property-properties/tsconfig.esnext.json
+++ b/experimental/PropertyDDS/packages/property-properties/tsconfig.esnext.json
@@ -3,5 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./lib",
 		"module": "esnext",
+		// bundler is required to allow resolution of property-changeset along ESM lines.
+		"moduleResolution": "bundler",
 	},
 }

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -64,6 +64,13 @@ module.exports = {
 			dependsOn: ["commonjs", "build:esnext", "api", "build:test", "build:copy"],
 			script: false,
 		},
+		"compile:esm:packages": {
+			// Note that "api-extractor:esnext" is included as "compile" intends
+			// to build complete packages and "api-extractor:esnext" currently
+			// generates package entrypoint files.
+			dependsOn: ["build:esnext", "api-extractor:esnext", "build:copy"],
+			script: false,
+		},
 		"commonjs": {
 			dependsOn: ["tsc", "build:test"],
 			script: false,
@@ -162,8 +169,8 @@ module.exports = {
 		// TODO: ensure webpack dependencies are correct and minimal, ideally just depending
 		// on "^api-extractor:esnext", "^build:esnext". Or distribute these setting to the
 		// individual packages that need them instead of having poor config in the root config.
-		"webpack": ["^api", "^tsc", "^build:esnext"],
-		"webpack:profile": ["^api", "^tsc", "^build:esnext"],
+		"webpack": ["^api-extractor:esnext", "^build:esnext"],
+		"webpack:profile": ["^api-extractor:esnext", "^build:esnext"],
 		"clean": {
 			before: ["*"],
 		},

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -87,7 +87,7 @@ module.exports = {
 		"ts2esm": [],
 		"tsc": tscDependsOn,
 		"place:cjs:package-stub": [], // no cross-package deps needed (without definition default is [^*])
-		"build:esnext": [...tscDependsOn, "^build:esnext"],
+		"build:esnext": ["^build:esnext", "^api-extractor:esnext", "build:genver"],
 		// Generic build:test script should be replaced by :esm or :cjs specific versions.
 		// "tsc" would be nice to eliminate from here, but plenty of packages still focus
 		// on CommonJS.
@@ -159,8 +159,11 @@ module.exports = {
 		"format:prettier": [],
 		"prettier": [],
 		"prettier:fix": [],
-		"webpack": ["^tsc", "^build:esnext"],
-		"webpack:profile": ["^tsc", "^build:esnext"],
+		// TODO: ensure webpack dependencies are correct and minimal, ideally just depending
+		// on "^api-extractor:esnext", "^build:esnext". Or distribute these setting to the
+		// individual packages that need them instead of having poor config in the root config.
+		"webpack": ["^api", "^tsc", "^build:esnext"],
+		"webpack:profile": ["^api", "^tsc", "^build:esnext"],
 		"clean": {
 			before: ["*"],
 		},

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"build-and-test:unit:esm": "fluid-build --task test:unit:esm --worker",
 		"build:api": "fluid-build --task build:api",
 		"build:compile": "fluid-build --task compile",
+		"build:compile:esm:packages": "fluid-build --task compile:esm:packages --worker",
 		"build:docs": "fluid-build --task build:docs",
 		"build:eslint": "fluid-build --task eslint",
 		"build:fast": "fluid-build --task build --worker",

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -124,16 +124,8 @@
 	},
 	"fluidBuild": {
 		"tasks": {
-			"build:esnext": [
-				"^api",
-				"^build:esnext"
-			],
 			"eslint": [
 				"api-extractor:esnext"
-			],
-			"tsc": [
-				"^api",
-				"^tsc"
 			]
 		}
 	},


### PR DESCRIPTION
`pnpm build:compile:esm:packages` will do a minimal ESM only package build.

Can be used to check validity of production code without hitting test collateral (except for a few test-oriented packages).

`build:esnext` tasks (`fluid-build --task build:esnext`) are able to complete without needing to build CommonJS with these changes:
  1. Remove extraneous `^tsc` dependencies in examples.
  2. Reduce general `build:esnext` to not depend on `^tsc` and `^api`.
  3. Reduce presence `^api` dependencies to `^api-extractor:esnext` and `^api-extractor:commonjs`.
  4. PropertyDDS packages configured to use bundler resolution (less strict Node16 resolution) and have exports defined in property-common. Previously `property-properties` would build using CommonJS `property-changeset`.

Note general `tsc` dependency is left to depend on `^api` and `^build:esnext`.