### PR TITLE
chore(eslint-config-fluid): clean up stale minimal-deprecated references

### DIFF
--- a/common/build/eslint-config-fluid/README.md
+++ b/common/build/eslint-config-fluid/README.md
@@ -28,7 +28,6 @@ eslint-config-fluid/
 │   ├── settings.mts            # Plugin settings (import-x, jsdoc)
 │   ├── rules/
 │   │   ├── base.mts            # Base rules from eslint:recommended, typescript-eslint, etc.
-│   │   ├── minimal-deprecated.mts  # Additional rules for minimal-deprecated config
 │   │   ├── recommended.mts     # Rules for recommended config (unicorn, type safety)
 │   │   └── strict.mts          # Rules for strict config (jsdoc requirements, explicit access)
 │   └── configs/

--- a/common/build/eslint-config-fluid/library/configs/base.mts
+++ b/common/build/eslint-config-fluid/library/configs/base.mts
@@ -15,7 +15,7 @@
  * - Core plugin registrations (eslint-comments, fluid, rushstack, jsdoc, promise, tsdoc, unicorn, unused-imports)
  * - Prettier config for disabling conflicting formatting rules
  *
- * All higher-level configs (recommended, strict) extend from this base.
+ * All higher-level configs (recommended, strict, strictBiome) extend from this base.
  */
 
 import eslintJs from "@eslint/js";

--- a/common/build/eslint-config-fluid/library/configs/base.mts
+++ b/common/build/eslint-config-fluid/library/configs/base.mts
@@ -15,7 +15,7 @@
  * - Core plugin registrations (eslint-comments, fluid, rushstack, jsdoc, promise, tsdoc, unicorn, unused-imports)
  * - Prettier config for disabling conflicting formatting rules
  *
- * All higher-level configs (minimal-deprecated, recommended, strict) extend from this base.
+ * All higher-level configs (recommended, strict) extend from this base.
  */
 
 import eslintJs from "@eslint/js";

--- a/common/build/eslint-config-fluid/library/configs/overrides.mts
+++ b/common/build/eslint-config-fluid/library/configs/overrides.mts
@@ -135,7 +135,7 @@ export const reactConfig = [
 		files: ["**/*.jsx", "**/*.tsx"],
 		...reactPlugin.configs.flat.recommended,
 	},
