### PR TITLE
fix: Give copilot-oce agent access the Loop integration pipeline, and let it check correct channel for pipeline messages

### DIFF
--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -7,6 +7,11 @@ mcp-servers:
     command: agency
     args: ["mcp", "ado", "--organization", "fluidframework"]
     tools: ["*"]
+  ado-office:
+    type: local
+    command: agency
+    args: ["mcp", "ado", "--organization", "office"]
+    tools: ["*"]
   enghub:
     type: local
     command: agency
@@ -77,12 +82,14 @@ The OCE rotation covers **three IcM teams**. Always search all three when lookin
 
 ### ADO Pipeline Definitions
 
-| Pipeline | Def ID | ADO Org/Project | Key Stages to Monitor |
-|---|---|---|---|
-| Build - client packages | 12 | `fluidframework/internal` | `build`, `run_checks`, `publish_npm_internal_*` |
-| E2E tests | 56 | `fluidframework/internal` | `e2e_odsp`, `e2e_local_server`, `e2e_azure_client_frs`, `e2e_azure_client_local_server` |
-| Stress tests | 63 | `fluidframework/internal` | `stress_tests_frs`, `stress_tests_tinylicious` |
-| Loop-FF integration | 29163 | `office/OC` | (external — run manually for pre-merge validation) |
+| Pipeline | Def ID | ADO Org/Project | MCP Server | Key Stages to Monitor |
+|---|---|---|---|---|
+| Build - client packages | 12 | `fluidframework/internal` | `ado` | `build`, `run_checks`, `publish_npm_internal_*` |
+| E2E tests | 56 | `fluidframework/internal` | `ado` | `e2e_odsp`, `e2e_local_server`, `e2e_azure_client_frs`, `e2e_azure_client_local_server` |
+| Stress tests | 63 | `fluidframework/internal` | `ado` | `stress_tests_frs`, `stress_tests_tinylicious` |
+| Loop-FF integration | 29163 | `office/OC` | `ado-office` | `Build And Run E2E Tests`, `Build And Run Unit Tests`, `Lint and Type Check` |
+
+**ADO MCP servers:** Two ADO MCP servers are configured — `ado` (for `fluidframework` org) and `ado-office` (for `office` org). When querying pipelines in `office/OC` (e.g., Loop-FF integration pipeline def 29163), use the `ado-office` MCP server tools. All other pipelines use the default `ado` tools.
 
 **ADO Build API result codes:** `result`: `2` = succeeded ✅, `4` = partiallySucceeded ⚠️, `8` = failed ❌. `status`: `1` = inProgress, `2` = completed.
 
@@ -160,6 +167,8 @@ This section covers the tasks you may perform. You are not limited to these — 
 ### Pipeline Health Monitoring
 
 - **Monitor key pipelines**: Check Build (def 12), E2E (def 56), and Stress (def 63) pipelines for `main` and `lts` branches. Focus on `stress_tests_frs`, `e2e_azure_client_frs`, and `e2e_azure_client_local_server` stages. Compare with historical health to distinguish new failures from ongoing flakiness.
+
+- **Monitor the Loop-FF integration pipeline**: Check the Loop-FF integration pipeline (def 29163 in `office/OC`, use `ado-office` MCP tools) for recent failures. This pipeline runs on `master` and validates that the latest FF packages don't break office-bohemia. Use `ado-office-pipelines_get_builds` with `definitions: [29163]` and `project: "OC"` to list recent runs. Summarize results (passed/failed, failed stage, error). A failing integration pipeline means the next FF bump to Loop will break — flag this to the OCE and recommend investigating the failing stage logs.
 
 - **Respond to Geneva pipeline alerts**: Find the TSG, walk through it, and help author a Kusto query showing error rate over time to demonstrate impact and resolution.
 

--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -97,7 +97,7 @@ The OCE rotation covers **three IcM teams**. Always search all three when lookin
 
 | Channel | Team ID | Channel ID |
 |---|---|---|
