### PR TITLE
Fix for CI: Manually updated the version of type-factory to match the last release

### DIFF
--- a/packages/framework/type-factory/package.json
+++ b/packages/framework/type-factory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/type-factory",
-	"version": "2.92.0",
+	"version": "2.93.0",
 	"description": "Shared types for exposing schema methods and properties to an LLM agent",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
The PR adding type-factory completed 12 minutes after the release PR. The release was for 2.93.0, and the version used in type-factory was 2.92.0. This PR corrects the version to unblock CI jobs.