### PR TITLE
Improve ci-readiness-check skill: build:docs check, phantom diff guidance, post-check change warning

### DIFF
--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -24,9 +24,9 @@ Before doing anything, ask the user:
 > I'll run a CI readiness check on your branch. Pick a mode (fastest to slowest):
 >
 > 1. **Cancel** — never mind, don't run checks
-> 2. **Quick** — auto-fix formatting only (Biome on changed files); skip all build-dependent checks (~15–20 seconds)
-> 3. **Full** — Quick + build unbuilt packages + regenerate API reports and type tests (~30 seconds – 2 minutes depending on package size)
-> 4. **Thorough** — Full + run tests in changed packages (~30 seconds – 5+ minutes; dominated by test suite size)
+> 2. **Quick** — auto-fix formatting, policy, and syncpack on changed packages; skip build-dependent checks (~30–60 seconds)
+> 3. **Full** — Quick + build unbuilt packages + ESLint + regenerate API reports and type tests (~1–3 minutes depending on package size)
+> 4. **Thorough** — Full + run tests in changed packages (~5+ minutes; dominated by test suite size)
 
 Wait for the user's response. If they say cancel (or anything clearly negative), stop here. Otherwise, note their choice and **immediately create tasks for all remaining steps** as described in the `<required>` block above before proceeding.
 
@@ -35,23 +35,20 @@ Wait for the user's response. If they say cancel (or anything clearly negative),
 Run the bundled script from the repository root:
 
 ```bash
-bash .claude/skills/ci-readiness-check/ci-readiness-check.sh [--quick] [base-branch]
+bash .claude/skills/ci-readiness-check/ci-readiness-check.sh [base-branch]
 ```
 
 The base branch defaults to `main`. Pass a different branch if needed (e.g., `next`).
 
-Pass `--quick` for Quick mode. This skips the full `checks:fix` pipeline (policy is repo-wide and lint is too slow) and only runs Biome formatting on changed files.
-
-The script handles:
+The script always runs the same checks regardless of mode — mode only affects what the agent does afterward:
 - Detecting which packages have changes vs the base branch
 - Installing dependencies if `node_modules` is missing
-- **Quick mode:** Running `biome format --write` on changed files only
-- **Full/Thorough mode:** Running `fluid-build --task checks:fix` scoped to changed packages, which auto-fixes:
+- Running `fluid-build --task checks:fix` scoped to changed packages, which auto-fixes:
   - Formatting (Biome)
   - Policy violations (flub — copyright headers, package.json sorting, etc.)
   - Dependency version consistency (syncpack)
   - Build version consistency
-- **Full/Thorough mode:** Verifying all checks pass after auto-fix (`fluid-build --task checks`)
+- Verifying all checks pass after auto-fix (`fluid-build --task checks`)
 - Checking for a changeset (via `flub check changeset`)
 - Reporting uncommitted changes, categorized (API reports, type tests, other)
 - Reporting which changed packages are built vs not built

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -24,9 +24,9 @@ Before doing anything, ask the user:
 > I'll run a CI readiness check on your branch. Pick a mode (fastest to slowest):
 >
 > 1. **Cancel** — never mind, don't run checks
-> 2. **Check** — auto-fix formatting, policy, and syncpack on changed packages (~30–60 seconds)
-> 3. **Build** — Check + build unbuilt packages + ESLint + regenerate API reports and type tests (~1–3 minutes)
-> 4. **Test** — Build + run the test suite in changed packages (~5+ minutes; dominated by test suite size)
+> 2. **Check** — auto-fix formatting, policy, and syncpack on changed packages (~5–10 seconds; always fast)
+> 3. **Build** — Check + build unbuilt packages + ESLint + regenerate API reports and type tests (~10–20 seconds if packages are already built; longer if a fresh compile is needed)
+> 4. **Test** — Build + run the test suite in changed packages (non-tree packages: ~10–30 seconds; tree: ~3+ minutes)
 
 Wait for the user's response. If they say cancel (or anything clearly negative), stop here. Otherwise, note their choice and **immediately create tasks for all remaining steps** as described in the `<required>` block above before proceeding.
 
@@ -134,7 +134,7 @@ cd <package-dir> && pnpm run typetests:gen
 
 Not all packages have type tests. Only run this where the script exists.
 
-# Step 8: Run tests (Thorough mode only)
+# Step 8: Run tests (Test mode only)
 
 If the user chose **Test** mode, run tests in each built changed package. Check the package's `package.json` for available test scripts and run whichever exist:
 
@@ -151,7 +151,7 @@ Run `git status` and report to the user:
 
 1. **Files auto-fixed** — formatting, policy, ESLint fixes. These are unstaged; the user should review and stage them.
 2. **Generated files updated** — API reports, type tests. These need to be committed with the PR.
-3. **Test results** — if Thorough mode, report pass/fail per package.
+3. **Test results** — if Test mode, report pass/fail per package.
 4. **Remaining issues** — anything the skill couldn't auto-fix (check failures, missing changeset, etc.).
 5. **Skipped checks** — anything skipped due to mode choice or unbuilt packages.
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -113,6 +113,22 @@ cd <package-dir> && pnpm exec fluid-build . -t build:api-reports
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
 
+**Only `@fluidframework/tree`: run `generate:entrypoint-sources` if you added new top-level exports.** `@fluidframework/tree` uses committed files in `src/entrypoints/` (e.g. `src/entrypoints/alpha.ts`) that explicitly list every named export by API tier. If you added a *new* top-level export (new type, class, function, or constant at the package root — not just adding members to an existing type), you must regenerate these files before running `build:api-reports`, otherwise the new export will be missing from the API surface:
+
+```bash
+cd packages/dds/tree && pnpm run generate:entrypoint-sources
+```
+
+This script writes to both `src/entrypoints/*.ts` and `lib/entrypoints/*.d.ts`. The `lib/` copy it writes has wrong import paths and must be fixed by rebuilding immediately after:
+
+```bash
+pnpm run build:esnext
+```
+
+Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index.js`, not `./index.js`. Then stage the `src/entrypoints/` changes and proceed to `build:api-reports`.
+
+If your change only adds members to an *existing* exported type (e.g. a new optional property on an existing interface), skip this — the entrypoints files don't need to change.
+
 **Only `@fluidframework/tree`: check for phantom key-reorder diffs.** After running `build:api-reports`, check `git diff` on the updated report. The known bug (see "Why be conservative" above) can produce spurious reorderings of union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. There are three cases:
 
 1. **The only diff is key reorderings** (no real API additions/removals): The entire diff is spurious. Restore the file and do not commit it:

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -115,20 +115,16 @@ cd <package-dir> && pnpm run build:api-reports
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
 
-**Phantom key-reorder diffs in `@fluidframework/tree` (and `fluid-framework`):** There is a known bug where API Extractor non-deterministically reorders union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — depending on whether TypeScript compiled incrementally (local) or from scratch (CI). This affects the `@fluidframework/tree` API report directly, and also `fluid-framework`'s report because it re-exports from `@fluidframework/tree` and API Extractor processes them the same way.
-
-After running `build:api-reports` on either package, check `git diff` on the updated report for these reorderings. There are three cases:
+**Only `@fluidframework/tree`: check for phantom key-reorder diffs.** After running `build:api-reports`, check `git diff` on the updated report. The known bug (see "Why be conservative" above) can produce spurious reorderings of union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. There are three cases:
 
 1. **The only diff is key reorderings** (no real API additions/removals): The entire diff is spurious. Restore the file and do not commit it:
    ```bash
    git checkout -- packages/dds/tree/api-report/tree.alpha.api.md
