### PR TITLE
build(client): split test build from library production

### DIFF
--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -57,6 +57,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -103,18 +106,6 @@
 		"jiti": "^2.6.1",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/common/driver-definitions/src/test/tsconfig.cjs.json
+++ b/packages/common/driver-definitions/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/common/driver-definitions/src/test/tsconfig.json
+++ b/packages/common/driver-definitions/src/test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": [],
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/common/driver-definitions/tsconfig.json
+++ b/packages/common/driver-definitions/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -57,6 +57,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -104,18 +107,6 @@
 		"jiti": "^2.6.1",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/drivers/debugger/src/test/tsconfig.cjs.json
+++ b/packages/drivers/debugger/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/drivers/debugger/src/test/tsconfig.json
+++ b/packages/drivers/debugger/src/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/drivers/debugger/tsconfig.json
+++ b/packages/drivers/debugger/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -44,6 +44,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -87,18 +90,6 @@
 		"jiti": "^2.6.1",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/drivers/file-driver/src/test/tsconfig.cjs.json
+++ b/packages/drivers/file-driver/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/drivers/file-driver/src/test/tsconfig.json
+++ b/packages/drivers/file-driver/src/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/drivers/file-driver/tsconfig.json
+++ b/packages/drivers/file-driver/tsconfig.json
@@ -1,12 +1,11 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"types": ["node"],
-		"noUnusedLocals": false,
 		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -44,6 +44,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -89,18 +92,6 @@
 		"nock": "^13.3.3",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/drivers/replay-driver/src/test/tsconfig.cjs.json
+++ b/packages/drivers/replay-driver/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/drivers/replay-driver/src/test/tsconfig.json
+++ b/packages/drivers/replay-driver/src/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/drivers/replay-driver/tsconfig.json
+++ b/packages/drivers/replay-driver/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -55,6 +55,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -124,18 +127,6 @@
 				],
 				"library": "main"
 			}
-		}
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
 		}
 	},
 	"typeValidation": {

--- a/packages/framework/client-logger/app-insights-logger/src/test/tsconfig.cjs.json
+++ b/packages/framework/client-logger/app-insights-logger/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/framework/client-logger/app-insights-logger/src/test/tsconfig.json
+++ b/packages/framework/client-logger/app-insights-logger/src/test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["node", "mocha"],
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/framework/client-logger/app-insights-logger/tsconfig.json
+++ b/packages/framework/client-logger/app-insights-logger/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "./lib",
-		"types": ["mocha", "node"],
 	},
 }

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -55,6 +55,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -125,18 +128,6 @@
 		"tinylicious": "^7.0.0",
 		"tslib": "^1.10.0",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"disabled": true

--- a/packages/framework/client-logger/fluid-telemetry/src/test/tsconfig.cjs.json
+++ b/packages/framework/client-logger/fluid-telemetry/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/framework/client-logger/fluid-telemetry/src/test/tsconfig.json
+++ b/packages/framework/client-logger/fluid-telemetry/src/test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["mocha"],
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/framework/client-logger/fluid-telemetry/tsconfig.json
+++ b/packages/framework/client-logger/fluid-telemetry/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "./lib",
-		"types": ["mocha"],
 		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -32,6 +32,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -100,18 +103,6 @@
 		"mocha": "^11.7.5",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"disabled": true

--- a/packages/test/test-pairwise-generator/src/test/tsconfig.cjs.json
+++ b/packages/test/test-pairwise-generator/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/test/test-pairwise-generator/src/test/tsconfig.json
+++ b/packages/test/test-pairwise-generator/src/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"noUncheckedIndexedAccess": false,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["node", "mocha"],
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/test/test-pairwise-generator/tsconfig.json
+++ b/packages/test/test-pairwise-generator/tsconfig.json
@@ -1,11 +1,10 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"types": ["mocha", "node"],
 		"noUncheckedIndexedAccess": false,
 	},
 }

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -65,6 +65,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -142,18 +145,6 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/tools/devtools/devtools/src/test/tsconfig.cjs.json
+++ b/packages/tools/devtools/devtools/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/tools/devtools/devtools/src/test/tsconfig.json
+++ b/packages/tools/devtools/devtools/src/test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["mocha"],
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/tools/devtools/devtools/tsconfig.json
+++ b/packages/tools/devtools/devtools/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "./lib",
-		"types": ["mocha"],
 		"exactOptionalPropertyTypes": false,
 	},
-	"include": ["src/**/*"],
 }


### PR DESCRIPTION
build(client): split test build from library production
Packages modified:
1. @fluidframework/file-driver
2. @fluidframework/debugger
3. @fluidframework/replay-driver
4. @fluidframework/fluid-telemetry
5. @fluidframework/driver-definitions
6. @fluid-private/test-pairwise-generator
7. @fluidframework/devtools
8. @fluidframework/app-insights-logger

This addressed incremental build errors where tsc cannot update output files that are also output per typetests. (Not all of these packages actually have type tests.)

Changes per package:
  - tsconfig.json: Changed "exclude" to ["src/test/**/*"], removed test-only "types" entries (e.g. "mocha")
  - src/test/tsconfig.json (new): ESM test config extending tsconfig.test.node16.json, with project reference back to parent
  - src/test/tsconfig.cjs.json (new): CJS test config extending the ESM test config, outputting to dist/test
  - package.json: Added build:test, build:test:esm, build:test:cjs scripts; removed fluidBuild.tasks section (no longer needed since build:esnext no longer compiles tests)

Notable per-package adjustments:
  - Packages without @types/node (app-insights-logger, driver-definitions, devtools, fluid-telemetry) use "types": [] or "types": ["mocha"] instead of "types": ["node"] in test tsconfig
  - test-pairwise-generator test tsconfig needed "noUncheckedIndexedAccess": false to match original behavior
  - debugger and file-driver retained "types": ["node"] in their main tsconfig since production code needs it