### PR TITLE
fix(devcontainer): disable agency install in AI-enabled devcontainer

### DIFF
--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -5,7 +5,7 @@
 		"dockerfile": "../Dockerfile",
 		"args": {
 			"NODE_VERSION": "24",
-			"INSTALL_AGENCY": "true",
+			// "INSTALL_AGENCY": "true",
 			"INSTALL_REPOVERLAY": "true"
 			// TODO: Figure out the playwright strategy
 			// "INSTALL_PLAYWRIGHT_CLI": "true"


### PR DESCRIPTION
## Summary
- Comments out the `INSTALL_AGENCY` build arg in the AI-agent devcontainer.json to disable the agency install
- The Dockerfile retains the install logic (guarded by the arg defaulting to `false`), so it can be re-enabled by simply uncommenting the build arg

## Test plan
- [x] Verify the AI-enabled devcontainer builds successfully without agency
- [x] Verify uncommenting `INSTALL_AGENCY` re-enables the install