### PR TITLE
fix(devcontainer): remove ADO auth features that block build and fix tour clickable text

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,10 +71,8 @@ ENV PATH="/home/node/.local/bin:/home/node/.cargo/bin:${PATH}"
 ARG INSTALL_PLAYWRIGHT_CLI=false
 RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
 
-# Agency is installed at runtime via postCreateCommand (ai-setup.sh) rather than
-# during the Docker build, because the installer requires Azure authentication
-# which is only available in the user's session. The PATH setup above (lines 39-63)
-# ensures agency is on PATH once installed.
+# Optionally install agency (installs to $HOME/.config/agency, must run as node user)
+RUN if [ "$INSTALL_AGENCY" = "true" ]; then curl --proto '=https' --tlsv1.2 -fsSL https://aka.ms/InstallTool.sh | sh -s agency; fi
 
 # Optionally install repoverlay
 ARG INSTALL_REPOVERLAY=false

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,8 +71,10 @@ ENV PATH="/home/node/.local/bin:/home/node/.cargo/bin:${PATH}"
 ARG INSTALL_PLAYWRIGHT_CLI=false
 RUN if [ "$INSTALL_PLAYWRIGHT_CLI" = "true" ]; then npm install -g @playwright/cli@latest; fi
 
-# Optionally install agency (installs to $HOME/.config/agency, must run as node user)
-RUN if [ "$INSTALL_AGENCY" = "true" ]; then curl --proto '=https' --tlsv1.2 -fsSL https://aka.ms/InstallTool.sh | sh -s agency; fi
+# Agency is installed at runtime via postCreateCommand (ai-setup.sh) rather than
+# during the Docker build, because the installer requires Azure authentication
+# which is only available in the user's session. The PATH setup above (lines 39-63)
+# ensures agency is on PATH once installed.
 
 # Optionally install repoverlay
 ARG INSTALL_REPOVERLAY=false

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -6,13 +6,7 @@ This codespace is pre-configured for AI-agent-assisted development of the Fluid 
 
 ## First-time Setup
 
-After creating a new AI-enabled Codespace, expect up to a dozen authentication prompts. This is excessive but anticipated — continue clicking through each prompt until they conclude.
-
-Agency **must** be installed manually after the Codespace starts:
-
-```bash
-pnpm install:agency
-```
+Agency **must** be installed manually after the Codespace starts. Run `pnpm install:agency` in the terminal — this requires Azure authentication and will open a browser window for sign-in.
 
 Then open a **new terminal** for the agent aliases to be available.
 
@@ -78,7 +72,6 @@ This enables running AI agents locally while the Codespace provides computing po
 | Repoverlay | Overlay system for context files (agents, skills) |
 | GitHub CLI (`gh`) | Pre-installed for PR workflows and SSH access |
 | SSH daemon | Enables `gh codespace ssh` connections |
-| ADO Codespaces Auth | Authenticate to Azure DevOps |
 | Agent aliases | Shell shortcuts for common AI commands |
 | Higher compute | 32 CPUs / 64 GB RAM (vs 16 CPUs for Standard) |
 

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -24,7 +24,6 @@
 				"dbaeumer.vscode-eslint",
 				"esbenp.prettier-vscode",
 				"MAI-EngineeringSystems.mai-ai-telemetry",
-				"ms-codespaces-tools.ado-codespaces-auth",
 				"ms-azure-devops.azure-pipelines",
 				"ms-azuretools.vscode-docker",
 				"mutantdino.resourcemonitor",
@@ -66,9 +65,6 @@
 		"ghcr.io/devcontainers/features/sshd:1": {
 			"version": "latest"
 		},
-		// Features needed for the ms-codespaces-tools.ado-codespaces-auth extension
-		"ghcr.io/microsoft/codespace-features/external-repository:4": {},
-		"ghcr.io/microsoft/codespace-features/artifacts-helper:3": {}
 	},
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
 	// can be lengthy enough that it's convenient.

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -64,7 +64,7 @@
 		// Enables SSH connections into the container using `gh codespace ssh`
 		"ghcr.io/devcontainers/features/sshd:1": {
 			"version": "latest"
-		},
+		}
 	},
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
 	// can be lengthy enough that it's convenient.

