### PR TITLE
feat(devcontainer): enable Claude Code sandbox in AI-enabled Codespace

### DIFF
--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -11,7 +11,12 @@
 			// "INSTALL_PLAYWRIGHT_CLI": "true"
 		}
 	},
-	"runArgs": ["--init"],
+	"runArgs": [
+		"--init",
+		"--security-opt=seccomp=unconfined",
+		"--security-opt=apparmor=unconfined",
+		"--cap-add=SYS_ADMIN"
+	],
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -42,6 +47,9 @@
 	"postCreateCommand": {
 		"ai-setup": "bash scripts/codespace-setup/ai-setup.sh",
 		"welcome-notice": "sudo cp .devcontainer/ai-agent/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
+	},
+	"postStartCommand": {
+		"bwrap-setup": "sudo mount --make-rshared /"
 	},
 	"remoteUser": "node",
 	"features": {

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -49,7 +49,8 @@
 		"welcome-notice": "sudo cp .devcontainer/ai-agent/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
 	},
 	"postStartCommand": {
-		"bwrap-setup": "sudo mount --make-rshared /"
+		"bwrap-setup": "sudo mount --make-rshared /",
+		"sandbox-tmpdir": "mkdir -p /tmp/claude"
 	},
 	"remoteUser": "node",
 	"features": {

--- a/.repoverlay/library/ff-claude/.claude/settings.json
+++ b/.repoverlay/library/ff-claude/.claude/settings.json
@@ -2,5 +2,9 @@
 	"permissions": {
 		"defaultMode": "auto"
 	},
-	"skipAutoPermissionPrompt": true
+	"skipAutoPermissionPrompt": true,
+	"sandbox": {
+		"enabled": true,
+		"enableWeakerNestedSandbox": true
+	}
 }

--- a/.repoverlay/library/ff-claude/.claude/settings.json
+++ b/.repoverlay/library/ff-claude/.claude/settings.json
@@ -5,6 +5,16 @@
 	"skipAutoPermissionPrompt": true,
 	"sandbox": {
 		"enabled": true,
-		"enableWeakerNestedSandbox": true
+		"enableWeakerNestedSandbox": true,
+		"allowedNetworkHosts": [
+			"api.github.com",
+			"registry.npmjs.org",
+			"developer.mozilla.org",
+			"www.typescriptlang.org",
+			"nodejs.org",
+			"www.npmjs.com",
+			"fluidframework.com",
+			"stackoverflow.com"
+		]
 	}
 }

--- a/.repoverlay/library/ff-oce/.claude/settings.json
+++ b/.repoverlay/library/ff-oce/.claude/settings.json
@@ -2,5 +2,9 @@
 	"permissions": {
 		"defaultMode": "auto"
 	},
-	"skipAutoPermissionPrompt": true
+	"skipAutoPermissionPrompt": true,
+	"sandbox": {
+		"enabled": true,
+		"enableWeakerNestedSandbox": true
+	}
 }

--- a/.repoverlay/library/ff-oce/.claude/settings.json
+++ b/.repoverlay/library/ff-oce/.claude/settings.json
@@ -5,6 +5,16 @@
 	"skipAutoPermissionPrompt": true,
 	"sandbox": {
 		"enabled": true,
-		"enableWeakerNestedSandbox": true
+		"enableWeakerNestedSandbox": true,
+		"allowedNetworkHosts": [
+			"api.github.com",
+			"registry.npmjs.org",
+			"developer.mozilla.org",
+			"www.typescriptlang.org",
+			"nodejs.org",
+			"www.npmjs.com",
+			"fluidframework.com",
+			"stackoverflow.com"
+		]
 	}
 }

--- a/.repoverlay/library/nori/.claude/settings.json
+++ b/.repoverlay/library/nori/.claude/settings.json
@@ -2,5 +2,9 @@
 	"permissions": {
 		"defaultMode": "auto"
 	},
-	"skipAutoPermissionPrompt": true
+	"skipAutoPermissionPrompt": true,
+	"sandbox": {
+		"enabled": true,
+		"enableWeakerNestedSandbox": true
+	}
 }

--- a/.repoverlay/library/nori/.claude/settings.json
+++ b/.repoverlay/library/nori/.claude/settings.json
@@ -5,6 +5,16 @@
 	"skipAutoPermissionPrompt": true,
 	"sandbox": {
 		"enabled": true,
-		"enableWeakerNestedSandbox": true
+		"enableWeakerNestedSandbox": true,
+		"allowedNetworkHosts": [
+			"api.github.com",
+			"registry.npmjs.org",
+			"developer.mozilla.org",
+			"www.typescriptlang.org",
+			"nodejs.org",
+			"www.npmjs.com",
+			"fluidframework.com",
+			"stackoverflow.com"
+		]
 	}
 }

