### PR TITLE
Remove isomorphic-fetch from odsp-doclib-utils

### DIFF
--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -121,8 +121,7 @@
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
-		"@fluidframework/telemetry-utils": "workspace:~",
-		"isomorphic-fetch": "^3.0.0"
+		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.2",
@@ -134,7 +133,6 @@
 		"@fluidframework/eslint-config-fluid": "catalog:eslint",
 		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.83.0",
 		"@microsoft/api-extractor": "7.52.11",
-		"@types/isomorphic-fetch": "^0.0.39",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "~20.19.30",
 		"c8": "^10.1.3",

--- a/packages/utils/odsp-doclib-utils/src/odspRequest.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspRequest.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import fetch from "isomorphic-fetch";
-
 import { type IOdspAuthRequestInfo, authRequestWithRetry } from "./odspAuth.js";
 
 // eslint-disable-next-line jsdoc/require-description -- TODO: Add documentation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16747,9 +16747,6 @@ importers:
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../telemetry-utils
-      isomorphic-fetch:
-        specifier: ^3.0.0
-        version: 3.0.0(encoding@0.1.13)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -16778,9 +16775,6 @@ importers:
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@20.19.30)
-      '@types/isomorphic-fetch':
-        specifier: ^0.0.39
-        version: 0.0.39
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -19794,9 +19788,6 @@ packages:
     resolution: {integrity: sha512-5heqtZMvQ4nXARY0o8rc8cjkJjct2ScM12yCJ/h731S9He93a2cv+kAhwPCNwTKDfNH9gjRfLG4VpAEYJU0/gQ==}
     peerDependencies:
       ioredis: '>=5'
-
-  '@types/isomorphic-fetch@0.0.39':
-    resolution: {integrity: sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -32883,8 +32874,6 @@ snapshots:
   '@types/ioredis-mock@8.2.6(ioredis@5.6.1)':
     dependencies:
       ioredis: 5.6.1
-
-  '@types/isomorphic-fetch@0.0.39': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 


### PR DESCRIPTION
## Summary
- Remove `isomorphic-fetch` (production dep) and `@types/isomorphic-fetch` (dev dep) from `@fluidframework/odsp-doclib-utils`
- Native `fetch` is available in all supported environments (Node 20.19.0+ and modern browsers), making this polyfill unnecessary
- The sibling `@fluidframework/odsp-driver` package already made this same transition (removing `node-fetch` in favor of native fetch) in v2.22.0, and the repo's client requirements already state that running with `--no-experimental-fetch` is not supported

## Test plan
- [x] `pnpm build` passes in `odsp-doclib-utils`
- [x] `pnpm test` passes in `odsp-doclib-utils` (39 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)