### PR TITLE
Port MessageCodec to ClientVersionDispatchingCodecBuilder

### DIFF
--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -37,8 +37,6 @@ export {
 } from "./discriminatedUnions.js";
 export {
 	Versioned,
-	makeVersionDispatchingCodec,
-	makeDiscontinuedCodecVersion,
 	makeDiscontinuedCodecAndSchema,
 	ClientVersionDispatchingCodecBuilder,
 	type CodecVersion,

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -22,7 +22,6 @@ import {
 	type JsonCompatibleReadOnlyObject,
 } from "../../util/index.js";
 import {
-	type ICodecFamily,
 	type ICodecOptions,
 	type IJsonCodec,
 	withSchemaValidation,
@@ -116,40 +115,6 @@ function makeVersionedValidatedCodec<
 }
 
 /**
- * Creates a codec which always throws a UsageError when encoding or decoding, indicating that the format version is discontinued.
- *
- * @deprecated Users of this should migrate to {@link ClientVersionDispatchingCodecBuilder} and use {@link makeDiscontinuedCodecAndSchema}.
- */
-export function makeDiscontinuedCodecVersion<
-	TDecoded,
-	TEncoded extends Versioned = VersionedJson,
-	TContext = unknown,
->(
-	options: ICodecOptions,
-	discontinuedVersion: FormatVersion,
-	discontinuedSince: SemanticVersion,
-): IJsonCodec<TDecoded, TEncoded, TEncoded, TContext> {
-	const codec: IJsonCodec<TDecoded, TEncoded, TEncoded, TContext> = {
-		encode: (_: TDecoded): TEncoded => {
-			throw new UsageError(
-				`Cannot encode data to format ${discontinuedVersion}. The codec was discontinued in Fluid Framework client version ${discontinuedSince}.`,
-			);
-		},
-		decode: (data: TEncoded): TDecoded => {
-			throw new UsageError(
-				`Cannot decode data in format ${data.version}. The codec was discontinued in Fluid Framework client version ${discontinuedSince}.`,
-			);
-		},
-	};
-	return makeVersionedValidatedCodec(
-		options,
-		new Set([discontinuedVersion]),
-		JsonCompatibleReadOnlySchema,
-		codec,
-	);
-}
-
-/**
  * Creates a codec version which always throws a UsageError when encoding or decoding, indicating that the format version is discontinued.
  */
 export function makeDiscontinuedCodecAndSchema<
@@ -177,31 +142,6 @@ export function makeDiscontinuedCodecAndSchema<
 			},
 		},
 	};
