### PR TITLE
fix: override brace-expansion and express to patched versions

### DIFF
--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -80,9 +80,11 @@
 			"js-yaml: overridden to fix CVE-2025-64718 (prototype pollution via merge keys).",
 			"diff: overridden to patched version to resolve a known ReDoS vulnerability.",
 			"minimatch: overridden to patched versions to resolve known security vulnerabilities across all major version ranges.",
-			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq and CVE-2024-11831. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support)."
+			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq and CVE-2024-11831. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support).",
+			"brace-expansion: overridden to ^1.1.12 to resolve CVE-2025-5889."
 		],
 		"overrides": {
+			"brace-expansion@>=1 <2": "^1.1.12",
 			"diff@>=5 <6": "^5.2.2",
 			"js-yaml": "^4.1.1",
 			"minimatch@>=3 <4": "^3.1.5",

--- a/common/build/eslint-config-fluid/pnpm-lock.yaml
+++ b/common/build/eslint-config-fluid/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@>=1 <2: ^1.1.12
   diff@>=5 <6: ^5.2.2
   js-yaml: ^4.1.1
   minimatch@>=3 <4: ^3.1.5
@@ -801,8 +802,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -2899,7 +2900,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3881,7 +3882,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@5.1.9:
     dependencies:

--- a/common/build/eslint-plugin-fluid/package.json
+++ b/common/build/eslint-plugin-fluid/package.json
@@ -55,9 +55,11 @@
 			"js-yaml: overridden to fix CVE-2025-64718 (prototype pollution via merge keys).",
 			"diff: overridden to patched version to resolve a known ReDoS vulnerability.",
 			"minimatch: overridden to patched versions to resolve known security vulnerabilities across all major version ranges.",
-			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support)."
+			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support).",
+			"brace-expansion: overridden to ^1.1.12 to resolve CVE-2025-5889."
 		],
 		"overrides": {
+			"brace-expansion@>=1 <2": "^1.1.12",
 			"diff@>=5 <6": "^5.2.2",
 			"js-yaml": "^4.1.1",
 			"qs": "^6.15.0",

--- a/common/build/eslint-plugin-fluid/pnpm-lock.yaml
+++ b/common/build/eslint-plugin-fluid/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@>=1 <2: ^1.1.12
   diff@>=5 <6: ^5.2.2
   js-yaml: ^4.1.1
   qs: ^6.15.0
@@ -367,8 +368,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -2273,7 +2274,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3489,7 +3490,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@5.1.9:
     dependencies:

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -78,10 +78,12 @@
 			"diff: overridden to patched versions to resolve a known ReDoS vulnerability. diff@7.x has no fix so it is bumped to 8.0.3.",
 			"tar: overridden to ^7.5.11 to resolve multiple security vulnerabilities in tar 6.x (EOL, no backport).",
 			"minimatch: overridden to patched versions to resolve known security vulnerabilities across all major version ranges.",
-			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support)."
+			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support).",
+			"express: overridden to ^4.21.2 to resolve CVE-2024-51999 in express 4.17.1."
 		],
 		"overrides": {
 			"@fluidframework/eslint-config-fluid": "link:../../common/build/eslint-config-fluid",
+			"express@>=4 <5": "^4.21.2",
 			"diff@>=5 <6": "^5.2.2",
 			"diff@>=7 <8": "^8.0.3",
 			"diff@>=8 <9": "^8.0.3",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@fluidframework/eslint-config-fluid': link:../../common/build/eslint-config-fluid
+  express@>=4 <5: ^4.21.2
   diff@>=5 <6: ^5.2.2
   diff@>=7 <8: ^8.0.3
   diff@>=8 <9: ^8.0.3


### PR DESCRIPTION
## Summary
- Overrides `brace-expansion@>=1 <2` to `^1.1.12` in eslint-config-fluid and eslint-plugin-fluid to resolve a known vulnerability
- Overrides `express@>=4 <5` to `^4.21.2` in server/historian to resolve a known vulnerability in express 4.17.1
- No code changes — config and lockfile updates only

## Test plan
- [x] CI passes across all workspace pipelines
- [x] No functional changes — overrides only affect transitive dependency resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)