### PR TITLE
Enable Claude auto mode for AI codespace profiles

### DIFF
--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -38,10 +38,10 @@ These aliases are available in all terminal sessions (after installing agency):
 
 | Alias | Command | Purpose |
 |---|---|---|
-| `claude` | `agency claude` | Default Claude Code model |
-| `haiku` | `agency claude -- --model haiku` | Fastest, cheapest option |
-| `sonnet` | `agency claude -- --model sonnet` | Balanced capabilities |
-| `opus` | `agency claude -- --model opus` | Most capable model |
+| `claude` | `repoverlay switch ff-claude && agency claude` | Default Claude Code model |
+| `haiku` | `repoverlay switch ff-claude && agency claude -- --model haiku` | Fastest, cheapest option |
+| `sonnet` | `repoverlay switch ff-claude && agency claude -- --model sonnet` | Balanced capabilities |
+| `opus` | `repoverlay switch ff-claude && agency claude -- --model opus` | Most capable model |
 | `nori` | `repoverlay switch nori && agency claude` | Switch to nori overlay and launch Claude |
 
 ### Copilot

--- a/.repoverlay/library/ff-claude/.claude/settings.json
+++ b/.repoverlay/library/ff-claude/.claude/settings.json
@@ -2,18 +2,5 @@
   "permissions": {
     "defaultMode": "auto"
   },
-  "skipAutoPermissionPrompt": true,
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true,
-    "network": {
-      "allowedDomains": [
-        "github.com",
-        "*.github.com",
-        "registry.npmjs.org",
-        "*.npmjs.org",
-        "*.nodejs.org"
-      ]
-    }
-  }
+  "skipAutoPermissionPrompt": true
 }

--- a/.repoverlay/library/ff-claude/.claude/settings.json
+++ b/.repoverlay/library/ff-claude/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "skipAutoPermissionPrompt": true,
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.github.com",
+        "registry.npmjs.org",
+        "*.npmjs.org",
+        "*.nodejs.org"
+      ]
+    }
+  }
+}

--- a/.repoverlay/library/ff-claude/.claude/settings.json
+++ b/.repoverlay/library/ff-claude/.claude/settings.json
@@ -1,6 +1,6 @@
 {
-  "permissions": {
-    "defaultMode": "auto"
-  },
-  "skipAutoPermissionPrompt": true
+	"permissions": {
+		"defaultMode": "auto"
+	},
+	"skipAutoPermissionPrompt": true
 }

--- a/.repoverlay/library/ff-claude/repoverlay.ccl
+++ b/.repoverlay/library/ff-claude/repoverlay.ccl
@@ -5,3 +5,9 @@ overlay =
   /= name: Display name for this overlay.
   /= Used in status output and when listing overlays.
   name = ff-claude
+
+/= mappings (optional): Remap file paths when applying the overlay.
+/= Keys are source paths (in the overlay), values are target paths (in the repo).
+/= Use this to rename files or place them in different locations.
+/= mappings =
+/=   .envrc.template = .envrc

--- a/.repoverlay/library/ff-claude/repoverlay.ccl
+++ b/.repoverlay/library/ff-claude/repoverlay.ccl
@@ -1,0 +1,7 @@
+/= Overlay configuration file.
+/= This file describes an overlay and how it should be applied.
+
+overlay =
+  /= name: Display name for this overlay.
+  /= Used in status output and when listing overlays.
+  name = ff-claude

--- a/.repoverlay/library/ff-oce/.claude/settings.json
+++ b/.repoverlay/library/ff-oce/.claude/settings.json
@@ -2,18 +2,5 @@
   "permissions": {
     "defaultMode": "auto"
   },
-  "skipAutoPermissionPrompt": true,
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true,
-    "network": {
-      "allowedDomains": [
-        "github.com",
-        "*.github.com",
-        "registry.npmjs.org",
-        "*.npmjs.org",
-        "*.nodejs.org"
-      ]
-    }
-  }
+  "skipAutoPermissionPrompt": true
 }

--- a/.repoverlay/library/ff-oce/.claude/settings.json
+++ b/.repoverlay/library/ff-oce/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "skipAutoPermissionPrompt": true,
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.github.com",
+        "registry.npmjs.org",
+        "*.npmjs.org",
+        "*.nodejs.org"
+      ]
+    }
+  }
+}

--- a/.repoverlay/library/ff-oce/.claude/settings.json
+++ b/.repoverlay/library/ff-oce/.claude/settings.json
@@ -1,6 +1,6 @@
 {
-  "permissions": {
-    "defaultMode": "auto"
-  },
-  "skipAutoPermissionPrompt": true
+	"permissions": {
+		"defaultMode": "auto"
+	},
+	"skipAutoPermissionPrompt": true
 }

--- a/.repoverlay/library/nori/.claude/settings.json
+++ b/.repoverlay/library/nori/.claude/settings.json
@@ -2,18 +2,5 @@
   "permissions": {
     "defaultMode": "auto"
   },
-  "skipAutoPermissionPrompt": true,
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true,
-    "network": {
-      "allowedDomains": [
-        "github.com",
-        "*.github.com",
-        "registry.npmjs.org",
-        "*.npmjs.org",
-        "*.nodejs.org"
-      ]
-    }
-  }
+  "skipAutoPermissionPrompt": true
 }

--- a/.repoverlay/library/nori/.claude/settings.json
+++ b/.repoverlay/library/nori/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "skipAutoPermissionPrompt": true,
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.github.com",
+        "registry.npmjs.org",
+        "*.npmjs.org",
+        "*.nodejs.org"
+      ]
+    }
+  }
+}

--- a/.repoverlay/library/nori/.claude/settings.json
+++ b/.repoverlay/library/nori/.claude/settings.json
@@ -1,6 +1,6 @@
 {
-  "permissions": {
-    "defaultMode": "auto"
-  },
-  "skipAutoPermissionPrompt": true
+	"permissions": {
+		"defaultMode": "auto"
+	},
+	"skipAutoPermissionPrompt": true
 }

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -5,10 +5,10 @@
 # shopt -s expand_aliases is bash-only; zsh expands aliases by default in interactive shells.
 [ -n "${BASH_VERSION:-}" ] && shopt -s expand_aliases
 
-alias claude="agency claude"
-alias haiku="agency claude -- --model haiku"
-alias sonnet="agency claude -- --model sonnet"
-alias opus="agency claude -- --model opus"
+alias claude="repoverlay switch ff-claude && agency claude"
+alias haiku="repoverlay switch ff-claude && agency claude -- --model haiku"
+alias sonnet="repoverlay switch ff-claude && agency claude -- --model sonnet"
+alias opus="repoverlay switch ff-claude && agency claude -- --model opus"
 
 alias nori="repoverlay switch nori && agency claude"
 


### PR DESCRIPTION
## Summary
- Creates a new `ff-claude` repoverlay with `defaultMode: "auto"` and `skipAutoPermissionPrompt: true` in `.claude/settings.json`
- Adds auto mode settings to existing `nori` and `ff-oce` overlay settings
- Updates `claude`, `haiku`, `sonnet`, and `opus` aliases to use `repoverlay switch ff-claude` so they pick up the auto mode config

With these changes, all Claude Code aliases in AI-enabled codespaces (`claude`, `haiku`, `sonnet`, `opus`, `nori`, and `copilot-oce`) will default to auto mode, which uses a background classifier to approve/block actions instead of prompting for each one.