-| FF Hot | `9ce27575-2f82-4689-abdb-bcff07e8063b` | `19:07c78dc203f74d24a204f097ffa0fd6b@thread.skype` |
+| FF Client OCE | `9ce27575-2f82-4689-abdb-bcff07e8063b` | `19:25dabf309c5c42a7abe4647c7c1b7990@thread.skype` |
 
 ### Access Groups & Prerequisites
 
@@ -182,7 +182,7 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 - **Kusto investigation**: Use the **ff-oce-kusto** skill for all telemetry work. This can range from basic information-gathering queries to extensive back-and-forth deep dives to root-cause a problem.
 
-- **Escalate to FF area experts**: Help compose a Teams message for FF Hot/FF Client channel summarizing the symptom, data gathered, hypothesis, and specific question. Tag appropriate subsystem owners (loader, runtime, driver, summarizer).
+- **Escalate to FF area experts**: Help compose a Teams message for FF Client OCE channel summarizing the symptom, data gathered, hypothesis, and specific question. Tag appropriate subsystem owners (loader, runtime, driver, summarizer).
 
 - **Assess error severity**: Given an error type (e.g., `DataCorruptionError`, connectivity drops, 429s), help assess per-session and per-document impact, and whether sessions recover. Design targeted Kusto queries to answer these questions.
 
@@ -204,9 +204,9 @@ This section covers the tasks you may perform. You are not limited to these — 
   3. Run the integration pipeline (Office/OC def 29163) on `master` with the FF Build Number.
   4. If it passes, changes are safe to merge.
 
-- **Audit bump pipeline alerts in FF Hot channel**: The integration pipeline posts failure alerts to the FF Hot Teams channel. Audit, acknowledge, and resolve these each shift.
+- **Audit bump pipeline alerts in FF Client OCE channel**: The integration pipeline posts failure alerts to the FF Client OCE Teams channel. Audit, acknowledge, and resolve these each shift.
 
-  **Finding alerts:** Use `ListChannelMessages` (not `SearchTeamsMessages`) on the FF Hot channel. Filter for messages where `from.id` is `azuredevops@microsoft.com`. Look back at most 2 weeks (one shift length).
+  **Finding alerts:** Use `ListChannelMessages` (not `SearchTeamsMessages`) on the FF Client OCE channel. Filter for messages where `from.id` is `azuredevops@microsoft.com`. Look back at most 2 weeks (one shift length).
 
   **Classifying alert status:**
   - **Acknowledged**: Has a text reply or positive emoji reaction (✅, ☑️, 👍, 👀).
@@ -225,7 +225,7 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 - **Draft RCA/Postmortem**: Cover timeline, root cause, impact, mitigation steps, and follow-up action items. Remind the engineer about the RCA-required flag.
 
-- **Compose expert engagement messages**: Draft concise messages for FF Client/FF Hot channels — symptom, data, hypothesis, and specific question.
+- **Compose expert engagement messages**: Draft concise messages for FF Client OCE channel — symptom, data, hypothesis, and specific question.
 
 - **Respond to "Request Assistance"**: Draft an initial acknowledgment that sets expectations, asks for missing context, and signals investigation is beginning.
 

--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -168,7 +168,7 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 - **Monitor key pipelines**: Check Build (def 12), E2E (def 56), and Stress (def 63) pipelines for `main` and `lts` branches. Focus on `stress_tests_frs`, `e2e_azure_client_frs`, and `e2e_azure_client_local_server` stages. Compare with historical health to distinguish new failures from ongoing flakiness.
 
