### PR TITLE
Increase timeout for import-testing tests to mitigate nondeterministic CI timeouts

### DIFF
--- a/examples/utils/import-testing/.mocharc.cjs
+++ b/examples/utils/import-testing/.mocharc.cjs
@@ -8,7 +8,7 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
-// The build tests can be slow, especially on CI somtimes.
+// The build tests can be slow, especially on CI sometimes.
 // 10-13 seconds is normal for them, but sometimes they take over 20 seconds.
 config.timeout = 50000;
 module.exports = config;

--- a/examples/utils/import-testing/.mocharc.cjs
+++ b/examples/utils/import-testing/.mocharc.cjs
@@ -8,5 +8,7 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
-config.timeout = 20000;
+// The build tests can be slow, especially on CI somtimes.
+// 10-13 seconds is normal for them, but sometimes they take over 20 seconds.
+config.timeout = 50000;
 module.exports = config;


### PR DESCRIPTION
## Description

Increase timeout for import-testing tests to mitigate random CI timeouts since the first of these tests occasionally times out on CI.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

