### PR TITLE
Remove use of isNullOrUndefined

### DIFF
--- a/packages/dds/sequence/src/test/sequenceDeltaEvent.spec.ts
+++ b/packages/dds/sequence/src/test/sequenceDeltaEvent.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "node:assert";
-import { isNullOrUndefined } from "node:util";
 
 import {
 	IMergeTreeDeltaCallbackArgs,
@@ -1995,10 +1994,7 @@ describe("collab", () => {
 					assert.equal(event.ranges[i].segment.properties?.[key], expected[i].props[key]);
 				}
 				if (expected[i].propDeltas === undefined) {
-					assert(
-						isNullOrUndefined(event.ranges[i].propertyDeltas) ||
-							Object.keys(event.ranges[i].propertyDeltas).length === 0,
-					);
+					assert(Object.keys(event.ranges[i].propertyDeltas).length === 0);
 				} else {
 					assert.equal(
 						Object.keys(event.ranges[i].propertyDeltas).length,


### PR DESCRIPTION
## Description

Remove use of isNullOrUndefined: it was deprecated in NodeJS 4 and removed in recent versions.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
