### PR TITLE
Fix changeset files to comply with formatting guidelines

### DIFF
--- a/.changeset/deprecate-id-compressor-core.md
+++ b/.changeset/deprecate-id-compressor-core.md
@@ -3,7 +3,7 @@
 "__section": deprecation
 ---
 
-Deprecated IIdCompressorCore interface
+Deprecate IIdCompressorCore interface
 
 The `IIdCompressorCore` interface is deprecated and will be removed from the public API surface in 2.100.0. This also affects the return types of `createIdCompressor` and `deserializeIdCompressor`, which currently return `IIdCompressor & IIdCompressorCore` but will be narrowed to `IIdCompressor`.
 

--- a/.changeset/eleven-beds-fold.md
+++ b/.changeset/eleven-beds-fold.md
@@ -1,9 +1,10 @@
 ---
 "fluid-framework": minor
 "@fluidframework/tree": minor
-"__section": breaking
+"__section": legacy
 ---
-The deprecated `getBranch` API has been removed
+
+The deprecated getBranch API has been removed
 
 To obtain a branch-like object, create a view from your tree via `viewWith`.
 Or, use `TreeAlpha.context` to get a view from a `TreeNode`.

--- a/.changeset/goofy-keys-wait.md
+++ b/.changeset/goofy-keys-wait.md
@@ -68,5 +68,5 @@ TreeAlpha.on(node as TreeNode, "nodeChanged", (data) => {
 ```
 
 > **Note:** The `delta` value may be `undefined` in two cases:
-> - The node was created locally and has not yet been inserted into a document tree (a known temporary limitation, tracked in AB#63261).
+> - The node was created locally and has not yet been inserted into a document tree (a known temporary limitation).
 > - The document was updated in a way that required multiple internal change passes in a single operation (for example, a data change combined with a schema upgrade).

--- a/.changeset/plain-tires-melt.md
+++ b/.changeset/plain-tires-melt.md
@@ -3,6 +3,7 @@
 "@fluidframework/tree": minor
 "__section": tree
 ---
+
 Adds TreeArrayNodeAlpha with a new splice method
 
 Adds a `splice` method on `TreeArrayNodeAlpha` that supports removing and inserting items in a single operation to align with JavaScript's Array splice API.
@@ -18,11 +19,11 @@ The alpha API is accessible by an `asAlpha` cast on existing TreeArrayNodes, or 
 ```typescript
 import { SchemaFactory, SchemaFactoryAlpha, asAlpha } from "@fluidframework/tree";
 
-// Using AsAlpha to cast an existing TreeArrayNode
+// Using asAlpha to cast an existing TreeArrayNode
 const sf = new SchemaFactory("example");
 const Inventory = sf.array("Inventory", sf.string);
 const inventory = new Inventory(["Apples", "Bananas", "Pears"]);
-const inventoryAlpha = asAlpha(inventory)
+const inventoryAlpha = asAlpha(inventory);
 
 // Using SchemaFactoryAlpha so splice is available directly
 const sf = new SchemaFactoryAlpha("example");

--- a/.changeset/plain-tires-melt.md
+++ b/.changeset/plain-tires-melt.md
@@ -4,7 +4,7 @@
 "__section": tree
 ---
 
-Adds TreeArrayNodeAlpha with a new splice method
+Add TreeArrayNodeAlpha with a new splice method
 
 Adds a `splice` method on `TreeArrayNodeAlpha` that supports removing and inserting items in a single operation to align with JavaScript's Array splice API.
 Returns the removed items as an array.


### PR DESCRIPTION
## Description

Updates four changesets in `.changeset/` to conform to the conventions documented in `.changeset/README.md`.

### Changes

**eleven-beds-fold.md**
- Added missing blank line between front matter and summary
- Removed backtick formatting from summary line (`getBranch` → `getBranch`) — code formatting is not permitted in summary lines
- Changed `__section` from `breaking` to `legacy` — per the README, the `breaking` section is reserved for major/server releases; removing a deprecated client API belongs in `legacy`

**plain-tires-melt.md**
- Added missing blank line between front matter and summary

**deprecate-id-compressor-core.md**
- Fixed summary tense from past ("Deprecated...") to imperative present ("Deprecate...") to match the "In this release, ..." framing prescribed by the README

**goofy-keys-wait.md**
- Removed internal issue reference (`[AB#63261](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/63261)`) from the body — per the README, issue and PR references should not be included in changesets as they are added automatically by the changelog generator

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