-}
-
-/**
- * Creates a codec which dispatches to the appropriate member of a codec family based on the version of
- * data it encounters.
- * @remarks
- * Each member of the codec family must write an explicit version number into the data it encodes (implementing {@link Versioned}).
- *
- * TODO: Users of this should migrate to {@link ClientVersionDispatchingCodecBuilder} so that the actual format version used can be encapsulated.
- */
-export function makeVersionDispatchingCodec<TDecoded, TContext>(
-	family: ICodecFamily<TDecoded, TContext>,
-	options: ICodecOptions & { writeVersion: FormatVersion },
-): IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext> {
-	const writeCodec = family.resolve(options.writeVersion);
-	const supportedVersions = new Set(family.getSupportedFormats());
-	return makeVersionedCodec(supportedVersions, options, {
-		encode(data, context): Versioned {
-			return writeCodec.encode(data, context) as Versioned;
-		},
-		decode(data: Versioned, context) {
-			const codec = family.resolve(data.version);
-			return codec.decode(data, context);
-		},
-	});
 }
 
 /**

--- a/packages/dds/tree/src/codec/versioned/index.ts
+++ b/packages/dds/tree/src/codec/versioned/index.ts
@@ -5,8 +5,6 @@
 
 export { Versioned, versionField } from "./format.js";
 export {
-	makeVersionDispatchingCodec,
-	makeDiscontinuedCodecVersion,
 	makeDiscontinuedCodecAndSchema,
 	ClientVersionDispatchingCodecBuilder,
 	type CodecVersion,

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -75,6 +75,5 @@ export {
 } from "./messageCodecs.js";
 export {
 	MessageFormatVersion,
-	messageFormatVersions,
 	supportedMessageFormatVersions,
 } from "./messageFormat.js";

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -69,9 +69,8 @@ export type {
 export type { DecodedMessage } from "./messageTypes.js";
 export {
 	getCodecTreeForMessageFormatWithChange,
-	clientVersionToMessageFormatVersion,
-	messageFormatVersionSelectorForSharedBranches,
-	makeMessageCodec,
+	makeMessageCodecBuilder,
+	messageCodecName,
 	type MessageEncodingContext,
 } from "./messageCodecs.js";
 export {

--- a/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
@@ -4,17 +4,18 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { TAnySchema } from "@sinclair/typebox";
 
-import { type ICodecOptions, type IJsonCodec, withSchemaValidation } from "../codec/index.js";
+import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	ChangeFamilyCodec,
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
-import { JsonCompatibleReadOnlySchema } from "../util/index.js";
+import {
+	type JsonCompatibleReadOnlyObject,
+	JsonCompatibleReadOnlySchema,
+} from "../util/index.js";
 
 import type { MessageEncodingContext } from "./messageCodecs.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
@@ -29,83 +30,67 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		EncodedRevisionTag,
 		ChangeEncodingContext
 	>,
-	options: ICodecOptions,
 	version:
 		| typeof MessageFormatVersion.v1
 		| typeof MessageFormatVersion.v2
 		| typeof MessageFormatVersion.v3
 		| typeof MessageFormatVersion.v4
 		| typeof MessageFormatVersion.v6,
-): IJsonCodec<
-	DecodedMessage<TChangeset>,
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnly,
-	MessageEncodingContext
-> {
-	return withSchemaValidation<
-		DecodedMessage<TChangeset>,
-		TAnySchema | typeof JsonCompatibleReadOnlySchema,
-		JsonCompatibleReadOnly,
-		JsonCompatibleReadOnly,
-		MessageEncodingContext
-	>(
-		Message(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema),
-		{
-			encode: (decoded: DecodedMessage<TChangeset>, context: MessageEncodingContext) => {
-				assert(decoded.type === "commit", 0xc68 /* Only commit messages are supported */);
-				assert(
-					decoded.branchId === "main",
-					0xc69 /* Only commit messages to main are supported */,
-				);
-				const { commit, sessionId: originatorId } = decoded;
-				const message: Message = {
-					revision: revisionTagCodec.encode(commit.revision, {
-						originatorId,
-						idCompressor: context.idCompressor,
-						revision: undefined,
-					}),
+): CodecAndSchema<DecodedMessage<TChangeset>, MessageEncodingContext> {
+	const schema = Message(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
+	return {
+		schema,
+		encode: (
+			decoded: DecodedMessage<TChangeset>,
+			context: MessageEncodingContext,
+		): Message & JsonCompatibleReadOnlyObject & Versioned => {
+			assert(decoded.type === "commit", 0xc68 /* Only commit messages are supported */);
+			assert(
+				decoded.branchId === "main",
+				0xc69 /* Only commit messages to main are supported */,
+			);
+			const { commit, sessionId: originatorId } = decoded;
+			return {
+				revision: revisionTagCodec.encode(commit.revision, {
 					originatorId,
-					changeset: changeCodec.encode(commit.change, {
-						originatorId,
-						schema: context.schema,
-						idCompressor: context.idCompressor,
-						revision: commit.revision,
-					}),
-					version,
-				};
-				return message as unknown as JsonCompatibleReadOnly;
-			},
-			decode: (
-				encoded: JsonCompatibleReadOnly,
-				context: MessageEncodingContext,
-			): DecodedMessage<TChangeset> => {
-				const {
-					revision: encodedRevision,
-					originatorId,
-					changeset,
-				} = encoded as unknown as Message;
-
-				const revision = revisionTagCodec.decode(encodedRevision, {
-					originatorId,
-					revision: undefined,
 					idCompressor: context.idCompressor,
-				});
-
-				return {
-					branchId: "main",
-					type: "commit",
-					commit: {
-						revision,
-						change: changeCodec.decode(changeset, {
-							originatorId,
-							revision,
-							idCompressor: context.idCompressor,
-						}),
-					},
-					sessionId: originatorId,
-				};
-			},
+					revision: undefined,
+				}),
+				originatorId,
+				changeset: changeCodec.encode(commit.change, {
+					originatorId,
+					schema: context.schema,
+					idCompressor: context.idCompressor,
+					revision: commit.revision,
+				}),
+				version,
+			};
 		},
-		options.jsonValidator,
-	);
+		decode: (
+			encoded: Message & JsonCompatibleReadOnlyObject & Versioned,
+			context: MessageEncodingContext,
+		): DecodedMessage<TChangeset> => {
+			const { revision: encodedRevision, originatorId, changeset } = encoded;
+
+			const revision = revisionTagCodec.decode(encodedRevision, {
+				originatorId,
+				revision: undefined,
+				idCompressor: context.idCompressor,
+			});
+
+			return {
+				branchId: "main",
+				type: "commit",
+				commit: {
+					revision,
+					change: changeCodec.decode(changeset, {
+						originatorId,
+						revision,
+						idCompressor: context.idCompressor,
+					}),
+				},
+				sessionId: originatorId,
+			};
+		},
+	};
 }

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -6,14 +6,14 @@
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { type TAnySchema, Type } from "@sinclair/typebox";
 
