### PR TITLE
unhydrated array node delta payload fix

### DIFF
--- a/.changeset/good-dryers-strive.md
+++ b/.changeset/good-dryers-strive.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/tree": minor
+"__section": fix
+---
+Array node nodeChanged delta payload now populated for unhydrated nodes
+
+The `delta` field in `NodeChangedDataDelta` was previously `undefined` for array nodes that had not yet been inserted into a document tree (unhydrated nodes). It now correctly reflects the operation that was performed, using the same [Quill](https://quilljs.com/docs/)-style semantics as hydrated nodes.

--- a/packages/dds/tree/src/simple-tree/api/treeAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeAlpha.ts
@@ -42,11 +42,9 @@ export interface NodeChangedDataDelta {
 	/**
 	 * The sequential operations describing what changed in the array node.
 	 * @remarks
-	 * The value may be `undefined` in two cases:
-	 * - The node was created locally and has not yet been inserted into a document tree (a known
-	 * temporary limitation, tracked in AB#63261).
-	 * - The document was updated in a way that required multiple internal change passes in a single
-	 * operation (for example, a data change combined with a schema upgrade).
+	 * The value may be `undefined` when the document was updated in a way that required multiple
+	 * internal changes pass in a single operation (for example, a data change combined with a
+	 * schema upgrade).
 	 *
 	 * See {@link ArrayNodeDeltaOp} for op semantics.
 	 */

--- a/packages/dds/tree/src/simple-tree/api/treeAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeAlpha.ts
@@ -43,7 +43,7 @@ export interface NodeChangedDataDelta {
 	 * The sequential operations describing what changed in the array node.
 	 * @remarks
 	 * The value may be `undefined` when the document was updated in a way that required multiple
-	 * internal changes pass in a single operation (for example, a data change combined with a
+	 * internal change passes in a single operation (for example, a data change combined with a
 	 * schema upgrade).
 	 *
 	 * See {@link ArrayNodeDeltaOp} for op semantics.

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -11,6 +11,8 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import {
 	type AnchorEvents,
 	dummyRoot,
+	type DeltaDetachedNodeId,
+	type DeltaMark,
 	type FieldKey,
 	type FieldKindIdentifier,
 	type ITreeCursorSynchronous,
@@ -270,11 +272,10 @@ export class UnhydratedFlexTreeNode
 		return this.data.value;
 	}
 
-	public emitChangedEvent(key: FieldKey): void {
+	public emitChangedEvent(key: FieldKey, marks?: readonly DeltaMark[]): void {
 		this._events.emit("childrenChangedAfterBatch", {
 			changedFields: new Set([key]),
-			// Unhydrated nodes are not visited by the delta pipeline, so no field marks are available.
-			fieldMarks: new Map(),
+			fieldMarks: marks === undefined ? new Map() : new Map([[key, marks]]),
 		});
 
 		// Also emit subtree changed event for this node and all ancestors.
@@ -440,11 +441,14 @@ export class UnhydratedFlexTreeField
 	 * @param edit - A function which receives the current `MapTree`s that comprise the contents of the field so that it may be mutated.
 	 * The function may mutate the array in place or return a new array.
 	 * If a new array is returned then it will be used as the new contents of the field, otherwise the original array will be continue to be used.
+	 * @param marks - Delta marks describing the mutation for this field, used to populate the `delta` payload on `nodeChanged` events.
+	 * If omitted, the event will have no delta for this field.
 	 * @remarks All edits to the field (i.e. mutations of the field's MapTrees) should be directed through this function.
 	 * This function ensures that the parent MapTree has no empty fields (which is an invariant of `MapTree`) after the mutation.
 	 */
 	protected edit(
 		edit: (mapTrees: UnhydratedFlexTreeNode[]) => void | UnhydratedFlexTreeNode[],
+		marks?: readonly DeltaMark[],
 	): void {
 		// Clear parents for all old map trees.
 		for (const tree of this.children) {
@@ -458,7 +462,7 @@ export class UnhydratedFlexTreeField
 			tree.adoptBy(this, index);
 		}
 
-		this.parent?.emitChangedEvent(this.key);
+		this.parent?.emitChangedEvent(this.key, marks);
 	}
 
 	public getFieldPath(): NormalizedFieldUpPath {
@@ -527,6 +531,53 @@ class UnhydratedRequiredField
 	}
 }
 
+// Dummy detached node ID used when building unhydrated delta marks.
+// deltaMarksToArrayOps only checks presence (not value) of attach/detach, so any value works.
+const dummyDetachedNodeId = { minor: 0 } satisfies DeltaDetachedNodeId;
+
+/**
+ * Builds delta marks for an intra-field move expressed as sequential Quill-style ops.
+ *
+ * @remarks
+ * A forward move (`sourceIndex < destIndex`) is expressed as:
+ * `retain(sourceIndex), remove(count), retain(between), insert(count)`
+ *
+ * A backward move (`destIndex < sourceIndex`) is expressed as:
+ * `retain(destIndex), insert(count), retain(between), remove(count)`
+ */
+function buildUnhydratedMoveMarks(
+	sourceIndex: number,
+	count: number,
+	destIndex: number,
+): readonly DeltaMark[] {
+	const marks: DeltaMark[] = [];
+	if (sourceIndex < destIndex) {
+		// Moving forward: source comes before destination in the original array.
+		if (sourceIndex > 0) {
+			marks.push({ count: sourceIndex });
+		}
+		marks.push({ count, detach: dummyDetachedNodeId });
+		const between = destIndex - sourceIndex - count;
+		if (between > 0) {
+			marks.push({ count: between });
+		}
+		marks.push({ count, attach: dummyDetachedNodeId });
+	} else if (destIndex < sourceIndex) {
+		// Moving backward: destination comes before source in the original array.
+		if (destIndex > 0) {
+			marks.push({ count: destIndex });
+		}
+		marks.push({ count, attach: dummyDetachedNodeId });
+		const between = sourceIndex - destIndex;
+		if (between > 0) {
+			marks.push({ count: between });
+		}
+		marks.push({ count, detach: dummyDetachedNodeId });
+	}
+	// sourceIndex === destIndex is a no-op; return empty marks (event should not fire anyway).
+	return marks;
+}
+
 /**
  * The {@link Unhydrated} implementation of {@link FlexTreeSequenceField}.
  */
@@ -541,6 +592,9 @@ export class UnhydratedSequenceField
 				assert(c instanceof UnhydratedFlexTreeNode, 0xbb8 /* Expected unhydrated node */);
 			}
 			const newContentChecked = newContent as readonly UnhydratedFlexTreeNode[];
+			const marks: DeltaMark[] = [];
+			if (index > 0) marks.push({ count: index }); // retain elements before insertion point
+			marks.push({ count: newContentChecked.length, attach: dummyDetachedNodeId });
 			this.edit((mapTrees) => {
 				if (newContent.length < 1000) {
 					// For "smallish arrays" (`1000` is not empirically derived), the `splice` function is appropriate...
@@ -549,23 +603,27 @@ export class UnhydratedSequenceField
 					// ...but we avoid using `splice` + spread for very large input arrays since there is a limit on how many elements can be spread (too many will overflow the stack).
 					return [...mapTrees.slice(0, index), ...newContentChecked, ...mapTrees.slice(index)];
 				}
-			});
+			}, marks);
 		},
 		remove: (index, count): UnhydratedFlexTreeNode[] => {
 			for (let i = index; i < index + count; i++) {
 				const c = this.children[i];
 				assert(c !== undefined, 0xa0b /* Unexpected sparse array */);
 			}
+			const marks: DeltaMark[] = [];
+			if (index > 0) marks.push({ count: index }); // retain elements before removal point
+			marks.push({ count, detach: dummyDetachedNodeId });
 			let removed: UnhydratedFlexTreeNode[] | undefined;
 			this.edit((mapTrees) => {
 				removed = mapTrees.splice(index, count);
-			});
+			}, marks);
 			return removed ?? fail(0xb4a /* Expected removed to be set by edit */);
 		},
 		move: (sourceIndex, count, destIndex, source?): void => {
 			const sourceField = source ?? this;
 			if (sourceField === this) {
 				// Within-field move: do both operations in a single edit to emit only one event
+				const marks = buildUnhydratedMoveMarks(sourceIndex, count, destIndex);
 				this.edit((mapTrees) => {
 					const removed = mapTrees.splice(sourceIndex, count);
 					// Adjust destination index if it comes after the source
@@ -581,7 +639,7 @@ export class UnhydratedSequenceField
 							...mapTrees.slice(adjustedDest),
 						];
 					}
-				});
+				}, marks);
 			} else {
 				// Cross-field move: remove from source, insert into destination
 				// Each field emits one event (correct behavior for different fields)

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -536,20 +536,26 @@ class UnhydratedRequiredField
 const dummyDetachedNodeId = { minor: 0 } satisfies DeltaDetachedNodeId;
 
 /**
- * Builds delta marks for an intra-field move expressed as sequential Quill-style ops.
+ * Builds {@link DeltaMark}s for an intra-field move.
  *
- * @remarks
- * A forward move (`sourceIndex < destIndex`) is expressed as:
- * `retain(sourceIndex), remove(count), retain(between), insert(count)`
+ * @example Forward move (`sourceIndex < destIndex`):
+ * ```
+ * retain(sourceIndex), detach(count), retain(between), attach(count)
+ * ```
  *
- * A backward move (`destIndex < sourceIndex`) is expressed as:
- * `retain(destIndex), insert(count), retain(between), remove(count)`
+ * @example Backward move (`destIndex < sourceIndex`):
+ * ```
+ * retain(destIndex), attach(count), retain(between), detach(count)
+ * ```
  */
 function buildUnhydratedMoveMarks(
 	sourceIndex: number,
 	count: number,
 	destIndex: number,
 ): readonly DeltaMark[] {
+	assert(sourceIndex >= 0, 0xbb9 /* sourceIndex must be non-negative */);
+	assert(count > 0, 0xbba /* count must be positive */);
+	assert(destIndex >= 0, 0xbbb /* destIndex must be non-negative */);
 	const marks: DeltaMark[] = [];
 	if (sourceIndex < destIndex) {
 		// Moving forward: source comes before destination in the original array.

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -2737,133 +2737,143 @@ describe("treeNodeApi", () => {
 			assert.equal(eventCount, 1);
 		});
 
-		// TODO AB#63261: Once delta event support for unhydrated nodes is implemented, convert this
-		// describe block to describeWithHydration to cover both hydrated and unhydrated paths.
-		describe(`'nodeChanged' delta payload for array operations`, () => {
-			// These tests verify the concrete ArrayNodeDeltaOp values emitted for specific
-			// array mutations.  The delta follows Quill-style semantics:
-			//   retain  – elements that remain in place (leading unchanged elements)
-			//   insert  – elements added to the array
-			//   remove  – elements removed from the array
-			// Trailing unchanged elements are NOT represented by a trailing retain op.
-			const sb = new SchemaFactory("nodeChanged-delta-content");
-			class TestArray extends sb.array("TestArray", [sb.number]) {}
+		describeHydration(
+			`'nodeChanged' delta payload for array operations`,
+			(init) => {
+				// These tests verify the concrete ArrayNodeDeltaOp values emitted for specific
+				// array mutations.  The delta follows Quill-style semantics:
+				//   retain  – elements that remain in place (leading unchanged elements)
+				//   insert  – elements added to the array
+				//   remove  – elements removed from the array
+				// Trailing unchanged elements are NOT represented by a trailing retain op.
+				const sb = new SchemaFactory("nodeChanged-delta-content");
+				class TestArray extends sb.array("TestArray", [sb.number]) {}
 
-			it(`insertAtEnd emits a leading retain followed by an insert`, () => {
-				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
-				view.initialize([1, 2, 3]);
-				const root = view.root;
+				it(`insertAtEnd emits a leading retain followed by an insert`, () => {
+					const root = init(TestArray, [1, 2, 3]);
 
-				const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-				TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 
-				root.insertAtEnd(4);
+					root.insertAtEnd(4);
 
-				assert.deepEqual(deltas, [
-					[
-						{ type: "retain", count: 3 },
-						{ type: "insert", count: 1 },
-					],
-				]);
-			});
+					assert.deepEqual(deltas, [
+						[
+							{ type: "retain", count: 3 },
+							{ type: "insert", count: 1 },
+						],
+					]);
+				});
 
-			it(`insertAt(0) emits only an insert op (no leading retain)`, () => {
-				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
-				view.initialize([1, 2, 3]);
-				const root = view.root;
+				it(`insertAt(0) emits only an insert op (no leading retain)`, () => {
+					const root = init(TestArray, [1, 2, 3]);
 
-				const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-				TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 
-				root.insertAt(0, 0);
+					root.insertAt(0, 0);
 
-				assert.deepEqual(deltas, [[{ type: "insert", count: 1 }]]);
-			});
+					assert.deepEqual(deltas, [[{ type: "insert", count: 1 }]]);
+				});
 
-			it(`removeAt(0) emits only a remove op (no leading retain)`, () => {
-				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
-				view.initialize([1, 2, 3]);
-				const root = view.root;
+				it(`removeAt(0) emits only a remove op (no leading retain)`, () => {
+					const root = init(TestArray, [1, 2, 3]);
 
-				const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-				TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 
-				root.removeAt(0);
+					root.removeAt(0);
 
-				assert.deepEqual(deltas, [[{ type: "remove", count: 1 }]]);
-			});
+					assert.deepEqual(deltas, [[{ type: "remove", count: 1 }]]);
+				});
 
-			it(`removeAt(end) emits a leading retain followed by a remove`, () => {
-				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
-				view.initialize([1, 2, 3]);
-				const root = view.root;
+				it(`removeAt(end) emits a leading retain followed by a remove`, () => {
+					const root = init(TestArray, [1, 2, 3]);
 
-				const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-				TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 
-				root.removeAt(2);
+					root.removeAt(2);
 
-				assert.deepEqual(deltas, [
-					[
-						{ type: "retain", count: 2 },
-						{ type: "remove", count: 1 },
-					],
-				]);
-			});
+					assert.deepEqual(deltas, [
+						[
+							{ type: "retain", count: 2 },
+							{ type: "remove", count: 1 },
+						],
+					]);
+				});
 
-			it(`moveRangeToEnd(0, 1) emits remove + retain + insert`, () => {
-				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
-				view.initialize([1, 2, 3]);
-				const root = view.root;
+				it(`moveRangeToEnd(0, 1) emits remove + retain + insert (forward move)`, () => {
+					const root = init(TestArray, [1, 2, 3]);
 
-				const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-				TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 
-				root.moveRangeToEnd(0, 1);
+					root.moveRangeToEnd(0, 1);
 
-				assert.deepEqual(deltas, [
-					[
-						{ type: "remove", count: 1 },
-						{ type: "retain", count: 2 },
-						{ type: "insert", count: 1 },
-					],
-				]);
-			});
+					assert.deepEqual(deltas, [
+						[
+							{ type: "remove", count: 1 },
+							{ type: "retain", count: 2 },
+							{ type: "insert", count: 1 },
+						],
+					]);
+				});
 
-			it(`nested child modification alongside removal produces a retain op`, () => {
-				// When an element's nested properties change (but it is not itself
-				// inserted or removed) AND another element is removed in the same delta,
-				// the marks for the array field include a {fields} mark for the
-				// unchanged-at-array-level element. deltaMarksToArrayOps converts that
-				// to a "retain" op.
-				const sb2 = new SchemaFactory("retain-delta");
-				class RetainItem extends sb2.object("RetainItem", { value: sb2.number }) {}
-				class RetainArray extends sb2.array("RetainArray", [RetainItem]) {}
+				it(`moveRangeToStart(2, 3) emits insert + retain + remove (backward move)`, () => {
+					const root = init(TestArray, [1, 2, 3]);
 
-				const view = getView(new TreeViewConfiguration({ schema: RetainArray }));
-				view.initialize([{ value: 1 }, { value: 2 }, { value: 3 }]);
-				const root = view.root;
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 
-				const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-				TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+					root.moveRangeToStart(2, 3);
 
-				// Use a fork to compose two changes into a single delta: modify
-				// element 0's nested property and remove element 1. The merged
-				// delta's marks are [{count:1,fields:{...}}, {count:1,detach:id}],
-				// which produce [retain 1, remove 1].
-				const { forkView, forkCheckout } = getViewForForkedBranch(view);
-				forkView.root[0].value = 99;
-				forkView.root.removeAt(1);
-				view.checkout.merge(forkCheckout);
+					assert.deepEqual(deltas, [
+						[
+							{ type: "insert", count: 1 },
+							{ type: "retain", count: 2 },
+							{ type: "remove", count: 1 },
+						],
+					]);
+				});
+			},
+			() => {
+				it(`nested child modification alongside removal produces a retain op (hydrated only)`, () => {
+					// When an element's nested properties change (but it is not itself
+					// inserted or removed) AND another element is removed in the same delta,
+					// the marks for the array field include a {fields} mark for the
+					// unchanged-at-array-level element. deltaMarksToArrayOps converts that
+					// to a "retain" op. This relies on the hydrated delta pipeline and is
+					// not applicable to unhydrated nodes.
+					const sb2 = new SchemaFactory("retain-delta");
+					class RetainItem extends sb2.object("RetainItem", { value: sb2.number }) {}
+					class RetainArray extends sb2.array("RetainArray", [RetainItem]) {}
 
-				assert.deepEqual(deltas, [
-					[
-						{ type: "retain", count: 1 },
-						{ type: "remove", count: 1 },
-					],
-				]);
-			});
-		});
+					const view = getView(new TreeViewConfiguration({ schema: RetainArray }));
+					view.initialize([{ value: 1 }, { value: 2 }, { value: 3 }]);
+					const root = view.root;
+
+					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
+					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
+
+					// Use a fork to compose two changes into a single delta: modify
+					// element 0's nested property and remove element 1. The merged
+					// delta's marks are [{count:1,fields:{...}}, {count:1,detach:id}],
+					// which produce [retain 1, remove 1].
+					const { forkView, forkCheckout } = getViewForForkedBranch(view);
+					forkView.root[0].value = 99;
+					forkView.root.removeAt(1);
+					view.checkout.merge(forkCheckout);
+
+					assert.deepEqual(deltas, [
+						[
+							{ type: "retain", count: 1 },
+							{ type: "remove", count: 1 },
+						],
+					]);
+				});
+			},
+		);
 
 		it(`'nodeChanged' uses property keys, not stored keys, for the list of changed properties`, () => {
 			const sb = new SchemaFactory("test");

--- a/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
@@ -159,50 +159,6 @@ describe("array node delta in nodeChanged", () => {
 	const schemaFactory = new SchemaFactory("test");
 	const MyArray = schemaFactory.array("myArray", schemaFactory.number);
 
-	describeHydration("delta presence", (init, hydrated) => {
-		it("delta is undefined for unhydrated arrays, defined for hydrated arrays", () => {
-			// Unhydrated nodes are not visited by the delta pipeline, so no field marks are
-			// available and delta is always undefined.  Hydrated nodes have marks and delta
-			// is always defined (for a single unbuffered edit).
-			const myArray = init(MyArray, [1, 2, 3]);
-
-			const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-			TreeAlpha.on(myArray, "nodeChanged", ({ delta }) => {
-				deltas.push(delta);
-			});
-
-			myArray.insertAtEnd(4);
-
-			assert.equal(deltas.length, 1);
-			if (hydrated) {
-				assert.notEqual(deltas[0], undefined, "hydrated array should have a defined delta");
-			} else {
-				assert.equal(
-					deltas[0],
-					undefined,
-					"unhydrated array delta should be undefined — no delta pipeline",
-				);
-			}
-		});
-	});
-
-	it("delta is defined for a single unbuffered edit", () => {
-		const myArray = hydrate(MyArray, [1, 2, 3]);
-
-		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-		TreeAlpha.on(myArray, "nodeChanged", ({ delta }) => {
-			deltas.push(delta);
-		});
-
-		myArray.insertAtEnd(4);
-
-		assert.equal(deltas.length, 1);
-		assert.deepEqual(deltas[0], [
-			{ type: "retain", count: 3 },
-			{ type: "insert", count: 1 },
-		]);
-	});
-
 	it("delta is defined when array is modified once within buffered events", () => {
 		const myArray = hydrate(MyArray, [1, 2, 3]);
 
@@ -337,36 +293,6 @@ describe("array node delta in nodeChanged", () => {
 			{ type: "retain", count: 1 },
 			{ type: "remove", count: 1 },
 		]);
-	});
-
-	it("insert at position 0 produces no leading retain", () => {
-		// Sparse encoding: no retain is emitted before the insert when operating at the start.
-		const myArray = hydrate(MyArray, [1, 2, 3]);
-
-		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-		TreeAlpha.on(myArray, "nodeChanged", ({ delta }) => {
-			deltas.push(delta);
-		});
-
-		myArray.insertAt(0, 99);
-
-		assert.equal(deltas.length, 1);
-		assert.deepEqual(deltas[0], [{ type: "insert", count: 1 }]);
-	});
-
-	it("remove at position 0 produces no leading retain", () => {
-		// Sparse encoding: no retain is emitted before the remove when operating at the start.
-		const myArray = hydrate(MyArray, [1, 2, 3]);
-
-		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-		TreeAlpha.on(myArray, "nodeChanged", ({ delta }) => {
-			deltas.push(delta);
-		});
-
-		myArray.removeAt(0);
-
-		assert.equal(deltas.length, 1);
-		assert.deepEqual(deltas[0], [{ type: "remove", count: 1 }]);
 	});
 
 	it("object node nodeChanged does not include delta", () => {
@@ -588,32 +514,16 @@ describe("array move events", () => {
 		});
 	});
 
-	describe("move delta payloads", () => {
+	describeHydration("move delta payloads", (init) => {
 		const sf = new SchemaFactory("move-delta");
 		const MoveArray = sf.array("MoveArray", sf.number);
-
-		it("move within array emits remove + retain + insert delta", () => {
-			const arr = hydrate(MoveArray, [1, 2, 3]);
-			const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
-			TreeAlpha.on(arr, "nodeChanged", ({ delta }) => deltas.push(delta));
-
-			arr.moveToEnd(0);
-
-			assert.deepEqual(deltas, [
-				[
-					{ type: "remove", count: 1 },
-					{ type: "retain", count: 2 },
-					{ type: "insert", count: 1 },
-				],
-			]);
-		});
 
 		it("cross-field move emits correct delta on source and destination arrays", () => {
 			const MoveParent = sf.object("MoveParent", {
 				array1: MoveArray,
 				array2: MoveArray,
 			});
-			const parent = hydrate(MoveParent, { array1: [1, 2, 3], array2: [4, 5] });
+			const parent = init(MoveParent, { array1: [1, 2, 3], array2: [4, 5] });
 			const delta1: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
 			const delta2: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
 			TreeAlpha.on(parent.array1, "nodeChanged", ({ delta }) => delta1.push(delta));
@@ -634,7 +544,7 @@ describe("array move events", () => {
 		});
 
 		it("moveRangeToEnd emits correct count in remove and insert ops", () => {
-			const arr = hydrate(MoveArray, [1, 2, 3, 4, 5]);
+			const arr = init(MoveArray, [1, 2, 3, 4, 5]);
 			const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
 			TreeAlpha.on(arr, "nodeChanged", ({ delta }) => deltas.push(delta));
 


### PR DESCRIPTION
## Description

Fixes delta being `undefined` for unhydrated array nodes in `nodeChanged` events.

Populates the delta field in `NodeChangedDataDelta` for unhydrated array nodes.