### PR TITLE
feat(devcontainer): add ADO MCP to agent aliases and improve CI readiness skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,6 @@
+# Fluid Framework — Claude Context
+
+## Azure DevOps
+
+The ADO project for work items and pipelines is **`internal`** (not `FluidFramework`).
+Use `internal` when calling ADO tools that require a project name.

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -21,7 +21,7 @@ Omit steps that don't apply (e.g. skip "Build unbuilt packages" if everything is
 
 Before doing anything, ask the user:
 
-> I'll run a CI readiness check on your branch. Pick a mode (fastest to slowest):
+> I can run a CI readiness check on your branch. Pick a mode (fastest to slowest):
 >
 > 1. Skip — skip the CI readiness check
 > 2. Check — auto-fix formatting, policy, and syncpack on changed packages (~5–10 seconds; always fast)

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: ci-readiness-check
-description: Quick pre-push check that catches common CI failures before you push. Use when the user says "ci readiness", "check ci", "pre-push check", "ready for CI", "prepare for push", "ci check", "ready to push", or wants to make sure their branch won't fail CI for silly reasons. This is NOT a full local CI run — it catches low-hanging fruit like forgotten formatting, stale API reports, missing changesets, and policy violations.
+description: Use when the user explicitly asks for a CI check — e.g. "ci readiness", "check ci", "pre-push check", "ready for CI", "ci check", "ready to push". Catches common CI failures before pushing — formatting, stale API reports, missing changesets, policy violations.
 ---
 
 <required>
-Step 1 below asks the user to pick a mode. **Immediately after they respond**, use TaskCreate to create one task per applicable step based on their choice — before doing any other work. Mark each task in_progress when you start it and completed when you finish. This prevents steps from being silently skipped as context grows.
+Step 1 asks the user to pick a mode. Immediately after they respond, use TaskCreate to create one task per applicable step based on their choice — before doing any other work. Mark each task in_progress when you start it and completed when you finish. This prevents steps from being silently skipped as context grows.
 
 Tasks to create by mode:
 
-- **Check:** Run CI script → Review output → Report final status
-- **Build:** Run CI script → Review output → Build unbuilt packages → ESLint auto-fix → Regenerate API reports → Run build:docs → Regenerate type tests → Report final status
-- **Test:** same as Build, plus Run tests
+- Check: Run CI script → Review output → Report final status
+- Build: Run CI script → Review output → Build unbuilt packages → ESLint auto-fix → Regenerate API reports → Run build:docs → Regenerate type tests → Report final status
+- Test: same as Build, plus Run tests
 
-For Build/Test: if `@fluidframework/tree` is among the changed packages **and its API surface likely changed**, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
+For Build/Test: if `@fluidframework/tree` is among the changed packages and its API surface likely changed, add a "Cascade API reports to aggregator packages" task after "Regenerate API reports".
 
 Omit steps that don't apply (e.g. skip "Build unbuilt packages" if everything is already built; skip "Regenerate API reports" and "Regenerate type tests" if the API surface didn't change).
 </required>
@@ -23,12 +23,12 @@ Before doing anything, ask the user:
 
 > I'll run a CI readiness check on your branch. Pick a mode (fastest to slowest):
 >
-> 1. **Cancel** — never mind, don't run checks
-> 2. **Check** — auto-fix formatting, policy, and syncpack on changed packages (~5–10 seconds; always fast)
-> 3. **Build** — Check + build unbuilt packages + ESLint + regenerate API reports and type tests (~10–20 seconds if packages are already built; longer if a fresh compile is needed)
-> 4. **Test** — Build + run the test suite in changed packages (non-tree packages: ~10–30 seconds; tree: ~3+ minutes)
+> 1. Skip — skip the CI readiness check
+> 2. Check — auto-fix formatting, policy, and syncpack on changed packages (~5–10 seconds; always fast)
+> 3. Build — Check + build unbuilt packages + ESLint + regenerate API reports and type tests
+> 4. Test — Build + run the test suite in changed packages (non-tree packages: ~10–30 seconds; tree: ~3+ minutes)
 
