### PR TITLE
Fixes issue in documentation generated by live site

### DIFF
--- a/docs/docs/data-structures/tree/transactions.mdx
+++ b/docs/docs/data-structures/tree/transactions.mdx
@@ -222,23 +222,14 @@ view.runTransaction(
 ```
 
 If `importantNode` is removed by a concurrent edit that is sequenced before this transaction, the transaction will be rolled back.
-
-:::note
-
 The `nodeInDocument` constraint is also available for use in the old transaction API via `Tree.runTransaction`.
 This is the only constraint which can be applied via `Tree.runTransaction`.
 
-:::
 
 #### `noChange` (Alpha)
 
 Requires that the document is in the exact same state when the transaction is applied as it was when the transaction was created.
 If _any_ concurrent edit is sequenced before the transaction, the constraint is violated and the transaction is rolled back.
-
-In some cases, SharedTree will attempt reapply transactions whose noChange constraint was violated.
-This happens when we detect that no visible change has occurred - eg, if an element was added and then removed, the add
-would violate noChange, but then with the remove happening directly after, we will reset the violated state of that constraint and apply its original transaction.
-
 
 ```typescript
 view.runTransaction(

--- a/docs/docs/data-structures/tree/transactions.mdx
+++ b/docs/docs/data-structures/tree/transactions.mdx
@@ -235,13 +235,10 @@ This is the only constraint which can be applied via `Tree.runTransaction`.
 Requires that the document is in the exact same state when the transaction is applied as it was when the transaction was created.
 If _any_ concurrent edit is sequenced before the transaction, the constraint is violated and the transaction is rolled back.
 
-:::note
-
 In some cases, SharedTree will attempt reapply transactions whose noChange constraint was violated.
 This happens when we detect that no visible change has occurred - eg, if an element was added and then removed, the add
-would violate noChange, but then with the remove happening directly after, we will unviolate the noChange constraint.
+would violate noChange, but then with the remove happening directly after, we will reset the violated state of that constraint and apply its original transaction.
 
-:::
 
 ```typescript
 view.runTransaction(


### PR DESCRIPTION
The doc pipeline is failing; this change removes the faulting block and removes a word that isnt a word