### PR TITLE
Allow skipping connection retries on load

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -344,6 +344,8 @@ export class ConnectionManager implements IConnectionManager {
 		reconnectAllowed: boolean,
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly props: IConnectionManagerFactoryArgs,
+		private readonly maxConnectionAttempts?: number,
+		private readonly allowReconnect: boolean = true,
 	) {
 		this.clientDetails = this.client.details;
 		this.defaultReconnectionMode = this.client.mode;
@@ -621,6 +623,17 @@ export class ConnectionManager implements IConnectionManager {
 				);
 
 				lastError = origError;
+
+				// When maxConnectionAttempts is set, do not retry beyond the allowed attempts.
+				// The consumer will own the retry policy.
+				if (
+					this.maxConnectionAttempts !== undefined &&
+					connectRepeatCount >= this.maxConnectionAttempts
+				) {
+					const error = normalizeError(origError, { props: fatalConnectErrorProp });
+					this.props.closeHandler(error);
+					throw error;
+				}
 
 				// We will not perform retries if the container disconnected and the ReconnectMode is set to Disabled or Never
 				// so break out of the re-connecting while-loop after first attempt
@@ -969,6 +982,17 @@ export class ConnectionManager implements IConnectionManager {
 		assert(this.connection !== undefined, 0x0eb /* "Missing connection for reconnect" */);
 
 		this.disconnectFromDeltaStream(reason);
+
+		// When allowReconnect is false, do not attempt to reconnect after a disconnect.
+		// Surface the error to the consumer who owns the retry policy.
+		if (!this.allowReconnect) {
+			if (reason.error === undefined) {
+				this.props.closeHandler();
+			} else {
+				this.props.closeHandler(normalizeError(reason.error));
+			}
+			return;
+		}
 
 		// We will always trigger reconnect, even if canRetry is false.
 		// Any truly fatal error state will result in container close upon attempted reconnect,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -344,8 +344,7 @@ export class ConnectionManager implements IConnectionManager {
 		reconnectAllowed: boolean,
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly props: IConnectionManagerFactoryArgs,
-		private readonly maxConnectionAttempts?: number,
-		private readonly allowReconnect: boolean = true,
+		private maxInitialConnectionAttempts?: number,
 	) {
 		this.clientDetails = this.client.details;
 		this.defaultReconnectionMode = this.client.mode;
@@ -624,11 +623,11 @@ export class ConnectionManager implements IConnectionManager {
 
 				lastError = origError;
 
-				// When maxConnectionAttempts is set, do not retry beyond the allowed attempts.
+				// When maxInitialConnectionAttempts is set, do not retry beyond the allowed attempts.
 				// The consumer will own the retry policy.
 				if (
-					this.maxConnectionAttempts !== undefined &&
-					connectRepeatCount >= this.maxConnectionAttempts
+					this.maxInitialConnectionAttempts !== undefined &&
+					connectRepeatCount >= this.maxInitialConnectionAttempts
 				) {
 					const error = normalizeError(origError, { props: fatalConnectErrorProp });
 					this.props.closeHandler(error);
@@ -700,6 +699,11 @@ export class ConnectionManager implements IConnectionManager {
 			});
 			return;
 		}
+
+		// Clear the max connection attempts limit now that a connection has been established.
+		// The limit is only intended to scope initial connection retries;
+		// once connected, normal reconnect behavior should apply.
+		this.maxInitialConnectionAttempts = undefined;
 
 		this.setupNewSuccessfulConnection(connection, requestedMode, reason);
 	}
@@ -982,17 +986,6 @@ export class ConnectionManager implements IConnectionManager {
 		assert(this.connection !== undefined, 0x0eb /* "Missing connection for reconnect" */);
 
 		this.disconnectFromDeltaStream(reason);
-
-		// When allowReconnect is false, do not attempt to reconnect after a disconnect.
-		// Surface the error to the consumer who owns the retry policy.
-		if (!this.allowReconnect) {
-			if (reason.error === undefined) {
-				this.props.closeHandler();
-			} else {
-				this.props.closeHandler(normalizeError(reason.error));
-			}
-			return;
-		}
 
 		// We will always trigger reconnect, even if canRetry is false.
 		// Any truly fatal error state will result in container close upon attempted reconnect,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1610,7 +1610,11 @@ export class Container
 			this.connectToDeltaStream(connectionArgs);
 		}
 
-		this.storageAdapter.connectToService(this.service);
+		// When DisableLoadConnectionRetries is enabled, use no internal retries.
+		// The consumer will own the retry policy.
+		const disableLoadRetries =
+			this.mc.config.getBoolean("Fluid.Container.DisableLoadConnectionRetries") === true;
+		this.storageAdapter.connectToService(this.service, disableLoadRetries ? 0 : undefined);
 
 		this.attachmentData = {
 			state: AttachState.Attached,
@@ -1995,6 +1999,8 @@ export class Container
 
 	private createDeltaManager(): DeltaManager<ConnectionManager> {
 		const serviceProvider = (): IDocumentService | undefined => this.service;
+		const disableLoadConnectionRetries =
+			this.mc.config.getBoolean("Fluid.Container.DisableLoadConnectionRetries") === true;
 		const deltaManager = new DeltaManager<ConnectionManager>(
 			serviceProvider,
 			createChildLogger({ logger: this.subLogger, namespace: "DeltaManager" }),
@@ -2007,6 +2013,8 @@ export class Container
 					this._canReconnect,
 					createChildLogger({ logger: this.subLogger, namespace: "ConnectionManager" }),
 					props,
+					disableLoadConnectionRetries ? 1 : undefined,
+					!disableLoadConnectionRetries,
 				),
 		);
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2013,8 +2013,7 @@ export class Container
 					this._canReconnect,
 					createChildLogger({ logger: this.subLogger, namespace: "ConnectionManager" }),
 					props,
-					disableLoadConnectionRetries ? 1 : undefined,
-					!disableLoadConnectionRetries,
+					disableLoadConnectionRetries ? 1 : undefined /* maxInitialConnectionAttempts */,
 				),
 		);
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -104,7 +104,7 @@ export class ContainerStorageAdapter
 		this.disposed = true;
 	}
 