-import { type ICodecOptions, type IJsonCodec, withSchemaValidation } from "../codec/index.js";
+import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	ChangeFamilyCodec,
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
+import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
 
 import { decodeBranchId, encodeBranchId } from "./branchIdCodec.js";
 import type { MessageEncodingContext } from "./messageCodecs.js";
@@ -29,105 +29,89 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		EncodedRevisionTag,
 		ChangeEncodingContext
 	>,
-	options: ICodecOptions,
 	version: typeof MessageFormatVersion.vSharedBranches,
-): IJsonCodec<
-	DecodedMessage<TChangeset>,
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnly,
-	MessageEncodingContext
-> {
-	return withSchemaValidation<
-		DecodedMessage<TChangeset>,
-		TAnySchema,
-		JsonCompatibleReadOnly,
-		JsonCompatibleReadOnly,
-		MessageEncodingContext
-	>(
-		Message(changeCodec.encodedSchema ?? Type.Any()),
-		{
-			encode: (
-				message: DecodedMessage<TChangeset>,
-				context: MessageEncodingContext,
-			): JsonCompatibleReadOnly => {
-				const type = message.type;
-				switch (type) {
-					case "commit": {
-						const changeContext: ChangeEncodingContext = {
+): CodecAndSchema<DecodedMessage<TChangeset>, MessageEncodingContext> {
+	const schema: TAnySchema = Message(changeCodec.encodedSchema ?? Type.Any());
+
+	return {
+		schema,
+		encode: (
+			message: DecodedMessage<TChangeset>,
+			context: MessageEncodingContext,
+		): Message & JsonCompatibleReadOnlyObject & Versioned => {
+			const type = message.type;
+			switch (type) {
+				case "commit": {
+					const changeContext: ChangeEncodingContext = {
+						originatorId: message.sessionId,
+						schema: context.schema,
+						idCompressor: context.idCompressor,
+						revision: message.commit.revision,
+					};
+
+					return {
+						revision: revisionTagCodec.encode(message.commit.revision, {
 							originatorId: message.sessionId,
-							schema: context.schema,
 							idCompressor: context.idCompressor,
-							revision: message.commit.revision,
-						};
-
-						return {
-							revision: revisionTagCodec.encode(message.commit.revision, {
-								originatorId: message.sessionId,
-								idCompressor: context.idCompressor,
-								revision: undefined,
-							}),
-							originatorId: message.sessionId,
-							changeset: changeCodec.encode(message.commit.change, changeContext),
-							branchId: encodeBranchId(context.idCompressor, message.branchId),
-							version,
-						} satisfies Message & JsonCompatibleReadOnly;
-					}
-					case "branch": {
-						return {
-							originatorId: message.sessionId,
-							branchId: encodeBranchId(context.idCompressor, message.branchId),
-							version,
-						} satisfies Message & JsonCompatibleReadOnly;
-					}
-					default: {
-						unreachableCase(type);
-					}
-				}
-			},
-			decode: (
-				encoded: JsonCompatibleReadOnly,
-				context: MessageEncodingContext,
-			): DecodedMessage<TChangeset> => {
-				const {
-					revision: encodedRevision,
-					originatorId,
-					changeset,
-					branchId: encodedBranchId,
-				} = encoded as unknown as Message;
-
-				const changeContext = {
-					originatorId,
-					revision: undefined,
-					idCompressor: context.idCompressor,
-				};
-
-				const branchId = decodeBranchId(context.idCompressor, encodedBranchId, changeContext);
-
-				if (changeset === undefined) {
-					return { type: "branch", sessionId: originatorId, branchId };
-				}
-
-				assert(
-					encodedRevision !== undefined,
-					0xc6a /* Commit messages must have a revision */,
-				);
-				const revision = revisionTagCodec.decode(encodedRevision, changeContext);
-
-				return {
-					type: "commit",
-					commit: {
-						revision,
-						change: changeCodec.decode(changeset, {
-							originatorId,
-							revision,
-							idCompressor: context.idCompressor,
+							revision: undefined,
 						}),
-					},
-					branchId,
-					sessionId: originatorId,
-				};
-			},
+						originatorId: message.sessionId,
+						changeset: changeCodec.encode(message.commit.change, changeContext),
+						branchId: encodeBranchId(context.idCompressor, message.branchId),
+						version,
+					};
+				}
+				case "branch": {
+					return {
+						originatorId: message.sessionId,
+						branchId: encodeBranchId(context.idCompressor, message.branchId),
+						version,
+					};
+				}
+				default: {
+					unreachableCase(type);
+				}
+			}
 		},
-		options.jsonValidator,
-	);
+		decode: (
+			encoded: Message & JsonCompatibleReadOnlyObject & Versioned,
+			context: MessageEncodingContext,
+		): DecodedMessage<TChangeset> => {
+			const {
+				revision: encodedRevision,
+				originatorId,
+				changeset,
+				branchId: encodedBranchId,
+			} = encoded;
+
+			const changeContext = {
+				originatorId,
+				revision: undefined,
+				idCompressor: context.idCompressor,
+			};
+
+			const branchId = decodeBranchId(context.idCompressor, encodedBranchId, changeContext);
+
+			if (changeset === undefined) {
+				return { type: "branch", sessionId: originatorId, branchId };
+			}
+
+			assert(encodedRevision !== undefined, 0xc6a /* Commit messages must have a revision */);
+			const revision = revisionTagCodec.decode(encodedRevision, changeContext);
+
+			return {
+				type: "commit",
+				commit: {
+					revision,
+					change: changeCodec.decode(changeset, {
+						originatorId,
+						revision,
+						idCompressor: context.idCompressor,
+					}),
+				},
+				branchId,
+				sessionId: originatorId,
+			};
+		},
+	};
 }

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -3,28 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
-import {
-	getConfigForMinVersionForCollab,
-	lowestMinVersionForCollab,
-} from "@fluidframework/runtime-utils/internal";
+import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
 import {
+	ClientVersionDispatchingCodecBuilder,
 	type CodecTree,
-	type CodecWriteOptions,
+	type CodecVersion,
 	type DependentFormatVersion,
 	FluidClientVersion,
-	type FormatVersion,
 	type ICodecFamily,
 	type ICodecOptions,
 	type IJsonCodec,
-	makeCodecFamily,
-	// This codec will be updated soon.
-	// eslint-disable-next-line import-x/no-deprecated
-	makeDiscontinuedCodecVersion,
-	makeVersionDispatchingCodec,
+	makeDiscontinuedCodecAndSchema,
 } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
@@ -32,11 +24,10 @@ import type {
 	RevisionTag,
 	SchemaAndPolicy,
 } from "../core/index.js";
-import { brand, unbrand, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import { makeV1ToV4CodecWithVersion } from "./messageCodecV1ToV4.js";
 import { makeSharedBranchesCodecWithVersion } from "./messageCodecVSharedBranches.js";
-import { MessageFormatVersion, messageFormatVersions } from "./messageFormat.js";
+import { MessageFormatVersion } from "./messageFormat.js";
 import type { DecodedMessage } from "./messageTypes.js";
 
 export interface MessageEncodingContext {
@@ -45,144 +36,109 @@ export interface MessageEncodingContext {
 }
 
 /**
- * Convert a MinimumVersionForCollab to a MessageFormatVersion.
- * @param clientVersion - The MinimumVersionForCollab to convert.
- * @returns The MessageFormatVersion that corresponds to the provided MinimumVersionForCollab.
+ * Codec name used to identify the message codec, see {@link makeMessageCodecBuilder}.
  */
-export function clientVersionToMessageFormatVersion(
-	clientVersion: MinimumVersionForCollab,
-	writeVersionOverride?: MessageFormatVersion,
-): MessageFormatVersion {
-	const compatibleVersion: MessageFormatVersion = brand(
-		getConfigForMinVersionForCollab(clientVersion, {
-			[lowestMinVersionForCollab]: MessageFormatVersion.v3,
-			[FluidClientVersion.v2_43]: MessageFormatVersion.v4,
-			[FluidClientVersion.v2_80]: MessageFormatVersion.v6,
-		}),
-	);
-	return writeVersionOverride ?? compatibleVersion;
-}
-
-export interface MessageCodecOptions {
-	readonly messageFormatSelector?: (
-		minVersionForCollab: MinimumVersionForCollab,
-	) => MessageFormatVersion;
-}
-
-function messageFormatVersionFromOptions(
-	options: MessageCodecOptions & CodecWriteOptions,
-): MessageFormatVersion {
-	const selector = options.messageFormatSelector ?? clientVersionToMessageFormatVersion;
-	return selector(options.minVersionForCollab);
-}
+export const messageCodecName = "Message";
 
 /**
- * Returns the version that should be used for testing shared branches.
+ * Options for constructing a message codec, see {@link makeMessageCodecBuilder}.
  */
-export function messageFormatVersionSelectorForSharedBranches(
-	clientVersion: MinimumVersionForCollab,
-): MessageFormatVersion {
-	return brand(MessageFormatVersion.vSharedBranches);
-}
-
-export function makeMessageCodec<TChangeset>(
-	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>,
-	dependentChangeFormatVersion: DependentFormatVersion<MessageFormatVersion>,
+interface MessageCodecBuilderOptions<TChangeset> extends ICodecOptions {
+	/** Codecs for encoding changesets. */
+	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>;
+	/** Maps each MessageFormatVersion to the corresponding changeset format version. */
+	dependentChangeFormatVersion: DependentFormatVersion<MessageFormatVersion>;
+	/** Codec for encoding revision tags within changesets. */
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
 		ChangeEncodingContext
-	>,
-	options: MessageCodecOptions & CodecWriteOptions,
-): IJsonCodec<
+	>;
+}
+
+/**
+ * Creates a {@link ClientVersionDispatchingCodecBuilder} for encoding/decoding messages.
+ */
+export function makeMessageCodecBuilder<TChangeset>(): ClientVersionDispatchingCodecBuilder<
+	MessageCodecBuilderOptions<TChangeset>,
 	DecodedMessage<TChangeset>,
-	JsonCompatibleReadOnly,
-	JsonCompatibleReadOnly,
-	MessageEncodingContext
+	MessageEncodingContext,
+	MessageFormatVersion | undefined,
+	typeof messageCodecName
 > {
-	const family = makeMessageCodecs(
-		changeCodecs,
-		dependentChangeFormatVersion,
-		revisionTagCodec,
-		options,
-	);
-	const writeVersion = messageFormatVersionFromOptions(options);
-	return makeVersionDispatchingCodec(family, { ...options, writeVersion });
-}
+	// See MessageFormatVersion and its members for documentation on what changed in each version.
+	const versions: CodecVersion<
+		DecodedMessage<TChangeset>,
+		MessageEncodingContext,
+		MessageFormatVersion | undefined,
+		MessageCodecBuilderOptions<TChangeset>
+	>[] = [
+		// The "undefined" wire format (no version field) is discontinued.
+		makeDiscontinuedCodecAndSchema(undefined, "2.73.0"),
+		makeDiscontinuedCodecAndSchema(MessageFormatVersion.v1, "2.73.0"),
+		makeDiscontinuedCodecAndSchema(MessageFormatVersion.v2, "2.73.0"),
+		{
+			minVersionForCollab: lowestMinVersionForCollab,
+			formatVersion: MessageFormatVersion.v3,
+			codec: (options: MessageCodecBuilderOptions<TChangeset>) =>
+				makeV1ToV4CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(MessageFormatVersion.v3),
+					),
+					options.revisionTagCodec,
+					MessageFormatVersion.v3,
+				),
+		},
+		{
+			minVersionForCollab: FluidClientVersion.v2_43,
+			formatVersion: MessageFormatVersion.v4,
+			codec: (options: MessageCodecBuilderOptions<TChangeset>) =>
+				makeV1ToV4CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(MessageFormatVersion.v4),
+					),
+					options.revisionTagCodec,
+					MessageFormatVersion.v4,
+				),
+		},
+		makeDiscontinuedCodecAndSchema(MessageFormatVersion.v5, "2.74.0"),
+		{
+			minVersionForCollab: FluidClientVersion.v2_80,
+			formatVersion: MessageFormatVersion.v6,
+			codec: (options: MessageCodecBuilderOptions<TChangeset>) =>
+				makeV1ToV4CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(MessageFormatVersion.v6),
+					),
+					options.revisionTagCodec,
+					MessageFormatVersion.v6,
+				),
+		},
+		{
+			minVersionForCollab: undefined,
+			formatVersion: MessageFormatVersion.vSharedBranches,
+			codec: (options: MessageCodecBuilderOptions<TChangeset>) =>
+				makeSharedBranchesCodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(MessageFormatVersion.vSharedBranches),
+					),
+					options.revisionTagCodec,
+					MessageFormatVersion.vSharedBranches,
+				),
+		},
+	];
 
