### PR TITLE
Opt into chunked forest for text

### DIFF
--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -26,10 +26,17 @@ import {
  */
 // eslint-disable-next-line import-x/no-internal-modules
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
-import { SchemaFactory, TreeViewConfiguration, type TreeView } from "@fluidframework/tree";
+import { SchemaFactory, type TreeView } from "@fluidframework/tree";
+import {
+	configuredSharedTreeAlpha,
+	ForestTypeOptimized,
+	TreeCompressionStrategy,
+	incrementalEncodingPolicyForAllowedTypes,
+	TreeViewConfigurationAlpha,
+	FluidClientVersion,
+} from "@fluidframework/tree/alpha";
 // eslint-disable-next-line import-x/no-internal-modules
 import { FormattedTextAsTree, TextAsTree } from "@fluidframework/tree/internal";
-import { SharedTree } from "@fluidframework/tree/legacy";
 import type { IFluidContainer } from "fluid-framework";
 // eslint-disable-next-line import-x/no-internal-modules, import-x/no-unassigned-import
 import "quill/dist/quill.snow.css";
@@ -57,12 +64,6 @@ function getTinyliciousEndpoint(): string {
 	return `http://localhost:${tinyliciousPort}`;
 }
 
-const containerSchema = {
-	initialObjects: {
-		tree: SharedTree,
-	},
-};
-
 const sf = new SchemaFactory("com.fluidframework.example.text-editor");
 
 export class TextEditorRoot extends sf.object("TextEditorRoot", {
@@ -70,7 +71,20 @@ export class TextEditorRoot extends sf.object("TextEditorRoot", {
 	formattedText: FormattedTextAsTree.Tree,
 }) {}
 
-export const treeConfig = new TreeViewConfiguration({ schema: TextEditorRoot });
+export const treeConfig = new TreeViewConfigurationAlpha({ schema: TextEditorRoot });
+
+const SharedTree = configuredSharedTreeAlpha({
+	forest: ForestTypeOptimized,
+	treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
+	shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(treeConfig),
+	minVersionForCollab: FluidClientVersion.v2_74,
+});
+
+const containerSchema = {
+	initialObjects: {
+		tree: SharedTree,
+	},
+};
 
 function getConnectionConfig(userId: string): AzureLocalConnectionConfig {
 	return {

--- a/packages/dds/tree/src/text/textDomain.ts
+++ b/packages/dds/tree/src/text/textDomain.ts
@@ -9,6 +9,7 @@ import { EmptyKey, mapCursorField, type ITreeCursorSynchronous } from "../core/i
 import {
 	eraseSchemaDetails,
 	getInnerNode,
+	incrementalSummaryHint,
 	SchemaFactory,
 	SchemaFactoryAlpha,
 	TreeArrayNode,
@@ -24,7 +25,12 @@ const sf = new SchemaFactoryAlpha("com.fluidframework.text");
 
 class TextNode
 	extends sf.object("Text", {
-		content: SchemaFactory.required([() => StringArray], { key: EmptyKey }),
+		content: sf.required(
+			sf.types([{ type: () => StringArray, metadata: {} }], {
+				custom: { [incrementalSummaryHint]: true },
+			}),
+			{ key: EmptyKey },
+		),
 	})
 	implements TextAsTree.Members
 {

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -18,6 +18,7 @@ import {
 	enumFromStrings,
 	eraseSchemaDetails,
 	getInnerNode,
+	incrementalSummaryHint,
 	SchemaFactory,
 	SchemaFactoryAlpha,
 	TreeArrayNode,
@@ -37,7 +38,12 @@ const sf = new SchemaFactoryAlpha("com.fluidframework.text.formatted");
 
 class TextNode
 	extends sf.object("Text", {
-		content: SchemaFactory.required([() => StringArray], { key: EmptyKey }),
+		content: sf.required(
+			sf.types([{ type: () => StringArray, metadata: {} }], {
+				custom: { [incrementalSummaryHint]: true },
+			}),
+			{ key: EmptyKey },
+		),
 	})
 	implements FormattedTextAsTree.Members
 {


### PR DESCRIPTION
# Summary 

Based of findings found while testing text memory and performance with `objectForest` vs `chunkedForest` it shows that plain text, but especially formatted, would benefit from using chunked forest. This PR enables `chunkedForest` for text and the `text-editor` app. Until the memory regression for plain text is fixed/improved this PR will remain in draft

Test findings are found on this [draft PR](https://github.com/microsoft/FluidFramework/pull/26950)