### PR TITLE
chore(build-cli): deprecate release report commands

### DIFF
--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -53,18 +53,18 @@ export class UnreleasedReportCommand extends BaseCommand<typeof UnreleasedReport
 	};
 
 	public async run(): Promise<void> {
+		const { flags } = this;
+
 		const deprecationWarning = chalk.bgRed(
 			chalk.white(chalk.bold(" DO NOT RELY ON THIS COMMAND ")),
 		);
 		const lines = Array.from({ length: 12 }, () => deprecationWarning).join("\n");
-		this.log(`\n${lines}`);
+		if (!flags.quiet) {
+			this.log(`\n${lines}\n`);
+		}
 		this.warning(
 			"This command is deprecated and will be removed in a future release. Release reports will no longer be generated.",
 		);
-		this.log(`${lines}\n`);
-
-		const { flags } = this;
-
 		const reportData = await fs.readFile(flags.fullReportFilePath, "utf8");
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -9,12 +9,20 @@ import { isInternalTestVersion } from "@fluid-tools/version-tools";
 import type { Logger } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import { formatISO } from "date-fns";
+import chalk from "picocolors";
 
 import { semverFlag } from "../../flags.js";
 import { BaseCommand } from "../../library/commands/base.js";
 import { type ReleaseReport, toReportKind } from "../../library/release.js";
 
 export class UnreleasedReportCommand extends BaseCommand<typeof UnreleasedReportCommand> {
+	// This command is deprecated and will be removed in a future release.
+	static readonly state = "deprecated" as const;
+	static readonly deprecationOptions = {
+		message:
+			"Release reports will no longer be generated in the future. This command will be removed in a future release.",
+	};
+
 	static readonly summary =
 		`Creates a release report for an unreleased build (one that is not published to npm), using an existing report in the "full" format as input.`;
 
@@ -45,6 +53,16 @@ export class UnreleasedReportCommand extends BaseCommand<typeof UnreleasedReport
 	};
 
 	public async run(): Promise<void> {
+		const deprecationWarning = chalk.bgRed(
+			chalk.white(chalk.bold(" DO NOT RELY ON THIS COMMAND ")),
+		);
+		const lines = Array.from({ length: 12 }, () => deprecationWarning).join("\n");
+		this.log(`\n${lines}`);
+		this.warning(
+			"This command is deprecated and will be removed in a future release. Release reports will no longer be generated.",
+		);
+		this.log(`${lines}\n`);
+
 		const { flags } = this;
 
 		const reportData = await fs.readFile(flags.fullReportFilePath, "utf8");

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -326,6 +326,13 @@ export abstract class ReleaseReportBaseCommand<
 export default class ReleaseReportCommand extends ReleaseReportBaseCommand<
 	typeof ReleaseReportCommand
 > {
+	// This command is deprecated and will be removed in a future release.
+	static readonly state = "deprecated" as const;
+	static readonly deprecationOptions = {
+		message:
+			"Release reports will no longer be generated in the future. This command will be removed in a future release.",
+	};
+
 	static readonly description = `Generates a report of Fluid Framework releases.
 
     The release report command is used to produce a report of all the packages that were released and their version. After a release, it is useful to generate this report to provide to customers, so they can update their dependencies to the most recent version.
@@ -394,6 +401,16 @@ export default class ReleaseReportCommand extends ReleaseReportBaseCommand<
 	releaseGroupName: ReleaseGroup | ReleasePackage | undefined;
 
 	public async run(): Promise<void> {
+		const deprecationWarning = chalk.bgRed(
+			chalk.white(chalk.bold(" DO NOT RELY ON THIS COMMAND ")),
+		);
+		const lines = Array.from({ length: 12 }, () => deprecationWarning).join("\n");
+		this.log(`\n${lines}`);
+		this.warning(
+			"This command is deprecated and will be removed in a future release. Release reports will no longer be generated.",
+		);
+		this.log(`${lines}\n`);
+
 		const { flags } = this;
 
 		const shouldOutputFiles = flags.output !== undefined;


### PR DESCRIPTION
## Summary

The release report commands were never intended to be used for anything other than reporting after a release. They have long been used for other purposes. Now, I want to delete them so I don't have to maintain them or code review them any more. There should be no need for these commands in 2026. They were created as a "fun addition" to the build tools in what was perhaps my greatest mistake in creating the build-tools. If we are relying on them, then we need to stop.

## Changes

- Marks `flub release report` and `flub release report-unreleased` as deprecated using oclif's built-in deprecation mechanism
- Adds a prominent warning banner (12 lines of "DO NOT RELY ON THIS COMMAND") printed on every invocation
- Release reports will no longer be generated in the future and these commands will be removed

## Test plan

- [x] Run `flub release report --help` and verify it shows deprecated status
- [x] Run `flub release report` and verify the warning banner is printed
- [x] Run `flub release report-unreleased --help` and verify it shows deprecated status