-Wait for the user's response. If they say cancel (or anything clearly negative), stop here. Otherwise, note their choice and **immediately create tasks for all remaining steps** as described in the `<required>` block above before proceeding.
+Wait for the user's response. If they say skip (or anything clearly negative), stop here. Otherwise, note their choice and immediately create tasks for all remaining steps as described in the required block above before proceeding.
 
 # Step 2: Run the script
 
@@ -40,121 +40,93 @@ bash .claude/skills/ci-readiness-check/ci-readiness-check.sh [base-branch]
 
 The base branch defaults to `main`. Pass a different branch if needed (e.g., `next`).
 
-The script always runs the same checks regardless of mode — mode only affects what the agent does afterward:
-- Detecting which packages have changes vs the base branch
-- Installing dependencies if `node_modules` is missing
-- Running `fluid-build --task checks:fix` scoped to changed packages, which auto-fixes:
-  - Formatting (Biome)
-  - Policy violations (flub — copyright headers, package.json sorting, etc.)
-  - Dependency version consistency (syncpack)
-  - Build version consistency
-- Verifying all checks pass after auto-fix (`fluid-build --task checks`)
-- Checking for a changeset (via `flub check changeset`)
-- Reporting uncommitted changes, categorized (API reports, type tests, other)
-- Reporting which changed packages are built vs not built
+The script detects changed packages, installs dependencies if needed, runs `fluid-build --task checks:fix` (auto-fixing formatting, policy, syncpack, and build version consistency), verifies all checks pass, checks for a changeset, and reports uncommitted changes and build status.
 
 # Step 3: Review output
 
-Read the script output. Report to the user:
-- How many packages changed
-- What was auto-fixed (formatting, policy, syncpack, versions)
-- Any checks that still fail after auto-fix
-- Changeset status
-- Uncommitted files
+Report to the user: packages changed, what was auto-fixed, any checks still failing, changeset status, and uncommitted files.
 
-**Check mode stops here.** In Check mode, skip steps 4–8 entirely — even for packages that happen to be already built. Note what was skipped in the final report (step 9).
+If you see unexpected generated artifacts unrelated to the branch's changes, do a clean build first (set `PKG` to the package directory path):
+
+```bash
+cd $PKG && pnpm exec fluid-build . --task clean && pnpm exec fluid-build . --task compile
+```
+
+Then re-run the CI readiness check. Stale build artifacts from a previous session are often the cause of false-positive diffs.
+
+Check mode stops here — skip steps 4–8 entirely. Note what was skipped in the final report.
 
 # Step 4: Handle unbuilt packages (Build and Test only)
 
-If the script reports unbuilt packages, build them:
-
 ```bash
-cd <package-dir> && pnpm exec fluid-build . --task compile
+cd $PKG && pnpm exec fluid-build . --task compile
 ```
 
 # Step 5: ESLint auto-fix (Build and Test only)
 
-For each built changed package, run:
 ```bash
-cd <package-dir> && pnpm exec fluid-build . -t eslint:fix
+cd $PKG && pnpm exec fluid-build . -t eslint:fix
 ```
 
-`eslint:fix` is the registered fluid-build task for linting. Fluid-build ensures compilation is current before running ESLint (important for TypeScript-aware rules) and uses incremental caching so it's fast when the package is already built. If it fails due to non-auto-fixable errors, note them but do not block — CI will catch those.
+`eslint:fix` ensures compilation is current before linting and uses incremental caching so it's fast when the package is already built. If it fails due to non-auto-fixable errors, note them but continue.
 
 # Determining if the public API surface changed
 
