### PR TITLE
fix(container-runtime): generate IdAlloc op only once per flush, prepended to first non-empty batch

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -10,7 +10,6 @@ import {
 	TelemetryDataTag,
 } from "@fluidframework/telemetry-utils/internal";
 
-import type { ICompressionRuntimeOptions } from "../compressionDefinitions.js";
 import { isContainerMessageDirtyable } from "../containerRuntime.js";
 import { asBatchMetadata, type IBatchMetadata } from "../metadata.js";
 import type { IPendingMessage } from "../pendingStateManager.js";
@@ -21,7 +20,6 @@ import type { BatchStartInfo } from "./remoteMessageProcessor.js";
 
 export interface IBatchManagerOptions {
 	readonly disableGroupedBatching: boolean;
-	readonly compressionOptions?: ICompressionRuntimeOptions;
 }
 
 export interface BatchSequenceNumbers {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -368,9 +368,14 @@ export class Outbox {
 			}
 			return;
 		}
-
-		this.flushInternal(this.blobAttachBatch, resubmitInfo);
-		this.flushInternal(this.mainBatch, resubmitInfo);
+		let sendIdAllocOp = true;
+		if (!this.blobAttachBatch.empty) {
+			this.flushInternal(this.blobAttachBatch, sendIdAllocOp, resubmitInfo);
+			sendIdAllocOp = false; // Only send ID alloc op for the first batch flushed, if needed. This ensures correct refSeq and prevents duplicate ID alloc ops.
+		}
+		if (!this.mainBatch.empty) {
+			this.flushInternal(this.mainBatch, sendIdAllocOp, resubmitInfo);
+		}
 	}
 
 	private flushEmptyBatch(
@@ -404,12 +409,10 @@ export class Outbox {
 
 	private flushInternal(
 		batchManager: BatchManager,
+		sendIdAllocOp: boolean, // undefined if not needed
 		resubmitInfo?: BatchResubmitInfo, // undefined if not resubmitting
 	): void {
-		if (batchManager.empty) {
-			return;
-		}
-
+		assert(!batchManager.empty, "Cannot flush an empty batch");
 		let rawBatch = batchManager.popBatch();
 
 		// On resubmit we use the original batch's staged state, so these should match as well.
@@ -435,7 +438,7 @@ export class Outbox {
 			// Note: Since this is happening in the same turn the ops were originally created with,
 			// and they haven't gone to PendingStateManager yet, we can just let them respect
 			// ContainerRuntime.inStagingMode.  So we do not plumb local 'staged' variable through here.
-			this.rebase(rawBatch, batchManager);
+			this.rebase(rawBatch, batchManager, sendIdAllocOp);
 			return;
 		}
 
@@ -450,7 +453,7 @@ export class Outbox {
 			// This ensures the refSeq is correct (matching the rest of the batch) and that
 			// ID ranges aren't lost during rebase (since reSubmit drops IdAllocation ops).
 			// Only generate for non-staged batches — ID alloc ops are always non-staged.
-			const idAllocMsg = this.params.generateIdAllocationOp();
+			const idAllocMsg = sendIdAllocOp ? this.params.generateIdAllocationOp() : undefined;
 			if (idAllocMsg !== undefined) {
 				rawBatch = { ...rawBatch, messages: [idAllocMsg, ...rawBatch.messages] };
 			}
@@ -478,8 +481,13 @@ export class Outbox {
 	 * they will end up back in the same batch manager they were flushed from and subsequently flushed.
 	 *
 	 * @param rawBatch - the batch to be rebased
+	 * @param sendIdAllocOp - whether to send ID allocation op
 	 */
-	private rebase(rawBatch: LocalBatch, batchManager: BatchManager): void {
+	private rebase(
+		rawBatch: LocalBatch,
+		batchManager: BatchManager,
+		sendIdAllocOp: boolean,
+	): void {
 		assert(!this.rebasing, 0x6fb /* Reentrancy */);
 
 		this.rebasing = true;
@@ -507,7 +515,9 @@ export class Outbox {
 			this.batchRebasesToReport--;
 		}
 
-		this.flushInternal(batchManager);
+		if (!batchManager.empty) {
+			this.flushInternal(batchManager, sendIdAllocOp);
+		}
 		this.rebasing = false;
 	}
 

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -371,7 +371,7 @@ export class Outbox {
 		let sendIdAllocOp = true;
 		if (!this.blobAttachBatch.empty) {
 			this.flushInternal(this.blobAttachBatch, sendIdAllocOp, resubmitInfo);
-			sendIdAllocOp = false; // Only send ID alloc op for the first batch flushed, if needed. This ensures correct refSeq and prevents duplicate ID alloc ops.
+			sendIdAllocOp = false; // Only send ID alloc op for the first batch flushed, if needed. Prevents duplicate ID alloc ops.
 		}
 		if (!this.mainBatch.empty) {
 			this.flushInternal(this.mainBatch, sendIdAllocOp, resubmitInfo);
@@ -409,7 +409,7 @@ export class Outbox {
 
 	private flushInternal(
 		batchManager: BatchManager,
-		sendIdAllocOp: boolean, // undefined if not needed
+		sendIdAllocOp: boolean,
 		resubmitInfo?: BatchResubmitInfo, // undefined if not resubmitting
 	): void {
 		assert(!batchManager.empty, "Cannot flush an empty batch");

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -57,7 +57,7 @@ describe("BatchManager", () => {
 	describe("addBatchMetadata", () => {
 		const makeLocalBatch = (...ops: string[]): LocalBatch => ({
 			messages: ops.map((data, i) => ({ runtimeOp: op(data), referenceSequenceNumber: i })),
-			referenceSequenceNumber: ops.length - 1,
+			referenceSequenceNumber: undefined,
 		});
 
 		for (const includeBatchId of [true, false])

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -349,7 +349,7 @@ describe("Outbox", () => {
 		outbox.submit(messages[1]);
 		outbox.flush();
 
-		// Flush 2 — no more ID alloc ops
+		// Flush 2 — idAlloc op prepended again (generateIdAllocationOp returns an op on every call in this test)
 		outbox.submit(messages[2]);
 		outbox.flush();
 
@@ -1183,7 +1183,7 @@ describe("Outbox", () => {
 			outbox.submit(mainMsg);
 			outbox.flush();
 
-			// Called once for blobAttach (returns idAlloc), once for main (returns undefined)
+			// Called once total — only for the first non-empty batch (blobAttach); main batch is skipped
 			assert.equal(
 				idAllocCallCount,
 				1,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -241,6 +241,7 @@ describe("Outbox", () => {
 		opGroupingConfig?: OpGroupingManagerConfig;
 		immediateMode?: boolean;
 		generateIdAllocationOp?: () => LocalBatchMessage | undefined;
+		reSubmit?: (message: PendingMessageResubmitData, squash: boolean) => void;
 	}) => {
 		const { submitFn, submitBatchFn, deltaManager } = params.context;
 
@@ -268,9 +269,11 @@ describe("Outbox", () => {
 				mockLogger,
 			),
 			getCurrentSequenceNumbers: () => currentSeqNumbers,
-			reSubmit: (message: PendingMessageResubmitData) => {
-				state.opsResubmitted++;
-			},
+			reSubmit:
+				params.reSubmit ??
+				((_message: PendingMessageResubmitData) => {
+					state.opsResubmitted++;
+				}),
 			opReentrancy: () => state.isReentrant,
 			generateIdAllocationOp: params.generateIdAllocationOp ?? (() => undefined),
 		});
@@ -328,23 +331,17 @@ describe("Outbox", () => {
 
 	it("Sending batches", () => {
 		const idAllocMessage = createMessage(ContainerMessageType.IdAllocation, "idAlloc");
-		let idAllocReturned = false;
 		const outbox = getOutbox({
 			context: getMockContext(),
-			// JIT callback: return an ID alloc op on the first call, then undefined
 			generateIdAllocationOp: () => {
-				if (!idAllocReturned) {
-					idAllocReturned = true;
-					return idAllocMessage;
-				}
-				return undefined;
+				return idAllocMessage;
 			},
 		});
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "4"),
-			createMessage(ContainerMessageType.FluidDataStoreOp, "5"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "2"),
+			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
 		// Flush 1 — JIT ID alloc op is prepended to the first non-empty batch (blobAttach is empty, so main batch)
@@ -359,7 +356,7 @@ describe("Outbox", () => {
 		// Not Flushed
 		outbox.submit(messages[3]);
 
-		assert.equal(state.opsSubmitted, 4); // 2 main + idAlloc from flush 1, 1 main from flush 2
+		assert.equal(state.opsSubmitted, 5);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
@@ -371,7 +368,7 @@ describe("Outbox", () => {
 					toSubmittedMessage(messages[1], false),
 				],
 				// Flush 2 (Main)
-				[toSubmittedMessage(messages[2])],
+				[toSubmittedMessage(idAllocMessage, true), toSubmittedMessage(messages[2])],
 			],
 			"Submitted batches are incorrect",
 		);
@@ -384,6 +381,7 @@ describe("Outbox", () => {
 			[messages[0], 1],
 			[messages[1], 1],
 			// Flush 2 (Main)
+			[idAllocMessage, 4],
 			[messages[2], 4],
 		] as const;
 		assert.deepEqual(
@@ -1163,6 +1161,127 @@ describe("Outbox", () => {
 			outbox.flush();
 
 			validateCounts(2, 1, 0);
+		});
+	});
+
+	describe("JIT IdAllocation (generateIdAllocationOp)", () => {
+		it("IdAlloc op is prepended to blobAttach batch when it flushes before main", () => {
+			const idAllocMessage = createMessage(ContainerMessageType.IdAllocation, "idAlloc");
+			let idAllocCallCount = 0;
+			const outbox = getOutbox({
+				context: getMockContext(),
+				generateIdAllocationOp: () => {
+					idAllocCallCount++;
+					return idAllocMessage;
+				},
+			});
+
+			const blobAttachMsg = createMessage(ContainerMessageType.BlobAttach, "blob0");
+			const mainMsg = createMessage(ContainerMessageType.FluidDataStoreOp, "main0");
+
+			outbox.submitBlobAttach(blobAttachMsg);
+			outbox.submit(mainMsg);
+			outbox.flush();
+
+			// Called once for blobAttach (returns idAlloc), once for main (returns undefined)
+			assert.equal(
+				idAllocCallCount,
+				1,
+				"generateIdAllocationOp should be called once per flush, and only the first flush (for blobAttach) should generate an IdAlloc op",
+			);
+			assert.deepEqual(
+				state.batchesSubmitted.map((x) => x.messages),
+				[
+					// BlobAttach batch: idAlloc prepended, batch markers applied to 2-msg batch
+					[toSubmittedMessage(idAllocMessage, true), toSubmittedMessage(blobAttachMsg, false)],
+					// Main batch: no idAlloc
+					[toSubmittedMessage(mainMsg)],
+				],
+				"IdAlloc should be prepended to blobAttach batch, not main",
+			);
+		});
+
+		it("Disconnected flush does not invoke generateIdAllocationOp", () => {
+			let idAllocCallCount = 0;
+			const outbox = getOutbox({
+				context: getMockContext(),
+				generateIdAllocationOp: () => {
+					idAllocCallCount++;
+					return createMessage(ContainerMessageType.IdAllocation, "idAlloc");
+				},
+			});
+
+			state.canSendOps = false;
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "0"));
+			outbox.flush();
+
+			assert.equal(
+				idAllocCallCount,
+				0,
+				"generateIdAllocationOp must not be called when disconnected",
+			);
+			assert.equal(state.opsSubmitted, 0, "No ops should be submitted when disconnected");
+			assert.equal(
+				state.pendingOpContents.length,
+				1,
+				"Op should still be tracked in pending state",
+			);
+		});
+
+		it("Rebase path invokes generateIdAllocationOp only after rebase completes", () => {
+			const idAllocMessage = createMessage(ContainerMessageType.IdAllocation, "idAlloc");
+			let idAllocCallCount = 0;
+			const message0 = createMessage(ContainerMessageType.FluidDataStoreOp, "0");
+			const message1 = createMessage(ContainerMessageType.FluidDataStoreOp, "1");
+
+			// Use a wrapper so reSubmit can reference outbox before it's assigned
+			const outboxWrapper: { outbox?: Outbox } = {};
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: { groupedBatchingEnabled: true },
+				generateIdAllocationOp: () => {
+					idAllocCallCount++;
+					return idAllocCallCount === 1 ? idAllocMessage : undefined;
+				},
+				// Re-push each resubmitted message, simulating ContainerRuntime.reSubmit behavior.
+				// This causes the second flushInternal call (after rebase) to see a non-empty batch,
+				// making it the right place to generate the IdAlloc op.
+				reSubmit: (message: PendingMessageResubmitData) => {
+					state.opsResubmitted++;
+					assert(outboxWrapper.outbox !== undefined);
+					outboxWrapper.outbox.submit({
+						runtimeOp: message.runtimeOp,
+						localOpMetadata: message.localOpMetadata,
+						metadata: message.opMetadata,
+						referenceSequenceNumber: Number.POSITIVE_INFINITY,
+					});
+				},
+			});
+			outboxWrapper.outbox = outbox;
+
+			// Submit messages as reentrant — triggers rebase on flush
+			state.isReentrant = true;
+			outbox.submit(message0);
+			outbox.submit(message1);
+			state.isReentrant = false;
+
+			outbox.flush();
+
+			// generateIdAllocationOp should be called exactly once:
+			// - NOT during the first flushInternal (which exits early into rebase)
+			// - YES during the second flushInternal (after rebase, with the freshly rebased batch)
+			assert.equal(
+				idAllocCallCount,
+				1,
+				"generateIdAllocationOp must be called exactly once, after rebase completes",
+			);
+			assert.equal(state.opsResubmitted, 2, "Both ops should be resubmitted during rebase");
+			// The idAlloc + 2 rebased ops are grouped into a single outbound op
+			assert.equal(
+				state.opsSubmitted,
+				1,
+				"Rebased batch (with idAlloc) should be sent as one grouped op",
+			);
 		});
 	});
 


### PR DESCRIPTION
The changes fix a bug where `generateIdAllocationOp()` could be called multiple times in a single flush — once for the blobAttach batch and once for the main batch — potentially producing duplicate or misplaced ID allocation ops.

- `flush() `now only calls flushInternal for non-empty batches (previously it called it unconditionally and let flushInternal return early).
- A `sendIdAllocOp: boolean` parameter is threaded through flushInternal and rebase. It is true only for the first non-empty batch flushed, ensuring `generateIdAllocationOp()` is invoked at most once per flush cycle — and only after any rebase is complete.
- (misc) Removing unused `compressionOptions` from `IBatchManagerOptions`
- (misc) Improve some tests readability.