### PR TITLE
Port EditManager codec to ClientVersionDispatchingCodecBuilder

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -559,9 +559,9 @@ export const currentVersion: MinimumVersionForCollab = runtimeUtilsCleanedPackag
  * - What should be included as children. For example should it include versioned codecs which dispatch base on the min version for collaboration? If so, what version of them should be used?
  * - What risks does having this mitigate?
  */
-export interface CodecTree {
+export interface CodecTree<TFormatVersion extends FormatVersion = FormatVersion> {
 	readonly name: string;
-	readonly version: FormatVersion;
+	readonly version: TFormatVersion;
 	readonly children?: readonly CodecTree[];
 }
 

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -39,6 +39,7 @@ export {
 	Versioned,
 	makeVersionDispatchingCodec,
 	makeDiscontinuedCodecVersion,
+	makeDiscontinuedCodecAndSchema,
 	ClientVersionDispatchingCodecBuilder,
 	type CodecVersion,
 	type CodecAndSchema,

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -12,13 +12,14 @@ import {
 	type SemanticVersion,
 } from "@fluidframework/runtime-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { Type, type TSchema } from "@sinclair/typebox";
+import type { TSchema } from "@sinclair/typebox";
 import { gt } from "semver-ts";
 
 import { pkgVersion } from "../../packageVersion.js";
-import type {
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnlyObject,
+import {
+	JsonCompatibleReadOnlySchema,
+	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
 } from "../../util/index.js";
 import {
 	type ICodecFamily,
@@ -117,8 +118,7 @@ function makeVersionedValidatedCodec<
 /**
  * Creates a codec which always throws a UsageError when encoding or decoding, indicating that the format version is discontinued.
  *
- * TODO: {@link ClientVersionDispatchingCodecBuilder} should get support for extra decode only entries and/or unstable formats (codecs without a minVersionForCollab that will never be selected for write unless overridden).
- * Once done, users of this should migrate to ClientVersionDispatchingCodecBuilder and this function can be simplified.
+ * @deprecated Users of this should migrate to {@link ClientVersionDispatchingCodecBuilder} and use {@link makeDiscontinuedCodecAndSchema}.
  */
 export function makeDiscontinuedCodecVersion<
 	TDecoded,
@@ -129,16 +129,6 @@ export function makeDiscontinuedCodecVersion<
 	discontinuedVersion: FormatVersion,
 	discontinuedSince: SemanticVersion,
 ): IJsonCodec<TDecoded, TEncoded, TEncoded, TContext> {
-	const schema = Type.Object(
-		{
-			version:
-				discontinuedVersion === undefined
-					? Type.Undefined()
-					: Type.Literal(discontinuedVersion),
-		},
-		// Using `additionalProperties: true` allows this schema to be used when loading data encoded by older versions even though they contain additional properties.
-		{ additionalProperties: true },
-	);
 	const codec: IJsonCodec<TDecoded, TEncoded, TEncoded, TContext> = {
 		encode: (_: TDecoded): TEncoded => {
 			throw new UsageError(
@@ -147,11 +137,46 @@ export function makeDiscontinuedCodecVersion<
 		},
 		decode: (data: TEncoded): TDecoded => {
 			throw new UsageError(
-				`Cannot decode data to format ${data.version}. The codec was discontinued in Fluid Framework client version ${discontinuedSince}.`,
+				`Cannot decode data in format ${data.version}. The codec was discontinued in Fluid Framework client version ${discontinuedSince}.`,
 			);
 		},
 	};
-	return makeVersionedValidatedCodec(options, new Set([discontinuedVersion]), schema, codec);
+	return makeVersionedValidatedCodec(
+		options,
+		new Set([discontinuedVersion]),
+		JsonCompatibleReadOnlySchema,
+		codec,
+	);
+}
+
+/**
+ * Creates a codec version which always throws a UsageError when encoding or decoding, indicating that the format version is discontinued.
+ */
+export function makeDiscontinuedCodecAndSchema<
+	TDecoded,
+	TContext,
+	TFormatVersion extends FormatVersion = FormatVersion,
+>(
+	discontinuedVersion: TFormatVersion,
+	discontinuedSince: SemanticVersion,
+): CodecVersion<TDecoded, TContext, TFormatVersion> {
+	return {
+		minVersionForCollab: undefined,
+		formatVersion: discontinuedVersion,
+		codec: {
+			schema: JsonCompatibleReadOnlySchema,
+			encode: (_data: TDecoded) => {
+				throw new UsageError(
+					`Cannot encode data to format ${discontinuedVersion}. The codec was discontinued in Fluid Framework client version ${discontinuedSince}.`,
+				);
+			},
+			decode: (data: unknown) => {
+				throw new UsageError(
+					`Cannot decode data in format ${discontinuedVersion}. The codec was discontinued in Fluid Framework client version ${discontinuedSince}.`,
+				);
+			},
+		},
+	};
 }
 
 /**
@@ -220,7 +245,7 @@ export interface CodecVersion<
 	TDecoded,
 	TContext,
 	TFormatVersion extends FormatVersion,
-	TBuildOptions extends ICodecOptions,
+	TBuildOptions extends ICodecOptions = ICodecOptions,
 > extends CodecVersionBase<
 		| CodecAndSchema<TDecoded, TContext>
 		| ((options: TBuildOptions) => CodecAndSchema<TDecoded, TContext>),
@@ -454,7 +479,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 		return this.buildDecoderInternal(options)[1];
 	}
 
-	public getCodecTree(clientVersion: MinimumVersionForCollab): CodecTree {
+	public getCodecTree(clientVersion: MinimumVersionForCollab): CodecTree<TFormatVersion> {
 		// TODO: add support for children codecs.
 		const selected = getWriteVersionNoOverrides(this.registry, clientVersion);
 		return {

--- a/packages/dds/tree/src/codec/versioned/index.ts
+++ b/packages/dds/tree/src/codec/versioned/index.ts
@@ -7,6 +7,7 @@ export { Versioned, versionField } from "./format.js";
 export {
 	makeVersionDispatchingCodec,
 	makeDiscontinuedCodecVersion,
+	makeDiscontinuedCodecAndSchema,
 	ClientVersionDispatchingCodecBuilder,
 	type CodecVersion,
 	type CodecAndSchema,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -30,16 +30,28 @@ import { makeV1toV4andV6CodecWithVersion } from "./editManagerCodecsV1toV4.js";
 import { makeSharedBranchesCodecWithVersion } from "./editManagerCodecsVSharedBranches.js";
 import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
 
+/**
+ * Context required for encoding/decoding the {@link EditManager}'s {@link SummaryData}.
+ */
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
 }
 
+/**
+ * Codec name used to identify the {@link EditManager} codec, see {@link makeEditManagerCodecBuilder}.
+ */
 export const editManagerCodecName = "EditManager";
 
+/**
+ * Options for constructing an {@link EditManager} codec, see {@link makeEditManagerCodecBuilder}.
+ */
 interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
+	/** Codecs for encoding changesets. */
 	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>;
+	/** Maps each EditManager format version to the corresponding changeset format version. */
 	dependentChangeFormatVersion: DependentFormatVersion<EditManagerFormatVersion>;
+	/** Codec for encoding revision tags within changesets. */
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
@@ -48,6 +60,9 @@ interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
 	>;
 }
 
+/**
+ * Creates a {@link ClientVersionDispatchingCodecBuilder} encoding for {@link SummaryData}.
+ */
 export function makeEditManagerCodecBuilder<
 	TChangeset,
 >(): ClientVersionDispatchingCodecBuilder<
@@ -57,6 +72,7 @@ export function makeEditManagerCodecBuilder<
 	EditManagerFormatVersion,
 	typeof editManagerCodecName
 > {
+	// See EditManagerFormatVersion and its members for documentation on what changed in each version.
 	const versions: CodecVersion<
 		SummaryData<TChangeset>,
 		EditManagerEncodingContext,
@@ -121,6 +137,10 @@ export function makeEditManagerCodecBuilder<
 	return ClientVersionDispatchingCodecBuilder.build(editManagerCodecName, versions);
 }
 
+/**
+ * Returns a {@link CodecTree} for the EditManager format at the given client version,
+ * with the provided change codec tree as a child.
+ */
 export function getCodecTreeForEditManagerFormatWithChange(
 	clientVersion: MinimumVersionForCollab,
 	changeFormat: CodecTree,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -3,176 +3,131 @@
  * Licensed under the MIT License.
  */
 
-import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
-import {
-	getConfigForMinVersionForCollab,
-	lowestMinVersionForCollab,
-} from "@fluidframework/runtime-utils/internal";
+import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
 import {
+	ClientVersionDispatchingCodecBuilder,
 	type CodecTree,
-	type CodecWriteOptions,
+	type CodecVersion,
 	type DependentFormatVersion,
 	FluidClientVersion,
-	type FormatVersion,
 	type ICodecFamily,
 	type ICodecOptions,
 	type IJsonCodec,
-	makeCodecFamily,
-	makeDiscontinuedCodecVersion,
+	makeDiscontinuedCodecAndSchema,
 } from "../codec/index.js";
-import { makeVersionDispatchingCodec } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	EncodedRevisionTag,
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import { brand, unbrand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { SummaryData } from "./editManager.js";
-import { makeV1CodecWithVersion } from "./editManagerCodecsV1toV4.js";
+import { makeV1toV4andV6CodecWithVersion } from "./editManagerCodecsV1toV4.js";
 import { makeSharedBranchesCodecWithVersion } from "./editManagerCodecsVSharedBranches.js";
-import {
-	EditManagerFormatVersion,
-	editManagerFormatVersions,
-} from "./editManagerFormatCommons.js";
+import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
 
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
 }
 
-/**
- * Convert a MinimumVersionForCollab to an EditManagerFormatVersion.
- * @param clientVersion - The MinimumVersionForCollab to convert.
- * @returns The EditManagerFormatVersion that corresponds to the provided MinimumVersionForCollab.
- */
-export function clientVersionToEditManagerFormatVersion(
-	clientVersion: MinimumVersionForCollab,
-	writeVersionOverride?: EditManagerFormatVersion,
-): EditManagerFormatVersion {
-	const compatibleVersion: EditManagerFormatVersion = brand(
-		getConfigForMinVersionForCollab(clientVersion, {
-			[lowestMinVersionForCollab]: EditManagerFormatVersion.v3,
-			[FluidClientVersion.v2_43]: EditManagerFormatVersion.v4,
-			[FluidClientVersion.v2_80]: EditManagerFormatVersion.v6,
-		}),
-	);
+export const editManagerCodecName = "EditManager";
 
-	return writeVersionOverride ?? compatibleVersion;
-}
-
-/**
- * Returns the version that should be used for testing shared branches.
- */
-export function editManagerFormatVersionSelectorForSharedBranches(
-	clientVersion: MinimumVersionForCollab,
-): EditManagerFormatVersion {
-	return brand(EditManagerFormatVersion.vSharedBranches);
-}
-
-export interface EditManagerCodecOptions {
-	readonly editManagerFormatSelector?: (
-		minVersionForCollab: MinimumVersionForCollab,
-	) => EditManagerFormatVersion;
-}
-
-function editManagerFormatVersionFromOptions(
-	options: EditManagerCodecOptions & CodecWriteOptions,
-): EditManagerFormatVersion {
-	const selector =
-		options.editManagerFormatSelector ?? clientVersionToEditManagerFormatVersion;
-	return selector(options.minVersionForCollab);
-}
-
-export function makeEditManagerCodec<TChangeset>(
-	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>,
-	dependentChangeFormatVersion: DependentFormatVersion<EditManagerFormatVersion>,
+interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
+	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>;
+	dependentChangeFormatVersion: DependentFormatVersion<EditManagerFormatVersion>;
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
 		ChangeEncodingContext
-	>,
-	options: EditManagerCodecOptions & CodecWriteOptions,
-): IJsonCodec<
+	>;
+}
+
+export function makeEditManagerCodecBuilder<
+	TChangeset,
+>(): ClientVersionDispatchingCodecBuilder<
+	EditManagerCodecOptions<TChangeset>,
 	SummaryData<TChangeset>,
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnly,
-	EditManagerEncodingContext
+	EditManagerEncodingContext,
+	EditManagerFormatVersion,
+	typeof editManagerCodecName
 > {
-	const family = makeEditManagerCodecs(
-		changeCodecs,
-		dependentChangeFormatVersion,
-		revisionTagCodec,
-		options,
-	);
-	const writeVersion = editManagerFormatVersionFromOptions(options);
-	return makeVersionDispatchingCodec(family, { ...options, writeVersion });
-}
+	const versions: CodecVersion<
+		SummaryData<TChangeset>,
+		EditManagerEncodingContext,
+		EditManagerFormatVersion,
+		EditManagerCodecOptions<TChangeset>
+	>[] = [
+		makeDiscontinuedCodecAndSchema(EditManagerFormatVersion.v1, "2.73.0"),
+		makeDiscontinuedCodecAndSchema(EditManagerFormatVersion.v2, "2.73.0"),
+		{
+			minVersionForCollab: lowestMinVersionForCollab,
+			formatVersion: EditManagerFormatVersion.v3,
+			codec: (options: EditManagerCodecOptions<TChangeset>) =>
+				makeV1toV4andV6CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(EditManagerFormatVersion.v3),
+					),
+					options.revisionTagCodec,
+					EditManagerFormatVersion.v3,
+				),
+		},
+		{
+			minVersionForCollab: FluidClientVersion.v2_43,
+			formatVersion: EditManagerFormatVersion.v4,
+			codec: (options: EditManagerCodecOptions<TChangeset>) =>
+				makeV1toV4andV6CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(EditManagerFormatVersion.v4),
+					),
+					options.revisionTagCodec,
+					EditManagerFormatVersion.v4,
+				),
+		},
+		makeDiscontinuedCodecAndSchema(EditManagerFormatVersion.v5, "2.74.0"),
+		{
+			minVersionForCollab: FluidClientVersion.v2_80,
+			formatVersion: EditManagerFormatVersion.v6,
+			codec: (options: EditManagerCodecOptions<TChangeset>) =>
+				makeV1toV4andV6CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(EditManagerFormatVersion.v6),
+					),
+					options.revisionTagCodec,
+					EditManagerFormatVersion.v6,
+				),
+		},
+		{
+			minVersionForCollab: undefined,
+			formatVersion: EditManagerFormatVersion.vSharedBranches,
+			codec: (options: EditManagerCodecOptions<TChangeset>) =>
+				makeSharedBranchesCodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(
+							EditManagerFormatVersion.vSharedBranches,
+						),
+					),
+					options.revisionTagCodec,
+					EditManagerFormatVersion.vSharedBranches,
+				),
+		},
+	];
 
