### PR TITLE
(tree) Add documentation for enabling incremental summary in tree

### DIFF
--- a/docs/docs/data-structures/tree/incremental-summary.mdx
+++ b/docs/docs/data-structures/tree/incremental-summary.mdx
@@ -1,0 +1,114 @@
+---
+title: Incremental Summary
+sidebar_position: 9
+---
+
+:::caution
+
+The APIs described on this page are currently `@alpha` and may change in future releases.
+These APIs should not be used in production.
+See [API Support Levels](../../build/releases-and-apitags.mdx#api-support-levels) for more information.
+
+:::
+
+Incremental summary is an optimization that avoids re-summarizing parts of the tree that have not changed between summaries.
+Types in a schema can opt in to incremental summarization by being marked with `incrementalSummaryHint`.
+These types are tracked as independent chunks in the summary.
+During summarization, if their content has not changed since the last summary, their previously generated summaries are reused.
+As a result, their data does not need to be re-encoded (saving processing time), and their summary trees do not need to be uploaded again (reducing summary upload size).
+
+## How to Enable
+
+Enabling incremental summary requires two steps: marking fields in your schema and configuring the `SharedTree` with the required options.
+
+### 1. Mark Fields in Your Schema
+
+Use `sf.types(...)` with `incrementalSummaryHint` in the `custom` metadata to opt a field in to incremental summarization.
+
+```typescript
+import { SchemaFactoryAlpha, incrementalSummaryHint } from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactoryAlpha("my-app");
+
+class Item extends sf.objectAlpha("Item", {
+    id: sf.number,
+    // This field will be incrementally summarized.
+    payload: sf.types([{ type: sf.string, metadata: {} }], {
+        custom: { [incrementalSummaryHint]: true },
+    }),
+}) {}
+
+class ItemList extends sf.arrayAlpha(
+    "ItemList",
+    // Each element of this array will be tracked as a separate incremental chunk.
+    sf.types([{ type: Item, metadata: {} }], {
+        custom: { [incrementalSummaryHint]: true },
+    }),
+) {}
+
+class Root extends sf.objectAlpha("Root", {
+    items: ItemList,
+}) {}
+```
+
+:::note
+
+Incremental summarization is applied to **fields**, not node kinds.
+Leaf values (string, number, boolean, null) can be incrementally summarized when they are stored in a field that is opted in via `incrementalSummaryHint` (for example, an object field whose allowed type is `string`).
+Root fields themselves cannot be incrementally summarized, and leaf node kinds do not expose child fields for the policy to apply to.
+
+:::
+
+### 2. Configure the SharedTree
+
+Pass all four required options when creating the `SharedTree` using `configuredSharedTreeAlpha`:
+
+```typescript
+import {
+    configuredSharedTreeAlpha,
+    ForestTypeOptimized,
+    TreeCompressionStrategy,
+    TreeViewConfigurationAlpha,
+    incrementalEncodingPolicyForAllowedTypes,
+    FluidClientVersion,
+} from "@fluidframework/tree/alpha";
+
+const config = new TreeViewConfigurationAlpha({ schema: Root });
+
+const TreeFactory = configuredSharedTreeAlpha({
+    forest: ForestTypeOptimized,
+    treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
+    shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(config),
+    minVersionForCollab: FluidClientVersion.v2_74,
+});
+
+const sharedTree = TreeFactory.create(runtime, "tree");
+```
+
+All four of the following configuration options must be set for incremental summary to take effect:
+
+| Option | Value |
+|---|---|
+| `forest` | `ForestTypeOptimized` |
+| `treeEncodeType` | `TreeCompressionStrategy.CompressedIncremental` |
+| `shouldEncodeIncrementally` | Result of `incrementalEncodingPolicyForAllowedTypes(config)` |
+| `minVersionForCollab` | `FluidClientVersion.v2_74` or higher |
+
+## How `incrementalEncodingPolicyForAllowedTypes` Works
+
+`incrementalEncodingPolicyForAllowedTypes` accepts a `TreeViewConfigurationAlpha` and returns a callback.
+During summarization, the callback is invoked for each field in the tree with the node identifier and field key.
+It returns `true` if the field was opted in via `incrementalSummaryHint`, directing the summarizer to encode that field as a separate, reusable chunk.
+
+Fields that are _not_ opted in are encoded into the main summary blob as usual.
+
+## Limitations
+
+-   Root fields cannot be incrementally summarized (the callback always returns `false` for them).
+-   If the view schema does not recognize a node type (for example, due to schema mismatch or unknown optional fields), that node falls back to non-incremental encoding.
+-   The `incrementalSummaryHint` symbol will be replaced by a dedicated metadata property once the APIs stabilize.
+
+## See Also
+
+-   [Schema Definition](./schema-definition/index.mdx) — Overview of defining schemas with `SchemaFactory`
+-   [API Support Levels](../../build/releases-and-apitags.mdx#api-support-levels) — Release channels and API stability

--- a/docs/docs/data-structures/tree/index.mdx
+++ b/docs/docs/data-structures/tree/index.mdx
@@ -27,6 +27,7 @@ For more detail, see the links below.
 - [Transactions](./transactions.mdx): how edits can be grouped into transactions
 - [Undo Redo Support](./undo-redo.mdx): how undo redo works on a `SharedTree`
 - [Schema Evolution](./schema-evolution/index.mdx): how to make and rollout changes to an existing `SharedTree` schema.
+- [Incremental Summary](./incremental-summary.mdx): an optimization that avoids re-summarizing unchanged parts of the tree.
 
 ## API Documentation
 

--- a/packages/dds/tree/INCREMENTAL_SUMMARY.md
+++ b/packages/dds/tree/INCREMENTAL_SUMMARY.md
@@ -1,0 +1,86 @@
+# Incremental Summary
+
+Incremental summary is an optimization where parts of the tree that don't change across summaries are not re-summarized. The types in a schema can be opted into incremental summarization by marking them with `incrementalSummaryHint`. These types are tracked as independent chunk in the summary and during summarization, if their content hasn't changed since the last summary, they are re-used from the last summary. So, their data doesn't need to be re-encoded (saving processing time) and their summary tree doesn't need to be uploaded (reducing summary upload size).
+
+> **Warning:** This is an alpha API and is actively under development. Interfaces and behavior may change in future releases without notice. Do not rely on it in production.
+
+## Requirements
+
+All five of the following must be set for incremental summary to take effect:
+
+| Requirement | Value |
+|---|---|
+| Forest type | [`ForestTypeOptimized`](./src/shared-tree/sharedTree.ts) |
+| Compression strategy | [`TreeCompressionStrategy.CompressedIncremental`](./src/feature-libraries/treeCompressionUtils.ts) |
+| [`shouldEncodeIncrementally`](./src/shared-tree/sharedTree.ts) option | result of [`incrementalEncodingPolicyForAllowedTypes(config)`](./src/simple-tree/api/incrementalAllowedTypes.ts) |
+| `minVersionForCollab` | [`FluidClientVersion.v2_74`](./src/codec/codec.ts) or higher |
+| Schema opt-in | Fields marked with [`incrementalSummaryHint`](./src/simple-tree/api/incrementalAllowedTypes.ts) |
+
+## How to Enable
+
+### 1. Mark fields in your schema
+
+Use `sf.types(...)` with `incrementalSummaryHint` in the `custom` metadata to opt a field in.
+
+```typescript
+import { SchemaFactoryAlpha, incrementalSummaryHint } from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactoryAlpha("my-app");
+
+class Item extends sf.objectAlpha("Item", {
+    id: sf.number,
+    // This field will be incrementally summarized.
+    payload: sf.types([{ type: sf.string, metadata: {} }], {
+        custom: { [incrementalSummaryHint]: true },
+    }),
+}) {}
+
+class ItemList extends sf.arrayAlpha(
+    "ItemList",
+    // Each element of this array will be tracked as a separate incremental chunk.
+    sf.types([{ type: Item, metadata: {} }], {
+        custom: { [incrementalSummaryHint]: true },
+    }),
+) {}
+
+class Root extends sf.objectAlpha("Root", {
+    items: ItemList,
+}) {}
+```
+
+> **Note:** Leaf nodes (string, number, boolean, null) are not incrementally summarized even when marked with `incrementalSummaryHint`.
+
+### 2. Configure the SharedTree
+
+Pass all four required options when creating the SharedTree:
+
+```typescript
+import {
+    ForestTypeOptimized,
+    TreeCompressionStrategy,
+    TreeViewConfigurationAlpha,
+} from "@fluidframework/tree/alpha";
+import { incrementalEncodingPolicyForAllowedTypes } from "@fluidframework/tree/alpha";
+import { FluidClientVersion } from "@fluidframework/tree/internal";
+
+const config = new TreeViewConfigurationAlpha({ schema: Root });
+
+const sharedTree = SharedTree.create(runtime, "tree", {
+    forest: ForestTypeOptimized,
+    treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
+    shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(config),
+    minVersionForCollab: FluidClientVersion.v2_74,
+});
+```
+
+## How `incrementalEncodingPolicyForAllowedTypes` Works
+
+`incrementalEncodingPolicyForAllowedTypes` takes a `TreeSchema` (typically a `TreeViewConfiguration`) and returns an `IncrementalEncodingPolicy` callback. During summarization, the callback is invoked for each field in the tree with the node identifier and field key. It returns `true` if the field was opted in via `incrementalSummaryHint`, directing the summarizer to encode that field as a separate, reusable chunk.
+
+Fields that are _not_ opted in are encoded into the main summary blob as usual.
+
+## Limitations and future work
+
+- Root fields cannot be incrementally summarized (the callback always returns `false` for them).
+- If the view schema doesn't recognize a node type (e.g., due to schema mismatch or unknown optional fields), that node falls back to non-incremental encoding.
+- This feature is `@alpha` and the `incrementalSummaryHint` symbol will be replaced by a dedicated metadata property once the APIs stabilize.

--- a/packages/dds/tree/INCREMENTAL_SUMMARY.md
+++ b/packages/dds/tree/INCREMENTAL_SUMMARY.md
@@ -1,6 +1,6 @@
 # Incremental Summary
 
-Incremental summary is an optimization where parts of the tree that don't change across summaries are not re-summarized. The types in a schema can be opted into incremental summarization by marking them with `incrementalSummaryHint`. These types are tracked as independent chunk in the summary and during summarization, if their content hasn't changed since the last summary, they are re-used from the last summary. So, their data doesn't need to be re-encoded (saving processing time) and their summary tree doesn't need to be uploaded (reducing summary upload size).
+Incremental summary is an optimization that avoids re-summarizing parts of the tree that don't change between summaries. Types in a schema can opt in to incremental summarization by being marked with `incrementalSummaryHint`. These types are tracked as independent chunks in the summary. During summarization, if their content hasn't changed since the last summary, their previously generated summaries are reused. As a result, their data doesn't need to be re-encoded (saving processing time), and their summary trees don't need to be uploaded again (reducing summary upload size).
 
 > **Warning:** This is an alpha API and is actively under development. Interfaces and behavior may change in future releases without notice. Do not rely on it in production.
 
@@ -48,29 +48,32 @@ class Root extends sf.objectAlpha("Root", {
 }) {}
 ```
 
-> **Note:** Leaf nodes (string, number, boolean, null) are not incrementally summarized even when marked with `incrementalSummaryHint`.
+> **Note:** Incremental summarization is applied to **fields**, not node kinds. Leaf values (string, number, boolean, null) can be incrementally summarized when they are stored in a field that is opted in via `incrementalSummaryHint` (for example, an object field whose allowed type is `string`). Root fields themselves cannot be incrementally summarized, and leaf node kinds do not expose child fields for the policy to apply to.
 
 ### 2. Configure the SharedTree
 
-Pass all four required options when creating the SharedTree:
+Pass all four required options when creating the SharedTree using `configuredSharedTreeAlpha`:
 
 ```typescript
 import {
+    configuredSharedTreeAlpha,
     ForestTypeOptimized,
     TreeCompressionStrategy,
     TreeViewConfigurationAlpha,
+    incrementalEncodingPolicyForAllowedTypes,
+    FluidClientVersion,
 } from "@fluidframework/tree/alpha";
-import { incrementalEncodingPolicyForAllowedTypes } from "@fluidframework/tree/alpha";
-import { FluidClientVersion } from "@fluidframework/tree/internal";
 
 const config = new TreeViewConfigurationAlpha({ schema: Root });
 
-const sharedTree = SharedTree.create(runtime, "tree", {
+const TreeFactory = configuredSharedTreeAlpha({
     forest: ForestTypeOptimized,
     treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
     shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(config),
     minVersionForCollab: FluidClientVersion.v2_74,
 });
+
+const sharedTree = TreeFactory.create(runtime, "tree");
 ```
 
 ## How `incrementalEncodingPolicyForAllowedTypes` Works


### PR DESCRIPTION
Added documentation to the tree repo that explains how to enable incremental summary for shared tree. See the .md file for details.

Also, added a document to the docs/ repo which reuses the tree's document. This doc will be published to fluidframework.com

[AB#59006](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/59006)