### PR TITLE
fix: Remove unused blob post API from Alfred

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
-import type * as git from "@fluidframework/gitresources";
 import { type IClient, type IClientJoin, ScopeType } from "@fluidframework/protocol-definitions";
 import {
 	type IRoom,
@@ -12,13 +10,9 @@ import {
 	createRuntimeMessage,
 } from "@fluidframework/server-lambdas";
 import { validateRequestParams, handleResponse } from "@fluidframework/server-services";
-import { BasicRestWrapper, NetworkError } from "@fluidframework/server-services-client";
+import { NetworkError } from "@fluidframework/server-services-client";
 import type * as core from "@fluidframework/server-services-core";
-import {
-	Lumberjack,
-	getLumberBaseProperties,
-	getGlobalTelemetryContext,
-} from "@fluidframework/server-services-telemetry";
+import { Lumberjack, getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 import {
 	throttle,
 	type IThrottleMiddlewareOptions,
@@ -26,14 +20,12 @@ import {
 	getBooleanFromConfig,
 	verifyToken,
 	verifyStorageToken,
-	logHttpMetrics,
 	denyListMiddleware,
 } from "@fluidframework/server-services-utils";
 import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { type Request, Router, type Response } from "express";
 import type { Provider } from "nconf";
 import sillyname from "sillyname";
-import { v4 as uuid } from "uuid";
 import winston from "winston";
 
 import { Constants, getSessionFromCache } from "../../../utils";
@@ -43,7 +35,6 @@ import {
 	craftClientLeaveMessage,
 	craftMapSet,
 	craftOpMessage,
-	type IBlobData,
 	type IMapSetOperation,
 } from "./restHelper";
 
@@ -156,33 +147,6 @@ export function create(
 				200,
 				() => handlePatchRootSuccess(request, mapSetBuilder, producer),
 			);
-		},
-	);
-
-	router.post(
-		"/:tenantId/:id/blobs",
-		validateRequestParams("tenantId", "id"),
-		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
-		denyListMiddleware(denyList),
-		// eslint-disable-next-line @typescript-eslint/no-misused-promises
-		async (request, response) => {
-			const tenantId = request.params.tenantId;
-			const blobData = request.body as IBlobData;
-			// TODO: why is this contacting external blob storage?
-			const externalHistorianUrl = config.get("worker:blobStorageUrl") as string;
-			const requestToken = fromUtf8ToBase64(tenantId);
-			const uri = `/repos/${tenantId}/git/blobs?token=${requestToken}`;
-			const requestBody: git.ICreateBlobParams = {
-				content: blobData.content,
-				encoding: "base64",
-			};
-			uploadBlob(externalHistorianUrl, uri, requestBody)
-				.then((data: git.ICreateBlobResponse) => {
-					response.status(200).json(data);
-				})
-				.catch((err) => {
-					response.status(400).end(err.toString());
-				});
 		},
 	);
 
@@ -397,33 +361,6 @@ async function checkDocumentExistence(
 		throw new Error("Cannot access document marked for deletion");
 	}
 }
-
-const uploadBlob = async (
-	baseUrl: string,
-	uri: string,
-	blobData: git.ICreateBlobParams,
-): Promise<git.ICreateBlobResponse> => {
-	const restWrapper = new BasicRestWrapper(
-		baseUrl,
-		undefined,
-		undefined,
-		undefined,
-		undefined,
-		undefined,
-		undefined,
-		undefined,
-		() =>
-			getGlobalTelemetryContext().getProperties().correlationId ??
-			uuid() /* getCorrelationId */,
-		() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
-		undefined /* refreshTokenIfNeeded */,
-		logHttpMetrics /* logHttpMetrics */,
-		() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
-	);
-	return restWrapper.post(uri, blobData, undefined, {
-		"Content-Type": "application/json",
-	});
-};
 
 async function handleBroadcastSignal(
 	request: Request,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/restHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/restHelper.ts
@@ -4,7 +4,6 @@
  */
 
 // Eventually this will become a library to craft various rest ops.
-import type * as git from "@fluidframework/gitresources";
 import {
 	type IClientJoin,
 	type IDocumentMessage,
@@ -17,12 +16,6 @@ export interface IMapSetOperation {
 	op: string;
 	path: string;
 	value: string;
-}
-
-export interface IBlobData {
-	content: string;
-
-	metadata: git.ICreateBlobParams;
 }
 
 export function craftClientJoinMessage(

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -270,14 +270,6 @@ describe("Routerlicious", () => {
 							"patch",
 						);
 					});
-					it("/:tenantId/:id/blobs", async () => {
-						await assertThrottle(
-							`/api/v1/${appTenant1.id}/${document1._id}/blobs`,
-							undefined,
-							undefined,
-							"post",
-						);
-					});
 					it("/api/v1/:tenantId/:id/broadcast-signal", async () => {
 						await assertThrottle(
 							`/api/v1/${appTenant1.id}/${document1._id}/broadcast-signal`,
@@ -846,12 +838,6 @@ describe("Routerlicious", () => {
 						await assertCorrelationId(
 							`/api/v1/${appTenant1.id}/${document1._id}/root`,
 							"patch",
-						);
-					});
-					it("/:tenantId/:id/blobs", async () => {
-						await assertCorrelationId(
-							`/api/v1/${appTenant1.id}/${document1._id}/blobs`,
-							"post",
 						);
 					});
 					it("/api/v1/:tenantId/:id/broadcast-signal", async () => {


### PR DESCRIPTION
## Description

Remove a used Alfred API call for blob post. The API call is questionable because it's unauthenticated. If used it would be blocked by Historian anyway, because there we require auth.

## Breaking Changes

Removes the POST `/:tenantId/:id/blobs` route from Alfred. This route is not used in the repo.