### PR TITLE
fix: Disable enableExpandArchives to address build timeout

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -184,6 +184,8 @@ extends:
       # Tentative workaround for the occasional Credscan failures
       credscan:
         batchSize: 4
+      binaryAnalysisCaching:
+        enableExpandArchives: false
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -184,6 +184,7 @@ extends:
       # Tentative workaround for the occasional Credscan failures
       credscan:
         batchSize: 4
+      # Workaround for "Binary Analysis Scan Optimization (Expand Archives)" timing out.
       binaryAnalysisCaching:
         enableExpandArchives: false
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.


### PR DESCRIPTION
## Description

Disable the `enableExpandArchives` flag to address a timeout in the "Binary Analysis Scan Optimization (Expand Archives)" build step.

## Breaking Changes

None.

## Reviewer Guidance

Observe the build for this PR.