-   # and/or
-   git checkout -- packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
    ```
 
-2. **The diff contains both real API changes and key reorderings in unrelated places:** Commit your real changes but manually revert the key-reorder lines. Open the file and flip the affected `"keyA" | "keyB"` back to whatever order is already committed — the reordering is spurious and must not appear in the PR diff. The real changes should be left as-is.
+2. **The diff contains both real API changes and key reorderings in unrelated places:** Commit your real changes but manually revert the key-reorder lines. Open the file and flip the affected `"keyA" | "keyB"` back to whatever order is already committed — the reordering is spurious and must not appear in the PR diff.
 
-3. **A key reordering appears within your newly added API:** This is exceedingly rare. It likely means the new type uses `Omit<>` and happened to be emitted in a different key order. In this case, commit whatever order the file has — there is no "right" order — and accept that CI may flip it back on the next regeneration. Flag this to the user.
+3. **A key reordering appears within your newly added API:** This is exceedingly rare (the new type uses `Omit<>` and was emitted in a different key order). Commit whatever order the file has — there is no "right" order — and accept that CI may flip it back on the next regeneration. Flag this to the user.
 
 ## 6b. Run `build:docs` to catch TSDoc errors
 
@@ -156,6 +152,8 @@ cd packages/framework/fluid-framework && pnpm run build:api-reports
 ```
 
 Only do this if the source package's reports actually changed (check `git diff` on its `api-report/` directory). If the source reports are unchanged, the aggregator's won't be either.
+
+If you ran `build:api-reports` on `fluid-framework`, apply the same phantom key-reorder check described in step 6a — the same bug affects its report for the same reason.
 
 # Step 7: Type test regeneration (Full and Thorough only)
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -79,10 +79,10 @@ cd <package-dir> && pnpm exec fluid-build . --task compile
 
 For each built changed package, run:
 ```bash
-cd <package-dir> && pnpm exec fluid-build . -t lint:fix
+cd <package-dir> && pnpm run eslint:fix
 ```
 
-`lint:fix` is the canonical lint entry point across all packages; fluid-build dispatches it to the correct underlying scripts (`eslint:fix`, formatting, etc.). If it fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
+All packages define `eslint:fix` as a direct ESLint invocation. If it fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
 
 # Determining if the public API surface changed
 
@@ -108,7 +108,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 For each built changed package that has a `build:api-reports` script, and where the public API surface likely changed (see criteria above):
 
 ```bash
-cd <package-dir> && pnpm exec fluid-build . -t build:api-reports
+cd <package-dir> && pnpm run build:api-reports
 ```
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
@@ -141,8 +141,8 @@ If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag ref
 If `@fluidframework/tree`'s API reports actually changed (check `git diff` on `packages/dds/tree/api-report/`), also regenerate the aggregator packages that re-export from it:
 
 ```bash
-cd packages/framework/fluid-framework && pnpm exec fluid-build . -t build:api-reports
-cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api-reports
+cd packages/framework/fluid-framework && pnpm run build:api-reports
+cd packages/service-clients/azure-client && pnpm run build:api-reports
 ```
 
 If the tree reports are unchanged, skip this — the aggregator reports won't change either.

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -79,10 +79,10 @@ cd <package-dir> && pnpm exec fluid-build . --task compile
 
 For each built changed package, run:
 ```bash
-cd <package-dir> && pnpm run eslint:fix
+cd <package-dir> && pnpm exec fluid-build . -t eslint:fix
 ```
 
-All packages define `eslint:fix` as a direct ESLint invocation. If it fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
+`eslint:fix` is the registered fluid-build task for linting. Fluid-build ensures compilation is current before running ESLint (important for TypeScript-aware rules) and uses incremental caching so it's fast when the package is already built. If it fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
 
 # Determining if the public API surface changed
 
@@ -108,7 +108,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 For each built changed package that has a `build:api-reports` script, and where the public API surface likely changed (see criteria above):
 
 ```bash
-cd <package-dir> && pnpm run build:api-reports
+cd <package-dir> && pnpm exec fluid-build . -t build:api-reports
 ```
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
@@ -141,8 +141,8 @@ If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag ref
 If `@fluidframework/tree`'s API reports actually changed (check `git diff` on `packages/dds/tree/api-report/`), also regenerate the aggregator packages that re-export from it:
 
 ```bash
-cd packages/framework/fluid-framework && pnpm run build:api-reports
-cd packages/service-clients/azure-client && pnpm run build:api-reports
+cd packages/framework/fluid-framework && pnpm exec fluid-build . -t build:api-reports
+cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api-reports
 ```
 
 If the tree reports are unchanged, skip this — the aggregator reports won't change either.

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -11,7 +11,7 @@ description: Quick pre-push check that catches common CI failures before you pus
 3. Review script output and report results to the user.
 4. If the user chose Full or Thorough mode and there are unbuilt packages, build them.
 5. For each built changed package, run ESLint auto-fix.
-6. For each built changed package where the user-facing API surface changed, regenerate API reports and check for downstream cascade. Also run `build:docs` to catch TSDoc errors.
+6. For each built changed package, run `build:docs` to catch TSDoc errors. If the user-facing API surface changed, also regenerate API reports and check for downstream cascade.
 7. For each built changed package where the user-facing API surface changed, regenerate type tests.
 8. If the user chose Thorough mode, run tests in changed packages.
 9. Report final status: what was fixed, what needs staging, any remaining issues.
@@ -127,7 +127,7 @@ git checkout -- packages/dds/tree/api-report/tree.alpha.api.md
 For each built changed package that has a `build:docs` script, run it regardless of whether the API surface changed (TSDoc link errors can come from any modified source file):
 
 ```bash
-cd <package-dir> && pnpm run build:docs 2>&1 | grep -E "Error|Warning"
+cd <package-dir> && pnpm run build:docs
 ```
 
 If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag references an ambiguous name (most commonly a member that exists as both a static and instance declaration). Fix by linking to an unambiguous target — for example, link to the interface that declares the member (which has exactly one declaration) rather than the class that exposes it as both static and instance. The TSDoc `:instance`/`:static` system selectors are **not** supported by this version of API Extractor.

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -12,7 +12,7 @@ Tasks to create by mode:
 - **Full:** Run CI script → Review output → Build unbuilt packages → ESLint auto-fix → Regenerate API reports → Run build:docs → Regenerate type tests → Report final status
 - **Thorough:** same as Full, plus Run tests
 
