### PR TITLE
build(build-infrastructure): switch from ESM to CJS output

### DIFF
--- a/build-tools/packages/build-infrastructure/package.json
+++ b/build-tools/packages/build-infrastructure/package.json
@@ -10,17 +10,10 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"type": "module",
 	"exports": {
 		".": {
-			"import": {
-				"types": "./lib/index.d.ts",
-				"default": "./lib/index.js"
-			},
-			"require": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			}
+			"types": "./lib/index.d.ts",
+			"default": "./lib/index.js"
 		}
 	},
 	"main": "lib/index.js",
@@ -30,8 +23,6 @@
 	},
 	"files": [
 		"/bin",
-		"/dist",
-		"!dist/test",
 		"/lib",
 		"!lib/test",
 		"/oclif.manifest.json"
@@ -47,7 +38,7 @@
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
-		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc _api-extractor-temp",
+		"clean": "rimraf --glob lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc _api-extractor-temp",
 		"compile": "fluid-build . --task compile",
 		"eslint": "eslint --quiet --format stylish src",
 		"eslint:fix": "eslint --quiet --format stylish src --fix --fix-type problem,suggestion,layout",


### PR DESCRIPTION
## Description

Switch `@fluid-tools/build-infrastructure` from ESM (`"type": "module"`) to CJS output by removing the `type` field from `package.json`. With `module: Node16`, tsc now reads the package type as CommonJS and emits CJS to `lib/`.

**Why not dual ESM/CJS?** Both `build-cli` (ESM) and `build-tools` (CJS) consume `build-infrastructure`. If both run in the same Node process — which they do, since `build-cli` imports from `build-tools` — a dual-build package would load two separate module instances (one ESM, one CJS). This causes the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard): `instanceof` checks, identity comparisons, and shared state break across the boundary. CJS-only avoids this because ESM can import CJS without creating a second copy.

Changes:
- Remove `"type": "module"` from `package.json`
- Simplify `exports` to a single entry (no import/require conditions)
- Remove `/dist` from `files` and `clean` script (no dual output)
- `.mjs` bin files are unchanged (always ESM regardless of package type)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

All dependencies were already pinned to CJS-compatible versions (`execa@^5`, `globby@^11`, `detect-indent@^6`, `read-pkg-up@^7`). No `import.meta` or top-level `await` in source. 52 tests pass.