-/**
- * @privateRemarks Exported for testing.
- */
-export function makeMessageCodecs<TChangeset>(
-	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>,
-	dependentChangeFormatVersion: DependentFormatVersion<MessageFormatVersion>,
-	revisionTagCodec: IJsonCodec<
-		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
-		ChangeEncodingContext
-	>,
-	options: ICodecOptions,
-): ICodecFamily<DecodedMessage<TChangeset>, MessageEncodingContext> {
-	const registry: [
-		FormatVersion,
-		IJsonCodec<
-			DecodedMessage<TChangeset>,
-			JsonCompatibleReadOnly,
-			JsonCompatibleReadOnly,
-			MessageEncodingContext
-		>,
-	][] = [...messageFormatVersions].map((version) => {
-		switch (version) {
-			case unbrand(MessageFormatVersion.undefined):
-			case unbrand(MessageFormatVersion.v1):
-			case unbrand(MessageFormatVersion.v2): {
-				const versionOrUndefined =
-					version === unbrand(MessageFormatVersion.undefined) ? undefined : version;
-				return [
-					versionOrUndefined,
-					// This codec will be updated soon.
-					// eslint-disable-next-line import-x/no-deprecated
-					makeDiscontinuedCodecVersion(options, versionOrUndefined, "2.73.0"),
-				];
-			}
-			case unbrand(MessageFormatVersion.v3):
-			case unbrand(MessageFormatVersion.v4):
-			case unbrand(MessageFormatVersion.v6): {
-				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
-				return [
-					version,
-					makeV1ToV4CodecWithVersion(changeCodec, revisionTagCodec, options, version),
-				];
-			}
-			case unbrand(MessageFormatVersion.v5): {
-				// This codec will be updated soon.
-				// eslint-disable-next-line import-x/no-deprecated
-				return [version, makeDiscontinuedCodecVersion(options, version, "2.74.0")];
-			}
-			case unbrand(MessageFormatVersion.vSharedBranches): {
-				const changeCodec = changeCodecs.resolve(dependentChangeFormatVersion.lookup(version));
-				return [
-					version,
-					makeSharedBranchesCodecWithVersion(changeCodec, revisionTagCodec, options, version),
-				];
-			}
-			default: {
-				unreachableCase(version);
-			}
-		}
-	});
-	return makeCodecFamily(registry);
+	return ClientVersionDispatchingCodecBuilder.build(messageCodecName, versions);
 }
 
 export function getCodecTreeForMessageFormatWithChange(
 	clientVersion: MinimumVersionForCollab,
 	changeFormat: CodecTree,
 ): CodecTree {
+	const builder = makeMessageCodecBuilder();
 	return {
-		name: "Message",
-		version: clientVersionToMessageFormatVersion(clientVersion),
+		...builder.getCodecTree(clientVersion),
 		children: [changeFormat],
 	};
 }

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -65,6 +65,3 @@ export const supportedMessageFormatVersions: ReadonlySet<MessageFormatVersion> =
 	MessageFormatVersion.v6,
 	MessageFormatVersion.vSharedBranches,
 ]);
