### PR TITLE
Bump benchmark to 0.54

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluid-tools/benchmark
 
+## 0.54.0
+
 ## 0.53.0
 
 -   Memory benchmarks now have much more aggressive GC to collect more stable results.

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.53.0",
+	"version": "0.54.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Version bump for benchmark, defining the end of what goes into 0.53.

With https://github.com/microsoft/FluidFramework/pull/26866 pasing, it seems like 0.53 is in a good state for use in client, and is ready to release.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
