### PR TITLE
Bump benchmark to 0.55

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluid-tools/benchmark
 
+## 0.55.0
+
 ## 0.54.0
 
 -   Fixed `--parentProcess` mode incorrectly matching tests whose full title is a substring of another test's full title. The child process filter now uses an exact-match regex (`--grep ^title$`) instead of substring matching (`--fgrep title`). For example, if a suite contained tests named `foo` and `foobar` in the same suite, running `foo` in a child process with `--fgrep foo` would also match `foobar`, causing both tests to run and assuming both are benchmarks, produce an error (versions prior to 0.53 would produce incorrect results instead of an error).

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.54.0",
+	"version": "0.55.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Bump benchmark to 0.55.0 to prepare for releasing 0.54.0.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