-export const messageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set(
-	Object.values(MessageFormatVersion),
-);

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -54,11 +54,7 @@ import { EditManager, minimumPossibleSequenceNumber } from "./editManager.js";
 import { makeEditManagerCodecBuilder } from "./editManagerCodecs.js";
 import type { EditManagerFormatVersion, SeqNumber } from "./editManagerFormatCommons.js";
 import { EditManagerSummarizer } from "./editManagerSummarizer.js";
-import {
-	type MessageCodecOptions,
-	type MessageEncodingContext,
-	makeMessageCodec,
-} from "./messageCodecs.js";
+import { type MessageEncodingContext, makeMessageCodecBuilder } from "./messageCodecs.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
 import type { DecodedMessage } from "./messageTypes.js";
 import type { ResubmitMachine } from "./resubmitMachine.js";
@@ -77,9 +73,7 @@ export interface ClonableSchemaAndPolicy extends SchemaAndPolicy {
 	schema: TreeStoredSchemaRepository;
 }
 
-export interface SharedTreeCoreOptionsInternal
-	extends CodecWriteOptions,
-		MessageCodecOptions {}
+export interface SharedTreeCoreOptionsInternal extends CodecWriteOptions {}
 
 export interface EnrichmentConfig<TChange> {
 	readonly enricher: ChangeEnricher<TChange>;
@@ -206,12 +200,12 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			0x350 /* Index summary element keys must be unique */,
 		);
 
