### PR TITLE
fix(container-runtime): Fix navigator assignment in Hardware Stats tests

### DIFF
--- a/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
@@ -34,7 +34,7 @@ function setNavigator(
 
 function restoreNavigator() {
 	if (originalNavigatorDescriptor === undefined) {
-		// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- this branch can be removed after upgrading to Node 22, which always provides a built-in navigator descriptor
+		// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- this branch can be removed after upgrading to Node 22, which always provides a built-in navigator descriptor (AB#68707)
 		delete (globalThis as Record<string, unknown>).navigator;
 	} else {
 		Object.defineProperty(globalThis, "navigator", originalNavigatorDescriptor);

--- a/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
@@ -17,6 +17,8 @@ import {
 import { ContainerRuntime, getDeviceSpec } from "../containerRuntime.js";
 import { FluidDataStoreRegistry } from "../dataStoreRegistry.js";
 
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
 function setNavigator(
 	// eslint-disable-next-line @rushstack/no-new-null -- testing behavior with global
 	navigator: Partial<Navigator & { deviceMemory?: number }> | undefined | null,
@@ -28,6 +30,15 @@ function setNavigator(
 		writable: true,
 		configurable: true,
 	});
+}
+
+function restoreNavigator() {
+	if (originalNavigatorDescriptor === undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- this branch can be removed after upgrading to Node 22, which always provides a built-in navigator descriptor
+		delete (globalThis as Record<string, unknown>).navigator;
+	} else {
+		Object.defineProperty(globalThis, "navigator", originalNavigatorDescriptor);
+	}
 }
 
 describe("Hardware Stats", () => {
@@ -59,6 +70,10 @@ describe("Hardware Stats", () => {
 			}),
 			existing: false,
 		});
+
+	afterEach(() => {
+		restoreNavigator();
+	});
 
 	beforeEach(async () => {
 		mockLogger = new MockLogger();

--- a/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
@@ -21,7 +21,13 @@ function setNavigator(
 	// eslint-disable-next-line @rushstack/no-new-null -- testing behavior with global
 	navigator: Partial<Navigator & { deviceMemory?: number }> | undefined | null,
 ) {
-	global.navigator = navigator as Navigator;
+	// In Node 22+, globalThis.navigator is a read-only getter, so direct
+	// assignment throws. Use Object.defineProperty to override it.
+	Object.defineProperty(globalThis, "navigator", {
+		value: navigator,
+		writable: true,
+		configurable: true,
+	});
 }
 
 describe("Hardware Stats", () => {


### PR DESCRIPTION
[AB#71218](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71218)

## Description

The `getDeviceSpec()` function reads `navigator.deviceMemory` and `navigator.hardwareConcurrency` to report hardware info via telemetry when a container loads. The Hardware Stats test mocks `navigator` to simulate three states: a normal object with values, `null`, and `undefined`.

On Node 20, `navigator` wasn't a built-in global, so direct assignment worked. Node 22 added a built-in `navigator` (for web platform alignment) exposed as a read-only getter, so direct assignment now throws `TypeError: Cannot set property navigator of #<Object> which has only a getter`.

Fix: use `Object.defineProperty` to override the property instead of direct assignment. This is the standard way to replace a getter-backed property in JavaScript, so this is the correct approach going forward, not a temporary workaround. The `restoreNavigator` cleanup in `afterEach` ensures the override doesn't leak into other test suites.

[AB#68707](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/68707) tracks several potential simplifications once we've upgraded to Node 22:

- The `delete` branch in `restoreNavigator` can be removed since Node 22 always provides a descriptor to restore.
- The `null`/`undefined` test cases could be dropped since no supported environment (Node 22+ or browsers) has a missing navigator.
- We'd still need the mock to test the browser-like case where `deviceMemory` is present (Node's navigator doesn't have it). We could also add an unmocked test verifying behavior with Node 22's real navigator (`hardwareConcurrency` set, `deviceMemory` undefined), covering both real environments without testing impossible states.

This is a prerequisite for upgrading the repo to Node 22 (#26934).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).