### PR TITLE
Move validation of schema change codec up to tree change codec

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -203,6 +203,27 @@ export interface IJsonCodec<
 }
 
 /**
+ * Part of a codec.
+ * @remarks
+ * Encode and decode logic and schema for some chunk of data.
+ * Can be composed into larger codecs, and eventually versioned at the top level using
+ * {@link VersionDispatchingCodecBuilder}.
+ *
+ * This portion of a codec is not responsible for managing versioning or validation of the data against the schema.
+ */
+export interface JsonCodecPart<TDecoded, TEncodedSchema extends TAnySchema, TContext = void>
+	extends IEncoder<TDecoded, Static<TEncodedSchema>, TContext>,
+		IDecoder<TDecoded, Static<TEncodedSchema>, TContext> {
+	/**
+	 * TypeBox schema which describes the encoded format for this chunk of data.
+	 * @remarks
+	 * The user of this codec can use this to build its own larger schema,
+	 * until eventually it is provided to the {@link VersionDispatchingCodecBuilder}.
+	 */
+	encodedSchema: TEncodedSchema;
+}
+
+/**
  * Type erase the more detailed encoded type from a codec.
  */
 export function eraseEncodedType<
@@ -398,6 +419,7 @@ export function withSchemaValidation<
 			}
 			return codec.decode(encoded, context);
 		},