-- **Monitor the Loop-FF integration pipeline**: Check the Loop-FF integration pipeline (def 29163 in `office/OC`, use `ado-office` MCP tools) for recent failures. This pipeline runs on `master` and validates that the latest FF packages don't break office-bohemia. Use `ado-office-pipelines_get_builds` with `definitions: [29163]` and `project: "OC"` to list recent runs. Summarize results (passed/failed, failed stage, error). A failing integration pipeline means the next FF bump to Loop will break — flag this to the OCE and recommend investigating the failing stage logs.
+- **Monitor the Loop-FF integration pipeline**: Check the Loop-FF integration pipeline (def 29163 in `office/OC`, use `ado-office` MCP tools) for recent failures. This pipeline runs on `master` and validates that the latest FF packages don't break office-bohemia. Use `ado-office-pipelines_get_builds` with `definitions: [29163]` and `project: "OC"` to list recent runs. Summarize results (passed/failed, failed stage, error). A failing integration pipeline means the next FF bump to Loop is likely to break — flag this to the OCE and recommend investigating the failing stage logs.
 
 - **Respond to Geneva pipeline alerts**: Find the TSG, walk through it, and help author a Kusto query showing error rate over time to demonstrate impact and resolution.
 

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
@@ -56,7 +56,7 @@ If it fails, retry with a simple `summarize ErrorCount = count()` fallback (no `
 
 #### Agent 5 — Teams Pipeline Alerts
 
-Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:07c78dc203f74d24a204f097ffa0fd6b@thread.skype`, top 50. Filter for messages from Azure DevOps in the last 2 weeks. Classify each as **Acknowledged** (has a text reply or ✅/☑️/👍/👀 reaction), **Resolved** (reply confirming fix), or **Unacknowledged** (no replies, no meaningful reactions). Report: Date, Description, Status, Action Needed.
+Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:25dabf309c5c42a7abe4647c7c1b7990@thread.skype`, top 50. Filter for messages from Azure DevOps in the last 2 weeks. Classify each as **Acknowledged** (has a text reply or ✅/☑️/👍/👀 reaction), **Resolved** (reply confirming fix), or **Unacknowledged** (no replies, no meaningful reactions). Report: Date, Description, Status, Action Needed.
 
 #### Agent 6 — WorkIQ
 

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
@@ -90,7 +90,7 @@ Generated: <timestamp>
 | Partner | Error Count | Notes |
 | --- | --- | --- |
 
-### 🔔 Integration Pipeline Alerts (FF Hot, last 2 weeks)
+### 🔔 Integration Pipeline Alerts (FF Client OCE channel, last 2 weeks)
 | Date | Description | Status | Action Needed |
 | --- | --- | --- | --- |
 

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
@@ -83,8 +83,8 @@ Generated: <timestamp>
 | --- | --- | --- | --- | --- |
 
 ### 🔗 Loop-FF Integration Pipeline (last 5 runs)
-| Build ID | Result | Finished | Build Number | Notes |
-| --- | --- | --- | --- | --- |
+| Build ID | Branch | Result | Finished | Build Number | Notes |
+| --- | --- | --- | --- | --- | --- |
 
 ### 📊 Error Rates (last 1h)
 | Partner | Error Count | Notes |

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
@@ -22,7 +22,7 @@ Before gathering any data, use the `ask_user` tool:
 - If **Yes**: proceed to Step 1. Present the dashboard in the console.
 - If **Yes, and write it to a file**: proceed to Step 1. Write the dashboard to `oce-dashboard-<YYYYMMDD-HHmmss>.md` in the current working directory instead of printing it to the console. Just confirm the filename when done.
 
-### Step 1: Launch 5 background agents in parallel
+### Step 1: Launch 6 background agents in parallel
 
 Use the `task` tool with `mode: "background"` for each. Instruct each agent to **always terminate** — either return its results or respond with "FAILED: \<reason\>" if the tool call errors or auth fails. Agents must never hang or retry indefinitely.
 
@@ -36,7 +36,11 @@ Call `icm-search_incidents_by_owning_team_id` for each team: **98481** (FF Hot),
 
 Call `ado-pipelines_get_builds` for each pipeline definition (**12** = Build, **56** = E2E, **63** = Stress) with `project: "internal"`, `branchName: "refs/heads/main"`, `statusFilter: "Completed"`, `top: 3`, `queryOrder: "FinishTimeDescending"`. Result codes: **2** = ✅, **4** = ⚠️, **8** = ❌. Report build ID, result, finish time, and overall trend.
 
-#### Agent 3 — Kusto Error Rates
+#### Agent 3 — Loop-FF Integration Pipeline
+
+Call `ado-office-pipelines_get_builds` with `project: "OC"`, `definitions: [29163]`, `top: 5`, `queryOrder: "FinishTimeDescending"`. **Important:** Use the `ado-office` MCP server tools (NOT the default `ado` tools) — this pipeline is in the `office` ADO org, not `fluidframework`. Result codes: **2** = ✅, **4** = ⚠️, **8** = ❌. Report build ID, result, finish time, branch, and build number. Flag any failures — a failing integration pipeline means the next FF bump to Loop will break.
+
+#### Agent 4 — Kusto Error Rates
 
 Do **not** load the ff-oce-kusto skill. Call `kusto-kusto_query` with `cluster_uri: "https://kusto.aria.microsoft.com"`, `database: "6a8929bcfc6d44e9b13fee392ada9cf0"`, and this query:
 
@@ -50,11 +54,11 @@ Office_Fluid_FluidRuntime_Error
 
 If it fails, retry with a simple `summarize ErrorCount = count()` fallback (no `by` clause). Report as a table: Partner, Error Count.
 
-#### Agent 4 — Teams Pipeline Alerts
+#### Agent 5 — Teams Pipeline Alerts
 
 Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:07c78dc203f74d24a204f097ffa0fd6b@thread.skype`, top 50. Filter for messages from Azure DevOps in the last 2 weeks. Classify each as **Acknowledged** (has a text reply or ✅/☑️/👍/👀 reaction), **Resolved** (reply confirming fix), or **Unacknowledged** (no replies, no meaningful reactions). Report: Date, Description, Status, Action Needed.
 
-#### Agent 5 — WorkIQ
+#### Agent 6 — WorkIQ
 
 Call `workiq-ask_work_iq`: "Do I have any pending emails, action items, or meeting follow-ups related to Fluid Framework, FF Client, FF Hot, or Fluid Relay from the last week?" Summarize any actionable items.
 
@@ -76,6 +80,10 @@ Generated: <timestamp>
 
 ### 🔧 Pipeline Health (main, last 3 runs)
 | Pipeline | Run 1 | Run 2 | Run 3 | Trend |
+| --- | --- | --- | --- | --- |
+
+### 🔗 Loop-FF Integration Pipeline (last 5 runs)
+| Build ID | Result | Finished | Build Number | Notes |
 | --- | --- | --- | --- | --- |
 
 ### 📊 Error Rates (last 1h)


### PR DESCRIPTION
 ## Description
 
Add the `ado-office` MCP server and Loop-FF integration pipeline monitoring to the FF Client OCE agent and dashboard.
 
Previously, the agent could only query ADO pipelines in the `fluidframework` org. The Loop-FF integration pipeline (def 29163) lives in `office/OC`, so it was invisible to the dashboard. This adds:
 
 - A second ADO MCP server (`ado-office`) targeting the `office` org
 - Explicit `MCP Server` column in the pipeline definitions table
 - A new dashboard agent (Agent 3) that checks the last 5 Loop-FF integration builds and flags failures
 - Pipeline monitoring instructions for the Loop-FF integration pipeline in the OCE task list
 - Corrected Teams channel ID for pipeline alert monitoring (FF Client OCE channel instead of FF Hot)
 
 ## Reviewer Guidance
 
 - Changes are limited to two `.repoverlay` agent/skill markdown files — no production code.
 - To test: select the `ff-oce` agent and say "generate shift dashboard". Confirm the dashboard now includes a **Loop-FF Integration Pipeline** section alongside the existing pipeline health table.
 - The `ado-office` MCP server uses the same `agency mcp ado` command as the existing `ado` server, just pointed at a different org.