-export function makeEditManagerCodecs<TChangeset>(
-	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>,
-	dependentChangeFormatVersion: DependentFormatVersion<EditManagerFormatVersion>,
-	revisionTagCodec: IJsonCodec<
-		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
-		ChangeEncodingContext
-	>,
-	options: ICodecOptions,
-): ICodecFamily<SummaryData<TChangeset>, EditManagerEncodingContext> {
-	const registry: [
-		FormatVersion,
-		IJsonCodec<
-			SummaryData<TChangeset>,
-			JsonCompatibleReadOnly,
-			JsonCompatibleReadOnly,
-			EditManagerEncodingContext
-		>,
-	][] = Array.from(editManagerFormatVersions, (version) => {
-		switch (version) {
-			case unbrand(EditManagerFormatVersion.v1):
-			case unbrand(EditManagerFormatVersion.v2): {
-				return [version, makeDiscontinuedCodecVersion(options, version, "2.73.0")];
-			}
-			case unbrand(EditManagerFormatVersion.v3):
-			case unbrand(EditManagerFormatVersion.v4):
-			case unbrand(EditManagerFormatVersion.v6): {
-				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
-				return [
-					version,
-					makeV1CodecWithVersion(changeCodec, revisionTagCodec, options, version),
-				];
-			}
-			case unbrand(EditManagerFormatVersion.v5): {
-				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
-			}
-			case unbrand(EditManagerFormatVersion.vSharedBranches): {
-				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
-				return [
-					version,
-					makeSharedBranchesCodecWithVersion(changeCodec, revisionTagCodec, options, version),
-				];
-			}
-			default: {
-				unreachableCase(version);
-			}
-		}
-	});
-	return makeCodecFamily(registry);
+	return ClientVersionDispatchingCodecBuilder.build(editManagerCodecName, versions);
 }
 
 export function getCodecTreeForEditManagerFormatWithChange(
 	clientVersion: MinimumVersionForCollab,
 	changeFormat: CodecTree,
 ): CodecTree {
+	const builder = makeEditManagerCodecBuilder();
 	return {
-		name: "EditManager",
-		version: clientVersionToEditManagerFormatVersion(clientVersion),
+		...builder.getCodecTree(clientVersion),
 		children: [changeFormat],
 	};
 }

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -28,7 +28,7 @@ export interface EditManagerEncodingContext {
 }
 
 /**
- * Create the provided version of the EditManager codec.
+ * Create the provided version of the {@link EditManager} codec (which encodes it's {@link SummaryData}).
  * @remarks
  * The changeCodec and revisionTagCodec are not explicitly versioned, so the exact right version of them must be provided here
  * or data will be incompatible.

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -5,14 +5,18 @@
 
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 
-import { type ICodecOptions, type IJsonCodec, withSchemaValidation } from "../codec/index.js";
+import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	EncodedRevisionTag,
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import { type JsonCompatibleReadOnly, JsonCompatibleReadOnlySchema } from "../util/index.js";
+import {
+	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
+	JsonCompatibleReadOnlySchema,
+} from "../util/index.js";
 
 import type { SummaryData } from "./editManager.js";
 import { decodeSharedBranch, encodeSharedBranch } from "./editManagerCodecsCommons.js";
@@ -23,7 +27,15 @@ export interface EditManagerEncodingContext {
 	readonly schema?: SchemaAndPolicy;
 }
 
-export function makeV1CodecWithVersion<TChangeset>(
+/**
+ * Create the provided version of the EditManager codec.
+ * @remarks
+ * The changeCodec and revisionTagCodec are not explicitly versioned, so the exact right version of them must be provided here
+ * or data will be incompatible.
+ *
+ * TODO: this file should be renamed as this is used for v6 as well.
+ */
+export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 	changeCodec: IJsonCodec<
 		TChangeset,
 		JsonCompatibleReadOnly,