+		encodedSchema: schema,
 	};
 }
 

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -551,6 +551,14 @@ export const FluidClientVersion = {
  */
 export const currentVersion: MinimumVersionForCollab = runtimeUtilsCleanedPackageVersion;
 
+/**
+ * TODO:
+ * This needs to be documented.
+ * Its documentation should cover at least the following:
+ * - Is this used for anything other than testing.
+ * - What should be included as children. For example should it include versioned codecs which dispatch base on the min version for collaboration? If so, what version of them should be used?
+ * - What risks does having this mitigate?
+ */
 export interface CodecTree {
 	readonly name: string;
 	readonly version: FormatVersion;

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -28,6 +28,7 @@ export {
 	extractJsonValidator,
 	type CodecName,
 	eraseEncodedType,
+	type JsonCodecPart,
 } from "./codec.js";
 export {
 	DiscriminatedUnionDispatcher,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -196,8 +196,6 @@ export {
 	type SchemaChange,
 	makeSchemaChangeCodec,
 	EncodedSchemaChange,
-	getCodecTreeForSchemaChangeFormat,
-	SchemaChangeFormatVersion,
 } from "./schema-edits/index.js";
 
 export { makeMitigatedChangeFamily } from "./mitigatedChangeFamily.js";

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -194,7 +194,7 @@ export { DetachedFieldIndexSummarizer } from "./detachedFieldIndexSummarizer.js"
 
 export {
 	type SchemaChange,
-	makeSchemaChangeCodecs,
+	makeSchemaChangeCodec,
 	EncodedSchemaChange,
 	getCodecTreeForSchemaChangeFormat,
 	SchemaChangeFormatVersion,

--- a/packages/dds/tree/src/feature-libraries/schema-edits/index.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/index.ts
@@ -3,10 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export {
-	makeSchemaChangeCodec,
-	getCodecTreeForSchemaChangeFormat,
-	SchemaChangeFormatVersion,
-} from "./schemaChangeCodecs.js";
+export { makeSchemaChangeCodec } from "./schemaChangeCodecs.js";
 export type { SchemaChange } from "./schemaChangeTypes.js";
 export { EncodedSchemaChange } from "./schemaChangeFormat.js";

--- a/packages/dds/tree/src/feature-libraries/schema-edits/index.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/index.ts
@@ -4,7 +4,7 @@
  */
 
 export {
-	makeSchemaChangeCodecs,
+	makeSchemaChangeCodec,
 	getCodecTreeForSchemaChangeFormat,
 	SchemaChangeFormatVersion,
 } from "./schemaChangeCodecs.js";

--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
@@ -4,35 +4,12 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 
-import type { CodecTree, CodecWriteOptions, JsonCodecPart } from "../../codec/index.js";
-import { strictEnum, type Values } from "../../util/index.js";
+import type { CodecWriteOptions, JsonCodecPart } from "../../codec/index.js";
 import { schemaCodecBuilder } from "../schema-index/index.js";
 
 import { EncodedSchemaChange } from "./schemaChangeFormat.js";
 import type { SchemaChange } from "./schemaChangeTypes.js";
-
-/**
- * The format version for the schema change.
- * @remarks
- * The SchemaChangeFormat is not explicitly versioned in the data.
- */
-export const SchemaChangeFormatVersion = strictEnum("SchemaChangeFormatVersion", {
-	v1: 1,
-});
-export type SchemaChangeFormatVersion = Values<typeof SchemaChangeFormatVersion>;
-
-export function getCodecTreeForSchemaChangeFormat(
-	version: SchemaChangeFormatVersion,
-	clientVersion: MinimumVersionForCollab,
-): CodecTree {
-	return {
-		name: "SchemaChange",
-		version,
-		children: [schemaCodecBuilder.getCodecTree(clientVersion)],
-	};
-}
 
 /**
  * Creates a codec for schema changes.

--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
@@ -6,14 +6,7 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 
-import {
-	type CodecTree,
-	type CodecWriteOptions,
-	type ICodecFamily,
-	type IJsonCodec,
-	makeCodecFamily,
-	withSchemaValidation,
-} from "../../codec/index.js";
+import type { CodecTree, CodecWriteOptions, JsonCodecPart } from "../../codec/index.js";
 import { strictEnum, type Values } from "../../util/index.js";
 import { schemaCodecBuilder } from "../schema-index/index.js";
 
@@ -21,28 +14,9 @@ import { EncodedSchemaChange } from "./schemaChangeFormat.js";
 import type { SchemaChange } from "./schemaChangeTypes.js";
 
 /**
- * Create a family of schema change codecs.
- * @param options - Specifies common codec options, including which `validator` to use.
- * @returns The composed codec family.
- * @remarks
- * Data encoded with this codec is not versioned.
- * Users of this codec must therefore ensure that the decoder always knows which version was used.
- */
-export function makeSchemaChangeCodecs(
-	options: CodecWriteOptions,
-): ICodecFamily<SchemaChange> {
-	// TODO:
-	// Inlining the schema change codec V1 into its parent codec,
-	// removing the use of codec family here.
-	return makeCodecFamily([[SchemaChangeFormatVersion.v1, makeSchemaChangeCodecV1(options)]]);
-}
-
-/**
  * The format version for the schema change.
  * @remarks
  * The SchemaChangeFormat is not explicitly versioned in the data.
- *
- * TODO: Inline this codec's formats into the parent codec that references it, rather than treating this like a versioned codec. See related notes in makeSchemaChangeCodecs.
  */
 export const SchemaChangeFormatVersion = strictEnum("SchemaChangeFormatVersion", {
 	v1: 1,
@@ -61,16 +35,16 @@ export function getCodecTreeForSchemaChangeFormat(
 }
 
 /**
- * This is independently versioned from the schemaCodec version.
+ * Creates a codec for schema changes.
  * @param options - The codec options.
- * @returns The composed schema change codec.
+ * @returns The composed schema change codec part.
  */
-function makeSchemaChangeCodecV1(
+export function makeSchemaChangeCodec(
 	options: CodecWriteOptions,
-): IJsonCodec<SchemaChange, EncodedSchemaChange> {
+): JsonCodecPart<SchemaChange, typeof EncodedSchemaChange> {
 	const schemaCodec = schemaCodecBuilder.build(options);
-	const schemaChangeCodec: IJsonCodec<SchemaChange, EncodedSchemaChange> = {
-		encode: (schemaChange) => {
+	return {
+		encode: (schemaChange: SchemaChange): EncodedSchemaChange => {
 			assert(
 				!schemaChange.isInverse,
 				0x933 /* Inverse schema changes should never be transmitted */,
@@ -80,7 +54,7 @@ function makeSchemaChangeCodecV1(
 				old: schemaCodec.encode(schemaChange.schema.old),
 			};
 		},
-		decode: (encoded) => {
+		decode: (encoded: EncodedSchemaChange): SchemaChange => {
 			return {
 				schema: {
 					new: schemaCodec.decode(encoded.new),
@@ -91,6 +65,4 @@ function makeSchemaChangeCodecV1(
 		},
 		encodedSchema: EncodedSchemaChange,
 	};
-
-	return withSchemaValidation(EncodedSchemaChange, schemaChangeCodec, options.jsonValidator);
 }

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -535,7 +535,7 @@ function getCodecTreeForEditManagerFormat(clientVersion: MinimumVersionForCollab
 	const change = changeFormatVersionForEditManager.lookup(
 		clientVersionToEditManagerFormatVersion(clientVersion),
 	);
-	const changeCodecTree = getCodecTreeForChangeFormat(change, clientVersion);
+	const changeCodecTree = getCodecTreeForChangeFormat(change);
 	return getCodecTreeForEditManagerFormatWithChange(clientVersion, changeCodecTree);
 }
 
@@ -543,7 +543,7 @@ function getCodecTreeForMessageFormat(clientVersion: MinimumVersionForCollab): C
 	const change = changeFormatVersionForMessage.lookup(
 		clientVersionToMessageFormatVersion(clientVersion),
 	);
-	const changeCodecTree = getCodecTreeForChangeFormat(change, clientVersion);
+	const changeCodecTree = getCodecTreeForChangeFormat(change);
 	return getCodecTreeForMessageFormatWithChange(clientVersion, changeCodecTree);
 }
 

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -535,7 +535,7 @@ function getCodecTreeForEditManagerFormat(clientVersion: MinimumVersionForCollab
 	const change = changeFormatVersionForEditManager.lookup(
 		clientVersionToEditManagerFormatVersion(clientVersion),
 	);
-	const changeCodecTree = getCodecTreeForChangeFormat(change);
+	const changeCodecTree = getCodecTreeForChangeFormat(change, clientVersion);
 	return getCodecTreeForEditManagerFormatWithChange(clientVersion, changeCodecTree);
 }
 
@@ -543,7 +543,7 @@ function getCodecTreeForMessageFormat(clientVersion: MinimumVersionForCollab): C
 	const change = changeFormatVersionForMessage.lookup(
 		clientVersionToMessageFormatVersion(clientVersion),
 	);
-	const changeCodecTree = getCodecTreeForChangeFormat(change);
+	const changeCodecTree = getCodecTreeForChangeFormat(change, clientVersion);
 	return getCodecTreeForMessageFormatWithChange(clientVersion, changeCodecTree);
 }
 

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -4,6 +4,7 @@
  */
 
 import { fail } from "@fluidframework/core-utils/internal";
+import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 
 import {
 	type CodecTree,
@@ -22,6 +23,7 @@ import {
 	defaultSchemaPolicy,
 	getCodecTreeForModularChangeFormat,
 	makeSchemaChangeCodec,
+	schemaCodecBuilder,
 } from "../feature-libraries/index.js";
 import {
 	strictEnum,
@@ -120,13 +122,17 @@ export const dependenciesForChangeFormat = new Map<
 
 export function getCodecTreeForChangeFormat(
 	version: SharedTreeChangeFormatVersion,
+	clientVersion: MinimumVersionForCollab,
 ): CodecTree {
 	const { modularChange } =
 		dependenciesForChangeFormat.get(version) ?? fail(0xc78 /* Unknown change format */);
 	return {
 		name: "SharedTreeChange",
 		version,
-		children: [getCodecTreeForModularChangeFormat(modularChange)],
+		children: [
+			getCodecTreeForModularChangeFormat(modularChange),
+			schemaCodecBuilder.getCodecTree(clientVersion),
+		],
 	};
 }
 

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -12,7 +12,6 @@ import {
 	DiscriminatedUnionDispatcher,
 	type FormatVersion,
 	type ICodecFamily,
-	type ICodecOptions,
 	type IJsonCodec,
 	makeCodecFamily,
 	withSchemaValidation,
@@ -21,12 +20,11 @@ import type { ChangeEncodingContext, TreeStoredSchema } from "../core/index.js";
 import {
 	ModularChangeFormatVersion,
 	type ModularChangeset,
-	type SchemaChange,
 	SchemaChangeFormatVersion,
 	defaultSchemaPolicy,
 	getCodecTreeForModularChangeFormat,
 	getCodecTreeForSchemaChangeFormat,
-	makeSchemaChangeCodecs,
+	makeSchemaChangeCodec,
 } from "../feature-libraries/index.js";
 import {
 	strictEnum,
@@ -45,9 +43,6 @@ export function makeSharedTreeChangeCodecFamily(
 	modularChangeCodecFamily: ICodecFamily<ModularChangeset, ChangeEncodingContext>,
 	options: CodecWriteOptions,
 ): ICodecFamily<SharedTreeChange, ChangeEncodingContext> {
-	// TODO: since this is using the SchemaChangeCodec without explicit versioning,
-	// it would probably be better to depend on its format directly without going through the codec family.
-	const schemaChangeCodecs = makeSchemaChangeCodecs(options);
 	const versions: [
 		FormatVersion,
 		IJsonCodec<
@@ -56,22 +51,15 @@ export function makeSharedTreeChangeCodecFamily(
 			EncodedSharedTreeChange,
 			ChangeEncodingContext
 		>,
-	][] = [...dependenciesForChangeFormat.entries()].map(
-		([format, { modularChange, schemaChange }]) => [
-			format,
-			makeSharedTreeChangeCodec(
-				modularChangeCodecFamily.resolve(modularChange),
-				schemaChangeCodecs.resolve(schemaChange),
-				options,
-			),
-		],
-	);
+	][] = [...dependenciesForChangeFormat.entries()].map(([format, { modularChange }]) => [
+		format,
+		makeSharedTreeChangeCodec(modularChangeCodecFamily.resolve(modularChange), options),
+	]);
 	return makeCodecFamily(versions);
 }
 
 interface ChangeFormatDependencies {
 	readonly modularChange: ModularChangeFormatVersion;
-	readonly schemaChange: SchemaChangeFormatVersion;
 }
 
 /**
@@ -117,21 +105,18 @@ export const dependenciesForChangeFormat = new Map<
 		SharedTreeChangeFormatVersion.v3,
 		{
 			modularChange: ModularChangeFormatVersion.v3,
-			schemaChange: SchemaChangeFormatVersion.v1,
 		},
 	],
 	[
 		SharedTreeChangeFormatVersion.v4,
 		{
 			modularChange: ModularChangeFormatVersion.v4,
-			schemaChange: SchemaChangeFormatVersion.v1,
 		},
 	],
 	[
 		SharedTreeChangeFormatVersion.v5,
 		{
 			modularChange: ModularChangeFormatVersion.v5,
-			schemaChange: SchemaChangeFormatVersion.v1,
 		},
 	],
 ]);
@@ -140,14 +125,14 @@ export function getCodecTreeForChangeFormat(
 	version: SharedTreeChangeFormatVersion,
 	clientVersion: MinimumVersionForCollab,
 ): CodecTree {
-	const { modularChange, schemaChange } =
+	const { modularChange } =
 		dependenciesForChangeFormat.get(version) ?? fail(0xc78 /* Unknown change format */);
 	return {
 		name: "SharedTreeChange",
 		version,
 		children: [
 			getCodecTreeForModularChangeFormat(modularChange),
-			getCodecTreeForSchemaChangeFormat(schemaChange, clientVersion),
+			getCodecTreeForSchemaChangeFormat(SchemaChangeFormatVersion.v1, clientVersion),
 		],
 	};
 }
@@ -159,14 +144,14 @@ function makeSharedTreeChangeCodec(
 		JsonCompatibleReadOnly,
 		ChangeEncodingContext
 	>,
-	schemaChangeCodec: IJsonCodec<SchemaChange>,
-	codecOptions: ICodecOptions,
+	codecOptions: CodecWriteOptions,
 ): IJsonCodec<
 	SharedTreeChange,
 	EncodedSharedTreeChange,
 	EncodedSharedTreeChange,
 	ChangeEncodingContext
 > {
+	const schemaChangeCodec = makeSchemaChangeCodec(codecOptions);
 	const decoderLibrary = new DiscriminatedUnionDispatcher<
 		EncodedSharedTreeInnerChange,
 		[context: ChangeEncodingContext],
@@ -187,7 +172,7 @@ function makeSharedTreeChangeCodec(
 	});
 
 	return withSchemaValidation(
-		EncodedSharedTreeChange,
+		EncodedSharedTreeChange(schemaChangeCodec.encodedSchema),
 		{
 			encode: (change, context) => {
 				const changes: EncodedSharedTreeInnerChange[] = [];

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -4,7 +4,6 @@
  */
 
 import { fail } from "@fluidframework/core-utils/internal";
-import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 
 import {
 	type CodecTree,
@@ -20,10 +19,8 @@ import type { ChangeEncodingContext, TreeStoredSchema } from "../core/index.js";
 import {
 	ModularChangeFormatVersion,
 	type ModularChangeset,
-	SchemaChangeFormatVersion,
 	defaultSchemaPolicy,
 	getCodecTreeForModularChangeFormat,
-	getCodecTreeForSchemaChangeFormat,
 	makeSchemaChangeCodec,
 } from "../feature-libraries/index.js";
 import {
@@ -123,17 +120,13 @@ export const dependenciesForChangeFormat = new Map<
 
 export function getCodecTreeForChangeFormat(
 	version: SharedTreeChangeFormatVersion,
-	clientVersion: MinimumVersionForCollab,
 ): CodecTree {
 	const { modularChange } =
 		dependenciesForChangeFormat.get(version) ?? fail(0xc78 /* Unknown change format */);
 	return {
 		name: "SharedTreeChange",
 		version,
-		children: [
-			getCodecTreeForModularChangeFormat(modularChange),
-			getCodecTreeForSchemaChangeFormat(SchemaChangeFormatVersion.v1, clientVersion),
-		],
+		children: [getCodecTreeForModularChangeFormat(modularChange)],
 	};
 }
 

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFormat.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFormat.ts
@@ -3,17 +3,32 @@
  * Licensed under the MIT License.
  */
 
-import { type Static, Type } from "@sinclair/typebox";
+import { type Static, type TSchema, Type } from "@sinclair/typebox";
 
+import type { EncodedSchemaChange } from "../feature-libraries/index.js";
 import { JsonCompatibleReadOnlySchema } from "../util/index.js";
 
-export const EncodedSharedTreeInnerChange = Type.Object({
-	schema: Type.Optional(JsonCompatibleReadOnlySchema),
-	data: Type.Optional(JsonCompatibleReadOnlySchema),
-});
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function EncodedSharedTreeInnerChange<TEncodedSchema extends TSchema>(
+	encodedSchemaSchema: TEncodedSchema,
+) {
+	return Type.Object({
+		schema: Type.Optional(encodedSchemaSchema),
+		data: Type.Optional(JsonCompatibleReadOnlySchema),
+	});
+}
 
-export type EncodedSharedTreeInnerChange = Static<typeof EncodedSharedTreeInnerChange>;
+export type EncodedSharedTreeInnerChange<
+	TEncodedSchema extends TSchema = typeof EncodedSchemaChange,
+> = Static<ReturnType<typeof EncodedSharedTreeInnerChange<TEncodedSchema>>>;
 
-export const EncodedSharedTreeChange = Type.Array(EncodedSharedTreeInnerChange);
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function EncodedSharedTreeChange<TEncodedSchema extends TSchema>(
+	encodedSchemaSchema: TEncodedSchema,
+) {
+	return Type.Array(EncodedSharedTreeInnerChange(encodedSchemaSchema));
+}
 
-export type EncodedSharedTreeChange = Static<typeof EncodedSharedTreeChange>;
+export type EncodedSharedTreeChange<
+	TEncodedSchema extends TSchema = typeof EncodedSchemaChange,
+> = Static<ReturnType<typeof EncodedSharedTreeChange<TEncodedSchema>>>;

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -10,6 +10,7 @@ import { validateAssertionError } from "@fluidframework/test-runtime-utils/inter
 
 import { currentVersion, type CodecWriteOptions } from "../../codec/index.js";
 import { TreeStoredSchemaRepository, type ChangeEncodingContext } from "../../core/index.js";
+import { FormatValidatorBasic } from "../../external-utilities/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { decode } from "../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 // eslint-disable-next-line import-x/no-internal-modules
@@ -40,7 +41,6 @@ import { brand } from "../../util/index.js";
 import { ajvValidator } from "../codec/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../snapshots/index.js";
 import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
-import { FormatValidatorBasic } from "../../external-utilities/index.js";
 
 const codecOptions: CodecWriteOptions = {
 	jsonValidator: ajvValidator,

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -37,6 +37,7 @@ import type { Changeset } from "../../feature-libraries/sequence-field/types.js"
 import { makeSharedTreeChangeCodecFamily } from "../../shared-tree/sharedTreeChangeCodecs.js";
 import { brand } from "../../util/index.js";
 import { ajvValidator } from "../codec/index.js";
+import { takeJsonSnapshot, useSnapshotDirectory } from "../snapshots/index.js";
 import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
 
 const codecOptions: CodecWriteOptions = {
@@ -45,6 +46,42 @@ const codecOptions: CodecWriteOptions = {
 };
 
 describe("sharedTreeChangeCodec", () => {
+	useSnapshotDirectory("sharedTreeChangeCodec");
+	it("codec schema snapshot", () => {
+		const dummyFieldBatchCodec: FieldBatchCodec = {
+			encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {
+				assert.fail();
+			},
+			decode: (data: EncodedFieldBatch, context: FieldBatchEncodingContext): FieldBatch => {
+				assert.fail();
+			},
+			writeVersion: FieldBatchFormatVersion.v2,
+		};
+
+		const modularChangeCodecs = makeModularChangeCodecFamily(
+			fieldKindConfigurations,
+			testRevisionTagCodec,
+			dummyFieldBatchCodec,
+			codecOptions,
+		);
+
+		const sharedTreeChangeCodec = makeSharedTreeChangeCodecFamily(
+			modularChangeCodecs,
+			codecOptions,
+		);
+
+		const formats = [...sharedTreeChangeCodec.getSupportedFormats()];
+		const schema = formats.map((format) => {
+			const codec = sharedTreeChangeCodec.resolve(format);
+			assert(codec.encodedSchema !== undefined);
+			return { version: format, schema: codec.encodedSchema };
+		});
+		// Capture the portion of the schema validated at the root.
+		// Currently this does not included the schema for the modular change which is validated separately in the modular change codec,
+		// but it does include the schema for the inner change wrapper.
+		takeJsonSnapshot(schema);
+	});
+
 	it("passes down the context's schema to the fieldBatchCodec", () => {
 		const dummyFieldBatchCodec: FieldBatchCodec = {
 			encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -6,9 +6,10 @@
 import { strict as assert } from "node:assert";
 
 import type { SessionId } from "@fluidframework/id-compressor";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import { currentVersion, type CodecWriteOptions } from "../../codec/index.js";
-import { TreeStoredSchemaRepository } from "../../core/index.js";
+import { TreeStoredSchemaRepository, type ChangeEncodingContext } from "../../core/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { decode } from "../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 // eslint-disable-next-line import-x/no-internal-modules
@@ -39,6 +40,7 @@ import { brand } from "../../util/index.js";
 import { ajvValidator } from "../codec/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../snapshots/index.js";
 import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
+import { FormatValidatorBasic } from "../../external-utilities/index.js";
 
 const codecOptions: CodecWriteOptions = {
 	jsonValidator: ajvValidator,
@@ -47,21 +49,19 @@ const codecOptions: CodecWriteOptions = {
 
 describe("sharedTreeChangeCodec", () => {
 	useSnapshotDirectory("sharedTreeChangeCodec");
-	it("codec schema snapshot", () => {
-		const dummyFieldBatchCodec: FieldBatchCodec = {
-			encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {
-				assert.fail();
-			},
-			decode: (data: EncodedFieldBatch, context: FieldBatchEncodingContext): FieldBatch => {
-				assert.fail();
-			},
-			writeVersion: FieldBatchFormatVersion.v2,
-		};
 
+	// Dummy FieldBatchCodec codec which asserts when encoding or decoding.
+	const failFieldBatchCodec: FieldBatchCodec = {
+		encode: (): EncodedFieldBatch => assert.fail(),
+		decode: (): FieldBatch => assert.fail(),
+		writeVersion: FieldBatchFormatVersion.v2,
+	};
+
+	it("codec schema snapshot", () => {
 		const modularChangeCodecs = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
 			testRevisionTagCodec,
-			dummyFieldBatchCodec,
+			failFieldBatchCodec,
 			codecOptions,
 		);
 
@@ -80,6 +80,29 @@ describe("sharedTreeChangeCodec", () => {
 		// Currently this does not included the schema for the modular change which is validated separately in the modular change codec,
 		// but it does include the schema for the inner change wrapper.
 		takeJsonSnapshot(schema);
+	});
+
+	// This ensures that the schema for schema changes is getting included in the TreeChangeCodec's schema.
+	it("rejects malformed schema-change data", () => {
+		const modularChangeCodecs = makeModularChangeCodecFamily(
+			fieldKindConfigurations,
+			testRevisionTagCodec,
+			failFieldBatchCodec,
+			{ jsonValidator: FormatValidatorBasic },
+		);
+		const codec = makeSharedTreeChangeCodecFamily(modularChangeCodecs, codecOptions).resolve(
+			3,
+		);
+
+		assert.throws(
+			() =>
+				codec.decode(
+					// missing 'old' field
+					[{ schema: { new: {} } }],
+					{} as unknown as ChangeEncodingContext,
+				),
+			validateAssertionError(/must have required property 'old'/),
+		);
 	});
 
 	it("passes down the context's schema to the fieldBatchCodec", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -77,7 +77,7 @@ describe("sharedTreeChangeCodec", () => {
 			return { version: format, schema: codec.encodedSchema };
 		});
 		// Capture the portion of the schema validated at the root.
-		// Currently this does not included the schema for the modular change which is validated separately in the modular change codec,
+		// Currently this does not include the schema for the modular change which is validated separately in the modular change codec,
 		// but it does include the schema for the inner change wrapper.
 		takeJsonSnapshot(schema);
 	});

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_0.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_0.json
@@ -49,14 +49,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 1
-                }
-              ]
+              "name": "Schema",
+              "version": 1
             }
           ]
         }
@@ -97,14 +91,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 1
-                }
-              ]
+              "name": "Schema",
+              "version": 1
             }
           ]
         }

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_43.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_43.json
@@ -49,14 +49,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }
@@ -97,14 +91,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_52.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_52.json
@@ -49,14 +49,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }
@@ -97,14 +91,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_73.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_73.json
@@ -49,14 +49,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }
@@ -97,14 +91,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_74.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_74.json
@@ -49,14 +49,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }
@@ -97,14 +91,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_80.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v2_80.json
@@ -49,14 +49,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }
@@ -97,14 +91,8 @@
               ]
             },
             {
-              "name": "SchemaChange",
-              "version": 1,
-              "children": [
-                {
-                  "name": "Schema",
-                  "version": 2
-                }
-              ]
+              "name": "Schema",
+              "version": 2
             }
           ]
         }

--- a/packages/dds/tree/src/test/snapshots/output/sharedTreeChangeCodec/codec schema snapshot.json
+++ b/packages/dds/tree/src/test/snapshots/output/sharedTreeChangeCodec/codec schema snapshot.json
@@ -1,0 +1,71 @@
+[
+  {
+    "version": 3,
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "new": {},
+              "old": {}
+            },
+            "required": [
+              "new",
+              "old"
+            ]
+          },
+          "data": {}
+        }
+      }
+    }
+  },
+  {
+    "version": 4,
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "new": {},
+              "old": {}
+            },
+            "required": [
+              "new",
+              "old"
+            ]
+          },
+          "data": {}
+        }
+      }
+    }
+  },
+  {
+    "version": 5,
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "new": {},
+              "old": {}
+            },
+            "required": [
+              "new",
+              "old"
+            ]
+          },
+          "data": {}
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Description

Move validation of schema change codec up to tree change codec.

This is incremental progress toward a state where we consistently use codec versions only in places where we include the version in the actual encoded data and dispatch based on that.

For places where we do not do explicit versioning of data, we want to use alternatively clearly distinct schemes modularizing the code for handling different data and different versions of the encodings for that data. This case can be strongly typed and use normal direct code dependencies to pull in the relevant logic.
As part of this, moving all the schema validation logic further up the stack toward where the version dispatching happens (which is what this PR is doing) helps is get toward a point where we can snapshot the schema for each version of our codecs, and use that to help validate the format not changed. This approach also reduces the need to do schema validation to fewer places, eventually to only within ClientVersionDispatchingCodecBuilder once fully applied.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