-	public connectToService(service: IDocumentService): void {
+	public connectToService(service: IDocumentService, maxRetries?: number): void {
 		if (!(this._storageService instanceof BlobOnlyStorage)) {
 			return;
 		}
@@ -113,6 +113,7 @@ export class ContainerStorageAdapter
 		const retriableStorage = (this._storageService = new RetriableDocumentStorageService(
 			storageServiceP,
 			this.logger,
+			maxRetries,
 		));
 
 		// A storage service wrapper which intercept calls to uploadSummaryWithContext and ensure they include

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -30,6 +30,7 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
 	constructor(
 		private readonly internalStorageServiceP: Promise<IDocumentStorageService>,
 		private readonly logger: ITelemetryLoggerExt,
+		private readonly maxRetries?: number,
 	) {
 		this.internalStorageServiceP
 			.then((s) => (this.internalStorageService = s))
@@ -167,9 +168,15 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
 	}
 
 	private async runWithRetry<T>(api: () => Promise<T>, callName: string): Promise<T> {
-		return runWithRetry(api, callName, this.logger, {
-			onRetry: (_delayInMs: number, error: unknown) =>
-				this.checkStorageDisposed(callName, error),
-		});
+		return runWithRetry(
+			api,
+			callName,
+			this.logger,
+			{
+				onRetry: (_delayInMs: number, error: unknown) =>
+					this.checkStorageDisposed(callName, error),
+			},
+			this.maxRetries,
+		);
 	}
 }

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -9,6 +9,7 @@ import type { IProvideLayerCompatDetails } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { FluidErrorTypes, type ConfigTypes } from "@fluidframework/core-interfaces/internal";
 import type {
+	IDocumentService,
 	IDocumentServiceFactory,
 	IResolvedUrl,
 	IUrlResolver,
@@ -209,5 +210,97 @@ describe("loader unit test", () => {
 		});
 		const container = await loader.createDetachedContainer({ package: "none" });
 		await container.attach({ url: "none" });
+	});
+});
+
+describe("DisableLoadConnectionRetries", () => {
+	const resolvedUrl: IResolvedUrl = {
+		id: uuid(),
+		endpoints: {},
+		tokens: {},
+		type: "fluid",
+		url: `https://localhost/tenant/${uuid()}`,
+	};
+
+	const urlResolver = failSometimeProxy<IUrlResolver>({
+		resolve: async () => resolvedUrl,
+	});
+
+	function createRetryableError(message: string): Error {
+		const error = new Error(message);
+		(error as unknown as { canRetry: boolean }).canRetry = true;
+		return error;
+	}
+
+	it("load rejects when connectToStorage fails with retryable error and flag is enabled", async () => {
+		const documentServiceFactory = failSometimeProxy<
+			IDocumentServiceFactory & IProvideLayerCompatDetails
+		>({
+			createDocumentService: async () =>
+				failSometimeProxy<IDocumentService>({
+					policies: {},
+					resolvedUrl,
+					connectToStorage: async () => {
+						throw createRetryableError("transient storage failure");
+					},
+					connectToDeltaStream: async () => new Promise(() => {}),
+					on: AbsentProperty,
+					off: AbsentProperty,
+					dispose: () => {},
+				}),
+			ILayerCompatDetails: AbsentProperty,
+		});
+
+		const loader = new Loader({
+			codeLoader: createTestCodeLoaderProxy(),
+			documentServiceFactory,
+			urlResolver,
+			configProvider: {
+				getRawConfig: (name): ConfigTypes =>
+					name === "Fluid.Container.DisableLoadConnectionRetries" ? true : undefined,
+			},
+		});
+
+		// With the flag enabled, the load should reject immediately instead of retrying.
+		await assert.rejects(
+			async () => loader.resolve({ url: "test" }),
+			"Load should reject when storage connection fails with retries disabled",
+		);
+	});
+
+	it("load rejects when connectToDeltaStream fails with retryable error and flag is enabled", async () => {
+		const documentServiceFactory = failSometimeProxy<
+			IDocumentServiceFactory & IProvideLayerCompatDetails
+		>({
+			createDocumentService: async () =>
+				failSometimeProxy<IDocumentService>({
+					policies: {},
+					resolvedUrl,
+					connectToStorage: async () => new Promise(() => {}),
+					connectToDeltaStream: async (): Promise<never> => {
+						throw createRetryableError("transient connection failure");
+					},
+					on: AbsentProperty,
+					off: AbsentProperty,
+					dispose: () => {},
+				}),
+			ILayerCompatDetails: AbsentProperty,
+		});
+
+		const loader = new Loader({
+			codeLoader: createTestCodeLoaderProxy(),
+			documentServiceFactory,
+			urlResolver,
+			configProvider: {
+				getRawConfig: (name): ConfigTypes =>
+					name === "Fluid.Container.DisableLoadConnectionRetries" ? true : undefined,
+			},
+		});
+
+		// With the flag enabled, the load should reject immediately instead of retrying.
+		await assert.rejects(
+			async () => loader.resolve({ url: "test" }),
+			"Load should reject when delta connection fails with retries disabled",
+		);
 	});
 });


### PR DESCRIPTION
Currently, we continue to retry retriable errors indefinitely on container load. However in case of certain consumers where there is limited time (30/60 seconds) for the load, we should not have infinite retries even on retriable errors.

If the consumer of `load` wants to handle the retry mechanism (i.e. via the `loadExistingContainer` free function), they can enable the `"Fluid.Container.DisableLoadConnectionRetries"` flag. This flag will cause no internal retries to occur and let any error surface to the consumer of `load`.

[AB#42777](https://dev.azure.com/fluidframework/internal/_workitems/edit/42777)