### PR TITLE
Update perf benchmarks pipeline to use new version of script

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -87,7 +87,7 @@ steps:
   - task: AzureCLI@2
     displayName: 'Log in to retrieve tenant credentials'
     inputs:
-      azureSubscription: 'Fluid Framework Tests'
+      azureSubscription: 'FF Pipeline Authentication'
       # This injects environment variables into the below script. See https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines
       addSpnToEnvironment: true
       scriptType: 'bash'
@@ -108,5 +108,5 @@ steps:
         set -eu -o pipefail
 
         # Increase the maximum time to wait for a tenant to 1 hour to accommodate multiple test runs at the same time.
-        pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN
+        pnpm exec trips-setup --waitTime=3600 --accessToken=$SYSTEM_ACCESSTOKEN --useFic
         echo "##vso[task.setvariable variable=tenantSetupSuccess;]true"

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -548,6 +548,7 @@ stages:
               token__package__import__location: $(token__package__import__location)
               login__odsp__fic__test__users: $(login__odsp__fic__test__users)
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              login__microsoft__clientId: $(login-microsoft-clientId)
             ${{ else }}:
               login__microsoft__clientId: $(login-microsoft-clientId)
             ${{ if eq( endpointObject.endpointName, 'frs' ) }}:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -545,8 +545,9 @@ stages:
             FLUID_ENDPOINTNAME: ${{ endpointObject.endpointName }}
             FLUID_LOGGER_PROPS: '{ "hostName": "Benchmark", "displayName": "${{variables.pipelineIdentifierForTelemetry}}" }'
             ${{ if eq(endpointObject.endpointName, 'odsp') }}:
-              login__odsp__test__tenants: $(tenantCreds)
-              login__microsoft__clientId: $(appClientId)
+              token__package__import__location: $(token__package__import__location)
+              login__odsp__fic__test__users: $(login__odsp__fic__test__users)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             ${{ else }}:
               login__microsoft__clientId: $(login-microsoft-clientId)
             ${{ if eq( endpointObject.endpointName, 'frs' ) }}:
@@ -612,7 +613,7 @@ stages:
           - task: AzureCLI@2
             displayName: 'Log in to release tenant credentials'
             inputs:
-              azureSubscription: 'Fluid Framework Tests'
+              azureSubscription: 'FF Pipeline Authentication'
               addSpnToEnvironment: true
               scriptType: 'bash'
               scriptLocation: 'inlineScript'
@@ -625,12 +626,15 @@ stages:
           # Release the tenant back to the tenant pool
           - task: Bash@3
             displayName: 'Release tenant credentials'
+            env:
+              login__odsp__fic__test__users: $(login__odsp__fic__test__users)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:
               targetType: 'inline'
               script: |
                 set -eu -o pipefail
 
-                pnpm exec trips-cleanup --reservationId=$(stringBearerToken)
+                pnpm exec trips-cleanup --useFic
             condition: eq(variables['tenantSetupSuccess'], 'true')
 
         - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self


### PR DESCRIPTION
Use the updated tenant script command to acquire test resources for the performance benchmarks. 

[AB#52057](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/52057)