### PR TITLE
Revert "Remove isomorphic-fetch from odsp-doclib-utils"

### DIFF
--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -121,7 +121,8 @@
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
-		"@fluidframework/telemetry-utils": "workspace:~"
+		"@fluidframework/telemetry-utils": "workspace:~",
+		"isomorphic-fetch": "^3.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.2",
@@ -133,6 +134,7 @@
 		"@fluidframework/eslint-config-fluid": "catalog:eslint",
 		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.91.0",
 		"@microsoft/api-extractor": "7.52.11",
+		"@types/isomorphic-fetch": "^0.0.39",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "~20.19.30",
 		"c8": "^10.1.3",

--- a/packages/utils/odsp-doclib-utils/src/odspRequest.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspRequest.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import fetch from "isomorphic-fetch";
+
 import { type IOdspAuthRequestInfo, authRequestWithRetry } from "./odspAuth.js";
 
 // eslint-disable-next-line jsdoc/require-description -- TODO: Add documentation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16845,6 +16845,9 @@ importers:
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../telemetry-utils
+      isomorphic-fetch:
+        specifier: ^3.0.0
+        version: 3.0.0(encoding@0.1.13)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -16873,6 +16876,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: 7.52.11
         version: 7.52.11(patch_hash=c85b3a060bd0e2928f5892cfe09e062ab940a339dbd9de3a7cafbd309b724069)(@types/node@20.19.30)
+      '@types/isomorphic-fetch':
+        specifier: ^0.0.39
+        version: 0.0.39
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -19886,6 +19892,9 @@ packages:
     resolution: {integrity: sha512-5heqtZMvQ4nXARY0o8rc8cjkJjct2ScM12yCJ/h731S9He93a2cv+kAhwPCNwTKDfNH9gjRfLG4VpAEYJU0/gQ==}
     peerDependencies:
       ioredis: '>=5'
+
+  '@types/isomorphic-fetch@0.0.39':
+    resolution: {integrity: sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -32967,6 +32976,8 @@ snapshots:
   '@types/ioredis-mock@8.2.6(ioredis@5.6.1)':
     dependencies:
       ioredis: 5.6.1
+
+  '@types/isomorphic-fetch@0.0.39': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 


### PR DESCRIPTION
Reverts microsoft/FluidFramework#26842.

Seems like the removal of isomorphic-fetch broke the integration pipeline with Loop, where we see complaints like `fetch is not defined` during e2e tests.