### PR TITLE
Remove ID Allocation Batch, instead JIT generating ID Allocations right before submitting other batch types

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2737,10 +2737,11 @@ export class ContainerRuntime
 		this.emitDirtyDocumentEvent = false;
 
 		try {
-			// Any ID Allocation ops that failed to submit after the pending state was queued need to have
-			// the corresponding ranges resubmitted. This immediately takes all unfinalized ranges from
-			// the compressor and flushes them as a standalone batch, before replay begins.
-			this.outbox.flushUnfinalizedIdRanges();
+			// Signal to the outbox that the next JIT ID allocation should use the comprehensive
+			// unfinalized range (instead of incremental). The range will be prepended to the
+			// first replayed batch, preserving batch structure for fork detection.
+			this.outbox.requestUnfinalizedIdRanges();
+			//* CLAUDE: We need to handle the case where replayPendingStates submits to ops.
 
 			// replay the ops
 			this.pendingStateManager.replayPendingStates();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2014,6 +2014,28 @@ export class ContainerRuntime
 			}),
 			reSubmit: this.reSubmit.bind(this),
 			opReentrancy: () => this.dataModelChangeRunner.running,
+			generateIdAllocationOp: (
+				useUnfinalizedRange: boolean,
+			): LocalBatchMessage | undefined => {
+				if (this._idCompressor === undefined) {
+					return undefined;
+				}
+				const idRange = useUnfinalizedRange
+					? this._idCompressor.takeUnfinalizedCreationRange()
+					: this._idCompressor.takeNextCreationRange();
+				if (idRange.ids === undefined) {
+					return undefined;
+				}
+				const idAllocationMessage: ContainerRuntimeIdAllocationMessage = {
+					type: ContainerMessageType.IdAllocation,
+					contents: idRange,
+				};
+				return {
+					runtimeOp: idAllocationMessage,
+					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
+					staged: false,
+				};
+			},
 		});
 
 		this._quorum = quorum;
@@ -2716,11 +2738,9 @@ export class ContainerRuntime
 
 		try {
 			// Any ID Allocation ops that failed to submit after the pending state was queued need to have
-			// the corresponding ranges resubmitted (note this call replaces the typical resubmit flow).
-			// Since we don't submit ID Allocation ops when staged, any outstanding ranges would be from
-			// before staging mode so we can simply say staged: false.
-			this.submitIdAllocationOpIfNeeded({ resubmitOutstandingRanges: true, staged: false });
-			this.scheduleFlush();
+			// the corresponding ranges resubmitted. This immediately takes all unfinalized ranges from
+			// the compressor and flushes them as a standalone batch, before replay begins.
+			this.outbox.flushUnfinalizedIdRanges();
 
 			// replay the ops
 			this.pendingStateManager.replayPendingStates();
@@ -3630,9 +3650,10 @@ export class ContainerRuntime
 
 				this.stageControls = undefined;
 
-				// During Staging Mode, we avoid submitting any ID Allocation ops (apart from resubmitting pre-staging ops).
-				// Now that we've exited, we need to submit an ID Allocation op for any IDs that were generated while in Staging Mode.
-				this.submitIdAllocationOpIfNeeded({ staged: false });
+				// During Staging Mode, we avoid submitting any ID Allocation ops.
+				// IDs accumulated during staging will be captured by JIT ID allocation
+				// at the next non-staged flush (during commit replay or the next regular submit).
+				// For discard, IDs harmlessly remain in the compressor.
 				discardOrCommit();
 
 				this.channelCollection.notifyStagingMode(false);
@@ -4663,33 +4684,6 @@ export class ContainerRuntime
 		return this.blobManager.lookupTemporaryBlobStorageId(localId);
 	}
 
-	private submitIdAllocationOpIfNeeded({
-		resubmitOutstandingRanges = false,
-		staged,
-	}: {
-		resubmitOutstandingRanges?: boolean;
-		staged: boolean;
-	}): void {
-		if (this._idCompressor) {
-			const idRange = resubmitOutstandingRanges
-				? this._idCompressor.takeUnfinalizedCreationRange()
-				: this._idCompressor.takeNextCreationRange();
-			// Don't include the idRange if there weren't any Ids allocated
-			if (idRange.ids !== undefined) {
-				const idAllocationMessage: ContainerRuntimeIdAllocationMessage = {
-					type: ContainerMessageType.IdAllocation,
-					contents: idRange,
-				};
-				const idAllocationBatchMessage: LocalBatchMessage = {
-					runtimeOp: idAllocationMessage,
-					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
-					staged,
-				};
-				this.outbox.submitIdAllocation(idAllocationBatchMessage);
-			}
-		}
-	}
-
 	private submit(
 		containerRuntimeMessage: LocalContainerRuntimeMessage,
 		localOpMetadata: unknown = undefined,
@@ -4733,10 +4727,8 @@ export class ContainerRuntime
 				0xbba /* Unexpected message type submitted in Staging Mode */,
 			);
 
-			// Before submitting any non-staged change, submit the ID Allocation op to cover any compressed IDs included in the op.
-			if (!staged) {
-				this.submitIdAllocationOpIfNeeded({ staged: false });
-			}
+			// ID Allocation ops are generated just-in-time at flush time by the Outbox,
+			// ensuring correct refSeq even after rebase. No need to submit them here.
 
 			// Allow document schema controller to send a message if it needs to propose change in document schema.
 			// If it needs to send a message, it will call provided callback with payload of such message and rely

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2741,7 +2741,6 @@ export class ContainerRuntime
 			// unfinalized range (instead of incremental). The range will be prepended to the
 			// first replayed batch, preserving batch structure for fork detection.
 			this.outbox.requestUnfinalizedIdRanges();
