### PR TITLE
Fixed `--parentProcess` mode partial match

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.54.0
 
+-   Fixed `--parentProcess` mode incorrectly matching tests whose full title is a substring of another test's full title. The child process filter now uses an exact-match regex (`--grep ^title$`) instead of substring matching (`--fgrep title`).
+
 ## 0.53.0
 
 -   Memory benchmarks now have much more aggressive GC to collect more stable results.

--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.54.0
 
--   Fixed `--parentProcess` mode incorrectly matching tests whose full title is a substring of another test's full title. The child process filter now uses an exact-match regex (`--grep ^title$`) instead of substring matching (`--fgrep title`).
+-   Fixed `--parentProcess` mode incorrectly matching tests whose full title is a substring of another test's full title. The child process filter now uses an exact-match regex (`--grep ^title$`) instead of substring matching (`--fgrep title`). For example, if a suite contained tests named `foo` and `foobar` in the same suite, running `foo` in a child process with `--fgrep foo` would also match `foobar`, causing both tests to run and assuming both are benchmarks, produce an error (versions prior to 0.53 would produce incorrect results instead of an error).
 
 ## 0.53.0
 

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -49,17 +49,25 @@ export function buildChildArgs(
 	// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
 	// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
 	// put in mocha's --node-option flag.
-	const childArgs = [...execArgv, ...argv];
-	childArgs.push("--childProcess");
+	let childArgs = [...execArgv, ...argv];
 
 	// Remove arguments for any existing test filters.
 	for (const flag of ["--grep", "--fgrep"]) {
-		const flagIndex = childArgs.indexOf(flag);
-		if (flagIndex > 0) {
+		let flagIndex: number;
+		while ((flagIndex = childArgs.indexOf(flag)) >= 0) {
 			// Remove the flag, and the argument after it (all these flags take one argument)
 			childArgs.splice(flagIndex, 2);
 		}
 	}
+
+	// Remove arguments for debugging if they're present; in order to debug child processes we need
+	// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
+	// of scope for now.
+	childArgs = childArgs.filter((x) => !x.match(/^(--inspect|--debug).*/));
+
+	// Add new flags:
+
+	childArgs.push("--childProcess");
 
 	// Add test filter so child process only runs the current test.
 	// Use --grep with an anchored regex for an exact match, since --fgrep does substring matching
@@ -68,14 +76,6 @@ export function buildChildArgs(
 	// TODO: once only supporting NodeJS 24+, we can use the new RegExp.escape function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
 	const escapedTitle = testFullTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 	childArgs.push("--grep", `^${escapedTitle}$`);
-
-	// Remove arguments for debugging if they're present; in order to debug child processes we need
-	// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
-	// of scope for now.
-	let inspectArgIndex: number = -1;
-	while ((inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >= 0) {
-		childArgs.splice(inspectArgIndex, 1);
-	}
 
 	return childArgs;
 }

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -83,12 +83,13 @@ export function buildChildArgs(
 /**
  * Runs the specified test in a child process and returns the results.
  * @remarks
+ * Instead of running the benchmark in this process, this creates create a new process to run it.
+ * This can reduce the impact of prior tests (and test order more generally) on performance through effects like JIT and heap state.
+ *
  * The provided test must write a {@link BenchmarkResult} to stdout.
  * See {@link recordTestResult} which does this for child processes.
  */
 async function runTestInChildProcess(testFullTitle: string): Promise<CollectedData> {
-	// Instead of running the benchmark in this process, create a new process.
-	// See {@link isParentProcess} for why.
 	// Launch new process, with:
 	// - mocha filter to run only this test.
 	// - --childProcess flag added (so data will be returned via stdout as json)

--- a/tools/benchmark/src/mocha/runner.ts
+++ b/tools/benchmark/src/mocha/runner.ts
@@ -26,6 +26,61 @@ export async function supportParentProcess(
 }
 
 /**
+ * Build the argument list for the child process from the parent process's arguments.
+ *
+ * @remarks
+ * This is a pure function extracted from {@link runTestInChildProcess} to make the
+ * argument-building logic independently testable.
+ *
+ * @param testFullTitle - The full title of the mocha test to run.
+ * @param execArgv - Node-specific flags (typically `process.execArgv`).
+ * @param argv - The command-line arguments (typically `process.argv.slice(1)`).
+ * @returns The argument list for the child process.
+ */
+export function buildChildArgs(
+	testFullTitle: string,
+	execArgv: readonly string[],
+	argv: readonly string[],
+): string[] {
+	// execArgv[0] should be the script for mocha thats currently running (.../node_modules/mocha/lib/cli/cli.js)
+	// But this is not the case for mocha parallel mode due to how it sets up its workers.
+	// This is one of the main reasons mocha parallel mode is not currently supported here.
+
+	// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
+	// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
+	// put in mocha's --node-option flag.
+	const childArgs = [...execArgv, ...argv];
+	childArgs.push("--childProcess");
+
+	// Remove arguments for any existing test filters.
+	for (const flag of ["--grep", "--fgrep"]) {
+		const flagIndex = childArgs.indexOf(flag);
+		if (flagIndex > 0) {
+			// Remove the flag, and the argument after it (all these flags take one argument)
+			childArgs.splice(flagIndex, 2);
+		}
+	}
+
+	// Add test filter so child process only runs the current test.
+	// Use --grep with an anchored regex for an exact match, since --fgrep does substring matching
+	// and would incorrectly match tests whose full title contains another test's full title.
+	// Escape any special regex characters in the test title to avoid changing the meaning of the regex.
+	// TODO: once only supporting NodeJS 24+, we can use the new RegExp.escape function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
+	const escapedTitle = testFullTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	childArgs.push("--grep", `^${escapedTitle}$`);
+
+	// Remove arguments for debugging if they're present; in order to debug child processes we need
+	// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
+	// of scope for now.
+	let inspectArgIndex: number = -1;
+	while ((inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >= 0) {
+		childArgs.splice(inspectArgIndex, 1);
+	}
+
+	return childArgs;
+}
+
+/**
  * Runs the specified test in a child process and returns the results.
  * @remarks
  * The provided test must write a {@link BenchmarkResult} to stdout.
@@ -41,37 +96,7 @@ async function runTestInChildProcess(testFullTitle: string): Promise<CollectedDa
 	// Pull the command (Node.js most likely) out of the first argument since spawnSync takes it separately.
 	const command = process.argv0 ?? fail("there must be a command");
 
-	const reusedArgs = process.argv.slice(1);
-
-	// reusedArgs[0] should be the script for mocha thats currently running (.../node_modules/mocha/lib/cli/cli.js)
-	// But this is not the case for mocha parallel mode due to how it sets up its workers.
-	// This is one of the main reasons mocha parallel mode is not currently supported here.
-
-	// We expect all node-specific flags to be present in execArgv so they can be passed to the child process.
-	// At some point mocha was processing the expose-gc flag itself and not passing it here, unless explicitly
-	// put in mocha's --node-option flag.
-	const childArgs = [...process.execArgv, ...reusedArgs];
-	childArgs.push("--childProcess");
-
-	// Remove arguments for any existing test filters.
-	for (const flag of ["--grep", "--fgrep"]) {
-		const flagIndex = childArgs.indexOf(flag);
-		if (flagIndex > 0) {
-			// Remove the flag, and the argument after it (all these flags take one argument)
-			childArgs.splice(flagIndex, 2);
-		}
-	}
-
-	// Add test filter so child process only run the current test.
-	childArgs.push("--fgrep", testFullTitle);
-
-	// Remove arguments for debugging if they're present; in order to debug child processes we need
-	// to specify a new debugger port for each, or they'll fail to start. Doable, but leaving it out
-	// of scope for now.
-	let inspectArgIndex: number = -1;
-	while ((inspectArgIndex = childArgs.findIndex((x) => x.match(/^(--inspect|--debug).*/))) >= 0) {
-		childArgs.splice(inspectArgIndex, 1);
-	}
+	const childArgs = buildChildArgs(testFullTitle, process.execArgv, process.argv.slice(1));
 
 	// Do this import only if isParentProcess to enable running in the web as long as isParentProcess is false.
 	const childProcess = await import("node:child_process");

--- a/tools/benchmark/src/test/mocha/runner.spec.ts
+++ b/tools/benchmark/src/test/mocha/runner.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { supportParentProcess } from "../../mocha/runner.js";
+import { buildChildArgs, supportParentProcess } from "../../mocha/runner.js";
 import type { CollectedData } from "../../reportTypes.js";
 import { isResultError, ValueType } from "../../reportTypes.js";
 import { isChildProcess } from "../../Configuration.js";
@@ -22,6 +22,62 @@ const sampleResult: CollectedData = [
 ];
 
 describe("runner", () => {
+	describe("buildChildArgs", () => {
+		it("adds --childProcess flag", () => {
+			const result = buildChildArgs("my test", [], ["mocha.js"]);
+			assert(result.includes("--childProcess"));
+		});
+
+		it("adds --grep with anchored exact-match regex", () => {
+			const result = buildChildArgs("my test", [], ["mocha.js"]);
+			const grepIndex = result.indexOf("--grep");
+			assert(grepIndex >= 0, "--grep flag should be present");
+			assert.equal(result[grepIndex + 1], "^my test$");
+		});
+
+		it("escapes regex special characters in the test title", () => {
+			const result = buildChildArgs("test (with) special.*chars?", [], ["mocha.js"]);
+			const grepIndex = result.indexOf("--grep");
+			assert.equal(result[grepIndex + 1], "^test \\(with\\) special\\.\\*chars\\?$");
+		});
+
+		it("removes existing --grep filter from args", () => {
+			const result = buildChildArgs("my test", [], ["mocha.js", "--grep", "old filter"]);
+			const grepIndices = result.reduce<number[]>(
+				(acc, arg, i) => (arg === "--grep" ? [...acc, i] : acc),
+				[],
+			);
+			assert.equal(grepIndices.length, 1, "should have exactly one --grep");
+			assert.equal(result[grepIndices[0] + 1], "^my test$");
+		});
+
+		it("removes existing --fgrep filter from args", () => {
+			const result = buildChildArgs("my test", [], ["mocha.js", "--fgrep", "old filter"]);
+			assert(!result.includes("--fgrep"), "--fgrep should be removed");
+			const grepIndex = result.indexOf("--grep");
+			assert.equal(result[grepIndex + 1], "^my test$");
+		});
+
+		it("removes --inspect and --debug flags", () => {
+			const result = buildChildArgs(
+				"my test",
+				["--inspect", "--inspect-brk=9229"],
+				["mocha.js"],
+			);
+			assert(!result.some((a) => a.startsWith("--inspect")));
+			assert(!result.some((a) => a.startsWith("--debug")));
+		});
+
+		it("preserves execArgv before argv", () => {
+			const result = buildChildArgs("my test", ["--max-old-space-size=4096"], ["mocha.js"]);
+			const maxOldIndex = result.indexOf("--max-old-space-size=4096");
+			const mochaIndex = result.indexOf("mocha.js");
+			assert(maxOldIndex >= 0);
+			assert(mochaIndex >= 0);
+			assert(maxOldIndex < mochaIndex, "execArgv entries should precede argv entries");
+		});
+	});
+
 	describe("supportParentProcess", () => {
 		it("calls run() and returns its result when isParentProcess is false", async () => {
 			const result = await supportParentProcess("test title", false, async () => {


### PR DESCRIPTION
## Description

Fixed `--parentProcess` mode incorrectly matching tests whose full title is a substring of another test's full title. The child process filter now uses an exact-match regex (`--grep ^title$`) instead of substring matching (`--fgrep title`).

This bug was detected by the improved validation of output added in 0.53 which reported errors due to this bug when run on preexisting tests which previously silently produced incorrect data ( In this case "findOverlappingIntervals on string of length 25000 with 200 equally spaced intervals and 25000 segments" vs "findOverlappingIntervals on string of length 25000 with 200 equally spaced intervals and 25000 segments with endpoint resolution"

Also refactors argument handling code for more testability.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
