### PR TITLE
Use JsonCodecPart more

### DIFF
--- a/packages/dds/tree/src/core/rebase/revisionTagCodec.ts
+++ b/packages/dds/tree/src/core/rebase/revisionTagCodec.ts
@@ -6,16 +6,16 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 
-import type { IJsonCodec } from "../../codec/index.js";
+import type { JsonCodecPart } from "../../codec/index.js";
 import type { ChangeEncodingContext } from "../change-family/index.js";
 
-import type { EncodedRevisionTag, RevisionTag } from "./types.js";
+import { RevisionTagSchema, type EncodedRevisionTag, type RevisionTag } from "./types.js";
 
 export class RevisionTagCodec
-	implements
-		IJsonCodec<RevisionTag, EncodedRevisionTag, EncodedRevisionTag, ChangeEncodingContext>
+	implements JsonCodecPart<RevisionTag, typeof RevisionTagSchema, ChangeEncodingContext>
 {
 	public localSessionId: SessionId;
+	public readonly encodedSchema = RevisionTagSchema;
 
 	public constructor(private readonly idCompressor: IIdCompressor) {
 		this.localSessionId = idCompressor.localSessionId;

--- a/packages/dds/tree/src/feature-libraries/changeAtomIdCodec.ts
+++ b/packages/dds/tree/src/feature-libraries/changeAtomIdCodec.ts
@@ -3,23 +3,23 @@
  * Licensed under the MIT License.
  */
 
-import type { IJsonCodec } from "../codec/index.js";
+import type { JsonCodecPart } from "../codec/index.js";
 import type {
 	ChangeAtomId,
 	ChangeEncodingContext,
-	EncodedChangeAtomId,
-	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../core/index.js";
 
+import { EncodedChangeAtomId } from "./modular-schema/index.js";
+
 export function makeChangeAtomIdCodec(
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
-): IJsonCodec<ChangeAtomId, EncodedChangeAtomId, EncodedChangeAtomId, ChangeEncodingContext> {
+): JsonCodecPart<ChangeAtomId, typeof EncodedChangeAtomId, ChangeEncodingContext> {
 	return {
 		encode(changeAtomId: ChangeAtomId, context: ChangeEncodingContext): EncodedChangeAtomId {
 			return changeAtomId.revision === undefined || changeAtomId.revision === context.revision
@@ -34,5 +34,6 @@ export function makeChangeAtomIdCodec(
 					}
 				: { localId: changeAtomId, revision: context.revision };
 		},
+		encodedSchema: EncodedChangeAtomId,
 	};
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ICodecFamily, IJsonCodec } from "../../codec/index.js";
+import type { ICodecFamily, JsonCodecPart } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	DeltaDetachedNodeChanges,
@@ -11,10 +11,10 @@ import type {
 	DeltaDetachedNodeRename,
 	DeltaFieldChanges,
 	DeltaFieldMap,
-	EncodedRevisionTag,
 	RevisionMetadataSource,
 	RevisionReplacer,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import type { IdAllocator, Invariant } from "../../util/index.js";
 
@@ -57,10 +57,9 @@ export interface FieldChangeHandler<
 	_typeCheck?: Invariant<TChangeset>;
 	readonly rebaser: FieldChangeRebaser<TChangeset>;
 	readonly codecsFactory: (
-		revisionTagCodec: IJsonCodec<
+		revisionTagCodec: JsonCodecPart<
 			RevisionTag,
-			EncodedRevisionTag,
-			EncodedRevisionTag,
+			typeof RevisionTagSchema,
 			ChangeEncodingContext
 		>,
 	) => ICodecFamily<TChangeset, FieldChangeEncodingContext>;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
@@ -9,6 +9,7 @@ import type { TAnySchema } from "@sinclair/typebox";
 import {
 	type ICodecOptions,
 	type IJsonCodec,
+	type JsonCodecPart,
 	type SchemaValidationFunction,
 	extractJsonValidator,
 	withSchemaValidation,
@@ -22,6 +23,7 @@ import type {
 	ITreeCursorSynchronous,
 	RevisionInfo,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import {
 	type IdAllocator,
@@ -279,10 +281,9 @@ export function decodeNodeChangesetFromJson(
 export function encodeDetachedNodes(
 	detachedNodes: ChangeAtomIdBTree<TreeChunk> | undefined,
 	context: ChangeEncodingContext,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
@@ -336,10 +337,9 @@ export function encodeDetachedNodes(
 export function decodeDetachedNodes(
 	encoded: EncodedBuilds | undefined,
 	context: ChangeEncodingContext,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
@@ -385,10 +385,9 @@ export function decodeDetachedNodes(
 export function encodeRevisionInfos(
 	revisions: readonly RevisionInfo[],
 	context: ChangeEncodingContext,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): EncodedRevisionInfo[] | undefined {
@@ -424,10 +423,9 @@ export function encodeRevisionInfos(
 export function decodeRevisionInfos(
 	revisions: readonly EncodedRevisionInfo[] | undefined,
 	context: ChangeEncodingContext,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): RevisionInfo[] | undefined {
@@ -461,10 +459,9 @@ export function encodeChange(
 			codec: FieldCodec;
 		}
 	>,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
@@ -513,10 +510,9 @@ export function decodeChange(
 			codec: FieldCodec;
 		}
 	>,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
@@ -579,10 +575,9 @@ export function decodeChange(
 
 export function getFieldChangesetCodecs(
 	fieldKinds: FieldKindConfiguration,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	codecOptions: ICodecOptions,
@@ -628,10 +623,9 @@ export function getFieldChangesetCodecs(
 
 export function makeModularChangeCodecV1(
 	fieldKinds: FieldKindConfiguration,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV2.ts
@@ -6,12 +6,13 @@
 import {
 	type ICodecOptions,
 	type IJsonCodec,
+	type JsonCodecPart,
 	withSchemaValidation,
 } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
-	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import type { FieldBatchCodec } from "../chunked-forest/index.js";
 import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
@@ -34,10 +35,9 @@ type ModularChangeCodec = IJsonCodec<
 
 export function makeModularChangeCodecV2(
 	fieldKinds: FieldKindConfiguration,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -8,13 +8,13 @@ import { fail } from "@fluidframework/core-utils/internal";
 import {
 	type ICodecFamily,
 	type ICodecOptions,
-	type IJsonCodec,
+	type JsonCodecPart,
 	makeCodecFamily,
 } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
-	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import { strictEnum, type Values } from "../../util/index.js";
 import type { FieldBatchCodec } from "../chunked-forest/index.js";
@@ -27,10 +27,9 @@ import type { ModularChangeset } from "./modularChangeTypes.js";
 
 export function makeModularChangeCodecFamily(
 	fieldKindConfigurations: ReadonlyMap<ModularChangeFormatVersion, FieldKindConfiguration>,
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecV2.ts
@@ -5,32 +5,31 @@
 
 import type { TAnySchema } from "@sinclair/typebox";
 
-import type { IJsonCodec } from "../../codec/index.js";
+import type { IJsonCodec, JsonCodecPart } from "../../codec/index.js";
 import type {
+	RevisionTagSchema,
 	ChangeAtomId,
 	ChangeEncodingContext,
-	EncodedRevisionTag,
 	RevisionTag,
 } from "../../core/index.js";
 import type { Mutable } from "../../util/index.js";
 import { makeChangeAtomIdCodec } from "../changeAtomIdCodec.js";
-import {
-	EncodedNodeChangeset,
-	type EncodedChangeAtomId,
-	type FieldChangeEncodingContext,
+import type {
+	FieldChangeEncodingContext,
+	EncodedChangeAtomId,
 } from "../modular-schema/index.js";
+import { EncodedNodeChangeset } from "../modular-schema/index.js";
 
 import { EncodedOptionalChangeset, EncodedRegisterId } from "./optionalFieldChangeFormatV2.js";
 import type { OptionalChangeset, RegisterId, Replace } from "./optionalFieldChangeTypes.js";
 
 function makeRegisterIdCodec(
-	changeAtomIdCodec: IJsonCodec<
+	changeAtomIdCodec: JsonCodecPart<
 		ChangeAtomId,
-		EncodedChangeAtomId,
-		EncodedChangeAtomId,
+		typeof EncodedChangeAtomId,
 		ChangeEncodingContext
 	>,
-): IJsonCodec<RegisterId, EncodedRegisterId, EncodedRegisterId, ChangeEncodingContext> {
+): JsonCodecPart<RegisterId, typeof EncodedRegisterId, ChangeEncodingContext> {
 	return {
 		encode: (registerId: RegisterId, context: ChangeEncodingContext) => {
 			if (registerId === "self") {
@@ -49,10 +48,9 @@ function makeRegisterIdCodec(
 }
 
 export function makeOptionalFieldCodec(
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): IJsonCodec<

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { type ICodecFamily, type IJsonCodec, makeCodecFamily } from "../../codec/index.js";
+import { type ICodecFamily, type JsonCodecPart, makeCodecFamily } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
-	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import type { FieldChangeEncodingContext } from "../modular-schema/index.js";
 
@@ -15,10 +15,9 @@ import type { OptionalChangeset } from "./optionalFieldChangeTypes.js";
 import { makeOptionalFieldCodec as makeV2Codec } from "./optionalFieldCodecV2.js";
 
 export const makeOptionalFieldCodecFamily = (
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): ICodecFamily<OptionalChangeset, FieldChangeEncodingContext> =>

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
@@ -10,12 +10,14 @@ import {
 	DiscriminatedUnionDispatcher,
 	type DiscriminatedUnionLibrary,
 	type IJsonCodec,
+	type JsonCodecPart,
 } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	ChangesetLocalId,
 	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import { type JsonCompatibleReadOnly, type Mutable, brand } from "../../util/index.js";
 import { makeChangeAtomIdCodec } from "../changeAtomIdCodec.js";
@@ -43,10 +45,9 @@ import {
 import { isNoopMark, normalizeCellRename } from "./utils.js";
 
 export function makeV2CodecHelpers(
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): SequenceCodecHelpers<MarkEffect, Encoded.MarkEffect> {
@@ -261,10 +262,9 @@ export function makeV2CodecHelpers(
 }
 
 export function makeV2Codec(
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): IJsonCodec<

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV3.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV3.ts
@@ -5,11 +5,15 @@
 
 import type { TAnySchema } from "@sinclair/typebox";
 
-import { DiscriminatedUnionDispatcher, type IJsonCodec } from "../../codec/index.js";
+import {
+	DiscriminatedUnionDispatcher,
+	type IJsonCodec,
+	type JsonCodecPart,
+} from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
-	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import type { JsonCompatibleReadOnly } from "../../util/index.js";
 import {
@@ -23,10 +27,9 @@ import type { Changeset, Mark, MarkEffect, Rename } from "./types.js";
 import { isNoopMark } from "./utils.js";
 
 export function makeV3Codec(
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): IJsonCodec<

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { type IJsonCodec, makeCodecFamily, type ICodecFamily } from "../../codec/index.js";
+import { type JsonCodecPart, makeCodecFamily, type ICodecFamily } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
-	EncodedRevisionTag,
 	RevisionTag,
+	RevisionTagSchema,
 } from "../../core/index.js";
 import type { FieldChangeEncodingContext } from "../modular-schema/index.js";
 
@@ -16,10 +16,9 @@ import { makeV3Codec } from "./sequenceFieldCodecV3.js";
 import type { Changeset, MarkList } from "./types.js";
 
 export const sequenceFieldChangeCodecFactory = (
-	revisionTagCodec: IJsonCodec<
+	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
-		EncodedRevisionTag,
-		EncodedRevisionTag,
+		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
 ): ICodecFamily<MarkList, FieldChangeEncodingContext> =>


### PR DESCRIPTION
## Description

Use JsonCodecPart to highlight when code is part of a larger codec, and does not include schema validation or version dispatch.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