--- a/.devcontainer/ai-agent/first-run-notice.txt
+++ b/.devcontainer/ai-agent/first-run-notice.txt
@@ -4,7 +4,7 @@ This codespace is configured for AI-agent-assisted workflows with 32 CPUs and
 64 GB RAM. It includes additional CLI tooling (GitHub CLI, SSH, agency, repoverlay).
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!  IMPORTANT: To use AI agents, run the following command first:             !!
+!!  To use AI agents, run the following command first:                       !!
 !!                                                                            !!
 !!      pnpm install:agency                                                   !!
 !!                                                                            !!

--- a/.tours/welcome.tour
+++ b/.tours/welcome.tour
@@ -12,7 +12,7 @@
     },
     {
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
-      "line": 13,
+      "line": 9,
       "title": "Install Agency",
       "description": "**Before you can use any AI agents, you must install agency.**\n\nRun `pnpm install:agency` in the terminal. This requires Azure authentication — a browser window will open for you to sign in. Then open a **new terminal** for the aliases to take effect.\n\nAgency is the CLI tool that manages AI agent sessions. It wraps Claude Code, GitHub Copilot, and other agents with consistent configuration."
     },

--- a/.tours/welcome.tour
+++ b/.tours/welcome.tour
@@ -14,7 +14,7 @@
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
       "line": 13,
       "title": "Install Agency",
-      "description": "**Before you can use any AI agents, you must install agency:**\n\n```bash\npnpm install:agency\n```\n\nThen open a **new terminal** for the aliases to take effect.\n\nAgency is the CLI tool that manages AI agent sessions. It wraps Claude Code, GitHub Copilot, and other agents with consistent configuration."
+      "description": "**Before you can use any AI agents, you must install agency.**\n\nRun `pnpm install:agency` in the terminal. This requires Azure authentication — a browser window will open for you to sign in. Then open a **new terminal** for the aliases to take effect.\n\nAgency is the CLI tool that manages AI agent sessions. It wraps Claude Code, GitHub Copilot, and other agents with consistent configuration."
     },
     {
       "file": "scripts/codespace-setup/agent-aliases.sh",
@@ -38,13 +38,13 @@
       "file": "scripts/codespace-setup/agent-aliases.sh",
       "line": 21,
       "title": "Resetting Overlays",
-      "description": "If you need to reset your repoverlay state (remove all overlays and return to a clean repo state), use:\n\n```bash\nai-reset\n```\n\nThis runs `repoverlay remove --all` and is useful when switching between different workflows or troubleshooting overlay issues."
+      "description": "If you need to reset your repoverlay state (remove all overlays and return to a clean repo state), run `ai-reset` in the terminal.\n\nThis runs `repoverlay remove --all` and is useful when switching between different workflows or troubleshooting overlay issues."
     },
     {
       "file": ".devcontainer/ai-agent/devcontainer.json",
       "line": 1,
       "title": "Codespace Configuration",
-      "description": "This devcontainer profile includes several additions beyond the Standard profile:\n\n- **Agency CLI** and **Repoverlay** (installed via build args)\n- **GitHub CLI** (`gh`) for PR workflows and SSH access\n- **SSH daemon** enabling `gh codespace ssh` from your local terminal\n- **ADO Codespaces Auth** for Azure DevOps authentication\n- **32 CPUs / 64 GB RAM** (vs 16 CPUs for Standard)\n\n**Tip:** You can connect to this codespace from your local terminal with `gh codespace ssh` to run AI agents locally while using the codespace's compute."
+      "description": "This devcontainer profile includes several additions beyond the Standard profile:\n\n- **Agency CLI** and **Repoverlay** (installed via build args)\n- **GitHub CLI** (`gh`) for PR workflows and SSH access\n- **SSH daemon** enabling `gh codespace ssh` from your local terminal\n- **32 CPUs / 64 GB RAM** (vs 16 CPUs for Standard)\n\n**Tip:** You can connect to this codespace from your local terminal with `gh codespace ssh` to run AI agents locally while using the codespace's compute."
     },
     {
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",


### PR DESCRIPTION
## Summary

- Remove `ado-codespaces-auth` extension and its two supporting devcontainer features (`external-repository`, `artifacts-helper`) — these trigger Azure authentication during the Docker image build, blocking non-interactive builds (e.g. local `devcontainer up`).
- Replace fenced code blocks in CodeTour step descriptions with inline code so commands like `pnpm install:agency` and `ai-reset` are no longer rendered as clickable elements that insert text into the active editor instead of the terminal.
- Streamline GETTING_STARTED.md first-time setup section — remove the auth prompt warning (caused by the now-removed ADO features) and consolidate the agency install instructions.