### PR TITLE
Remove DisableFlushBeforeProcess feature flag

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1532,13 +1532,6 @@ export class ContainerRuntime
 		return runtimeCompatDetailsForLoader;
 	}
 
-	/**
-	 * If true, will skip Outbox flushing before processing an incoming message (and on DeltaManager "op" event for loader back-compat),
-	 * and instead the Outbox will check for a split batch on every submit.
-	 * This is a kill-bit switch for this simplification of logic, in case it causes unexpected issues.
-	 */
-	private readonly skipSafetyFlushDuringProcessStack: boolean;
-
 	private readonly extensions = new Map<ContainerExtensionId, ExtensionEntry>();
 
 	/***/
@@ -1988,10 +1981,6 @@ export class ContainerRuntime
 
 		const legacySendBatchFn = makeLegacySendBatchFn(submitFn, this.innerDeltaManager);
 
-		this.skipSafetyFlushDuringProcessStack =
-			// Keep the old flag name even though we renamed the class member (it shipped in 2.31.0)
-			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableFlushBeforeProcess") === true;
-
 		this.outbox = new Outbox({
 			shouldSend: () => this.shouldSendOps(),
 			pendingStateManager: this.pendingStateManager,
@@ -2002,8 +1991,6 @@ export class ContainerRuntime
 			config: {
 				compressionOptions,
 				maxBatchSizeInBytes: runtimeOptions.maxBatchSizeInBytes,
-				// If we disable flush before process, we must be ready to flush partial batches
-				flushPartialBatches: this.skipSafetyFlushDuringProcessStack,
 			},
 			logger: this.mc.logger,
 			groupingManager: opGroupingManager,
@@ -2060,14 +2047,12 @@ export class ContainerRuntime
 		this.lastEmittedDirty = this.computeCurrentDirtyState();
 		context.updateDirtyContainerState(this.lastEmittedDirty);
 
-		if (!this.skipSafetyFlushDuringProcessStack) {
-			// Reference Sequence Number may have just changed, and it must be consistent across a batch,
-			// so we should flush now to clear the way for the next ops.
-			// NOTE: This will be redundant whenever CR.process was called for the op (since we flush there too) -
-			// But we need this coverage for old loaders that don't call ContainerRuntime.process for non-runtime messages.
-			// (We have to call flush _before_ processing a runtime op, but after is ok for non-runtime op)
-			this.deltaManager.on("op", () => this.flush());
-		}
+		// Reference Sequence Number may have just changed, and it must be consistent across a batch,
+		// so we should flush now to clear the way for the next ops.
+		// NOTE: This will be redundant whenever CR.process was called for the op (since we flush there too) -
+		// But we need this coverage for old loaders that don't call ContainerRuntime.process for non-runtime messages.
+		// (We have to call flush _before_ processing a runtime op, but after is ok for non-runtime op)
+		this.deltaManager.on("op", () => this.flush());
 
 		// logging hardware telemetry
 		this.baseLogger.send({
@@ -2093,7 +2078,6 @@ export class ContainerRuntime
 			featureGates: JSON.stringify({
 				...featureGatesForTelemetry,
 				closeSummarizerDelayOverride,
-				disableFlushBeforeProcess: this.skipSafetyFlushDuringProcessStack,
 			}),
 			telemetryDocumentId: this.telemetryDocumentId,
 			groupedBatchingEnabled: this.groupedBatchingEnabled,
@@ -3015,10 +2999,8 @@ export class ContainerRuntime
 
 		this.verifyNotClosed();
 
-		if (!this.skipSafetyFlushDuringProcessStack) {
-			// Reference Sequence Number may be about to change, and it must be consistent across a batch, so flush now
-			this.flush();
-		}
+		// Reference Sequence Number may be about to change, and it must be consistent across a batch, so flush now
+		this.flush();
 
 		this.ensureNoDataModelChanges(() => {
 			this.processInboundMessageOrBatch(messageCopy, local);

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -48,12 +48,6 @@ export interface IOutboxConfig {
 	 * The maximum size of a batch that we can send over the wire.
 	 */
 	readonly maxBatchSizeInBytes: number;
-	/**
-	 * If true, maybeFlushPartialBatch will flush the batch if the reference sequence number changed
-	 * since the batch started. Otherwise, it will throw in this case (apart from reentrancy which is handled elsewhere).
-	 * Once the new throw-based flow is proved in a production environment, this option will be removed.
-	 */
-	readonly flushPartialBatches: boolean;
 }
 
 export interface IOutboxParameters {
@@ -295,10 +289,7 @@ export class Outbox {
 			this.logger.sendTelemetryEvent(
 				{
 					// Only log error if this is truly unexpected
-					category:
-						expectedDueToReentrancy || this.params.config.flushPartialBatches
-							? "generic"
-							: "error",
+					category: expectedDueToReentrancy ? "generic" : "error",
 					eventName: "ReferenceSequenceNumberMismatch",
 					details: {
 						expectedDueToReentrancy,
@@ -312,12 +303,6 @@ export class Outbox {
 				},
 				errorWrapper.value,
 			);
-		}
-
-		// If we're configured to flush partial batches, do that now and return (don't throw)
-		if (this.params.config.flushPartialBatches) {
-			this.flushAll();
-			return;
 		}
 
 		// If we are in a reentrant context, we know this can happen without causing any harm.

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -552,88 +552,71 @@ describe("Runtime", () => {
 
 			// NOTE: This test is examining a case that only occurs with an old Loader that doesn't tell ContainerRuntime when processing system ops.
 			// In other words, when the MockDeltaManager bumps its lastSequenceNumber, ContainerRuntime.process would be called in the current code, but not with legacy loader.
-			for (const skipSafetyFlushDuringProcessStack of [true, undefined]) {
-				it(`Inbound (non-runtime) op triggers flush due to refSeq changing [skipSafetyFlush=${skipSafetyFlushDuringProcessStack}]`, async () => {
-					const submittedBatches: {
-						messages: IBatchMessage[];
-						referenceSequenceNumber: number;
-					}[] = [];
+			it("Inbound (non-runtime) op triggers flush due to refSeq changing", async () => {
+				const submittedBatches: {
+					messages: IBatchMessage[];
+					referenceSequenceNumber: number;
+				}[] = [];
 
-					const mockContext = getMockContext({
-						settings: {
-							"Fluid.ContainerRuntime.DisableFlushBeforeProcess":
-								skipSafetyFlushDuringProcessStack,
-						},
-					});
-					(
-						mockContext as { submitBatchFn: IContainerContext["submitBatchFn"] }
-					).submitBatchFn = (
-						messages: IBatchMessage[],
-						referenceSequenceNumber: number = -1,
-					) => {
+				const mockContext = getMockContext();
+				(mockContext as { submitBatchFn: IContainerContext["submitBatchFn"] }).submitBatchFn =
+					(messages: IBatchMessage[], referenceSequenceNumber: number = -1) => {
 						submittedOps.push(...messages); // Reusing submittedOps since submitFn won't be invoked due to submitBatchFn's presence
 						submittedBatches.push({ messages, referenceSequenceNumber });
 						return 999; // CSN not used in test asserts below
 					};
 
-					const containerRuntime = await ContainerRuntime.loadRuntime2({
-						context: mockContext as IContainerContext,
-						registry: new FluidDataStoreRegistry([]),
-						existing: false,
-						runtimeOptions: {},
-						provideEntryPoint: mockProvideEntryPoint,
-					});
-
-					// Submit the first message
-					submitDataStoreOp(containerRuntime, "1", testDataStoreMessage);
-					assert.strictEqual(submittedOps.length, 0, "No ops submitted yet");
-
-					// Bump lastSequenceNumber and trigger the "op" event artificially to simulate processing a non-runtime op
-					// When [skipSafetyFlushDuringProcessStack: FALSE], this will trigger a flush, which allows us to safely submit more ops next
-					const mockDeltaManager = mockContext.deltaManager as MockDeltaManager;
-					++mockDeltaManager.lastSequenceNumber;
-					mockDeltaManager.emit("op", {
-						clientId: mockClientId,
-						sequenceNumber: mockDeltaManager.lastSequenceNumber,
-						clientSequenceNumber: 1,
-						type: MessageType.ClientJoin,
-						contents: "test content",
-					});
-
-					const expectedSubmitCount = skipSafetyFlushDuringProcessStack === true ? 0 : 1;
-					assert.equal(
-						submittedOps.length,
-						expectedSubmitCount,
-						"Submitted op count wrong after first op",
-					);
-
-					// Submit the second message
-					// When [skipSafetyFlushDuringProcessStack: TRUE], this will trigger a flush via Outbox.maybeFlushPartialBatch
-					submitDataStoreOp(containerRuntime, "2", {
-						type: "op",
-						content: { address: "test-address", contents: "test-contents2" },
-					});
-					assert.equal(
-						submittedOps.length,
-						1,
-						"By now we expect the first op to have been submitted in both configurations",
-					);
-
-					// Wait for the next tick for the second message to be flushed
-					await Promise.resolve();
-
-					// Validate that the messages were submitted
-					assert.equal(submittedOps.length, 2, "Two messages should be submitted");
-					assert.deepEqual(
-						submittedBatches,
-						[
-							{ messages: [submittedOps[0]], referenceSequenceNumber: 0 }, // The first op
-							{ messages: [submittedOps[1]], referenceSequenceNumber: 1 }, // The second op
-						],
-						"Two batches should be submitted with different refSeq",
-					);
+				const containerRuntime = await ContainerRuntime.loadRuntime2({
+					context: mockContext as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: {},
+					provideEntryPoint: mockProvideEntryPoint,
 				});
-			}
+
+				// Submit the first message
+				submitDataStoreOp(containerRuntime, "1", testDataStoreMessage);
+				assert.strictEqual(submittedOps.length, 0, "No ops submitted yet");
+
+				// Bump lastSequenceNumber and trigger the "op" event artificially to simulate processing a non-runtime op
+				// This will trigger a flush, which allows us to safely submit more ops next
+				const mockDeltaManager = mockContext.deltaManager as MockDeltaManager;
+				++mockDeltaManager.lastSequenceNumber;
+				mockDeltaManager.emit("op", {
+					clientId: mockClientId,
+					sequenceNumber: mockDeltaManager.lastSequenceNumber,
+					clientSequenceNumber: 1,
+					type: MessageType.ClientJoin,
+					contents: "test content",
+				});
+
+				assert.equal(submittedOps.length, 1, "Submitted op count wrong after first op");
+
+				// Submit the second message
+				submitDataStoreOp(containerRuntime, "2", {
+					type: "op",
+					content: { address: "test-address", contents: "test-contents2" },
+				});
+				assert.equal(
+					submittedOps.length,
+					1,
+					"Second op not yet submitted (scheduled for next microtask)",
+				);
+
+				// Wait for the next tick for the second message to be flushed
+				await Promise.resolve();
+
+				// Validate that the messages were submitted
+				assert.equal(submittedOps.length, 2, "Two messages should be submitted");
+				assert.deepEqual(
+					submittedBatches,
+					[
+						{ messages: [submittedOps[0]], referenceSequenceNumber: 0 }, // The first op
+						{ messages: [submittedOps[1]], referenceSequenceNumber: 1 }, // The second op
+					],
+					"Two batches should be submitted with different refSeq",
+				);
+			});
 
 			it("IdAllocation op from replayPendingStates is flushed, preventing outboxSequenceNumberCoherencyCheck error", async () => {
 				// Start out disconnected since step 1 is to trigger ID Allocation op on reconnect
@@ -1826,7 +1809,6 @@ describe("Runtime", () => {
 				const featureGates = {
 					"Fluid.ContainerRuntime.IdCompressorEnabled": true,
 					"Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs": 1337,
-					"Fluid.ContainerRuntime.DisableFlushBeforeProcess": true,
 				};
 				await ContainerRuntime.loadRuntime2({
 					context: localGetMockContext(featureGates) as IContainerContext,
@@ -1844,7 +1826,6 @@ describe("Runtime", () => {
 						idCompressorMode: "on",
 						featureGates: JSON.stringify({
 							closeSummarizerDelayOverride: 1337,
-							disableFlushBeforeProcess: true,
 						}),
 						groupedBatchingEnabled: true,
 					},

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -48,11 +48,6 @@ import type {
 	IPendingMessage,
 } from "../../pendingStateManager.js";
 
-function typeFromBatchedOp(message: LocalBatchMessage): string {
-	assert(message.runtimeOp !== undefined, "PRECONDITION: runtimeOp is undefined");
-	return message.runtimeOp.type;
-}
-
 // Make a mock op with distinguishable contents
 function op(data: string): LocalContainerRuntimeMessage {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -243,7 +243,6 @@ describe("Outbox", () => {
 		chunkSizeInBytes?: number;
 		opGroupingConfig?: OpGroupingManagerConfig;
 		immediateMode?: boolean;
-		flushPartialBatches?: boolean;
 	}) => {
 		const { submitFn, submitBatchFn, deltaManager } = params.context;
 
@@ -262,7 +261,6 @@ describe("Outbox", () => {
 			config: {
 				maxBatchSizeInBytes: params.maxBatchSize ?? maxBatchSizeInBytes,
 				compressionOptions: params.compressionOptions ?? DefaultCompressionOptions,
-				flushPartialBatches: params.flushPartialBatches ?? false,
 			},
 			logger: mockLogger,
 			groupingManager: new OpGroupingManager(
@@ -856,147 +854,6 @@ describe("Outbox", () => {
 			() => outbox.submit(messages[1]),
 			"Since we incremented referenceSequenceNumber to 1, this should throw",
 		);
-	});
-
-	it("Splits the batch when an out of order message is detected (if partial flushing is enabled)", () => {
-		const outbox = getOutbox({
-			context: getMockContext(),
-			flushPartialBatches: true,
-		});
-		const messages = [
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-				referenceSequenceNumber: 1,
-			},
-		];
-
-		currentSeqNumbers.referenceSequenceNumber = 1;
-
-		outbox.submit(messages[0]);
-		outbox.submit(messages[1]);
-		outbox.flush();
-
-		assert.equal(state.opsSubmitted, messages.length);
-		assert.equal(state.individualOpsSubmitted.length, 0);
-		assert.equal(state.batchesSubmitted.length, 2);
-		assert.deepEqual(
-			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[0])], [toSubmittedMessage(messages[1])]],
-		);
-		assert.deepEqual(
-			state.batchesSubmitted.map((x) => x.referenceSequenceNumber),
-			[0, 1],
-		);
-		assert.equal(state.deltaManagerFlushCalls, 0);
-		const rawMessagesInFlushOrder = [messages[0], messages[1]];
-		assert.deepEqual(
-			state.pendingOpContents,
-			rawMessagesInFlushOrder.map((message, i) => ({
-				runtimeOp: message.runtimeOp,
-				referenceSequenceNumber: message.referenceSequenceNumber,
-				localOpMetadata: message.localOpMetadata,
-				opMetadata: message.metadata,
-				batchStartCsn: i + 1, // Each message should have been in its own batch. CSN starts at 1.
-			})),
-		);
-
-		mockLogger.assertMatch([
-			{
-				eventName: "Outbox:ReferenceSequenceNumberMismatch",
-			},
-		]);
-	});
-
-	for (const messages of [
-		[
-			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 1,
-			},
-		],
-		[
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
-				referenceSequenceNumber: 1,
-			},
-		],
-	] as LocalBatchMessage[][]) {
-		it("Flushes all batches when an out of order message is detected in either flow (if partial flushing is enabled)", () => {
-			const outbox = getOutbox({
-				context: getMockContext(),
-				flushPartialBatches: true,
-			});
-			for (const message of messages) {
-				currentSeqNumbers.referenceSequenceNumber = message.referenceSequenceNumber;
-				if (typeFromBatchedOp(message) === ContainerMessageType.IdAllocation) {
-					outbox.submitIdAllocation(message);
-				} else {
-					outbox.submit(message);
-				}
-			}
-
-			assert.equal(state.opsSubmitted, messages.length - 1);
-			assert.equal(state.individualOpsSubmitted.length, 0);
-			assert.equal(state.batchesSubmitted.length, 1);
-			assert.deepEqual(
-				state.batchesSubmitted.map((x) => x.messages),
-				[[toSubmittedMessage(messages[0]), toSubmittedMessage(messages[1])]],
-			);
-
-			mockLogger.assertMatch([
-				{
-					eventName: "Outbox:ReferenceSequenceNumberMismatch",
-				},
-			]);
-		});
-	}
-
-	it("Does not throw when an out of order message is detected (if partial flushing is enabled)", () => {
-		const outbox = getOutbox({
-			context: getMockContext(),
-			flushPartialBatches: true,
-		});
-		const messages: LocalBatchMessage[] = [
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-				referenceSequenceNumber: 1,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-				referenceSequenceNumber: 2,
-			},
-		];
-
-		assert.doesNotThrow(() => {
-			for (const message of messages) {
-				currentSeqNumbers.referenceSequenceNumber = message.referenceSequenceNumber;
-				outbox.submit(message);
-			}
-		}, "Shouldn't throw if partial flushing is enabled");
 	});
 
 	it("Log at most 3 reference sequence number mismatch events", () => {

--- a/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
@@ -161,18 +161,6 @@ describeCompat("Fewer batches", "NoCompat", (getTestObjectProvider, apis) => {
 	];
 
 	itExpects(
-		"Reference sequence number mismatch when doing op reentry submits two batches",
-		expectedErrors,
-		async () => {
-			// By default, we would flush a batch when we detect a reference sequence number mismatch
-			await processOutOfOrderOp({
-				["Fluid.ContainerRuntime.DisableFlushBeforeProcess"]: true,
-			});
-			assert.strictEqual(capturedBatches.length, 2);
-		},
-	);
-
-	itExpects(
 		"Op reentry submits two batches due to flush before processing",
 		expectedErrors,
 		async () => {


### PR DESCRIPTION
## Summary
- Remove the `Fluid.ContainerRuntime.DisableFlushBeforeProcess` kill-bit switch, hardcoding the default flush-before-process behavior
- Remove the `flushPartialBatches` config option from `IOutboxConfig` and the corresponding partial-batch flushing code path in `maybeFlushPartialBatch()`
- Remove the `skipSafetyFlushDuringProcessStack` member from `ContainerRuntime`
- Clean up related tests and telemetry

The flag has been in production long enough to confirm the throw-based flow is correct. Per the original code comment: "Once the new throw-based flow is proved in a production environment, this option will be removed."

Requested by @markfields in https://github.com/microsoft/FluidFramework/pull/26577#discussion_r2949126702

## Test plan
- [x] Existing tests pass (parameterized test simplified to only test the default behavior)
- [x] Tests for the removed `flushPartialBatches: true` code path are removed since the code path no longer exists
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)