-Steps 6 and 7 require judging whether a package's public API surface changed. Use these criteria:
+Steps 6 and 7 only run if the public API surface changed. Proceed if: `src/index.ts` or any entry point (`src/alpha.ts`, `src/beta.ts`, `src/legacy.ts`, `src/internal.ts`) was modified; any exported type/interface/class/function signature changed; or `package.json` `exports` changed. Skip if only tests, internal implementation, comments, or function bodies (not signatures) changed.
 
-**API likely changed — proceed with the check:**
-- `src/index.ts` or any entry point file (`src/alpha.ts`, `src/beta.ts`, `src/legacy.ts`, `src/internal.ts`) was modified
-- Any file that defines an exported type, interface, class, or function whose **signature** changed (not just the implementation body)
-- The package's `package.json` `exports` field changed
-
-**API did not change — skip the check:**
-- Only test files changed (`src/test/`, `*.spec.ts`, `*.test.ts`)
-- Only internal implementation changed with no exported signature differences
-- Only comments, documentation, or non-code files changed
-- Only a function body changed (not its signature)
-
-**Why be conservative:** Running `build:api-reports` when nothing actually changed can introduce spurious diffs that look like real API changes. This is especially true for `@fluidframework/tree` and `fluid-framework`, which have a known API Extractor bug that non-deterministically reorders some generated types. Only run it when you're confident the public API actually changed.
+Running `build:api-reports` when nothing changed can introduce spurious diffs — especially for `@fluidframework/tree` and `fluid-framework`, which have a known API Extractor bug with non-deterministic type ordering.
 
 # Step 6: API reports and cross-package cascade (Build and Test only)
 
-> **If `@fluidframework/tree` is among the changed packages AND its API surface likely changed** (per the criteria above): read `.claude/skills/ci-readiness-check/tree-api-checks.md` now. It has required pre-steps (before `build:api-reports`) and post-steps (after `build:api-reports` and cascade) specific to that package. Do this before proceeding with 6a. For pure implementation changes to tree (no exported signature changes), skip it.
+If `@fluidframework/tree` is among the changed packages and its API surface likely changed, read `.claude/skills/ci-readiness-check/tree-api-checks.md` before proceeding with 6a.
 
 ## 6a. Regenerate API reports
 
-For each built changed package that has a `build:api-reports` script, and where the public API surface likely changed (see criteria above):
-
 ```bash
-cd <package-dir> && pnpm exec fluid-build . -t build:api-reports
+cd $PKG && pnpm exec fluid-build . -t build:api-reports
 ```
 
-If API Extractor fails with `ae-missing-release-tag`, the new export needs a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`). Add the appropriate tag to the function/class/interface, rebuild the package, then retry `build:api-reports`. Check other exports in the same package to see which tag is conventional — most public exports use `@public`.
+If API Extractor fails with `ae-missing-release-tag`, add a TSDoc release tag (`@alpha`, `@beta`, `@public`, or `@internal`) to the new export, rebuild, then retry.
 
 ## 6b. Run `build:docs` to catch TSDoc errors
 
-**Critical:** `build:api-reports` uses an API Extractor config that suppresses `ae-unresolved-link` errors. CI catches these via a separate `build:docs` step that uses the package-root `api-extractor.json` without that suppression. You must run `build:docs` locally to catch these before pushing.
-
-For each built changed package that has a `build:docs` script, run it regardless of whether the API surface changed (TSDoc link errors can come from any modified source file):
+`build:api-reports` suppresses `ae-unresolved-link` errors; CI catches these via `build:docs`. Run for each built changed package with a `build:docs` script, regardless of API surface change:
 
 ```bash
-cd <package-dir> && pnpm run build:docs
+cd $PKG && pnpm run build:docs
 ```
 
-If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag references an ambiguous name (most commonly a member that exists as both a static and instance declaration). Fix by linking to an unambiguous target — for example, link to the interface that declares the member (which has exactly one declaration) rather than the class that exposes it as both static and instance. The TSDoc `:instance`/`:static` system selectors are **not** supported by this version of API Extractor.
+If you see `ae-unresolved-link` errors, the `{@link}` or `{@inheritdoc}` tag references an ambiguous name. Fix by linking to an unambiguous target. The TSDoc `:instance`/`:static` selectors are not supported by this version of API Extractor.
 
 # Step 7: Type test regeneration (Build and Test only)
 
-For each built changed package that has a `typetests:gen` script in its `package.json`, and where the public API surface likely changed (see criteria above):
+For each built changed package with a `typetests:gen` script and where the public API surface likely changed:
 
 ```bash
