### PR TITLE
Add telemetry to DistributedTokenBucketThrottler

### DIFF
--- a/server/routerlicious/packages/services/src/throttling/distributedTokenBucketThrottler.ts
+++ b/server/routerlicious/packages/services/src/throttling/distributedTokenBucketThrottler.ts
@@ -217,22 +217,24 @@ export class DistributedTokenBucketThrottler implements IThrottler {
 			`Token bucket for ${id} is exhausted`,
 			retryAfterInSeconds,
 		);
-		if (this.config.enableEnhancedTelemetry) {
-			const telemetryProperties = getThrottlingBaseTelemetryProperties(id);
-			this.logger?.warn(`Token bucket for ${id} is exhausted`, {
+		const telemetryProperties = getThrottlingBaseTelemetryProperties(id);
+		this.logger?.warn(`Token bucket for ${id} is exhausted`, {
+			...telemetryProperties.baseLumberjackProperties,
+			retryAfterInSeconds,
+			localRetryAfterInMs: timeUntilLocalTokensCanBeConsumedMs,
+			distributedRetryAfterInMs: timeUntilDistributedTokensCanBeConsumedMs,
+			error: throttlingError,
+		});
+		Lumberjack.warning(
+			`Token bucket for ${id} is exhausted`,
+			{
 				...telemetryProperties.baseLumberjackProperties,
 				retryAfterInSeconds,
-				error: throttlingError,
-			});
-			Lumberjack.warning(
-				`Token bucket for ${id} is exhausted`,
-				{
-					...telemetryProperties.baseLumberjackProperties,
-					retryAfterInSeconds,
-				},
-				throttlingError,
-			);
-		}
+				localRetryAfterInMs: timeUntilLocalTokensCanBeConsumedMs,
+				distributedRetryAfterInMs: timeUntilDistributedTokensCanBeConsumedMs,
+			},
+			throttlingError,
+		);
 		throw throttlingError;
 	}
 

--- a/server/routerlicious/packages/services/src/throttling/distributedTokenBucketThrottler.ts
+++ b/server/routerlicious/packages/services/src/throttling/distributedTokenBucketThrottler.ts
@@ -219,10 +219,12 @@ export class DistributedTokenBucketThrottler implements IThrottler {
 		);
 		const telemetryProperties = getThrottlingBaseTelemetryProperties(id);
 		this.logger?.warn(`Token bucket for ${id} is exhausted`, {
-			...telemetryProperties.baseLumberjackProperties,
-			retryAfterInSeconds,
-			localRetryAfterInMs: timeUntilLocalTokensCanBeConsumedMs,
-			distributedRetryAfterInMs: timeUntilDistributedTokensCanBeConsumedMs,
+			messageMetaData: {
+				...telemetryProperties.baseMessageMetaData,
+				retryAfterInSeconds,
+				localRetryAfterInMs: timeUntilLocalTokensCanBeConsumedMs,
+				distributedRetryAfterInMs: timeUntilDistributedTokensCanBeConsumedMs,
+			},
 			error: throttlingError,
 		});
 		Lumberjack.warning(


### PR DESCRIPTION
## Description

Removes the "enableEnhancedTelemetry" check for the 'token bucket for ${id} is exhausted' log, this is so that we are able to determine the type of throttling that is occurring based on server-side telemetry.
Additionally adds localRetryAfterInMs and distributedRetryAfterInMs properties, used to determine from server telemetry whether it was a local token bucket throttle or a distributed token bucket throttle.