### PR TITLE
fix(build-tools): allow Js builds to be incremental

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -59,6 +59,7 @@ const incrementalOptions = [
 	"declarationDir",
 	"useDefineForClassFields",
 	"preserveValueImports",
+	"allowJs",
 
 	// affectsSemanticDiagnostics === true
 	"noImplicitAny",
@@ -90,6 +91,7 @@ const incrementalOptions = [
 	"strict",
 	"strictBindCallApply",
 	"strictFunctionTypes",
+	"checkJs",
 ].sort(); // sort it so that the result of the filter is sorted as well.
 
 function filterIncrementalOptions(options: any): Record<string, unknown> {

--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -84,10 +84,8 @@ const incrementalOptions = [
 	"suppressExcessPropertyErrors",
 	"suppressImplicitAnyIndexErrors",
 	"noStrictGenericChecks",
-	"useDefineForClassFields",
 
 	"skipLibCheck",
-	"skipdefaultlibcheck",
 	"strict",
 	"strictBindCallApply",
 	"strictFunctionTypes",


### PR DESCRIPTION
`allowJs` and `checkJs` were missing from the `incrementalOptions` list in `tscUtils.ts`. TypeScript stores these in `.tsbuildinfo`, but `filterIncrementalOptions()` stripped them from the config side only, causing a permanent mismatch that triggered a rebuild every time.

Additionally fix two deficiencies from #10160 as suggest by Copilot review:
- "useDefineForClassFields" was doubly defined and can be removed.
- "skipdefaultlibcheck" was incorrectly cased, thus has not effect and can be removed.