### PR TITLE
Use pnpm for compat testing package installation

### DIFF
--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -122,8 +122,10 @@ async function removeInstalled(version: string): Promise<void> {
 
 // See https://github.com/nodejs/node-v0.x-archive/issues/2318.
 // Note that execFile and execFileSync are used to avoid command injection vulnerability flagging from CodeQL.
-const npmCmd =
-	process.platform.includes("win") && !process.platform.includes("darwin") ? "npm.cmd" : "npm";
+// pnpm is used instead of npm for package installation to enable security flags (--ignore-scripts, --prefer-offline).
+// The registry is inherited from the process environment: in CI, NPM_CONFIG_USERCONFIG points to an .npmrc configured
+// for the Azure Artifacts feed, which pnpm honors the same way npm does.
+const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 /**
  * Resolves a version range or alias to a specific version number.
@@ -166,18 +168,18 @@ export function resolveVersion(requested: string, installed: boolean): string {
 		let result: string | undefined;
 		try {
 			result = execFileSync(
-				npmCmd,
-				["v", `"@fluidframework/container-loader@${requested}"`, "version", "--json"],
+				pnpmCmd,
+				["view", `"@fluidframework/container-loader@${requested}"`, "version", "--json"],
 				{
 					encoding: "utf8",
-					// When using npm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+					// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
 					shell: true,
 				},
 			);
 		} catch (error: any) {
 			debugger;
 			throw new Error(
-				`Error while running: ${npmCmd} v "@fluidframework/container-loader@${requested}" version --json`,
+				`Error while running: ${pnpmCmd} view "@fluidframework/container-loader@${requested}" version --json`,
 			);
 		}
 		if (result === "" || result === undefined) {
@@ -262,17 +264,15 @@ export async function ensureInstalled(
 					// will otherwise propagate to these commands but fail to resolve.
 					NODE_OPTIONS: "",
 				},
-				// When using npm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+				// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
 				// @ts-expect-error ExecOptions does not acknowledge boolean for `shell` as a valid option (at least as of @types/node@18.19.1)
 				shell: true,
 			};
 			// Install the packages
 			await new Promise<void>((resolve, reject) =>
 				execFile(
-					npmCmd,
-					// Added --verbose to try to troubleshoot AB#6195.
-					// We should probably remove it if when find the root cause and fix for that.
-					["init", "--yes", "--verbose"],
+					pnpmCmd,
+					["init"],
 					options,
 					(error, stdout, stderr) => {
 						if (error) {
@@ -292,13 +292,15 @@ export async function ensureInstalled(
 			);
 			await new Promise<void>((resolve, reject) =>
 				execFile(
-					npmCmd,
-					// Added --verbose to try to troubleshoot AB#6195.
-					// We should probably remove it when we find the root cause and fix for that.
+					pnpmCmd,
 					[
-						"i",
-						"--no-package-lock",
-						"--verbose",
+						"add",
+						// Prevent postinstall/preinstall scripts from running in installed packages,
+						// which would otherwise execute arbitrary code from newly-published releases.
+						"--ignore-scripts",
+						// Use the pnpm content-addressable store cache when available, reducing
+						// exposure to packages published since the cache was last populated.
+						"--prefer-offline",
 						...adjustedPackageList.map((pkg) => `${pkg}@${version}`),
 					],
 					options,

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -137,8 +137,10 @@ minimumReleaseAge: ${minimumReleaseAgeMinutes}
 
 trustPolicy: no-downgrade
 # See: https://github.com/orgs/pnpm/discussions/11084
+# Packages with similar issues can be added to this list after manual vetting + verification that the situation is similar.
 trustPolicyExclude:
   - 'semver@6.3.1'
+  - 'engine.io-client@3.5.6'
 `;
 
 // Queries the registry that pnpm is currently configured to use, so that the isolated install

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -141,6 +141,9 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   - 'semver@6.3.1'
   - 'engine.io-client@3.5.6'
+
+packages:
+  - '.'
 `;
 
 // Queries the registry that pnpm is currently configured to use, so that the isolated install
@@ -328,7 +331,6 @@ export async function ensureInstalled(
 					pnpmCmd,
 					[
 						"add",
-						"--ignore-scripts",
 						// Use the pnpm content-addressable store cache when available, reducing
 						// exposure to packages published since the cache was last populated.
 						"--prefer-offline",

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -220,19 +220,6 @@ export function resolveVersion(requested: string, installed: boolean): string {
 	}
 }
 
-async function ensureModulePath(version: string, modulePath: string): Promise<void> {
-	const release = await lock(baseModulePath, { retries: { forever: true } });
-	try {
-		console.log(`Installing version ${version} at ${modulePath}`);
-		if (!existsSync(modulePath)) {
-			// Create the under the baseModulePath lock
-			mkdirSync(modulePath, { recursive: true });
-		}
-	} finally {
-		release();
-	}
-}
-
 /**
  * Ensures the requested package version is installed locally.
  *
@@ -253,8 +240,6 @@ export async function ensureInstalled(
 		return { version, modulePath };
 	}
 
-	await ensureModulePath(version, modulePath);
-
 	// Adjust package list based on the minVersion for each package. If the requested version is
 	// less than the minVersion, skip that package.
 	const adjustedPackageList = packageList
@@ -265,15 +250,25 @@ export async function ensureInstalled(
 		adjustedPackageList.push("@fluid-experimental/sequence-deprecated");
 	}
 
-	// Release the base path but lock the modulePath so we can do parallel installs
-	const release = await lock(modulePath, { retries: { forever: true } });
+	// Ensure baseModulePath exists before locking it. isInstalled() guarantees this on the
+	// normal path, but when force=true we skip that call so we must ensure it explicitly.
+	await ensureInstalledJsonLazy;
+
+	// Serialize all installations under a single lock. Concurrent pnpm invocations conflict
+	// on pnpm's global content-addressable store; running them serially avoids this while
+	// still benefiting from the store cache for fast repeated installs.
+	const release = await lock(baseModulePath, { retries: { forever: true } });
 	try {
+		console.log(`Installing version ${version} at ${modulePath}`);
+		if (!existsSync(modulePath)) {
+			mkdirSync(modulePath, { recursive: true });
+		}
+
 		if (force) {
-			// remove version from install.json under the modulePath lock
 			await removeInstalled(version);
 		}
 
-		// Check installed status again under lock the modulePath lock
+		// Check installed status again under lock.
 		if (force || !(await isInstalled(version))) {
 			const options: ExecOptions = {
 				cwd: modulePath,
@@ -289,7 +284,7 @@ export async function ensureInstalled(
 			};
 
 			// Pin the isolated install directory to the same registry pnpm is using in the parent
-			// process and enforce a minimum package age. Writing these files before `pnpm init`
+			// process and enforce a minimum package age. Writing pnpm-workspace.yaml here
 			// makes pnpm treat modulePath as a workspace root so the settings are scoped here only.
 			const registry = getPnpmRegistry();
 			writeFileSync(
@@ -307,22 +302,14 @@ export async function ensureInstalled(
 				{ encoding: "utf8" },
 			);
 
-			// Install the packages
-			await new Promise<void>((resolve, reject) =>
-				execFile(pnpmCmd, ["init"], options, (error, stdout, stderr) => {
-					if (error) {
-						const errorString =
-							error instanceof Error
-								? `${error.message}\n${error.stack}`
-								: JSON.stringify(error);
-						reject(
-							new Error(
-								`Failed to initialize install directory ${modulePath}\nError:${errorString}\nStdOut:${stdout}\nStdErr:${stderr}`,
-							),
-						);
-					}
-					resolve();
-				}),
+			// Write a minimal package.json so pnpm add has a manifest to update.
+			// Done with writeFileSync rather than `pnpm init` so that it is idempotent:
+			// `pnpm init` fails if package.json already exists (e.g. force=true on a previously
+			// installed version, or a revision bump that clears installed.json but leaves the dir).
+			writeFileSync(
+				path.join(modulePath, "package.json"),
+				JSON.stringify({ name: "legacy-compat-install", version: "1.0.0" }, undefined, 2),
+				{ encoding: "utf8" },
 			);
 			await new Promise<void>((resolve, reject) =>
 				execFile(
@@ -360,10 +347,8 @@ export async function ensureInstalled(
 		}
 		return { version, modulePath };
 	} catch (e) {
-		// rmdirSync recursive flags introduced in Node v12.10
-		// Remove the `as any` cast once node typing is updated.
 		try {
-			(rmdirSync as any)(modulePath, { recursive: true });
+			rmdirSync(modulePath, { recursive: true });
 		} catch (ex) {
 			// TODO: document why we are ignoring the error here
 		}

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -33,7 +33,9 @@ const getModulePath = (version: string): string => path.join(baseModulePath, ver
 const resolutionCache = new Map<string, string>();
 
 // Increment the revision if we want to force installation (e.g. package list changed)
-export const revision = 4;
+// Bumped to 5: switched from npm to pnpm with node-linker=hoisted; cached installs with the
+// old npm flat layout or the pnpm isolated layout must be reinstalled.
+export const revision = 5;
 
 interface InstalledJson {
 	revision: number;
@@ -123,9 +125,28 @@ async function removeInstalled(version: string): Promise<void> {
 // See https://github.com/nodejs/node-v0.x-archive/issues/2318.
 // Note that execFile and execFileSync are used to avoid command injection vulnerability flagging from CodeQL.
 // pnpm is used instead of npm for package installation to enable security flags (--ignore-scripts, --prefer-offline).
-// The registry is inherited from the process environment: in CI, NPM_CONFIG_USERCONFIG points to an .npmrc configured
-// for the Azure Artifacts feed, which pnpm honors the same way npm does.
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+// Minimum age (in minutes) a package version must have before pnpm will install it.
+// This guards against supply-chain attacks that exploit the window between a compromised publish and detection.
+// 1 day expressed in minutes (requires pnpm >= 10.16.0).
+// N-1/N-2 Fluid versions are always older than this threshold, so compatibility testing is unaffected.
+const minimumReleaseAgeMinutes = 1 * 24 * 60;
+
+// Queries the registry that pnpm is currently configured to use, so that the isolated install
+// directory can be explicitly pinned to the same registry. In CI, pnpm is configured via
+// NPM_CONFIG_USERCONFIG to use the Azure Artifacts feed; locally it falls back to the public registry.
+let cachedPnpmRegistry: string | undefined;
+function getPnpmRegistry(): string {
+	if (cachedPnpmRegistry === undefined) {
+		cachedPnpmRegistry = execFileSync(pnpmCmd, ["config", "get", "registry"], {
+			encoding: "utf8",
+			// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+			shell: true,
+		}).trim();
+	}
+	return cachedPnpmRegistry;
+}
 
 /**
  * Resolves a version range or alias to a specific version number.
@@ -268,6 +289,26 @@ export async function ensureInstalled(
 				// @ts-expect-error ExecOptions does not acknowledge boolean for `shell` as a valid option (at least as of @types/node@18.19.1)
 				shell: true,
 			};
+
+			// Pin the isolated install directory to the same registry pnpm is using in the parent
+			// process and enforce a minimum package age. Writing these files before `pnpm init`
+			// makes pnpm treat modulePath as a workspace root so the settings are scoped here only.
+			const registry = getPnpmRegistry();
+			writeFileSync(
+				path.join(modulePath, ".npmrc"),
+				// node-linker=hoisted gives a flat node_modules layout (npm-compatible), which
+				// loadPackage() requires to resolve both direct and transitive dependencies by
+				// their package name. Without this, pnpm's default isolated layout places
+				// transitive deps under node_modules/.pnpm/ and they cannot be found.
+				`registry=${registry}\nnode-linker=hoisted\n`,
+				{ encoding: "utf8" },
+			);
+			writeFileSync(
+				path.join(modulePath, "pnpm-workspace.yaml"),
+				`minimumReleaseAge: ${minimumReleaseAgeMinutes}\n`,
+				{ encoding: "utf8" },
+			);
+
 			// Install the packages
 			await new Promise<void>((resolve, reject) =>
 				execFile(pnpmCmd, ["init"], options, (error, stdout, stderr) => {

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -138,7 +138,7 @@ minimumReleaseAge: ${minimumReleaseAgeMinutes}
 trustPolicy: no-downgrade
 # See: https://github.com/orgs/pnpm/discussions/11084
 trustPolicyExclude:
-  - 'semver@6'
+  - 'semver@6.3.1'
 `;
 
 // Queries the registry that pnpm is currently configured to use, so that the isolated install
@@ -261,6 +261,8 @@ export async function ensureInstalled(
 		return { version, modulePath };
 	}
 
+	await ensureModulePath(version, modulePath);
+
 	// Adjust package list based on the minVersion for each package. If the requested version is
 	// less than the minVersion, skip that package.
 	const adjustedPackageList = packageList
@@ -270,12 +272,6 @@ export async function ensureInstalled(
 	if (versionHasMovedSparsedMatrix(version)) {
 		adjustedPackageList.push("@fluid-experimental/sequence-deprecated");
 	}
-
-	// Ensure baseModulePath exists before locking it. isInstalled() guarantees this on the
-	// normal path, but when force=true we skip that call so we must ensure it explicitly.
-	await ensureInstalledJsonLazy;
-
-	await ensureModulePath(version, modulePath);
 
 	// Release the base path but lock the modulePath so we can do parallel installs
 	const release = await lock(modulePath, { retries: { forever: true } });
@@ -330,8 +326,6 @@ export async function ensureInstalled(
 					pnpmCmd,
 					[
 						"add",
-						// Prevent postinstall/preinstall scripts from running in installed packages,
-						// which would otherwise execute arbitrary code from newly-published releases.
 						"--ignore-scripts",
 						// Use the pnpm content-addressable store cache when available, reducing
 						// exposure to packages published since the cache was last populated.

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -228,6 +228,19 @@ export function resolveVersion(requested: string, installed: boolean): string {
 	}
 }
 
+async function ensureModulePath(version: string, modulePath: string): Promise<void> {
+	const release = await lock(baseModulePath, { retries: { forever: true } });
+	try {
+		console.log(`Installing version ${version} at ${modulePath}`);
+		if (!existsSync(modulePath)) {
+			// Create the under the baseModulePath lock
+			mkdirSync(modulePath, { recursive: true });
+		}
+	} finally {
+		release();
+	}
+}
+
 /**
  * Ensures the requested package version is installed locally.
  *
@@ -262,21 +275,17 @@ export async function ensureInstalled(
 	// normal path, but when force=true we skip that call so we must ensure it explicitly.
 	await ensureInstalledJsonLazy;
 
-	// Serialize all installations under a single lock. Concurrent pnpm invocations conflict
-	// on pnpm's global content-addressable store; running them serially avoids this while
-	// still benefiting from the store cache for fast repeated installs.
-	const release = await lock(baseModulePath, { retries: { forever: true } });
-	try {
-		console.log(`Installing version ${version} at ${modulePath}`);
-		if (!existsSync(modulePath)) {
-			mkdirSync(modulePath, { recursive: true });
-		}
+	await ensureModulePath(version, modulePath);
 
+	// Release the base path but lock the modulePath so we can do parallel installs
+	const release = await lock(modulePath, { retries: { forever: true } });
+	try {
 		if (force) {
+			// remove version from install.json under the modulePath lock
 			await removeInstalled(version);
 		}
 
-		// Check installed status again under lock.
+		// Check installed status again under the modulePath lock
 		if (force || !(await isInstalled(version))) {
 			const options: ExecFileOptions = {
 				cwd: modulePath,

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -138,13 +138,11 @@ const minimumReleaseAgeMinutes = 1 * 24 * 60;
 // NPM_CONFIG_USERCONFIG to use the Azure Artifacts feed; locally it falls back to the public registry.
 let cachedPnpmRegistry: string | undefined;
 function getPnpmRegistry(): string {
-	if (cachedPnpmRegistry === undefined) {
-		cachedPnpmRegistry = execFileSync(pnpmCmd, ["config", "get", "registry"], {
-			encoding: "utf8",
-			// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-			shell: true,
-		}).trim();
-	}
+	cachedPnpmRegistry ??= execFileSync(pnpmCmd, ["config", "get", "registry"], {
+		encoding: "utf8",
+		// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+		shell: true,
+	}).trim();
 	return cachedPnpmRegistry;
 }
 

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -270,25 +270,20 @@ export async function ensureInstalled(
 			};
 			// Install the packages
 			await new Promise<void>((resolve, reject) =>
-				execFile(
-					pnpmCmd,
-					["init"],
-					options,
-					(error, stdout, stderr) => {
-						if (error) {
-							const errorString =
-								error instanceof Error
-									? `${error.message}\n${error.stack}`
-									: JSON.stringify(error);
-							reject(
-								new Error(
-									`Failed to initialize install directory ${modulePath}\nError:${errorString}\nStdOut:${stdout}\nStdErr:${stderr}`,
-								),
-							);
-						}
-						resolve();
-					},
-				),
+				execFile(pnpmCmd, ["init"], options, (error, stdout, stderr) => {
+					if (error) {
+						const errorString =
+							error instanceof Error
+								? `${error.message}\n${error.stack}`
+								: JSON.stringify(error);
+						reject(
+							new Error(
+								`Failed to initialize install directory ${modulePath}\nError:${errorString}\nStdOut:${stdout}\nStdErr:${stderr}`,
+							),
+						);
+					}
+					resolve();
+				}),
 			);
 			await new Promise<void>((resolve, reject) =>
 				execFile(

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -128,10 +128,18 @@ async function removeInstalled(version: string): Promise<void> {
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 // Minimum age (in minutes) a package version must have before pnpm will install it.
-// This guards against supply-chain attacks that exploit the window between a compromised publish and detection.
-// 1 day expressed in minutes (requires pnpm >= 10.16.0).
-// N-1/N-2 Fluid versions are always older than this threshold, so compatibility testing is unaffected.
 const minimumReleaseAgeMinutes = 1 * 24 * 60;
+
+// Enforce reasonable security settings on compat package installs to mitigate risk of supply-chain attacks.
+// See https://pnpm.io/supply-chain-security for context on the flags used here.
+const pnpmWorkspaceYamlContent = `
+minimumReleaseAge: ${minimumReleaseAgeMinutes}
+
+trustPolicy: no-downgrade
+# See: https://github.com/orgs/pnpm/discussions/11084
+trustPolicyExclude:
+  - 'semver@6'
+`;
 
 // Queries the registry that pnpm is currently configured to use, so that the isolated install
 // directory can be explicitly pinned to the same registry. In CI, pnpm is configured via
@@ -296,11 +304,9 @@ export async function ensureInstalled(
 				`registry=${registry}\nnode-linker=hoisted\n`,
 				{ encoding: "utf8" },
 			);
-			writeFileSync(
-				path.join(modulePath, "pnpm-workspace.yaml"),
-				`minimumReleaseAge: ${minimumReleaseAgeMinutes}\n`,
-				{ encoding: "utf8" },
-			);
+			writeFileSync(path.join(modulePath, "pnpm-workspace.yaml"), pnpmWorkspaceYamlContent, {
+				encoding: "utf8",
+			});
 
 			// Write a minimal package.json so pnpm add has a manifest to update.
 			// Done with writeFileSync rather than `pnpm init` so that it is idempotent:

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -5,7 +5,7 @@
 
 /* Utilities to manage finding, installing and loading legacy versions */
 
-import { ExecOptions, execFileSync, execFile } from "node:child_process";
+import { execFileSync, execFile, type ExecFileOptions } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
@@ -278,7 +278,7 @@ export async function ensureInstalled(
 
 		// Check installed status again under lock.
 		if (force || !(await isInstalled(version))) {
-			const options: ExecOptions = {
+			const options: ExecFileOptions = {
 				cwd: modulePath,
 				env: {
 					...process.env,
@@ -287,7 +287,6 @@ export async function ensureInstalled(
 					NODE_OPTIONS: "",
 				},
 				// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-				// @ts-expect-error ExecOptions does not acknowledge boolean for `shell` as a valid option (at least as of @types/node@18.19.1)
 				shell: true,
 			};
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -404,7 +404,7 @@ stages:
             timeoutInMinutes: 3
             continueOnError: true
             inputs:
-              key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}" | "$(compatVersionCacheKey)"'
+              key: '"compat-version-installs" | cache-bust-1 | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}" | "$(compatVersionCacheKey)"'
               path: $(compatVersionInstallsPath)
 
         # Only check out tenants from the tenant pool if we are running tests against ODSP

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -404,6 +404,7 @@ stages:
             timeoutInMinutes: 3
             continueOnError: true
             inputs:
+              # Increment the number on the cache-bust key (no special semantics) to force a new cache key.
               key: '"compat-version-installs" | cache-bust-1 | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}" | "$(compatVersionCacheKey)"'
               path: $(compatVersionInstallsPath)
 


### PR DESCRIPTION
## Description

Updates `test-version-utils` to use `pnpm` rather than `npm` for installing packages as part of compat testing.

pnpm v10 (which we are on) includes some useful security features by default that npm does not (such as not running postinstall scripts unless allowlisted), as well as ones that can be opted into, such as demanding a minimum release age, which this PR sets to 1 day.

Includes some minor opportunistic cleanup of nearby code, mostly around better typechecking.