### PR TITLE
fix: Update prompting to call out Teams reactions limitation

### DIFF
--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -209,11 +209,13 @@ This section covers the tasks you may perform. You are not limited to these — 
   **Finding alerts:** Use `ListChannelMessages` (not `SearchTeamsMessages`) on the FF Client OCE channel. Filter for messages where `from.id` is `azuredevops@microsoft.com`. Look back at most 2 weeks (one shift length).
 
   **Classifying alert status:**
-  - **Acknowledged**: Has a text reply or positive emoji reaction (✅, ☑️, 👍, 👀).
+  - **Acknowledged**: Has a text reply in the thread.
   - **Resolved**: Has a reply confirming no further action needed ("rolled back", "transient", "fixed in PR #1234").
-  - **Unacknowledged**: No text replies and no meaningful emoji reactions. Do not rely on `lastModifiedDateTime` — emoji reactions update it without adding a reply.
+  - **Unacknowledged**: No text replies in the thread.
 
-  **Actions:** Surface unacknowledged alerts and offer to post "acknowledged!". For acknowledged-but-unresolved, summarize the thread and suggest follow-up. Present results as a table (date, description, status, recommended action).
+  > **⚠️ Tool limitation:** The Teams MCP tool does not include emoji reactions in its response (the `reactions` field is absent from both `ListChannelMessages` and `GetChatMessage`). Alerts acknowledged only via emoji (👍, ✅, etc.) will appear as "Unacknowledged." Always confirm with the OCE before treating an alert as unacknowledged.
+
+  **Actions:** Surface unacknowledged alerts and **ask the user to verify** before offering to post "acknowledged!". For acknowledged-but-unresolved, summarize the thread and suggest follow-up. Present results as a table (date, description, status, recommended action).
 
 - **Monitor partner ring deployments**: Run Kusto queries to check for Fluid error rate spikes correlated with ring promotions (Dogfood → MSIT → Production).
 

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
@@ -56,7 +56,9 @@ If it fails, retry with a simple `summarize ErrorCount = count()` fallback (no `
 
 #### Agent 5 — Teams Pipeline Alerts
 
-Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:25dabf309c5c42a7abe4647c7c1b7990@thread.skype`, top 50. Filter for messages from Azure DevOps in the last 2 weeks. Classify each as **Acknowledged** (has a text reply or ✅/☑️/👍/👀 reaction), **Resolved** (reply confirming fix), or **Unacknowledged** (no replies, no meaningful reactions). Report: Date, Description, Status, Action Needed.
+Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:25dabf309c5c42a7abe4647c7c1b7990@thread.skype`, top 50. Filter for messages from Azure DevOps in the last 2 weeks. Classify each as **Acknowledged** (has a text reply), **Resolved** (reply confirming fix), or **Unacknowledged** (no text replies). Report: Date, Description, Status, Action Needed.
+
+> **⚠️ Tool limitation:** The Teams MCP tool does not include emoji reactions in its response. Alerts acknowledged only via emoji (👍, ✅, etc.) will appear as "Unacknowledged." Always cross-check before acting on unacknowledged alerts.
 
 #### Agent 6 — WorkIQ
 


### PR DESCRIPTION
## Description

Copilot OCE currently cannot read Teams reactions via `ListChannelMessages`. Call out this limitation in its prompts.
