### PR TITLE
update examples to have tinylicious

### DIFF
--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -38,6 +38,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -85,6 +86,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -39,6 +39,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -80,6 +81,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -71,6 +72,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -33,6 +33,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -92,6 +93,7 @@
 		"rimraf": "^6.1.3",
 		"sass-loader": "^16.0.1",
 		"style-loader": "^4.0.0",
+		"tinylicious": "^7.0.0",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",
 		"url-loader": "^4.1.1",

--- a/examples/apps/diceroller/package.json
+++ b/examples/apps/diceroller/package.json
@@ -34,6 +34,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -69,6 +70,7 @@
 		"jiti": "^2.6.1",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -81,6 +82,7 @@
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
 		"style-loader": "^4.0.0",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -33,6 +33,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -72,6 +73,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -82,6 +83,7 @@
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
 		"style-loader": "^4.0.0",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -71,6 +72,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -85,6 +86,7 @@
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
 		"style-loader": "^4.0.0",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -89,6 +90,7 @@
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
 		"style-loader": "^4.0.0",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -32,6 +32,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -34,6 +34,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -74,6 +75,7 @@
 		"jiti": "^2.6.1",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -34,6 +34,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -78,6 +79,7 @@
 		"jiti": "^2.6.1",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -31,6 +31,7 @@
 		"test": "npm run test:jest",
 		"test:jest": "jest --ci",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest --ci",
+		"tinylicious": "tinylicious",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"
 	},
@@ -70,6 +71,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^23.6.0",
 		"rimraf": "^6.1.3",
+		"tinylicious": "^7.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -589,6 +592,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -713,6 +719,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -894,6 +903,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.103.0)
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1003,6 +1015,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -1302,6 +1317,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.103.0)
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -1423,6 +1441,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -1638,6 +1659,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.103.0)
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -5651,6 +5675,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -5817,6 +5844,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.103.0)
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -5995,6 +6025,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.103.0)
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -6279,6 +6312,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -6415,6 +6451,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)
@@ -6536,6 +6575,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tinylicious:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.19.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.4.5)))(typescript@5.4.5)


### PR DESCRIPTION
## Summary

The auto generated readme says to run pnpm tinylicious in another terminal to start a tinylicious server, but some examples didn't have tinylicious as a dependency. Now all examples that need tinylicious have it as a start script/dependency