-cd <package-dir> && pnpm run typetests:gen
+cd $PKG && pnpm run typetests:gen
 ```
-
-Not all packages have type tests. Only run this where the script exists.
 
 # Step 8: Run tests (Test mode only)
 
-If the user chose **Test** mode, run tests in each built changed package. Check the package's `package.json` for available test scripts and run whichever exist:
+Run whichever test scripts exist in each built changed package:
 
 ```bash
-cd <package-dir> && pnpm run test:mocha
-cd <package-dir> && pnpm run test:jest
+cd $PKG && pnpm run test:mocha
+cd $PKG && pnpm run test:jest
 ```
 
-Some packages have both, some have one, some have neither. Only run what exists. Skip performance tests (`test:benchmark`, `test:stress`) and real service tests (`test:realsvc`) — those are too slow and flaky for a pre-push check. If tests fail, report the failures but continue with remaining packages — collect all results for the final report.
+Skip `test:benchmark`, `test:stress`, and `test:realsvc` — too slow and flaky for a pre-push check. Report all results for the final report even if some fail.
 
 # Step 9: Final status
 
-Run `git status` and report to the user:
+Run `git status` and report:
 
-1. **Files auto-fixed** — formatting, policy, ESLint fixes. These are unstaged; the user should review and stage them.
-2. **Generated files updated** — API reports, type tests. These need to be committed with the PR.
-3. **Test results** — if Test mode, report pass/fail per package.
-4. **Remaining issues** — anything the skill couldn't auto-fix (check failures, missing changeset, etc.).
-5. **Skipped checks** — anything skipped due to mode choice or unbuilt packages.
+1. Files auto-fixed — formatting, policy, ESLint fixes (unstaged; user should review and stage)
+2. Generated files updated — API reports, type tests (need to be committed with the PR)
+3. Test results — if Test mode, pass/fail per package
+4. Remaining issues — anything the skill couldn't auto-fix
+5. Skipped checks — anything skipped due to mode choice or unbuilt packages
 
 End with a clear statement: "Your branch is ready to push" or "These issues remain: ..."
 
-**If further code changes are made after this check** (e.g. fixing a review comment, addressing a lint error manually, or any other edit), re-run ESLint and — if the API surface changed — regenerate API reports before pushing. A CI readiness check only reflects the state of the code at the time it was run.
+If further code changes are made after this check, re-run ESLint and — if the API surface changed — regenerate API reports before pushing.

--- a/.claude/skills/fluid-pr/SKILL.md
+++ b/.claude/skills/fluid-pr/SKILL.md
@@ -77,7 +77,7 @@ git remote get-url origin
 
 If the URL contains `microsoft/FluidFramework`, **stop** — pushing a branch directly to the main repo is almost certainly not intended. Tell the user they likely need to push to their fork instead. Do not proceed.
 
-Once the checks in steps 2–3 pass silently, compose the title and body, print them as text, then use the `AskUserQuestion` tool with the four options as described in step 6. This is the only point where the skill asks the user a question.
+Once the checks in steps 2–3 pass silently, compose the title and body, print them as text, then use the `AskUserQuestion` tool with the four options as described in step 6. Aside from any prompt shown by `ci-readiness-check` in step 1, this is the only point where the `fluid-pr` flow asks the user a question.
 
 ```bash
 # Push branch (first time)

