### PR TITLE
Fix crash in getPreReleaseDependencies for workspace dependencies.

### DIFF
--- a/build-tools/packages/build-cli/src/commands/release/prepare.ts
+++ b/build-tools/packages/build-cli/src/commands/release/prepare.ts
@@ -70,7 +70,7 @@ export class ReleasePrepareCommand extends BaseCommand<typeof ReleasePrepareComm
 
 		this.logHr();
 		for (const [name, check] of allChecks) {
-			this.log(chalk.gray(`Running check: ${name}`));
+			this.info(chalk.gray(`Running check: ${name}`));
 			// eslint-disable-next-line no-await-in-loop -- the checks are supposed to run serially
 			let checkResult: CheckResult;
 			try {

--- a/build-tools/packages/build-cli/src/commands/release/prepare.ts
+++ b/build-tools/packages/build-cli/src/commands/release/prepare.ts
@@ -16,6 +16,8 @@ import {
 	CheckNoLocalChanges,
 	CheckNoPolicyViolations,
 	CheckNoUntaggedAsserts,
+	CheckResult,
+	CheckResultFailure,
 } from "../../library/releasePrepChecks.js";
 
 /**
@@ -68,15 +70,25 @@ export class ReleasePrepareCommand extends BaseCommand<typeof ReleasePrepareComm
 
 		this.logHr();
 		for (const [name, check] of allChecks) {
+			this.log(chalk.gray(`Running check: ${name}`));
 			// eslint-disable-next-line no-await-in-loop -- the checks are supposed to run serially
-			const checkResult = await check(context, pkgOrReleaseGroup);
-			const checkPassed = checkResult === undefined;
-			const icon = checkPassed
-				? chalk.bgGreen(chalk.black(" ✔︎ "))
-				: chalk.bgRed(chalk.white(" ✖︎ "));
+			let checkResult: CheckResult;
+			try {
+				checkResult = await check(context, pkgOrReleaseGroup);
+			} catch (err: unknown) {
+				checkResult = {
+					message: `Uncaught error when running check: ${(err as Error).message}`,
+					fatal: true,
+				} satisfies CheckResultFailure;
+			}
+			const icon =
+				checkResult === undefined
+					? chalk.bgGreen(chalk.black(" ✔︎ "))
+					: chalk.bgRed(chalk.white(" ✖︎ "));
 
-			this.log(`${icon} ${checkPassed ? name : chalk.red(checkResult.message)}`);
-			if (!checkPassed) {
+			this.log(`${icon} ${name}`);
+			if (checkResult !== undefined) {
+				this.logIndent(chalk.red(`  ${checkResult.message}`), 6);
 				if (checkResult.fixCommand !== undefined) {
 					this.logIndent(
 						`${chalk.yellow(`Possible fix command:`)} ${chalk.yellow(

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -302,7 +302,7 @@ export async function getPreReleaseDependencies(
 			catalogCache.set(workspaceRoot, catalogs);
 		}
 
-		for (const { name: depName, version: depVersion } of pkg.combinedDependencies) {
+		for (const { name: depName, version: depVersion, depClass } of pkg.combinedDependencies) {
 			// If it's not a dep we're looking to update, skip to the next dep
 			if (!updateDependenciesOnThesePackages.includes(depName)) {
 				continue;
@@ -311,9 +311,16 @@ export async function getPreReleaseDependencies(
 			// Resolve catalog: references before passing to semver
 			const resolvedVersion = resolveCatalogVersion(depName, depVersion, catalogs);
 
-			// Skip workspace versions: assume they are fine.
 			if (resolvedVersion.startsWith("workspace:")) {
-				continue;
+				// We do not have logic for handling workspace version to packages outside the release group.
+				// Currently we only do this for dev deps,
+				// and allowing prerelease dev deps to go undetected is low risk, so continue here instead of erroring.
+				if (depClass === "dev") {
+					continue;
+				}
+				throw new Error(
+					`Unexpected workspace dependency for non-dev dep ${depName} in package ${pkg.name}. Resolved version: ${resolvedVersion}`,
+				);
 			}
 
 			// Convert the range into the minimum version

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -311,6 +311,11 @@ export async function getPreReleaseDependencies(
 			// Resolve catalog: references before passing to semver
 			const resolvedVersion = resolveCatalogVersion(depName, depVersion, catalogs);
 
+			// Skip workspace versions: assume they are fine.
+			if (resolvedVersion.startsWith("workspace:")) {
+				continue;
+			}
+
 			// Convert the range into the minimum version
 			const minVer = semver.minVersion(resolvedVersion);
 			if (minVer === null) {

--- a/build-tools/packages/build-cli/src/library/releasePrepChecks.ts
+++ b/build-tools/packages/build-cli/src/library/releasePrepChecks.ts
@@ -5,7 +5,7 @@
 
 import { MonoRepo, type Package } from "@fluidframework/build-tools";
 import execa from "execa";
-import { ResetMode } from "simple-git";
+
 import {
 	checkPackagesCompatLayerGeneration,
 	DEFAULT_GENERATION_DIR,
@@ -82,7 +82,7 @@ export interface CheckResultFailure {
  * The results of a {@link CheckFunction}. If a CheckResult is `true`, then the check succeeded. Otherwise the result is
  * a {@link CheckResultFailure}.
  */
-type CheckResult = CheckResultFailure | undefined;
+export type CheckResult = CheckResultFailure | undefined;
 
 /**
  * Checks that there are no local changes in the local repository. This failure is fatal to ensure changes aren't lost.
@@ -97,10 +97,8 @@ export const CheckNoLocalChanges: CheckFunction = async (
 	const status = await gitRepo.gitClient.status();
 	if (!status.isClean()) {
 		return {
-			message:
-				"There are some local changes. The branch should be clean. Stopping further checks to ensure changes aren't lost. Stash your changes and try again.",
+			message: "There are some local changes. The branch should be clean.",
 			fixCommand: "git stash",
-			fatal: true,
 		};
 	}
 };
@@ -230,17 +228,18 @@ export const CheckNoUntaggedAsserts: CheckFunction = async (
 	// policy-check is scoped to the path that it's run in. Since we have multiple folders at the root that represent
 	// the client release group, we can't easily scope it to just the client. Thus, we always run it at the root just
 	// like we do in CI.
-	await execa("npm", ["run", "policy-check:asserts"], {
-		cwd: context.root,
-	});
+	const result = await execa(
+		"npm",
+		["exec", "flub", "--", "generate", "assertTags", "--all", "--requireTagged"],
+		{
+			cwd: context.root,
+			reject: false,
+		},
+	);
 
-	// check for policy check violation
-	const gitRepo = await context.getGitRepository();
-	const afterPolicyCheckStatus = await gitRepo.gitClient.status();
-	if (!afterPolicyCheckStatus.isClean()) {
-		await gitRepo.gitClient.reset(ResetMode.HARD);
+	if (result.exitCode !== 0) {
 		return {
-			message: "Found some untagged asserts. These should be tagged before release.",
+			message: `Assert tagging reported:\n${result.stdout}\n${result.stderr}\nAll asserts must be tagged before release.`,
 			fixCommand: "pnpm run policy-check:asserts",
 		};
 	}


### PR DESCRIPTION
## Description

Skip validating workspace versions in getPreReleaseDependencies to avoid `TypeError: Invalid comparator: workspace:~` crash.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

