### PR TITLE
fix(test-service-load): Always set `disableSchemaUpgrade` to false in stress tests

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -118,7 +118,7 @@ export function generateRuntimeOptions(
 		enableGroupedBatching: [true, false],
 		createBlobPayloadPending: [true, undefined],
 		explicitSchemaControl: [true, false],
-		disableSchemaUpgrade: [true, false],
+		disableSchemaUpgrade: [false],
 	};
 
 	const pairwiseOptions = generatePairwiseOptions<IContainerRuntimeOptionsInternal>(


### PR DESCRIPTION
## Description

This PR always sets `disableSchemaUpgrade` to false for stress tests. This option is intended to be used in scenarios where all connected clients share the same value for `disableSchemaUpgrade`.