### PR TITLE
Better seperate the versions of the field batch codec format

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -40,8 +40,10 @@ import {
 import type { IncrementalDecoder } from "./codecs.js";
 import {
 	type EncodedAnyShape,
-	type EncodedChunkShape,
-	type EncodedFieldBatch,
+	type EncodedChunkShapeV1,
+	type EncodedChunkShapeV2,
+	type EncodedFieldBatchV1OrV2,
+	type EncodedFieldBatchV2,
 	type EncodedIncrementalChunkShape,
 	type EncodedInlineArrayShape,
 	type EncodedNestedArrayShape,
@@ -49,7 +51,7 @@ import {
 	type EncodedValueShape,
 	FieldBatchFormatVersion,
 	SpecialField,
-} from "./format.js";
+} from "./format/index.js";
 
 export interface IdDecodingContext {
 	idCompressor: IIdCompressor;
@@ -62,7 +64,7 @@ export interface IdDecodingContext {
  * Decode `chunk` into a TreeChunk.
  */
 export function decode(
-	chunk: EncodedFieldBatch,
+	chunk: EncodedFieldBatchV1OrV2,
 	idDecodingContext: { idCompressor: IIdCompressor; originatorId: SessionId },
 	incrementalDecoder?: IncrementalDecoder,
 ): TreeChunk[] {
@@ -75,8 +77,8 @@ export function decode(
 }
 
 const decoderLibrary = new DiscriminatedUnionDispatcher<
-	EncodedChunkShape,
-	[context: DecoderContext<EncodedChunkShape>],
+	EncodedChunkShapeV1 | EncodedChunkShapeV2,
+	[context: DecoderContext<EncodedChunkShapeV1 | EncodedChunkShapeV2>],
 	ChunkDecoder
 >({
 	a(shape: EncodedNestedArrayShape, context): ChunkDecoder {
@@ -91,8 +93,11 @@ const decoderLibrary = new DiscriminatedUnionDispatcher<
 	d(shape: EncodedAnyShape): ChunkDecoder {
 		return anyDecoder;
 	},
-	e(shape: EncodedIncrementalChunkShape, cache): ChunkDecoder {
-		return new IncrementalChunkDecoder(cache);
+	e(
+		shape: EncodedIncrementalChunkShape,
+		context: DecoderContext<EncodedChunkShapeV2>,
+	): ChunkDecoder {
+		return new IncrementalChunkDecoder(context);
 	},
 });
 
@@ -242,14 +247,14 @@ export class InlineArrayDecoder implements ChunkDecoder {
  * Decoder for {@link EncodedIncrementalChunkShape}s.
  */
 export class IncrementalChunkDecoder implements ChunkDecoder {
-	public constructor(private readonly context: DecoderContext<EncodedChunkShape>) {}
+	public constructor(private readonly context: DecoderContext<EncodedChunkShapeV2>) {}
 	public decode(_: readonly ChunkDecoder[], stream: StreamCursor): TreeChunk {
 		assert(
 			this.context.incrementalDecoder !== undefined,
 			0xc27 /* incremental decoder not available for incremental field decoding */,
 		);
 
-		const chunkDecoder = (batch: EncodedFieldBatch): TreeChunk => {
+		const chunkDecoder = (batch: EncodedFieldBatchV2): TreeChunk => {
 			assert(
 				batch.version >= FieldBatchFormatVersion.v2,
 				0xc9f /* Unsupported FieldBatchFormatVersion for incremental chunks; must be v2 or higher */,
@@ -292,10 +297,10 @@ type BasicFieldDecoder = (
 ) => [FieldKey, TreeChunk];
 
 /**
- * Get a decoder for fields of a provided (via `shape` and `context`) {@link EncodedChunkShape}.
+ * Get a decoder for fields of a provided (via `shape` and `context`) {@link EncodedChunkShapeV1}.
  */
 function fieldDecoder(
-	context: DecoderContext<EncodedChunkShape>,
+	context: DecoderContext<EncodedChunkShapeV1 | EncodedChunkShapeV2>,
 	key: FieldKey,
 	shape: number,
 ): BasicFieldDecoder {
@@ -314,7 +319,7 @@ export class NodeDecoder implements ChunkDecoder {
 	private readonly fieldDecoders: readonly BasicFieldDecoder[];
 	public constructor(
 		private readonly shape: EncodedNodeShape,
-		private readonly context: DecoderContext<EncodedChunkShape>,
+		private readonly context: DecoderContext<EncodedChunkShapeV1 | EncodedChunkShapeV2>,
 	) {
 		this.type = shape.type === undefined ? undefined : context.identifier(shape.type);
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -297,7 +297,7 @@ type BasicFieldDecoder = (
 ) => [FieldKey, TreeChunk];
 
 /**
- * Get a decoder for fields of a provided (via `shape` and `context`) {@link EncodedChunkShapeV1}.
+ * Get a decoder for fields of a provided (via `shape` and `context`).
  */
 function fieldDecoder(
 	context: DecoderContext<EncodedChunkShapeV1OrV2>,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -40,7 +40,7 @@ import {
 import type { IncrementalDecoder } from "./codecs.js";
 import {
 	type EncodedAnyShape,
-	type EncodedChunkShapeV1,
+	type EncodedChunkShapeV1OrV2,
 	type EncodedChunkShapeV2,
 	type EncodedFieldBatchV1OrV2,
 	type EncodedFieldBatchV2,
@@ -77,8 +77,8 @@ export function decode(
 }
 
 const decoderLibrary = new DiscriminatedUnionDispatcher<
-	EncodedChunkShapeV1 | EncodedChunkShapeV2,
-	[context: DecoderContext<EncodedChunkShapeV1 | EncodedChunkShapeV2>],
+	EncodedChunkShapeV1OrV2,
+	[context: DecoderContext<EncodedChunkShapeV1OrV2>],
 	ChunkDecoder
 >({
 	a(shape: EncodedNestedArrayShape, context): ChunkDecoder {
@@ -300,7 +300,7 @@ type BasicFieldDecoder = (
  * Get a decoder for fields of a provided (via `shape` and `context`) {@link EncodedChunkShapeV1}.
  */
 function fieldDecoder(
-	context: DecoderContext<EncodedChunkShapeV1 | EncodedChunkShapeV2>,
+	context: DecoderContext<EncodedChunkShapeV1OrV2>,
 	key: FieldKey,
 	shape: number,
 ): BasicFieldDecoder {
@@ -319,7 +319,7 @@ export class NodeDecoder implements ChunkDecoder {
 	private readonly fieldDecoders: readonly BasicFieldDecoder[];
 	public constructor(
 		private readonly shape: EncodedNodeShape,
-		private readonly context: DecoderContext<EncodedChunkShapeV1 | EncodedChunkShapeV2>,
+		private readonly context: DecoderContext<EncodedChunkShapeV1OrV2>,
 	) {
 		this.type = shape.type === undefined ? undefined : context.identifier(shape.type);
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
@@ -17,7 +17,8 @@ import {
 } from "./chunkCodecUtilities.js";
 import type { IdDecodingContext } from "./chunkDecoding.js";
 import type { IncrementalDecoder } from "./codecs.js";
-import type { EncodedFieldBatchGeneric, IdentifierOrIndex } from "./formatGeneric.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import type { EncodedFieldBatchGeneric, IdentifierOrIndex } from "./format/formatGeneric.js";
 
 /**
  * General purpose shape based tree decoder which gets its support for specific shapes from the caller.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
@@ -17,8 +17,7 @@ import {
 } from "./chunkCodecUtilities.js";
 import type { IdDecodingContext } from "./chunkDecoding.js";
 import type { IncrementalDecoder } from "./codecs.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import type { EncodedFieldBatchGeneric, IdentifierOrIndex } from "./format/formatGeneric.js";
+import type { EncodedFieldBatchGeneric, IdentifierOrIndex } from "./format/index.js";
 
 /**
  * General purpose shape based tree decoder which gets its support for specific shapes from the caller.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
@@ -14,8 +14,7 @@ import {
 	type DeduplicationTable,
 	jsonMinimizingFilter,
 } from "./chunkCodecUtilities.js";
-import type { FieldBatchFormatVersion } from "./format.js";
-import type { EncodedFieldBatchGeneric } from "./formatGeneric.js";
+import type { FieldBatchFormatVersion, EncodedFieldBatchGeneric } from "./format/index.js";
 
 /**
  * An identifier which can be compressed using {@link Counter}.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -27,11 +27,11 @@ import { TreeCompressionStrategy } from "../../treeCompressionUtils.js";
 import { decode } from "./chunkDecoding.js";
 import type { FieldBatch } from "./fieldBatch.js";
 import {
-	type EncodedFieldBatch,
-	FieldBatchFormatVersion,
 	EncodedFieldBatchV1,
 	EncodedFieldBatchV2,
-} from "./format.js";
+	FieldBatchFormatVersion,
+	type EncodedFieldBatchV1OrV2,
+} from "./format/index.js";
 import type { IncrementalEncodingPolicy } from "./incrementalEncodingPolicy.js";
 import { schemaCompressedEncodeV1, schemaCompressedEncodeV2 } from "./schemaBasedEncode.js";
 import { uncompressedEncodeV1, uncompressedEncodeV2 } from "./uncompressedEncode.js";
@@ -67,7 +67,7 @@ export interface IncrementalEncoder {
 	 */
 	encodeIncrementalField(
 		cursor: ITreeCursorSynchronous,
-		chunkEncoder: (chunk: TreeChunk) => EncodedFieldBatch,
+		chunkEncoder: (chunk: TreeChunk) => EncodedFieldBatchV2,
 	): ChunkReferenceId[];
 }
 
@@ -87,7 +87,7 @@ export interface IncrementalDecoder {
 	 */
 	decodeIncrementalChunk(
 		referenceId: ChunkReferenceId,
-		chunkDecoder: (encoded: EncodedFieldBatch) => TreeChunk,
+		chunkDecoder: (encoded: EncodedFieldBatchV2) => TreeChunk,
 	): TreeChunk;
 }
 /**
@@ -117,25 +117,28 @@ export type FieldBatchCodec = ReturnType<typeof fieldBatchCodecBuilder.build>;
  */
 function makeFieldBatchCodecForVersion(
 	version: FieldBatchFormatVersion,
-	uncompressedEncodeFn: (batch: FieldBatch) => EncodedFieldBatch,
+	uncompressedEncodeFn: (batch: FieldBatch) => EncodedFieldBatchV1OrV2,
 	schemaCompressedEncodeFn: (
 		schema: StoredSchemaCollection,
 		policy: SchemaPolicy,
 		fieldBatch: FieldBatch,
 		idCompressor: IIdCompressor,
 		incrementalEncoder: IncrementalEncoder | undefined,
-	) => EncodedFieldBatch,
+	) => EncodedFieldBatchV1OrV2,
 	encodedFieldBatchType: TSchema,
 ): CodecAndSchema<FieldBatch, FieldBatchEncodingContext> {
 	return {
-		encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {
+		encode: (
+			data: FieldBatch,
+			context: FieldBatchEncodingContext,
+		): EncodedFieldBatchV1OrV2 => {
 			for (const cursor of data) {
 				assert(
 					cursor.mode === CursorLocationType.Fields,
 					0x8a3 /* FieldBatch expects fields cursors */,
 				);
 			}
-			let encoded: EncodedFieldBatch;
+			let encoded: EncodedFieldBatchV1OrV2;
 			let incrementalEncoder: IncrementalEncoder | undefined;
 			switch (context.encodeType) {
 				case TreeCompressionStrategy.Uncompressed: {
@@ -176,7 +179,10 @@ function makeFieldBatchCodecForVersion(
 			// TODO: consider checking input data was in schema.
 			return encoded;
 		},
-		decode: (data: EncodedFieldBatch, context: FieldBatchEncodingContext): FieldBatch => {
+		decode: (
+			data: EncodedFieldBatchV1OrV2,
+			context: FieldBatchEncodingContext,
+		): FieldBatch => {
 			// TODO: consider checking data is in schema.
 			return decode(
 				data,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -30,13 +30,14 @@ import type { IncrementalEncoder } from "./codecs.js";
 import type { FieldBatch } from "./fieldBatch.js";
 import {
 	type EncodedAnyShape,
-	type EncodedChunkShape,
-	type EncodedFieldBatch,
+	type EncodedChunkShapeV1,
+	type EncodedChunkShapeV2,
+	type EncodedFieldBatchV1OrV2,
 	type EncodedNestedArrayShape,
 	type EncodedValueShape,
 	FieldBatchFormatVersion,
 	SpecialField,
-} from "./format.js";
+} from "./format/index.js";
 
 /**
  * Encode data from `FieldBatch` into an `EncodedFieldBatch`.
@@ -48,7 +49,7 @@ import {
 export function compressedEncode(
 	fieldBatch: FieldBatch,
 	context: EncoderContext,
-): EncodedFieldBatch {
+): EncodedFieldBatchV1OrV2 {
 	const batchBuffer: BufferFormat[] = [];
 
 	// Populate buffer, including shape and identifier references
@@ -60,8 +61,8 @@ export function compressedEncode(
 	return updateShapesAndIdentifiersEncoding(context.version, batchBuffer);
 }
 
-export type BufferFormat = BufferFormatGeneric<EncodedChunkShape>;
-export type Shape = ShapeGeneric<EncodedChunkShape>;
+export type BufferFormat = BufferFormatGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2>;
+export type Shape = ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2>;
 
 /**
  * Like {@link FieldEncoder}, except data will be prefixed with the key.
@@ -163,7 +164,7 @@ export function asNodesEncoder(encoder: NodeEncoder): NodesEncoder {
 /**
  * Encodes a chunk with {@link EncodedAnyShape} by prefixing the data with its shape.
  */
-export class AnyShape extends ShapeGeneric<EncodedChunkShape> {
+export class AnyShape extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2> {
 	private constructor() {
 		super();
 	}
@@ -172,7 +173,7 @@ export class AnyShape extends ShapeGeneric<EncodedChunkShape> {
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
 		shapes: DeduplicationTable<Shape>,
-	): EncodedChunkShape {
+	): EncodedChunkShapeV1 | EncodedChunkShapeV2 {
 		const encodedAnyShape: EncodedAnyShape = 0;
 		return { d: encodedAnyShape };
 	}
@@ -268,7 +269,7 @@ export const anyFieldEncoder: FieldEncoder = {
  * which is an easy way to keep all the related code together without extra objects.
  */
 export class InlineArrayEncoder
-	extends ShapeGeneric<EncodedChunkShape>
+	extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2>
 	implements NodesEncoder, FieldEncoder
 {
 	public static readonly empty: InlineArrayEncoder = new InlineArrayEncoder(0, {
@@ -328,7 +329,7 @@ export class InlineArrayEncoder
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
 		shapes: DeduplicationTable<Shape>,
-	): EncodedChunkShape {
+	): EncodedChunkShapeV1 {
 		return {
 			b: {
 				length: this.length,
@@ -352,7 +353,7 @@ export class InlineArrayEncoder
 /**
  * Encodes the shape for a nested array as {@link EncodedNestedArrayShape} shape.
  */
-export class NestedArrayShape extends ShapeGeneric<EncodedChunkShape> {
+export class NestedArrayShape extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2> {
 	/**
 	 * @param innerShape - The shape of each item in this nested array.
 	 */
@@ -363,7 +364,7 @@ export class NestedArrayShape extends ShapeGeneric<EncodedChunkShape> {
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
 		shapes: DeduplicationTable<Shape>,
-	): EncodedChunkShape {
+	): EncodedChunkShapeV1 | EncodedChunkShapeV2 {
 		const shape: EncodedNestedArrayShape =
 			shapes.valueToIndex.get(this.innerShape) ??
 			fail(0xb4f /* index for shape not found in table */);
@@ -422,11 +423,11 @@ export class NestedArrayEncoder implements FieldEncoder {
 /**
  * Encodes the shape for an incremental chunk as {@link EncodedIncrementalChunkShape} shape.
  */
-export class IncrementalChunkShape extends ShapeGeneric<EncodedChunkShape> {
+export class IncrementalChunkShape extends ShapeGeneric<EncodedChunkShapeV2> {
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
 		shapes: DeduplicationTable<Shape>,
-	): EncodedChunkShape {
+	): EncodedChunkShapeV2 {
 		return {
 			e: 0 /* EncodedIncrementalChunkShape */,
 		};

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -31,6 +31,7 @@ import type { FieldBatch } from "./fieldBatch.js";
 import {
 	type EncodedAnyShape,
 	type EncodedChunkShapeV1,
+	type EncodedChunkShapeV1OrV2,
 	type EncodedChunkShapeV2,
 	type EncodedFieldBatchV1OrV2,
 	type EncodedNestedArrayShape,
@@ -61,8 +62,8 @@ export function compressedEncode(
 	return updateShapesAndIdentifiersEncoding(context.version, batchBuffer);
 }
 
-export type BufferFormat = BufferFormatGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2>;
-export type Shape = ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2>;
+export type BufferFormat = BufferFormatGeneric<EncodedChunkShapeV1OrV2>;
+export type Shape = ShapeGeneric<EncodedChunkShapeV1OrV2>;
 
 /**
  * Like {@link FieldEncoder}, except data will be prefixed with the key.
@@ -164,7 +165,7 @@ export function asNodesEncoder(encoder: NodeEncoder): NodesEncoder {
 /**
  * Encodes a chunk with {@link EncodedAnyShape} by prefixing the data with its shape.
  */
-export class AnyShape extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2> {
+export class AnyShape extends ShapeGeneric<EncodedChunkShapeV1OrV2> {
 	private constructor() {
 		super();
 	}
@@ -173,7 +174,7 @@ export class AnyShape extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkSha
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
 		shapes: DeduplicationTable<Shape>,
-	): EncodedChunkShapeV1 | EncodedChunkShapeV2 {
+	): EncodedChunkShapeV1 {
 		const encodedAnyShape: EncodedAnyShape = 0;
 		return { d: encodedAnyShape };
 	}
@@ -269,7 +270,7 @@ export const anyFieldEncoder: FieldEncoder = {
  * which is an easy way to keep all the related code together without extra objects.
  */
 export class InlineArrayEncoder
-	extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2>
+	extends ShapeGeneric<EncodedChunkShapeV1OrV2>
 	implements NodesEncoder, FieldEncoder
 {
 	public static readonly empty: InlineArrayEncoder = new InlineArrayEncoder(0, {
@@ -353,7 +354,7 @@ export class InlineArrayEncoder
 /**
  * Encodes the shape for a nested array as {@link EncodedNestedArrayShape} shape.
  */
-export class NestedArrayShape extends ShapeGeneric<EncodedChunkShapeV1 | EncodedChunkShapeV2> {
+export class NestedArrayShape extends ShapeGeneric<EncodedChunkShapeV1OrV2> {
 	/**
 	 * @param innerShape - The shape of each item in this nested array.
 	 */
@@ -364,7 +365,7 @@ export class NestedArrayShape extends ShapeGeneric<EncodedChunkShapeV1 | Encoded
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
 		shapes: DeduplicationTable<Shape>,
-	): EncodedChunkShapeV1 | EncodedChunkShapeV2 {
+	): EncodedChunkShapeV1OrV2 {
 		const shape: EncodedNestedArrayShape =
 			shapes.valueToIndex.get(this.innerShape) ??
 			fail(0xb4f /* index for shape not found in table */);

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatGeneric.ts
@@ -5,7 +5,7 @@
 
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
 
-import type { FieldBatchFormatVersion } from "./format.js";
+import type { FieldBatchFormatVersion } from "./versions.js";
 
 /**
  * Identifier OR Index of an identifier in the identifier list.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV1.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV1.ts
@@ -100,6 +100,9 @@ export const EncodedValueShape = Type.Union([
 ]);
 export type EncodedValueShape = undefined | Static<typeof EncodedValueShape>;
 
+/**
+ * The encoded form of a {@link Shape} for a node.
+ */
 export type EncodedNodeShape = Static<typeof EncodedNodeShape>;
 export const EncodedNodeShape = Type.Object(
 	{
@@ -123,6 +126,11 @@ export const EncodedNodeShape = Type.Object(
 	{ additionalProperties: false },
 );
 
+/**
+ * The chunk shapes supported by the V1 format.
+ * @remarks
+ * See {@link EncodedChunkShapeV1}.
+ */
 export const shapesV1 = {
 	/**
 	 * {@link EncodedNestedArrayShape} union member.
@@ -157,8 +165,8 @@ export const shapesV1 = {
  * to prevent a union with more options from being assignable to this one, we include Never.
  * This matters in this case because the V2 format only differs in that it has another entry in this Union.
  */
+export type EncodedChunkShapeV1 = Static<typeof EncodedChunkShapeV1>;
 export const EncodedChunkShapeV1 = Type.Object(
 	{ ...shapesV1, e: Type.Optional(Type.Never()) },
 	unionOptions,
 );
-export type EncodedChunkShapeV1 = Static<typeof EncodedChunkShapeV1>;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV1.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV1.ts
@@ -5,49 +5,21 @@
 
 import { type Static, Type } from "@sinclair/typebox";
 
-import { unionOptions } from "../../../codec/index.js";
-import { strictEnum, type Values } from "../../../util/index.js";
+import { unionOptions } from "../../../../codec/index.js";
 
-import {
-	Count,
-	EncodedFieldBatchGeneric,
-	IdentifierOrIndex,
-	ShapeIndex,
-} from "./formatGeneric.js";
-
-/**
- * The format version for the field batch.
- */
-export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
-	/**
-	 * Initial version.
-	 * @remarks
-	 * For simplicity of implementation the format for this version allows the same chunk shapes as v2, but must not use {@link EncodedIncrementalChunkShape}
-	 * as older clients will not know how to handle that shape but think they can handle this format.
-	 */
-	v1: 1,
-	/**
-	 * Adds support for incremental encoding of chunks.
-	 * @remarks
-	 * {@link EncodedIncrementalChunkShape} was added in this version.
-	 */
-	v2: 2,
-});
-export type FieldBatchFormatVersion = Values<typeof FieldBatchFormatVersion>;
-
-// Compatible versions used for format/version validation.
-// TODO: A proper version update policy will need to be documented.
-export const validVersions = new Set([...Object.values(FieldBatchFormatVersion)]);
+import { Count, IdentifierOrIndex, ShapeIndex } from "./formatGeneric.js";
 
 /**
  * Top level length is implied from length of data array.
  * All content are of this shape.
  */
+export type EncodedNestedArrayShape = Static<typeof EncodedNestedArrayShape>;
 export const EncodedNestedArrayShape = ShapeIndex;
 
 /**
  * Inline array.
  */
+export type EncodedInlineArrayShape = Static<typeof EncodedInlineArrayShape>;
 export const EncodedInlineArrayShape = Type.Object(
 	{
 		length: Count,
@@ -64,18 +36,21 @@ export const EncodedInlineArrayShape = Type.Object(
  *
  * Used for polymorphism.
  */
+export type EncodedAnyShape = Static<typeof EncodedAnyShape>;
 export const EncodedAnyShape = Type.Literal(0);
 
 /**
  * Encoded content is a {@link ChunkReferenceId}.
  * This represents the shape of a chunk that is encoded separately and is referenced by its {@link ChunkReferenceId}.
  */
+export type EncodedIncrementalChunkShape = Static<typeof EncodedIncrementalChunkShape>;
 export const EncodedIncrementalChunkShape = Type.Literal(0);
 
 /**
  * Content of the encoded field is specified by the Shape referenced by the ShapeIndex.
  * This is a tuple for conciseness.
  */
+export type EncodedFieldShape = Static<typeof EncodedFieldShape>;
 export const EncodedFieldShape = Type.Tuple([
 	/**
 	 * Field key for this field.
@@ -86,33 +61,6 @@ export const EncodedFieldShape = Type.Tuple([
 	 */
 	ShapeIndex,
 ]);
-
-export type EncodedFieldShape = Static<typeof EncodedFieldShape>;
-
-enum CounterRelativeTo {
-	// Relative to previous node of same type in depth first pre-order traversal.
-	PreviousNodeOfType_DepthFirstPreOrder,
-	// TODO: add alternative relative mode relative to previous note at a path to allow delta encoded sequences (like points where x and y are delta encoded relative to previous points).
-}
-
-enum CounterMode {
-	Number,
-	// TODO: document wrap modes and bit skipping. Note UUID subVersion here (ex: UUIDv4)
-	UUID,
-}
-
-/**
- * Delta encoded value relative to a previous node's value.
- */
-export const EncodedCounter = Type.Object(
-	{
-		relativeTo: Type.Enum(CounterRelativeTo),
-		// If not provided, delta inline in data.
-		delta: Type.Optional(Type.Number()),
-		mode: Type.Enum(CounterMode),
-	},
-	{ additionalProperties: false },
-);
 
 /**
  * Used in {@link EncodedValueShape} for special field kind handling.
@@ -159,6 +107,7 @@ export const EncodedValueShape = Type.Union([
 ]);
 export type EncodedValueShape = undefined | Static<typeof EncodedValueShape>;
 
+export type EncodedNodeShape = Static<typeof EncodedNodeShape>;
 export const EncodedNodeShape = Type.Object(
 	{
 		/**
@@ -181,6 +130,25 @@ export const EncodedNodeShape = Type.Object(
 	{ additionalProperties: false },
 );
 
+export const shapesV1 = {
+	/**
+	 * {@link EncodedNestedArrayShape} union member.
+	 */
+	a: Type.Optional(EncodedNestedArrayShape),
+	/**
+	 * {@link EncodedInlineArrayShape} union member.
+	 */
+	b: Type.Optional(EncodedInlineArrayShape),
+	/**
+	 * {@link EncodedNodeShape} union member.
+	 */
+	c: Type.Optional(EncodedNodeShape),
+	/**
+	 * {@link EncodedAnyShape} union member.
+	 */
+	d: Type.Optional(EncodedAnyShape),
+} as const;
+
 /**
  * Discriminated union that represents the shapes of chunks in the encoded data.
  * "Chunk" here refers to a chunk of tree data, rooted at a range of nodes, that is encoded as a
@@ -191,52 +159,13 @@ export const EncodedNodeShape = Type.Object(
  * This is similar to other such concepts in the system.
  *
  * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
+ * @privateRemarks
+ * Because the TypeScript types for how we model these unions don't require exactly one property,
+ * to prevent a union with more options from being assignable to this one, we include Never.
+ * This matters in this case because the V2 format only differs in that it has another entry in this Union.
  */
-export const EncodedChunkShape = Type.Object(
-	{
-		/**
-		 * {@link EncodedNestedArrayShape} union member.
-		 */
-		a: Type.Optional(EncodedNestedArrayShape),
-		/**
-		 * {@link EncodedInlineArrayShape} union member.
-		 */
-		b: Type.Optional(EncodedInlineArrayShape),
-		/**
-		 * {@link EncodedNodeShape} union member.
-		 */
-		c: Type.Optional(EncodedNodeShape),
-		/**
-		 * {@link EncodedAnyShape} union member.
-		 */
-		d: Type.Optional(EncodedAnyShape),
-		/**
-		 * {@link EncodedIncrementalChunkShape} union member.
-		 */
-		e: Type.Optional(EncodedIncrementalChunkShape),
-	},
+export const EncodedChunkShapeV1 = Type.Object(
+	{ ...shapesV1, e: Type.Optional(Type.Never()) },
 	unionOptions,
 );
-
-export type EncodedChunkShape = Static<typeof EncodedChunkShape>;
-
-export type EncodedNestedArrayShape = Static<typeof EncodedNestedArrayShape>;
-export type EncodedInlineArrayShape = Static<typeof EncodedInlineArrayShape>;
-export type EncodedNodeShape = Static<typeof EncodedNodeShape>;
-export type EncodedAnyShape = Static<typeof EncodedAnyShape>;
-export type EncodedIncrementalChunkShape = Static<typeof EncodedIncrementalChunkShape>;
-
-export const EncodedFieldBatchV1 = EncodedFieldBatchGeneric(
-	FieldBatchFormatVersion.v1,
-	EncodedChunkShape,
-);
-export type EncodedFieldBatchV1 = Static<typeof EncodedFieldBatchV1>;
-
-export const EncodedFieldBatchV2 = EncodedFieldBatchGeneric(
-	FieldBatchFormatVersion.v2,
-	EncodedChunkShape,
-);
-export type EncodedFieldBatchV2 = Static<typeof EncodedFieldBatchV2>;
-
-export const EncodedFieldBatch = Type.Union([EncodedFieldBatchV1, EncodedFieldBatchV2]);
-export type EncodedFieldBatch = Static<typeof EncodedFieldBatch>;
+export type EncodedChunkShapeV1 = Static<typeof EncodedChunkShapeV1>;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV1.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV1.ts
@@ -40,13 +40,6 @@ export type EncodedAnyShape = Static<typeof EncodedAnyShape>;
 export const EncodedAnyShape = Type.Literal(0);
 
 /**
- * Encoded content is a {@link ChunkReferenceId}.
- * This represents the shape of a chunk that is encoded separately and is referenced by its {@link ChunkReferenceId}.
- */
-export type EncodedIncrementalChunkShape = Static<typeof EncodedIncrementalChunkShape>;
-export const EncodedIncrementalChunkShape = Type.Literal(0);
-
-/**
  * Content of the encoded field is specified by the Shape referenced by the ShapeIndex.
  * This is a tuple for conciseness.
  */

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV2.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV2.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+import { unionOptions } from "../../../../codec/index.js";
+
+import { shapesV1 } from "./formatV1.js";
+
+/**
+ * Encoded content is a {@link ChunkReferenceId}.
+ * This represents the shape of a chunk that is encoded separately and is referenced by its {@link ChunkReferenceId}.
+ */
+export type EncodedIncrementalChunkShape = Static<typeof EncodedIncrementalChunkShape>;
+export const EncodedIncrementalChunkShape = Type.Literal(0);
+
+/**
+ * V2 extension of {@link EncodedChunkShapeV1}.
+ * @remarks
+ * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
+ */
+export const EncodedChunkShapeV2 = Type.Object(
+	{
+		...shapesV1,
+		e: Type.Optional(EncodedIncrementalChunkShape),
+	},
+	unionOptions,
+);
+
+export type EncodedChunkShapeV2 = Static<typeof EncodedChunkShapeV2>;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV2.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatV2.ts
@@ -21,6 +21,7 @@ export const EncodedIncrementalChunkShape = Type.Literal(0);
  * @remarks
  * See {@link DiscriminatedUnionDispatcher} for more information on this pattern.
  */
+export type EncodedChunkShapeV2 = Static<typeof EncodedChunkShapeV2>;
 export const EncodedChunkShapeV2 = Type.Object(
 	{
 		...shapesV1,
@@ -28,5 +29,3 @@ export const EncodedChunkShapeV2 = Type.Object(
 	},
 	unionOptions,
 );
-
-export type EncodedChunkShapeV2 = Static<typeof EncodedChunkShapeV2>;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/index.ts
@@ -24,4 +24,8 @@ export {
 	type EncodedFieldBatchV1AndV2,
 	type EncodedChunkShapeV1OrV2,
 } from "./versions.js";
-export type { ShapeIndex, EncodedFieldBatchGeneric } from "./formatGeneric.js";
+export type {
+	ShapeIndex,
+	IdentifierOrIndex,
+	EncodedFieldBatchGeneric,
+} from "./formatGeneric.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/index.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export type {
+	EncodedChunkShapeV1,
+	EncodedInlineArrayShape,
+	EncodedNestedArrayShape,
+	EncodedNodeShape,
+	EncodedValueShape,
+	EncodedFieldShape,
+} from "./formatV1.js";
+export {
+	EncodedAnyShape,
+	SpecialField,
+} from "./formatV1.js";
+export { EncodedIncrementalChunkShape, EncodedChunkShapeV2 } from "./formatV2.js";
+export {
+	FieldBatchFormatVersion,
+	EncodedFieldBatchV1,
+	EncodedFieldBatchV2,
+	type EncodedFieldBatchV1OrV2,
+	type EncodedFieldBatchV1AndV2,
+	type EncodedChunkShapeV1OrV2,
+} from "./versions.js";
+export type { ShapeIndex, EncodedFieldBatchGeneric } from "./formatGeneric.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
@@ -14,6 +14,7 @@ import { EncodedChunkShapeV2 } from "./formatV2.js";
 /**
  * The format version for the field batch.
  */
+export type FieldBatchFormatVersion = Values<typeof FieldBatchFormatVersion>;
 export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
 	/**
 	 * Initial version.
@@ -29,14 +30,23 @@ export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
 	 */
 	v2: 2,
 });
-export type FieldBatchFormatVersion = Values<typeof FieldBatchFormatVersion>;
 
+/**
+ * Encoded {@link FieldBatch} using V1 format.
+ * @remarks
+ * Does not support {@link EncodedIncrementalChunkShape}.
+ */
 export type EncodedFieldBatchV1 = Static<typeof EncodedFieldBatchV1>;
 export const EncodedFieldBatchV1 = EncodedFieldBatchGeneric(
 	FieldBatchFormatVersion.v1,
 	EncodedChunkShapeV1,
 );
 
+/**
+ * Encoded {@link FieldBatch} using V2 format.
+ * @remarks
+ * Adds support for {@link EncodedIncrementalChunkShape}.
+ */
 export type EncodedFieldBatchV2 = Static<typeof EncodedFieldBatchV2>;
 export const EncodedFieldBatchV2 = EncodedFieldBatchGeneric(
 	FieldBatchFormatVersion.v2,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Static } from "@sinclair/typebox";
+
+import { strictEnum, type Values } from "../../../../util/index.js";
+
+import { EncodedFieldBatchGeneric } from "./formatGeneric.js";
+import { EncodedChunkShapeV1 } from "./formatV1.js";
+import { EncodedChunkShapeV2 } from "./formatV2.js";
+
+/**
+ * The format version for the field batch.
+ */
+export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
+	/**
+	 * Initial version.
+	 * @remarks
+	 * For simplicity of implementation the format for this version allows the same chunk shapes as v2, but must not use {@link EncodedIncrementalChunkShape}
+	 * as older clients will not know how to handle that shape but think they can handle this format.
+	 */
+	v1: 1,
+	/**
+	 * Adds support for incremental encoding of chunks.
+	 * @remarks
+	 * {@link EncodedIncrementalChunkShape} was added in this version.
+	 */
+	v2: 2,
+});
+export type FieldBatchFormatVersion = Values<typeof FieldBatchFormatVersion>;
+
+export const validVersions = new Set([...Object.values(FieldBatchFormatVersion)]);
+
+export type EncodedFieldBatchV1 = Static<typeof EncodedFieldBatchV1>;
+export const EncodedFieldBatchV1 = EncodedFieldBatchGeneric(
+	FieldBatchFormatVersion.v1,
+	EncodedChunkShapeV1,
+);
+
+export type EncodedFieldBatchV2 = Static<typeof EncodedFieldBatchV2>;
+export const EncodedFieldBatchV2 = EncodedFieldBatchGeneric(
+	FieldBatchFormatVersion.v2,
+	EncodedChunkShapeV2,
+);
+
+/**
+ * Encoded {@link FieldBatch}, which might use V2 features, but might also have been from a V1 encoder.
+ * @remarks
+ * Type wise, equivalent to V2, as that is a superset of V1.
+ * Used instead of just V2 for clarity.
+ */
+export type EncodedFieldBatchV1OrV2 = EncodedFieldBatchV1 | EncodedFieldBatchV2;
+
+/**
+ * Encoded data, compatible with both V1 and V2 formats.
+ * @remarks
+ * This is the intersection of the two versions, which is possible because V2 is a non-breaking extension of V1.
+ * This type can be used when the code is compatible with both versions and does not need to distinguish between them.
+ *
+ * Type wise, equivalent to V1, as that is a subset of V2.
+ * Used instead of just V1 for clarity.
+ */
+export type EncodedFieldBatchV1AndV2 = EncodedFieldBatchV1 & EncodedFieldBatchV2;
+
+/**
+ * Encoded chunk shape, which might use V2 features, but might also have been from a V1 encoder.
+ * @remarks
+ * Type wise, equivalent to V2, as that is a superset of V1.
+ * Used instead of just V2 for clarity.
+ */
+export type EncodedChunkShapeV1OrV2 = EncodedChunkShapeV1 | EncodedChunkShapeV2;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
@@ -31,8 +31,6 @@ export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
 });
 export type FieldBatchFormatVersion = Values<typeof FieldBatchFormatVersion>;
 
-export const validVersions = new Set([...Object.values(FieldBatchFormatVersion)]);
-
 export type EncodedFieldBatchV1 = Static<typeof EncodedFieldBatchV1>;
 export const EncodedFieldBatchV1 = EncodedFieldBatchGeneric(
 	FieldBatchFormatVersion.v1,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/index.ts
@@ -3,8 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export type { EncodedFieldBatch } from "./format.js";
-export { FieldBatchFormatVersion } from "./format.js";
+export type {
+	EncodedFieldBatchV1,
+	EncodedFieldBatchV1OrV2,
+	EncodedFieldBatchV2,
+} from "./format/index.js";
+export { FieldBatchFormatVersion } from "./format/index.js";
 export type { FieldBatch } from "./fieldBatch.js";
 export {
 	type FieldBatchCodec,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeEncoder.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeEncoder.ts
@@ -24,7 +24,11 @@ import {
 	type NodeEncoder,
 	encodeValue,
 } from "./compressedEncode.js";
-import type { EncodedChunkShape, EncodedFieldShape, EncodedValueShape } from "./format.js";
+import type {
+	EncodedChunkShapeV1OrV2,
+	EncodedFieldShape,
+	EncodedValueShape,
+} from "./format/index.js";
 
 /**
  * Encodes a node with the {@link EncodedNodeShape} shape.
@@ -32,7 +36,10 @@ import type { EncodedChunkShape, EncodedFieldShape, EncodedValueShape } from "./
  * The fact this is also a Shape is an implementation detail of the encoder: that allows the shape it uses to be itself,
  * which is an easy way to keep all the related code together without extra objects.
  */
-export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements NodeEncoder {
+export class NodeShapeBasedEncoder
+	extends Shape<EncodedChunkShapeV1OrV2>
+	implements NodeEncoder
+{
 	/**
 	 * Set of keys for fields that are encoded using {@link NodeShapeBasedEncoder.specializedFieldEncoders}.
 	 * TODO: Ensure uniform chunks, encoding and identifier generation sort fields the same.
@@ -80,7 +87,7 @@ export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements N
 	public encodeNode(
 		cursor: ITreeCursorSynchronous,
 		context: EncoderContext,
-		outputBuffer: BufferFormat<EncodedChunkShape>,
+		outputBuffer: BufferFormat<EncodedChunkShapeV1OrV2>,
 	): void {
 		if (this.type === undefined) {
 			outputBuffer.push(new IdentifierToken(cursor.type));
@@ -94,7 +101,7 @@ export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements N
 			cursor.exitField();
 		}
 
-		const otherFieldsBuffer: BufferFormat<EncodedChunkShape> = [];
+		const otherFieldsBuffer: BufferFormat<EncodedChunkShapeV1OrV2> = [];
 
 		forEachField(cursor, () => {
 			const key = cursor.getFieldKey();
@@ -115,8 +122,8 @@ export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements N
 
 	public encodeShape(
 		identifiers: DeduplicationTable<string>,
-		shapes: DeduplicationTable<Shape<EncodedChunkShape>>,
-	): EncodedChunkShape {
+		shapes: DeduplicationTable<Shape<EncodedChunkShapeV1OrV2>>,
+	): EncodedChunkShapeV1OrV2 {
 		return {
 			c: {
 				type: encodeOptionalIdentifier(this.type, identifiers),
@@ -129,7 +136,7 @@ export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements N
 
 	public countReferencedShapesAndIdentifiers(
 		identifiers: Counter<string>,
-		shapeDiscovered: (shape: Shape<EncodedChunkShape>) => void,
+		shapeDiscovered: (shape: Shape<EncodedChunkShapeV1OrV2>) => void,
 	): void {
 		if (this.type !== undefined) {
 			identifiers.add(this.type);
@@ -145,7 +152,7 @@ export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements N
 		}
 	}
 
-	public get shape(): Shape<EncodedChunkShape> {
+	public get shape(): Shape<EncodedChunkShapeV1OrV2> {
 		return this;
 	}
 }
@@ -153,7 +160,7 @@ export class NodeShapeBasedEncoder extends Shape<EncodedChunkShape> implements N
 export function encodeFieldShapes(
 	fieldEncoders: readonly KeyedFieldEncoder[],
 	identifiers: DeduplicationTable<string>,
-	shapes: DeduplicationTable<Shape<EncodedChunkShape>>,
+	shapes: DeduplicationTable<Shape<EncodedChunkShapeV1OrV2>>,
 ): EncodedFieldShape[] | undefined {
 	if (fieldEncoders.length === 0) {
 		return undefined;
@@ -182,14 +189,14 @@ function encodeOptionalIdentifier(
 
 function encodeOptionalFieldShape(
 	encoder: FieldEncoder | undefined,
-	shapes: DeduplicationTable<Shape<EncodedChunkShape>>,
+	shapes: DeduplicationTable<Shape<EncodedChunkShapeV1OrV2>>,
 ): number | undefined {
 	return encoder === undefined ? undefined : dedupShape(encoder.shape, shapes);
 }
 
 function dedupShape(
-	shape: Shape<EncodedChunkShape>,
-	shapes: DeduplicationTable<Shape<EncodedChunkShape>>,
+	shape: Shape<EncodedChunkShapeV1OrV2>,
+	shapes: DeduplicationTable<Shape<EncodedChunkShapeV1OrV2>>,
 ): number {
 	return shapes.valueToIndex.get(shape) ?? fail(0xb51 /* missing shape */);
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
@@ -34,13 +34,13 @@ import {
 } from "./compressedEncode.js";
 import type { FieldBatch } from "./fieldBatch.js";
 import {
-	type EncodedFieldBatch,
 	type EncodedFieldBatchV1,
+	type EncodedFieldBatchV1OrV2,
 	type EncodedFieldBatchV2,
 	type EncodedValueShape,
 	FieldBatchFormatVersion,
 	SpecialField,
-} from "./format.js";
+} from "./format/index.js";
 import { defaultIncrementalEncodingPolicy } from "./incrementalEncodingPolicy.js";
 import { NodeShapeBasedEncoder } from "./nodeEncoder.js";
 
@@ -55,7 +55,7 @@ export function schemaCompressedEncodeV1(
 	fieldBatch: FieldBatch,
 	idCompressor: IIdCompressor,
 ): EncodedFieldBatchV1 {
-	return schemaCompressedEncode(
+	const encoded: EncodedFieldBatchV1OrV2 = schemaCompressedEncode(
 		schema,
 		policy,
 		fieldBatch,
@@ -63,6 +63,8 @@ export function schemaCompressedEncodeV1(
 		undefined /* incrementalEncoder */,
 		brand(FieldBatchFormatVersion.v1),
 	);
+	// Since incrementalEncoder was not provided, no V2 features should be used, and this cast should be safe.
+	return encoded as EncodedFieldBatchV1;
 }
 
 /**
@@ -104,7 +106,7 @@ function schemaCompressedEncode(
 	idCompressor: IIdCompressor,
 	incrementalEncoder: IncrementalEncoder | undefined,
 	version: FieldBatchFormatVersion,
-): EncodedFieldBatch {
+): EncodedFieldBatchV1OrV2 {
 	return compressedEncode(
 		fieldBatch,
 		buildContext(schema, policy, idCompressor, incrementalEncoder, version),

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/uncompressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/uncompressedEncode.ts
@@ -12,15 +12,15 @@ import { brand } from "../../../util/index.js";
 import type { FluidSerializableReadOnly } from "../../valueUtilities.js";
 
 import type { FieldBatch } from "./fieldBatch.js";
-import {
-	FieldBatchFormatVersion,
-	type EncodedFieldBatch,
-	type EncodedFieldBatchV1,
-	type EncodedFieldBatchV2,
-	type EncodedNestedArrayShape,
-	type EncodedNodeShape,
-} from "./format.js";
-import type { ShapeIndex } from "./formatGeneric.js";
+import type {
+	EncodedFieldBatchV1,
+	EncodedFieldBatchV1AndV2,
+	EncodedFieldBatchV2,
+	EncodedNestedArrayShape,
+	EncodedNodeShape,
+	ShapeIndex,
+} from "./format/index.js";
+import { FieldBatchFormatVersion } from "./format/index.js";
 
 /**
  * Encode data from `cursor` in the simplest way supported by `EncodedChunk` using {@link FieldBatchFormatVersion.v1}.
@@ -49,7 +49,7 @@ export function uncompressedEncodeV2(batch: FieldBatch): EncodedFieldBatchV2 {
 function uncompressedEncode(
 	batch: FieldBatch,
 	version: FieldBatchFormatVersion,
-): EncodedFieldBatch {
+): EncodedFieldBatchV1AndV2 {
 	const rootFields = batch.map(encodeSequence);
 	return {
 		version,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
@@ -16,7 +16,6 @@ export {
 } from "./chunkTree.js";
 export { buildChunkedForest } from "./chunkedForest.js";
 export {
-	type EncodedFieldBatch,
 	FieldBatchFormatVersion,
 	type FieldBatch,
 	type FieldBatchCodec,
@@ -26,5 +25,7 @@ export {
 	type ChunkReferenceId,
 	type IncrementalEncodingPolicy,
 	defaultIncrementalEncodingPolicy,
+	type EncodedFieldBatchV1OrV2,
+	type EncodedFieldBatchV2,
 } from "./codec/index.js";
 export { emptyChunk } from "./emptyChunk.js";

--- a/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
@@ -23,7 +23,7 @@ import {
 } from "../../util/index.js";
 import type {
 	ChunkReferenceId,
-	EncodedFieldBatch,
+	EncodedFieldBatchV2,
 	IncrementalEncoderDecoder,
 	IncrementalEncodingPolicy,
 	TreeChunk,
@@ -48,7 +48,7 @@ interface ChunkLoadProperties {
 	/**
 	 * The encoded contents of the chunk.
 	 */
-	readonly encodedContents: EncodedFieldBatch;
+	readonly encodedContents: EncodedFieldBatchV2;
 	/**
 	 * The path for this chunk's contents in the summary tree relative to the forest's summary tree.
 	 * This path is used to generate a summary handle for the chunk if it doesn't change between summaries.
@@ -263,7 +263,7 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 				}
 				const chunkContents = (await args.readAndParseChunk(
 					chunkContentsPath,
-				)) as EncodedFieldBatch; // TODO: this should use a codec to validate the data instead of just type casting.
+				)) as EncodedFieldBatchV2; // TODO: this should use a codec to validate the data instead of just type casting.
 				this.loadedChunksMap.set(chunkReferenceId, {
 					encodedContents: chunkContents,
 					summaryPath: chunkSubTreePath,
@@ -336,7 +336,7 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 	 */
 	public encodeIncrementalField(
 		cursor: ITreeCursorSynchronous,
-		chunkEncoder: (chunk: TreeChunk) => EncodedFieldBatch,
+		chunkEncoder: (chunk: TreeChunk) => EncodedFieldBatchV2,
 	): ChunkReferenceId[] {
 		// Validate that a summary is currently being tracked and that the tracked summary properties are defined.
 		const trackedSummaryProperties = this.requireTrackingSummary();
@@ -478,7 +478,7 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 	 */
 	public decodeIncrementalChunk(
 		referenceId: ChunkReferenceId,
-		chunkDecoder: (encoded: EncodedFieldBatch) => TreeChunk,
+		chunkDecoder: (encoded: EncodedFieldBatchV2) => TreeChunk,
 	): TreeChunk {
 		const ChunkLoadProperties = this.loadedChunksMap.get(`${referenceId}`);
 		assert(ChunkLoadProperties !== undefined, 0xc86 /* Encoded incremental chunk not found */);

--- a/packages/dds/tree/src/feature-libraries/indexing/anchorTreeIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/indexing/anchorTreeIndex.ts
@@ -60,6 +60,8 @@ export class AnchorTreeIndex<TKey, TValue> implements TreeIndex<TKey, TValue> {
 	private readonly keyFinders = new Map<TreeNodeSchemaIdentifier, KeyFinder<TKey> | null>();
 	/**
 	 * The actual index from keys to anchor nodes.
+	 * @remarks
+	 * Should not store empty values (and thus values should be a valid {@link TreeIndexNodes}).
 	 */
 	private readonly keyToNodes = new Map<TKey, AnchorNode[]>();
 	/**
@@ -271,7 +273,8 @@ export class AnchorTreeIndex<TKey, TValue> implements TreeIndex<TKey, TValue> {
 	public *allEntries(): IterableIterator<[TKey, TValue]> {
 		this.checkNotDisposed();
 		for (const [key, nodes] of this.keyToNodes.entries()) {
-			const value = this.getValue(nodes as unknown as TreeIndexNodes<AnchorNode>);
+			assert(hasElement(nodes), "expected at least one node for each key in the index");
+			const value = this.getValue(nodes);
 			if (value !== undefined) {
 				yield [key, value];
 			}
@@ -420,13 +423,15 @@ export class AnchorTreeIndex<TKey, TValue> implements TreeIndex<TKey, TValue> {
 			indexedNodes !== undefined,
 			0xa90 /* destroyed anchor node should be tracked by index */,
 		);
-		const index = indexedNodes.indexOf(anchorNode);
-		assert(index !== -1, 0xa91 /* destroyed anchor node should be tracked by index */);
 		const newNodes = filterNodes(indexedNodes, (n) => n !== anchorNode);
-		if (newNodes !== undefined && newNodes.length > 0) {
-			this.keyToNodes.set(key, newNodes);
-		} else {
+		if (newNodes === undefined) {
 			this.keyToNodes.delete(key);
+		} else {
+			assert(
+				newNodes.length < indexedNodes.length,
+				0xa91 /* destroyed anchor node should be tracked by index */,
+			);
+			this.keyToNodes.set(key, newNodes);
 		}
 		this.nodeToKey.delete(anchorNode);
 		assert(
@@ -444,7 +449,7 @@ export class AnchorTreeIndex<TKey, TValue> implements TreeIndex<TKey, TValue> {
 			return nodeStatus === TreeStatus.InDocument;
 		});
 
-		if (attachedNodes !== undefined && hasElement(attachedNodes)) {
+		if (attachedNodes !== undefined) {
 			return this.getValue(attachedNodes);
 		}
 	}
@@ -456,11 +461,13 @@ export class AnchorTreeIndex<TKey, TValue> implements TreeIndex<TKey, TValue> {
 function filterNodes(
 	anchorNodes: readonly AnchorNode[] | undefined,
 	filter: (node: AnchorNode) => boolean,
-): AnchorNode[] | undefined {
+): (AnchorNode[] & TreeIndexNodes<AnchorNode>) | undefined {
 	if (anchorNodes !== undefined) {
-		return anchorNodes.filter(filter);
+		const filtered = anchorNodes.filter(filter);
+		if (hasElement(filtered)) {
+			return filtered;
+		}
 	}
-
 	return undefined;
 }
 

--- a/packages/dds/tree/src/test/codec/utils.ts
+++ b/packages/dds/tree/src/test/codec/utils.ts
@@ -68,8 +68,8 @@ export function makeValueCodec<Schema extends TSchema, TContext>(
 	return withSchemaValidation(
 		schema,
 		{
-			encode: (x: Static<Schema>) => x as unknown as JsonCompatibleReadOnly,
-			decode: (x: JsonCompatibleReadOnly) => x as unknown as Static<Schema>,
+			encode: (x: Static<Schema>) => x as JsonCompatibleReadOnly,
+			decode: (x: JsonCompatibleReadOnly) => x as Static<Schema>,
 		},
 		validator,
 	);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -37,7 +37,7 @@ import { ChunkedForest } from "../../../feature-libraries/chunked-forest/chunked
 // eslint-disable-next-line import-x/no-internal-modules
 import { decode } from "../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 import type {
-	EncodedFieldBatch,
+	EncodedFieldBatchV1OrV2,
 	FieldBatchEncodingContext,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/index.js";
@@ -208,10 +208,13 @@ describe("End to end chunked encoding", () => {
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
 		function stringify(content: unknown) {
-			const insertedChunk = decode((content as FormatCommon).fields as EncodedFieldBatch, {
-				idCompressor,
-				originatorId: idCompressor.localSessionId,
-			});
+			const insertedChunk = decode(
+				(content as FormatCommon).fields as EncodedFieldBatchV1OrV2,
+				{
+					idCompressor,
+					originatorId: idCompressor.localSessionId,
+				},
+			);
 			assert.equal(insertedChunk, chunk);
 			assert(chunk.isShared());
 			return JSON.stringify(content);
@@ -241,10 +244,13 @@ describe("End to end chunked encoding", () => {
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
 		function stringify(content: unknown) {
-			const insertedChunk = decode((content as FormatCommon).fields as EncodedFieldBatch, {
-				idCompressor,
-				originatorId: idCompressor.localSessionId,
-			});
+			const insertedChunk = decode(
+				(content as FormatCommon).fields as EncodedFieldBatchV1OrV2,
+				{
+					idCompressor,
+					originatorId: idCompressor.localSessionId,
+				},
+			);
 			assert.equal(insertedChunk, chunk);
 			assert(chunk.isShared());
 			return JSON.stringify(content);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -23,10 +23,10 @@ import type {
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/compressedEncode.js";
 import type {
-	EncodedFieldBatch,
+	EncodedFieldBatchV1OrV2,
 	FieldBatchFormatVersion,
 	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format.js";
+} from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { IncrementalDecoder } from "../../../../feature-libraries/chunked-forest/codec/index.js";
 import {
@@ -95,7 +95,7 @@ function testDecode(
 	version: FieldBatchFormatVersion,
 	idCompressor?: IIdCompressor,
 	incrementalDecoder?: IncrementalDecoder,
-): EncodedFieldBatch {
+): EncodedFieldBatchV1OrV2 {
 	const chunk = updateShapesAndIdentifiersEncoding(
 		version,
 		cloneArrays(buffer),

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
@@ -31,9 +31,10 @@ import {
 } from "../../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { DecoderContext } from "../../../../feature-libraries/chunked-forest/codec/chunkDecodingGeneric.js";
-import type {
-	ChunkReferenceId,
-	IncrementalDecoder,
+import {
+	fieldBatchCodecBuilder,
+	type ChunkReferenceId,
+	type IncrementalDecoder,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/codecs.js";
 import {
@@ -44,10 +45,6 @@ import {
 	SpecialField,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
-import {
-	validVersions,
-	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 import {
 	emptyChunk,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -101,7 +98,9 @@ describe("chunkDecoding", () => {
 	describe("decode", () => {
 		// Smoke test for top level decode function.
 		// All real functionality should be tested in more specific tests.
-		for (const version of validVersions) {
+		for (const version of fieldBatchCodecBuilder.registry.map(
+			(entry) => entry.formatVersion,
+		)) {
 			describe(`FieldBatchFormatVersion ${version}`, () => {
 				it("minimal", () => {
 					const result = decode(

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
@@ -37,14 +37,17 @@ import type {
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/codecs.js";
 import {
-	type EncodedChunkShape,
-	SpecialField,
-	FieldBatchFormatVersion,
-	type EncodedFieldBatch,
+	type EncodedChunkShapeV1,
+	type EncodedFieldBatchV1OrV2,
 	type EncodedNodeShape,
+	FieldBatchFormatVersion,
+	SpecialField,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
+import {
 	validVersions,
 	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format.js";
+} from "../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 import {
 	emptyChunk,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -400,7 +403,7 @@ describe("chunkDecoding", () => {
 			const cache = new DecoderContext(
 				["key"],
 				// This is unused, but used to bounds check the index into decoders, so it needs 2 items.
-				[null as unknown as EncodedChunkShape, null as unknown as EncodedChunkShape],
+				[null as unknown as EncodedChunkShapeV1, null as unknown as EncodedChunkShapeV1],
 				idDecodingContext,
 				undefined /* incrementalDecoder */,
 			);
@@ -435,7 +438,7 @@ describe("chunkDecoding", () => {
 		const fieldBatchVersion = brand<FieldBatchFormatVersion>(FieldBatchFormatVersion.v2);
 
 		function createMockIncrementalDecoder(
-			chunksMap: Map<ChunkReferenceId, EncodedFieldBatch>,
+			chunksMap: Map<ChunkReferenceId, EncodedFieldBatchV1OrV2>,
 		): IncrementalDecoder {
 			return {
 				decodeIncrementalChunk: (referenceId, chunkDecoder) => {
@@ -449,7 +452,7 @@ describe("chunkDecoding", () => {
 		function createMockEncodedIdentifierBatch(
 			nodeIdentifier: TreeNodeSchemaIdentifier,
 			value: TreeValue,
-		): EncodedFieldBatch {
+		): EncodedFieldBatchV1OrV2 {
 			const shape: EncodedNodeShape = {
 				type: nodeIdentifier,
 				value: SpecialField.Identifier,
@@ -469,13 +472,13 @@ describe("chunkDecoding", () => {
 
 		it("empty", () => {
 			const referenceId = brand<ChunkReferenceId>(0);
-			const emptyBatch: EncodedFieldBatch = {
+			const emptyBatch: EncodedFieldBatchV1OrV2 = {
 				version: fieldBatchVersion,
 				identifiers: [],
 				shapes: [{ a: 0 }],
 				data: [[0, []]],
 			};
-			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatch>();
+			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatchV1OrV2>();
 			chunksMap.set(referenceId, emptyBatch);
 
 			const mockIncrementalDecoder = createMockIncrementalDecoder(chunksMap);
@@ -491,11 +494,11 @@ describe("chunkDecoding", () => {
 			const referenceId = brand<ChunkReferenceId>(1);
 			const compressedId = testIdCompressor.generateCompressedId();
 			const nodeIdentifier: TreeNodeSchemaIdentifier = brand("identifier");
-			const batch: EncodedFieldBatch = createMockEncodedIdentifierBatch(
+			const batch: EncodedFieldBatchV1OrV2 = createMockEncodedIdentifierBatch(
 				nodeIdentifier,
 				compressedId,
 			);
-			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatch>();
+			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatchV1OrV2>();
 
 			chunksMap.set(referenceId, batch);
 			const mockIncrementalDecoder = createMockIncrementalDecoder(chunksMap);
@@ -517,7 +520,7 @@ describe("chunkDecoding", () => {
 			const referenceId2 = brand<ChunkReferenceId>(2);
 			const nodeIdentifier: TreeNodeSchemaIdentifier = brand("identifier");
 			// The encoded incremental chunk contains a nested array with another incremental chunk.
-			const batch1: EncodedFieldBatch = {
+			const batch1: EncodedFieldBatchV1OrV2 = {
 				version: fieldBatchVersion,
 				identifiers: [],
 				shapes: [
@@ -532,12 +535,12 @@ describe("chunkDecoding", () => {
 			};
 
 			const compressedId2 = testIdCompressor.generateCompressedId();
-			const batch2: EncodedFieldBatch = createMockEncodedIdentifierBatch(
+			const batch2: EncodedFieldBatchV1OrV2 = createMockEncodedIdentifierBatch(
 				nodeIdentifier,
 				compressedId2,
 			);
 
-			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatch>();
+			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatchV1OrV2>();
 			chunksMap.set(referenceId1, batch1);
 			chunksMap.set(referenceId2, batch2);
 
@@ -576,13 +579,13 @@ describe("chunkDecoding", () => {
 
 		it("fails for unsupported FieldBatchFormatVersion.v1", () => {
 			const referenceId = brand<ChunkReferenceId>(0);
-			const emptyBatch: EncodedFieldBatch = {
+			const emptyBatch: EncodedFieldBatchV1OrV2 = {
 				version: brand(FieldBatchFormatVersion.v1),
 				identifiers: [],
 				shapes: [{ a: 0 }],
 				data: [[0, []]],
 			};
-			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatch>();
+			const chunksMap = new Map<ChunkReferenceId, EncodedFieldBatchV1OrV2>();
 			chunksMap.set(referenceId, emptyBatch);
 
 			const mockIncrementalDecoder = createMockIncrementalDecoder(chunksMap);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -25,7 +25,7 @@ import {
 import {
 	EncodedFieldBatchGeneric,
 	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/formatGeneric.js";
+} from "../../../../feature-libraries/chunked-forest/codec/format/formatGeneric.js";
 import {
 	FieldBatchFormatVersion,
 	type TreeChunk,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -54,15 +54,18 @@ import {
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/compressedEncode.js";
 import {
-	type EncodedChunkShape,
-	EncodedFieldBatch,
+	type EncodedChunkShapeV1,
 	EncodedFieldBatchV1,
 	EncodedFieldBatchV2,
+	type EncodedFieldBatchV1OrV2,
 	type EncodedValueShape,
 	FieldBatchFormatVersion,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
+import {
 	validVersions,
 	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format.js";
+} from "../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 import type {
 	ChunkReferenceId,
 	IncrementalDecoder,
@@ -113,11 +116,14 @@ function makeFieldBatchCodec(
 			minVersionForCollab: lowestMinVersionForCollab,
 			formatVersion: version,
 			codec: {
-				encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {
+				encode: (
+					data: FieldBatch,
+					context: FieldBatchEncodingContext,
+				): EncodedFieldBatchV1OrV2 => {
 					return compressedEncode(data, encoderContext);
 				},
 				decode: (
-					data: EncodedFieldBatchV1 | EncodedFieldBatchV2,
+					data: EncodedFieldBatchV1OrV2,
 					fieldBatchContext: FieldBatchEncodingContext,
 				): FieldBatch => {
 					// TODO: consider checking data is in schema.
@@ -188,17 +194,18 @@ describe("compressedEncode", () => {
 	const mockHandle = new MockHandle("x");
 
 	describe("encodeValue", () => {
-		const testValues: [string, Value, EncodedValueShape, BufferFormat<EncodedChunkShape>][] = [
-			["none", undefined, false, []],
-			["optional none", undefined, undefined, [false]],
-			["optional some", 5, undefined, [true, 5]],
-			["handle", mockHandle, undefined, [true, mockHandle]],
-			["required", false, true, [false]],
-			["constant", 5, [5], []],
-		];
+		const testValues: [string, Value, EncodedValueShape, BufferFormat<EncodedChunkShapeV1>][] =
+			[
+				["none", undefined, false, []],
+				["optional none", undefined, undefined, [false]],
+				["optional some", 5, undefined, [true, 5]],
+				["handle", mockHandle, undefined, [true, mockHandle]],
+				["required", false, true, [false]],
+				["constant", 5, [5], []],
+			];
 		for (const [name, value, shape, encoded] of testValues) {
 			it(name, () => {
-				const buffer: BufferFormat<EncodedChunkShape> = [];
+				const buffer: BufferFormat<EncodedChunkShapeV1> = [];
 				encodeValue(value, shape, buffer);
 				assert.deepEqual(buffer, encoded);
 				const processed = updateShapesAndIdentifiersEncoding(fieldBatchVersion, [buffer]);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -62,10 +62,6 @@ import {
 	FieldBatchFormatVersion,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
-import {
-	validVersions,
-	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 import type {
 	ChunkReferenceId,
 	IncrementalDecoder,
@@ -87,6 +83,7 @@ import {
 	defaultIncrementalEncodingPolicy,
 	fieldKinds,
 	jsonableTreeFromFieldCursor,
+	fieldBatchCodecBuilder,
 } from "../../../../feature-libraries/index.js";
 import { type JsonCompatibleReadOnly, brand } from "../../../../util/index.js";
 import { testTrees as schemalessTestTrees } from "../../../cursorTestSuite.js";
@@ -144,7 +141,7 @@ const fieldBatchVersion = brand<FieldBatchFormatVersion>(FieldBatchFormatVersion
 describe("compressedEncode", () => {
 	// This is a good smoke test for compressedEncode,
 	// but also provides good coverage of anyNodeEncoder, anyFieldEncoder as well as AnyShape which they are built on.
-	for (const version of validVersions) {
+	for (const version of fieldBatchCodecBuilder.registry.map((entry) => entry.formatVersion)) {
 		describe(`schemaless test trees FieldBatchFormatVersion V${version}`, () => {
 			useSnapshotDirectory(`chunked-forest-compressed-schemaless/V${version}`);
 			for (const [name, jsonable] of schemalessTestTrees) {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	EncodedFieldBatchV1OrV2,
 	EncodedFieldBatchV1AndV2,
-	type EncodedFieldBatchV2,
-	type EncodedFieldBatchV1,
+	EncodedFieldBatchV2,
+	EncodedFieldBatchV1,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 import { allowUnused } from "../../../../../simple-tree/index.js";

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 import { allowUnused } from "../../../../../simple-tree/index.js";
 import {
+	isAssignableTo,
 	requireTrue,
 	type areSafelyAssignable,
 	type requireAssignableTo,
@@ -23,12 +24,15 @@ import {
 // This is not quite as trivial as it should be since the way we model unions is prone to this kind of issue,
 // so this validates that the fix for that (the Never added in EncodedChunkShapeV1) is working as intended.
 
+// Validated the documented properties of EncodedFieldBatchV1OrV2 and
+// EncodedFieldBatchV1AndV2 regarding what types they are equivalent to.
 allowUnused<requireTrue<areSafelyAssignable<EncodedFieldBatchV2, EncodedFieldBatchV1OrV2>>>();
 allowUnused<requireTrue<areSafelyAssignable<EncodedFieldBatchV1, EncodedFieldBatchV1AndV2>>>();
 
-allowUnused<requireFalse<areSafelyAssignable<EncodedFieldBatchV1, EncodedFieldBatchV1OrV2>>>();
-allowUnused<
-	requireFalse<areSafelyAssignable<EncodedFieldBatchV2, EncodedFieldBatchV1AndV2>>
->();
+// Validate the "Never" in V1's shape is working to ensure V2 is NOT assignable to V1.
+// This is important since V2 supports incremental chunk shapes that V1 does not support.
+allowUnused<requireFalse<isAssignableTo<EncodedFieldBatchV2, EncodedFieldBatchV1>>>();
+allowUnused<requireFalse<isAssignableTo<EncodedFieldBatchV2, EncodedFieldBatchV1AndV2>>>();
 
+// V1 is assignable to V2: V2 is backward-compatible and can represent all V1 data.
 allowUnused<requireAssignableTo<EncodedFieldBatchV1, EncodedFieldBatchV2>>();

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
@@ -18,7 +18,7 @@ import {
 	type requireFalse,
 } from "../../../../../util/index.js";
 
-// Validate assignability of the various formats is working a expected.
+// Validate assignability of the various formats is working as expected.
 // This is to ensure that code using the TypeScript types for type safety is being constrained as expected.
 // This is not quite as trivial as it should be since the way we model unions is prone to this kind of issue,
 // so this validates that the fix for that (the Never added in EncodedChunkShapeV1) is working as intended.

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/format/versions.spec.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	EncodedFieldBatchV1OrV2,
+	EncodedFieldBatchV1AndV2,
+	type EncodedFieldBatchV2,
+	type EncodedFieldBatchV1,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../../../../feature-libraries/chunked-forest/codec/format/versions.js";
+import { allowUnused } from "../../../../../simple-tree/index.js";
+import {
+	requireTrue,
+	type areSafelyAssignable,
+	type requireAssignableTo,
+	type requireFalse,
+} from "../../../../../util/index.js";
+
+// Validate assignability of the various formats is working a expected.
+// This is to ensure that code using the TypeScript types for type safety is being constrained as expected.
+// This is not quite as trivial as it should be since the way we model unions is prone to this kind of issue,
+// so this validates that the fix for that (the Never added in EncodedChunkShapeV1) is working as intended.
+
+allowUnused<requireTrue<areSafelyAssignable<EncodedFieldBatchV2, EncodedFieldBatchV1OrV2>>>();
+allowUnused<requireTrue<areSafelyAssignable<EncodedFieldBatchV1, EncodedFieldBatchV1AndV2>>>();
+
+allowUnused<requireFalse<areSafelyAssignable<EncodedFieldBatchV1, EncodedFieldBatchV1OrV2>>>();
+allowUnused<
+	requireFalse<areSafelyAssignable<EncodedFieldBatchV2, EncodedFieldBatchV1AndV2>>
+>();
+
+allowUnused<requireAssignableTo<EncodedFieldBatchV1, EncodedFieldBatchV2>>();

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
@@ -40,10 +40,6 @@ import {
 	SpecialField,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
-import {
-	validVersions,
-	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { NodeShapeBasedEncoder } from "../../../../feature-libraries/chunked-forest/codec/nodeEncoder.js";
 import {
@@ -446,7 +442,7 @@ describe("schemaBasedEncoding", () => {
 		assert.deepEqual(bufferFull, [[0]]);
 	});
 
-	for (const version of validVersions) {
+	for (const version of fieldBatchCodecBuilder.registry.map((entry) => entry.formatVersion)) {
 		describe(`test trees FieldBatchFormatVersion V${version}`, () => {
 			useSnapshotDirectory(`chunked-forest-schema-compressed/V${version}`);
 			// TODO: test non size 1 batches

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
@@ -36,11 +36,14 @@ import {
 } from "../../../../feature-libraries/chunked-forest/codec/compressedEncode.js";
 import {
 	FieldBatchFormatVersion,
+	type EncodedFieldBatchV2,
 	SpecialField,
-	validVersions,
-	type EncodedFieldBatch,
 	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/format.js";
+} from "../../../../feature-libraries/chunked-forest/codec/format/index.js";
+import {
+	validVersions,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../../../feature-libraries/chunked-forest/codec/format/versions.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { NodeShapeBasedEncoder } from "../../../../feature-libraries/chunked-forest/codec/nodeEncoder.js";
 import {
@@ -361,7 +364,7 @@ describe("schemaBasedEncoding", () => {
 				),
 				encodeIncrementalField: (
 					cursor: ITreeCursorSynchronous,
-					chunkEncoder: (chunk: TreeChunk) => EncodedFieldBatch,
+					chunkEncoder: (chunk: TreeChunk) => EncodedFieldBatchV2,
 				): ChunkReferenceId[] => {
 					const fieldKey = cursor.getFieldKey();
 					assert(fieldKey === "incrementalField", "should only encode incremental fields");

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/incrementalSummaryBuilder.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/incrementalSummaryBuilder.spec.ts
@@ -15,7 +15,7 @@ import { validateAssertionError } from "@fluidframework/test-runtime-utils/inter
 
 import type { ITreeCursorSynchronous } from "../../../core/index.js";
 import {
-	type EncodedFieldBatch,
+	type EncodedFieldBatchV1OrV2,
 	type ChunkReferenceId,
 	type TreeChunk,
 	defaultIncrementalEncodingPolicy,
@@ -97,7 +97,7 @@ const testCursor = { getFieldLength: () => 1 } as unknown as ITreeCursorSynchron
 
 const stringify = JSON.stringify;
 const mockForestSummaryRootContent = "test-summary-content";
-const mockEncodedChunk = {} as unknown as EncodedFieldBatch;
+const mockEncodedChunk = {} as unknown as EncodedFieldBatchV1OrV2;
 const initialSequenceNumber = 0;
 
 describe("ForestIncrementalSummaryBuilder", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -16,7 +16,7 @@ import { decode } from "../../feature-libraries/chunked-forest/codec/chunkDecodi
 // eslint-disable-next-line import-x/no-internal-modules
 import { uncompressedEncodeV1 } from "../../feature-libraries/chunked-forest/codec/uncompressedEncode.js";
 import type {
-	EncodedFieldBatch,
+	EncodedFieldBatchV1OrV2,
 	FieldBatchCodec,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../feature-libraries/chunked-forest/index.js";
@@ -52,7 +52,7 @@ describe("sharedTreeChangeCodec", () => {
 
 	// Dummy FieldBatchCodec codec which asserts when encoding or decoding.
 	const failFieldBatchCodec: FieldBatchCodec = {
-		encode: (): EncodedFieldBatch => assert.fail(),
+		encode: (): EncodedFieldBatchV1OrV2 => assert.fail(),
 		decode: (): FieldBatch => assert.fail(),
 		writeVersion: FieldBatchFormatVersion.v2,
 	};
@@ -107,12 +107,18 @@ describe("sharedTreeChangeCodec", () => {
 
 	it("passes down the context's schema to the fieldBatchCodec", () => {
 		const dummyFieldBatchCodec: FieldBatchCodec = {
-			encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {
+			encode: (
+				data: FieldBatch,
+				context: FieldBatchEncodingContext,
+			): EncodedFieldBatchV1OrV2 => {
 				// Checks that the context's schema matches the schema passed into the sharedTreeChangeCodec.
 				assert.equal(context.schema?.schema, dummyTestSchema);
 				return uncompressedEncodeV1(data);
 			},
-			decode: (data: EncodedFieldBatch, context: FieldBatchEncodingContext): FieldBatch => {
+			decode: (
+				data: EncodedFieldBatchV1OrV2,
+				context: FieldBatchEncodingContext,
+			): FieldBatch => {
 				return decode(data, {
 					idCompressor: context.idCompressor,
 					originatorId: context.originatorId,

--- a/packages/dds/tree/src/test/snapshots/output/codecFormats/snapshot of supported codec formats_FieldBatch_codec.json
+++ b/packages/dds/tree/src/test/snapshots/output/codecFormats/snapshot of supported codec formats_FieldBatch_codec.json
@@ -136,8 +136,7 @@
                 "type": "number"
               },
               "e": {
-                "const": 0,
-                "type": "number"
+                "not": {}
               }
             }
           }


### PR DESCRIPTION
## Description

Better seperate the version of the field batch codec format.
This ensures that schema validation will reject shapes that are specific to v2 (incremental chunks) if encoding to v1.

This also helps prepare for adding a third version.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
