### PR TITLE
Filter out some tree benchmarks from non perf mode for faster testing

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -60,14 +60,22 @@ import {
 // number of nodes in test for wide trees
 const nodesCountWide = [
 	[1, BenchmarkType.Measurement],
-	[100, BenchmarkType.Perspective],
-	[500, BenchmarkType.Measurement],
+	...(isInPerformanceTestingMode
+		? [
+				[100, BenchmarkType.Perspective],
+				[500, BenchmarkType.Measurement],
+			]
+		: []),
 ];
 // number of nodes in test for deep trees
 const nodesCountDeep = [
 	[1, BenchmarkType.Measurement],
-	[10, BenchmarkType.Perspective],
-	[100, BenchmarkType.Measurement],
+	...(isInPerformanceTestingMode
+		? [
+				[10, BenchmarkType.Perspective],
+				[100, BenchmarkType.Measurement],
+			]
+		: []),
 ];
 
 // TODO: ADO#7111 Schema should be fixed to enable schema based encoding.

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -24,7 +24,7 @@ import { hydrateNode } from "./utils.js";
 
 // number of nodes in test for wide trees
 const nodesCountWide = [
-	[1, BenchmarkType.Measurement],
+	[2, BenchmarkType.Measurement],
 	...(isInPerformanceTestingMode
 		? [
 				[100, BenchmarkType.Perspective],

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -24,15 +24,23 @@ import { hydrateNode } from "./utils.js";
 
 // number of nodes in test for wide trees
 const nodesCountWide = [
-	[10, BenchmarkType.Measurement],
-	[100, BenchmarkType.Perspective],
-	[500, BenchmarkType.Measurement],
+	[1, BenchmarkType.Measurement],
+	...(isInPerformanceTestingMode
+		? [
+				[100, BenchmarkType.Perspective],
+				[500, BenchmarkType.Measurement],
+			]
+		: []),
 ];
 // number of nodes in test for deep trees
 const nodesCountDeep = [
 	[1, BenchmarkType.Measurement],
-	[10, BenchmarkType.Perspective],
-	[100, BenchmarkType.Measurement],
+	...(isInPerformanceTestingMode
+		? [
+				[10, BenchmarkType.Perspective],
+				[100, BenchmarkType.Measurement],
+			]
+		: []),
 ];
 
 describe("SimpleTree benchmarks", () => {


### PR DESCRIPTION

## Description

Filter out some benchmarks from non perf mode for faster testing.

On CI this saves ~8 seconds (3:40 to 3:32).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
