### PR TITLE
fix: upgrade @azure/msal-browser to v5 in shared-tree-demo

### DIFF
--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -32,7 +32,7 @@
 		"webpack:dev": "webpack --env development"
 	},
 	"dependencies": {
-		"@azure/msal-browser": "^3.25.0",
+		"@azure/msal-browser": "^5.0.0",
 		"@fluidframework/odsp-client": "workspace:~",
 		"@fluidframework/odsp-doclib-utils": "workspace:~",
 		"css-loader": "^7.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4705,8 +4705,8 @@ importers:
   examples/service-clients/odsp-client/shared-tree-demo:
     dependencies:
       '@azure/msal-browser':
-        specifier: ^3.25.0
-        version: 3.30.0
+        specifier: ^5.0.0
+        version: 5.6.1
       '@fluidframework/odsp-client':
         specifier: workspace:~
         version: link:../../../../packages/service-clients/odsp-client
@@ -17201,20 +17201,12 @@ packages:
     resolution: {integrity: sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/msal-browser@3.30.0':
-    resolution: {integrity: sha512-I0XlIGVdM4E9kYP5eTjgW8fgATdzwxJvQ6bm2PNiHaZhEuUz47NYw1xHthC9R+lXz4i9zbShS0VdLyxd7n0GGA==}
-    engines: {node: '>=0.8.0'}
-
   '@azure/msal-browser@5.6.1':
     resolution: {integrity: sha512-Ylmp8yngH7YRLV5mA1aF4CNS6WsJTPbVXaA0Tb1x1Gv/J3BM3hE4Q7nDaf7dRfU00FcxDBBudTjqlpH74ZSsgw==}
     engines: {node: '>=0.8.0'}
 
   '@azure/msal-common@14.16.0':
     resolution: {integrity: sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-common@14.16.1':
-    resolution: {integrity: sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==}
     engines: {node: '>=0.8.0'}
 
   '@azure/msal-common@16.4.0':
@@ -28346,17 +28338,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/msal-browser@3.30.0':
-    dependencies:
-      '@azure/msal-common': 14.16.1
-
   '@azure/msal-browser@5.6.1':
     dependencies:
       '@azure/msal-common': 16.4.0
 
   '@azure/msal-common@14.16.0': {}
-
-  '@azure/msal-common@14.16.1': {}
 
   '@azure/msal-common@16.4.0': {}
 


### PR DESCRIPTION
## Summary

- Upgrades `@azure/msal-browser` from `^3.25.0` to `^5.0.0` (resolves to `5.6.1`) in `@fluid-example/shared-tree-demo`
- Resolves a known security vulnerability — no patched `3.x` release exists
- Removes `@azure/msal-browser@3.30.0` from the lockfile entirely

## Compatibility

The v5 API used in `src/tokenProvider.ts` is fully compatible: `PublicClientApplication`, `initialize()`, `getAllAccounts()`, `loginPopup()`, `setActiveAccount()`, and `acquireTokenSilent()` are unchanged between v3 and v5.

## Test plan

- [x] CI passes across all workspace pipelines
- [x] `pnpm-lock.yaml` no longer references `@azure/msal-browser@3.30.0`
- [ ] Manual verification: odsp-client shared-tree-demo runs end-to-end with MSAL auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)