### PR TITLE
fix: restore token expiry validation when maxTokenLifetimeSec is unconfigured

### DIFF
--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -366,7 +366,11 @@ export function createRouteContext(
 	restTenantThrottlers: Map<string, IThrottler>,
 ): IHistorianRouteContext {
 	const router: Router = Router();
-	const maxTokenLifetimeSec = config.get("maxTokenLifetimeSec") as number | undefined;
+	const rawMaxTokenLifetimeSec = config.get("maxTokenLifetimeSec");
+	const maxTokenLifetimeSec: number | undefined =
+		typeof rawMaxTokenLifetimeSec === "number" && Number.isFinite(rawMaxTokenLifetimeSec)
+			? rawMaxTokenLifetimeSec
+			: undefined;
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
 		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
@@ -436,9 +440,12 @@ export function verifyToken(
 				}
 			}
 
+			if (!claims.exp || !claims.iat) {
+				throw new NetworkError(403, "Invalid token expiry");
+			}
 			if (
 				maxTokenLifetimeSec !== undefined &&
-				(!claims.exp || !claims.iat || claims.exp - claims.iat > maxTokenLifetimeSec)
+				claims.exp - claims.iat > maxTokenLifetimeSec
 			) {
 				throw new NetworkError(403, "Invalid token expiry");
 			}

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -366,11 +366,7 @@ export function createRouteContext(
 	restTenantThrottlers: Map<string, IThrottler>,
 ): IHistorianRouteContext {
 	const router: Router = Router();
-	const rawMaxTokenLifetimeSec = config.get("maxTokenLifetimeSec");
-	const maxTokenLifetimeSec: number | undefined =
-		typeof rawMaxTokenLifetimeSec === "number" && Number.isFinite(rawMaxTokenLifetimeSec)
-			? rawMaxTokenLifetimeSec
-			: undefined;
+	const maxTokenLifetimeSec = config.get("maxTokenLifetimeSec") as number | undefined;
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
 		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -351,7 +351,7 @@ export function queryParamToString(value: any): string | undefined {
  */
 export interface IHistorianRouteContext {
 	router: Router;
-	maxTokenLifetimeSec: number;
+	maxTokenLifetimeSec: number | undefined;
 	tenantThrottleOptions: Partial<IThrottleMiddlewareOptions>;
 	restTenantGeneralThrottler: IThrottler | undefined;
 }
@@ -366,7 +366,7 @@ export function createRouteContext(
 	restTenantThrottlers: Map<string, IThrottler>,
 ): IHistorianRouteContext {
 	const router: Router = Router();
-	const maxTokenLifetimeSec = (config.get("maxTokenLifetimeSec") as number | null) ?? 0;
+	const maxTokenLifetimeSec = config.get("maxTokenLifetimeSec") as number | undefined;
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
 		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
@@ -380,7 +380,7 @@ export function createRouteContext(
 export function verifyToken(
 	revokedTokenChecker: IRevokedTokenChecker | undefined,
 	requiredScopes: string[],
-	maxTokenLifetimeSec: number,
+	maxTokenLifetimeSec: number | undefined,
 ): RequestHandler {
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	return async (request, response, next) => {
@@ -436,7 +436,10 @@ export function verifyToken(
 				}
 			}
 
-			if (!claims.exp || !claims.iat || claims.exp - claims.iat > maxTokenLifetimeSec) {
+			if (
+				maxTokenLifetimeSec !== undefined &&
+				(!claims.exp || !claims.iat || claims.exp - claims.iat > maxTokenLifetimeSec)
+			) {
 				throw new NetworkError(403, "Invalid token expiry");
 			}
 			const lifeTimeMSec = claims.exp * 1000 - new Date().getTime();

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -1339,10 +1339,9 @@ describe("createRouteContext", () => {
 		assert.strictEqual(ctx.restTenantGeneralThrottler, undefined);
 	});
 
-	it("maxTokenLifetimeSec is a number (0) when config key is absent", () => {
+	it("maxTokenLifetimeSec is undefined when config key is absent", () => {
 		const providerWithoutKey = new nconf.Provider({}).defaults({});
 		const ctx = createRouteContext(providerWithoutKey, throttlers);
-		assert.strictEqual(typeof ctx.maxTokenLifetimeSec, "number");
-		assert.strictEqual(ctx.maxTokenLifetimeSec, 0);
+		assert.strictEqual(ctx.maxTokenLifetimeSec, undefined);
 	});
 });


### PR DESCRIPTION
## Summary

The `createRouteContext()` refactoring in #26606 (merged March 3) added a `?? 0` null-coalescing fallback for `maxTokenLifetimeSec`. When the config key is absent (as in the Docker Historian config), this changed the value from `undefined` to `0`, causing the expiry range check to reject **every** token:

```typescript
// Before: undefined — (exp - iat > undefined) is always false → tokens pass
// After:  0         — (exp - iat > 0) is always true → all tokens rejected
```

This broke all Docker e2e test runs since March 3, causing ~1,700 auto-filed flaky test issues.

### Changes
- Allow `maxTokenLifetimeSec` to be `undefined` in `IHistorianRouteContext` and `verifyToken()`
- Keep `!claims.exp || !claims.iat` validation unconditional — tokens missing these claims are always rejected
- Only make the *range* check (`exp - iat > maxTokenLifetimeSec`) conditional on the value being configured
- Update test to assert `undefined` instead of `0` when config key is absent

Fixes [AB#62821](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/62821)

## Test plan
- [x] CI passes (historian build + server pipelines)
- [x] Docker e2e tests should stop failing with "Invalid token expiry"
- [x] Existing `createRouteContext` tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)