### PR TITLE
improvement(client-core-interfaces): remove unused impls

### DIFF
--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -92,8 +92,8 @@ export declare abstract class ErasedType<out Name = unknown> {
  * Implement interfaces which extend this by sub-classing {@link ErasedTypeImplementation}.
  *
  * This class should only be a `type` package export, preventing users from extending it directly.
- * But since {@link ErasedTypeImplementation} does extend it an implementation
- * for ctor must be provided, unlike {@link ErasedType}.
+ * But since {@link ErasedTypeImplementation} does extend it, an implementation
+ * of the constructor must be provided, unlike {@link ErasedType}.
  *
  * Since {@link ErasedTypeImplementation} is exported as `@internal`, this restricts implementations of the sealed interfaces to users of `@internal` APIs, which should be anything within this release group.
  * Any finer grained restrictions can be done as documentation, but not type enforced.

--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -74,8 +74,9 @@ export declare abstract class ErasedType<out Name = unknown> {
 
 	/**
 	 * Since this class is a compile time only type brand, `instanceof` will never work with it.
-	 * This `Symbol.hasInstance` declaration ensures that `instanceof` will error if used,
-	 * (no definition) and in TypeScript 5.3 and newer will produce a compile time error if used.
+	 * This `Symbol.hasInstance` declaration (no definition) ensures that `instanceof` will
+	 * produce `ReferenceError` if used at runtime. And in TypeScript 5.3 and newer will produce
+	 * a compile time error if used.
 	 */
 	public static [Symbol.hasInstance](value: never): value is never;
 }

--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -57,7 +57,7 @@
  * @sealed
  * @public
  */
-export abstract class ErasedType<out Name = unknown> {
+export declare abstract class ErasedType<out Name = unknown> {
 	/**
 	 * Compile time only marker to make type checking more strict.
 	 * This method will not exist at runtime and accessing it is invalid.
@@ -70,18 +70,14 @@ export abstract class ErasedType<out Name = unknown> {
 	/**
 	 * This class should never exist at runtime, so make it un-constructable.
 	 */
-	private constructor() {}
+	private constructor();
 
 	/**
 	 * Since this class is a compile time only type brand, `instanceof` will never work with it.
-	 * This `Symbol.hasInstance` implementation ensures that `instanceof` will error if used,
-	 * and in TypeScript 5.3 and newer will produce a compile time error if used.
+	 * This `Symbol.hasInstance` declaration ensures that `instanceof` will error if used,
+	 * (no definition) and in TypeScript 5.3 and newer will produce a compile time error if used.
 	 */
-	public static [Symbol.hasInstance](value: never): value is never {
-		throw new Error(
-			"ErasedType is a compile time type brand not a real class that can be used with `instanceof` at runtime.",
-		);
-	}
+	public static [Symbol.hasInstance](value: never): value is never;
 }
 
 /**
@@ -102,7 +98,7 @@ export abstract class ErasedType<out Name = unknown> {
  * @beta
  * @system
  */
-export abstract class ErasedBaseType<out Name = unknown> {
+export declare abstract class ErasedBaseType<out Name = unknown> {
 	/**
 	 * Compile time only marker to make type checking more strict.
 	 * This method will not exist at runtime and accessing it is invalid.
@@ -119,7 +115,7 @@ export abstract class ErasedBaseType<out Name = unknown> {
 	 * However protected is almost as good since this class is not package exported,
 	 * and it allows ErasedTypeImplementation to extend this class.
 	 */
-	protected constructor() {}
+	protected constructor();
 }
 
 /**

--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -91,6 +91,8 @@ export declare abstract class ErasedType<out Name = unknown> {
  * Implement interfaces which extend this by sub-classing {@link ErasedTypeImplementation}.
  *
  * This class should only be a `type` package export, preventing users from extending it directly.
+ * But since {@link ErasedTypeImplementation} does extend it an implementation
+ * for ctor must be provided, unlike {@link ErasedType}.
  *
  * Since {@link ErasedTypeImplementation} is exported as `@internal`, this restricts implementations of the sealed interfaces to users of `@internal` APIs, which should be anything within this release group.
  * Any finer grained restrictions can be done as documentation, but not type enforced.
@@ -98,7 +100,7 @@ export declare abstract class ErasedType<out Name = unknown> {
  * @beta
  * @system
  */
-export declare abstract class ErasedBaseType<out Name = unknown> {
+export abstract class ErasedBaseType<out Name = unknown> {
 	/**
 	 * Compile time only marker to make type checking more strict.
 	 * This method will not exist at runtime and accessing it is invalid.
@@ -115,7 +117,7 @@ export declare abstract class ErasedBaseType<out Name = unknown> {
 	 * However protected is almost as good since this class is not package exported,
 	 * and it allows ErasedTypeImplementation to extend this class.
 	 */
-	protected constructor();
+	protected constructor() {}
 }
 
 /**


### PR DESCRIPTION
`ErasedType` is never to be instantiated nor checked for `instanceof`. Thus, don't need implementations. Remove those implementations.