-	// react-hooks/recommended rules (from minimal-deprecated.js lines 451)
+	// react-hooks/recommended rules
 	{
 		files: ["**/*.jsx", "**/*.tsx"],
 		plugins: {
@@ -154,7 +154,7 @@ export const reactConfig = [
 		files: ["**/*.jsx", "**/*.tsx"],
 		...reactPlugin.configs.flat["jsx-runtime"],
 	},
-	// Custom overrides from minimal-deprecated.js (lines 453-459)
+	// Custom overrides for react-hooks rules
 	{
 		files: ["**/*.jsx", "**/*.tsx"],
 		rules: {

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -18,7 +18,7 @@ module.exports = {
 		es2024: false,
 		node: true,
 	},
-	extends: ["./minimal-deprecated.js", "plugin:unicorn/recommended"],
+	extends: ["./base.js", "plugin:unicorn/recommended"],
 	plugins: ["eslint-plugin-tsdoc"],
 	rules: {
 		// RECOMMENDED RULES

--- a/common/build/eslint-plugin-fluid/DEV.md
+++ b/common/build/eslint-plugin-fluid/DEV.md
@@ -54,9 +54,8 @@ In `@fluidframework/eslint-config-fluid`, update the version of `@fluid-internal
 
 ### 4. Add New Rule to the Appropriate Config
 
-Depending on the scope of the rule, add it to one of the following configurations (NOTE: `recommended.js` extends `minimal-deprecated.js`, and `strict.js` extends `recommended.js`):
+Depending on the scope of the rule, add it to one of the following configurations (NOTE: `strict.js` extends `recommended.js`):
 
-- `minimal-deprecated.js`
 - `recommended.js`
 - `strict.js`
 

--- a/common/build/eslint-plugin-fluid/DEV.md
+++ b/common/build/eslint-plugin-fluid/DEV.md
@@ -54,8 +54,9 @@ In `@fluidframework/eslint-config-fluid`, update the version of `@fluid-internal
 
 ### 4. Add New Rule to the Appropriate Config
 
-Depending on the scope of the rule, add it to one of the following configurations (NOTE: `strict.js` extends `recommended.js`):
+Depending on the scope of the rule, add it to one of the following configurations (NOTE: `recommended.js` extends `base.js`, and `strict.js` extends `recommended.js`):
 
+- `base.js`
 - `recommended.js`
 - `strict.js`
 

--- a/scripts/generate-flat-eslint-configs.ts
+++ b/scripts/generate-flat-eslint-configs.ts
@@ -13,7 +13,6 @@
  *
  * Heuristic:
  *  - If .eslintrc.cjs extends "@fluidframework/eslint-config-fluid/strict" => use strict flat config.
- *  - If it extends "@fluidframework/eslint-config-fluid/minimal-deprecated" => use minimalDeprecated.
  *  - Otherwise (includes base or recommended) => use recommended.
  *  - Extracts local rules and overrides from .eslintrc.cjs and includes them in the flat config.
  *
@@ -43,7 +42,7 @@ const typescriptMode = args.includes("--typescript");
 interface PackageTarget {
 	packageDir: string;
 	legacyConfigPath: string;
-	flatVariant: "strict" | "minimalDeprecated" | "recommended";
+	flatVariant: "strict" | "recommended";
 	legacyConfig?: unknown;
 	eslintIgnorePatterns?: string[];
 	/** Rules and overrides merged from local extends (e.g., ../../.eslintrc.cjs) */
@@ -201,8 +200,6 @@ async function findLegacyConfigs(
 					const extendsContent = extendsMatch[1];
 					if (extendsContent.includes("eslint-config-fluid/strict")) {
 						variant = "strict";
-					} else if (extendsContent.includes("eslint-config-fluid/minimal-deprecated")) {
-						variant = "minimalDeprecated";
 					}
 				}
 
@@ -900,7 +897,7 @@ ${imports}
 			}
 
 			// Add react/react-hooks rules scoped to jsx/tsx files where the plugin is loaded
-			// The base config (minimal-deprecated.js) loads react and react-hooks plugins for *.jsx and *.tsx files
+			// The base config loads react and react-hooks plugins for *.jsx and *.tsx files
 			if (Object.keys(reactRules).length > 0) {
 				configContent += `\t{\n\t\tfiles: ["**/*.jsx", "**/*.tsx"],\n\t\trules: ${serializeValue(reactRules, "\t\t")},\n\t},\n`;
 			}


### PR DESCRIPTION
## Description

Removes remaining references to the `minimal-deprecated` eslint configuration that was collapsed into `base` in #26801. These are stale comments, docs, and code paths that were missed in that PR.

- **`recommended.js`**: Fixed broken `extends` from `./minimal-deprecated.js` (deleted file) to `./base.js`
- **`README.md`**: Removed `minimal-deprecated.mts` from the directory tree listing (file no longer exists)
- **`library/configs/base.mts`**: Removed `minimal-deprecated` from doc comment listing config tiers
- **`library/configs/overrides.mts`**: Removed stale `minimal-deprecated.js` line-number references in comments
- **`eslint-plugin-fluid/DEV.md`**: Removed `minimal-deprecated.js` from the config list
- **`generate-flat-eslint-configs.ts`**: Removed dead `minimalDeprecated` variant from type, detection heuristic, and comments

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The broken `extends` in `recommended.js` (pointing at the deleted `minimal-deprecated.js`) suggests the legacy `.js` configs in the package root (`base.js`, `recommended.js`, `strict.js`, `strict-biome.js`) may no longer be exercised by any consumer. No `.eslintrc` files in the repo reference them. If that's the case, we may want to delete them entirely in a follow-up rather than maintaining them — would appreciate reviewer input on that.