-		this.messageCodec = makeMessageCodec(
-			changeFamily.codecs,
-			changeFormatVersionForMessage,
-			new RevisionTagCodec(idCompressor),
-			options,
-		);
+		this.messageCodec = makeMessageCodecBuilder<TChange>().build({
+			...options,
+			changeCodecs: changeFamily.codecs,
+			dependentChangeFormatVersion: changeFormatVersionForMessage,
+			revisionTagCodec: new RevisionTagCodec(idCompressor),
+		});
 
 		if (enrichmentConfig !== undefined) {
 			this.registerSharedBranchForEditing(

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -66,10 +66,10 @@ import {
 import { schemaCodecBuilder } from "../feature-libraries/index.js";
 import {
 	type BranchId,
-	clientVersionToMessageFormatVersion,
 	type ClonableSchemaAndPolicy,
 	getCodecTreeForEditManagerFormatWithChange,
 	getCodecTreeForMessageFormatWithChange,
+	makeMessageCodecBuilder,
 	type SharedTreeCoreOptionsInternal,
 	MessageFormatVersion,
 	SharedTreeCore,
@@ -539,9 +539,9 @@ function getCodecTreeForEditManagerFormat(clientVersion: MinimumVersionForCollab
 }
 
 function getCodecTreeForMessageFormat(clientVersion: MinimumVersionForCollab): CodecTree {
-	const change = changeFormatVersionForMessage.lookup(
-		clientVersionToMessageFormatVersion(clientVersion),
-	);
+	const messageVersion = makeMessageCodecBuilder().getCodecTree(clientVersion).version;
+	assert(messageVersion !== undefined, "Deprecated 'undefined' version shouldn't be selected");
+	const change = changeFormatVersionForMessage.lookup(messageVersion);
 	const changeCodecTree = getCodecTreeForChangeFormat(change, clientVersion);
 	return getCodecTreeForMessageFormatWithChange(clientVersion, changeCodecTree);
 }
@@ -720,7 +720,6 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	treeEncodeType: TreeCompressionStrategy.Compressed,
 	disposeForksAfterTransaction: true,
 	shouldEncodeIncrementally: defaultIncrementalEncodingPolicy,
-	messageFormatSelector: clientVersionToMessageFormatVersion,
 	enableSharedBranches: false,
 	writeVersionOverrides: new Map(),
 	allowPossiblyIncompatibleWriteVersionOverrides: false,

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -9,7 +9,7 @@ import type { SessionId } from "@fluidframework/id-compressor";
 import { createSessionId } from "@fluidframework/id-compressor/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-import { currentVersion, DependentFormatVersion } from "../../codec/index.js";
+import { currentVersion, DependentFormatVersion, makeCodecFamily } from "../../codec/index.js";
 import type {
 	EncodedRevisionTag,
 	GraphCommit,
@@ -18,7 +18,7 @@ import type {
 import { FormatValidatorBasic } from "../../external-utilities/index.js";
 import { MessageFormatVersion } from "../../shared-tree-core/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import { makeMessageCodec, makeMessageCodecs } from "../../shared-tree-core/messageCodecs.js";
+import { makeMessageCodecBuilder } from "../../shared-tree-core/messageCodecs.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { DecodedMessage } from "../../shared-tree-core/messageTypes.js";
 import { TestChange } from "../testChange.js";
@@ -142,13 +142,15 @@ const testCases: EncodingTestData<
 };
 
 describe("message codec", () => {
-	const family = makeMessageCodecs(
-		TestChange.codecs,
-		DependentFormatVersion.fromUnique(1),
-		testRevisionTagCodec,
-		{
-			jsonValidator: FormatValidatorBasic,
-		},
+	const builder = makeMessageCodecBuilder<TestChange>();
+	const built = builder.applyOptions({
+		changeCodecs: TestChange.codecs,
+		dependentChangeFormatVersion: DependentFormatVersion.fromUnique(1),
+		revisionTagCodec: testRevisionTagCodec,
+		jsonValidator: FormatValidatorBasic,
+	});
+	const family = makeCodecFamily(
+		built.map((codec) => [codec.formatVersion, codec.codec] as const),
 	);
 	makeEncodingTestSuite(family, testCases, undefined, [
 		MessageFormatVersion.v3,
@@ -164,15 +166,13 @@ describe("message codec", () => {
 	]);
 
 	describe("dispatching codec", () => {
-		const codec = makeMessageCodec(
-			TestChange.codecs,
-			DependentFormatVersion.fromUnique(1),
-			testRevisionTagCodec,
-			{
-				jsonValidator: FormatValidatorBasic,
-				minVersionForCollab: currentVersion,
-			},
-		);
+		const codec = makeMessageCodecBuilder<TestChange>().build({
+			changeCodecs: TestChange.codecs,
+			dependentChangeFormatVersion: DependentFormatVersion.fromUnique(1),
+			revisionTagCodec: testRevisionTagCodec,
+			jsonValidator: FormatValidatorBasic,
+			minVersionForCollab: currentVersion,
+		});
 
 		const sessionId: SessionId = "sessionId" as SessionId;
 		it("Drops parent commit fields on encode", () => {
@@ -213,7 +213,7 @@ describe("message codec", () => {
 			});
 			assert.throws(
 				() => codec.decode(JSON.parse(encoded), { idCompressor: testIdCompressor }),
-				validateUsageError(/Unsupported version -1 encountered while decoding data/),
+				validateUsageError(/Unsupported version -1 encountered while decoding Message data./),
 			);
 		});
 	});

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -16,7 +16,7 @@ import {
 } from "@fluidframework/shared-object-base/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { FluidClientVersion } from "./codec/index.js";
+import { FluidClientVersion, type FormatVersion } from "./codec/index.js";
 import {
 	SharedTreeKernel,
 	type ITreePrivate,
@@ -28,7 +28,8 @@ import {
 import {
 	editManagerCodecName,
 	EditManagerFormatVersion,
-	messageFormatVersionSelectorForSharedBranches,
+	messageCodecName,
+	MessageFormatVersion,
 } from "./shared-tree-core/index.js";
 import { SharedTreeFactoryType, SharedTreeAttributes } from "./sharedTreeAttributes.js";
 import type { ITree } from "./simple-tree/index.js";
@@ -223,9 +224,9 @@ function resolveFormatOptions(options: SharedTreeOptions): SharedTreeOptionsInte
 }
 
 const sharedBranchesOptions: SharedTreeOptionsInternal = {
-	messageFormatSelector: messageFormatVersionSelectorForSharedBranches,
-	writeVersionOverrides: new Map([
+	writeVersionOverrides: new Map<string, FormatVersion>([
 		[editManagerCodecName, EditManagerFormatVersion.vSharedBranches],
+		[messageCodecName, MessageFormatVersion.vSharedBranches],
 	]),
 	allowPossiblyIncompatibleWriteVersionOverrides: true,
 };


### PR DESCRIPTION
## Description

Ports makeMessageCodec/makeMessageCodecs to use ClientVersionDispatchingCodecBuilder, following the same pattern established for makeEditManagerCodec.
Also removes the APIs that are now dead as a result since this was the last codec doing version dispatching without ClientVersionDispatchingCodecBuilder.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