-For Full/Thorough: if `@fluidframework/tree` is among the changed packages, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
+For Full/Thorough: if `@fluidframework/tree` is among the changed packages **and its API surface likely changed**, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
 
 Omit steps that don't apply (e.g. skip "Build unbuilt packages" if everything is already built; skip "Regenerate API reports" and "Regenerate type tests" if the API surface didn't change).
 </required>
@@ -103,7 +103,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 
 # Step 6: API reports and cross-package cascade (Full and Thorough only)
 
-> **If `@fluidframework/tree` is among the changed packages:** read `.claude/skills/ci-readiness-check/tree-api-checks.md` now. It has required pre-steps (before `build:api-reports`) and post-steps (after `build:api-reports` and cascade) specific to that package. Do this before proceeding with 6a.
+> **If `@fluidframework/tree` is among the changed packages AND its API surface likely changed** (per the criteria above): read `.claude/skills/ci-readiness-check/tree-api-checks.md` now. It has required pre-steps (before `build:api-reports`) and post-steps (after `build:api-reports` and cascade) specific to that package. Do this before proceeding with 6a. For pure implementation changes to tree (no exported signature changes), skip it.
 
 ## 6a. Regenerate API reports
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -99,9 +99,11 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 - Only comments, documentation, or non-code files changed
 - Only a function body changed (not its signature)
 
-**Why be conservative:** There is a known bug in API Extractor that non-deterministically reorders some generated types in the `@fluidframework/tree` package (and, by cascade, `fluid-framework`). The ordering is stable within a single fresh compilation (local and CI will agree), but it can silently flip between different compilations — e.g. after clearing `tsbuildinfo` or after TypeScript version changes. Running `build:api-reports` unnecessarily on those packages can produce a phantom diff that looks like a real API change but isn't. Only run it when you're confident the public API actually changed.
+**Why be conservative:** Running `build:api-reports` when nothing actually changed can introduce spurious diffs that look like real API changes. This is especially true for `@fluidframework/tree` and `fluid-framework`, which have a known API Extractor bug that non-deterministically reorders some generated types. Only run it when you're confident the public API actually changed.
 
 # Step 6: API reports and cross-package cascade (Full and Thorough only)
+
+> **If `@fluidframework/tree` is among the changed packages:** read `.claude/skills/ci-readiness-check/tree-api-checks.md` now. It has required pre-steps (before `build:api-reports`) and post-steps (after `build:api-reports` and cascade) specific to that package. Do this before proceeding with 6a.
 
 ## 6a. Regenerate API reports
 
