### PR TITLE
Update performance benchmarks pipeline to use FIC arguments

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -86,7 +86,7 @@ steps:
   - task: AzureCLI@2
     displayName: 'Log in to retrieve tenant credentials'
     inputs:
-      azureSubscription: 'Fluid Framework Tests'
+      azureSubscription: 'FF Pipeline Authentication'
       # This injects environment variables into the below script. See https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines
       addSpnToEnvironment: true
       scriptType: 'bash'
@@ -107,5 +107,5 @@ steps:
         set -eu -o pipefail
 
         # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
-        pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN
+        pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --useFic
         echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -603,7 +603,7 @@ stages:
           - task: AzureCLI@2
             displayName: 'Log in to release tenant credentials'
             inputs:
-              azureSubscription: 'Fluid Framework Tests'
+              azureSubscription: 'FF Pipeline Authentication'
               addSpnToEnvironment: true
               scriptType: 'bash'
               scriptLocation: 'inlineScript'
@@ -621,7 +621,7 @@ stages:
               script: |
                 set -eu -o pipefail
 
-                pnpm exec trips-cleanup --reservationId=$(stringBearerToken)
+                pnpm exec trips-cleanup --useFic
             condition: eq(variables['tenantSetupSuccess'], 'true')
 
         - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self


### PR DESCRIPTION
Use the updated tenant acquisition script in the performance benchmarks pipeline. 

[AB#52057](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/52057)