--- a/DEV.md
+++ b/DEV.md
@@ -180,3 +180,36 @@ When `strictDepBuilds: true`, pnpm requires explicit approval before running bui
 - **Sub-workspaces with own lockfiles**: Both `pnpm.onlyBuiltDependencies` in the workspace's `package.json` AND `onlyBuiltDependencies` in the workspace's `pnpm-workspace.yaml` (due to [pnpm bug #9082](https://github.com/pnpm/pnpm/issues/9082))
 
 To approve a new package's build scripts, add it to the appropriate `onlyBuiltDependencies` list(s).
+
+## Claude Sandboxing Configuration
+
+The default configuration of the codespace Docker container is not compatible with [Claude sandboxing](https://code.claude.com/docs/en/sandboxing).
+There are multiple settings that need to be tweaked in both the container and Claude.
+
+### Container security flags ([`devcontainer.json`](.devcontainer/ai-agent/devcontainer.json) `runArgs`)
+
+Claude's sandbox uses [bubblewrap (bwrap)](https://github.com/containers/bubblewrap) to isolate processes in a user namespace with restricted mount/filesystem access. bwrap requires three capabilities that Docker containers don't grant by default:
+
+| Flag | Why bwrap needs it |
+|------|--------------------|
+| `--security-opt apparmor=unconfined` | Docker's default AppArmor profile blocks `mount` and `pivot_root` syscalls that bwrap uses to build its mount namespace. |
+| `--cap-add SYS_ADMIN` | bwrap needs `CAP_SYS_ADMIN` to create new mount namespaces and perform bind mounts inside them. |
+| `--security-opt seccomp=unconfined` | Docker's default seccomp profile blocks `unshare`, `pivot_root`, and some `mount` calls. bwrap needs all three. |
+
+### Root mount propagation ([`postStartCommand`](.devcontainer/ai-agent/devcontainer.json))
+
+bwrap bind-mounts host paths into its sandbox namespace. For these mounts to propagate correctly, the root mount (`/`) must be marked as **shared**. Docker defaults to **private** propagation, which causes bwrap mounts to silently fail. The `postStartCommand` runs:
+
+```shell
+sudo mount --make-rshared /
+```
+
+This recursively marks all mount points as shared, allowing bwrap's bind mounts to work.
+
+### `enableWeakerNestedSandbox` ([Claude settings](.repoverlay/library/ff-claude/.claude/settings.json))
+
+Even with the above flags, Docker still blocks mounting a fresh `/proc` filesystem inside a user namespace — a kernel-level restriction that `CAP_SYS_ADMIN` and AppArmor changes cannot override. Claude's full-strength sandbox requires this `/proc` mount. The `enableWeakerNestedSandbox` setting tells Claude to use a weaker sandbox variant that skips the `/proc` mount while still providing filesystem isolation via bwrap.
+
+### `--copy` flag for repoverlay ([`agent-aliases.sh`](scripts/codespace-setup/agent-aliases.sh))
+
+repoverlay defaults to applying overlays as symlinks (e.g., `.claude/settings.json` -> `.repoverlay/library/ff-claude/.claude/settings.json`). bwrap cannot follow symlinks when constructing its mount namespace — it bind-mounts individual paths, and a symlink at the source causes a "No such file or directory" error even when the target is within the same repo. The `--copy` flag in `agent-aliases.sh` forces repoverlay to copy files instead, avoiding this limitation.

--- a/DEV.md
+++ b/DEV.md
@@ -206,6 +206,10 @@ sudo mount --make-rshared /
 
 This recursively marks all mount points as shared, allowing bwrap's bind mounts to work.
 
+### Sandbox TMPDIR ([`postStartCommand`](.devcontainer/ai-agent/devcontainer.json))
+
+Claude Code sets `TMPDIR=/tmp/claude` inside the sandbox, but doesn't create the directory itself. The sandbox allowlist permits writes to `/tmp/claude`, and the weaker sandbox bind-mounts the real `/tmp` into the namespace, so the directory just needs to exist on the host. Without it, any tool that resolves `TMPDIR` on startup (pnpm, node, etc.) crashes with `ENOENT`. The `postStartCommand` runs `mkdir -p /tmp/claude` to pre-create it. This is a workaround for a Claude Code bug ([anthropics/claude-code#21654](https://github.com/anthropics/claude-code/issues/21654)).
+
 ### `enableWeakerNestedSandbox` ([Claude settings](.repoverlay/library/ff-claude/.claude/settings.json))
 
 Even with the above flags, Docker still blocks mounting a fresh `/proc` filesystem inside a user namespace — a kernel-level restriction that `CAP_SYS_ADMIN` and AppArmor changes cannot override. Claude's full-strength sandbox requires this `/proc` mount. The `enableWeakerNestedSandbox` setting tells Claude to use a weaker sandbox variant that skips the `/proc` mount while still providing filesystem isolation via bwrap.

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -5,17 +5,17 @@
 # shopt -s expand_aliases is bash-only; zsh expands aliases by default in interactive shells.
 [ -n "${BASH_VERSION:-}" ] && shopt -s expand_aliases
 
-alias claude="repoverlay switch ff-claude && agency claude"
-alias haiku="repoverlay switch ff-claude && agency claude -- --model haiku"
-alias sonnet="repoverlay switch ff-claude && agency claude -- --model sonnet"
-alias opus="repoverlay switch ff-claude && agency claude -- --model opus"
+alias claude="repoverlay switch --copy ff-claude && agency claude"
+alias haiku="repoverlay switch --copy ff-claude && agency claude -- --model haiku"
+alias sonnet="repoverlay switch --copy ff-claude && agency claude -- --model sonnet"
+alias opus="repoverlay switch --copy ff-claude && agency claude -- --model opus"
 
-alias nori="repoverlay switch nori && agency claude"
+alias nori="repoverlay switch --copy nori && agency claude"
 
 alias copilot="agency copilot"
 alias copilot-ado="agency copilot --mcp 'ado --org fluidframework'"
 alias copilot-kusto="agency copilot --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'"
-alias copilot-oce="repoverlay switch ff-oce && copilot -- --agent ff-oce"
+alias copilot-oce="repoverlay switch --copy ff-oce && copilot -- --agent ff-oce"
 alias copilot-work="agency copilot --mcp 'workiq'"
 
 alias ai-reset="repoverlay remove --all"


### PR DESCRIPTION
## Description

Enables Claude Code's [bubblewrap](https://github.com/containers/bubblewrap) (bwrap) sandbox in the AI-enabled Codespace. The sandbox wraps every Bash tool call in a bwrap container with restricted filesystem write access and a separate user namespace, so that AI-generated shell commands cannot modify files outside of the working directory and a few other allowed paths.

Before this change, every sandboxed command failed immediately with a bwrap error. Five distinct failure modes had to be resolved — each is detailed below with its fix, the alternatives considered, and the security implications.

---

### Change 1: `seccomp=unconfined` in devcontainer.json

**File:** `.devcontainer/ai-agent/devcontainer.json`

**Problem:** Docker's default seccomp profile blocks the `clone(CLONE_NEWUSER)` syscall. Bubblewrap calls `clone` with `CLONE_NEWNS|CLONE_NEWUSER` to create a new user + mount namespace, which is the foundation of its sandbox. Without this, bwrap fails immediately:
```
bwrap: No permissions to create new namespace, likely because the kernel does not allow
non-privileged user namespaces.
```

**Fix:** `--security-opt=seccomp=unconfined` in `runArgs` removes the seccomp filter entirely.

**Alternatives considered:** A custom seccomp profile that allows only `clone(CLONE_NEWUSER)` while preserving everything else. Rejected because seccomp profiles don't support deltas — you must embed the full Docker default (~700 lines of JSON) and patch it, which isn't worth the maintenance cost for a dev Codespace.

**Security implications:** Seccomp filtering is defense-in-depth against kernel exploits via rarely-used syscalls. Removing it means any syscall the kernel supports is callable. In practice, `seccomp=unconfined` is the standard approach for dev containers that need user namespace support (nested Docker, Podman, Flatpak, etc.) and is already widely used in Codespace configurations. The AI-enabled profile already grants significant trust to its workload (source code, tokens, SSH keys); removing seccomp filtering does not materially expand the attack surface.

---

### Change 2: `apparmor=unconfined` in devcontainer.json

**File:** `.devcontainer/ai-agent/devcontainer.json`

**Problem:** Docker's `docker-default` AppArmor profile blocks `mount(MS_SLAVE)` inside user namespaces with EACCES, even when the root mount is correctly in a shared peer group and all capabilities are present:
```
bwrap: Failed to make / slave: Permission denied
```
Diagnosed via `strace`: the failing syscall returned EACCES (from the LSM/AppArmor layer), not EPERM (which would indicate a capabilities issue). Confirmed by checking `/proc/self/attr/current` showing `docker-default (enforce)`, and by observing that even `sudo bwrap` failed identically.

**Fix:** Added `--security-opt=apparmor=unconfined` to `runArgs`.

**Alternatives considered:** A custom AppArmor profile that allows mount operations within user namespaces. Rejected for the same reason as the custom seccomp profile — maintenance cost for a dev Codespace doesn't justify the complexity.

**Security implications:** AppArmor provides mandatory access control (file access restrictions, capability restrictions, network restrictions). Disabling it removes this layer. Combined with `seccomp=unconfined`, the container now has no Linux Security Module restrictions. This is acceptable for a dev Codespace where the user already has full shell access and root via sudo — AppArmor was not providing meaningful additional protection in this context.

---

### Change 3: `enableWeakerNestedSandbox: true` in sandbox settings

**Files:** `.repoverlay/library/{ff-claude,nori,ff-oce}/.claude/settings.json`

**Problem:** Claude Code's sandbox defaults to `--unshare-pid` (PID namespace isolation), which requires bwrap to mount a **fresh** `proc` filesystem inside the new namespace. Docker blocks fresh proc mounts inside user namespaces — this is a kernel-level restriction that persists **even with** `CAP_SYS_ADMIN` (Change 4) and `apparmor=unconfined` (Change 2). We verified this explicitly: after the container was rebuilt with all three `runArgs` flags applied, `mount -t proc proc /tmp/testproc` inside `unshare --user` still fails with `permission denied`. The error:
```
bwrap: Can't mount proc on /newroot/proc: Operation not permitted
```

**Fix:** `"enableWeakerNestedSandbox": true` tells Claude Code to skip PID namespace isolation. Without `--unshare-pid`, bwrap bind-mounts the existing `/proc` instead of mounting a fresh one, avoiding the blocked syscall entirely.

**Why this can't be removed:** One might expect that granting `CAP_SYS_ADMIN` and disabling AppArmor would be enough to allow fresh proc mounts. It isn't — Docker enforces an additional mount mask (`/proc/` paths in the OCI spec's `maskedPaths`) that prevents mounting new proc filesystems inside user namespaces regardless of capabilities or LSM policy. This is a Docker security boundary that cannot be relaxed from `devcontainer.json`. The `enableWeakerNestedSandbox` setting is therefore required independently of Changes 2 and 4.

**Security implications:** Without PID namespace isolation, sandboxed commands can enumerate other processes via `/proc`. In a single-user Codespace this is not a meaningful boundary — all processes run as the same user, `/proc/<pid>/environ` is readable regardless, and PIDs are trivially enumerable. The isolation that matters (filesystem write limits, separate user namespace) is unaffected.

The settings are placed in the **repoverlay** configs (not a global `.claude/settings.json`) so they only apply when an AI profile is active and aren't clobbered when a user runs `repoverlay switch`.

---

### Change 4: `CAP_SYS_ADMIN` + `postStartCommand: mount --make-rshared /`

**File:** `.devcontainer/ai-agent/devcontainer.json`

**Problem:** After fixing the first two issues, bwrap still failed:
```
bwrap: Failed to make / slave: Permission denied
```
The root mount inside the container has `private` propagation (no peer group), so bwrap's `mount(MS_SLAVE)` call fails with EPERM because there's no shared peer group to become a slave of.

**Fix:** Two parts:
1. `--cap-add=SYS_ADMIN` in `runArgs` — grants the capability needed to run `mount --make-rshared`.
2. `"postStartCommand": {"bwrap-setup": "sudo mount --make-rshared /"}` — puts the root mount into a shared peer group on every container start. This runs at start time (not build time) because mount propagation is runtime state, not filesystem state.

**Alternatives considered:** None — this is the only way to set mount propagation. The `--make-rshared` flag requires `CAP_SYS_ADMIN`, and the mount must happen at runtime.

**Security implications:** `CAP_SYS_ADMIN` is the broadest Linux capability — it allows mounting filesystems, loading kernel modules (if available), configuring namespaces, and more. In a dev Codespace, the user already has `sudo` access and can escalate to root freely, so this doesn't grant net-new power. The capability is needed only for the `mount --make-rshared` command, but Linux capabilities cannot be scoped to specific operations.

---

### Change 5: `repoverlay switch --copy` in agent aliases

**File:** `scripts/codespace-setup/agent-aliases.sh`

**Problem:** The repoverlay system creates a **symlink** at `.claude/settings.json` pointing to `.repoverlay/library/<overlay>/.claude/settings.json`. Claude Code's bwrap sandbox includes this path in its deny-write mount list and tries to create a bind mount point at this path inside the new root filesystem. When bwrap encounters the symlink, it follows it to the target path — but the target directory doesn't exist yet inside the sandbox's mount namespace, causing:
```
bwrap: Can't create file at /workspaces/FluidFramework/.claude/settings.json: No such file or directory
```

**Fix:** Added `--copy` flag to all `repoverlay switch` calls in the agent aliases. This makes repoverlay copy the settings file instead of symlinking it, so bwrap sees a regular file.

**Alternatives considered:**
1. *Fix in Claude Code's bwrap setup* — resolve symlinks before creating mount points. This would be the proper fix but requires changes to Claude Code itself, which is outside this repo's control.
2. *Manual `cp` workaround* — replace the symlink with a file copy after `repoverlay switch`. Rejected because it would break on every subsequent `repoverlay switch` unless automated.

**Security implications:** None. This changes how a config file is deployed (copy vs symlink), not what it contains.

---

## Security Summary

The container now runs with `seccomp=unconfined`, `apparmor=unconfined`, and `CAP_SYS_ADMIN`. This is a broad privilege grant. The justification:

1. **This is a dev Codespace, not a production environment.** The user already has full shell access, `sudo` to root, and access to secrets (tokens, SSH keys). These security layers were not providing meaningful additional protection.
2. **The trade-off is net positive.** In exchange for relaxing container-level security (which protects against the *user*), we gain bwrap sandboxing (which protects against *AI-generated commands*). The more relevant threat model for an AI-enabled Codespace is constraining what the AI agent can do, not constraining what the human user can do.
3. **This is standard practice.** `seccomp=unconfined` is widely used in dev containers. `apparmor=unconfined` and `CAP_SYS_ADMIN` are commonly added for Docker-in-Docker, Podman, and similar nested-container scenarios.

---

## Verification

All tests were run inside a rebuilt Codespace container with the `runArgs`-based configuration (commit `b4f862e2b9`). Tests 1-8 verify the container configuration; Tests 9-13 verify the end-to-end sandbox behavior.

### Container configuration tests

| # | Test | Result |
|---|------|--------|
| 1 | `runArgs` in devcontainer.json contains `--security-opt=seccomp=unconfined`, `--security-opt=apparmor=unconfined`, `--cap-add=SYS_ADMIN` | PASS |
| 2 | `/proc/self/attr/current` shows `unconfined` (not `docker-default`) | PASS |
| 3 | `unshare --user --map-root-user /usr/bin/id` succeeds (user namespaces work) | PASS |
| 4 | Root mount in `/proc/self/mountinfo` contains `shared:N` (peer group exists) | PASS — `shared:328` |
| 5 | `bwrap --ro-bind /usr /usr ... /usr/bin/echo "bwrap works"` prints `bwrap works` | PASS |
| 6 | Fresh proc mount in user namespace fails (confirms `enableWeakerNestedSandbox` is still needed) | PASS — still FAILED even with CAP_SYS_ADMIN + apparmor=unconfined |
| 7 | All three repoverlay settings files contain `sandbox.enabled: true` and `sandbox.enableWeakerNestedSandbox: true` | PASS |
| 8 | `sudo mount --make-rshared /` succeeds (CAP_SYS_ADMIN present) | PASS |

### End-to-end sandbox tests

| # | Test | Result |
|---|------|--------|
| 9 | `echo hello` through sandbox succeeds with no bwrap errors | PASS |
| 10 | `/proc/self/ns/user` differs inside vs outside sandbox (`user:[4026532286]` vs `user:[4026531837]`) | PASS |
| 11 | `touch /etc/pwned` blocked inside sandbox (`Read-only file system`) | PASS |
| 12 | Write to `/workspaces/FluidFramework` works inside sandbox | PASS |
| 13 | `--copy` overlay produces a regular file (not symlink) after `repoverlay switch` | PASS |

### Known issue (not this PR)

**TMPDIR broken in sandbox:** Claude Code sets `TMPDIR=/tmp/claude` but doesn't pre-create the directory, and `/tmp` is read-only inside the sandbox. Commands needing temp dirs will fail. This is a Claude Code bug, not this PR.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The main thing to evaluate is the security trade-off: relaxing three container-level security mechanisms (`seccomp`, `apparmor`, `CAP_SYS_ADMIN`) to enable bwrap sandboxing of AI-generated shell commands. The argument is that bwrap sandboxing is more relevant to the AI-agent threat model than container-level hardening in a single-user dev environment.
