### PR TITLE
Remove IFluidRunnable interfaces from core-interfaces

### DIFF
--- a/examples/data-objects/clicker/src/agent.ts
+++ b/examples/data-objects/clicker/src/agent.ts
@@ -3,17 +3,19 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import-x/no-internal-modules -- #26908: `core-interfaces` internal used in examples
-import { IFluidRunnable } from "@fluidframework/core-interfaces/internal";
 import { SharedCounter } from "@fluidframework/counter/legacy";
 
-// Sample agent to run.
-export class ClickerAgent implements IFluidRunnable {
-	constructor(private readonly counter: SharedCounter) {}
+/**
+ * Simple interface for a runnable agent.
+ */
+interface IRunnable {
+	run(...args: any[]): Promise<void>;
+	stop(reason?: string): void;
+}
 
-	public get IFluidRunnable(): IFluidRunnable {
-		return this;
-	}
+// Sample agent to run.
+export class ClickerAgent implements IRunnable {
+	constructor(private readonly counter: SharedCounter) {}
 
 	private readonly logIncrement = (incrementValue: number, currentValue: number): void => {
 		console.log(`Incremented by ${incrementValue}. New value ${currentValue}`);

--- a/packages/common/core-interfaces/src/fluidLoadable.ts
+++ b/packages/common/core-interfaces/src/fluidLoadable.ts
@@ -29,24 +29,3 @@ export interface IFluidLoadable extends IProvideFluidLoadable {
 	 */
 	readonly handle: IFluidHandle;
 }
-
-/**
- * @internal
- */
-export const IFluidRunnable: keyof IProvideFluidRunnable = "IFluidRunnable";
-
-/**
- * @internal
- */
-export interface IProvideFluidRunnable {
-	readonly IFluidRunnable: IFluidRunnable;
-}
-/**
- * @internal
- */
-export interface IFluidRunnable {
-	// TODO: Use `unknown` instead (API-Breaking)
-
-	run(...args: any[]): Promise<void>;
-	stop(reason?: string): void;
-}

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -30,8 +30,8 @@ export type {
 	TransformedEvent,
 } from "./events.js";
 
-export type { IProvideFluidLoadable, IProvideFluidRunnable } from "./fluidLoadable.js";
-export { IFluidLoadable, IFluidRunnable } from "./fluidLoadable.js";
+export type { IProvideFluidLoadable } from "./fluidLoadable.js";
+export { IFluidLoadable } from "./fluidLoadable.js";
 
 // TypeScript forgets the index signature when customers augment IRequestHeader if we export *.
 // So we export the explicit members as a workaround:


### PR DESCRIPTION
## Summary
- Remove `IFluidRunnable`, `IProvideFluidRunnable`, and associated const from `core-interfaces` — these `@internal` interfaces were too basic to provide customer value
- Inline a local `IRunnable` interface in the clicker example (the only consumer)

[AB#26908](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26908)

## Test plan
- [ ] Verify clicker example still compiles and runs
- [ ] Verify core-interfaces builds cleanly without the removed exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)