--- a/.claude/skills/fluid-pr/SKILL.md
+++ b/.claude/skills/fluid-pr/SKILL.md
@@ -6,16 +6,17 @@ description: Use when creating a pull request in the Fluid Framework repo. Compo
 <required>
 *CRITICAL* Add the following steps to your Todo list using TodoWrite:
 
-1. Confirm you are NOT on `main` or any release branch. If you are, stop and tell the user: you cannot create a PR from a protected branch — they need to create or switch to a feature branch first.
-2. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead.
-3. Compose the PR title following Fluid Framework conventions.
-4. Compose the PR body following the official template.
-5. Print the proposed title and body as text, then immediately use the `AskUserQuestion` tool to let the user choose what to do next. Use these exact options:
+1. Run the ci-readiness-check skill. If the user skips it, continue. If it reports remaining issues, tell the user and ask whether to proceed with the PR anyway — but always continue with the PR skill regardless of their answer.
+2. Confirm you are NOT on `main` or any release branch. If you are, stop and tell the user: you cannot create a PR from a protected branch — they need to create or switch to a feature branch first.
+3. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead.
+4. Compose the PR title following Fluid Framework conventions.
+5. Compose the PR body following the official template.
+6. Print the proposed title and body as text, then immediately use the `AskUserQuestion` tool to let the user choose what to do next. Use these exact options:
    - "Create PR" — Push the branch and open the pull request
    - "Create draft PR" — Push the branch and open a draft pull request
    - "Edit" — Revise the title or body before creating
    - "Cancel" — Don't create a PR
-6. If the user picks "Edit", apply their edits and re-present (go back to step 5). If "Create PR" or "Create draft PR", push and create accordingly. If "Cancel", stop.
+7. If the user picks "Edit", apply their edits and re-present (go back to step 6). If "Create PR" or "Create draft PR", push and create accordingly. If "Cancel", stop.
 </required>
 
 # PR Title Conventions
@@ -76,7 +77,7 @@ git remote get-url origin
 
 If the URL contains `microsoft/FluidFramework`, **stop** — pushing a branch directly to the main repo is almost certainly not intended. Tell the user they likely need to push to their fork instead. Do not proceed.
 