@@ -36,66 +48,49 @@ export function makeV1CodecWithVersion<TChangeset>(
 		EncodedRevisionTag,
 		ChangeEncodingContext
 	>,
-	options: ICodecOptions,
 	version: EncodedEditManager<TChangeset>["version"],
-): IJsonCodec<
-	SummaryData<TChangeset>,
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnly,
-	EditManagerEncodingContext
-> {
-	const format = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
+): CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> {
+	const schema = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
 
-	const codec: IJsonCodec<
-		SummaryData<TChangeset>,
-		EncodedEditManager<TChangeset>,
-		EncodedEditManager<TChangeset>,
-		EditManagerEncodingContext
-	> = withSchemaValidation(
-		format,
-		{
-			encode: (data, context: EditManagerEncodingContext) => {
-				const mainBranch = encodeSharedBranch(
+	const codec: CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> = {
+		schema,
+		encode: (
+			data: SummaryData<TChangeset>,
+			context: EditManagerEncodingContext,
+		): EncodedEditManager<TChangeset> & Versioned & JsonCompatibleReadOnlyObject => {
+			const mainBranch = encodeSharedBranch(
+				changeCodec,
+				revisionTagCodec,
+				data.main,
+				context,
+				data.originator,
+			);
+			const encoded: EncodedEditManager<TChangeset> = {
+				trunk: mainBranch.trunk,
+				branches: mainBranch.peers,
+				version,
+			};
+			return encoded as EncodedEditManager<TChangeset> &
+				Versioned &
+				JsonCompatibleReadOnlyObject;
+		},
+		decode: (
+			json: EncodedEditManager<TChangeset> & JsonCompatibleReadOnly,
+			context: EditManagerEncodingContext,
+		): SummaryData<TChangeset> => {
+			return {
+				main: decodeSharedBranch(
 					changeCodec,
 					revisionTagCodec,
-					data.main,
+					{
+						trunk: json.trunk,
+						peers: json.branches,
+					},
 					context,
-					data.originator,
-				);
-				const json: EncodedEditManager<TChangeset> = {
-					trunk: mainBranch.trunk,
-					branches: mainBranch.peers,
-					version,
-				};
-				return json;
-			},
-			decode: (
-				json: EncodedEditManager<TChangeset>,
-				context: EditManagerEncodingContext,
-			): SummaryData<TChangeset> => {
-				return {
-					main: decodeSharedBranch(
-						changeCodec,
-						revisionTagCodec,
-						{
-							trunk: json.trunk,
-							peers: json.branches,
-						},
-						context,
-						undefined, // originatorId is not encoded in v1
-					),
-				};
-			},
+					undefined, // Non "vSharedBranches" versions do not encode the summary originatorId.
+				),
+			};
 		},
-		options.jsonValidator,
-	);
-	// TODO: makeVersionedValidatedCodec and withSchemaValidation should allow the codec to decode JsonCompatibleReadOnly, or Versioned or something like that,
-	// and not leak the internal encoded format in the API surface.
-	// Fixing that would remove the need for this cast.
-	return codec as unknown as IJsonCodec<
-		SummaryData<TChangeset>,
-		JsonCompatibleReadOnly,
-		JsonCompatibleReadOnly,
-		EditManagerEncodingContext
-	>;
+	};
+	return codec;
 }

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 
-import { type ICodecOptions, type IJsonCodec, withSchemaValidation } from "../codec/index.js";
+import type { CodecAndSchema, IJsonCodec } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	EncodedRevisionTag,
@@ -15,6 +15,7 @@ import type {
 } from "../core/index.js";
 import {
 	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
 	JsonCompatibleReadOnlySchema,
 	type Mutable,
 } from "../util/index.js";
@@ -43,107 +44,83 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		EncodedRevisionTag,
 		ChangeEncodingContext
 	>,
-	options: ICodecOptions,
 	version: EncodedEditManager<TChangeset>["version"],
-): IJsonCodec<
-	SummaryData<TChangeset>,
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnly,
-	EditManagerEncodingContext
-> {
-	const format = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
+): CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> {
+	const schema = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
 
-	const codec: IJsonCodec<
-		SummaryData<TChangeset>,
-		EncodedEditManager<TChangeset>,
-		EncodedEditManager<TChangeset>,
-		EditManagerEncodingContext
-	> = withSchemaValidation(
-		format,
-		{
-			encode: (data: SummaryData<TChangeset>, context: EditManagerEncodingContext) => {
-				const mainBranch = encodeSharedBranch(
-					changeCodec,
-					revisionTagCodec,
-					data.main,
-					context,
-					data.originator,
-				);
-				assert(
-					data.originator !== undefined,
-					0xca5 /* Cannot encode vSharedBranches summary without originator */,
-				);
-				const json: Mutable<EncodedEditManager<TChangeset>> = {
-					main: mainBranch,
-					originator: data.originator,
-					version,
-				};
-				if (data.branches !== undefined && data.branches.size > 0) {
-					const branches: EncodedSharedBranch<TChangeset>[] = [];
-					for (const [_, branch] of data.branches) {
-						branches.push(
-							encodeSharedBranch(
-								changeCodec,
-								revisionTagCodec,
-								branch,
-								context,
-								data.originator,
-							),
-						);
-					}
-					json.branches = branches;
-				}
-				return json;
-			},
-			decode: (
-				json: EncodedEditManager<TChangeset>,
-				context: EditManagerEncodingContext,
-			): SummaryData<TChangeset> => {
-				const mainBranch = decodeSharedBranch(
-					changeCodec,
-					revisionTagCodec,
-					json.main,
-					context,
-					json.originator,
-				);
-
-				const decoded: Mutable<SummaryData<TChangeset>> = {
-					main: mainBranch,
-					originator: json.originator,
-				};
-
-				if (json.branches !== undefined) {
-					const branches = new Map<BranchId, SharedBranchSummaryData<TChangeset>>();
-					for (const branch of json.branches) {
-						const decodedBranch = decodeSharedBranch(
+	const codec: CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> = {
+		schema,
+		encode: (data: SummaryData<TChangeset>, context: EditManagerEncodingContext) => {
+			const mainBranch = encodeSharedBranch(
+				changeCodec,
+				revisionTagCodec,
+				data.main,
+				context,
+				data.originator,
+			);
+			assert(
+				data.originator !== undefined,
+				0xca5 /* Cannot encode vSharedBranches summary without originator */,
+			);
+			const json: Mutable<EncodedEditManager<TChangeset>> = {
+				main: mainBranch,
+				originator: data.originator,
+				version,
+			};
+			if (data.branches !== undefined && data.branches.size > 0) {
+				const branches: EncodedSharedBranch<TChangeset>[] = [];
+				for (const [_, branch] of data.branches) {
+					branches.push(
+						encodeSharedBranch(
 							changeCodec,
 							revisionTagCodec,
 							branch,
 							context,
-							json.originator,
-						);
-						assert(
-							decodedBranch.id !== undefined,
-							0xc66 /* Shared branches must have an id */,
-						);
-						assert(!branches.has(decodedBranch.id), 0xc67 /* Duplicate shared branch id */);
-						branches.set(decodedBranch.id, decodedBranch);
-					}
-
-					decoded.branches = branches;
+							data.originator,
+						),
+					);
 				}
-				return decoded;
-			},
+				json.branches = branches;
+			}
+			return json as EncodedEditManager<TChangeset> & JsonCompatibleReadOnlyObject;
 		},
-		options.jsonValidator,
-	);
-	// TODO: makeVersionedValidatedCodec and withSchemaValidation should allow the codec to decode JsonCompatibleReadOnly, or Versioned or something like that,
-	// and not leak the internal encoded format in the API surface.
-	// Fixing that would remove the need for this cast.
-	return codec as unknown as IJsonCodec<
-		SummaryData<TChangeset>,
-		JsonCompatibleReadOnly,
-		JsonCompatibleReadOnly,
-		EditManagerEncodingContext
-	>;
+		decode: (
+			json: EncodedEditManager<TChangeset> & JsonCompatibleReadOnlyObject,
+			context: EditManagerEncodingContext,
+		): SummaryData<TChangeset> => {
+			const mainBranch = decodeSharedBranch(
+				changeCodec,
+				revisionTagCodec,
+				json.main,
+				context,
+				json.originator,
+			);
+
+			const decoded: Mutable<SummaryData<TChangeset>> = {
+				main: mainBranch,
+				originator: json.originator,
+			};
+
+			if (json.branches !== undefined) {
+				const branches = new Map<BranchId, SharedBranchSummaryData<TChangeset>>();
+				for (const branch of json.branches) {
+					const decodedBranch = decodeSharedBranch(
+						changeCodec,
+						revisionTagCodec,
+						branch,
+						context,
+						json.originator,
+					);
+					assert(decodedBranch.id !== undefined, 0xc66 /* Shared branches must have an id */);
+					assert(!branches.has(decodedBranch.id), 0xc67 /* Duplicate shared branch id */);
+					branches.set(decodedBranch.id, decodedBranch);
+				}
+
+				decoded.branches = branches;
+			}
+			return decoded;
+		},
+	};
+
+	return codec;
 }

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -43,11 +43,9 @@ export { DefaultResubmitMachine } from "./defaultResubmitMachine.js";
 export { type ChangeEnricher } from "./changeEnricher.js";
 
 export {
-	makeEditManagerCodec,
+	makeEditManagerCodecBuilder,
 	getCodecTreeForEditManagerFormatWithChange,
-	type EditManagerCodecOptions,
-	clientVersionToEditManagerFormatVersion,
-	editManagerFormatVersionSelectorForSharedBranches,
+	editManagerCodecName,
 } from "./editManagerCodecs.js";
 export {
 	EditManagerFormatVersion,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -21,6 +21,8 @@ import {
 	type ICodecOptions,
 	type IJsonCodec,
 	makeCodecFamily,
+	// This codec will be updated soon.
+	// eslint-disable-next-line import-x/no-deprecated
 	makeDiscontinuedCodecVersion,
 	makeVersionDispatchingCodec,
 } from "../codec/index.js";
@@ -140,6 +142,8 @@ export function makeMessageCodecs<TChangeset>(
 					version === unbrand(MessageFormatVersion.undefined) ? undefined : version;
 				return [
 					versionOrUndefined,
+					// This codec will be updated soon.
+					// eslint-disable-next-line import-x/no-deprecated
 					makeDiscontinuedCodecVersion(options, versionOrUndefined, "2.73.0"),
 				];
 			}
@@ -153,6 +157,8 @@ export function makeMessageCodecs<TChangeset>(
 				];
 			}
 			case unbrand(MessageFormatVersion.v5): {
+				// This codec will be updated soon.
+				// eslint-disable-next-line import-x/no-deprecated
 				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
 			}
 			case unbrand(MessageFormatVersion.vSharedBranches): {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -51,7 +51,7 @@ import { BranchCommitEnricher } from "./branchCommitEnricher.js";
 import type { ChangeEnricher } from "./changeEnricher.js";
 import { DefaultResubmitMachine } from "./defaultResubmitMachine.js";
 import { EditManager, minimumPossibleSequenceNumber } from "./editManager.js";
-import { makeEditManagerCodec, type EditManagerCodecOptions } from "./editManagerCodecs.js";
+import { makeEditManagerCodecBuilder } from "./editManagerCodecs.js";
 import type { EditManagerFormatVersion, SeqNumber } from "./editManagerFormatCommons.js";
 import { EditManagerSummarizer } from "./editManagerSummarizer.js";
 import {
@@ -79,7 +79,6 @@ export interface ClonableSchemaAndPolicy extends SchemaAndPolicy {
 
 export interface SharedTreeCoreOptionsInternal
 	extends CodecWriteOptions,
-		EditManagerCodecOptions,
 		MessageCodecOptions {}
 
 export interface EnrichmentConfig<TChange> {
@@ -186,12 +185,12 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		this.registerSharedBranch("main");
 
 		const revisionTagCodec = new RevisionTagCodec(idCompressor);
-		const editManagerCodec = makeEditManagerCodec(
-			this.editManager.changeFamily.codecs,
-			changeFormatVersionForEditManager,
+		const editManagerCodec = makeEditManagerCodecBuilder<TChange>().build({
+			...options,
+			changeCodecs: this.editManager.changeFamily.codecs,
+			dependentChangeFormatVersion: changeFormatVersionForEditManager,
 			revisionTagCodec,
-			options,
-		);
+		});
 		this.summarizables = [
 			new EditManagerSummarizer(
 				this.editManager,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -66,7 +66,6 @@ import {
 import { schemaCodecBuilder } from "../feature-libraries/index.js";
 import {
 	type BranchId,
-	clientVersionToEditManagerFormatVersion,
 	clientVersionToMessageFormatVersion,
 	type ClonableSchemaAndPolicy,
 	getCodecTreeForEditManagerFormatWithChange,
@@ -75,6 +74,7 @@ import {
 	MessageFormatVersion,
 	SharedTreeCore,
 	EditManagerFormatVersion,
+	makeEditManagerCodecBuilder,
 } from "../shared-tree-core/index.js";
 import {
 	type ImplicitFieldSchema,
@@ -532,9 +532,8 @@ export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs<
 ]);
 
 function getCodecTreeForEditManagerFormat(clientVersion: MinimumVersionForCollab): CodecTree {
-	const change = changeFormatVersionForEditManager.lookup(
-		clientVersionToEditManagerFormatVersion(clientVersion),
-	);
+	const editManagerVersion = makeEditManagerCodecBuilder().getCodecTree(clientVersion).version;
+	const change = changeFormatVersionForEditManager.lookup(editManagerVersion);
 	const changeCodecTree = getCodecTreeForChangeFormat(change, clientVersion);
 	return getCodecTreeForEditManagerFormatWithChange(clientVersion, changeCodecTree);
 }
@@ -721,7 +720,6 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	treeEncodeType: TreeCompressionStrategy.Compressed,
 	disposeForksAfterTransaction: true,
 	shouldEncodeIncrementally: defaultIncrementalEncodingPolicy,
-	editManagerFormatSelector: clientVersionToEditManagerFormatVersion,
 	messageFormatSelector: clientVersionToMessageFormatVersion,
 	enableSharedBranches: false,
 	writeVersionOverrides: new Map(),

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -7,11 +7,11 @@ import { strict as assert } from "node:assert";
 
 import type { SessionId } from "@fluidframework/id-compressor";
 
-import { DependentFormatVersion } from "../../../codec/index.js";
+import { DependentFormatVersion, makeCodecFamily } from "../../../codec/index.js";
 import type { ChangeEncodingContext } from "../../../core/index.js";
 import { FormatValidatorBasic } from "../../../external-utilities/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import { makeEditManagerCodecs } from "../../../shared-tree-core/editManagerCodecs.js";
+import { makeEditManagerCodecBuilder } from "../../../shared-tree-core/editManagerCodecs.js";
 import {
 	EditManagerFormatVersion,
 	type SharedBranchSummaryData,
@@ -203,15 +203,17 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown, ChangeEncodi
 
 export function testCodec(): void {
 	describe("Codec", () => {
-		const family = makeEditManagerCodecs(
-			TestChange.codecs,
-			DependentFormatVersion.fromUnique(1),
-			testRevisionTagCodec,
-			{
-				jsonValidator: FormatValidatorBasic,
-			},
+		const builder = makeEditManagerCodecBuilder<TestChange>();
+		const built = builder.applyOptions({
+			changeCodecs: TestChange.codecs,
+			dependentChangeFormatVersion: DependentFormatVersion.fromUnique(1),
+			revisionTagCodec: testRevisionTagCodec,
+			jsonValidator: FormatValidatorBasic,
+		});
+		const family = makeCodecFamily(
+			built.map((codec) => [codec.formatVersion, codec.codec] as const),
 		);
-		// Versions 1 through 4 do not encode the summary originator ID.
+		// Non "vSharedBranches" versions do not encode the summary originatorId.
 		makeEncodingTestSuite(family, testCases, assertEquivalentSummaryDataIgnoreOriginator, [
 			EditManagerFormatVersion.v3,
 			EditManagerFormatVersion.v4,

--- a/packages/dds/tree/src/test/shared-tree-core/editManagerSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/editManagerSummarizer.spec.ts
@@ -31,11 +31,11 @@ import {
 } from "../../shared-tree-core/editManagerSummarizer.js";
 import {
 	EditManagerSummarizer,
-	makeEditManagerCodec,
+	makeEditManagerCodecBuilder,
 	summarizablesMetadataKey,
 	type SharedTreeSummarizableMetadata,
 } from "../../shared-tree-core/index.js";
-import { testChangeFamilyFactory } from "../testChange.js";
+import { testChangeFamilyFactory, type TestChange } from "../testChange.js";
 import { testIdCompressor } from "../utils.js";
 
 // eslint-disable-next-line import-x/no-internal-modules
@@ -53,9 +53,12 @@ function createEditManagerSummarizer(options?: {
 		Array.from(editManagerFormatVersions, (e) => [e, 1]),
 	);
 	const minVersionForCollab = options?.minVersionForCollab ?? FluidClientVersion.v2_74;
-	const codec = makeEditManagerCodec(family.codecs, changeFormatVersion, revisionTagCodec, {
+	const codec = makeEditManagerCodecBuilder<TestChange>().build({
 		jsonValidator: FormatValidatorBasic,
 		minVersionForCollab,
+		changeCodecs: family.codecs,
+		dependentChangeFormatVersion: changeFormatVersion,
+		revisionTagCodec,
 	});
 	const summarizer = new EditManagerSummarizer(
 		editManager,

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1198,7 +1198,7 @@ export function makeDiscontinuedEncodingTestSuite(
 			it("throws when decoding", () => {
 				assert.throws(
 					() => jsonCodec.decode({ version }, {}),
-					validateUsageError(/Cannot decode data to format/),
+					validateUsageError(/Cannot decode data in format/),
 				);
 			});
 		});

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -26,7 +26,8 @@ import {
 	type SharedTreeKernelView,
 } from "./shared-tree/index.js";
 import {
-	editManagerFormatVersionSelectorForSharedBranches,
+	editManagerCodecName,
+	EditManagerFormatVersion,
 	messageFormatVersionSelectorForSharedBranches,
 } from "./shared-tree-core/index.js";
 import { SharedTreeFactoryType, SharedTreeAttributes } from "./sharedTreeAttributes.js";
@@ -223,5 +224,8 @@ function resolveFormatOptions(options: SharedTreeOptions): SharedTreeOptionsInte
 
 const sharedBranchesOptions: SharedTreeOptionsInternal = {
 	messageFormatSelector: messageFormatVersionSelectorForSharedBranches,
-	editManagerFormatSelector: editManagerFormatVersionSelectorForSharedBranches,
+	writeVersionOverrides: new Map([
+		[editManagerCodecName, EditManagerFormatVersion.vSharedBranches],
+	]),
+	allowPossiblyIncompatibleWriteVersionOverrides: true,
 };


### PR DESCRIPTION
## Description

Port EditManager codec to ClientVersionDispatchingCodecBuilder.

This is the second to last of the version dispatched codecs to be ported to the new builder system.
This deduplicates logic related to schema validation, version dispatching etc.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

