### PR TITLE
Remove tree checkout's `branch` method

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -518,7 +518,7 @@ export class SchematizingSimpleTreeView<
 
 	public fork(): ReturnType<TreeBranchAlpha["fork"]> &
 		SchematizingSimpleTreeView<TRootSchema> {
-		return this.checkout.branch().viewWith(this.config);
+		return this.checkout.fork().viewWith(this.config);
 	}
 
 	public merge(context: TreeBranchAlpha, disposeMerged = true): void {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -401,7 +401,7 @@ export class SharedTreeKernel
 	}
 
 	private checkoutBranch(branchId: BranchId): TreeCheckout {
-		const checkout = this.checkout.branch();
+		const checkout = this.checkout.fork();
 		checkout.switchBranch(this.getSharedBranch(branchId));
 		this.registerSharedBranchForEditing(branchId, checkout);
 		this.registerCheckout(branchId, checkout);

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -242,8 +242,7 @@ export interface ITreeCheckout
 	 */
 	readonly transaction: Transactor;
 
-	// TODO: rename to fork() and remove the separate fork() method on TreeCheckout.
-	branch(): ITreeCheckout;
+	fork(): ITreeCheckout;
 
 	/**
 	 * Replaces all schema with the provided schema.
@@ -833,11 +832,6 @@ export class TreeCheckout implements ITreeCheckout {
 		this.applySerializedChange(change);
 	}
 
-	@throwIfBroken
-	public fork(): TreeCheckout {
-		return this.branch();
-	}
-
 	public isBranch(): this is TreeBranchAlpha {
 		return true;
 	}
@@ -1132,11 +1126,12 @@ export class TreeCheckout implements ITreeCheckout {
 	 * Transactions may nest, meaning that a transaction may be started while a transaction is already ongoing.
 	 *
 	 * To avoid updating observers of the view state with intermediate results during a transaction,
-	 * use {@link ITreeCheckout#branch} and {@link ISharedTreeFork#merge}.
+	 * use {@link ITreeCheckout#fork} and {@link ISharedTreeFork#merge}.
 	 */
 	#transaction: SquashingTransactionStack<SharedTreeEditBuilder, SharedTreeChange>;
 
-	public branch(): TreeCheckout {
+	@throwIfBroken
+	public fork(): TreeCheckout {
 		this.checkNotDisposed(
 			"The parent branch has already been disposed and can no longer create new branches.",
 		);

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -67,7 +67,7 @@ describe("Editing", () => {
 		it("concurrent inserts", () => {
 			const tree1 = makeTreeFromJsonSequence([]);
 			insert(tree1, 0, "y");
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			insert(tree1, 0, "x");
 			insert(tree2, 1, "a", "c");
@@ -82,18 +82,18 @@ describe("Editing", () => {
 		it("replace vs insert", () => {
 			const root = makeTreeFromJsonSequence(["A", "C"]);
 
-			const tree1 = root.branch();
+			const tree1 = root.fork();
 			remove(tree1, 0, 2);
 			insert(tree1, 0, "a", "c");
 
-			const tree2 = root.branch();
+			const tree2 = root.fork();
 			insert(tree2, 1, "b");
 
-			const merge1then2 = root.branch();
+			const merge1then2 = root.fork();
 			merge1then2.merge(tree1, false);
 			merge1then2.merge(tree2, false);
 
-			const merge2then1 = root.branch();
+			const merge2then1 = root.fork();
 			merge2then1.merge(tree2, false);
 			merge2then1.merge(tree1, false);
 
@@ -102,7 +102,7 @@ describe("Editing", () => {
 
 		it("can rebase remove over move", () => {
 			const tree1 = makeTreeFromJsonSequence([]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 			insert(tree1, 0, "a", "b");
 			tree2.rebaseOnto(tree1);
 
@@ -121,7 +121,7 @@ describe("Editing", () => {
 
 		it("can rebase intra-field move over inter-field move of same node and its parent", () => {
 			const tree1 = makeTreeFromJsonSequence([[], ["X", "Y"]]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			tree1.transaction.start();
 			tree1.editor.move(
@@ -150,7 +150,7 @@ describe("Editing", () => {
 				},
 			]);
 
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const fooArrayPath: NormalizedUpPath = {
 				parent: rootNode,
@@ -196,7 +196,7 @@ describe("Editing", () => {
 				},
 			]);
 
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const fooArrayPath: NormalizedUpPath = {
 				parent: rootNode,
@@ -238,10 +238,10 @@ describe("Editing", () => {
 
 		it("can order concurrent inserts within concurrently removed content", () => {
 			const tree = makeTreeFromJsonSequence(["A", "B", "C", "D"]);
-			const delAB = tree.branch();
-			const delCD = tree.branch();
-			const addX = tree.branch();
-			const addY = tree.branch();
+			const delAB = tree.fork();
+			const delCD = tree.fork();
+			const addX = tree.fork();
+			const addY = tree.fork();
 
 			// Make deletions in two steps to ensure that gap tracking handles comparing insertion places that
 			// were affected by different removes.
@@ -265,8 +265,8 @@ describe("Editing", () => {
 
 		it("can rebase a change under a node whose insertion is also rebased", () => {
 			const tree1 = makeTreeFromJsonSequence(["B"]);
-			const tree2 = tree1.branch();
-			const tree3 = tree1.branch();
+			const tree2 = tree1.fork();
+			const tree3 = tree1.fork();
 
 			insert(tree2, 1, "C");
 			tree3.editor.sequenceField(rootField).insert(0, chunkFromJsonTrees([{}]));
@@ -287,9 +287,9 @@ describe("Editing", () => {
 			for (const index of [0, 1, 2, 3]) {
 				const startingState = ["A", "B", "C", "D"];
 				const tree = makeTreeFromJsonSequence(startingState);
-				const tree1 = tree.branch();
-				const tree2 = tree.branch();
-				const tree3 = tree.branch();
+				const tree1 = tree.fork();
+				const tree2 = tree.fork();
+				const tree3 = tree.fork();
 
 				remove(tree1, index, 1);
 				remove(tree2, index, 1);
@@ -311,7 +311,7 @@ describe("Editing", () => {
 
 		it("can rebase local dependent inserts", () => {
 			const tree1 = makeTreeFromJsonSequence(["y"]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			insert(tree1, 0, "x");
 
@@ -349,7 +349,7 @@ describe("Editing", () => {
 
 		it("can rebase a local remove", () => {
 			const addW = makeTreeFromJsonSequence(["x", "y"]);
-			const delY = addW.branch();
+			const delY = addW.fork();
 
 			remove(delY, 1, 1);
 			insert(addW, 0, "w");
@@ -367,7 +367,7 @@ describe("Editing", () => {
 				parentIndex: 0,
 			};
 			const tree1 = makeTreeFromJson({ foo: ["A", "B", "C"] }, true);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const { undoStack } = createTestUndoRedoStacks(tree1.events);
 			remove(tree1, 0, 1);
@@ -398,9 +398,9 @@ describe("Editing", () => {
 
 		it("inserts that concurrently target the same insertion point do not interleave their contents", () => {
 			const tree = makeTreeFromJsonSequence([]);
-			const abc = tree.branch();
-			const rst = tree.branch();
-			const xyz = tree.branch();
+			const abc = tree.fork();
+			const rst = tree.fork();
+			const xyz = tree.fork();
 
 			insert(abc, 0, "a", "b", "c");
 			insert(rst, 0, "r", "s", "t");
@@ -419,26 +419,26 @@ describe("Editing", () => {
 
 		it("merge-left tie-breaking does not interleave concurrent left to right inserts", () => {
 			const tree = makeTreeFromJsonSequence([]);
-			const a = tree.branch();
-			const r = tree.branch();
-			const x = tree.branch();
+			const a = tree.fork();
+			const r = tree.fork();
+			const x = tree.fork();
 
 			insert(a, 0, "a");
-			const b = a.branch();
+			const b = a.fork();
 			insert(b, 1, "b");
-			const c = b.branch();
+			const c = b.fork();
 			insert(c, 2, "c");
 
 			insert(r, 0, "r");
-			const s = r.branch();
+			const s = r.fork();
 			insert(s, 1, "s");
-			const t = s.branch();
+			const t = s.fork();
 			insert(s, 2, "t");
 
 			insert(x, 0, "x");
-			const y = x.branch();
+			const y = x.fork();
 			insert(y, 1, "y");
-			const z = y.branch();
+			const z = y.fork();
 			insert(z, 2, "z");
 
 			tree.merge(x);
@@ -465,26 +465,26 @@ describe("Editing", () => {
 		// TODO: update and activate this test once merge-right is supported.
 		it.skip("merge-right tie-breaking does not interleave concurrent right to left inserts", () => {
 			const tree = makeTreeFromJsonSequence([]);
-			const c = tree.branch();
-			const t = tree.branch();
-			const z = tree.branch();
+			const c = tree.fork();
+			const t = tree.fork();
+			const z = tree.fork();
 
 			insert(c, 0, "c");
-			const b = c.branch();
+			const b = c.fork();
 			insert(b, 0, "b");
-			const a = b.branch();
+			const a = b.fork();
 			insert(a, 0, "a");
 
 			insert(t, 0, "t");
-			const s = t.branch();
+			const s = t.fork();
 			insert(s, 0, "s");
-			const r = s.branch();
+			const r = s.fork();
 			insert(r, 0, "r");
 
 			insert(z, 0, "z");
-			const y = z.branch();
+			const y = z.fork();
 			insert(y, 0, "y");
-			const x = y.branch();
+			const x = y.fork();
 			insert(x, 0, "x");
 
 			tree.merge(z);
@@ -514,7 +514,7 @@ describe("Editing", () => {
 
 		it("can rebase insert and remove over insert in the same gap", () => {
 			const tree1 = makeTreeFromJsonSequence([]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			insert(tree1, 0, "B");
 
@@ -528,7 +528,7 @@ describe("Editing", () => {
 
 		it("concurrent insert with nested change", () => {
 			const tree1 = makeTreeFromJsonSequence([]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			insert(tree1, 0, "a");
 			expectJsonTree(tree1, ["a"]);
@@ -547,7 +547,7 @@ describe("Editing", () => {
 
 		it("can rebase intra-field move over insert", () => {
 			const tree1 = makeTreeFromJsonSequence(["A", "B"]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			insert(tree1, 2, "C");
 
@@ -561,7 +561,7 @@ describe("Editing", () => {
 
 		it("can concurrently edit and move a subtree", () => {
 			const tree1 = makeTreeFromJsonSequence(["A", { foo: "B" }]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const editor = tree1.editor.valueField({ parent: rootNode2, field: brand("foo") });
 			editor.set(chunkFromJsonTrees(["C"]));
@@ -579,7 +579,7 @@ describe("Editing", () => {
 
 		it("can concurrently edit and move a subtree (Move first)", () => {
 			const tree1 = makeTreeFromJsonSequence(["A", { foo: "B" }]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			// Move B before A.
 			tree1.editor.move(rootField, 1, 1, rootField, 0);
@@ -597,7 +597,7 @@ describe("Editing", () => {
 
 		it("can concurrently edit and move a subtree (Move first) in a list under a node", () => {
 			const tree1 = makeTreeFromJson({ seq: [{ foo: "A" }, "B"] });
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const seqList: NormalizedUpPath = {
 				parent: rootNode,
@@ -629,7 +629,7 @@ describe("Editing", () => {
 				foo: [{ baz: "A" }],
 				bar: ["B"],
 			});
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const fooList: NormalizedUpPath = {
 				parent: rootNode,
@@ -673,7 +673,7 @@ describe("Editing", () => {
 
 		it("can rebase node deletion over cross-field move of descendant", () => {
 			const tree1 = makeTreeFromJsonSequence([{ foo: ["A"] }]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const fooList: NormalizedUpPath = {
 				parent: rootNode,
@@ -700,7 +700,7 @@ describe("Editing", () => {
 				foo: [{ baz: "A" }],
 				bar: ["B"],
 			});
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const fooList: NormalizedUpPath = {
 				parent: rootNode,
@@ -762,7 +762,7 @@ describe("Editing", () => {
 
 		it("move, remove, restore", () => {
 			const tree1 = makeTreeFromJsonSequence(["a", "b"]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const cursor = tree1.forest.allocateCursor();
 			moveToDetachedField(tree1.forest, cursor);
@@ -796,7 +796,7 @@ describe("Editing", () => {
 
 		it("move adjacent nodes to separate destinations", () => {
 			const tree = makeTreeFromJsonSequence(["A", "B", "C", "D"]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			tree2.transaction.start();
 
@@ -809,7 +809,7 @@ describe("Editing", () => {
 
 		it("move separate nodes to adjacent destinations", () => {
 			const tree = makeTreeFromJsonSequence(["A", "B", "C", "D"]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			tree2.transaction.start();
 
@@ -822,7 +822,7 @@ describe("Editing", () => {
 
 		it("ancestor of move destination removed", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			const { undoStack } = createTestUndoRedoStacks(tree.events);
 
@@ -853,7 +853,7 @@ describe("Editing", () => {
 
 		it("ancestor of move source removed", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			const { undoStack } = createTestUndoRedoStacks(tree.events);
 
@@ -884,7 +884,7 @@ describe("Editing", () => {
 
 		it("ancestor of move source removed then revived", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 			const sequence = tree.editor.sequenceField(rootField);
@@ -911,7 +911,7 @@ describe("Editing", () => {
 
 		it("node being concurrently moved and removed with source ancestor revived", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 			// Remove source's ancestor concurrently
@@ -941,7 +941,7 @@ describe("Editing", () => {
 
 		it("remove, undo, childchange rebased over childchange", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["b"] }]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree2.events);
 
 			const sequenceUpPath: NormalizedUpPath = {
@@ -970,7 +970,7 @@ describe("Editing", () => {
 
 		it("childchange rebase over remove, undo, childchange", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["b"] }]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 			const sequenceUpPath: NormalizedUpPath = {
@@ -1001,7 +1001,7 @@ describe("Editing", () => {
 
 		it("node being concurrently moved and revived with source ancestor removed", () => {
 			const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 			// Remove ["a"]
@@ -1041,7 +1041,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			const undoTree1 = createTestUndoRedoStacks(tree.events);
 			const undoTree2 = createTestUndoRedoStacks(tree2.events);
@@ -1081,7 +1081,7 @@ describe("Editing", () => {
 				0,
 			);
 
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			const sequence = tree.editor.sequenceField(rootField);
 
@@ -1145,7 +1145,7 @@ describe("Editing", () => {
 
 		it("can handle concurrent moves of the same node", () => {
 			const tree1 = makeTreeFromJsonSequence([{ foo: [], bar: [] }, "A"]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const fooList: NormalizedUpPath = {
 				parent: rootNode,
@@ -1636,7 +1636,7 @@ describe("Editing", () => {
 
 		it("can rebase a move over the deletion of the source parent", () => {
 			const tree = makeTreeFromJson({ src: ["A", "B"], dst: ["C", "D"] });
-			const childBranch = tree.branch();
+			const childBranch = tree.fork();
 
 			const srcList: NormalizedUpPath = {
 				parent: rootNode,
@@ -1675,7 +1675,7 @@ describe("Editing", () => {
 
 		it("can rebase a move over the deletion of the destination parent", () => {
 			const tree = makeTreeFromJson({ src: ["A", "B"], dst: ["C", "D"] });
-			const childBranch = tree.branch();
+			const childBranch = tree.fork();
 
 			const srcList: NormalizedUpPath = {
 				parent: rootNode,
@@ -1714,7 +1714,7 @@ describe("Editing", () => {
 
 		it("can rebase a move over the deletion of the source and destination parents", () => {
 			const tree = makeTreeFromJson({ src: ["A", "B"], dst: ["C", "D"] });
-			const childBranch = tree.branch();
+			const childBranch = tree.fork();
 
 			const srcList: NormalizedUpPath = {
 				parent: rootNode,
@@ -1822,7 +1822,7 @@ describe("Editing", () => {
 				parentIndex: 0,
 			};
 
-			const branch = tree.branch();
+			const branch = tree.fork();
 			branch.transaction.start();
 			branch.editor.addNodeExistsConstraint(tmpList);
 			branch.editor.move(
@@ -1861,8 +1861,8 @@ describe("Editing", () => {
 
 		it("rebase changes to field untouched by base", () => {
 			const tree = makeTreeFromJson({ foo: [{ bar: "A" }, { baz: "B" }] });
-			const tree1 = tree.branch();
-			const tree2 = tree.branch();
+			const tree1 = tree.fork();
+			const tree2 = tree.fork();
 
 			const fooList: NormalizedUpPath = {
 				parent: rootNode,
@@ -1917,7 +1917,7 @@ describe("Editing", () => {
 
 		it("concurrent cycle creating move", () => {
 			const tree = makeTreeFromJsonSequence([["foo"], ["bar"]]);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 
 			const fooList = rootNode;
 			const barList = rootNode2;
@@ -1943,13 +1943,13 @@ describe("Editing", () => {
 
 		it("rebase insert within revive", () => {
 			const tree = makeTreeFromJsonSequence(["y"]);
-			const tree1 = tree.branch();
+			const tree1 = tree.fork();
 
 			const { undoStack } = createTestUndoRedoStacks(tree1.events);
 			insert(tree1, 1, "a", "c");
 			remove(tree1, 1, 2); // Remove ac
 
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			undoStack.pop()?.revert(); // Restores ac
 			insert(tree1, 2, "b");
@@ -1984,9 +1984,9 @@ describe("Editing", () => {
 				}),
 			);
 
-			const treeA = tree.branch();
-			const treeC = tree.branch();
-			const treeD = tree.branch();
+			const treeA = tree.fork();
+			const treeC = tree.fork();
+			const treeD = tree.fork();
 
 			treeD.editor.move(root0Array, 0, 1, root1Array, 0);
 			tree.merge(treeD, false);
@@ -2158,7 +2158,7 @@ describe("Editing", () => {
 					const undoQueues: number[][] = makeArray(nbPeers, () => []);
 
 					const tree = makeTreeFromJsonSequence(startState);
-					const peers = makeArray(nbPeers, () => tree.branch());
+					const peers = makeArray(nbPeers, () => tree.fork());
 					const peerUndoStacks = peers.map((peer) => createTestUndoRedoStacks(peer.events));
 					for (const step of scenario) {
 						const iPeer = step.peer;
@@ -2285,7 +2285,7 @@ describe("Editing", () => {
 
 						it(`even if it was ${disruption.title} concurrently to (and sequenced before) the revert`, () => {
 							const tree1 = makeTreeFromJson({ foo: "X" });
-							const tree2 = tree1.branch();
+							const tree2 = tree1.fork();
 
 							const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree1.events);
 							action.delegate(tree1);
@@ -2307,7 +2307,7 @@ describe("Editing", () => {
 
 						it(`even if it was ${disruption.title} concurrently to (and sequenced before) the ${action.title}`, () => {
 							const tree1 = makeTreeFromJson({ foo: "X" });
-							const tree2 = tree1.branch();
+							const tree2 = tree1.fork();
 
 							disruption.delegate(tree1, fooField);
 
@@ -2336,8 +2336,8 @@ describe("Editing", () => {
 		describe("can rebase a set over another set", () => {
 			it("from a non-empty state", () => {
 				const tree1 = makeTreeFromJson({ foo: "1" });
-				const tree2 = tree1.branch();
-				const tree3 = tree1.branch();
+				const tree2 = tree1.fork();
+				const tree3 = tree1.fork();
 
 				tree2.editor
 					.valueField({ parent: rootNode, field: brand("foo") })
@@ -2357,8 +2357,8 @@ describe("Editing", () => {
 
 			it("from an empty state", () => {
 				const tree1 = makeTreeFromJson({});
-				const tree2 = tree1.branch();
-				const tree3 = tree1.branch();
+				const tree2 = tree1.fork();
+				const tree3 = tree1.fork();
 
 				tree2.editor
 					.optionalField({ parent: rootNode, field: brand("foo") })
@@ -2378,7 +2378,7 @@ describe("Editing", () => {
 
 		it("can rebase a node replacement and a dependent edit to the new node", () => {
 			const tree1 = checkoutWithContent(emptyJsonContent);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			tree1.editor.optionalField(rootField).set(chunkFromJsonTrees(["41"]), true);
 
@@ -2399,7 +2399,7 @@ describe("Editing", () => {
 
 		it("can rebase a node replacement and a dependent edit to the new node incrementally", () => {
 			const tree1 = checkoutWithContent(emptyJsonContent);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			tree1.editor.optionalField(rootField).set(chunkFromJsonTrees(["41"]), true);
 
@@ -2418,7 +2418,7 @@ describe("Editing", () => {
 
 		it("can rebase a node edit over an unrelated edit", () => {
 			const tree1 = makeTreeFromJson({ foo: "40", bar: "123" });
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			tree1.editor
 				.optionalField({
@@ -2438,7 +2438,7 @@ describe("Editing", () => {
 
 		it("can rebase a node edit over the node being replaced and restored", () => {
 			const tree1 = makeTreeFromJson({ foo: "40" });
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree1.events);
 
 			tree1.editor.optionalField(rootField).set(chunkFromJsonTrees([{ foo: "41" }]), false);
@@ -2457,7 +2457,7 @@ describe("Editing", () => {
 
 		it("can rebase over successive sets", () => {
 			const tree1 = checkoutWithContent(emptyJsonContent);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			tree1.editor.optionalField(rootField).set(chunkFromJsonTrees(["1"]), true);
 			tree2.editor.optionalField(rootField).set(chunkFromJsonTrees(["2"]), true);
@@ -2485,7 +2485,7 @@ describe("Editing", () => {
 
 		it("can rebase populating a new node over an unrelated change", () => {
 			const tree1 = makeTreeFromJson({});
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			tree1.editor
 				.optionalField({ parent: rootNode, field: brand("foo") })
@@ -2552,7 +2552,7 @@ describe("Editing", () => {
 
 						it(`even if it was ${disruption.title} concurrently to (and sequenced before) the revert`, () => {
 							const tree1 = makeTreeFromJson("A", true);
-							const tree2 = tree1.branch();
+							const tree2 = tree1.fork();
 
 							const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree1.events);
 							action.delegate(tree1);
@@ -2574,7 +2574,7 @@ describe("Editing", () => {
 
 						it(`even if it was ${disruption.title} concurrently to (and sequenced before) the ${action.title}`, () => {
 							const tree1 = makeTreeFromJson("A", true);
-							const tree2 = tree1.branch();
+							const tree2 = tree1.fork();
 
 							disruption.delegate(tree1, false);
 
@@ -2600,7 +2600,7 @@ describe("Editing", () => {
 
 		it("undo restores the removed node even when that node has been concurrently replaced", () => {
 			const tree = makeTreeFromJson("42", true);
-			const tree2 = tree.branch();
+			const tree2 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree2.events);
 
 			tree.editor.optionalField(rootField).set(chunkFromJsonTrees(["43"]), false);
@@ -2625,7 +2625,7 @@ describe("Editing", () => {
 			// Exercises a scenario where a transaction's inverse must be computed as part of a rebase sandwich.
 			it("Can rebase a series of edits including a transaction", () => {
 				const tree = makeTreeFromJson("42");
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				tree2.transaction.start();
 				tree2.editor.optionalField(rootField).set(chunkFromJsonTrees(["43"]), false);
@@ -2644,7 +2644,7 @@ describe("Editing", () => {
 
 			it("can rebase a transaction containing a node replacement and a dependent edit to the new node", () => {
 				const tree1 = checkoutWithContent(emptyJsonContent);
-				const tree2 = tree1.branch();
+				const tree2 = tree1.fork();
 
 				tree1.editor.optionalField(rootField).set(chunkFromJsonTrees(["41"]), true);
 
@@ -2669,7 +2669,7 @@ describe("Editing", () => {
 
 			it("Can set and remove a node within a transaction", () => {
 				const tree = checkoutWithContent(emptyJsonContent);
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				tree2.transaction.start();
 				tree2.editor.optionalField(rootField).set(chunkFromJsonTrees(["42"]), true);
@@ -2686,7 +2686,7 @@ describe("Editing", () => {
 
 		it("simplified repro for 0x7cf from anchors-undo-redo fuzz seed 0", () => {
 			const tree = makeTreeFromJson(1, true);
-			const fork = tree.branch();
+			const fork = tree.fork();
 
 			tree.editor.optionalField(rootField).set(chunkFromJsonTrees([2]), false);
 
@@ -2715,7 +2715,7 @@ describe("Editing", () => {
 				});
 				treeSequence.insert(0, chunkFromJsonTrees(["bar"]));
 
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Remove a
 				remove(tree, 0, 1);
@@ -2744,7 +2744,7 @@ describe("Editing", () => {
 			it("handles ancestor remove", () => {
 				const tree = makeTreeFromJsonSequence([{ foo: ["A"] }]);
 
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				const fooArrayNodePath: NormalizedUpPath = {
 					parent: rootNode,
@@ -2784,7 +2784,7 @@ describe("Editing", () => {
 				const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 				insert(tree, 0, "A", "D");
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Remove D
 				remove(tree, 1, 1);
@@ -2836,7 +2836,7 @@ describe("Editing", () => {
 				});
 				optional.set(chunkFromJsonTrees(["x"]), true);
 
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Remove foo
 				optional.set(undefined, false);
@@ -2870,7 +2870,7 @@ describe("Editing", () => {
 				});
 				optional.set(chunkFromJsonTrees(["x"]), true);
 
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				optional.set(undefined, false);
 				undoStack.pop()?.revert();
@@ -2895,7 +2895,7 @@ describe("Editing", () => {
 
 			it("existence constraint on node inserted in prior transaction", () => {
 				const tree = makeTreeFromJsonSequence([]);
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Insert "a"
 				// State should be: ["a"]
@@ -2923,7 +2923,7 @@ describe("Editing", () => {
 
 			it("can add constraint to node inserted in same transaction", () => {
 				const tree = makeTreeFromJsonSequence([{}]);
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Constrain on "a" existing and insert "b" if it does
 				// State should be (if "a" exists): [{ foo: "a"}, "b"]
@@ -2964,7 +2964,7 @@ describe("Editing", () => {
 				});
 				optional.set(chunkFromJsonTrees(["x"]), true);
 
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Remove foo
 				optional.set(undefined, false);
@@ -3000,7 +3000,7 @@ describe("Editing", () => {
 
 			it("transaction dropped when constrained node is inserted under a concurrently removed ancestor", () => {
 				const tree = makeTreeFromJsonSequence([{}]);
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Remove node from root sequence
 				const tree1RootSequence = tree.editor.sequenceField(rootField);
@@ -3032,7 +3032,7 @@ describe("Editing", () => {
 
 			it("not violated by move out under remove", () => {
 				const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				tree.transaction.start();
 				tree.editor.move(
@@ -3068,7 +3068,7 @@ describe("Editing", () => {
 
 			it("transaction dropped when constrained node is moved under a concurrently removed ancestor", () => {
 				const tree = makeTreeFromJsonSequence([{ foo: ["a"] }, {}]);
-				const tree2 = tree.branch();
+				const tree2 = tree.fork();
 
 				// Move "a" from foo to foo2 in the second node in the root sequence and then remove
 				// the second node in the root sequence
@@ -3178,7 +3178,7 @@ describe("Editing", () => {
 
 			it("inverse constraint violated while rebasing the original change", () => {
 				const tree = makeTreeFromJson({ foo: "A", bar: "old" });
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				// Make transaction on a branch that does the following:
 				// 1. Changes value of "bar" to "new".
@@ -3222,7 +3222,7 @@ describe("Editing", () => {
 
 		it("Rebase over conflicted change", () => {
 			const tree1 = makeTreeFromJsonSequence(["A", "B"]);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			// Remove A
 			remove(tree1, 0, 1);
@@ -3235,7 +3235,7 @@ describe("Editing", () => {
 			remove(tree2, 1, 1);
 			tree2.transaction.commit();
 
-			const tree3 = tree1.branch();
+			const tree3 = tree1.fork();
 
 			// This edit will be rebased over the conflicted transaction.
 			insert(tree3, 1, "C");
@@ -3253,30 +3253,30 @@ describe("Editing", () => {
 		it("Rebase over a commit that depends on a commit that has become conflicted", () => {
 			const rootTree = makeTreeFromJsonSequence(["C", "D"]);
 
-			const removeAnRestoreC = rootTree.branch();
+			const removeAnRestoreC = rootTree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(removeAnRestoreC.events);
 			remove(removeAnRestoreC, 0, 1);
-			const removeC = removeAnRestoreC.branch();
+			const removeC = removeAnRestoreC.fork();
 			expectJsonTree(removeC, ["D"]);
 
 			(undoStack.pop() ?? assert.fail("Missing undo")).revert();
 			unsubscribe();
-			const restoreC = removeAnRestoreC.branch();
+			const restoreC = removeAnRestoreC.fork();
 			expectJsonTree(restoreC, ["C", "D"]);
 
-			const addA = removeC.branch();
+			const addA = removeC.fork();
 			addA.transaction.start();
 			addA.editor.addNodeExistsConstraint(rootNode);
 			addA.editor.sequenceField(rootField).insert(0, chunkFromJsonTrees(["A"]));
 			addA.transaction.commit();
 			expectJsonTree(addA, ["A", "D"]);
 
-			const addB = addA.branch();
+			const addB = addA.fork();
 			addB.editor.sequenceField(rootField).insert(1, chunkFromJsonTrees(["B"]));
 			expectJsonTree(addB, ["A", "B", "D"]);
 
 			// Removing "D" will violate the constraint in the transaction that adds A.
-			const removeD = removeC.branch();
+			const removeD = removeC.fork();
 			remove(removeD, 0, 1);
 			expectJsonTree(removeD, []);
 
@@ -3286,7 +3286,7 @@ describe("Editing", () => {
 			rootTree.merge(addA); // No-op
 			expectJsonTree(rootTree, []);
 
-			const partiallyRebasedRestoreC = rootTree.branch();
+			const partiallyRebasedRestoreC = rootTree.fork();
 			partiallyRebasedRestoreC.merge(restoreC);
 			expectJsonTree(partiallyRebasedRestoreC, ["C"]);
 
@@ -3304,7 +3304,7 @@ describe("Editing", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				// Add a No Change constraint and make an edit
 				branch.transaction.start();
@@ -3327,7 +3327,7 @@ describe("Editing", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				// Add a No Change constraint and make an edit
 				branch.transaction.start();
@@ -3351,7 +3351,7 @@ describe("Editing", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				// Add a No Change constraint and make an edit
 				branch.transaction.start();
@@ -3369,7 +3369,7 @@ describe("Editing", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				// Add multiple No Change constraints and make edits
 				branch.transaction.start();
@@ -3392,7 +3392,7 @@ describe("Editing", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				// Add a No Change constraint and make an edit
 				const { undoStack, unsubscribe } = createTestUndoRedoStacks(branch.events);
@@ -3423,7 +3423,7 @@ describe("Editing", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
-				const branch = tree.branch();
+				const branch = tree.fork();
 
 				const { undoStack, unsubscribe } = createTestUndoRedoStacks(branch.events);
 				branch.transaction.start();
@@ -3453,7 +3453,7 @@ describe("Editing", () => {
 		// Fork the tree so we can undo the removal of the root without undoing later changes
 		// Note: if forking of the undo/redo stack is supported, this test can be simplified
 		// slightly by deleting the root node before forking.
-		const restoreRoot = tree.branch();
+		const restoreRoot = tree.fork();
 		const { undoStack, unsubscribe } = createTestUndoRedoStacks(restoreRoot.events);
 		restoreRoot.editor.sequenceField(rootField).remove(0, 1);
 		tree.merge(restoreRoot, false);
@@ -3482,7 +3482,7 @@ describe("Editing", () => {
 	describe("Anchors", () => {
 		it("anchors to content created on a branch survive rebasing of the branch", () => {
 			const tree = makeTreeFromJson({});
-			const branch = tree.branch();
+			const branch = tree.fork();
 
 			branch.editor
 				.sequenceField({ parent: rootNode, field: brand("seq") })
@@ -3587,7 +3587,7 @@ describe("Editing", () => {
 
 		it("on a child branch", () => {
 			const tree = makeTreeFromJsonSequence([initialState]);
-			const child = tree.branch();
+			const child = tree.fork();
 			abortTransaction(child);
 		});
 	});

--- a/packages/dds/tree/src/test/shared-tree/repairData.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/repairData.spec.ts
@@ -267,7 +267,7 @@ describe("Repair Data", () => {
 			);
 
 			// create a fork before the creation of the repair data
-			const _ = view2.checkout.branch();
+			const _ = view2.checkout.fork();
 
 			// get an anchor on the peer to the node we're removing
 			const anchorAOnTree2 = TestAnchor.fromValue(view2.checkout.forest, "A");

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -180,9 +180,6 @@ describe("schematizeTree", () => {
 			forest: { isEmpty } as IForestSubscription,
 			editor: undefined as unknown as ISharedTreeEditor,
 			transaction: undefined as unknown as Transactor,
-			branch(): ITreeCheckout {
-				throw new Error("Function not implemented.");
-			},
 			fork(): ITreeCheckout {
 				throw new Error("Function not implemented.");
 			},

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1615,7 +1615,7 @@ describe("SharedTree", () => {
 				provider.synchronizeMessages();
 
 				// fork the tree
-				const branch = resubmitter.checkout.branch();
+				const branch = resubmitter.checkout.fork();
 
 				// edit the removed tree on the fork
 				const branchView = new SchematizingSimpleTreeView(
@@ -2217,7 +2217,7 @@ describe("SharedTree", () => {
 			Tree.runTransaction(parentView, () => {
 				parentView.root.insertAtStart("B");
 			});
-			const childCheckout = parentTree.kernel.checkout.branch();
+			const childCheckout = parentTree.kernel.checkout.fork();
 			const childView = new SchematizingSimpleTreeView(
 				childCheckout,
 				new TreeViewConfiguration({

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -224,7 +224,7 @@ describe("sharedTreeView", () => {
 			"can fork and apply edits without affecting the parent",
 			({ view: parentView, tree: parentTree }) => {
 				parentView.root.insertAtStart("parent");
-				const childTree = parentTree.branch();
+				const childTree = parentTree.fork();
 				const childView = childTree.viewWith(parentView.config);
 				childView.root.insertAtStart("child");
 				assert.deepEqual([...parentView.root], ["parent"]);
@@ -235,7 +235,7 @@ describe("sharedTreeView", () => {
 		itView(
 			"can apply edits without affecting a fork",
 			({ view: parentView, tree: parentTree }) => {
-				const childTree = parentTree.branch();
+				const childTree = parentTree.fork();
 				const childView = childTree.viewWith(parentView.config);
 				assert.equal(parentView.root[0], undefined);
 				assert.equal(childView.root[0], undefined);
@@ -246,7 +246,7 @@ describe("sharedTreeView", () => {
 		);
 
 		itView("can merge changes into a parent", ({ view: parentView, tree: parentTree }) => {
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(parentView.config);
 			childView.root.insertAtStart("view");
 			parentTree.merge(childTree);
@@ -254,7 +254,7 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("can rebase over a parent view", ({ view: parentView, tree: parentTree }) => {
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(parentView.config);
 			parentView.root.insertAtStart("root");
 			assert.equal(childView.root[0], undefined);
@@ -263,10 +263,10 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("can rebase over a child view", ({ view, tree }) => {
-			const parentTree = tree.branch();
+			const parentTree = tree.fork();
 			const parentView = parentTree.viewWith(view.config);
 			parentView.root.insertAtStart("P1");
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(view.config);
 			parentView.root.insertAtStart("P2");
 			childView.root.insertAtStart("C1");
@@ -276,11 +276,11 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("merge changes through multiple views", ({ view: viewA, tree: treeA }) => {
-			const treeB = treeA.branch();
+			const treeB = treeA.fork();
 			const viewB = treeB.viewWith(viewA.config);
-			const treeC = treeB.branch();
+			const treeC = treeB.fork();
 			const viewC = treeC.viewWith(viewA.config);
-			const treeD = treeC.branch();
+			const treeD = treeC.fork();
 			const viewD = treeD.viewWith(viewA.config);
 			viewD.root.insertAtStart("view");
 			treeC.merge(treeD);
@@ -294,11 +294,11 @@ describe("sharedTreeView", () => {
 		itView(
 			"merge correctly when multiple ancestors are mutated",
 			({ view: viewA, tree: treeA }) => {
-				const treeB = treeA.branch();
+				const treeB = treeA.fork();
 				const viewB = treeB.viewWith(viewA.config);
-				const treeC = treeB.branch();
+				const treeC = treeB.fork();
 				const viewC = treeC.viewWith(viewA.config);
-				const treeD = treeC.branch();
+				const treeD = treeC.fork();
 				const viewD = treeD.viewWith(viewA.config);
 				viewB.root.insertAtStart("B");
 				viewC.root.insertAtStart("C");
@@ -312,10 +312,10 @@ describe("sharedTreeView", () => {
 		);
 
 		itView("can merge a parent view into a child", ({ view, tree }) => {
-			const parentTree = tree.branch();
+			const parentTree = tree.fork();
 			const parentView = parentTree.viewWith(view.config);
 			parentView.root.insertAtStart("P1");
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(view.config);
 			parentView.root.insertAtStart("P2");
 			childView.root.insertAtStart("C1");
@@ -325,11 +325,11 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("can perform a complicated merge scenario", ({ view: viewA, tree: treeA }) => {
-			const treeB = treeA.branch();
+			const treeB = treeA.fork();
 			const viewB = treeB.viewWith(viewA.config);
-			const treeC = treeB.branch();
+			const treeC = treeB.fork();
 			const viewC = treeC.viewWith(viewA.config);
-			const treeD = treeC.branch();
+			const treeD = treeC.fork();
 			const viewD = treeD.viewWith(viewA.config);
 			viewB.root.insertAtStart("A1");
 			viewC.root.insertAtStart("B1");
@@ -339,7 +339,7 @@ describe("sharedTreeView", () => {
 			viewB.root.insertAtStart("A2");
 			viewC.root.insertAtStart("B2");
 			treeB.merge(treeC);
-			const treeE = treeB.branch();
+			const treeE = treeB.fork();
 			const viewE = treeE.viewWith(viewA.config);
 			viewB.root.insertAtStart("A3");
 			treeE.rebaseOnto(treeB);
@@ -395,7 +395,7 @@ describe("sharedTreeView", () => {
 				cursor.firstNode();
 				const anchor = cursor.buildAnchor();
 				cursor.clear();
-				const childTree = parentTree.branch();
+				const childTree = parentTree.fork();
 				const childView = childTree.viewWith(parentView.config);
 				childView.root.insertAtStart("B");
 				parentTree.merge(childTree);
@@ -419,7 +419,7 @@ describe("sharedTreeView", () => {
 				cursor.firstNode();
 				const anchor = cursor.buildAnchor();
 				cursor.clear();
-				const childTree = parentTree.branch();
+				const childTree = parentTree.fork();
 				const childView = childTree.viewWith(parentView.config);
 				parentView.root.insertAtStart("P");
 				childView.root.insertAtStart("B");
@@ -452,7 +452,7 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("can be mutated after merging", ({ view: parentView, tree: parentTree }) => {
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(parentView.config);
 			childView.root.insertAtStart("A");
 			parentTree.merge(childTree, false);
@@ -464,7 +464,7 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("can rebase after merging", ({ view: parentView, tree: parentTree }) => {
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(parentView.config);
 			childView.root.insertAtStart("A");
 			parentTree.merge(childTree, false);
@@ -475,7 +475,7 @@ describe("sharedTreeView", () => {
 
 		itView("can be read after merging", ({ view: parentView, tree: parentTree }) => {
 			parentView.root.insertAtStart("root");
-			const childTree = parentTree.branch();
+			const childTree = parentTree.fork();
 			const childView = childTree.viewWith(parentView.config);
 			parentTree.merge(childTree, false);
 			assert.equal(childView.root[0], "root");
@@ -494,7 +494,7 @@ describe("sharedTreeView", () => {
 				}
 
 				assert.equal(getSchema(parentView.checkout), "schemaA");
-				const childTree = parentTree.branch();
+				const childTree = parentTree.fork();
 				const childView = childTree.viewWith(new TreeViewConfiguration({ schema: schemaB }));
 				childView.upgradeSchema();
 				assert.equal(getSchema(parentView.checkout), "schemaA");
@@ -527,8 +527,8 @@ describe("sharedTreeView", () => {
 					enableSchemaValidation,
 				}),
 			);
-			const baseTree = branch1.branch();
-			const tree = baseTree.branch();
+			const baseTree = branch1.fork();
+			const tree = baseTree.fork();
 			const view = tree.viewWith(view1.config);
 			// Modify the view, but tree2 should remain unchanged until the edit merges all the way up
 			view.root.insertAtStart("42");
@@ -557,8 +557,8 @@ describe("sharedTreeView", () => {
 			provider.synchronizeMessages();
 			let opsReceived = 0;
 			provider.trees[1].on("op", () => (opsReceived += 1));
-			const baseBranch = branch1.branch();
-			const tree = baseBranch.branch();
+			const baseBranch = branch1.fork();
+			const tree = baseBranch.fork();
 			const view = tree.viewWith(view1.config);
 			view.root.insertAtStart("A");
 			view.root.insertAtStart("B");
@@ -656,17 +656,17 @@ describe("sharedTreeView", () => {
 			Tree.runTransaction(view, () => {
 				view.root.insertAtEnd("42");
 				assert.throws(
-					() => tree.branch(),
+					() => tree.fork(),
 					validateUsageError("A view cannot be forked while it has a pending transaction."),
 				);
 			});
-			tree.branch();
+			tree.fork();
 		});
 
 		itView(
 			"rejects merges while a transaction is in progress on the target view",
 			({ view, tree }) => {
-				const treeBranch = tree.branch();
+				const treeBranch = tree.fork();
 				const viewBranch = treeBranch.viewWith(view.config);
 				viewBranch.root.insertAtEnd("42");
 
@@ -684,7 +684,7 @@ describe("sharedTreeView", () => {
 		itView(
 			"rejects merges while a transaction is in progress on the source view",
 			({ view, tree }) => {
-				const treeBranch = tree.branch();
+				const treeBranch = tree.fork();
 				const viewBranch = treeBranch.viewWith(view.config);
 				view.root.insertAtEnd("42");
 				viewBranch.root.insertAtEnd("43");
@@ -704,7 +704,7 @@ describe("sharedTreeView", () => {
 		itView(
 			"rejects rebases while a transaction is in progress on the source view",
 			({ view, tree }) => {
-				const treeBranch = tree.branch();
+				const treeBranch = tree.fork();
 				const viewBranch = treeBranch.viewWith(view.config);
 				view.root.insertAtEnd("42");
 
@@ -722,7 +722,7 @@ describe("sharedTreeView", () => {
 		itView(
 			"rejects rebases while a transaction is in progress on the target view",
 			({ view, tree }) => {
-				const treeBranch = tree.branch();
+				const treeBranch = tree.fork();
 				const viewBranch = treeBranch.viewWith(view.config);
 				view.root.insertAtEnd("42");
 				viewBranch.root.insertAtEnd("43");
@@ -740,7 +740,7 @@ describe("sharedTreeView", () => {
 		);
 
 		itView("do not affect pre-existing forks", ({ view, tree }) => {
-			const treeBranch = tree.branch();
+			const treeBranch = tree.fork();
 			const viewBranch = treeBranch.viewWith(view.config);
 			view.root.insertAtEnd("A");
 			Tree.runTransaction(viewBranch, () => {
@@ -841,14 +841,14 @@ describe("sharedTreeView", () => {
 
 	describe("disposal", () => {
 		itView("forks can be disposed", ({ view, tree }) => {
-			const treeBranch = tree.branch();
+			const treeBranch = tree.fork();
 			const viewBranch = treeBranch.viewWith(view.config);
 			viewBranch.dispose();
 			assert.equal(treeBranch.disposed, true);
 		});
 
 		itView("disposed forks cannot be edited or double-disposed", ({ view, tree }) => {
-			const treeBranch = tree.branch();
+			const treeBranch = tree.fork();
 			const viewBranch = treeBranch.viewWith(view.config);
 			treeBranch.dispose();
 			assert.throws(() => treeBranch.dispose());
@@ -960,7 +960,7 @@ describe("sharedTreeView", () => {
 			// Fork the main branch with new schema.
 			const sf2 = new SchemaFactory("schema1");
 			const newSchema = [sf2.array(sf2.string), sf2.array([sf2.string, sf2.number])];
-			const branch2 = branch1.branch();
+			const branch2 = branch1.fork();
 			const view2 = branch2.viewWith(
 				new TreeViewConfiguration({ schema: newSchema, enableSchemaValidation }),
 			);
@@ -1004,7 +1004,7 @@ describe("sharedTreeView", () => {
 			// Get the checkout of the parent branch and fork it before disposing it. The branch is disposed
 			// so that a new view can be created from it with a new schema.
 			const checkout1 = view1.checkout;
-			const checkout2 = view1.checkout.branch();
+			const checkout2 = view1.checkout.fork();
 			view1.dispose();
 
 			// Create a new schema - schema2.
@@ -1187,7 +1187,7 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("disposing of a view also disposes of its revertibles", ({ view, tree }) => {
-			const treeBranch = tree.branch();
+			const treeBranch = tree.fork();
 			const viewBranch = asAlpha(treeBranch.viewWith(view.config));
 			const revertiblesCreated: Revertible[] = [];
 			const unsubscribe = viewBranch.events.on("changed", ({ getRevertible }) => {
@@ -1218,7 +1218,7 @@ describe("sharedTreeView", () => {
 		});
 
 		itView("can be reverted after rebasing", ({ view, tree }) => {
-			const treeBranch = tree.branch();
+			const treeBranch = tree.fork();
 			const viewBranch = asAlpha(treeBranch.viewWith(view.config));
 			viewBranch.root.insertAtStart("A");
 
@@ -1832,7 +1832,7 @@ describe("sharedTreeView", () => {
 			const view = getView(config);
 			view.initialize(5);
 			const fork1 = view.fork();
-			const fork2 = fork1.checkout.branch().viewWith(config);
+			const fork2 = fork1.checkout.fork().viewWith(config);
 
 			// Break the transitive fork.
 			assert.throws(
@@ -1975,7 +1975,7 @@ function itView<
 		);
 
 		if (fork) {
-			const treeBranch = view.checkout.branch();
+			const treeBranch = view.checkout.fork();
 			const viewBranch = treeBranch.viewWith(view.config);
 			assert(viewBranch instanceof SchematizingSimpleTreeView);
 			return { view: viewBranch, tree: treeBranch, logger };
@@ -2006,7 +2006,7 @@ function itView<
 	itFunction(`${title} (forked view)`, () => {
 		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
-		const branch = tree.kernel.checkout.branch();
+		const branch = tree.kernel.checkout.fork();
 		callWithView(fn, (config) => {
 			const view = branch.viewWith(config);
 			assert(view instanceof SchematizingSimpleTreeView);

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -229,7 +229,7 @@ describe("Undo and redo", () => {
 			const itFn = skip ? it.skip : it;
 			itFn(`${name} (act on fork undo on fork - ${attachStr})`, () => {
 				const view = createCheckout(initialState, attached);
-				const fork = view.branch();
+				const fork = view.fork();
 
 				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(fork.events);
 				edit(fork, view);
@@ -256,7 +256,7 @@ describe("Undo and redo", () => {
 			// TODO: unskip once forking revertibles is supported
 			it.skip(`${name} (act on view undo on fork - ${attachStr})`, () => {
 				const view = createCheckout(initialState, attached);
-				const fork = view.branch();
+				const fork = view.fork();
 
 				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(fork.events);
 				edit(view, fork);
@@ -282,7 +282,7 @@ describe("Undo and redo", () => {
 
 			itFn(`${name} (act on view undo on view - ${attachStr})`, () => {
 				const view = createCheckout(initialState, attached);
-				const fork = view.branch();
+				const fork = view.fork();
 
 				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
 				edit(view, fork);
@@ -309,7 +309,7 @@ describe("Undo and redo", () => {
 			// TODO: unskip once forking revertibles is supported
 			it.skip(`${name} (act on fork undo on view - ${attachStr})`, () => {
 				const view = createCheckout(initialState, attached);
-				const fork = view.branch();
+				const fork = view.fork();
 
 				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
 				edit(fork, view);
@@ -335,7 +335,7 @@ describe("Undo and redo", () => {
 
 			it(`${name} multiple times (${attachStr})`, () => {
 				const tree = createCheckout(initialState, attached);
-				const fork = tree.branch();
+				const fork = tree.fork();
 
 				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 				edit(tree, fork);
@@ -364,7 +364,7 @@ describe("Undo and redo", () => {
 
 		it(`can undo before and after rebasing a branch (${attachStr})`, () => {
 			const tree1 = createCheckout([0, 0, 0], attached);
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree2.events);
 			tree1.editor.sequenceField(rootField).insert(3, chunkFromJsonTrees([1]));
@@ -389,7 +389,7 @@ describe("Undo and redo", () => {
 			tree1.editor.sequenceField(rootField).remove(0, 1);
 			tree1.editor.sequenceField(rootField).remove(1, 1);
 
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 			const { undoStack: undoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
 				tree2.events,
 			);
@@ -414,7 +414,7 @@ describe("Undo and redo", () => {
 			undoStack1.pop()?.revert();
 			undoStack1.pop()?.revert();
 
-			const tree2 = tree1.branch();
+			const tree2 = tree1.fork();
 			const { redoStack: redoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
 				tree2.events,
 			);
@@ -448,7 +448,7 @@ describe("Undo and redo", () => {
 			const tree = createCheckout(["A", "B"], attached);
 
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
-			const branch = tree.branch();
+			const branch = tree.fork();
 			branch.editor.sequenceField(rootField).insert(2, chunkFromJsonTrees(["C"]));
 			branch.editor.sequenceField(rootField).remove(0, 1);
 			tree.merge(branch);
@@ -470,7 +470,7 @@ describe("Undo and redo", () => {
 
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
-			const branch = tree.branch();
+			const branch = tree.fork();
 
 			branch.editor.sequenceField(rootField).insert(2, chunkFromJsonTrees(["C"]));
 			tree.merge(branch, false);

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -2489,7 +2489,7 @@ describe("treeNodeApi", () => {
 			Tree.on(root, "nodeChanged", () => shallowChanges++);
 			Tree.on(root, "treeChanged", () => deepChanges++);
 
-			const branch = checkout.branch();
+			const branch = checkout.fork();
 			branch.editor
 				.valueField({ parent: rootNode, field: brand("prop1") })
 				.set(chunkFromJsonableTrees([{ type: brand(numberSchema.identifier), value: 2 }]));

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -139,7 +139,7 @@ export function pretty(arg: unknown): number | string {
 export function getViewForForkedBranch<const TSchema extends ImplicitFieldSchema>(
 	originalView: SchematizingSimpleTreeView<TSchema>,
 ): { forkView: SchematizingSimpleTreeView<TSchema>; forkCheckout: TreeCheckout } {
-	const forkCheckout = originalView.checkout.branch();
+	const forkCheckout = originalView.checkout.fork();
 	return {
 		forkView: new SchematizingSimpleTreeView<TSchema>(
 			forkCheckout,

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -205,7 +205,7 @@ export function generateTestTrees(options: SharedTreeOptions): TestTree[] {
 				provider.synchronizeMessages();
 
 				const branch1 = view1.checkout;
-				const tree2 = branch1.branch();
+				const tree2 = branch1.fork();
 				const view2 = tree2.viewWith(view1.config);
 				view1.root.insertAt(0, "y");
 				tree2.rebaseOnto(branch1);
@@ -223,7 +223,7 @@ export function generateTestTrees(options: SharedTreeOptions): TestTree[] {
 				assert.deepEqual(view1.root, ["x", "y", "a", "b", "c"]);
 				assert.deepEqual(view1.root, view2.root);
 
-				const tree3 = branch1.branch();
+				const tree3 = branch1.fork();
 				const view3 = tree3.viewWith(view1.config);
 				view1.root.insertAt(0, "z");
 				view3.root.insertAt(1, "d", "e");

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1470,11 +1470,8 @@ export class MockTreeCheckout implements ITreeCheckout {
 	}
 
 	public disposed = false;
-	public branch(): ITreeCheckout {
+	public fork(): ITreeCheckout {
 		throw new Error("Method 'branch' not implemented in MockTreeCheckout.");
-	}
-	public fork(): TreeBranchAlpha {
-		throw new Error("Method 'fork' not implemented in MockTreeCheckout.");
 	}
 	public isBranch(): this is TreeBranchAlpha {
 		throw new Error("Method 'isBranch' not implemented in MockTreeCheckout.");


### PR DESCRIPTION
This is redundant with `fork` and `fork` is preferred. This does not affect user facing APIs, only internal APIs. The only significant changes are in `treeCheckout.ts` - all other changes are trivially derived from the removal.