-Once the checks in steps 1–2 pass silently, compose the title and body, print them as text, then use the `AskUserQuestion` tool with the four options as described in step 5. This is the only point where the skill asks the user a question.
+Once the checks in steps 2–3 pass silently, compose the title and body, print them as text, then use the `AskUserQuestion` tool with the four options as described in step 6. This is the only point where the skill asks the user a question.
 
 ```bash
 # Push branch (first time)

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -8,6 +8,11 @@ This codespace is pre-configured for AI-agent-assisted development of the Fluid 
 
 Agency **must** be installed manually after the Codespace starts. Run `pnpm install:agency` in the terminal — this requires Azure authentication and will open a browser window for sign-in.
 
+> [!NOTE]
+> `pnpm install:agency` is supported in **VS Code** (desktop or SSH). It may not work in a
+> browser-based Codespace because the OAuth redirect requires a local browser and authentication may
+> not complete correctly.
+
 Then open a **new terminal** for the agent aliases to be available.
 
 ## Quick Start
@@ -32,11 +37,11 @@ These aliases are available in all terminal sessions (after installing agency):
 
 | Alias | Command | Purpose |
 |---|---|---|
-| `claude` | `repoverlay switch ff-claude && agency claude` | Default Claude Code model |
-| `haiku` | `repoverlay switch ff-claude && agency claude -- --model haiku` | Fastest, cheapest option |
-| `sonnet` | `repoverlay switch ff-claude && agency claude -- --model sonnet` | Balanced capabilities |
-| `opus` | `repoverlay switch ff-claude && agency claude -- --model opus` | Most capable model |
-| `nori` | `repoverlay switch nori && agency claude` | Switch to nori overlay and launch Claude |
+| `claude` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework'` | Default Claude Code model |
+| `haiku` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model haiku` | Fastest, cheapest option |
+| `sonnet` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model sonnet` | Balanced capabilities |
+| `opus` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model opus` | Most capable model |
+| `nori` | `repoverlay switch --copy nori && agency claude --mcp 'ado --org fluidframework'` | Switch to nori overlay and launch Claude |
 
 ### Copilot
 
@@ -45,7 +50,7 @@ These aliases are available in all terminal sessions (after installing agency):
 | `copilot` | `agency copilot` | Standard GitHub Copilot |
 | `copilot-ado` | `agency copilot --mcp 'ado --org fluidframework'` | Azure DevOps integration |
 | `copilot-kusto` | `agency copilot --mcp 'kusto ...'` | Telemetry queries |
-| `copilot-oce` | `repoverlay switch ff-oce && copilot -- --agent ff-oce` | On-Call Engineer workflows |
+| `copilot-oce` | `repoverlay switch --copy ff-oce && copilot -- --agent ff-oce` | On-Call Engineer workflows |
 | `copilot-work` | `agency copilot --mcp 'workiq'` | WorkIQ integration |
 
 ### Utility

--- a/.devcontainer/ai-agent/first-run-notice.txt
+++ b/.devcontainer/ai-agent/first-run-notice.txt
@@ -4,11 +4,14 @@ This codespace is configured for AI-agent-assisted workflows with 32 CPUs and
 64 GB RAM. It includes additional CLI tooling (GitHub CLI, SSH, agency, repoverlay).
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!  To use AI agents, run the following command first:                       !!
+!!  To use AI agents, run the following command first:                        !!
 !!                                                                            !!
 !!      pnpm install:agency                                                   !!
 !!                                                                            !!
 !!  Then open a NEW terminal for the agent aliases to be available.           !!
+!!                                                                            !!
+!!  NOTE: pnpm install:agency requires VS Code (desktop or SSH).              !!
+!!  It may not work in a browser-based Codespace.                             !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 AI agent aliases (provided by agency):

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -5,12 +5,12 @@
 # shopt -s expand_aliases is bash-only; zsh expands aliases by default in interactive shells.
 [ -n "${BASH_VERSION:-}" ] && shopt -s expand_aliases
 
-alias claude="repoverlay switch --copy ff-claude && agency claude"
-alias haiku="repoverlay switch --copy ff-claude && agency claude -- --model haiku"
-alias sonnet="repoverlay switch --copy ff-claude && agency claude -- --model sonnet"
-alias opus="repoverlay switch --copy ff-claude && agency claude -- --model opus"
+alias claude="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework'"
+alias haiku="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model haiku"
+alias sonnet="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model sonnet"
+alias opus="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model opus"
 
-alias nori="repoverlay switch --copy nori && agency claude"
+alias nori="repoverlay switch --copy nori && agency claude --mcp 'ado --org fluidframework'"
 
 alias copilot="agency copilot"
 alias copilot-ado="agency copilot --mcp 'ado --org fluidframework'"


### PR DESCRIPTION
## Description

Adds the ADO MCP server (`--mcp 'ado --org fluidframework'`) to all Claude and nori agent aliases in the AI agent codespace, so agents can interact with ADO work items and pipelines out of the box without manual setup.

Also adds a note (in both GETTING_STARTED.md and the first-run notice) that `pnpm install:agency` requires VS Code (desktop or SSH) — it may not complete correctly in a browser-based Codespace due to the OAuth redirect flow.

Adds `.claude/CLAUDE.md` to capture shared Claude context that isn't managed by repoverlay — starting with the ADO project name (`internal`) so agents don't have to discover it by trial and error.

CI skill improvements:
- Ran nori-lint on ci-readiness-check and fixed all static rule violations (bold formatting, line count, description phrasing, XML placeholder tags)
- fluid-pr now runs ci-readiness-check as a prerequisite before creating a PR
- Refined skill triggers so "push" language routes to fluid-pr (which runs the check internally) rather than triggering ci-readiness-check directly

## Reviewer Guidance

The review process is outlined on https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines.