### PR TITLE
Update test tenant acquisition for real service e2e test pipeline 

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -447,11 +447,13 @@ stages:
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
               token__package__import__location: $(token__package__import__location)
               login__odsp__fic__test__users: $(login__odsp__fic__test__users)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               login__microsoft__clientId: $(appClientId)
               login__odspdf__test__tenants: $(tenantCreds)
             ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
               token__package__import__location: $(token__package__import__location)
               login__odsp__fic__test__users: $(login__odsp__fic__test__users)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               login__microsoft__clientId: $(appClientId)
               login__odsp__test__tenants: $(tenantCreds)
           inputs:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -413,7 +413,7 @@ stages:
           - task: AzureCLI@2
             displayName: 'Log in to retrieve tenant credentials'
             inputs:
-              azureSubscription: 'Fluid Framework Odsp Tests TestTRS'
+              azureSubscription: 'FF Pipeline Authentication'
               # This injects environment variables into the below script. See https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines
               addSpnToEnvironment: true
               scriptType: 'bash'

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -433,7 +433,7 @@ stages:
                 set -eu -o pipefail
 
                 # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
-                pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --odspEndpoint=${{ parameters.odspTenantType }}
+                pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --odspEndpoint=${{ parameters.odspTenantType }} --useFic
                 echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"
 
         # run the test
@@ -446,9 +446,13 @@ stages:
             # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
             # The e2e test workload references the keys (login__*).
             ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
+              token__package__import__location: $(token__package__import__location)
+              login__odsp__fic__test__users: $(login__odsp__fic__test__users)
               login__microsoft__clientId: $(appClientId)
               login__odspdf__test__tenants: $(tenantCreds)
             ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
+              token__package__import__location: $(token__package__import__location)
+              login__odsp__fic__test__users: $(login__odsp__fic__test__users)
               login__microsoft__clientId: $(appClientId)
               login__odsp__test__tenants: $(tenantCreds)
           inputs:
@@ -527,7 +531,7 @@ stages:
               targetType: 'inline'
               script: |
                 set -eu -o pipefail
-                pnpm exec trips-cleanup --reservationId=$(stringBearerToken) --odspEndpoint=${{ parameters.odspTenantType }}
+                pnpm exec trips-cleanup --reservationId=$(stringBearerToken) --odspEndpoint=${{ parameters.odspTenantType }} --useFic
             condition: eq(variables['tenantSetupSuccess'], 'true')
 
         # Log Test Failures

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -413,14 +413,13 @@ stages:
           - task: AzureCLI@2
             displayName: 'Log in to retrieve tenant credentials'
             inputs:
-              azureSubscription: 'Fluid Framework Tests'
+              azureSubscription: 'Fluid Framework Odsp Tests TestTRS'
               # This injects environment variables into the below script. See https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines
               addSpnToEnvironment: true
               scriptType: 'bash'
               scriptLocation: 'inlineScript'
               inlineScript: |
                 set -eu -o pipefail
-
                 az login --service-principal -u $servicePrincipalId -p $idToken --tenant $tenantId
 
           - task: Bash@3

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -530,6 +530,7 @@ stages:
             displayName: 'Release tenant credentials'
             env:
               login__odsp__fic__test__users: $(login__odsp__fic__test__users)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:
               targetType: 'inline'
               script: |

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -515,7 +515,7 @@ stages:
           - task: AzureCLI@2
             displayName: 'Log in to release tenant credentials'
             inputs:
-              azureSubscription: 'Fluid Framework Tests'
+              azureSubscription: 'FF Pipeline Authentication'
               addSpnToEnvironment: true
               scriptType: 'bash'
               scriptLocation: 'inlineScript'

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -528,6 +528,8 @@ stages:
           # Release the tenant back to the tenant pool
           - task: Bash@3
             displayName: 'Release tenant credentials'
+            env:
+              login__odsp__fic__test__users: $(login__odsp__fic__test__users)
             inputs:
               targetType: 'inline'
               script: |

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -532,7 +532,7 @@ stages:
               targetType: 'inline'
               script: |
                 set -eu -o pipefail
-                pnpm exec trips-cleanup --reservationId=$(stringBearerToken) --odspEndpoint=${{ parameters.odspTenantType }} --useFic
+                pnpm exec trips-cleanup --odspEndpoint=${{ parameters.odspTenantType }} --useFic
             condition: eq(variables['tenantSetupSuccess'], 'true')
 
         # Log Test Failures


### PR DESCRIPTION
Use federated tokens as the credential method for authentication in the e2e and stress pipeline templates. 

[AB#52057](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/52057)