@@ -111,35 +113,7 @@ For each built changed package that has a `build:api-reports` script, and where 
 cd <package-dir> && pnpm exec fluid-build . -t build:api-reports
 ```
 
-If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
-
-**Only `@fluidframework/tree`: run `generate:entrypoint-sources` if you added new top-level exports.** `@fluidframework/tree` uses committed files in `src/entrypoints/` (e.g. `src/entrypoints/alpha.ts`) that explicitly list every named export by API tier. If you added a *new* top-level export (new type, class, function, or constant at the package root — not just adding members to an existing type), you must regenerate these files before running `build:api-reports`, otherwise the new export will be missing from the API surface:
-
-```bash
-cd packages/dds/tree && pnpm run generate:entrypoint-sources
-```
-
-This script writes to both `src/entrypoints/*.ts` and `lib/entrypoints/*.d.ts`. The `lib/` copy it writes has wrong import paths and must be fixed by rebuilding immediately after:
-
-```bash
-pnpm run build:esnext
-```
-
-Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index.js`, not `./index.js`. Then stage the `src/entrypoints/` changes and proceed to `build:api-reports`.
-
-If your change only adds members to an *existing* exported type (e.g. a new optional property on an existing interface), skip this — the entrypoints files don't need to change.
-
-**Only `@fluidframework/tree`: check for phantom key-reorder diffs.** After running `build:api-reports`, check `git diff` on the updated report. The known bug (see "Why be conservative" above) can produce spurious reorderings of union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change.
-
-A key-reorder diff is a phantom if: only the order of string literal keys in an `Omit<>` changes, nothing is added or removed.
-
-**Always commit the file that `build:api-reports` produces** — do not manually flip key order or restore from git. The local fresh build and CI agree on the same ordering, so the build output is exactly what CI expects. If you restore the old order instead, CI will fail.
-
-There are two situations:
-
-1. **The only diff is key reorderings** (no real API additions/removals): Commit the updated file. The reordering is spurious but CI requires it.
-
-2. **The diff contains both real API changes and key reorderings:** Commit the entire file as-is. Both the real changes and the reorderings match what CI will produce.
+If API Extractor fails with `ae-missing-release-tag`, the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
 
 ## 6b. Run `build:docs` to catch TSDoc errors
 
@@ -152,19 +126,6 @@ cd <package-dir> && pnpm run build:docs
 ```
 
 If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag references an ambiguous name (most commonly a member that exists as both a static and instance declaration). Fix by linking to an unambiguous target — for example, link to the interface that declares the member (which has exactly one declaration) rather than the class that exposes it as both static and instance. The TSDoc `:instance`/`:static` system selectors are **not** supported by this version of API Extractor.
-
-## 6c. Cross-package cascade
-
-If `@fluidframework/tree`'s API reports actually changed (check `git diff` on `packages/dds/tree/api-report/`), also regenerate the aggregator packages that re-export from it:
-
-```bash
-cd packages/framework/fluid-framework && pnpm exec fluid-build . -t build:api-reports
-cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api-reports
-```
-
-If the tree reports are unchanged, skip this — the aggregator reports won't change either.
-
-After running either of these, apply the same phantom key-reorder check described in step 6a — the same bug affects their reports for the same reason.
 
 # Step 7: Type test regeneration (Full and Thorough only)
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -101,7 +101,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 - Only comments, documentation, or non-code files changed
 - Only a function body changed (not its signature)
 
-**Why be conservative:** There is a known bug in API Extractor where it non-deterministically reorders some generated types in the `@fluidframework/tree` package specifically. The output differs between local and CI, producing bogus diffs that look like real changes but aren't. Running API Extractor unnecessarily on that package can introduce these confusing phantom diffs. Only run it when you're confident the public API actually changed.
+**Why be conservative:** There is a known bug in API Extractor where it non-deterministically reorders some generated types in the `@fluidframework/tree` package (and, by cascade, `fluid-framework`). The output differs between local and CI builds, producing bogus diffs that look like real changes but aren't. Running API Extractor unnecessarily on those packages can introduce phantom diffs. Only run it when you're confident the public API actually changed.
 
 # Step 6: API reports and cross-package cascade (Full and Thorough only)
 
@@ -115,10 +115,20 @@ cd <package-dir> && pnpm run build:api-reports
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
 
-**Handling phantom key-reorder diffs in `@fluidframework/tree`:** After running `build:api-reports` on `@fluidframework/tree`, check `git diff` on the updated report. If the **only** changes are key reorderings within type signatures (e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"`, with no added or removed API members), this is a spurious local-machine artifact — do NOT commit it. Restore the file:
-```bash
-git checkout -- packages/dds/tree/api-report/tree.alpha.api.md
-```
+**Phantom key-reorder diffs in `@fluidframework/tree` (and `fluid-framework`):** There is a known bug where API Extractor non-deterministically reorders union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — depending on whether TypeScript compiled incrementally (local) or from scratch (CI). This affects the `@fluidframework/tree` API report directly, and also `fluid-framework`'s report because it re-exports from `@fluidframework/tree` and API Extractor processes them the same way.
+
+After running `build:api-reports` on either package, check `git diff` on the updated report for these reorderings. There are three cases:
+
+1. **The only diff is key reorderings** (no real API additions/removals): The entire diff is spurious. Restore the file and do not commit it:
+   ```bash
+   git checkout -- packages/dds/tree/api-report/tree.alpha.api.md
+   # and/or
+   git checkout -- packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+   ```
+
+2. **The diff contains both real API changes and key reorderings in unrelated places:** Commit your real changes but manually revert the key-reorder lines. Open the file and flip the affected `"keyA" | "keyB"` back to whatever order is already committed — the reordering is spurious and must not appear in the PR diff. The real changes should be left as-is.
+
+3. **A key reordering appears within your newly added API:** This is exceedingly rare. It likely means the new type uses `Omit<>` and happened to be emitted in a different key order. In this case, commit whatever order the file has — there is no "right" order — and accept that CI may flip it back on the next regeneration. Flag this to the user.
 
 ## 6b. Run `build:docs` to catch TSDoc errors
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -8,11 +8,11 @@ Step 1 below asks the user to pick a mode. **Immediately after they respond**, u
 
 Tasks to create by mode:
 
-- **Quick:** Run CI script → Review output → Report final status
-- **Full:** Run CI script → Review output → Build unbuilt packages → ESLint auto-fix → Regenerate API reports → Run build:docs → Regenerate type tests → Report final status
-- **Thorough:** same as Full, plus Run tests
+- **Check:** Run CI script → Review output → Report final status
+- **Build:** Run CI script → Review output → Build unbuilt packages → ESLint auto-fix → Regenerate API reports → Run build:docs → Regenerate type tests → Report final status
+- **Test:** same as Build, plus Run tests
 
-For Full/Thorough: if `@fluidframework/tree` is among the changed packages **and its API surface likely changed**, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
+For Build/Test: if `@fluidframework/tree` is among the changed packages **and its API surface likely changed**, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
 
 Omit steps that don't apply (e.g. skip "Build unbuilt packages" if everything is already built; skip "Regenerate API reports" and "Regenerate type tests" if the API surface didn't change).
 </required>
@@ -24,9 +24,9 @@ Before doing anything, ask the user:
 > I'll run a CI readiness check on your branch. Pick a mode (fastest to slowest):
 >
 > 1. **Cancel** — never mind, don't run checks
-> 2. **Quick** — auto-fix formatting, policy, and syncpack on changed packages; skip build-dependent checks (~30–60 seconds)
-> 3. **Full** — Quick + build unbuilt packages + ESLint + regenerate API reports and type tests (~1–3 minutes depending on package size)
-> 4. **Thorough** — Full + run tests in changed packages (~5+ minutes; dominated by test suite size)
+> 2. **Check** — auto-fix formatting, policy, and syncpack on changed packages (~30–60 seconds)
+> 3. **Build** — Check + build unbuilt packages + ESLint + regenerate API reports and type tests (~1–3 minutes)
+> 4. **Test** — Build + run the test suite in changed packages (~5+ minutes; dominated by test suite size)
 
 Wait for the user's response. If they say cancel (or anything clearly negative), stop here. Otherwise, note their choice and **immediately create tasks for all remaining steps** as described in the `<required>` block above before proceeding.
 
@@ -62,9 +62,9 @@ Read the script output. Report to the user:
 - Changeset status
 - Uncommitted files
 
-**Quick mode stops here.** In Quick mode, skip steps 4–8 entirely — even for packages that happen to be already built. Note what was skipped in the final report (step 9).
+**Check mode stops here.** In Check mode, skip steps 4–8 entirely — even for packages that happen to be already built. Note what was skipped in the final report (step 9).
 
-# Step 4: Handle unbuilt packages (Full and Thorough only)
+# Step 4: Handle unbuilt packages (Build and Test only)
 
 If the script reports unbuilt packages, build them:
 
@@ -72,7 +72,7 @@ If the script reports unbuilt packages, build them:
 cd <package-dir> && pnpm exec fluid-build . --task compile
 ```
 
-# Step 5: ESLint auto-fix (Full and Thorough only)
+# Step 5: ESLint auto-fix (Build and Test only)
 
 For each built changed package, run:
 ```bash
@@ -98,7 +98,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 
 **Why be conservative:** Running `build:api-reports` when nothing actually changed can introduce spurious diffs that look like real API changes. This is especially true for `@fluidframework/tree` and `fluid-framework`, which have a known API Extractor bug that non-deterministically reorders some generated types. Only run it when you're confident the public API actually changed.
 
-# Step 6: API reports and cross-package cascade (Full and Thorough only)
+# Step 6: API reports and cross-package cascade (Build and Test only)
 
 > **If `@fluidframework/tree` is among the changed packages AND its API surface likely changed** (per the criteria above): read `.claude/skills/ci-readiness-check/tree-api-checks.md` now. It has required pre-steps (before `build:api-reports`) and post-steps (after `build:api-reports` and cascade) specific to that package. Do this before proceeding with 6a. For pure implementation changes to tree (no exported signature changes), skip it.
 
@@ -124,7 +124,7 @@ cd <package-dir> && pnpm run build:docs
 
 If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag references an ambiguous name (most commonly a member that exists as both a static and instance declaration). Fix by linking to an unambiguous target — for example, link to the interface that declares the member (which has exactly one declaration) rather than the class that exposes it as both static and instance. The TSDoc `:instance`/`:static` system selectors are **not** supported by this version of API Extractor.
 
-# Step 7: Type test regeneration (Full and Thorough only)
+# Step 7: Type test regeneration (Build and Test only)
 
 For each built changed package that has a `typetests:gen` script in its `package.json`, and where the public API surface likely changed (see criteria above):
 
@@ -136,7 +136,7 @@ Not all packages have type tests. Only run this where the script exists.
 
 # Step 8: Run tests (Thorough mode only)
 
-If the user chose **Thorough** mode, run tests in each built changed package. Check the package's `package.json` for available test scripts and run whichever exist:
+If the user chose **Test** mode, run tests in each built changed package. Check the package's `package.json` for available test scripts and run whichever exist:
 
 ```bash
 cd <package-dir> && pnpm run test:mocha

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -10,8 +10,8 @@ description: Quick pre-push check that catches common CI failures before you pus
 2. Run the CI readiness script.
 3. Review script output and report results to the user.
 4. If the user chose Full or Thorough mode and there are unbuilt packages, build them.
-5. For each built changed package where the user-facing API surface changed, regenerate API reports and check for downstream cascade.
-6. For each built changed package, run ESLint auto-fix.
+5. For each built changed package, run ESLint auto-fix.
+6. For each built changed package where the user-facing API surface changed, regenerate API reports and check for downstream cascade. Also run `build:docs` to catch TSDoc errors.
 7. For each built changed package where the user-facing API surface changed, regenerate type tests.
 8. If the user chose Thorough mode, run tests in changed packages.
 9. Report final status: what was fixed, what needs staging, any remaining issues.
@@ -75,9 +75,22 @@ If the script reports unbuilt packages, build them:
 cd <package-dir> && pnpm exec fluid-build . --task compile
 ```
 
+# Step 5: ESLint auto-fix (Full and Thorough only)
+
+**Run ESLint BEFORE regenerating API reports.** ESLint can modify source files (e.g. simplifying expressions, reordering imports), and those changes must be baked in before API Extractor processes the code. If you run API reports first and ESLint second, you may need to regenerate API reports again.
+
+For each built changed package, check its `package.json` for the available lint fix script and run it:
+```bash
+# Check which script exists — packages use different names
+cd <package-dir> && node -p "Object.keys(require('./package.json').scripts || {}).filter(s => /eslint.fix|lint.fix/.test(s))"
+cd <package-dir> && pnpm run <script-name>
+```
+
+Common script names: `eslint:fix`, `lint:fix`. Only run what exists. If the script fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
+
 # Determining if the public API surface changed
 
-Steps 5 and 7 require judging whether a package's public API surface changed. Use these criteria:
+Steps 6 and 7 require judging whether a package's public API surface changed. Use these criteria:
 
 **API likely changed — proceed with the check:**
 - `src/index.ts` or any entry point file (`src/alpha.ts`, `src/beta.ts`, `src/legacy.ts`, `src/internal.ts`) was modified
@@ -92,7 +105,9 @@ Steps 5 and 7 require judging whether a package's public API surface changed. Us
 
 **Why be conservative:** There is a known bug in API Extractor where it non-deterministically reorders some generated types in the `@fluidframework/tree` package specifically. The output differs between local and CI, producing bogus diffs that look like real changes but aren't. Running API Extractor unnecessarily on that package can introduce these confusing phantom diffs. Only run it when you're confident the public API actually changed.
 
-# Step 5: API reports and cross-package cascade (Full and Thorough only)
+# Step 6: API reports and cross-package cascade (Full and Thorough only)
+
+## 6a. Regenerate API reports
 
 For each built changed package that has a `build:api-reports` script, and where the public API surface likely changed (see criteria above):
 
@@ -102,7 +117,26 @@ cd <package-dir> && pnpm run build:api-reports
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
 
-**Cross-package cascade:** After regenerating API reports for a package, check if any "aggregator" packages re-export from it. If so, their API reports are now stale too.
+**Handling phantom key-reorder diffs in `@fluidframework/tree`:** After running `build:api-reports` on `@fluidframework/tree`, check `git diff` on the updated report. If the **only** changes are key reorderings within type signatures (e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"`, with no added or removed API members), this is a spurious local-machine artifact — do NOT commit it. Restore the file:
+```bash
+git checkout -- packages/dds/tree/api-report/tree.alpha.api.md
+```
+
+## 6b. Run `build:docs` to catch TSDoc errors
+
+**Critical:** `build:api-reports` uses an API Extractor config that suppresses `ae-unresolved-link` errors. CI catches these via a separate `build:docs` step that uses the package-root `api-extractor.json` without that suppression. You must run `build:docs` locally to catch these before pushing.
+
+For each built changed package that has a `build:docs` script, run it regardless of whether the API surface changed (TSDoc link errors can come from any modified source file):
+
+```bash
+cd <package-dir> && pnpm run build:docs 2>&1 | grep -E "Error|Warning"
+```
+
+If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag references an ambiguous name (most commonly a member that exists as both a static and instance declaration). Fix by linking to an unambiguous target — for example, link to the interface that declares the member (which has exactly one declaration) rather than the class that exposes it as both static and instance. The TSDoc `:instance`/`:static` system selectors are **not** supported by this version of API Extractor.
+
+## 6c. Cross-package cascade
+
+After regenerating API reports for a package, check if any "aggregator" packages re-export from it. If so, their API reports are now stale too.
 
 Read the source index files of these aggregator packages and look for imports from the changed package:
 - `packages/framework/fluid-framework/src/index.ts`
@@ -114,17 +148,6 @@ cd packages/framework/fluid-framework && pnpm run build:api-reports
 ```
 
 Only do this if the source package's reports actually changed (check `git diff` on its `api-report/` directory). If the source reports are unchanged, the aggregator's won't be either.
-
-# Step 6: ESLint auto-fix (Full and Thorough only)
-
-For each built changed package, check its `package.json` for the available lint fix script and run it:
-```bash
-# Check which script exists — packages use different names
-cd <package-dir> && node -p "Object.keys(require('./package.json').scripts || {}).filter(s => /eslint.fix|lint.fix/.test(s))"
-cd <package-dir> && pnpm run <script-name>
-```
-
-Common script names: `eslint:fix`, `lint:fix`. Only run what exists. If the script fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
 
 # Step 7: Type test regeneration (Full and Thorough only)
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -4,17 +4,17 @@ description: Quick pre-push check that catches common CI failures before you pus
 ---
 
 <required>
-*CRITICAL* Add the following steps to your Todo list using TodoWrite:
+Step 1 below asks the user to pick a mode. **Immediately after they respond**, use TaskCreate to create one task per applicable step based on their choice — before doing any other work. Mark each task in_progress when you start it and completed when you finish. This prevents steps from being silently skipped as context grows.
 
-1. Confirm with the user before proceeding.
-2. Run the CI readiness script.
-3. Review script output and report results to the user.
-4. If the user chose Full or Thorough mode and there are unbuilt packages, build them.
-5. For each built changed package, run ESLint auto-fix.
-6. For each built changed package, run `build:docs` to catch TSDoc errors. If the user-facing API surface changed, also regenerate API reports and check for downstream cascade.
-7. For each built changed package where the user-facing API surface changed, regenerate type tests.
-8. If the user chose Thorough mode, run tests in changed packages.
-9. Report final status: what was fixed, what needs staging, any remaining issues.
+Tasks to create by mode:
+
+- **Quick:** Run CI script → Review output → Report final status
+- **Full:** Run CI script → Review output → Build unbuilt packages → ESLint auto-fix → Regenerate API reports → Run build:docs → Regenerate type tests → Report final status
+- **Thorough:** same as Full, plus Run tests
+
+For Full/Thorough: if `@fluidframework/tree` is among the changed packages, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
+
+Omit steps that don't apply (e.g. skip "Build unbuilt packages" if everything is already built; skip "Regenerate API reports" and "Regenerate type tests" if the API surface didn't change).
 </required>
 
 # Step 1: Confirm with the user
@@ -28,7 +28,7 @@ Before doing anything, ask the user:
 > 3. **Full** — Quick + build unbuilt packages + regenerate API reports and type tests (~30 seconds – 2 minutes depending on package size)
 > 4. **Thorough** — Full + run tests in changed packages (~30 seconds – 5+ minutes; dominated by test suite size)
 
-Wait for the user's response. If they say cancel (or anything clearly negative), stop here. Otherwise, note their choice and proceed.
+Wait for the user's response. If they say cancel (or anything clearly negative), stop here. Otherwise, note their choice and **immediately create tasks for all remaining steps** as described in the `<required>` block above before proceeding.
 
 # Step 2: Run the script
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -77,14 +77,12 @@ cd <package-dir> && pnpm exec fluid-build . --task compile
 
 # Step 5: ESLint auto-fix (Full and Thorough only)
 
-For each built changed package, check its `package.json` for the available lint fix script and run it:
+For each built changed package, run:
 ```bash
-# Check which script exists — packages use different names
-cd <package-dir> && node -p "Object.keys(require('./package.json').scripts || {}).filter(s => /eslint.fix|lint.fix/.test(s))"
-cd <package-dir> && pnpm run <script-name>
+cd <package-dir> && pnpm exec fluid-build . -t lint:fix
 ```
 
-Common script names: `eslint:fix`, `lint:fix`. Only run what exists. If the script fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
+`lint:fix` is the canonical lint entry point across all packages; fluid-build dispatches it to the correct underlying scripts (`eslint:fix`, formatting, etc.). If it fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
 
 # Determining if the public API surface changed
 
@@ -110,7 +108,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 For each built changed package that has a `build:api-reports` script, and where the public API surface likely changed (see criteria above):
 
 ```bash
-cd <package-dir> && pnpm run build:api-reports
+cd <package-dir> && pnpm exec fluid-build . -t build:api-reports
 ```
 
 If API Extractor fails with `ae-missing-release-tag` (most commonly in `@fluidframework/tree`), the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
@@ -140,20 +138,16 @@ If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag ref
 
 ## 6c. Cross-package cascade
 
-After regenerating API reports for a package, check if any "aggregator" packages re-export from it. If so, their API reports are now stale too.
+If `@fluidframework/tree`'s API reports actually changed (check `git diff` on `packages/dds/tree/api-report/`), also regenerate the aggregator packages that re-export from it:
 
-Read the source index files of these aggregator packages and look for imports from the changed package:
-- `packages/framework/fluid-framework/src/index.ts`
-- `packages/service-clients/azure-client/src/index.ts`
-
-For example, if you changed `@fluidframework/tree` and `fluid-framework/src/index.ts` contains `export * from "@fluidframework/tree/alpha"`, then also run:
 ```bash
-cd packages/framework/fluid-framework && pnpm run build:api-reports
+cd packages/framework/fluid-framework && pnpm exec fluid-build . -t build:api-reports
+cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api-reports
 ```
 
-Only do this if the source package's reports actually changed (check `git diff` on its `api-report/` directory). If the source reports are unchanged, the aggregator's won't be either.
+If the tree reports are unchanged, skip this — the aggregator reports won't change either.
 
-If you ran `build:api-reports` on `fluid-framework`, apply the same phantom key-reorder check described in step 6a — the same bug affects its report for the same reason.
+After running either of these, apply the same phantom key-reorder check described in step 6a — the same bug affects their reports for the same reason.
 
 # Step 7: Type test regeneration (Full and Thorough only)
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -99,7 +99,7 @@ Steps 6 and 7 require judging whether a package's public API surface changed. Us
 - Only comments, documentation, or non-code files changed
 - Only a function body changed (not its signature)
 
-**Why be conservative:** There is a known bug in API Extractor where it non-deterministically reorders some generated types in the `@fluidframework/tree` package (and, by cascade, `fluid-framework`). The output differs between local and CI builds, producing bogus diffs that look like real changes but aren't. Running API Extractor unnecessarily on those packages can introduce phantom diffs. Only run it when you're confident the public API actually changed.
+**Why be conservative:** There is a known bug in API Extractor that non-deterministically reorders some generated types in the `@fluidframework/tree` package (and, by cascade, `fluid-framework`). The ordering is stable within a single fresh compilation (local and CI will agree), but it can silently flip between different compilations — e.g. after clearing `tsbuildinfo` or after TypeScript version changes. Running `build:api-reports` unnecessarily on those packages can produce a phantom diff that looks like a real API change but isn't. Only run it when you're confident the public API actually changed.
 
 # Step 6: API reports and cross-package cascade (Full and Thorough only)
 
@@ -129,16 +129,17 @@ Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index
 
 If your change only adds members to an *existing* exported type (e.g. a new optional property on an existing interface), skip this — the entrypoints files don't need to change.
 
-**Only `@fluidframework/tree`: check for phantom key-reorder diffs.** After running `build:api-reports`, check `git diff` on the updated report. The known bug (see "Why be conservative" above) can produce spurious reorderings of union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. There are three cases:
+**Only `@fluidframework/tree`: check for phantom key-reorder diffs.** After running `build:api-reports`, check `git diff` on the updated report. The known bug (see "Why be conservative" above) can produce spurious reorderings of union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change.
 
-1. **The only diff is key reorderings** (no real API additions/removals): The entire diff is spurious. Restore the file and do not commit it:
-   ```bash
-   git checkout -- packages/dds/tree/api-report/tree.alpha.api.md
-   ```
+A key-reorder diff is a phantom if: only the order of string literal keys in an `Omit<>` changes, nothing is added or removed.
 
-2. **The diff contains both real API changes and key reorderings in unrelated places:** Commit your real changes but manually revert the key-reorder lines. Open the file and flip the affected `"keyA" | "keyB"` back to whatever order is already committed — the reordering is spurious and must not appear in the PR diff.
+**Always commit the file that `build:api-reports` produces** — do not manually flip key order or restore from git. The local fresh build and CI agree on the same ordering, so the build output is exactly what CI expects. If you restore the old order instead, CI will fail.
 
-3. **A key reordering appears within your newly added API:** This is exceedingly rare (the new type uses `Omit<>` and was emitted in a different key order). Commit whatever order the file has — there is no "right" order — and accept that CI may flip it back on the next regeneration. Flag this to the user.
+There are two situations:
+
+1. **The only diff is key reorderings** (no real API additions/removals): Commit the updated file. The reordering is spurious but CI requires it.
+
+2. **The diff contains both real API changes and key reorderings:** Commit the entire file as-is. Both the real changes and the reorderings match what CI will produce.
 
 ## 6b. Run `build:docs` to catch TSDoc errors
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -77,8 +77,6 @@ cd <package-dir> && pnpm exec fluid-build . --task compile
 
 # Step 5: ESLint auto-fix (Full and Thorough only)
 
-**Run ESLint BEFORE regenerating API reports.** ESLint can modify source files (e.g. simplifying expressions, reordering imports), and those changes must be baked in before API Extractor processes the code. If you run API reports first and ESLint second, you may need to regenerate API reports again.
-
 For each built changed package, check its `package.json` for the available lint fix script and run it:
 ```bash
 # Check which script exists — packages use different names
@@ -181,3 +179,5 @@ Run `git status` and report to the user:
 5. **Skipped checks** — anything skipped due to mode choice or unbuilt packages.
 
 End with a clear statement: "Your branch is ready to push" or "These issues remain: ..."
+
+**If further code changes are made after this check** (e.g. fixing a review comment, addressing a lint error manually, or any other edit), re-run ESLint and — if the API surface changed — regenerate API reports before pushing. A CI readiness check only reflects the state of the code at the time it was run.

--- a/.claude/skills/ci-readiness-check/ci-readiness-check.sh
+++ b/.claude/skills/ci-readiness-check/ci-readiness-check.sh
@@ -3,13 +3,12 @@
 #
 # CI Readiness Check — quick pre-push sanity check for Fluid Framework.
 #
-# Usage: ci-readiness-check.sh [--quick] [base-branch]
+# Usage: ci-readiness-check.sh [base-branch]
 #
-# Detects which packages changed vs a base branch, then:
-#   --quick mode: formats changed files with Biome only (fast)
-#   default mode: runs full `fluid-build --task checks:fix` scoped to
-#     changed packages (formatting, policy, syncpack, versions) + verifies
-#   Both modes: check changeset, report uncommitted changes and build status
+# Detects which packages changed vs a base branch, then runs
+# `fluid-build --task checks:fix` scoped to changed packages
+# (formatting, policy, syncpack, versions) and verifies all checks pass.
+# Also checks for a changeset, reports uncommitted changes and build status.
 #
 # Designed to be run by the ci-readiness-check skill, which handles
 # build-dependent checks (API reports, ESLint, type tests) after this script.
@@ -18,16 +17,12 @@
 set -euo pipefail
 
 # Resolve the repo root (works from any directory) and parse arguments.
-# Accepts an optional --quick flag and an optional base branch (default: main).
+# Accepts an optional base branch argument (default: main).
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-QUICK_MODE=false
 BASE_BRANCH="main"
 
 for arg in "$@"; do
-    case "${arg}" in
-        --quick) QUICK_MODE=true ;;
-        *) BASE_BRANCH="${arg}" ;;
-    esac
+    BASE_BRANCH="${arg}"
 done
 
 # --- Output helpers ---
@@ -170,58 +165,28 @@ done
 CHECKS_FIX_OK=true
 CHECKS_OK=true
 
-if [ "${QUICK_MODE}" = true ]; then
-    # ---------- Phase 1 (Quick): Format changed files only ----------
-    section "Formatting changed files (Quick mode)"
+# ---------- Phase 1: Auto-fix all checks ----------
+section "Running checks:fix on changed packages"
 
-    # Collect only formattable files from the changed list and run biome
-    # format --write on them directly. This avoids the slower repo-wide
-    # policy checks and lint that checks:fix would trigger.
-    FORMAT_FILES=()
-    while IFS= read -r file; do
-        case "${file}" in
-            *.ts|*.tsx|*.js|*.jsx|*.json|*.jsonc|*.css) FORMAT_FILES+=("${REPO_ROOT}/${file}") ;;
-        esac
-    done <<< "${CHANGED_FILES}"
-
-    if [ ${#FORMAT_FILES[@]} -gt 0 ]; then
-        echo "Formatting ${#FORMAT_FILES[@]} changed file(s) with Biome..."
-        if (cd "${REPO_ROOT}" && pnpm exec biome format --write "${FORMAT_FILES[@]}" 2>&1); then
-            ok "Formatting complete"
-        else
-            warn "Biome formatting had issues"
-            CHECKS_FIX_OK=false
-        fi
-    else
-        ok "No formattable files changed"
-    fi
-
-    echo ""
-    warn "Quick mode: skipped policy, syncpack, version checks, and lint"
+# Use fluid-build --task checks:fix scoped to just the changed packages.
+# This runs: biome format --write, flub check policy --fix, syncpack fix,
+# and buildVersion --fix — all in the correct dependency order.
+echo "Running: fluid-build --task checks:fix ${PKG_ARGS}"
+if (cd "${REPO_ROOT}" && pnpm exec fluid-build --task checks:fix ${PKG_ARGS} 2>&1); then
+    ok "checks:fix completed"
 else
-    # ---------- Phase 1 (Full/Thorough): Auto-fix all checks ----------
-    section "Running checks:fix on changed packages"
+    warn "checks:fix had issues (some fixes may still have been applied)"
+    CHECKS_FIX_OK=false
+fi
 
-    # Use fluid-build --task checks:fix scoped to just the changed packages.
-    # This runs: biome format --write, flub check policy --fix, syncpack fix,
-    # and buildVersion --fix — all in the correct dependency order.
-    echo "Running: fluid-build --task checks:fix ${PKG_ARGS}"
-    if (cd "${REPO_ROOT}" && pnpm exec fluid-build --task checks:fix ${PKG_ARGS} 2>&1); then
-        ok "checks:fix completed"
-    else
-        warn "checks:fix had issues (some fixes may still have been applied)"
-        CHECKS_FIX_OK=false
-    fi
+# ---------- Phase 2: Verify checks pass ----------
+section "Verifying checks pass"
 
-    # ---------- Phase 2: Verify checks pass ----------
-    section "Verifying checks pass"
-
-    if (cd "${REPO_ROOT}" && pnpm exec fluid-build --task checks ${PKG_ARGS} 2>&1) >/dev/null 2>&1; then
-        ok "All checks pass"
-    else
-        CHECKS_OK=false
-        fail "Some checks still failing after auto-fix. Re-run for details: pnpm exec fluid-build --task checks ${PKG_ARGS}"
-    fi
+if (cd "${REPO_ROOT}" && pnpm exec fluid-build --task checks ${PKG_ARGS} 2>&1) >/dev/null 2>&1; then
+    ok "All checks pass"
+else
+    CHECKS_OK=false
+    fail "Some checks still failing after auto-fix. Re-run for details: pnpm exec fluid-build --task checks ${PKG_ARGS}"
 fi
 
 # ---------- Phase 3: Changeset check ----------

--- a/.claude/skills/ci-readiness-check/tree-api-checks.md
+++ b/.claude/skills/ci-readiness-check/tree-api-checks.md
@@ -4,13 +4,11 @@ This document is read by the `ci-readiness-check` skill when `@fluidframework/tr
 
 ---
 
-## Before running `build:api-reports`: check for new top-level exports
+## Before running `build:api-reports`: regenerate entrypoint sources if `index.ts` changed
 
-`@fluidframework/tree` uses committed files in `src/entrypoints/` (e.g. `src/entrypoints/alpha.ts`) that explicitly list every named export by API tier. If you added a **new top-level export** (a new type, class, function, or constant at the package root — not just adding members to an existing type), you must regenerate these files before running `build:api-reports`. Otherwise the new export will be missing from the API surface.
+`@fluidframework/tree` uses committed files in `src/entrypoints/` (e.g. `src/entrypoints/alpha.ts`) that explicitly list every named export by API tier. These must be kept in sync with `src/index.ts`.
 
-To check: run `git diff` on `src/entrypoints/` — if your new export doesn't appear there, it needs to be added.
-
-Run the generator:
+**Run `generate:entrypoint-sources` if you touched `src/index.ts`** — this covers all cases that affect the entrypoints: adding or removing a top-level export, and changing the API tier of an existing export (e.g. promoting something from `@alpha` to `@public`). If your changes didn't touch `src/index.ts` at all, skip this step.
 
 ```bash
 cd packages/dds/tree && pnpm run generate:entrypoint-sources
@@ -23,8 +21,6 @@ pnpm run build:esnext
 ```
 
 Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index.js`, not `./index.js`. Then stage the `src/entrypoints/` changes and proceed to `build:api-reports`.
-
-If your change only adds members to an existing exported type (e.g. a new optional property on an existing interface), skip this — the entrypoints files don't need to change.
 
 ---
 

--- a/.claude/skills/ci-readiness-check/tree-api-checks.md
+++ b/.claude/skills/ci-readiness-check/tree-api-checks.md
@@ -1,0 +1,58 @@
+# Tree-specific API check guidance
+
+This document is read by the `ci-readiness-check` skill when `@fluidframework/tree` is among the changed packages. Follow these instructions **in addition to** the general steps in `SKILL.md`.
+
+---
+
+## Before running `build:api-reports`: check for new top-level exports
+
+`@fluidframework/tree` uses committed files in `src/entrypoints/` (e.g. `src/entrypoints/alpha.ts`) that explicitly list every named export by API tier. If you added a **new top-level export** (a new type, class, function, or constant at the package root — not just adding members to an existing type), you must regenerate these files before running `build:api-reports`. Otherwise the new export will be missing from the API surface.
+
+To check: run `git diff` on `src/entrypoints/` — if your new export doesn't appear there, it needs to be added.
+
+Run the generator:
+
+```bash
+cd packages/dds/tree && pnpm run generate:entrypoint-sources
+```
+
+This script writes to both `src/entrypoints/*.ts` and `lib/entrypoints/*.d.ts`. The `lib/` copy has wrong import paths and must be fixed by rebuilding immediately after:
+
+```bash
+pnpm run build:esnext
+```
+
+Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index.js`, not `./index.js`. Then stage the `src/entrypoints/` changes and proceed to `build:api-reports`.
+
+If your change only adds members to an existing exported type (e.g. a new optional property on an existing interface), skip this — the entrypoints files don't need to change.
+
+---
+
+## After running `build:api-reports`: check for phantom key-reorder diffs
+
+There is a known bug in API Extractor that non-deterministically reorders union key strings within `Omit<>` type signatures in this package — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. The ordering is stable within a single fresh compilation (local and CI agree), but it can silently flip between compilations after clearing `tsbuildinfo` or after TypeScript version changes.
+
+A diff is a phantom key-reorder if: only the order of string literal keys in an `Omit<>` changes; nothing is added or removed.
+
+**Always commit the file that `build:api-reports` produces.** Do not manually flip key order or restore from git. The local fresh build and CI agree on the same ordering, so the build output is exactly what CI expects. If you restore the old order, CI will fail.
+
+There are two situations:
+
+1. **The only diff is key reorderings** (no real API additions/removals): Commit the updated file. The reordering is spurious but CI requires it.
+
+2. **The diff contains both real API changes and key reorderings:** Commit the entire file as-is. Both the real changes and the reorderings match what CI will produce.
+
+---
+
+## After tree reports updated: cascade to aggregator packages
+
+If `@fluidframework/tree`'s API reports actually changed (check `git diff` on `packages/dds/tree/api-report/`), also regenerate the reports for packages that re-export from it:
+
+```bash
+cd packages/framework/fluid-framework && pnpm exec fluid-build . -t build:api-reports
+cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api-reports
+```
+
+If the tree reports are unchanged, skip this — the aggregator reports won't change either.
+
+After running either of these, apply the same phantom key-reorder check above — the same bug affects their reports for the same reason.


### PR DESCRIPTION
## Summary

Improvements to the `ci-readiness-check` skill based on real usage against `@fluidframework/tree` changes.

### New: TaskCreate-based step tracking to prevent skipped steps

The skill now instructs the agent to create tasks (via `TaskCreate`) for every applicable step immediately after the user picks a mode — before doing any other work. Each task is marked `in_progress` when started and `completed` when done. This prevents steps from being silently dropped as context window fills up during a long check. The task list is mode-aware: Quick mode gets 3 tasks, Full/Thorough get the full set, and the tree cascade task is only added when `@fluidframework/tree` is among the changed packages.

### New: `build:docs` step to catch `ae-unresolved-link` errors

`build:api-reports` inherits a config that suppresses `ae-unresolved-link`, but CI catches these via `build:docs` which uses the unfiltered `api-extractor.json`. Added an explicit step 6b to run `build:docs` after API reports, with guidance on fixing ambiguous `{@link}` tags (the TSDoc `:instance`/`:static` selectors are unsupported in this version of API Extractor).

### New: `generate:entrypoint-sources` guidance for tree — extracted to `tree-api-checks.md`

`@fluidframework/tree` uses committed files in `src/entrypoints/` that explicitly list every named export by API tier. Run `generate:entrypoint-sources` any time `src/index.ts` is touched — this covers new exports, removals, and tier changes (e.g. promoting from `@alpha` to `@public`). The script clobbers `lib/entrypoints/` with wrong import paths, requiring a `build:esnext` follow-up.

### Refactored: tree-specific guidance extracted to `tree-api-checks.md`

All three tree-specific sections (`generate:entrypoint-sources`, phantom key-reorder, cascade to `fluid-framework`/`azure-client`) moved to a new sub-document. The main `SKILL.md` now has a single prominent trigger at the top of step 6: "If `@fluidframework/tree` is among the changed packages, read `tree-api-checks.md` now." This keeps the main skill clean for non-tree work while ensuring the complex tree-specific logic isn't missed when it matters.

### Corrected: phantom key-reorder guidance

Initial guidance said "restore the file, don't commit it" — which is exactly backwards. Corrected: always commit what `build:api-reports` produces. Local fresh builds and CI agree on the same ordering; restoring the old order causes CI to fail.

### ESLint step ordering

ESLint (step 5) runs before API report regeneration (step 6) so that any auto-fixes affecting exported signatures are in place before API Extractor runs. Added a note to re-run relevant checks after any further code changes.