### PR TITLE
Deduplicate logic in charactersCopy and getString

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -106,6 +106,7 @@ export {
 	type ChunkedCursor,
 	DetachedFieldIndexFormatVersion,
 	detachedFieldIndexCodecBuilder,
+	forEachNodeSubsequence,
 } from "./tree/index.js";
 
 export {

--- a/packages/dds/tree/src/core/tree/cursor.ts
+++ b/packages/dds/tree/src/core/tree/cursor.ts
@@ -429,6 +429,7 @@ export function forEachNode<TCursor extends ITreeCursor = ITreeCursor>(
 
 /**
  * Iterates over a subrange of nodes in the current field, invoking a callback for each.
+ * See {@link forEachNode} for a version that visits all nodes in the field.
  *
  * @param cursor - cursor at a field whose nodes will be visited.
  * @param startIndex - index of first node to visit. Must be non-negative.

--- a/packages/dds/tree/src/core/tree/cursor.ts
+++ b/packages/dds/tree/src/core/tree/cursor.ts
@@ -442,7 +442,7 @@ export function forEachNodeSubsequence<TCursor extends ITreeCursor = ITreeCursor
 	endIndex: number,
 	f: (cursor: TCursor) => void,
 ): void {
-	assert(cursor.mode === CursorLocationType.Fields, 0x3bd /* should be in fields */);
+	assert(cursor.mode === CursorLocationType.Fields, "should be in fields");
 
 	assert(startIndex >= 0, "invalid startIndex");
 	assert(endIndex >= startIndex, "invalid endIndex");

--- a/packages/dds/tree/src/core/tree/cursor.ts
+++ b/packages/dds/tree/src/core/tree/cursor.ts
@@ -428,7 +428,7 @@ export function forEachNode<TCursor extends ITreeCursor = ITreeCursor>(
 }
 
 /**
- * Iterates over each node in the current field, invoking a callback for each.
+ * Iterates over a subrange of nodes in the current field, invoking a callback for each.
  *
  * @param cursor - cursor at a field whose nodes will be visited.
  * @param startIndex - index of first node to visit. Must be non-negative.

--- a/packages/dds/tree/src/core/tree/cursor.ts
+++ b/packages/dds/tree/src/core/tree/cursor.ts
@@ -134,7 +134,7 @@ export interface ITreeCursor {
 	getFieldKey(): FieldKey;
 
 	/**
-	 * @returns the number of immediate children in the current field.
+	 * Returns the number of immediate children in the current field.
 	 *
 	 * Allowed when `mode` is `Fields`, and not `pending`.
 	 */
@@ -334,6 +334,8 @@ export interface ITreeCursorSynchronous extends ITreeCursor {
 }
 
 /**
+ * Applies a mapping function to each field of the current node, returning the results as an array.
+ *
  * @param cursor - tree whose fields will be visited.
  * @param f - builds output from field, which will be selected in cursor when cursor is provided.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
@@ -353,6 +355,8 @@ export function mapCursorFields<T, TCursor extends ITreeCursor = ITreeCursor>(
 }
 
 /**
+ * Iterates over each field of the current node, invoking a callback for each.
+ *
  * @param cursor - cursor at a node whose fields will be visited.
  * @param f - For on each field.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
@@ -368,6 +372,8 @@ export function forEachField<TCursor extends ITreeCursor = ITreeCursor>(
 }
 
 /**
+ * Applies a mapping function to each node of the current field, returning the results as an array.
+ *
  * @param cursor - tree whose field will be visited.
  * @param f - builds output from field member, which will be selected in cursor when cursor is provided.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
@@ -386,6 +392,8 @@ export function mapCursorField<T, TCursor extends ITreeCursor = ITreeCursor>(
 }
 
 /**
+ * Lazily iterates over each node in the current field, yielding the result of applying a mapping function to each.
+ *
  * @param cursor - The tree whose field will be visited.
  * @param f - Builds output from field member, which will be selected in cursor when cursor is provided.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
@@ -403,6 +411,8 @@ export function* iterateCursorField<T, TCursor extends ITreeCursor = ITreeCursor
 }
 
 /**
+ * Iterates over each node in the current field, invoking a callback for each.
+ *
  * @param cursor - cursor at a field whose nodes will be visited.
  * @param f - For on each node.
  * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
@@ -418,6 +428,46 @@ export function forEachNode<TCursor extends ITreeCursor = ITreeCursor>(
 }
 
 /**
+ * Iterates over each node in the current field, invoking a callback for each.
+ *
+ * @param cursor - cursor at a field whose nodes will be visited.
+ * @param startIndex - index of first node to visit. Must be non-negative.
+ * @param endIndex - index of first node to NOT visit. Must be greater than or equal to `startIndex`.
+ * @param f - For on each node.
+ * If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
+ */
+export function forEachNodeSubsequence<TCursor extends ITreeCursor = ITreeCursor>(
+	cursor: TCursor,
+	startIndex: number,
+	endIndex: number,
+	f: (cursor: TCursor) => void,
+): void {
+	assert(cursor.mode === CursorLocationType.Fields, 0x3bd /* should be in fields */);
+
+	assert(startIndex >= 0, "invalid startIndex");
+	assert(endIndex >= startIndex, "invalid endIndex");
+	const outputLength = endIndex - startIndex;
+	if (outputLength === 0) {
+		// Avoids out of bounds index on cursor.enterNode when requesting 0 length subarray at end of array.
+		return;
+	}
+
+	cursor.enterNode(startIndex);
+	for (let i = 0; i < outputLength; i++) {
+		f(cursor);
+		const hasNext = cursor.nextNode();
+		if (!hasNext) {
+			assert(i === outputLength - 1, "requested endIndex is out of bounds");
+			return;
+		}
+	}
+	cursor.exitNode();
+}
+
+/**
+ * Deeply iterates over each node in the current subtree (rooted at a node or field),
+ * invoking a callback for each.
+ *
  * @param cursor - cursor at a field or node.
  * @param f - Function to invoke for each node.
  * If `f` moves the cursor, it must put it back to where it was at the beginning of `f` before returning.

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -29,6 +29,7 @@ export {
 	inCursorNode,
 	CursorMarker,
 	isCursor,
+	forEachNodeSubsequence,
 } from "./cursor.js";
 export type {
 	ProtoNodes,

--- a/packages/dds/tree/src/test/core/tree/cursor.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/cursor.spec.ts
@@ -1,0 +1,98 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+
+import {
+	CursorLocationType,
+	forEachNodeSubsequence,
+	type TreeNodeSchemaIdentifier,
+} from "../../../core/index.js";
+import { cursorForJsonableTreeField } from "../../../feature-libraries/index.js";
+import { numberSchema } from "../../../simple-tree/index.js";
+import { brand } from "../../../util/index.js";
+
+/** Creates a cursor in Fields mode over nodes with values 0 through length - 1. */
+function makeFieldCursor(length: number) {
+	const numberType = brand<TreeNodeSchemaIdentifier>(numberSchema.identifier);
+	const cursor = cursorForJsonableTreeField(
+		Array.from({ length }, (_, i) => ({ type: numberType, value: i })),
+	);
+	assert.equal(cursor.mode, CursorLocationType.Fields);
+	return cursor;
+}
+
+describe("cursor", () => {
+	describe("forEachNodeSubsequence", () => {
+		/**
+		 * Validates that forEachNodeSubsequence visits exactly the nodes at indices
+		 * [startIndex, endIndex) and leaves the cursor in Fields mode afterward.
+		 */
+		function checkSubsequence(length: number, startIndex: number, endIndex: number): void {
+			const cursor = makeFieldCursor(length);
+			const visited: number[] = [];
+			forEachNodeSubsequence(cursor, startIndex, endIndex, (c) => {
+				visited.push(c.value as number);
+			});
+			const expected = Array.from({ length: endIndex - startIndex }, (_, i) => startIndex + i);
+			assert.deepEqual(visited, expected);
+			assert.equal(cursor.mode, CursorLocationType.Fields);
+		}
+
+		it("visits all nodes when range covers entire field", () => {
+			checkSubsequence(3, 0, 3);
+		});
+
+		it("visits a middle subsequence", () => {
+			checkSubsequence(5, 1, 4);
+		});
+
+		it("visits only the first node", () => {
+			checkSubsequence(3, 0, 1);
+		});
+
+		it("visits only the last node", () => {
+			checkSubsequence(3, 2, 3);
+		});
+
+		it("visits nothing for empty range (startIndex === endIndex)", () => {
+			checkSubsequence(3, 1, 1);
+		});
+
+		it("visits nothing for zero-length range at end of field", () => {
+			checkSubsequence(2, 2, 2);
+		});
+
+		it("visits nothing when field is empty and range is [0, 0)", () => {
+			checkSubsequence(0, 0, 0);
+		});
+
+		it("throws for negative startIndex", () => {
+			const cursor = makeFieldCursor(2);
+			assert.throws(
+				() => forEachNodeSubsequence(cursor, -1, 1, () => {}),
+				validateAssertionError(/invalid startIndex/),
+			);
+		});
+
+		it("throws when endIndex is less than startIndex", () => {
+			const cursor = makeFieldCursor(2);
+			assert.throws(
+				() => forEachNodeSubsequence(cursor, 2, 1, () => {}),
+				validateAssertionError(/invalid endIndex/),
+			);
+		});
+
+		it("throws when endIndex is out of bounds", () => {
+			const cursor = makeFieldCursor(2);
+			assert.throws(
+				() => forEachNodeSubsequence(cursor, 0, 3, () => {}),
+				validateAssertionError(/requested endIndex is out of bounds/),
+			);
+		});
+	});
+});

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -8,7 +8,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	EmptyKey,
-	mapCursorField,
+	forEachNodeSubsequence,
 	type FieldKey,
 	type ITreeCursorSynchronous,
 } from "../core/index.js";
