### PR TITLE
chore(lint): move inline type imports to import type statements in drivers

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -15,21 +15,20 @@ import type {
 	IConnect,
 	IConnected,
 	IDocumentMessage,
+	ISentSignalMessage,
 	ISignalClient,
 	ITokenClaims,
 	ISequencedDocumentMessage,
 	ISignalMessage,
 } from "@fluidframework/driver-definitions/internal";
-import {
-	type ISentSignalMessage,
-	ScopeType,
-} from "@fluidframework/driver-definitions/internal";
+import { ScopeType } from "@fluidframework/driver-definitions/internal";
 import {
 	UsageError,
 	createGenericNetworkError,
 	type DriverErrorTelemetryProps,
 } from "@fluidframework/driver-utils/internal";
 import type {
+	IFluidErrorBase,
 	ITelemetryLoggerExt,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
@@ -40,7 +39,6 @@ import {
 	getCircularReplacer,
 	isFluidError,
 	normalizeError,
-	type IFluidErrorBase,
 } from "@fluidframework/telemetry-utils/internal";
 import type { Socket } from "socket.io-client";
 


### PR DESCRIPTION
## Description

In `driver-base/documentDeltaConnection.ts`, move `ISentSignalMessage` and `IFluidErrorBase` from inline `type` positions in value import statements to their corresponding `import type` statements from the same source. This keeps type-only imports cleanly separated from value imports.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).