### PR TITLE
Ensure a summarizer stop request is respected after connecting

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -102,6 +102,7 @@ export class SummaryManager
 	private latestClientId: string | undefined;
 	private state = SummaryManagerState.Off;
 	private summarizer?: ISummarizer;
+	private pendingStopReason?: SummarizerStopReason;
 	private _disposed = false;
 	private summarizerStopTimeout?: ReturnType<typeof setTimeout>;
 	/**
@@ -287,6 +288,13 @@ export class SummaryManager
 				this.summarizer = summarizer;
 				this.setupForwardedEvents(summarizer);
 
+				// A stop may have been requested while we were awaiting summarizer creation.
+				// Replay it now so the summarizer can observe the stop intent and move to exit.
+				if (this.pendingStopReason !== undefined) {
+					summarizer.stop(this.pendingStopReason);
+					this.pendingStopReason = undefined;
+				}
+
 				// Re-validate that it need to be running. Due to asynchrony, it may be not the case anymore
 				// If we can't run the LastSummary, simply return as to avoid paying the cost of launching
 				// the summarizer at all.
@@ -375,6 +383,7 @@ export class SummaryManager
 	private cleanupAfterSummarizerStop(): void {
 		this.summarizerGeneration++;
 		this.state = SummaryManagerState.Off;
+		this.pendingStopReason = undefined;
 
 		// Clear any pending stop timeout to avoid it firing for a different summarizer
 		if (this.summarizerStopTimeout !== undefined) {
@@ -396,6 +405,7 @@ export class SummaryManager
 			return;
 		}
 		this.state = SummaryManagerState.Stopping;
+		this.pendingStopReason = reason;
 
 		// Stopping the running summarizer client should trigger a change
 		// in states when the running summarizer closes
@@ -502,6 +512,7 @@ export class SummaryManager
 		this.connectedState.off("connected", this.handleConnected);
 		this.connectedState.off("disconnected", this.handleDisconnected);
 		this.cleanupForwardedEvents();
+		this.pendingStopReason = undefined;
 		if (this.summarizerStopTimeout !== undefined) {
 			clearTimeout(this.summarizerStopTimeout);
 		}

--- a/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
@@ -73,6 +73,8 @@ describe("Summary Manager", () => {
 	const mockRuntime = new MockRuntime(mockDeltaManager);
 	let summaryManager: SummaryManager;
 	let runningSummarizer: RunningSummarizer;
+	let testMinOpsForLastSummaryAttemptOverride: number | undefined;
+	let testMaxAckWaitTimeOverride: number | undefined;
 	// let runCount: number;
 	const summarizerClientId = "test";
 
@@ -135,6 +137,7 @@ describe("Summary Manager", () => {
 		public state: "notStarted" | "running" | "stopped" = "notStarted";
 		public readonly stopDeferred = new Deferred<string | undefined>();
 		public readonly runDeferred = new Deferred<void>();
+		public testStopReason: string | undefined;
 
 		constructor() {
 			super();
@@ -148,6 +151,7 @@ describe("Summary Manager", () => {
 		}
 		public close() {}
 		public stop(reason?: string): void {
+			this.testStopReason = reason;
 			this.stopDeferred.resolve(reason);
 		}
 		public async run(onBehalfOf: string): Promise<SummarizerStopReason> {
@@ -161,6 +165,12 @@ describe("Summary Manager", () => {
 					...{
 						initialSummarizerDelayMs: 0,
 					},
+					...(testMinOpsForLastSummaryAttemptOverride === undefined
+						? {}
+						: { minOpsForLastSummaryAttempt: testMinOpsForLastSummaryAttemptOverride }),
+					...(testMaxAckWaitTimeOverride === undefined
+						? {}
+						: { maxAckWaitTime: testMaxAckWaitTimeOverride }),
 				},
 				// submitSummaryCallback
 				async (options) => {
@@ -179,6 +189,11 @@ describe("Summary Manager", () => {
 				(reason) => {},
 				mockRuntime as unknown as ISummarizerRuntime,
 			);
+			runningSummarizer.on("summarize", (...args) => {
+				// Forward event
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+				this.emit("summarize" as any, ...args);
+			});
 			await Promise.all([this.stopDeferred.promise, this.runDeferred.promise]);
 			await runningSummarizer.waitStop(true);
 			this.state = "stopped";
@@ -274,6 +289,11 @@ describe("Summary Manager", () => {
 		connectedState.removeAllListeners();
 		throttler.delayMs = 0;
 		mockDeltaManager.lastSequenceNumber = 0;
+		testMinOpsForLastSummaryAttemptOverride = undefined;
+		testMaxAckWaitTimeOverride = undefined;
+		if (summarizer !== undefined) {
+			summarizer.testStopReason = undefined;
+		}
 		requestCalls = 0;
 		clock.reset();
 
@@ -500,6 +520,45 @@ describe("Summary Manager", () => {
 			connectedState.disconnect();
 			await flushPromises();
 			assertState(SummaryManagerState.Stopping, "Should be stopping");
+		});
+
+		it("Should honor pending stop requested before summarizer is created", async () => {
+			testMinOpsForLastSummaryAttemptOverride = 0;
+			testMaxAckWaitTimeOverride = 1;
+			throttler.delayMs = 0;
+			createSummaryManager({
+				opsToBypassInitialDelay: 0,
+				connected: true,
+			});
+			const summarizeEvents: { isLastSummary?: boolean }[] = [];
+			summaryManager.on("summarize", (event) => {
+				summarizeEvents.push(event as { isLastSummary?: boolean });
+			});
+			clientElection.electClient(thisClientId);
+			await flushPromises();
+			assertState(SummaryManagerState.Running, "Summarizer should be starting");
+			assertRequests(1, "Should request summarizer");
+
+			// Request stop before createSummarizerFn resolves.
+			connectedState.disconnect();
+			await flushPromises();
+			assertState(SummaryManagerState.Stopping, "Should be stopping after disconnect");
+
+			completeSummarizerRequest();
+			await flushPromises();
+			assert.strictEqual(
+				summarizer.testStopReason,
+				"parentNotConnected",
+				"Should replay parent stop reason to late-created summarizer",
+			);
+
+			summarizer.runDeferred.resolve();
+			clock.tick(1);
+			await flushPromises();
+			assert(
+				summarizeEvents.some((event) => event.isLastSummary === true),
+				"Should emit summarize event with isLastSummary=true",
+			);
 		});
 
 		it("Should wait for throttler delay before starting summarizer", async () => {


### PR DESCRIPTION
When taking a look at summarizer telemetry, I observed a weird race condition around connection and last summaries. If the parent disconnects and reconnects before the summarizer finishes loading then it won't stop as the parent expects. 

Example flow:

1. Parent is elected
2. Start loading summarizer
3. Parent disconnects
4. Attempt to call `summarizer?.stop(...)` does nothing since the summarizer has not finished loading (see `createSummarizerFn()`)
5. Parent reconnects
6. Summarizer finishes loading and returns instance to parent
7. Summarizer doesn't recognize that it was supposed to stop, so it continues to live as normal
8. Parent hits `"SummarizerStopTimeout"` since it expected its summarizer to stop

This PR adds a stop check right after step 6.

[AB#61863](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/61863)