### PR TITLE
Deprecate IIdCompressorCore ahead of making it internal in 2.100

### DIFF
--- a/.changeset/deprecate-id-compressor-core.md
+++ b/.changeset/deprecate-id-compressor-core.md
@@ -1,0 +1,14 @@
+---
+"@fluidframework/id-compressor": minor
+"__section": deprecation
+---
+
+Deprecated `IIdCompressorCore` interface
+
+The `IIdCompressorCore` interface is deprecated and will be removed from the public API surface in 2.100.0. This also affects the return types of `createIdCompressor` and `deserializeIdCompressor`, which currently return `IIdCompressor & IIdCompressorCore` but will be narrowed to `IIdCompressor`.
+
+#### Migration
+
+- **`serialize()`**: Use the new `serializeIdCompressor(compressor, withSession)` free function instead of calling `compressor.serialize(withSession)` directly.
+- **`takeNextCreationRange()`, `takeUnfinalizedCreationRange()`, `finalizeCreationRange()`, `beginGhostSession()`**: These are internal runtime operations that should not be called by external consumers. If you depend on these APIs, please file an issue on the FluidFramework repository describing your use case.
+- **Return types of `createIdCompressor` / `deserializeIdCompressor`**: Stop relying on the `IIdCompressorCore` portion of the intersection type. Type your variables as `IIdCompressor` instead of `IIdCompressor & IIdCompressorCore`.

--- a/.changeset/deprecate-id-compressor-core.md
+++ b/.changeset/deprecate-id-compressor-core.md
@@ -3,7 +3,7 @@
 "__section": deprecation
 ---
 
-Deprecated `IIdCompressorCore` interface
+Deprecated IIdCompressorCore interface
 
 The `IIdCompressorCore` interface is deprecated and will be removed from the public API surface in 2.100.0. This also affects the return types of `createIdCompressor` and `deserializeIdCompressor`, which currently return `IIdCompressor & IIdCompressorCore` but will be narrowed to `IIdCompressor`.
 

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -46,6 +46,7 @@ import type {
 	IChannelServices,
 } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
+// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 import type { IIdCompressorCore } from "@fluidframework/id-compressor/internal";
 import {
 	isISharedObjectHandle,
@@ -547,6 +548,7 @@ export interface DDSFuzzSuiteOptions {
 	 */
 	idCompressorFactory?: (
 		summary?: FuzzSerializedIdCompressor,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	) => IIdCompressor & IIdCompressorCore;
 
 	/**
@@ -1486,6 +1488,7 @@ async function loadDetached<TChannelFactory extends IChannelFactory>(
 }
 
 function finalizeAllocatedIds(client: {
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	dataStoreRuntime: { idCompressor?: IIdCompressorCore };
 }): void {
 	const compressor = client.dataStoreRuntime.idCompressor;

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -548,7 +548,7 @@ export interface DDSFuzzSuiteOptions {
 	 */
 	idCompressorFactory?: (
 		summary?: FuzzSerializedIdCompressor,
-	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
+		// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	) => IIdCompressor & IIdCompressorCore;
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -95,6 +95,7 @@ import { FetchSource, MessageType } from "@fluidframework/driver-definitions/int
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	IIdCompressorCore,
 	IdCreationRange,
 	SerializedIdCompressorWithNoSession,
@@ -1164,6 +1165,7 @@ export class ContainerRuntime
 			idCompressorMode = desiredIdCompressorMode;
 		}
 
+		// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 		const createIdCompressorFn = (): IIdCompressor & IIdCompressorCore => {
 			/**
 			 * Because the IdCompressor emits so much telemetry, this function is used to sample
@@ -1356,6 +1358,7 @@ export class ContainerRuntime
 		return this.documentsSchemaController.sessionSchema.runtime;
 	}
 
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	private _idCompressor: (IIdCompressor & IIdCompressorCore) | undefined;
 
 	// We accumulate Id compressor Ops while Id compressor is not loaded yet (only for "delayed" mode)
@@ -1371,6 +1374,7 @@ export class ContainerRuntime
 	/**
 	 * {@inheritDoc @fluidframework/runtime-definitions#IContainerRuntimeBase.idCompressor}
 	 */
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	public get idCompressor(): (IIdCompressor & IIdCompressorCore) | undefined {
 		// Expose ID Compressor only if it's On from the start.
 		// If container uses delayed mode, then we can only expose generateDocumentUniqueId() and nothing else.
@@ -1591,6 +1595,7 @@ export class ContainerRuntime
 
 		blobManagerLoadInfo: IBlobManagerLoadInfo,
 		private readonly _storage: IContainerStorageService,
+		// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 		private readonly createIdCompressorFn: () => IIdCompressor & IIdCompressorCore,
 
 		private readonly documentsSchemaController: DocumentsSchemaController,

--- a/packages/runtime/id-compressor/api-report/id-compressor.legacy.beta.api.md
+++ b/packages/runtime/id-compressor/api-report/id-compressor.legacy.beta.api.md
@@ -44,7 +44,7 @@ export interface IIdCompressor {
     tryRecompress(uncompressed: StableId): SessionSpaceCompressedId | undefined;
 }
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export interface IIdCompressorCore {
     beginGhostSession(ghostSessionId: SessionId, ghostSessionCallback: () => void): void;
     finalizeCreationRange(range: IdCreationRange): void;
@@ -74,6 +74,12 @@ export type SerializedIdCompressorWithNoSession = SerializedIdCompressor & {
 export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & {
     readonly _hasLocalState: "1281acae-6d14-47e7-bc92-71c8ee0819cb";
 };
+
+// @beta @legacy
+export function serializeIdCompressor(compressor: IIdCompressor, withSession: true): SerializedIdCompressorWithOngoingSession;
+
+// @beta @legacy
+export function serializeIdCompressor(compressor: IIdCompressor, withSession: false): SerializedIdCompressorWithNoSession;
 
 // @public
 export type SessionId = StableId & {

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -899,10 +899,7 @@ export function toIdCompressorWithCore(
 	compressor: IIdCompressor,
 	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore {
-	assert(
-		"serialize" in compressor,
-		"Expected compressor to implement IIdCompressorCore",
-	);
+	assert("serialize" in compressor, "Expected compressor to implement IIdCompressorCore");
 	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	return compressor as IIdCompressor & IIdCompressorCore;
 }

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -40,6 +40,7 @@ import {
 } from "./sessions.js";
 import type {
 	IIdCompressor,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	IIdCompressorCore,
 	IdCreationRange,
 	OpSpaceCompressedId,
@@ -76,6 +77,7 @@ function rangeFinalizationError(expectedStart: number, actualStart: number): Log
 /**
  * See {@link IIdCompressor} and {@link IIdCompressorCore}
  */
+// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	/**
 	 * Max allowed initial cluster size.
@@ -736,23 +738,40 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 /**
  * Create a new {@link IIdCompressor}.
+ *
+ * @remarks
+ * The returned compressor previously also implemented {@link IIdCompressorCore}, but that
+ * interface is {@link IIdCompressorCore | deprecated} and will be removed from the return
+ * type in a future release. Consumers should type variables as {@link IIdCompressor} and
+ * use {@link (serializeIdCompressor:1)} for serialization instead of calling `serialize()` directly.
+ *
  * @legacy @beta
  */
 export function createIdCompressor(
 	logger?: ITelemetryBaseLogger,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore;
 /**
  * Create a new {@link IIdCompressor}.
  * @param sessionId - The seed ID for the compressor.
+ *
+ * @remarks
+ * The returned compressor previously also implemented {@link IIdCompressorCore}, but that
+ * interface is {@link IIdCompressorCore | deprecated} and will be removed from the return
+ * type in a future release. Consumers should type variables as {@link IIdCompressor} and
+ * use {@link (serializeIdCompressor:1)} for serialization instead of calling `serialize()` directly.
+ *
  * @legacy @beta
  */
 export function createIdCompressor(
 	sessionId: SessionId,
 	logger?: ITelemetryBaseLogger,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore;
 export function createIdCompressor(
 	sessionIdOrLogger?: SessionId | ITelemetryBaseLogger,
 	loggerOrUndefined?: ITelemetryBaseLogger,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore {
 	let localSessionId: SessionId;
 	let logger: ITelemetryBaseLogger | undefined;
@@ -776,25 +795,42 @@ export function createIdCompressor(
 
 /**
  * Deserializes the supplied state into an ID compressor.
+ *
+ * @remarks
+ * The returned compressor previously also implemented {@link IIdCompressorCore}, but that
+ * interface is {@link IIdCompressorCore | deprecated} and will be removed from the return
+ * type in a future release. Consumers should type variables as {@link IIdCompressor} and
+ * use {@link (serializeIdCompressor:1)} for serialization instead of calling `serialize()` directly.
+ *
  * @legacy @beta
  */
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressorWithOngoingSession,
 	logger?: ITelemetryLoggerExt,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore;
 /**
  * Deserializes the supplied state into an ID compressor.
+ *
+ * @remarks
+ * The returned compressor previously also implemented {@link IIdCompressorCore}, but that
+ * interface is {@link IIdCompressorCore | deprecated} and will be removed from the return
+ * type in a future release. Consumers should type variables as {@link IIdCompressor} and
+ * use {@link (serializeIdCompressor:1)} for serialization instead of calling `serialize()` directly.
+ *
  * @legacy @beta
  */
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressorWithNoSession,
 	newSessionId: SessionId,
 	logger?: ITelemetryLoggerExt,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore;
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressor | SerializedIdCompressorWithNoSession,
 	sessionIdOrLogger: SessionId | ITelemetryLoggerExt | undefined,
 	loggerOrUndefined?: ITelemetryLoggerExt,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 ): IIdCompressor & IIdCompressorCore {
 	if (typeof sessionIdOrLogger === "string") {
 		return IdCompressor.deserialize({
@@ -812,4 +848,61 @@ export function deserializeIdCompressor(
 		serialized: serialized as SerializedIdCompressorWithOngoingSession,
 		logger: sessionIdOrLogger,
 	});
+}
+
+/**
+ * Serializes an ID compressor.
+ * @param compressor - The compressor to serialize.
+ * @param withSession - If true, the serialized state will include local session
+ * state (for stashing). If false, only finalized state is included (for summaries).
+ * @legacy @beta
+ */
+export function serializeIdCompressor(
+	compressor: IIdCompressor,
+	withSession: true,
+): SerializedIdCompressorWithOngoingSession;
+/**
+ * Serializes an ID compressor.
+ * @param compressor - The compressor to serialize.
+ * @param withSession - If true, the serialized state will include local session
+ * state (for stashing). If false, only finalized state is included (for summaries).
+ * @legacy @beta
+ */
+export function serializeIdCompressor(
+	compressor: IIdCompressor,
+	withSession: false,
+): SerializedIdCompressorWithNoSession;
+export function serializeIdCompressor(
+	compressor: IIdCompressor,
+	withSession: boolean,
+): SerializedIdCompressorWithOngoingSession | SerializedIdCompressorWithNoSession {
+	const core = toIdCompressorWithCore(compressor);
+	return withSession ? core.serialize(true) : core.serialize(false);
+}
+
+/**
+ * Casts an {@link IIdCompressor} to include {@link IIdCompressorCore}.
+ *
+ * @remarks
+ * Compressors returned by `createIdCompressor` and `deserializeIdCompressor`
+ * always implement both {@link IIdCompressor} and {@link IIdCompressorCore}, but their
+ * return types are narrowed to {@link IIdCompressor} to keep {@link IIdCompressorCore}
+ * out of the `@legacy` API surface. Internal consumers that need access to core
+ * compressor operations (serialization, range management, etc.) should use this function.
+ *
+ * @param compressor - A compressor created by `createIdCompressor` or
+ * `deserializeIdCompressor`.
+ * @returns The same compressor, typed to include {@link IIdCompressorCore}.
+ * @internal
+ */
+export function toIdCompressorWithCore(
+	compressor: IIdCompressor,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
+): IIdCompressor & IIdCompressorCore {
+	assert(
+		"serialize" in compressor,
+		0xcd7 /* Expected compressor to implement IIdCompressorCore */,
+	);
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
+	return compressor as IIdCompressor & IIdCompressorCore;
 }

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -886,7 +886,7 @@ export function serializeIdCompressor(
  * @remarks
  * Compressors returned by `createIdCompressor` and `deserializeIdCompressor`
  * always implement both {@link IIdCompressor} and {@link IIdCompressorCore}, but their
- * return types are narrowed to {@link IIdCompressor} to keep {@link IIdCompressorCore}
+ * return types will be narrowed to {@link IIdCompressor} to keep {@link IIdCompressorCore}
  * out of the `@legacy` API surface. Internal consumers that need access to core
  * compressor operations (serialization, range management, etc.) should use this function.
  *
@@ -901,7 +901,7 @@ export function toIdCompressorWithCore(
 ): IIdCompressor & IIdCompressorCore {
 	assert(
 		"serialize" in compressor,
-		0xcd7 /* Expected compressor to implement IIdCompressorCore */,
+		"Expected compressor to implement IIdCompressorCore",
 	);
 	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	return compressor as IIdCompressor & IIdCompressorCore;

--- a/packages/runtime/id-compressor/src/index.ts
+++ b/packages/runtime/id-compressor/src/index.ts
@@ -7,7 +7,12 @@
  * Exports for `id-compressor`
  */
 
-export { createIdCompressor, deserializeIdCompressor } from "./idCompressor.js";
+export {
+	createIdCompressor,
+	deserializeIdCompressor,
+	serializeIdCompressor,
+	toIdCompressorWithCore,
+} from "./idCompressor.js";
 export {
 	createSessionId,
 	assertIsStableId,

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -9,7 +9,12 @@ import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { take } from "@fluid-private/stochastic-test-utils";
 import { createChildLogger, MockLogger } from "@fluidframework/telemetry-utils/internal";
 
-import { IdCompressor, createIdCompressor, deserializeIdCompressor } from "../idCompressor.js";
+import {
+	IdCompressor,
+	createIdCompressor,
+	deserializeIdCompressor,
+	serializeIdCompressor,
+} from "../idCompressor.js";
 import type {
 	OpSpaceCompressedId,
 	SerializedIdCompressorWithNoSession,
@@ -1148,6 +1153,25 @@ describe("IdCompressor", () => {
 			mockLogger.assertMatchAny([
 				{ eventName: "RuntimeIdCompressor:SerializedIdCompressorSize" },
 			]);
+		});
+	});
+
+	describe("serializeIdCompressor", () => {
+		it("produces the same result as the underlying serialize(true)", () => {
+			const compressor = CompressorFactory.createCompressor(Client.Client1);
+			compressor.generateCompressedId();
+			const direct = compressor.serialize(true);
+			const wrapper = serializeIdCompressor(compressor, true);
+			assert.deepStrictEqual(wrapper, direct);
+		});
+
+		it("produces the same result as the underlying serialize(false)", () => {
+			const compressor = CompressorFactory.createCompressor(Client.Client1);
+			compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			const direct = compressor.serialize(false);
+			const wrapper = serializeIdCompressor(compressor, false);
+			assert.deepStrictEqual(wrapper, direct);
 		});
 	});
 

--- a/packages/runtime/id-compressor/src/types/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/types/idCompressor.ts
@@ -75,6 +75,19 @@ import type {
  *
  * These two spaces naturally define a rule: consumers of compressed IDs should use session-space IDs, but serialized forms such as ops
  * should use op-space IDs.
+ *
+ * @privateremarks To be made internal in 2.100.0
+ *
+ * @deprecated `IIdCompressorCore` will be removed from the public API in 2.100.0.
+ *
+ * - If you use `serialize()`, use the free function
+ * {@link (serializeIdCompressor:1) | serializeIdCompressor(compressor, withSession)} instead.
+ *
+ * - `takeNextCreationRange`, `takeUnfinalizedCreationRange`, `finalizeCreationRange`, and
+ * `beginGhostSession` are internal runtime operations. External consumers should not call
+ * them directly. If you depend on these APIs, please file an issue on the FluidFramework
+ * repository describing your use case.
+ *
  * @legacy @beta
  */
 export interface IIdCompressorCore {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -50,6 +50,7 @@ import {
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import {
 	createIdCompressor,
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	type IIdCompressorCore,
 	type IdCreationRange,
 } from "@fluidframework/id-compressor/internal";
@@ -869,6 +870,7 @@ export class MockFluidDataStoreRuntime
 		entryPoint?: IFluidHandle<FluidObject>;
 		id?: string;
 		logger?: ITelemetryBaseLogger;
+		// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 		idCompressor?: IIdCompressor & IIdCompressorCore;
 		attachState?: AttachState;
 		registry?: readonly IChannelFactory[];
@@ -938,6 +940,7 @@ export class MockFluidDataStoreRuntime
 	public quorum = new MockQuorumClients();
 	private readonly audience = new MockAudience();
 	public containerRuntime?: MockContainerRuntime;
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	public idCompressor: (IIdCompressor & IIdCompressorCore) | undefined;
 	private readonly deltaConnections: MockDeltaConnection[] = [];
 	private readonly registry?: ReadonlyMap<string, IChannelFactory>;

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -17,6 +17,7 @@ import {
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
+// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 import type { IIdCompressorCore } from "@fluidframework/id-compressor/internal";
 import {
 	CreateChildSummarizerNodeFn,
@@ -57,6 +58,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public storage: IRuntimeStorageService = undefined as any;
 	public IFluidDataStoreRegistry: IFluidDataStoreRegistry = undefined as any;
 	public IFluidHandleContext: IFluidHandleContext = undefined as any;
+	// eslint-disable-next-line import-x/no-deprecated -- Will be undeprecated in 2.100.0 when it becomes an internal API
 	public idCompressor: IIdCompressorCore & IIdCompressor = undefined as any;
 	public readonly gcThrowOnTombstoneUsage = false;
 	public readonly gcTombstoneEnforcementAllowed = false;


### PR DESCRIPTION
Resolves [AB#63316](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/63316)

## Description

`IIdCompressorCore` was always meant to be an internal detail, not exposed in any API surface to consumers.  It leaked due to free functions `createIdCompressor` and `deserializeIdCompressor` including it in their return type, as well as the utility of the `serialize` function on the interface.

This PR deprecates it, including a migration plan in the changeset.

To see the final state we'll release in `2.100.0`, see 94bfedf7c91

## Breaking Changes

None, this is merely deprecating / announcing the upcoming change.  See #26903
