### PR TITLE
Remove ID allocation batches and JIT generate Id alloc batches.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2064,6 +2064,28 @@ export class ContainerRuntime
 			}),
 			reSubmit: this.reSubmit.bind(this),
 			opReentrancy: () => this.dataModelChangeRunner.running,
+			generateIdAllocationOp: (
+				useUnfinalizedRange: boolean,
+			): LocalBatchMessage | undefined => {
+				if (this._idCompressor === undefined) {
+					return undefined;
+				}
+				const idRange = useUnfinalizedRange
+					? this._idCompressor.takeUnfinalizedCreationRange()
+					: this._idCompressor.takeNextCreationRange();
+				if (idRange.ids === undefined) {
+					return undefined;
+				}
+				const idAllocationMessage: ContainerRuntimeIdAllocationMessage = {
+					type: ContainerMessageType.IdAllocation,
+					contents: idRange,
+				};
+				return {
+					runtimeOp: idAllocationMessage,
+					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
+					staged: false,
+				};
+			},
 		});
 
 		this._quorum = quorum;
@@ -3682,9 +3704,6 @@ export class ContainerRuntime
 
 						this.stageControls = undefined;
 
-						// During Staging Mode, we avoid submitting any ID Allocation ops (apart from resubmitting pre-staging ops).
-						// Now that we've exited, we need to submit an ID Allocation op for any IDs that were generated while in Staging Mode.
-						this.submitIdAllocationOpIfNeeded({ staged: false });
 						const batchInfos = discardOrCommit();
 						event.reportProgress({
 							details: {
@@ -4728,33 +4747,6 @@ export class ContainerRuntime
 		return this.blobManager.lookupTemporaryBlobStorageId(localId);
 	}
 
-	private submitIdAllocationOpIfNeeded({
-		resubmitOutstandingRanges = false,
-		staged,
-	}: {
-		resubmitOutstandingRanges?: boolean;
-		staged: boolean;
-	}): void {
-		if (this._idCompressor) {
-			const idRange = resubmitOutstandingRanges
-				? this._idCompressor.takeUnfinalizedCreationRange()
-				: this._idCompressor.takeNextCreationRange();
-			// Don't include the idRange if there weren't any Ids allocated
-			if (idRange.ids !== undefined) {
-				const idAllocationMessage: ContainerRuntimeIdAllocationMessage = {
-					type: ContainerMessageType.IdAllocation,
-					contents: idRange,
-				};
-				const idAllocationBatchMessage: LocalBatchMessage = {
-					runtimeOp: idAllocationMessage,
-					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
-					staged,
-				};
-				this.outbox.submitIdAllocation(idAllocationBatchMessage);
-			}
-		}
-	}
-
 	private submit(
 		containerRuntimeMessage: LocalContainerRuntimeMessage,
 		localOpMetadata: unknown = undefined,
@@ -4797,11 +4789,6 @@ export class ContainerRuntime
 				!staged || canStageMessageOfType(type),
 				0xbba /* Unexpected message type submitted in Staging Mode */,
 			);
-
-			// Before submitting any non-staged change, submit the ID Allocation op to cover any compressed IDs included in the op.
-			if (!staged) {
-				this.submitIdAllocationOpIfNeeded({ staged: false });
-			}
 
 			// Allow document schema controller to send a message if it needs to propose change in document schema.
 			// If it needs to send a message, it will call provided callback with payload of such message and rely

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2064,15 +2064,11 @@ export class ContainerRuntime
 			}),
 			reSubmit: this.reSubmit.bind(this),
 			opReentrancy: () => this.dataModelChangeRunner.running,
-			generateIdAllocationOp: (
-				useUnfinalizedRange: boolean,
-			): LocalBatchMessage | undefined => {
+			generateIdAllocationOp: (): LocalBatchMessage | undefined => {
 				if (this._idCompressor === undefined) {
 					return undefined;
 				}
-				const idRange = useUnfinalizedRange
-					? this._idCompressor.takeUnfinalizedCreationRange()
-					: this._idCompressor.takeNextCreationRange();
+				const idRange = this._idCompressor.takeNextCreationRange();
 				if (idRange.ids === undefined) {
 					return undefined;
 				}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4282,7 +4282,6 @@ export class ContainerRuntime
 					outboxLength: this.outbox.messageCount,
 					mainBatchLength: this.outbox.mainBatchMessageCount,
 					blobAttachBatchLength: this.outbox.blobAttachBatchMessageCount,
-					idAllocationBatchLength: this.outbox.idAllocationBatchMessageCount,
 				},
 			);
 		}
@@ -4845,7 +4844,7 @@ export class ContainerRuntime
 		// Incoming ops still break the batch via direct this.flush() calls elsewhere
 		// (deltaManager "op" handler, process(), connection changes, getPendingLocalState,
 		// exitStagingMode). Those all bypass scheduleFlush(), so they're unaffected by this check.
