### PR TITLE
fix: bump jsrsasign to patched version

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -88,7 +88,7 @@
 	},
 	"dependencies": {
 		"@fluidframework/driver-definitions": "workspace:~",
-		"jsrsasign": "^11.0.0",
+		"jsrsasign": "^11.1.1",
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/server-services-core": "^7.0.0",
 		"@fluidframework/server-test-utils": "^7.0.0",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"jsrsasign": "^11.0.0",
+		"jsrsasign": "^11.1.1",
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
-		"jsrsasign": "^11.0.0",
+		"jsrsasign": "^11.1.1",
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"jsrsasign": "^11.0.0",
+		"jsrsasign": "^11.1.1",
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/common/driver-definitions
       jsrsasign:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -10012,8 +10012,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       jsrsasign:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -10604,8 +10604,8 @@ importers:
         specifier: workspace:~
         version: link:../routerlicious-driver
       jsrsasign:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -13442,8 +13442,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       jsrsasign:
-        specifier: ^11.0.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -24126,8 +24126,8 @@ packages:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jsrsasign@11.1.0:
-    resolution: {integrity: sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==}
+  jsrsasign@11.1.1:
+    resolution: {integrity: sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==}
 
   jssm@5.104.2:
     resolution: {integrity: sha512-2UGO9psXneFRqMq2xzme3d+ralxRTWQAckGgU6c99UZBY2+AI2H9JYtKmHPScYiNr7/yaV2Id3bYVlmtFGyqLg==}
@@ -30383,7 +30383,7 @@ snapshots:
   '@fluidframework/azure-service-utils@2.91.0':
     dependencies:
       '@fluidframework/driver-definitions': 2.91.0
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       uuid: 11.1.0
 
   '@fluidframework/build-common@2.0.3': {}
@@ -30968,7 +30968,7 @@ snapshots:
       '@fluidframework/server-services-core': 7.0.0
       '@fluidframework/server-test-utils': 7.0.0
       '@fluidframework/telemetry-utils': 2.91.0
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -31353,7 +31353,7 @@ snapshots:
       '@fluidframework/server-test-utils': 7.0.0
       debug: 4.4.3(supports-color@8.1.1)
       events_pkg: events@3.3.0
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -31397,7 +31397,7 @@ snapshots:
       crc-32: 1.2.0
       debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       jwt-decode: 3.1.2
       querystring: 0.2.1
       sillyname: 0.1.0
@@ -31415,7 +31415,7 @@ snapshots:
       crc-32: 1.2.0
       debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       jwt-decode: 4.0.0
       sillyname: 0.1.0
       uuid: 11.1.0
@@ -31624,7 +31624,7 @@ snapshots:
       '@fluidframework/runtime-definitions': 2.91.0
       '@fluidframework/runtime-utils': 2.91.0
       '@fluidframework/telemetry-utils': 2.91.0
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -31693,7 +31693,7 @@ snapshots:
       '@fluidframework/driver-definitions': 2.91.0
       '@fluidframework/driver-utils': 2.91.0
       '@fluidframework/routerlicious-driver': 2.91.0(encoding@0.1.13)
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -38652,7 +38652,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.3
 
-  jsrsasign@11.1.0: {}
+  jsrsasign@11.1.1: {}
 
   jssm@5.104.2:
     dependencies:

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -86,7 +86,8 @@
 			"tar: overridden to ^7.5.11 to resolve multiple security vulnerabilities in tar 6.x (EOL, no backport).",
 			"minimatch: overridden to patched versions to resolve known security vulnerabilities across all major version ranges.",
 			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support).",
-			"express: overridden to ^4.22.1 to resolve a known vulnerability in express 4.21.2."
+			"express: overridden to ^4.22.1 to resolve a known vulnerability in express 4.21.2.",
+			"jsrsasign: overridden to ^11.1.1 to resolve CVE-2026-4598 and CVE-2026-4601."
 		],
 		"overrides": {
 			"diff@>=5 <6": "^5.2.2",
@@ -112,7 +113,8 @@
 			"minimatch@>=9 <10": "^9.0.9",
 			"minimatch@>=10 <11": "^10.2.4",
 			"serialize-javascript@>=6 <7": "^7.0.4",
-			"express@>=4 <5": "^4.22.1"
+			"express@>=4 <5": "^4.22.1",
+			"jsrsasign": "^11.1.1"
 		},
 		"onlyBuiltDependencies": [
 			"core-js",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   minimatch@>=10 <11: ^10.2.4
   serialize-javascript@>=6 <7: ^7.0.4
   express@>=4 <5: ^4.22.1
+  jsrsasign: ^11.1.1
 
 importers:
 
@@ -3771,8 +3772,8 @@ packages:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jsrsasign@11.1.0:
-    resolution: {integrity: sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==}
+  jsrsasign@11.1.1:
+    resolution: {integrity: sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==}
 
   jssm@5.104.2:
     resolution: {integrity: sha512-2UGO9psXneFRqMq2xzme3d+ralxRTWQAckGgU6c99UZBY2+AI2H9JYtKmHPScYiNr7/yaV2Id3bYVlmtFGyqLg==}
@@ -6386,7 +6387,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       ipaddr.js: 2.3.0
       json-stringify-safe: 5.0.1
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       jwt-decode: 4.0.0
       sillyname: 0.1.0
       uuid: 11.1.0
@@ -10106,7 +10107,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.4
 
-  jsrsasign@11.1.0: {}
+  jsrsasign@11.1.1: {}
 
   jssm@5.104.2:
     dependencies:

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -78,7 +78,8 @@
 			"tar: overridden to ^7.5.11 to resolve multiple security vulnerabilities in tar 6.x (EOL, no backport).",
 			"minimatch: overridden to patched versions to resolve known security vulnerabilities across all major version ranges.",
 			"serialize-javascript: overridden to ^7.0.4 to resolve GHSA-5c6j-r48x-rmvq. No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support).",
-			"express: overridden to ^4.22.1 to resolve a known vulnerability in express 4.21.2."
+			"express: overridden to ^4.22.1 to resolve a known vulnerability in express 4.21.2.",
+			"jsrsasign: overridden to ^11.1.1 to resolve CVE-2026-4598 and CVE-2026-4601."
 		],
 		"overrides": {
 			"express@>=4 <5": "^4.22.1",
@@ -106,7 +107,8 @@
 			"minimatch@>=8 <9": "^8.0.7",
 			"minimatch@>=9 <10": "^9.0.9",
 			"minimatch@>=10 <11": "^10.2.4",
-			"serialize-javascript@>=6 <7": "^7.0.4"
+			"serialize-javascript@>=6 <7": "^7.0.4",
+			"jsrsasign": "^11.1.1"
 		},
 		"onlyBuiltDependencies": [
 			"core-js",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -31,6 +31,7 @@ overrides:
   minimatch@>=9 <10: ^9.0.9
   minimatch@>=10 <11: ^10.2.4
   serialize-javascript@>=6 <7: ^7.0.4
+  jsrsasign: ^11.1.1
 
 importers:
 
@@ -3902,8 +3903,8 @@ packages:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jsrsasign@11.1.0:
-    resolution: {integrity: sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==}
+  jsrsasign@11.1.1:
+    resolution: {integrity: sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==}
 
   jssm@5.104.2:
     resolution: {integrity: sha512-2UGO9psXneFRqMq2xzme3d+ralxRTWQAckGgU6c99UZBY2+AI2H9JYtKmHPScYiNr7/yaV2Id3bYVlmtFGyqLg==}
@@ -6690,7 +6691,7 @@ snapshots:
       crc-32: 1.2.0
       debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
-      jsrsasign: 11.1.0
+      jsrsasign: 11.1.1
       jwt-decode: 4.0.0
       sillyname: 0.1.0
       uuid: 11.1.0
@@ -10657,7 +10658,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.3
 
-  jsrsasign@11.1.0: {}
+  jsrsasign@11.1.1: {}
 
   jssm@5.104.2:
     dependencies:

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -67,7 +67,7 @@
 		"@fluidframework/server-test-utils": "workspace:~",
 		"debug": "^4.3.4",
 		"events_pkg": "npm:events@^3.1.0",
-		"jsrsasign": "^11.0.0",
+		"jsrsasign": "^11.1.1",
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -68,7 +68,7 @@
 		"debug": "^4.3.4",
 		"ipaddr.js": "^2.2.0",
 		"json-stringify-safe": "^5.0.1",
-		"jsrsasign": "^11.0.0",
+		"jsrsasign": "^11.1.1",
 		"jwt-decode": "^4.0.0",
 		"sillyname": "^0.1.0",
 		"uuid": "^11.1.0"

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -453,8 +453,8 @@ importers:
         specifier: npm:events@^3.1.0
         version: events@3.3.0
       jsrsasign:
-        specifier: ^11.0.0
-        version: 11.0.0
+        specifier: ^11.1.1
+        version: 11.1.1
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1182,8 +1182,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       jsrsasign:
-        specifier: ^11.0.0
-        version: 11.0.0
+        specifier: ^11.1.1
+        version: 11.1.1
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
@@ -6295,8 +6295,8 @@ packages:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jsrsasign@11.0.0:
-    resolution: {integrity: sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==}
+  jsrsasign@11.1.1:
+    resolution: {integrity: sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==}
 
   jssm@5.104.2:
     resolution: {integrity: sha512-2UGO9psXneFRqMq2xzme3d+ralxRTWQAckGgU6c99UZBY2+AI2H9JYtKmHPScYiNr7/yaV2Id3bYVlmtFGyqLg==}
@@ -8483,6 +8483,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-deepmerge@7.0.3:
     resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
     engines: {node: '>=14.13.1'}
@@ -9894,7 +9900,7 @@ snapshots:
       '@fluidframework/server-test-utils': 7.0.0
       debug: 4.4.1
       events_pkg: events@3.3.0
-      jsrsasign: 11.0.0
+      jsrsasign: 11.1.1
       uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -9980,7 +9986,7 @@ snapshots:
       crc-32: 1.2.0
       debug: 4.4.1
       json-stringify-safe: 5.0.1
-      jsrsasign: 11.0.0
+      jsrsasign: 11.1.1
       jwt-decode: 4.0.0
       sillyname: 0.1.0
       uuid: 11.1.0
@@ -11483,7 +11489,7 @@ snapshots:
       minimatch: 9.0.9
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.1.6)
+      ts-api-utils: 2.5.0(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -14463,7 +14469,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.4
 
-  jsrsasign@11.0.0: {}
+  jsrsasign@11.1.1: {}
 
   jssm@5.104.2:
     dependencies:
@@ -17161,6 +17167,10 @@ snapshots:
   trough@2.2.0: {}
 
   ts-api-utils@2.4.0(typescript@5.1.6):
+    dependencies:
+      typescript: 5.1.6
+
+  ts-api-utils@2.5.0(typescript@5.1.6):
     dependencies:
       typescript: 5.1.6
 


### PR DESCRIPTION
## Summary

- Upgrades `jsrsasign` from `11.0.0`/`11.1.0` to `^11.1.1` across all workspaces to address known security vulnerabilities
- Updated `package.json` version constraints in 6 packages (`azure-service-utils`, `local-driver`, `tinylicious-driver`, `test-runtime-utils`, `server-local-server`, `server-services-client`)
- Added `jsrsasign: ^11.1.1` pnpm override in `server/gitrest` and `server/historian` (jsrsasign is transitive there via a published npm release of `@fluidframework/server-services-client`)
- Updated all affected `pnpm-lock.yaml` files

## Test plan

- [x] CI passes (builds and tests across affected packages)
- [ ] Confirm `jsrsasign@11.1.1` in all lockfiles after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)