### PR TITLE
increase LoaderDriver compatibility window from 3 to 12 months (#26620)

### DIFF
--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -93,7 +93,7 @@ Layer compatibility policy describes specific **support windows** between layers
 | Layer Boundary | Support Window | What This Means |
 | -------------- | -------------- | --------------- |
 | **Driver → Loader** | 12 months | Driver is compatible with Loader versions up to 12 months older |
-| **Loader → Driver** | 3 months | Loader is compatible with Driver versions up to 3 months older |
+| **Loader → Driver** | 12 months | Loader is compatible with Driver versions up to 12 months older |
 | **Runtime → Loader** | 12 months | Runtime is compatible with Loader versions up to 12 months older |
 | **Loader → Runtime** | 3 months | Loader is compatible with Runtime versions up to 3 months older |
 | **Runtime → DataStore** | 3 months | Runtime is compatible with DataStore versions up to 3 months older |

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -27,9 +27,9 @@ export const LayerCompatibilityPolicyWindowMonths = {
 	 */
 	DriverLoader: 12,
 	/**
-	 * Loader is compatible with Driver versions up to 3 months (or generations) older.
+	 * Loader is compatible with Driver versions up to 12 months (or generations) older.
 	 */
-	LoaderDriver: 3,
+	LoaderDriver: 12,
 	/**
 	 * Runtime is compatible with Loader versions up to 12 months (or generations) older.
 	 */


### PR DESCRIPTION
### Description

Porting https://github.com/microsoft/FluidFramework/pull/26620 from main.

- Increases the LoaderDriver layer compatibility window from 3 to 12 months, matching the DriverLoader window
- The previous 3-month window caused the current loader (gen 5) to reject the v2.63.0 driver (gen 1) with "The versions of the loader and driver are not compatible"