-		// Additionally, outbox.maybeFlushPartialBatch() (called on every submit) detects
+		// Additionally, outbox.outboxSequenceNumberCoherencyCheck() (called on every submit) detects
 		// sequence number changes and throws if unexpected changes are detected.
 		if (
 			this.inStagingMode &&

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -20,6 +20,7 @@ import { serializeOp } from "./opSerialization.js";
 import type { BatchStartInfo } from "./remoteMessageProcessor.js";
 
 export interface IBatchManagerOptions {
+	readonly disableGroupedBatching: boolean;
 	readonly compressionOptions?: ICompressionRuntimeOptions;
 }
 

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -26,11 +26,6 @@ export interface IBatchManagerOptions {
 	 * If true, the outbox is allowed to rebase the batch during flushing.
 	 */
 	readonly canRebase: boolean;
-
-	/**
-	 * If true, don't compare batchID of incoming batches to this. e.g. ID Allocation Batch IDs should be ignored
-	 */
-	readonly ignoreBatchId?: boolean;
 }
 
 export interface BatchSequenceNumbers {
@@ -127,8 +122,9 @@ export class BatchManager {
 
 	/**
 	 * Gets the pending batch and clears state for the next batch.
+	 * The caller is responsible for calling {@link addBatchMetadata} after any modifications (e.g. prepending messages).
 	 */
-	public popBatch(batchId?: BatchId): LocalBatch {
+	public popBatch(): LocalBatch {
 		assert(this.pendingBatch[0] !== undefined, 0xb8a /* expected non-empty batch */);
 		const batch: LocalBatch = {
 			messages: this.pendingBatch,
@@ -141,7 +137,7 @@ export class BatchManager {
 		this.clientSequenceNumber = undefined;
 		this.hasReentrantOps = false;
 
-		return addBatchMetadata(batch, batchId);
+		return batch;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -21,11 +21,6 @@ import type { BatchStartInfo } from "./remoteMessageProcessor.js";
 
 export interface IBatchManagerOptions {
 	readonly compressionOptions?: ICompressionRuntimeOptions;
-
-	/**
-	 * If true, the outbox is allowed to rebase the batch during flushing.
-	 */
-	readonly canRebase: boolean;
 }
 
 export interface BatchSequenceNumbers {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -212,8 +212,8 @@ export class Outbox {
 	constructor(private readonly params: IOutboxParameters) {
 		this.logger = createChildLogger({ logger: params.logger, namespace: "Outbox" });
 
-		this.mainBatch = new BatchManager({});
-		this.blobAttachBatch = new BatchManager({});
+		this.mainBatch = new BatchManager({ disableGroupedBatching: false });
+		this.blobAttachBatch = new BatchManager({ disableGroupedBatching: true });
 	}
 
 	public get messageCount(): number {
@@ -233,10 +233,7 @@ export class Outbox {
 	}
 
 	public containsUserChanges(): boolean {
-		return (
-			this.mainBatch.containsUserChanges() || this.blobAttachBatch.containsUserChanges()
-			// ID Allocation ops are not user changes
-		);
+		return this.mainBatch.containsUserChanges() || this.blobAttachBatch.containsUserChanges();
 	}
 
 	/**
@@ -374,7 +371,6 @@ export class Outbox {
 
 		this.flushInternal({
 			batchManager: this.blobAttachBatch,
-			disableGroupedBatching: true,
 			resubmitInfo,
 		});
 		this.flushInternal({
@@ -414,10 +410,9 @@ export class Outbox {
 
 	private flushInternal(params: {
 		batchManager: BatchManager;
-		disableGroupedBatching?: boolean;
 		resubmitInfo?: BatchResubmitInfo; // undefined if not resubmitting
 	}): void {
-		const { batchManager, disableGroupedBatching = false, resubmitInfo } = params;
+		const { batchManager, resubmitInfo } = params;
 		if (batchManager.empty) {
 			return;
 		}
@@ -432,8 +427,13 @@ export class Outbox {
 		);
 
 		const groupingEnabled =
-			!disableGroupedBatching && this.params.groupingManager.groupedBatchingEnabled();
-		if (rawBatch.hasReentrantOps === true && groupingEnabled) {
+			!batchManager.options.disableGroupedBatching &&
+			this.params.groupingManager.groupedBatchingEnabled();
+		if (rawBatch.hasReentrantOps === true) {
+			assert(
+				resubmitInfo === undefined,
+				"Re-submitting a batch with reentrant ops is not supported",
+			);
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// Rebase the current batch (resubmit the ops one-by-one) and then reinvoke flushInternal.
 			// If a batch contains reentrant ops (ops created as a result from processing another op)

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -369,14 +369,8 @@ export class Outbox {
 			return;
 		}
 
-		this.flushInternal({
-			batchManager: this.blobAttachBatch,
-			resubmitInfo,
-		});
-		this.flushInternal({
-			batchManager: this.mainBatch,
-			resubmitInfo,
-		});
+		this.flushInternal(this.blobAttachBatch, resubmitInfo);
+		this.flushInternal(this.mainBatch, resubmitInfo);
 	}
 
 	private flushEmptyBatch(
@@ -408,11 +402,10 @@ export class Outbox {
 		return;
 	}
 
-	private flushInternal(params: {
-		batchManager: BatchManager;
-		resubmitInfo?: BatchResubmitInfo; // undefined if not resubmitting
-	}): void {
-		const { batchManager, resubmitInfo } = params;
+	private flushInternal(
+		batchManager: BatchManager,
+		resubmitInfo?: BatchResubmitInfo, // undefined if not resubmitting
+	): void {
 		if (batchManager.empty) {
 			return;
 		}
@@ -469,9 +462,9 @@ export class Outbox {
 				clientSequenceNumber === undefined || clientSequenceNumber >= 0,
 				0x9d2 /* unexpected negative clientSequenceNumber (empty batch should yield undefined) */,
 			);
+		} else {
+			addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 		}
-
-		addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 
 		this.params.pendingStateManager.onFlushBatch(
 			rawBatch.messages,
@@ -514,7 +507,7 @@ export class Outbox {
 			this.batchRebasesToReport--;
 		}
 
-		this.flushInternal({ batchManager });
+		this.flushInternal(batchManager);
 		this.rebasing = false;
 	}
 

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -212,8 +212,8 @@ export class Outbox {
 	constructor(private readonly params: IOutboxParameters) {
 		this.logger = createChildLogger({ logger: params.logger, namespace: "Outbox" });
 
-		this.mainBatch = new BatchManager({ canRebase: true });
-		this.blobAttachBatch = new BatchManager({ canRebase: true });
+		this.mainBatch = new BatchManager({});
+		this.blobAttachBatch = new BatchManager({});
 	}
 
 	public get messageCount(): number {
@@ -227,12 +227,6 @@ export class Outbox {
 	public get blobAttachBatchMessageCount(): number {
 		return this.blobAttachBatch.length;
 	}
-
-	/**
-	 * @remarks With JIT ID allocation, pending IDs are tracked by the compressor, not the outbox.
-	 * This always returns 0. ID allocation ops are generated at flush time.
-	 */
-	public readonly idAllocationBatchMessageCount: number = 0;
 
 	public get isEmpty(): boolean {
 		return this.messageCount === 0;
@@ -256,7 +250,7 @@ export class Outbox {
 	 * last message processed by the ContainerRuntime. In the absence of op reentrancy, this
 	 * pair will remain stable during a single JS turn during which the batch is being built up.
 	 */
-	private maybeFlushPartialBatch(): void {
+	private outboxSequenceNumberCoherencyCheck(): void {
 		const mainBatchSeqNums = this.mainBatch.sequenceNumbers;
 		const blobAttachSeqNums = this.blobAttachBatch.sequenceNumbers;
 		assert(
@@ -316,13 +310,13 @@ export class Outbox {
 	}
 
 	public submit(message: LocalBatchMessage): void {
-		this.maybeFlushPartialBatch();
+		this.outboxSequenceNumberCoherencyCheck();
 
 		this.addMessageToBatchManager(this.mainBatch, message);
 	}
 
 	public submitBlobAttach(message: LocalBatchMessage): void {
-		this.maybeFlushPartialBatch();
+		this.outboxSequenceNumberCoherencyCheck();
 
 		this.addMessageToBatchManager(this.blobAttachBatch, message);
 	}
@@ -347,13 +341,13 @@ export class Outbox {
 	 */
 	public flush(resubmitInfo?: BatchResubmitInfo): void {
 		// We have nothing to flush if all batchManagers are empty, and we we're not needing to resubmit an empty batch placeholder
-		// Note that it's possible that there are unfinalized ranges in the ID Compressor,
-		// but there's no urgency to flush those if they're not referenced in any messages.
 		if (
 			this.blobAttachBatch.empty &&
 			this.mainBatch.empty &&
 			resubmitInfo?.batchId === undefined
 		) {
+			// Note that it's possible that there are unfinalized ranges in the ID Compressor,
+			// but there's no urgency to flush those if they're not referenced in any messages.
 			return;
 		}
 
@@ -439,11 +433,7 @@ export class Outbox {
 
 		const groupingEnabled =
 			!disableGroupedBatching && this.params.groupingManager.groupedBatchingEnabled();
-		if (
-			batchManager.options.canRebase &&
-			rawBatch.hasReentrantOps === true &&
-			groupingEnabled
-		) {
+		if (rawBatch.hasReentrantOps === true && groupingEnabled) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// Rebase the current batch (resubmit the ops one-by-one) and then reinvoke flushInternal.
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
@@ -498,7 +488,6 @@ export class Outbox {
 	 */
 	private rebase(rawBatch: LocalBatch, batchManager: BatchManager): void {
 		assert(!this.rebasing, 0x6fb /* Reentrancy */);
-		assert(batchManager.options.canRebase, 0x9a7 /* BatchManager does not support rebase */);
 
 		this.rebasing = true;
 		const squash = false;

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -460,7 +460,7 @@ export class Outbox {
 		// If so, do nothing, as pending state manager will resubmit it correctly on reconnect.
 		// Because flush() is a task that executes async (on clean stack), we can get here in disconnected state.
 		const shouldSendNow = this.params.shouldSend() && !staged;
-
+		let clientSequenceNumber: number | undefined;
 		if (shouldSendNow) {
 			// Generate ID Allocation op just-in-time, after rebase (if any), and before addBatchMetadata,
 			// so that the prepended idAllocMsg is correctly marked as the first op in the batch.
@@ -471,12 +471,7 @@ export class Outbox {
 			if (idAllocMsg !== undefined) {
 				rawBatch = { ...rawBatch, messages: [idAllocMsg, ...rawBatch.messages] };
 			}
-		}
-
-		addBatchMetadata(rawBatch, resubmitInfo?.batchId);
-
-		let clientSequenceNumber: number | undefined;
-		if (shouldSendNow) {
+			addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 			const virtualizedBatch = this.virtualizeBatch(rawBatch, groupingEnabled);
 
 			clientSequenceNumber = this.sendBatch(virtualizedBatch);
@@ -485,6 +480,8 @@ export class Outbox {
 				0x9d2 /* unexpected negative clientSequenceNumber (empty batch should yield undefined) */,
 			);
 		}
+
+		addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 
 		this.params.pendingStateManager.onFlushBatch(
 			rawBatch.messages,

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -28,6 +28,7 @@ import {
 	type BatchSequenceNumbers,
 	sequenceNumbersMatch,
 	type BatchId,
+	addBatchMetadata,
 } from "./batchManager.js";
 import type {
 	LocalBatchMessage,
@@ -65,6 +66,17 @@ export interface IOutboxParameters {
 	readonly getCurrentSequenceNumbers: () => BatchSequenceNumbers;
 	readonly reSubmit: (message: PendingMessageResubmitData, squash: boolean) => void;
 	readonly opReentrancy: () => boolean;
+	/**
+	 * JIT callback to generate an ID allocation op at flush time.
+	 * Called after rebase (if any), so the returned message has the correct refSeq.
+	 *
+	 * @param useUnfinalizedRange - If true, use `takeUnfinalizedCreationRange()` (for reconnect).
+	 * Otherwise use `takeNextCreationRange()` (normal flush).
+	 * @returns A LocalBatchMessage for the ID allocation op, or undefined if no IDs need allocating.
+	 */
+	readonly generateIdAllocationOp: (
+		useUnfinalizedRange: boolean,
+	) => LocalBatchMessage | undefined;
 }
 
 /**
@@ -189,7 +201,7 @@ export class Outbox {
 	private readonly logger: ITelemetryLoggerExt;
 	private readonly mainBatch: BatchManager;
 	private readonly blobAttachBatch: BatchManager;
-	private readonly idAllocationBatch: BatchManager;
+	private useUnfinalizedRangeOnNextFlush = false;
 	private batchRebasesToReport = 5;
 	private rebasing = false;
 
@@ -207,14 +219,10 @@ export class Outbox {
 
 		this.mainBatch = new BatchManager({ canRebase: true });
 		this.blobAttachBatch = new BatchManager({ canRebase: true });
-		this.idAllocationBatch = new BatchManager({
-			canRebase: false,
-			ignoreBatchId: true,
-		});
 	}
 
 	public get messageCount(): number {
-		return this.mainBatch.length + this.blobAttachBatch.length + this.idAllocationBatch.length;
+		return this.mainBatch.length + this.blobAttachBatch.length;
 	}
 
 	public get mainBatchMessageCount(): number {
@@ -225,9 +233,11 @@ export class Outbox {
 		return this.blobAttachBatch.length;
 	}
 
-	public get idAllocationBatchMessageCount(): number {
-		return this.idAllocationBatch.length;
-	}
+	/**
+	 * @remarks With JIT ID allocation, pending IDs are tracked by the compressor, not the outbox.
+	 * This always returns 0. ID allocation ops are generated at flush time.
+	 */
+	public readonly idAllocationBatchMessageCount: number = 0;
 
 	public get isEmpty(): boolean {
 		return this.messageCount === 0;
@@ -254,10 +264,8 @@ export class Outbox {
 	private maybeFlushPartialBatch(): void {
 		const mainBatchSeqNums = this.mainBatch.sequenceNumbers;
 		const blobAttachSeqNums = this.blobAttachBatch.sequenceNumbers;
-		const idAllocSeqNums = this.idAllocationBatch.sequenceNumbers;
 		assert(
-			sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums) &&
-				sequenceNumbersMatch(mainBatchSeqNums, idAllocSeqNums),
+			sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums),
 			0x58d /* Reference sequence numbers from both batches must be in sync */,
 		);
 
@@ -265,8 +273,7 @@ export class Outbox {
 
 		if (
 			sequenceNumbersMatch(mainBatchSeqNums, currentSequenceNumbers) &&
-			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers) &&
-			sequenceNumbersMatch(idAllocSeqNums, currentSequenceNumbers)
+			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers)
 		) {
 			// The reference sequence numbers are stable, there is nothing to do
 			return;
@@ -325,10 +332,13 @@ export class Outbox {
 		this.addMessageToBatchManager(this.blobAttachBatch, message);
 	}
 
-	public submitIdAllocation(message: LocalBatchMessage): void {
-		this.maybeFlushPartialBatch();
-
-		this.addMessageToBatchManager(this.idAllocationBatch, message);
+	/**
+	 * Signals that on the next JIT ID allocation, the outbox should use
+	 * `takeUnfinalizedCreationRange()` (comprehensive) instead of `takeNextCreationRange()` (incremental).
+	 * Used during reconnect so the first replayed batch includes all outstanding ID ranges.
+	 */
+	public requestUnfinalizedIdRanges(): void {
+		this.useUnfinalizedRangeOnNextFlush = true;
 	}
 
 	private addMessageToBatchManager(
@@ -351,8 +361,9 @@ export class Outbox {
 	 */
 	public flush(resubmitInfo?: BatchResubmitInfo): void {
 		// We have nothing to flush if all batchManagers are empty, and we we're not needing to resubmit an empty batch placeholder
+		// Note that it's possible that there are unfinalized ranges in the ID Compressor,
+		// but there's no urgency to flush those if they're not referenced in any messages.
 		if (
-			this.idAllocationBatch.empty &&
 			this.blobAttachBatch.empty &&
 			this.mainBatch.empty &&
 			resubmitInfo?.batchId === undefined
@@ -368,8 +379,7 @@ export class Outbox {
 	}
 
 	private flushAll(resubmitInfo?: BatchResubmitInfo): void {
-		const allBatchesEmpty =
-			this.idAllocationBatch.empty && this.blobAttachBatch.empty && this.mainBatch.empty;
+		const allBatchesEmpty = this.blobAttachBatch.empty && this.mainBatch.empty;
 		if (allBatchesEmpty) {
 			// If we're resubmitting with a batchId and all batches are empty, we need to flush an empty batch.
 			// Note that we currently resubmit one batch at a time, so on resubmit, 1 of the 2 batches will *always* be empty.
@@ -382,21 +392,19 @@ export class Outbox {
 			return;
 		}
 
-		// Don't use resubmittingBatchId for idAllocationBatch.
-		// ID Allocation messages are not directly resubmitted so don't pass the resubmitInfo
-		this.flushInternal({
-			batchManager: this.idAllocationBatch,
-			// Note: For now, we will never stage ID Allocation messages.
-			// They won't contain personal info and no harm in extra allocations in case of discarding the staged changes
-		});
+		// JIT ID allocation: generateJIT=true on both calls. takeNextCreationRange() is
+		// cumulative, so the first non-empty batch captures all pending IDs. The second
+		// call will return undefined (no remaining IDs). This is simpler than picking a target.
 		this.flushInternal({
 			batchManager: this.blobAttachBatch,
 			disableGroupedBatching: true,
 			resubmitInfo,
+			generateJIT: true,
 		});
 		this.flushInternal({
 			batchManager: this.mainBatch,
 			resubmitInfo,
+			generateJIT: true,
 		});
 	}
 
@@ -433,13 +441,14 @@ export class Outbox {
 		batchManager: BatchManager;
 		disableGroupedBatching?: boolean;
 		resubmitInfo?: BatchResubmitInfo; // undefined if not resubmitting
+		generateJIT?: boolean;
 	}): void {
-		const { batchManager, disableGroupedBatching = false, resubmitInfo } = params;
+		const { batchManager, disableGroupedBatching = false, resubmitInfo, generateJIT } = params;
 		if (batchManager.empty) {
 			return;
 		}
 
-		const rawBatch = batchManager.popBatch(resubmitInfo?.batchId);
+		let rawBatch = batchManager.popBatch();
 
 		// On resubmit we use the original batch's staged state, so these should match as well.
 		const staged = rawBatch.staged === true;
@@ -456,15 +465,31 @@ export class Outbox {
 			groupingEnabled
 		) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
+			// Rebase the current batch (resubmit the ops one-by-one) and then reinvoke flushInternal.
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
 			// it needs to be rebased so that we can ensure consistent reference sequence numbers
 			// and eventual consistency at the DDS level.
 			// Note: Since this is happening in the same turn the ops were originally created with,
 			// and they haven't gone to PendingStateManager yet, we can just let them respect
 			// ContainerRuntime.inStagingMode.  So we do not plumb local 'staged' variable through here.
-			this.rebase(rawBatch, batchManager);
+			this.rebase(rawBatch, batchManager, generateJIT);
 			return;
 		}
+
+		// Generate ID Allocation ops just-in-time, after rebase (if any).
+		// This ensures the refSeq is correct (matching the rest of the batch) and that
+		// ID ranges aren't lost during rebase (since reSubmit drops IdAllocation ops).
+		// Only generate for non-staged batches — ID alloc ops are always non-staged.
+		if (generateJIT === true && !staged) {
+			const useUnfinalized = this.useUnfinalizedRangeOnNextFlush;
+			this.useUnfinalizedRangeOnNextFlush = false;
+			const idAllocMsg = this.params.generateIdAllocationOp(useUnfinalized);
+			if (idAllocMsg !== undefined) {
+				rawBatch = { ...rawBatch, messages: [idAllocMsg, ...rawBatch.messages] };
+			}
+		}
+
+		addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 
 		let clientSequenceNumber: number | undefined;
 		// Did we disconnect? (i.e. is shouldSend false?)
@@ -484,7 +509,6 @@ export class Outbox {
 			rawBatch.messages,
 			clientSequenceNumber,
 			staged,
-			batchManager.options.ignoreBatchId,
 		);
 	}
 
@@ -494,7 +518,11 @@ export class Outbox {
 	 *
 	 * @param rawBatch - the batch to be rebased
 	 */
-	private rebase(rawBatch: LocalBatch, batchManager: BatchManager): void {
+	private rebase(
+		rawBatch: LocalBatch,
+		batchManager: BatchManager,
+		generateJIT?: boolean,
+	): void {
 		assert(!this.rebasing, 0x6fb /* Reentrancy */);
 		assert(batchManager.options.canRebase, 0x9a7 /* BatchManager does not support rebase */);
 
@@ -523,7 +551,7 @@ export class Outbox {
 			this.batchRebasesToReport--;
 		}
 
-		this.flushInternal({ batchManager });
+		this.flushInternal({ batchManager, generateJIT });
 		this.rebasing = false;
 	}
 
@@ -664,7 +692,6 @@ export class Outbox {
 	 */
 	public getBatchCheckpoints(): {
 		mainBatch: IBatchCheckpoint;
-		idAllocationBatch: IBatchCheckpoint;
 		blobAttachBatch: IBatchCheckpoint;
 	} {
 		// This variable is declared with a specific type so that we have a standard import of the IBatchCheckpoint type.
@@ -672,7 +699,6 @@ export class Outbox {
 		const mainBatch: IBatchCheckpoint = this.mainBatch.checkpoint();
 		return {
 			mainBatch,
-			idAllocationBatch: this.idAllocationBatch.checkpoint(),
 			blobAttachBatch: this.blobAttachBatch.checkpoint(),
 		};
 	}

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -70,13 +70,9 @@ export interface IOutboxParameters {
 	 * JIT callback to generate an ID allocation op at flush time.
 	 * Called after rebase (if any), so the returned message has the correct refSeq.
 	 *
-	 * @param useUnfinalizedRange - If true, use `takeUnfinalizedCreationRange()` (for reconnect).
-	 * Otherwise use `takeNextCreationRange()` (normal flush).
 	 * @returns A LocalBatchMessage for the ID allocation op, or undefined if no IDs need allocating.
 	 */
-	readonly generateIdAllocationOp: (
-		useUnfinalizedRange: boolean,
-	) => LocalBatchMessage | undefined;
+	readonly generateIdAllocationOp: () => LocalBatchMessage | undefined;
 }
 
 /**
@@ -201,7 +197,6 @@ export class Outbox {
 	private readonly logger: ITelemetryLoggerExt;
 	private readonly mainBatch: BatchManager;
 	private readonly blobAttachBatch: BatchManager;
-	private useUnfinalizedRangeOnNextFlush = false;
 	private batchRebasesToReport = 5;
 	private rebasing = false;
 
@@ -332,15 +327,6 @@ export class Outbox {
 		this.addMessageToBatchManager(this.blobAttachBatch, message);
 	}
 
-	/**
-	 * Signals that on the next JIT ID allocation, the outbox should use
-	 * `takeUnfinalizedCreationRange()` (comprehensive) instead of `takeNextCreationRange()` (incremental).
-	 * Used during reconnect so the first replayed batch includes all outstanding ID ranges.
-	 */
-	public requestUnfinalizedIdRanges(): void {
-		this.useUnfinalizedRangeOnNextFlush = true;
-	}
-
 	private addMessageToBatchManager(
 		batchManager: BatchManager,
 		message: LocalBatchMessage,
@@ -392,19 +378,14 @@ export class Outbox {
 			return;
 		}
 
-		// JIT ID allocation: generateJIT=true on both calls. takeNextCreationRange() is
-		// cumulative, so the first non-empty batch captures all pending IDs. The second
-		// call will return undefined (no remaining IDs). This is simpler than picking a target.
 		this.flushInternal({
 			batchManager: this.blobAttachBatch,
 			disableGroupedBatching: true,
 			resubmitInfo,
-			generateJIT: true,
 		});
 		this.flushInternal({
 			batchManager: this.mainBatch,
 			resubmitInfo,
-			generateJIT: true,
 		});
 	}
 
@@ -441,9 +422,8 @@ export class Outbox {
 		batchManager: BatchManager;
 		disableGroupedBatching?: boolean;
 		resubmitInfo?: BatchResubmitInfo; // undefined if not resubmitting
-		generateJIT?: boolean;
 	}): void {
-		const { batchManager, disableGroupedBatching = false, resubmitInfo, generateJIT } = params;
+		const { batchManager, disableGroupedBatching = false, resubmitInfo } = params;
 		if (batchManager.empty) {
 			return;
 		}
@@ -472,18 +452,22 @@ export class Outbox {
 			// Note: Since this is happening in the same turn the ops were originally created with,
 			// and they haven't gone to PendingStateManager yet, we can just let them respect
 			// ContainerRuntime.inStagingMode.  So we do not plumb local 'staged' variable through here.
-			this.rebase(rawBatch, batchManager, generateJIT);
+			this.rebase(rawBatch, batchManager);
 			return;
 		}
 
-		// Generate ID Allocation ops just-in-time, after rebase (if any).
-		// This ensures the refSeq is correct (matching the rest of the batch) and that
-		// ID ranges aren't lost during rebase (since reSubmit drops IdAllocation ops).
-		// Only generate for non-staged batches — ID alloc ops are always non-staged.
-		if (generateJIT === true && !staged) {
-			const useUnfinalized = this.useUnfinalizedRangeOnNextFlush;
-			this.useUnfinalizedRangeOnNextFlush = false;
-			const idAllocMsg = this.params.generateIdAllocationOp(useUnfinalized);
+		// Did we disconnect? (i.e. is shouldSend false?)
+		// If so, do nothing, as pending state manager will resubmit it correctly on reconnect.
+		// Because flush() is a task that executes async (on clean stack), we can get here in disconnected state.
+		const shouldSendNow = this.params.shouldSend() && !staged;
+
+		if (shouldSendNow) {
+			// Generate ID Allocation op just-in-time, after rebase (if any), and before addBatchMetadata,
+			// so that the prepended idAllocMsg is correctly marked as the first op in the batch.
+			// This ensures the refSeq is correct (matching the rest of the batch) and that
+			// ID ranges aren't lost during rebase (since reSubmit drops IdAllocation ops).
+			// Only generate for non-staged batches — ID alloc ops are always non-staged.
+			const idAllocMsg = this.params.generateIdAllocationOp();
 			if (idAllocMsg !== undefined) {
 				rawBatch = { ...rawBatch, messages: [idAllocMsg, ...rawBatch.messages] };
 			}
@@ -492,10 +476,7 @@ export class Outbox {
 		addBatchMetadata(rawBatch, resubmitInfo?.batchId);
 
 		let clientSequenceNumber: number | undefined;
-		// Did we disconnect? (i.e. is shouldSend false?)
-		// If so, do nothing, as pending state manager will resubmit it correctly on reconnect.
-		// Because flush() is a task that executes async (on clean stack), we can get here in disconnected state.
-		if (this.params.shouldSend() && !staged) {
+		if (shouldSendNow) {
 			const virtualizedBatch = this.virtualizeBatch(rawBatch, groupingEnabled);
 
 			clientSequenceNumber = this.sendBatch(virtualizedBatch);
@@ -518,11 +499,7 @@ export class Outbox {
 	 *
 	 * @param rawBatch - the batch to be rebased
 	 */
-	private rebase(
-		rawBatch: LocalBatch,
-		batchManager: BatchManager,
-		generateJIT?: boolean,
-	): void {
+	private rebase(rawBatch: LocalBatch, batchManager: BatchManager): void {
 		assert(!this.rebasing, 0x6fb /* Reentrancy */);
 		assert(batchManager.options.canRebase, 0x9a7 /* BatchManager does not support rebase */);
 
@@ -551,7 +528,7 @@ export class Outbox {
 			this.batchRebasesToReport--;
 		}
 
-		this.flushInternal({ batchManager, generateJIT });
+		this.flushInternal({ batchManager });
 		this.rebasing = false;
 	}
 

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -85,10 +85,6 @@ export interface IPendingMessage {
 		 */
 		length: number;
 		/**
-		 * If true, don't compare batchID of incoming batches to this. e.g. ID Allocation Batch IDs should be ignored
-		 */
-		ignoreBatchId?: boolean;
-		/**
 		 * If true, this batch is staged and should not actually be submitted on replayPendingStates.
 		 */
 		staged: boolean;
@@ -407,13 +403,11 @@ export class PendingStateManager implements IDisposable {
 	 * @param clientSequenceNumber - The CSN of the first message in the batch,
 	 * or undefined if the batch was not yet sent (e.g. by the time we flushed we lost the connection)
 	 * @param staged - Indicates whether batch is staged (not to be submitted while runtime is in Staging Mode)
-	 * @param ignoreBatchId - Whether to ignore the batchId in the batchStartInfo
 	 */
 	public onFlushBatch(
 		batch: LocalBatchMessage[] | [LocalEmptyBatchPlaceholder],
 		clientSequenceNumber: number | undefined,
 		staged: boolean,
-		ignoreBatchId?: boolean,
 	): void {
 		// clientId and batchStartCsn are used for generating the batchId so we can detect container forks
 		// where this batch was submitted by two different clients rehydrating from the same local state.
@@ -431,7 +425,7 @@ export class PendingStateManager implements IDisposable {
 			clientId !== undefined,
 			0xa33 /* clientId (from stateHandler) could only be undefined if we've never connected, but we have a CSN so we know that's not the case */,
 		);
-		const batchInfo = { clientId, batchStartCsn, length: batch.length, ignoreBatchId, staged };
+		const batchInfo = { clientId, batchStartCsn, length: batch.length, staged };
 		for (const message of batch) {
 			const {
 				runtimeOp,
@@ -512,23 +506,14 @@ export class PendingStateManager implements IDisposable {
 	 * @returns whether the batch IDs match
 	 */
 	private remoteBatchMatchesPendingBatch(remoteBatchStart: BatchStartInfo): boolean {
-		// Find the first pending message that uses Batch ID, to compare to the incoming remote batch.
-		// If there is no such message, then the incoming remote batch doesn't have a match here and we can return.
-		const firstIndexUsingBatchId = Array.from({
-			length: this.pendingMessages.length,
-		}).findIndex((_, i) => this.pendingMessages.get(i)?.batchInfo.ignoreBatchId !== true);
-		const pendingMessageUsingBatchId =
-			firstIndexUsingBatchId === -1
-				? undefined
-				: this.pendingMessages.get(firstIndexUsingBatchId);
-
-		if (pendingMessageUsingBatchId === undefined) {
+		const pendingMessage = this.pendingMessages.peekFront();
+		if (pendingMessage === undefined) {
 			return false;
 		}
 
 		// We must compare the effective batch IDs, since one of these ops
 		// may have been the original, not resubmitted, so wouldn't have its batch ID stamped yet.
-		const pendingBatchId = getEffectiveBatchId(pendingMessageUsingBatchId);
+		const pendingBatchId = getEffectiveBatchId(pendingMessage);
 		const inboundBatchId = getEffectiveBatchId(remoteBatchStart);
 
 		return pendingBatchId === inboundBatchId;
@@ -810,10 +795,7 @@ export class PendingStateManager implements IDisposable {
 			assert(batchMetadataFlag !== false, 0x41b /* We cannot process batches in chunks */);
 
 			// The next message starts a batch (possibly single-message), and we'll need its batchId.
-			const batchId =
-				pendingMessage.batchInfo.ignoreBatchId === true
-					? undefined
-					: getEffectiveBatchId(pendingMessage);
+			const batchId = getEffectiveBatchId(pendingMessage);
 
 			const staged = pendingMessage.batchInfo.staged;
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4777,7 +4777,6 @@ describe("Runtime", () => {
 				});
 
 				it("IdAllocation + reconnect while in staging mode does not hit coherency check", async () => {
-					// This is the highest-risk scenario from Mark's test plan.
 					// With JIT ID allocation, the ID alloc op is generated at flush time
 					// (via generateIdAllocationOp callback), so it naturally gets the correct refSeq.
 					// The "op" handler calls flush() directly, so the IdAllocation op still gets

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -649,21 +649,41 @@ describe("Runtime", () => {
 				await Promise.resolve();
 
 				// Generate another ID and submit a data store op referencing it.
-				// This triggers submitIdAllocationOpIfNeeded → takeNextCreationRange.
+				// At flush time, the JIT generateIdAllocationOp callback calls takeNextCreationRange.
 				// Because the unfinalized range was released during replay, both IDs
 				// are included in the resulting allocation range.
 				const id2 = compressor.generateCompressedId();
 				submitDataStoreOp(containerRuntime, "someDS", genTestDataStoreMessage({ id: id2 }));
 
-				// Let the Outbox flush so we can check submittedOps length
+				// Let the Outbox flush so we can check submittedOps length.
+				// With JIT ID allocation, the ID alloc op is prepended to the main batch,
+				// which gets grouped into a single grouped batch op.
 				await Promise.resolve();
-				assert.strictEqual(submittedOps.length, 2, "Expected 1 ID Allocation + 1 data op");
+				assert.strictEqual(
+					submittedOps.length,
+					1,
+					"Expected 1 grouped batch (containing ID Allocation + data op)",
+				);
+
+				// The grouped batch contains the ID allocation as its first inner message.
+				// Extract the ID allocation range from it to finalize.
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any -- test-only: extracting untyped grouped batch contents
+				const groupedContents = submittedOps[0].contents;
+				assert(
+					Array.isArray(groupedContents),
+					"Expected grouped batch contents to be an array",
+				);
+				assert.strictEqual(
+					groupedContents.length,
+					2,
+					"Expected 2 inner messages in grouped batch",
+				);
 
 				// Simulate processing the ID Allocation ack — finalize the range.
 				// Without the call to resetUnfinalizedCreationRange in replayPendingStates,
 				// this results in a "Ranges finalized out of order" error.
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-				compressor.finalizeCreationRange(submittedOps[0].contents);
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- test-only: extracting untyped grouped batch contents
+				compressor.finalizeCreationRange(groupedContents[0].contents.contents);
 
 				// Both IDs should now be finalized (positive final IDs in op space).
 				// Without resetUnfinalizedCreationRange, id1 would remain a local-only
@@ -4758,11 +4778,10 @@ describe("Runtime", () => {
 
 				it("IdAllocation + reconnect while in staging mode does not hit coherency check", async () => {
 					// This is the highest-risk scenario from Mark's test plan.
-					// The fix in b4e1fd1dd25 added scheduleFlush() after submitIdAllocationOpIfNeeded
-					// during replayPendingStates. With threshold suppression, that scheduleFlush()
-					// returns early if in staging mode and under threshold. But the "op" handler
-					// calls flush() directly, so the IdAllocation op still gets flushed before
-					// new ops with different refSeqs are submitted.
+					// With JIT ID allocation, the ID alloc op is generated at flush time
+					// (via generateIdAllocationOp callback), so it naturally gets the correct refSeq.
+					// The "op" handler calls flush() directly, so the IdAllocation op still gets
+					// flushed before new ops with different refSeqs are submitted.
 
 					// Start disconnected so we can trigger IdAllocation on reconnect
 					mockContext = getMockContext({ connected: false }) as IContainerContext;

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../../messageTypes.js";
 import type { IBatchMetadata } from "../../metadata.js";
 import {
+	addBatchMetadata,
 	BatchManager,
 	estimateSocketSize,
 	generateBatchId,
@@ -68,7 +69,7 @@ describe("BatchManager", () => {
 				/* reentrant */ false,
 			);
 
-			const batch = batchManager.popBatch(batchId);
+			const batch = addBatchMetadata(batchManager.popBatch(), batchId);
 			assert.deepEqual(
 				batch.messages.map((m) => m.metadata as IBatchMetadata),
 				[
@@ -82,7 +83,7 @@ describe("BatchManager", () => {
 				{ runtimeOp: op(), referenceSequenceNumber: 0 },
 				/* reentrant */ false,
 			);
-			const singleOpBatch = batchManager.popBatch(batchId);
+			const singleOpBatch = addBatchMetadata(batchManager.popBatch(), batchId);
 			assert.deepEqual(
 				singleOpBatch.messages.map((m) => m.metadata as IBatchMetadata),
 				[

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -52,7 +52,7 @@ const smallMessage = (size: number = 100): LocalBatchMessage => {
 };
 
 describe("BatchManager", () => {
-	const defaultOptions: IBatchManagerOptions = {};
+	const defaultOptions: IBatchManagerOptions = { disableGroupedBatching: false };
 
 	describe("addBatchMetadata", () => {
 		const makeLocalBatch = (...ops: string[]): LocalBatch => ({
@@ -124,6 +124,17 @@ describe("BatchManager", () => {
 		assert.equal(
 			estimateSocketSize(localBatchToOutboundBatch({ messages, referenceSequenceNumber: 0 })),
 			2400,
+		);
+	});
+
+	it("disableGroupedBatching is accessible via options", () => {
+		assert.equal(
+			new BatchManager({ disableGroupedBatching: true }).options.disableGroupedBatching,
+			true,
+		);
+		assert.equal(
+			new BatchManager({ disableGroupedBatching: false }).options.disableGroupedBatching,
+			false,
 		);
 	});
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -18,7 +18,11 @@ import {
 	generateBatchId,
 	localBatchToOutboundBatch,
 } from "../../opLifecycle/index.js";
-import type { IBatchManagerOptions, LocalBatchMessage } from "../../opLifecycle/index.js";
+import type {
+	IBatchManagerOptions,
+	LocalBatch,
+	LocalBatchMessage,
+} from "../../opLifecycle/index.js";
 
 // Make a mock op with distinguishable contents
 function op(data: string = "Some Data"): LocalContainerRuntimeMessage {
@@ -48,49 +52,39 @@ const smallMessage = (size: number = 100): LocalBatchMessage => {
 };
 
 describe("BatchManager", () => {
-	const defaultOptions: IBatchManagerOptions = {
-		canRebase: true,
-	};
+	const defaultOptions: IBatchManagerOptions = {};
 
-	for (const includeBatchId of [true, false])
-		it(`Batch metadata is set correctly [${includeBatchId ? "with" : "without"} batchId]`, () => {
-			const batchManager = new BatchManager(defaultOptions);
-			const batchId = includeBatchId ? "BATCH_ID" : undefined;
-			batchManager.push(
-				{ runtimeOp: op(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
-			);
-			batchManager.push(
-				{ runtimeOp: op(), referenceSequenceNumber: 1 },
-				/* reentrant */ false,
-			);
-			batchManager.push(
-				{ runtimeOp: op(), referenceSequenceNumber: 2 },
-				/* reentrant */ false,
-			);
-
-			const batch = addBatchMetadata(batchManager.popBatch(), batchId);
-			assert.deepEqual(
-				batch.messages.map((m) => m.metadata as IBatchMetadata),
-				[
-					{ batch: true, ...(includeBatchId ? { batchId } : undefined) }, // batchId propertly should be omitted (v. set to undefined) if not provided
-					undefined, // metadata not touched for intermediate messages
-					{ batch: false },
-				],
-			);
-
-			batchManager.push(
-				{ runtimeOp: op(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
-			);
-			const singleOpBatch = addBatchMetadata(batchManager.popBatch(), batchId);
-			assert.deepEqual(
-				singleOpBatch.messages.map((m) => m.metadata as IBatchMetadata),
-				[
-					includeBatchId ? { batchId } : undefined, // batchId propertly should be omitted (v. set to undefined) if not provided
-				],
-			);
+	describe("addBatchMetadata", () => {
+		const makeLocalBatch = (...ops: string[]): LocalBatch => ({
+			messages: ops.map((data, i) => ({ runtimeOp: op(data), referenceSequenceNumber: i })),
+			referenceSequenceNumber: ops.length - 1,
 		});
+
+		for (const includeBatchId of [true, false])
+			it(`sets metadata correctly [${includeBatchId ? "with" : "without"} batchId]`, () => {
+				const batchId = includeBatchId ? "BATCH_ID" : undefined;
+
+				// Multi-message batch: first gets batch:true, last gets batch:false, middle untouched
+				const batch = addBatchMetadata(makeLocalBatch("a", "b", "c"), batchId);
+				assert.deepEqual(
+					batch.messages.map((m) => m.metadata as IBatchMetadata),
+					[
+						{ batch: true, ...(includeBatchId ? { batchId } : undefined) }, // batchId should be omitted (not set to undefined) if not provided
+						undefined, // metadata not touched for intermediate messages
+						{ batch: false },
+					],
+				);
+
+				// Single-message batch: no batch flag, only batchId if provided
+				const singleOpBatch = addBatchMetadata(makeLocalBatch("a"), batchId);
+				assert.deepEqual(
+					singleOpBatch.messages.map((m) => m.metadata as IBatchMetadata),
+					[
+						includeBatchId ? { batchId } : undefined, // batchId should be omitted (not set to undefined) if not provided
+					],
+				);
+			});
+	});
 
 	it("BatchId Format", () => {
 		const clientId = "3627a2a9-963f-4e3b-a4d2-a31b1267ef29";

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -240,6 +240,7 @@ describe("Outbox", () => {
 		chunkSizeInBytes?: number;
 		opGroupingConfig?: OpGroupingManagerConfig;
 		immediateMode?: boolean;
+		generateIdAllocationOp?: () => LocalBatchMessage | undefined;
 	}) => {
 		const { submitFn, submitBatchFn, deltaManager } = params.context;
 
@@ -271,6 +272,7 @@ describe("Outbox", () => {
 				state.opsResubmitted++;
 			},
 			opReentrancy: () => state.isReentrant,
+			generateIdAllocationOp: params.generateIdAllocationOp ?? (() => undefined),
 		});
 	};
 
@@ -325,38 +327,51 @@ describe("Outbox", () => {
 	});
 
 	it("Sending batches", () => {
-		const outbox = getOutbox({ context: getMockContext() });
+		const idAllocMessage = createMessage(ContainerMessageType.IdAllocation, "idAlloc");
+		let idAllocReturned = false;
+		const outbox = getOutbox({
+			context: getMockContext(),
+			// JIT callback: return an ID alloc op on the first call, then undefined
+			generateIdAllocationOp: () => {
+				if (!idAllocReturned) {
+					idAllocReturned = true;
+					return idAllocMessage;
+				}
+				return undefined;
+			},
+		});
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.IdAllocation, "3"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "4"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "5"),
 		];
 
-		// Flush 1
+		// Flush 1 — JIT ID alloc op is prepended to the first non-empty batch (blobAttach is empty, so main batch)
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submitIdAllocation(messages[3]);
 		outbox.flush();
 
-		// Flush 2
-		outbox.submit(messages[4]);
+		// Flush 2 — no more ID alloc ops
+		outbox.submit(messages[2]);
 		outbox.flush();
 
 		// Not Flushed
-		outbox.submit(messages[5]);
+		outbox.submit(messages[3]);
 
-		assert.equal(state.opsSubmitted, messages.length - 1); // -1 for the non-flushed message
+		assert.equal(state.opsSubmitted, 4); // 2 main + idAlloc from flush 1, 1 main from flush 2
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
 			[
-				[toSubmittedMessage(messages[2], true), toSubmittedMessage(messages[3], false)],
-				[toSubmittedMessage(messages[0], true), toSubmittedMessage(messages[1], false)],
-				[toSubmittedMessage(messages[4])], // The last message was not batched
+				// Flush 1 (Main) — idAlloc prepended
+				[
+					toSubmittedMessage(idAllocMessage, true),
+					toSubmittedMessage(messages[0]),
+					toSubmittedMessage(messages[1], false),
+				],
+				// Flush 2 (Main)
+				[toSubmittedMessage(messages[2])],
 			],
 			"Submitted batches are incorrect",
 		);
@@ -364,14 +379,12 @@ describe("Outbox", () => {
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
-			[messages[2], 1],
-			[messages[3], 1],
-			// Flush 1 (Main)
-			[messages[0], 3],
-			[messages[1], 3],
+			// Flush 1 (Main with prepended idAlloc)
+			[idAllocMessage, 1],
+			[messages[0], 1],
+			[messages[1], 1],
 			// Flush 2 (Main)
-			[messages[4], 5],
+			[messages[2], 4],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -423,8 +436,7 @@ describe("Outbox", () => {
 				groupedBatchingEnabled: false,
 			},
 		});
-		// Flush 1 - resubmit multi-message batch including ID Allocation
-		outbox.submitIdAllocation(createMessage(ContainerMessageType.IdAllocation, "0")); // Separate batch, batch ID not used
+		// Flush 1 - resubmit multi-message batch
 		outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "1"));
 		outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "2"));
 		outbox.flush({ batchId: "batchId-A", staged: false });
@@ -449,7 +461,6 @@ describe("Outbox", () => {
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages.map((m) => m.metadata?.batchId)),
 			[
-				[undefined], // Flush 1 - ID Allocation (no batch ID used)
 				["batchId-A", undefined], // Flush 1 - Main
 				["batchId-B"], // Flush 2 - Main
 				["batchId-C", undefined], // Flush 3 - Blob Attach
@@ -461,7 +472,6 @@ describe("Outbox", () => {
 		assert.deepEqual(
 			state.pendingOpContents.map(({ opMetadata }) => asBatchMetadata(opMetadata)?.batchId),
 			[
-				undefined, // ID Allocation (no batch ID used)
 				"batchId-A",
 				undefined, // second message in batch
 				"batchId-B",
@@ -514,37 +524,33 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "4"),
 		];
 
 		// Flush 1
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submit(messages[3]);
+		outbox.submit(messages[2]);
 		outbox.flush();
 
 		// Flush 2
-		outbox.submit(messages[4]);
+		outbox.submit(messages[3]);
 		outbox.flush();
 
 		assert.equal(state.opsSubmitted, messages.length);
 		assert.equal(state.batchesSubmitted.length, 0);
 		assert.deepEqual(state.individualOpsSubmitted.length, messages.length);
-		assert.equal(state.deltaManagerFlushCalls, 3);
+		assert.equal(state.deltaManagerFlushCalls, 2);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
-			[messages[2], 1],
 			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[2], 1],
 			// Flush 2 (Main)
-			[messages[4], 5],
+			[messages[3], 4],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -573,45 +579,39 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submit(messages[3]);
+		outbox.submit(messages[2]);
 
 		outbox.flush();
 
-		const groupedMessages = opGroupingManager.groupBatch(
-			toOutboundBatch([messages[0], messages[1], messages[3]]),
-		);
+		const groupedMessages = opGroupingManager.groupBatch(toOutboundBatch(messages));
 
-		// Submits 2 ops, one for the id allocation and one for the grouped batch
-		assert.equal(state.opsSubmitted, 2);
-		assert.equal(state.batchesSubmitted.length, 2);
+		// Submits 1 grouped batch
+		assert.equal(state.opsSubmitted, 1);
+		assert.equal(state.batchesSubmitted.length, 1);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(
 			state.batchesCompressed,
-			[toOutboundBatch([messages[2]]), groupedMessages],
+			[groupedMessages],
 			"Compressed batches don't match expected",
 		);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[2])], [toSubmittedMessage(groupedMessages.messages[0])]],
+			[[toSubmittedMessage(groupedMessages.messages[0])]],
 			"Submitted batches don't match expected",
 		);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
-			[messages[2], 1],
 			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[2], 1],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -642,35 +642,27 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submit(messages[3]);
+		outbox.submit(messages[2]);
 
 		outbox.flush();
 
-		assert.equal(
-			state.opsSubmitted,
-			2,
-			"Expected 2 ops to be submitted, on ID Allocation and one for the grouped batch",
-		);
-		assert.equal(state.batchesSubmitted.length, 2);
+		assert.equal(state.opsSubmitted, 1, "Expected 1 op to be submitted for the grouped batch");
+		assert.equal(state.batchesSubmitted.length, 1);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(state.batchesCompressed, []);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
-			[messages[2], 1],
 			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[2], 1],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -740,39 +732,30 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submit(messages[3]);
+		outbox.submit(messages[2]);
 
 		outbox.flush();
 
-		const groupedMessages = opGroupingManager.groupBatch(
-			toOutboundBatch([messages[0], messages[1], messages[3]]),
-		);
+		const groupedMessages = opGroupingManager.groupBatch(toOutboundBatch(messages));
 
-		assert.deepEqual(state.batchesCompressed, [
-			toOutboundBatch([messages[2]]),
-			groupedMessages,
-		]);
-		assert.deepEqual(state.batchesSplit, [toOutboundBatch([messages[2]]), groupedMessages]);
+		assert.deepEqual(state.batchesCompressed, [groupedMessages]);
+		assert.deepEqual(state.batchesSplit, [groupedMessages]);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[2])], [toSubmittedMessage(groupedMessages.messages[0])]],
+			[[toSubmittedMessage(groupedMessages.messages[0])]],
 		);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
-			// Flush 1 (ID Allocation)
-			[messages[2], 1],
 			// Flush 1 (Main)
-			[messages[0], 2],
-			[messages[1], 2],
-			[messages[3], 2],
+			[messages[0], 1],
+			[messages[1], 1],
+			[messages[2], 1],
 		] as const;
 		assert.deepEqual(
 			state.pendingOpContents,
@@ -804,29 +787,22 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submit(messages[3]);
+		outbox.submit(messages[2]);
 
 		outbox.flush();
 
-		const groupedMessages = opGroupingManager.groupBatch(
-			toOutboundBatch([messages[0], messages[1], messages[3]]),
-		);
+		const groupedMessages = opGroupingManager.groupBatch(toOutboundBatch(messages));
 
-		assert.deepEqual(state.batchesCompressed, [
-			toOutboundBatch([messages[2]]),
-			groupedMessages,
-		]);
+		assert.deepEqual(state.batchesCompressed, [groupedMessages]);
 		assert.deepEqual(state.batchesSplit, []);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
-			[[toSubmittedMessage(messages[2])], [toSubmittedMessage(groupedMessages.messages[0])]],
+			[[toSubmittedMessage(groupedMessages.messages[0])]],
 		);
 	});
 
@@ -1193,21 +1169,24 @@ describe("Outbox", () => {
 			);
 		});
 
-		it("returns false when only idAllocationBatch has ops", () => {
-			const outbox = getOutbox({ context: getMockContext() });
-			const idAllocationOp: LocalBatchMessage = {
-				runtimeOp: {
-					type: ContainerMessageType.IdAllocation,
-				} satisfies Partial<LocalContainerRuntimeMessage> as LocalContainerRuntimeMessage,
-				referenceSequenceNumber: 1,
-				metadata: undefined,
-				localOpMetadata: {},
-			};
-			outbox.submitIdAllocation(idAllocationOp);
+		it("returns false when only JIT ID allocation ops would be generated", () => {
+			// With JIT ID allocation, pending IDs are tracked by the compressor, not the outbox.
+			// The outbox has no queued messages, so containsUserChanges should be false.
+			const outbox = getOutbox({
+				context: getMockContext(),
+				generateIdAllocationOp: () => ({
+					runtimeOp: {
+						type: ContainerMessageType.IdAllocation,
+					} satisfies Partial<LocalContainerRuntimeMessage> as LocalContainerRuntimeMessage,
+					referenceSequenceNumber: 1,
+					metadata: undefined,
+					localOpMetadata: {},
+				}),
+			});
 			assert.equal(
 				outbox.containsUserChanges(),
 				false,
-				"Should be false when only idAllocationBatch has ops",
+				"Should be false when no messages are queued (JIT ID alloc is not queued)",
 			);
 		});
 	});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -971,7 +971,7 @@ describe("Outbox", () => {
 			validateCounts(0, 0, 0);
 		});
 
-		it("batch has reentrant ops, but grouped batching is off", () => {
+		it("batch has reentrant ops, but grouped batching is off: rebase still happens", () => {
 			const outbox = getOutbox({
 				context: getMockContext(),
 				opGroupingConfig: {
@@ -984,12 +984,14 @@ describe("Outbox", () => {
 				createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
 			];
 
+			state.isReentrant = true;
 			outbox.submit(messages[0]);
 			outbox.submit(messages[1]);
+			state.isReentrant = false;
 
 			outbox.flush();
 
-			validateCounts(2, 1, 0);
+			validateCounts(0, 0, 2);
 		});
 
 		it("batch has reentrant ops", () => {
@@ -1032,6 +1034,72 @@ describe("Outbox", () => {
 			outbox.flush();
 
 			validateCounts(0, 0, 1);
+		});
+
+		it("reentrant blobAttach ops trigger rebase", () => {
+			// blobAttach batch has disableGroupedBatching:true, but reentrant ops must still rebase
+			// (previously, the disableGroupedBatching flag suppressed rebase for blobAttach)
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+			});
+
+			const messages = [
+				createMessage(ContainerMessageType.BlobAttach, "0"),
+				createMessage(ContainerMessageType.BlobAttach, "1"),
+			];
+
+			state.isReentrant = true;
+			outbox.submitBlobAttach(messages[0]);
+			outbox.submitBlobAttach(messages[1]);
+			state.isReentrant = false;
+
+			outbox.flush();
+
+			validateCounts(0, 0, 2);
+		});
+
+		it("non-reentrant blobAttach ops do not trigger rebase", () => {
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+			});
+
+			const messages = [
+				createMessage(ContainerMessageType.BlobAttach, "0"),
+				createMessage(ContainerMessageType.BlobAttach, "1"),
+			];
+
+			outbox.submitBlobAttach(messages[0]);
+			outbox.submitBlobAttach(messages[1]);
+
+			outbox.flush();
+
+			validateCounts(2, 1, 0);
+		});
+
+		it("throws when resubmitting a batch that has reentrant ops", () => {
+			// Resubmitting (flush with batchId) a batch that contains reentrant ops is not supported
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+			});
+
+			state.isReentrant = true;
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "0"));
+			state.isReentrant = false;
+
+			assert.throws(
+				() => outbox.flush({ batchId: "batchId", staged: false }),
+				(e: Error) =>
+					e.message === "Re-submitting a batch with reentrant ops is not supported",
+			);
 		});
 
 		it("should group the batch", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -21,7 +21,7 @@ import type {
 } from "../../messageTypes.js";
 import {
 	addBatchMetadata,
-	BatchManager,
+	type LocalBatch,
 	type OutboundBatchMessage,
 	type OutboundBatch,
 	type OutboundSingletonBatch,
@@ -357,33 +357,23 @@ describe("RemoteMessageProcessor", () => {
 	describe("Throws on invalid batches", () => {
 		it("Unexpected batch start marker mid-batch", () => {
 			let csn = 1;
-			const batchManager = new BatchManager({
-				canRebase: false,
-			});
-			batchManager.push(
-				{ runtimeOp: op("A1"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			batchManager.push(
-				{ runtimeOp: op("A2"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			batchManager.push(
-				{ runtimeOp: op("A3"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			const batchA = batchManager.popBatch();
+			const batchA: LocalBatch = {
+				messages: [
+					{ runtimeOp: op("A1"), referenceSequenceNumber: 1 },
+					{ runtimeOp: op("A2"), referenceSequenceNumber: 1 },
+					{ runtimeOp: op("A3"), referenceSequenceNumber: 1 },
+				],
+				referenceSequenceNumber: 1,
+			};
 			addBatchMetadata(batchA);
 			batchA.messages[2].metadata = undefined; // Wipe out the ending metadata so the next batch's start shows up mid-batch
-			batchManager.push(
-				{ runtimeOp: op("B1"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			batchManager.push(
-				{ runtimeOp: op("B2"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			const batchB = batchManager.popBatch();
+			const batchB: LocalBatch = {
+				messages: [
+					{ runtimeOp: op("B1"), referenceSequenceNumber: 1 },
+					{ runtimeOp: op("B2"), referenceSequenceNumber: 1 },
+				],
+				referenceSequenceNumber: 1,
+			};
 			addBatchMetadata(batchB);
 
 			const processor = getMessageProcessor();
@@ -414,22 +404,14 @@ describe("RemoteMessageProcessor", () => {
 
 		it("Unexpected batch end marker when no batch has started", () => {
 			let csn = 1;
-			const batchManager = new BatchManager({
-				canRebase: false,
-			});
-			batchManager.push(
-				{ runtimeOp: op("A1"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			batchManager.push(
-				{ runtimeOp: op("A2"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			batchManager.push(
-				{ runtimeOp: op("A3"), referenceSequenceNumber: 1 },
-				false /* reentrant */,
-			);
-			const batchA = batchManager.popBatch();
+			const batchA: LocalBatch = {
+				messages: [
+					{ runtimeOp: op("A1"), referenceSequenceNumber: 1 },
+					{ runtimeOp: op("A2"), referenceSequenceNumber: 1 },
+					{ runtimeOp: op("A3"), referenceSequenceNumber: 1 },
+				],
+				referenceSequenceNumber: 1,
+			};
 			addBatchMetadata(batchA);
 			batchA.messages[0].metadata = undefined; // Wipe out the starting metadata
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -20,6 +20,7 @@ import type {
 	LocalContainerRuntimeMessage,
 } from "../../messageTypes.js";
 import {
+	addBatchMetadata,
 	BatchManager,
 	type OutboundBatchMessage,
 	type OutboundBatch,
@@ -372,6 +373,7 @@ describe("RemoteMessageProcessor", () => {
 				false /* reentrant */,
 			);
 			const batchA = batchManager.popBatch();
+			addBatchMetadata(batchA);
 			batchA.messages[2].metadata = undefined; // Wipe out the ending metadata so the next batch's start shows up mid-batch
 			batchManager.push(
 				{ runtimeOp: op("B1"), referenceSequenceNumber: 1 },
@@ -382,6 +384,7 @@ describe("RemoteMessageProcessor", () => {
 				false /* reentrant */,
 			);
 			const batchB = batchManager.popBatch();
+			addBatchMetadata(batchB);
 
 			const processor = getMessageProcessor();
 
@@ -427,6 +430,7 @@ describe("RemoteMessageProcessor", () => {
 				false /* reentrant */,
 			);
 			const batchA = batchManager.popBatch();
+			addBatchMetadata(batchA);
 			batchA.messages[0].metadata = undefined; // Wipe out the starting metadata
 
 			const processor = getMessageProcessor();

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -155,7 +155,7 @@ describe("Pending State Manager", () => {
 			rollbackContent = [];
 			rollbackShouldThrow = false;
 
-			batchManager = new BatchManager({ canRebase: true });
+			batchManager = new BatchManager({});
 		});
 
 		it("should do nothing when rolling back empty pending stack", () => {

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -155,7 +155,7 @@ describe("Pending State Manager", () => {
 			rollbackContent = [];
 			rollbackShouldThrow = false;
 
-			batchManager = new BatchManager({});
+			batchManager = new BatchManager({ disableGroupedBatching: false });
 		});
 
 		it("should do nothing when rolling back empty pending stack", () => {

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -2262,8 +2262,7 @@ describeCompat(
 					async (c, d) => {
 						const counter = await d.getSharedObject<SharedCounter>(counterId);
 						// Include an ID Allocation op to get coverage of the special logic around these ops as well
-						// AB#26984: Actually don't, because the ID Compressor is hitting "Ranges finalized out of order" for this test
-						// getIdCompressor(counter)?.generateCompressedId();
+						getIdCompressor(counter)?.generateCompressedId();
 						counter.increment(incrementValue);
 					},
 				);


### PR DESCRIPTION
Using prototype https://github.com/microsoft/FluidFramework/pull/26779/changes/a244a1f0056b244abb8428ebc786d86587a771d4 as base. 

This branch removes the dedicated idAllocationBatch from the Outbox and replaces it with just-in-time (JIT) ID allocation op generation at flush time.

### Key Changes
**Core change — JIT ID allocation ([outbox.ts](vscode-webview://0setsnuqdgpe6inajv22i20l1mo21fcect4fpqbjjmsc3q1f9bv8/packages/runtime/container-runtime/src/opLifecycle/outbox.ts), [containerRuntime.ts](vscode-webview://0setsnuqdgpe6inajv22i20l1mo21fcect4fpqbjjmsc3q1f9bv8/packages/runtime/container-runtime/src/containerRuntime.ts)):**

- Previously: submitIdAllocationOpIfNeeded() was called eagerly before each non-staged op submission, pushing an ID alloc op into a separate idAllocationBatch in the Outbox.
- Now: A generateIdAllocationOp callback is passed to the Outbox via IOutboxParameters. At flush time (after any rebase), the outbox calls this JIT to generate the ID alloc op and prepends it to the batch being sent.

The ID alloc op is generated after rebase, so its refSeq always matches the rest of the batch.
ID ranges are no longer lost during rebase (previously reSubmit would drop IdAllocation ops and needed special handling with takeUnfinalizedCreationRange).
Simplifies the Outbox from 3 batch managers down to 2 (mainBatch + blobAttachBatch).

By removing ID allocation batches, we are effectively solving the inherent problem of not being able to track forking containers due to these batches being untraceable via batchId.