@@ -223,9 +223,10 @@ class StringArray extends sf.array("StringArray", [() => FormattedTextAsTree.Str
 		return result;
 	}
 
-	public charactersCopy(): string[] {
-		return this.withBorrowedSequenceCursor((cursor) =>
-			mapCursorField(cursor, () => {
+	private getCharactersSubarray(startIndex: number, endIndex: number): string[] {
+		return this.withBorrowedSequenceCursor((cursor) => {
+			const result: string[] = [];
+			forEachNodeSubsequence(cursor, startIndex, endIndex, () => {
 				debugAssert(
 					() =>
 						cursor.type === FormattedTextAsTree.StringAtom.identifier ||
@@ -256,55 +257,25 @@ class StringArray extends sf.array("StringArray", [() => FormattedTextAsTree.Str
 				}
 				cursor.exitNode();
 				cursor.exitField();
-				return content;
-			}),
-		);
+				result.push(content);
+			});
+			return result;
+		});
+	}
+
+	public charactersCopy(): string[] {
+		return this.getCharactersSubarray(0, this.length);
 	}
 
 	public fullString(): string {
 		return this.charactersCopy().join("");
 	}
-	public getString(startIndex: number, endIndex?: number): string {
-		const arrayLength = this.length;
-		if (startIndex < 0 || startIndex >= arrayLength) {
-			return "";
-		}
-		return this.withBorrowedSequenceCursor((cursor) => {
-			const limit = Math.min(endIndex ?? arrayLength, arrayLength) - startIndex;
-			let result = "";
 
-			cursor.enterNode(startIndex);
-			for (let index = 0; index < limit; index++) {
-				if (index > 0 && !cursor.nextNode()) {
-					break;
-				}
-
-				cursor.enterField(EmptyKey);
-				cursor.enterNode(0);
-				switch (cursor.type) {
-					case FormattedTextAsTree.StringTextAtom.identifier: {
-						cursor.enterField(EmptyKey);
-						cursor.enterNode(0);
-						result += cursor.value as string;
-						cursor.exitNode();
-						cursor.exitField();
-						break;
-					}
-					case FormattedTextAsTree.StringLineAtom.identifier: {
-						result += "\n";
-						break;
-					}
-					default: {
-						fail(0xcde /* Unsupported node type in text array */, () => `${cursor.type}`);
-					}
-				}
-				cursor.exitNode();
-				cursor.exitField();
-			}
-			cursor.exitNode();
-			return result;
-		});
+	public getString(startIndex: number, endIndex: number = this.length): string {
+		validateIndexRange(startIndex, endIndex, this, "FormattedTextAsTree.getString");
+		return this.getCharactersSubarray(startIndex, endIndex).join("");
 	}
+
 	public getUniformRun(startIndex: number, endIndex: number = this.length): number {
 		validateIndexRange(startIndex, endIndex, this, "FormattedTextAsTree.getUniformRun");
 		if (endIndex === startIndex) {


### PR DESCRIPTION
## Description

Deduplicate logic in charactersCopy and getString.

Add new forEachNodeSubsequence utility.

Make getString more strict about its inputs (and give nice errors).

Fix that there was a duplicated assert short code (blocking assert tagging for release).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