-			//* CLAUDE: We need to handle the case where replayPendingStates submits to ops.
 
 			// replay the ops
 			this.pendingStateManager.replayPendingStates();

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -26,11 +26,6 @@ export interface IBatchManagerOptions {
 	 * If true, the outbox is allowed to rebase the batch during flushing.
 	 */
 	readonly canRebase: boolean;
-
-	/**
-	 * If true, don't compare batchID of incoming batches to this. e.g. ID Allocation Batch IDs should be ignored
-	 */
-	readonly ignoreBatchId?: boolean;
 }
 
 export interface BatchSequenceNumbers {
@@ -127,8 +122,11 @@ export class BatchManager {
 
 	/**
 	 * Gets the pending batch and clears state for the next batch.
+	 *
+	 * @remarks The returned batch does not have batch metadata stamped (batch start/end markers, batchId).
+	 * The caller is responsible for calling {@link addBatchMetadata} after any modifications (e.g. prepending messages).
 	 */
-	public popBatch(batchId?: BatchId): LocalBatch {
+	public popBatch(): LocalBatch {
 		assert(this.pendingBatch[0] !== undefined, 0xb8a /* expected non-empty batch */);
 		const batch: LocalBatch = {
 			messages: this.pendingBatch,
@@ -141,7 +139,7 @@ export class BatchManager {
 		this.clientSequenceNumber = undefined;
 		this.hasReentrantOps = false;
 
-		return addBatchMetadata(batch, batchId);
+		return batch;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -209,6 +209,7 @@ export class Outbox {
 	private readonly blobAttachBatch: BatchManager;
 	private batchRebasesToReport = 5;
 	private rebasing = false;
+	private useUnfinalizedRangeOnNextFlush = false;
 
 	/**
 	 * Track the number of ops which were detected to have a mismatched
@@ -347,20 +348,12 @@ export class Outbox {
 	}
 
 	/**
-	 * Immediately takes all unfinalized ID ranges from the compressor and flushes them
-	 * as a standalone batch. Used during reconnect to resubmit comprehensive ID ranges
-	 * before replaying pending states.
+	 * Signals that on the next JIT ID allocation, the outbox should use
+	 * `takeUnfinalizedCreationRange()` (comprehensive) instead of `takeNextCreationRange()` (incremental).
+	 * Used during reconnect so the first replayed batch includes all outstanding ID ranges.
 	 */
-	public flushUnfinalizedIdRanges(): void {
-		const idAllocMsg = this.params.generateIdAllocationOp(/* useUnfinalizedRange */ true);
-		if (idAllocMsg === undefined) {
-			return;
-		}
-
-		//* Assert this, or just prepend anyway
-		// Outbox should be empty at reconnect time (before replay starts)
-		this.addMessageToBatchManager(this.mainBatch, idAllocMsg);
-		this.flushInternal({ batchManager: this.mainBatch });
+	public requestUnfinalizedIdRanges(): void {
+		this.useUnfinalizedRangeOnNextFlush = true;
 	}
 
 	private addMessageToBatchManager(
@@ -403,7 +396,6 @@ export class Outbox {
 	private flushAll(resubmitInfo?: BatchResubmitInfo): void {
 		const allBatchesEmpty = this.blobAttachBatch.empty && this.mainBatch.empty;
 		if (allBatchesEmpty) {
-			//* CLAUDE: Double-check this reasoning. Any concerns about empty batches given ID Allocation ops new placement?
 			// If we're resubmitting with a batchId and all batches are empty, we need to flush an empty batch.
 			// Note that we currently resubmit one batch at a time, so on resubmit, 1 of the 2 batches will *always* be empty.
 			// It's theoretically possible that we don't *need* to resubmit this empty batch, and in those cases, it'll safely be ignored
@@ -415,20 +407,19 @@ export class Outbox {
 			return;
 		}
 
-		// CLAUDE: What if we always try JIT in both calls to flushInternal?
-		// Determine which batch gets the JIT ID allocation op prepended.
-		// blobAttach flushes first, so prepend there if non-empty; otherwise prepend to main.
-		const generateJITForBlobAttach = !this.blobAttachBatch.empty;
+		// JIT ID allocation: generateJIT=true on both calls. takeNextCreationRange() is
+		// cumulative, so the first non-empty batch captures all pending IDs. The second
+		// call will return undefined (no remaining IDs). This is simpler than picking a target.
 		this.flushInternal({
 			batchManager: this.blobAttachBatch,
 			disableGroupedBatching: true,
 			resubmitInfo,
-			generateJIT: generateJITForBlobAttach,
+			generateJIT: true,
 		});
 		this.flushInternal({
 			batchManager: this.mainBatch,
 			resubmitInfo,
-			generateJIT: !generateJITForBlobAttach,
+			generateJIT: true,
 		});
 	}
 
@@ -505,7 +496,9 @@ export class Outbox {
 		// ID ranges aren't lost during rebase (since reSubmit drops IdAllocation ops).
 		// Only generate for non-staged batches — ID alloc ops are always non-staged.
 		if (generateJIT === true && !staged) {
-			const idAllocMsg = this.params.generateIdAllocationOp(/* useUnfinalizedRange */ false);
+			const useUnfinalized = this.useUnfinalizedRangeOnNextFlush;
+			this.useUnfinalizedRangeOnNextFlush = false;
+			const idAllocMsg = this.params.generateIdAllocationOp(useUnfinalized);
 			if (idAllocMsg !== undefined) {
 				rawBatch = { ...rawBatch, messages: [idAllocMsg, ...rawBatch.messages] };
 			}

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -25,6 +25,7 @@ import type {
 
 import {
 	BatchManager,
+	addBatchMetadata,
 	type BatchSequenceNumbers,
 	sequenceNumbersMatch,
 	type BatchId,
@@ -71,6 +72,17 @@ export interface IOutboxParameters {
 	readonly getCurrentSequenceNumbers: () => BatchSequenceNumbers;
 	readonly reSubmit: (message: PendingMessageResubmitData, squash: boolean) => void;
 	readonly opReentrancy: () => boolean;
+	/**
+	 * JIT callback to generate an ID allocation op at flush time.
+	 * Called after rebase (if any), so the returned message has the correct refSeq.
+	 *
+	 * @param useUnfinalizedRange - If true, use `takeUnfinalizedCreationRange()` (for reconnect).
+	 * Otherwise use `takeNextCreationRange()` (normal flush).
+	 * @returns A LocalBatchMessage for the ID allocation op, or undefined if no IDs need allocating.
+	 */
+	readonly generateIdAllocationOp: (
+		useUnfinalizedRange: boolean,
+	) => LocalBatchMessage | undefined;
 }
 
 /**
@@ -195,7 +207,6 @@ export class Outbox {
 	private readonly logger: ITelemetryLoggerExt;
 	private readonly mainBatch: BatchManager;
 	private readonly blobAttachBatch: BatchManager;
-	private readonly idAllocationBatch: BatchManager;
 	private batchRebasesToReport = 5;
 	private rebasing = false;
 
@@ -213,14 +224,10 @@ export class Outbox {
 
 		this.mainBatch = new BatchManager({ canRebase: true });
 		this.blobAttachBatch = new BatchManager({ canRebase: true });
-		this.idAllocationBatch = new BatchManager({
-			canRebase: false,
-			ignoreBatchId: true,
-		});
 	}
 
 	public get messageCount(): number {
-		return this.mainBatch.length + this.blobAttachBatch.length + this.idAllocationBatch.length;
+		return this.mainBatch.length + this.blobAttachBatch.length;
 	}
 
 	public get mainBatchMessageCount(): number {
@@ -231,9 +238,11 @@ export class Outbox {
 		return this.blobAttachBatch.length;
 	}
 
-	public get idAllocationBatchMessageCount(): number {
-		return this.idAllocationBatch.length;
-	}
+	/**
+	 * @remarks With JIT ID allocation, pending IDs are tracked by the compressor, not the outbox.
+	 * This always returns 0. ID allocation ops are generated at flush time.
+	 */
+	public readonly idAllocationBatchMessageCount: number = 0;
 
 	public get isEmpty(): boolean {
 		return this.messageCount === 0;
@@ -260,10 +269,8 @@ export class Outbox {
 	private maybeFlushPartialBatch(): void {
 		const mainBatchSeqNums = this.mainBatch.sequenceNumbers;
 		const blobAttachSeqNums = this.blobAttachBatch.sequenceNumbers;
-		const idAllocSeqNums = this.idAllocationBatch.sequenceNumbers;
 		assert(
-			sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums) &&
-				sequenceNumbersMatch(mainBatchSeqNums, idAllocSeqNums),
+			sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums),
 			0x58d /* Reference sequence numbers from both batches must be in sync */,
 		);
 
@@ -271,8 +278,7 @@ export class Outbox {
 
 		if (
 			sequenceNumbersMatch(mainBatchSeqNums, currentSequenceNumbers) &&
-			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers) &&
-			sequenceNumbersMatch(idAllocSeqNums, currentSequenceNumbers)
+			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers)
 		) {
 			// The reference sequence numbers are stable, there is nothing to do
 			return;
@@ -340,10 +346,21 @@ export class Outbox {
 		this.addMessageToBatchManager(this.blobAttachBatch, message);
 	}
 
-	public submitIdAllocation(message: LocalBatchMessage): void {
-		this.maybeFlushPartialBatch();
+	/**
+	 * Immediately takes all unfinalized ID ranges from the compressor and flushes them
+	 * as a standalone batch. Used during reconnect to resubmit comprehensive ID ranges
+	 * before replaying pending states.
+	 */
+	public flushUnfinalizedIdRanges(): void {
+		const idAllocMsg = this.params.generateIdAllocationOp(/* useUnfinalizedRange */ true);
+		if (idAllocMsg === undefined) {
+			return;
+		}
 
-		this.addMessageToBatchManager(this.idAllocationBatch, message);
+		//* Assert this, or just prepend anyway
+		// Outbox should be empty at reconnect time (before replay starts)
+		this.addMessageToBatchManager(this.mainBatch, idAllocMsg);
+		this.flushInternal({ batchManager: this.mainBatch });
 	}
 
 	private addMessageToBatchManager(
@@ -366,8 +383,9 @@ export class Outbox {
 	 */
 	public flush(resubmitInfo?: BatchResubmitInfo): void {
 		// We have nothing to flush if all batchManagers are empty, and we we're not needing to resubmit an empty batch placeholder
+		// Note that it's possible that there are unfinalized ranges in the ID Compressor,
+		// but there's no urgency to flush those if they're not referenced in any messages.
 		if (
-			this.idAllocationBatch.empty &&
 			this.blobAttachBatch.empty &&
 			this.mainBatch.empty &&
 			resubmitInfo?.batchId === undefined
@@ -383,9 +401,9 @@ export class Outbox {
 	}
 
 	private flushAll(resubmitInfo?: BatchResubmitInfo): void {
-		const allBatchesEmpty =
-			this.idAllocationBatch.empty && this.blobAttachBatch.empty && this.mainBatch.empty;
+		const allBatchesEmpty = this.blobAttachBatch.empty && this.mainBatch.empty;
 		if (allBatchesEmpty) {
+			//* CLAUDE: Double-check this reasoning. Any concerns about empty batches given ID Allocation ops new placement?
 			// If we're resubmitting with a batchId and all batches are empty, we need to flush an empty batch.
 			// Note that we currently resubmit one batch at a time, so on resubmit, 1 of the 2 batches will *always* be empty.
 			// It's theoretically possible that we don't *need* to resubmit this empty batch, and in those cases, it'll safely be ignored
@@ -397,21 +415,20 @@ export class Outbox {
 			return;
 		}
 
-		// Don't use resubmittingBatchId for idAllocationBatch.
-		// ID Allocation messages are not directly resubmitted so don't pass the resubmitInfo
-		this.flushInternal({
-			batchManager: this.idAllocationBatch,
-			// Note: For now, we will never stage ID Allocation messages.
-			// They won't contain personal info and no harm in extra allocations in case of discarding the staged changes
-		});
+		// CLAUDE: What if we always try JIT in both calls to flushInternal?
+		// Determine which batch gets the JIT ID allocation op prepended.
+		// blobAttach flushes first, so prepend there if non-empty; otherwise prepend to main.
+		const generateJITForBlobAttach = !this.blobAttachBatch.empty;
 		this.flushInternal({
 			batchManager: this.blobAttachBatch,
 			disableGroupedBatching: true,
 			resubmitInfo,
+			generateJIT: generateJITForBlobAttach,
 		});
 		this.flushInternal({
 			batchManager: this.mainBatch,
 			resubmitInfo,
+			generateJIT: !generateJITForBlobAttach,
 		});
 	}
 
@@ -448,13 +465,14 @@ export class Outbox {
 		batchManager: BatchManager;
 		disableGroupedBatching?: boolean;
 		resubmitInfo?: BatchResubmitInfo; // undefined if not resubmitting
+		generateJIT?: boolean;
 	}): void {
-		const { batchManager, disableGroupedBatching = false, resubmitInfo } = params;
+		const { batchManager, disableGroupedBatching = false, resubmitInfo, generateJIT } = params;
 		if (batchManager.empty) {
 			return;
 		}
 
-		const rawBatch = batchManager.popBatch(resubmitInfo?.batchId);
+		let rawBatch = batchManager.popBatch();
 
 		// On resubmit we use the original batch's staged state, so these should match as well.
 		const staged = rawBatch.staged === true;
@@ -471,15 +489,29 @@ export class Outbox {
 			groupingEnabled
 		) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
+			// Rebase the current batch (resubmit the ops one-by-one) and then reinvoke flushInternal.
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
 			// it needs to be rebased so that we can ensure consistent reference sequence numbers
 			// and eventual consistency at the DDS level.
 			// Note: Since this is happening in the same turn the ops were originally created with,
 			// and they haven't gone to PendingStateManager yet, we can just let them respect
 			// ContainerRuntime.inStagingMode.  So we do not plumb local 'staged' variable through here.
-			this.rebase(rawBatch, batchManager);
+			this.rebase(rawBatch, batchManager, generateJIT);
 			return;
 		}
+
+		// Generate ID Allocation ops just-in-time, after rebase (if any).
+		// This ensures the refSeq is correct (matching the rest of the batch) and that
+		// ID ranges aren't lost during rebase (since reSubmit drops IdAllocation ops).
+		// Only generate for non-staged batches — ID alloc ops are always non-staged.
+		if (generateJIT === true && !staged) {
+			const idAllocMsg = this.params.generateIdAllocationOp(/* useUnfinalizedRange */ false);
+			if (idAllocMsg !== undefined) {
+				rawBatch = { ...rawBatch, messages: [idAllocMsg, ...rawBatch.messages] };
+			}
+		}
+
+		addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 
 		let clientSequenceNumber: number | undefined;
 		// Did we disconnect? (i.e. is shouldSend false?)
@@ -499,7 +531,6 @@ export class Outbox {
 			rawBatch.messages,
 			clientSequenceNumber,
 			staged,
-			batchManager.options.ignoreBatchId,
 		);
 	}
 
@@ -509,7 +540,11 @@ export class Outbox {
 	 *
 	 * @param rawBatch - the batch to be rebased
 	 */
-	private rebase(rawBatch: LocalBatch, batchManager: BatchManager): void {
+	private rebase(
+		rawBatch: LocalBatch,
+		batchManager: BatchManager,
+		generateJIT?: boolean,
+	): void {
 		assert(!this.rebasing, 0x6fb /* Reentrancy */);
 		assert(batchManager.options.canRebase, 0x9a7 /* BatchManager does not support rebase */);
 
@@ -538,7 +573,7 @@ export class Outbox {
 			this.batchRebasesToReport--;
 		}
 
-		this.flushInternal({ batchManager });
+		this.flushInternal({ batchManager, generateJIT });
 		this.rebasing = false;
 	}
 
@@ -679,7 +714,6 @@ export class Outbox {
 	 */
 	public getBatchCheckpoints(): {
 		mainBatch: IBatchCheckpoint;
-		idAllocationBatch: IBatchCheckpoint;
 		blobAttachBatch: IBatchCheckpoint;
 	} {
 		// This variable is declared with a specific type so that we have a standard import of the IBatchCheckpoint type.
@@ -687,7 +721,6 @@ export class Outbox {
 		const mainBatch: IBatchCheckpoint = this.mainBatch.checkpoint();
 		return {
 			mainBatch,
-			idAllocationBatch: this.idAllocationBatch.checkpoint(),
 			blobAttachBatch: this.blobAttachBatch.checkpoint(),
 		};
 	}

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -85,10 +85,6 @@ export interface IPendingMessage {
 		 */
 		length: number;
 		/**
-		 * If true, don't compare batchID of incoming batches to this. e.g. ID Allocation Batch IDs should be ignored
-		 */
-		ignoreBatchId?: boolean;
-		/**
 		 * If true, this batch is staged and should not actually be submitted on replayPendingStates.
 		 */
 		staged: boolean;
@@ -403,13 +399,11 @@ export class PendingStateManager implements IDisposable {
 	 * @param clientSequenceNumber - The CSN of the first message in the batch,
 	 * or undefined if the batch was not yet sent (e.g. by the time we flushed we lost the connection)
 	 * @param staged - Indicates whether batch is staged (not to be submitted while runtime is in Staging Mode)
-	 * @param ignoreBatchId - Whether to ignore the batchId in the batchStartInfo
 	 */
 	public onFlushBatch(
 		batch: LocalBatchMessage[] | [LocalEmptyBatchPlaceholder],
 		clientSequenceNumber: number | undefined,
 		staged: boolean,
-		ignoreBatchId?: boolean,
 	): void {
 		// clientId and batchStartCsn are used for generating the batchId so we can detect container forks
 		// where this batch was submitted by two different clients rehydrating from the same local state.
@@ -443,7 +437,7 @@ export class PendingStateManager implements IDisposable {
 				localOpMetadata,
 				opMetadata,
 				// Note: We only will read this off the first message, but put it on all for simplicity
-				batchInfo: { clientId, batchStartCsn, length: batch.length, ignoreBatchId, staged },
+				batchInfo: { clientId, batchStartCsn, length: batch.length, staged },
 			};
 			this.pendingMessages.push(pendingMessage);
 		}
@@ -509,23 +503,14 @@ export class PendingStateManager implements IDisposable {
 	 * @returns whether the batch IDs match
 	 */
 	private remoteBatchMatchesPendingBatch(remoteBatchStart: BatchStartInfo): boolean {
-		// Find the first pending message that uses Batch ID, to compare to the incoming remote batch.
-		// If there is no such message, then the incoming remote batch doesn't have a match here and we can return.
-		const firstIndexUsingBatchId = Array.from({
-			length: this.pendingMessages.length,
-		}).findIndex((_, i) => this.pendingMessages.get(i)?.batchInfo.ignoreBatchId !== true);
-		const pendingMessageUsingBatchId =
-			firstIndexUsingBatchId === -1
-				? undefined
-				: this.pendingMessages.get(firstIndexUsingBatchId);
-
-		if (pendingMessageUsingBatchId === undefined) {
+		const pendingMessage = this.pendingMessages.peekFront();
+		if (pendingMessage === undefined) {
 			return false;
 		}
 
 		// We must compare the effective batch IDs, since one of these ops
 		// may have been the original, not resubmitted, so wouldn't have its batch ID stamped yet.
-		const pendingBatchId = getEffectiveBatchId(pendingMessageUsingBatchId);
+		const pendingBatchId = getEffectiveBatchId(pendingMessage);
 		const inboundBatchId = getEffectiveBatchId(remoteBatchStart);
 
 		return pendingBatchId === inboundBatchId;
@@ -802,10 +787,7 @@ export class PendingStateManager implements IDisposable {
 			assert(batchMetadataFlag !== false, 0x41b /* We cannot process batches in chunks */);
 
 			// The next message starts a batch (possibly single-message), and we'll need its batchId.
-			const batchId =
-				pendingMessage.batchInfo.ignoreBatchId === true
-					? undefined
-					: getEffectiveBatchId(pendingMessage);
+			const batchId = getEffectiveBatchId(pendingMessage);
 
 			const staged = pendingMessage.batchInfo.staged;
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -649,32 +649,30 @@ describe("Runtime", () => {
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				// 1st compressed id – queued while disconnected (goes to idAllocationBatch).
+				// 1st compressed id – queued while disconnected (stays in compressor with JIT).
 				containerRuntime.idCompressor?.generateCompressedId();
 
-				// Re-connect – replayPendingStates will submit only an idAllocation op.
-				// It's now in the Outbox and a flush is scheduled (including this flush was a bug fix)
+				// Re-connect – requestUnfinalizedIdRanges sets a flag for next JIT flush.
 				changeConnectionState(containerRuntime, true, mockClientId);
 
 				// Simulate a remote op arriving before we submit anything else.
 				// Bump refSeq and continue execution at the end of the microtask queue.
-				// This is how Inbound Queue works, and this is necessary to simulate here to allow scheduled flush to happen
 				++mockDeltaManager.lastSequenceNumber;
 				await Promise.resolve();
 
-				// 2nd compressed id – its idAllocation op will enter Outbox *after* the ref seq# bumped.
+				// 2nd compressed id – stays in compressor until flush.
 				const id2 = containerRuntime.idCompressor?.generateCompressedId();
 
-				// This would throw a DataProcessingError from codepath "outboxSequenceNumberCoherencyCheck"
-				// if we didn't schedule a flush after the idAllocation op submitted during the reconnect.
-				// (On account of the two ID Allocation ops having different refSeqs but being in the same batch)
+				// With JIT ID allocation, both IDs are captured in a single takeUnfinalizedCreationRange()
+				// call at flush time, producing one ID alloc op prepended to the data op batch.
+				// The refSeq coherency issue is eliminated because JIT generates the op at flush time.
 				submitDataStoreOp(containerRuntime, "someDS", genTestDataStoreMessage({ id: id2 }));
 
 				// Let the Outbox flush so we can check submittedOps length
 				await Promise.resolve();
 				assert(
-					submittedOps.length === 3,
-					"Expected 3 ops to be submitted (2 ID Allocation, 1 data)",
+					submittedOps.length === 2,
+					"Expected 2 ops to be submitted (1 JIT ID Allocation + 1 data, in one batch)",
 				);
 			});
 		});

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -670,9 +670,13 @@ describe("Runtime", () => {
 
 				// Let the Outbox flush so we can check submittedOps length
 				await Promise.resolve();
-				assert(
-					submittedOps.length === 2,
-					"Expected 2 ops to be submitted (1 JIT ID Allocation + 1 data, in one batch)",
+				assert.strictEqual(submittedOps.length, 1, "Expected a single grouped batch op");
+				const { type, contents } = submittedOps[0] as { type: string; contents: unknown[] }; // See IGroupedBatchMessageContents
+				assert.strictEqual(type, "groupedBatch", "Expected a groupedBatch op");
+				assert.strictEqual(
+					contents.length,
+					2,
+					"Expected 2 messages in the grouped batch (1 JIT ID Allocation + 1 data)",
 				);
 			});
 		});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../../messageTypes.js";
 import type { IBatchMetadata } from "../../metadata.js";
 import {
+	addBatchMetadata,
 	BatchManager,
 	estimateSocketSize,
 	generateBatchId,
@@ -68,7 +69,7 @@ describe("BatchManager", () => {
 				/* reentrant */ false,
 			);
 
-			const batch = batchManager.popBatch(batchId);
+			const batch = addBatchMetadata(batchManager.popBatch(), batchId);
 			assert.deepEqual(
 				batch.messages.map((m) => m.metadata as IBatchMetadata),
 				[
@@ -82,7 +83,7 @@ describe("BatchManager", () => {
 				{ runtimeOp: op(), referenceSequenceNumber: 0 },
 				/* reentrant */ false,
 			);
-			const singleOpBatch = batchManager.popBatch(batchId);
+			const singleOpBatch = addBatchMetadata(batchManager.popBatch(), batchId);
 			assert.deepEqual(
 				singleOpBatch.messages.map((m) => m.metadata as IBatchMetadata),
 				[

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -147,6 +147,7 @@ describe("Outbox", () => {
 		onFlushBatch: (
 			batch: LocalBatchMessage[],
 			clientSequenceNumber: number | undefined,
+			_staged: boolean,
 		): void => {
 			for (const {
 				runtimeOp,
@@ -235,6 +236,12 @@ describe("Outbox", () => {
 
 	let currentSeqNumbers: BatchSequenceNumbers = {};
 
+	/**
+	 * Queue of ID allocation ops to return from generateIdAllocationOp.
+	 * Each call to the JIT callback shifts the next message off this queue.
+	 */
+	let pendingIdAllocOps: (LocalBatchMessage | undefined)[] = [];
+
 	const getOutbox = (params: {
 		context: IContainerContext;
 		maxBatchSize?: number;
@@ -276,6 +283,9 @@ describe("Outbox", () => {
 				state.opsResubmitted++;
 			},
 			opReentrancy: () => state.isReentrant,
+			generateIdAllocationOp: (_useUnfinalizedRange: boolean) => {
+				return pendingIdAllocOps.shift() ?? undefined;
+			},
 		});
 	};
 
@@ -298,6 +308,7 @@ describe("Outbox", () => {
 		state.opsResubmitted = 0;
 		state.isReentrant = false;
 		currentSeqNumbers = {};
+		pendingIdAllocOps = [];
 		mockLogger.clear();
 	});
 
@@ -340,28 +351,34 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "5"),
 		];
 
-		// Flush 1
+		// Flush 1 - JIT ID alloc returns messages[2] (prepended to main batch)
+		// Note: only one JIT call per flush, returning one op. messages[3] will be in flush 2.
+		pendingIdAllocOps.push(messages[2]);
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submitIdAllocation(messages[3]);
 		outbox.flush();
 
-		// Flush 2
+		// Flush 2 - JIT ID alloc returns messages[3]
+		pendingIdAllocOps.push(messages[3]);
 		outbox.submit(messages[4]);
 		outbox.flush();
 
 		// Not Flushed
 		outbox.submit(messages[5]);
 
-		assert.equal(state.opsSubmitted, messages.length - 1); // -1 for the non-flushed message
+		assert.equal(state.opsSubmitted, 5); // 3 main + 2 JIT id alloc, minus the non-flushed
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
 			[
-				[toSubmittedMessage(messages[2], true), toSubmittedMessage(messages[3], false)],
-				[toSubmittedMessage(messages[0], true), toSubmittedMessage(messages[1], false)],
-				[toSubmittedMessage(messages[4])], // The last message was not batched
+				// Flush 1: ID alloc prepended to main batch
+				[
+					toSubmittedMessage(messages[2], true),
+					toSubmittedMessage(messages[0]),
+					toSubmittedMessage(messages[1], false),
+				],
+				// Flush 2: ID alloc prepended to main batch
+				[toSubmittedMessage(messages[3], true), toSubmittedMessage(messages[4], false)],
 			],
 			"Submitted batches are incorrect",
 		);
@@ -369,14 +386,13 @@ describe("Outbox", () => {
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
+			// Flush 1 (Main, with ID alloc prepended)
 			[messages[2], 1],
-			[messages[3], 1],
-			// Flush 1 (Main)
-			[messages[0], 3],
-			[messages[1], 3],
-			// Flush 2 (Main)
-			[messages[4], 5],
+			[messages[0], 1],
+			[messages[1], 1],
+			// Flush 2 (Main, with ID alloc prepended)
+			[messages[3], 4],
+			[messages[4], 4],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -428,8 +444,9 @@ describe("Outbox", () => {
 				groupedBatchingEnabled: false,
 			},
 		});
-		// Flush 1 - resubmit multi-message batch including ID Allocation
-		outbox.submitIdAllocation(createMessage(ContainerMessageType.IdAllocation, "0")); // Separate batch, batch ID not used
+		// Flush 1 - resubmit multi-message batch with JIT ID alloc prepended to main
+		const idAllocMsg0 = createMessage(ContainerMessageType.IdAllocation, "0");
+		pendingIdAllocOps.push(idAllocMsg0);
 		outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "1"));
 		outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "2"));
 		outbox.flush({ batchId: "batchId-A", staged: false });
@@ -454,8 +471,8 @@ describe("Outbox", () => {
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages.map((m) => m.metadata?.batchId)),
 			[
-				[undefined], // Flush 1 - ID Allocation (no batch ID used)
-				["batchId-A", undefined], // Flush 1 - Main
+				// Flush 1 - Main (ID alloc prepended; batchId on first message)
+				["batchId-A", undefined, undefined],
 				["batchId-B"], // Flush 2 - Main
 				["batchId-C", undefined], // Flush 3 - Blob Attach
 				[undefined], // Flush 4 - Main (no batch ID given)
@@ -466,9 +483,9 @@ describe("Outbox", () => {
 		assert.deepEqual(
 			state.pendingOpContents.map(({ opMetadata }) => asBatchMetadata(opMetadata)?.batchId),
 			[
-				undefined, // ID Allocation (no batch ID used)
-				"batchId-A",
+				"batchId-A", // ID alloc (prepended to main, gets the batchId as first message)
 				undefined, // second message in batch
+				undefined, // third message in batch
 				"batchId-B",
 				"batchId-C",
 				undefined, // second message in batch
@@ -524,10 +541,10 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "4"),
 		];
 
-		// Flush 1
+		// Flush 1 - JIT ID alloc returns messages[2], prepended to main batch
+		pendingIdAllocOps.push(messages[2]);
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
 		outbox.submit(messages[3]);
 		outbox.flush();
 
@@ -538,16 +555,15 @@ describe("Outbox", () => {
 		assert.equal(state.opsSubmitted, messages.length);
 		assert.equal(state.batchesSubmitted.length, 0);
 		assert.deepEqual(state.individualOpsSubmitted.length, messages.length);
-		assert.equal(state.deltaManagerFlushCalls, 3);
+		assert.equal(state.deltaManagerFlushCalls, 2); // 2 flushes (no separate ID alloc batch)
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
+			// Flush 1 (Main, with ID alloc prepended)
 			[messages[2], 1],
-			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[3], 1],
 			// Flush 2 (Main)
 			[messages[4], 5],
 		] as const;
@@ -582,41 +598,43 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
+		// JIT ID alloc returns messages[2], prepended to main batch
+		pendingIdAllocOps.push(messages[2]);
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
 
+		// With JIT, the ID alloc is prepended to the main batch before grouping.
+		// The grouped batch includes: [idAlloc, msg0, msg1, msg3]
 		const groupedMessages = opGroupingManager.groupBatch(
-			toOutboundBatch([messages[0], messages[1], messages[3]]),
+			toOutboundBatch([messages[2], messages[0], messages[1], messages[3]]),
 		);
 
-		// Submits 2 ops, one for the id allocation and one for the grouped batch
-		assert.equal(state.opsSubmitted, 2);
-		assert.equal(state.batchesSubmitted.length, 2);
+		// Submits 1 grouped batch (ID alloc is now part of the main batch)
+		assert.equal(state.opsSubmitted, 1);
+		assert.equal(state.batchesSubmitted.length, 1);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(
 			state.batchesCompressed,
-			[toOutboundBatch([messages[2]]), groupedMessages],
+			[groupedMessages],
 			"Compressed batches don't match expected",
 		);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[2])], [toSubmittedMessage(groupedMessages.messages[0])]],
+			[[toSubmittedMessage(groupedMessages.messages[0])]],
 			"Submitted batches don't match expected",
 		);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
+			// Flush 1 (Main, with ID alloc prepended)
 			[messages[2], 1],
-			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[3], 1],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -651,31 +669,31 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
+		// JIT ID alloc returns messages[2], prepended to main batch
+		pendingIdAllocOps.push(messages[2]);
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
 
 		assert.equal(
 			state.opsSubmitted,
-			2,
-			"Expected 2 ops to be submitted, on ID Allocation and one for the grouped batch",
+			1,
+			"Expected 1 op to be submitted (one grouped batch with ID alloc prepended)",
 		);
-		assert.equal(state.batchesSubmitted.length, 2);
+		assert.equal(state.batchesSubmitted.length, 1);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(state.batchesCompressed, []);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
+			// Flush 1 (Main, with ID alloc prepended)
 			[messages[2], 1],
-			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[3], 1],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -749,35 +767,32 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
+		// JIT ID alloc returns messages[2], prepended to main batch
+		pendingIdAllocOps.push(messages[2]);
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
 
 		const groupedMessages = opGroupingManager.groupBatch(
-			toOutboundBatch([messages[0], messages[1], messages[3]]),
+			toOutboundBatch([messages[2], messages[0], messages[1], messages[3]]),
 		);
 
-		assert.deepEqual(state.batchesCompressed, [
-			toOutboundBatch([messages[2]]),
-			groupedMessages,
-		]);
-		assert.deepEqual(state.batchesSplit, [toOutboundBatch([messages[2]]), groupedMessages]);
+		assert.deepEqual(state.batchesCompressed, [groupedMessages]);
+		assert.deepEqual(state.batchesSplit, [groupedMessages]);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[2])], [toSubmittedMessage(groupedMessages.messages[0])]],
+			[[toSubmittedMessage(groupedMessages.messages[0])]],
 		);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
+			// Flush 1 (Main, with ID alloc prepended)
 			[messages[2], 1],
-			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[3], 1],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -813,25 +828,23 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
+		// JIT ID alloc returns messages[2], prepended to main batch
+		pendingIdAllocOps.push(messages[2]);
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
 
 		const groupedMessages = opGroupingManager.groupBatch(
-			toOutboundBatch([messages[0], messages[1], messages[3]]),
+			toOutboundBatch([messages[2], messages[0], messages[1], messages[3]]),
 		);
 
-		assert.deepEqual(state.batchesCompressed, [
-			toOutboundBatch([messages[2]]),
-			groupedMessages,
-		]);
+		assert.deepEqual(state.batchesCompressed, [groupedMessages]);
 		assert.deepEqual(state.batchesSplit, []);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[2])], [toSubmittedMessage(groupedMessages.messages[0])]],
+			[[toSubmittedMessage(groupedMessages.messages[0])]],
 		);
 	});
 
@@ -911,65 +924,45 @@ describe("Outbox", () => {
 		]);
 	});
 
-	for (const messages of [
-		[
-			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 1,
-			},
-		],
-		[
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-				referenceSequenceNumber: 0,
-			},
-			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
-				referenceSequenceNumber: 1,
-			},
-		],
-	] as LocalBatchMessage[][]) {
-		it("Flushes all batches when an out of order message is detected in either flow (if partial flushing is enabled)", () => {
-			const outbox = getOutbox({
-				context: getMockContext(),
-				flushPartialBatches: true,
-			});
-			for (const message of messages) {
-				currentSeqNumbers.referenceSequenceNumber = message.referenceSequenceNumber;
-				if (typeFromBatchedOp(message) === ContainerMessageType.IdAllocation) {
-					outbox.submitIdAllocation(message);
-				} else {
-					outbox.submit(message);
-				}
-			}
-
-			assert.equal(state.opsSubmitted, messages.length - 1);
-			assert.equal(state.individualOpsSubmitted.length, 0);
-			assert.equal(state.batchesSubmitted.length, 1);
-			assert.deepEqual(
-				state.batchesSubmitted.map((x) => x.messages),
-				[[toSubmittedMessage(messages[0]), toSubmittedMessage(messages[1])]],
-			);
-
-			mockLogger.assertMatch([
-				{
-					eventName: "Outbox:ReferenceSequenceNumberMismatch",
-				},
-			]);
+	it("Flushes all batches when an out of order message is detected (if partial flushing is enabled)", () => {
+		const outbox = getOutbox({
+			context: getMockContext(),
+			flushPartialBatches: true,
 		});
-	}
+		const messages: LocalBatchMessage[] = [
+			{
+				...createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
+				referenceSequenceNumber: 0,
+			},
+			{
+				...createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
+				referenceSequenceNumber: 0,
+			},
+			{
+				...createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
+				referenceSequenceNumber: 1,
+			},
+		];
+
+		for (const message of messages) {
+			currentSeqNumbers.referenceSequenceNumber = message.referenceSequenceNumber;
+			outbox.submit(message);
+		}
+
+		assert.equal(state.opsSubmitted, messages.length - 1);
+		assert.equal(state.individualOpsSubmitted.length, 0);
+		assert.equal(state.batchesSubmitted.length, 1);
+		assert.deepEqual(
+			state.batchesSubmitted.map((x) => x.messages),
+			[[toSubmittedMessage(messages[0]), toSubmittedMessage(messages[1])]],
+		);
+
+		mockLogger.assertMatch([
+			{
+				eventName: "Outbox:ReferenceSequenceNumberMismatch",
+			},
+		]);
+	});
 
 	it("Does not throw when an out of order message is detected (if partial flushing is enabled)", () => {
 		const outbox = getOutbox({
@@ -1339,21 +1332,21 @@ describe("Outbox", () => {
 			);
 		});
 
-		it("returns false when only idAllocationBatch has ops", () => {
+		it("returns false when only pending ID allocation ops exist (JIT, not in outbox)", () => {
 			const outbox = getOutbox({ context: getMockContext() });
-			const idAllocationOp: LocalBatchMessage = {
+			// Queue a JIT ID allocation op - but don't submit any messages to the outbox
+			pendingIdAllocOps.push({
 				runtimeOp: {
 					type: ContainerMessageType.IdAllocation,
 				} satisfies Partial<LocalContainerRuntimeMessage> as LocalContainerRuntimeMessage,
 				referenceSequenceNumber: 1,
 				metadata: undefined,
 				localOpMetadata: {},
-			};
-			outbox.submitIdAllocation(idAllocationOp);
+			});
 			assert.equal(
 				outbox.containsUserChanges(),
 				false,
-				"Should be false when only idAllocationBatch has ops",
+				"Should be false when only JIT ID allocation ops are pending (not in outbox batches)",
 			);
 		});
 	});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -48,11 +48,6 @@ import type {
 	IPendingMessage,
 } from "../../pendingStateManager.js";
 
-function typeFromBatchedOp(message: LocalBatchMessage): string {
-	assert(message.runtimeOp !== undefined, "PRECONDITION: runtimeOp is undefined");
-	return message.runtimeOp.type;
-}
-
 // Make a mock op with distinguishable contents
 function op(data: string): LocalContainerRuntimeMessage {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2262,8 +2262,7 @@ describeCompat(
 					async (c, d) => {
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
 						// Include an ID Allocation op to get coverage of the special logic around these ops as well
-						// AB#26984: Actually don't, because the ID Compressor is hitting "Ranges finalized out of order" for this test
-						// getIdCompressor(counter)?.generateCompressedId();
+						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
 					},
 				);


### PR DESCRIPTION
## _PROTOTYPE / PROOF OF CONCEPT_

This gets rid of ID Allocation Batches in the batch stream which makes detecting forked containers more robust and simple.

(Incidental rebirth of #24510 a year later)
