### PR TITLE
fix: Prompt copilot-oce to check for Teams channel replies

### DIFF
--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -206,7 +206,9 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 - **Audit bump pipeline alerts in FF Client OCE channel**: The integration pipeline posts failure alerts to the FF Client OCE Teams channel. Audit, acknowledge, and resolve these each shift.
 
-  **Finding alerts:** Use `ListChannelMessages` (not `SearchTeamsMessages`) on the FF Client OCE channel. Filter for messages where `from.id` is `azuredevops@microsoft.com`. Look back at most 2 weeks (one shift length).
+  **Finding alerts:** Use `ListChannelMessages` (not `SearchTeamsMessages`) on the FF Client OCE channel **with `expand: "replies"`** to fetch threaded replies inline. Filter for messages where `from.displayName` is `"Azure DevOps"` or `from.id` is `azuredevops@microsoft.com`. Look back at most 2 weeks (one shift length).
+
+  **IMPORTANT — Fetching replies:** The Graph API returns `replies: null` by default. You **must** pass `expand: "replies"` to `ListChannelMessages` to get threaded replies. Without replies, you cannot determine acknowledgment status — do not classify alerts as unacknowledged based on missing reply data when `expand` was not set.
 
   **Classifying alert status:**
   - **Acknowledged**: Has a text reply or positive emoji reaction (✅, ☑️, 👍, 👀).

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-dashboard/SKILL.md
@@ -56,7 +56,7 @@ If it fails, retry with a simple `summarize ErrorCount = count()` fallback (no `
 
 #### Agent 5 — Teams Pipeline Alerts
 
-Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:25dabf309c5c42a7abe4647c7c1b7990@thread.skype`, top 50. Filter for messages from Azure DevOps in the last 2 weeks. Classify each as **Acknowledged** (has a text reply or ✅/☑️/👍/👀 reaction), **Resolved** (reply confirming fix), or **Unacknowledged** (no replies, no meaningful reactions). Report: Date, Description, Status, Action Needed.
+Call `teams-ListChannelMessages` with teamId `9ce27575-2f82-4689-abdb-bcff07e8063b`, channelId `19:25dabf309c5c42a7abe4647c7c1b7990@thread.skype`, top 50, **and `expand: "replies"`** to fetch threaded replies inline. The `expand` parameter is **required** — without it, `replies` will be `null` and acknowledgment status cannot be determined. Filter for messages from Azure DevOps (check `from.displayName` contains "Azure DevOps") in the last 2 weeks. Classify each as **Acknowledged** (has a text reply or ✅/☑️/👍/👀 reaction), **Resolved** (reply confirming fix), or **Unacknowledged** (no replies, no meaningful reactions). Report: Date, Description, Status, Action Needed.
 
 #### Agent 6 — WorkIQ
 


### PR DESCRIPTION
## Description

Copilot OCE was checking Teams messages for pipeline notifications, but it didn't catch acknowledgements because it wasn't looking for replies. This updates its prompt to look for replies.