### PR TITLE
Make typetest normalize apply to the gen scripts

### DIFF
--- a/build-tools/packages/build-cli/docs/typetests.md
+++ b/build-tools/packages/build-cli/docs/typetests.md
@@ -23,7 +23,9 @@ USAGE
 
 FLAGS
   -n, --normalize
-      Removes any unrecognized data from "typeValidation" in the package.json and adds any missing default settings.
+      Normalizes type test configuration in package.json. Removes unrecognized data from "typeValidation" and adds any
+      missing default settings. Also updates the "typetests:gen" script: adds or replaces it when type tests are enabled,
+      or removes it when disabled.
 
   -p, --previous
       Use the version immediately before the current version.

--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -111,6 +111,7 @@ If targeting prerelease versions, skipping versions, or using skipping some alte
 
 			if (this.flags.normalize) {
 				json.typeValidation = normalizeConfig(json.typeValidation);
+				normalizeTypeTestScript(json);
 			}
 		});
 	}
@@ -148,6 +149,24 @@ export function normalizeConfig(
 		normalized.broken = { ...defaultTypeValidationConfig.broken };
 	}
 	return normalized;
+}
+
+const typetestsGenScript = "flub generate typetests --dir . -v";
+
+/**
+ * Adds, removes, or replaces the `typetests:gen` script in the package.json `scripts` section
+ * based on whether type validation is enabled or disabled.
+ */
+export function normalizeTypeTestScript(pkgJson: PackageWithTypeTestSettings): void {
+	if (pkgJson.typeValidation?.disabled === true) {
+		if (pkgJson.scripts?.["typetests:gen"] !== undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete pkgJson.scripts["typetests:gen"];
+		}
+	} else if (pkgJson.typeValidation !== undefined) {
+		pkgJson.scripts ??= {};
+		pkgJson.scripts["typetests:gen"] = typetestsGenScript;
+	}
 }
 
 export enum VersionOptions {

--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -63,7 +63,7 @@ If targeting prerelease versions, skipping versions, or using skipping some alte
 		}),
 		normalize: Flags.boolean({
 			char: "n",
-			description: `Removes any unrecognized data from "typeValidation" in the package.json and adds any missing default settings.`,
+			description: `Normalizes type test configuration in package.json. Removes unrecognized data from "typeValidation" and adds any missing default settings. Also updates the "typetests:gen" script: adds or replaces it when type tests are enabled, or removes it when disabled.`,
 			exclusive: ["enable"],
 		}),
 		...PackageCommand.flags,

--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -154,8 +154,12 @@ export function normalizeConfig(
 const typetestsGenScript = "flub generate typetests --dir . -v";
 
 /**
- * Adds, removes, or replaces the `typetests:gen` script in the package.json `scripts` section
- * based on whether type validation is enabled or disabled.
+ * Normalizes the `typetests:gen` script in the package.json `scripts` section when the
+ * `typeValidation` node is present.
+ *
+ * If `typeValidation.disabled` is `true`, the script is removed. Otherwise, if `typeValidation`
+ * is defined, the script is added or replaced. If `typeValidation` is `undefined`, this function
+ * does not modify `scripts`.
  */
 export function normalizeTypeTestScript(pkgJson: PackageWithTypeTestSettings): void {
 	if (pkgJson.typeValidation?.disabled === true) {

--- a/build-tools/packages/build-cli/src/test/commands/typetests.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/typetests.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "mocha";
 
 import {
 	normalizeConfig,
+	normalizeTypeTestScript,
 	previousVersion,
 	resetBrokenTests,
 	updateTypeTestDependency,
@@ -208,6 +209,45 @@ describe("typetests tests", () => {
 				assert.equal(previousVersion(input), expected);
 			});
 		}
+	});
+
+	describe("normalizeTypeTestScript", () => {
+		it("adds script when typeValidation is enabled", () => {
+			const pkg: PackageWithTypeTestSettings = {
+				...packageMinimal(),
+				typeValidation: { broken: {} },
+			};
+			normalizeTypeTestScript(pkg);
+			expect(pkg.scripts?.["typetests:gen"]).to.equal("flub generate typetests --dir . -v");
+		});
+
+		it("removes script when typeValidation is disabled", () => {
+			const pkg: PackageWithTypeTestSettings = {
+				...packageMinimal(),
+				scripts: { "typetests:gen": "flub generate typetests --dir . -v" },
+				typeValidation: { disabled: true },
+			};
+			normalizeTypeTestScript(pkg);
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			expect(pkg.scripts?.["typetests:gen"]).to.not.exist;
+		});
+
+		it("replaces non-standard script value", () => {
+			const pkg: PackageWithTypeTestSettings = {
+				...packageMinimal(),
+				scripts: { "typetests:gen": "some-old-command" },
+				typeValidation: { broken: {} },
+			};
+			normalizeTypeTestScript(pkg);
+			expect(pkg.scripts?.["typetests:gen"]).to.equal("flub generate typetests --dir . -v");
+		});
+
+		it("does nothing when typeValidation is undefined", () => {
+			const pkg = packageMinimal();
+			normalizeTypeTestScript(pkg);
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			expect(pkg.scripts?.["typetests:gen"]).to.not.exist;
+		});
 	});
 
 	describe("normalizeConfig", () => {


### PR DESCRIPTION
## Description

Make typetest normalize apply to the gen scripts.
This should help mitigate confusion/risk around type tests appring enabled, but doing nothing due to missing gen scripts.

At least every release this will get normalized and cleaned up.
Mopre enforcement of consistancy is possible, but not included here.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
