### PR TITLE
docs(eslint-config-fluid): clean up 9.0.0 changelog

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,34 +1,6 @@
 # @fluidframework/eslint-config-fluid Changelog
 
-## 2.91.0
-
-Dependency updates only.
-
-## 2.90.0
-
-Dependency updates only.
-
-## 2.83.0
-
-Dependency updates only.
-
-## 2.82.0
-
-Dependency updates only.
-
-## 2.81.0
-
-Dependency updates only.
-
-## 2.80.0
-
-Dependency updates only.
-
-## 2.74.0
-
-Dependency updates only.
-
-## Unreleased
+## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 
 ### Native ESLint 9 Flat Config (No FlatCompat)
 
@@ -43,15 +15,6 @@ The `flat.mts` module now exports four configurations:
 - `minimalDeprecated` - Minimal configuration (deprecated, use recommended)
 - `strictBiome` - Strict configuration with Biome formatter compatibility
 
-#### Modular Structure
-
-The configuration is now organized into a modular structure under `library/`:
-
-- `library/constants.mts` - Shared constants (ignores, file patterns, import restrictions)
-- `library/settings.mts` - Plugin settings (import-x, jsdoc)
-- `library/rules/` - Rule definitions organized by config level (base, minimal-deprecated, recommended, strict)
-- `library/configs/` - Config builders and shared overrides
-
 ### Removed Rushstack Dependencies
 
 The following packages have been removed from dependencies:
@@ -60,19 +23,6 @@ The following packages have been removed from dependencies:
 - `@rushstack/eslint-plugin-security`
 
 The `@rushstack/eslint-plugin-security` plugin has been removed from all configurations. The `patch/modern-module-resolution.js` file has also been removed as it was only needed to support the `@rushstack/eslint-patch` dependency.
-
-### ESLint 9 Flat Config Support
-
-This package now supports ESLint 9 flat config format via a new `flat.mjs` export. The flat config wraps existing configs using `FlatCompat` from `@eslint/eslintrc` for backward compatibility.
-
-Key features:
-
-- New `flat.mjs` module exports `recommended`, `strict`, and `minimalDeprecated` configs for ESLint 9
-- Automatic handling of type-aware parsing configuration for JavaScript files and test files
-- Generated `eslint.config.mjs` files for all packages in the repository
-- Script to regenerate flat configs: `pnpm tsx scripts/generate-flat-eslint-configs.ts`
-
-Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the legacy `.eslintrc.cjs` format remains supported for backward compatibility. Migration is optional and not required.
 
 ### ESLint Rule Changes
 
@@ -90,7 +40,7 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 - `react-hooks/set-state-in-render`
 - `react-hooks/use-memo`
 
-**React-hooks rules temporarily downgraded to `"warn"`** (until ESLint 9 migration completes):
+**React-hooks rules temporarily set to `"warn"`** (to allow time to address violations before the next major release):
 
 - `react-hooks/rules-of-hooks`: Changed from `"error"` to `"warn"`
 - `react-hooks/exhaustive-deps`: Changed from `"error"` to `"warn"`
@@ -128,7 +78,7 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 
 #### Rule promotions
 
-**recommended -> minimal**
+The following rules have been added to the `minimal` config (in addition to `recommended`):
 
 - `@typescript-eslint/explicit-function-return-type`
 - `@typescript-eslint/no-import-type-side-effects`
@@ -138,8 +88,6 @@ Packages can now use `eslint.config.mjs` instead of `.eslintrc.cjs`, but the leg
 #### Rule modifications
 
 - `jsdoc/multiline-blocks`: Updated to allow single-line comments to be expressed as a single line. E.g. `/** Single-line comment */`.
-
-## [9.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v9.0_0)
 
 ### eslint-plugin-eslint-comments replaced by @eslint-community/eslint-plugin-eslint-comments
 

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -40,7 +40,7 @@ The `@rushstack/eslint-plugin-security` plugin has been removed from all configu
 - `react-hooks/set-state-in-render`
 - `react-hooks/use-memo`
 
-**React-hooks rules temporarily set to `"warn"`** (to allow time to address violations before the next major release):
+**`react-hooks` rules temporarily set to `"warn"`** (to allow time to address violations before the next major release):
 
 - `react-hooks/rules-of-hooks`: Changed from `"error"` to `"warn"`
 - `react-hooks/exhaustive-deps`: Changed from `"error"` to `"warn"`

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -78,7 +78,7 @@ The `@rushstack/eslint-plugin-security` plugin has been removed from all configu
 
 #### Rule promotions
 
-The following rules have been added to the `minimal` config (in addition to `recommended`):
+The following rules, which were previously enabled only in the `recommended` config, are now also enabled in the `minimal` config:
 
 - `@typescript-eslint/explicit-function-return-type`
 - `@typescript-eslint/no-import-type-side-effects`

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "9.1.0",
+	"version": "9.0.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "9.0.0",
+	"version": "9.1.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Summary

- Consolidates the unreleased section into the 9.0.0 changelog entry
- Removes duplicate/outdated sections (FlatCompat details, modular structure notes, dependency-only entries)
- Clarifies wording around temporarily warned react-hooks rules and rule promotions