### PR TITLE
Update version specifier for chai

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -100,7 +100,7 @@
 		"@types/semver": "^7.7.0",
 		"@types/sinon": "^17.0.3",
 		"c8": "^10.1.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^10.1.0",
 		"eslint": "catalog:eslint",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -83,7 +83,7 @@
 		"@types/semver": "^7.7.0",
 		"@types/sinon": "^17.0.3",
 		"c8": "^10.1.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"cross-env": "^10.1.0",
 		"eslint": "catalog:eslint",
 		"jiti": "^2.6.1",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -92,7 +92,7 @@
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "~20.19.30",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^10.1.0",
 		"easy-table": "^1.2.0",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -83,7 +83,7 @@
 		"@types/node": "~20.19.30",
 		"@types/sinon": "^17.0.3",
 		"c8": "^10.1.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"cross-env": "^10.1.0",
 		"eslint": "catalog:eslint",
 		"jiti": "^2.6.1",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -100,7 +100,7 @@
 		"@types/lru-cache": "^5.1.0",
 		"@types/mocha": "^10.0.10",
 		"c8": "^10.1.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^10.1.0",

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -115,7 +115,7 @@
 		"@types/chai": "^4.0.0",
 		"@types/mocha": "^10.0.10",
 		"@types/sinon": "^17.0.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "catalog:eslint",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -112,7 +112,7 @@
 		"@types/sinon": "^17.0.3",
 		"@types/sinon-chrome": "^2.2.11",
 		"c8": "^10.1.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"concurrently": "^9.2.1",
 		"copy-webpack-plugin": "^12.0.2",
 		"copyfiles": "^2.4.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -158,7 +158,7 @@
 		"@types/chai": "^4.0.0",
 		"@types/mocha": "^10.0.10",
 		"c8": "^10.1.3",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6571,7 +6571,7 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       copyfiles:
         specifier: ^2.4.1
@@ -6674,7 +6674,7 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       cross-env:
         specifier: ^10.1.0
@@ -6825,7 +6825,7 @@ importers:
         specifier: ~20.19.30
         version: 20.19.30
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       copyfiles:
         specifier: ^2.4.1
@@ -6910,7 +6910,7 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       cross-env:
         specifier: ^10.1.0
@@ -7334,7 +7334,7 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       concurrently:
         specifier: ^9.2.1
@@ -11137,7 +11137,7 @@ importers:
         specifier: ^17.0.3
         version: 17.0.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       concurrently:
         specifier: ^9.2.1
@@ -15982,7 +15982,7 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       concurrently:
         specifier: ^9.2.1
@@ -16172,7 +16172,7 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       concurrently:
         specifier: ^9.2.1


### PR DESCRIPTION
## Description

Due to the recent change to use [pnpm's time-based resolutionMode](https://pnpm.io/settings#resolutionmode) in our test pipelines, the versions of packages that get installed during those pipeline runs changed, and that surfaced a problem where we fail to import chai's `expect` from version 4.2.0 for some reason. I could not figure out why but confirmed that things work correctly with 4.3.0 (even though [the release notes](https://github.com/chaijs/chai/releases/tag/4.3.0) don't suggest anything that should affect that).

This PR updates the version range we declare for chai dependencies (which now match what the lockfile had already resolved) just so the test pipelines start installing 4.5.0 instead of 4.2.0, to get the performance benchmarks pipeline back to a healthy state.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
