### PR TITLE
docs(tree): withDefault user docs

### DIFF
--- a/docs/docs/data-structures/tree/index.mdx
+++ b/docs/docs/data-structures/tree/index.mdx
@@ -21,7 +21,7 @@ For more detail, see the links below.
 
 - [Tree Nodes](./nodes.mdx): how information is stored on a `SharedTree`
 	- [Node Types](./node-types.mdx): outlines the specific types that are stored by a `SharedTree`
-- [Schema Definition](./schema-definition.mdx): how the structure of a `SharedTree` is defined
+- [Schema Definition](./schema-definition/index.mdx): how the structure of a `SharedTree` is defined
 - [Reading and Editing](./reading-and-editing.mdx): how a `SharedTree` is read and edited through the APIs provided on the different node types
 - [Events](./events.mdx): the various events emitted by a `SharedTree` and what they can be used for
 - [Transactions](./transactions.mdx): how edits can be grouped into transactions

--- a/docs/docs/data-structures/tree/schema-definition/default-field-values.mdx
+++ b/docs/docs/data-structures/tree/schema-definition/default-field-values.mdx
@@ -48,7 +48,7 @@ const admin = new Person({ name: "Bob", age: 30, role: "admin" });
 default value:
 
 ```typescript
-class Config extends sf.object("Config", {
+class Config extends sf.objectAlpha("Config", {
   timeout: sf.withDefault(sf.optional(sf.number), 5000),
   retries: sf.withDefault(sf.optional(sf.number), 3),
 }) {}
@@ -68,12 +68,12 @@ const customConfig = new Config({ timeout: 10000 });
 When you provide a value directly, the data is copied for each use, ensuring each instance is independent:
 
 ```typescript
-class Metadata extends sf.object("Metadata", {
+class Metadata extends sf.objectAlpha("Metadata", {
   tags: sf.array(sf.string),
   version: sf.number,
 }) {}
 
-class Article extends sf.object("Article", {
+class Article extends sf.objectAlpha("Article", {
   title: sf.required(sf.string),
 
   // a node is provided directly, it is copied for each use
@@ -98,7 +98,7 @@ assert(article2.metadata.version === 1);
 Alternatively, you can use generator functions to explicitly create new instances:
 
 ```typescript
-class Article extends sf.object("Article", {
+class Article extends sf.objectAlpha("Article", {
   title: sf.required(sf.string),
 
   // generators are called each time to create a new instance
@@ -114,7 +114,7 @@ Insertable object literals, arrays, and map objects can be used in place of node
 and generator functions:
 
 ```typescript
-class Article extends sf.object("Article", {
+class Article extends sf.objectAlpha("Article", {
   title: sf.required(sf.string),
 
   // plain object literal instead of new Metadata(...)
@@ -135,7 +135,7 @@ class Article extends sf.object("Article", {
 Generator functions are called each time a new node is created, enabling dynamic defaults:
 
 ```typescript
-class Document extends sf.object("Document", {
+class Document extends sf.objectAlpha("Document", {
   id: sf.withDefault(sf.required(sf.string), () => crypto.randomUUID()),
   title: sf.required(sf.string),
 }) {}
@@ -150,7 +150,7 @@ Generator functions also work with primitive types:
 ```typescript
 let counter = 0;
 
-class GameState extends sf.object("GameState", {
+class GameState extends sf.objectAlpha("GameState", {
   playerId: sf.withDefault(
     sf.required(sf.string),
     () => `player-${counter++}`,
@@ -201,10 +201,10 @@ const DefaultTag = sf.objectRecursiveAlpha("Tag", {
 
 class TreeNode extends sf.objectRecursiveAlpha("TreeNode", {
   value: sf.number,
-  // ✅ Safe: default is a non-recursive node
+  // ✅ Safe: the default uses a different recursive type, not TreeNode itself
   tag: SchemaFactoryAlpha.withDefaultRecursive(
     sf.optional(DefaultTag),
-    () => new DefaultTag({ id: 0, child: new DefaultTag({ id: 1 }) }),
+    () => new DefaultTag({ id: 0 }),
   ),
   child: sf.optionalRecursive([() => TreeNode]),
 }) {}

--- a/docs/docs/data-structures/tree/schema-definition/default-field-values.mdx
+++ b/docs/docs/data-structures/tree/schema-definition/default-field-values.mdx
@@ -1,0 +1,259 @@
+---
+title: Default Field Values
+sidebar_position: 2
+---
+
+# Default Field Values
+
+The `withDefault` API is available on [`SchemaFactoryAlpha`](../../../api/fluid-framework/schemafactoryalpha-class). It allows you to specify default values for fields,
+making them optional in constructors even when the field is marked as [`required`](../../../api/fluid-framework/schemastatics-interface.md#required-propertysignature) in the schema.
+This provides a better developer experience by reducing boilerplate when creating objects.
+
+The `withDefault` API wraps a field schema and defines a default value to use when the field is not provided during
+construction. The default value must be of an allowed type of the field. You can provide defaults in two ways:
+
+- **A value**: When a value is provided directly, the data is copied for each use to ensure independence between instances.
+- **A generator function**: A function that is called each time to produce a fresh value.
+
+Defaults are evaluated eagerly during node construction.
+
+## Required Fields with Defaults
+
+```typescript
+import { SchemaFactoryAlpha, TreeAlpha } from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactoryAlpha("example");
+
+class Person extends sf.objectAlpha("Person", {
+  name: sf.required(sf.string),
+  age: sf.withDefault(sf.required(sf.number), -1),
+  role: sf.withDefault(sf.required(sf.string), "guest"),
+}) {}
+
+// Before: all fields were required
+// const person = new Person({ name: "Alice", age: -1, role: "guest" });
+
+// After: fields with defaults are optional in the constructor
+const person = new Person({ name: "Alice" });
+// person.age === -1
+// person.role === "guest"
+
+// You can still provide values to override the defaults
+const admin = new Person({ name: "Bob", age: 30, role: "admin" });
+```
+
+## Optional Fields with Custom Defaults
+
+[Optional fields](./index.mdx#setting-properties-as-optional) ([`sf.optional`](../../../api/fluid-framework/schemastatics-interface.md#optional-propertysignature)) already default to `undefined`, but `withDefault` allows you to specify a different
+default value:
+
+```typescript
+class Config extends sf.object("Config", {
+  timeout: sf.withDefault(sf.optional(sf.number), 5000),
+  retries: sf.withDefault(sf.optional(sf.number), 3),
+}) {}
+
+// All fields are optional, using custom defaults when not provided
+const config = new Config({});
+// config.timeout === 5000
+// config.retries === 3
+
+const customConfig = new Config({ timeout: 10000 });
+// customConfig.timeout === 10000
+// customConfig.retries === 3
+```
+
+## Value Defaults vs Function Defaults
+
+When you provide a value directly, the data is copied for each use, ensuring each instance is independent:
+
+```typescript
+class Metadata extends sf.object("Metadata", {
+  tags: sf.array(sf.string),
+  version: sf.number,
+}) {}
+
+class Article extends sf.object("Article", {
+  title: sf.required(sf.string),
+
+  // a node is provided directly, it is copied for each use
+  metadata: sf.withDefault(
+    sf.optional(Metadata),
+    new Metadata({ tags: [], version: 1 }),
+  ),
+
+  // also works with arrays
+  authors: sf.withDefault(sf.optional(sf.array(sf.string)), []),
+}) {}
+
+const article1 = new Article({ title: "First" });
+const article2 = new Article({ title: "Second" });
+
+// each article gets its own independent copy
+assert(article1.metadata !== article2.metadata);
+article1.metadata.version = 2; // Doesn't affect article2
+assert(article2.metadata.version === 1);
+```
+
+Alternatively, you can use generator functions to explicitly create new instances:
+
+```typescript
+class Article extends sf.object("Article", {
+  title: sf.required(sf.string),
+
+  // generators are called each time to create a new instance
+  metadata: sf.withDefault(
+    sf.optional(Metadata),
+    () => new Metadata({ tags: [], version: 1 }),
+  ),
+  authors: sf.withDefault(sf.optional(sf.array(sf.string)), () => []),
+}) {}
+```
+
+Insertable object literals, arrays, and map objects can be used in place of node instances in both static defaults
+and generator functions:
+
+```typescript
+class Article extends sf.object("Article", {
+  title: sf.required(sf.string),
+
+  // plain object literal instead of new Metadata(...)
+  metadata: sf.withDefault(sf.optional(Metadata), () => ({
+    tags: [],
+    version: 1,
+  })),
+
+  // plain array instead of new ArrayNode(...)
+  authors: sf.withDefault(sf.optional(sf.array(sf.string)), () => [
+    "anonymous",
+  ]),
+}) {}
+```
+
+### Dynamic Defaults
+
+Generator functions are called each time a new node is created, enabling dynamic defaults:
+
+```typescript
+class Document extends sf.object("Document", {
+  id: sf.withDefault(sf.required(sf.string), () => crypto.randomUUID()),
+  title: sf.required(sf.string),
+}) {}
+
+const doc1 = new Document({ title: "First Document" });
+const doc2 = new Document({ title: "Second Document" });
+// doc1.id !== doc2.id (each gets a unique UUID)
+```
+
+Generator functions also work with primitive types:
+
+```typescript
+let counter = 0;
+
+class GameState extends sf.object("GameState", {
+  playerId: sf.withDefault(
+    sf.required(sf.string),
+    () => `player-${counter++}`,
+  ),
+  score: sf.withDefault(sf.required(sf.number), () =>
+    Math.floor(Math.random() * 100),
+  ),
+  isActive: sf.withDefault(sf.required(sf.boolean), () => counter % 2 === 0),
+}) {}
+```
+
+## Recursive Types
+
+`withDefaultRecursive` is available for use inside [recursive schemas](./index.mdx#recursive-schema). Use `objectRecursiveAlpha` (rather than
+`objectRecursive`) when defining recursive schemas with defaults, as it correctly makes defaulted fields optional in
+the constructor for all field kinds including `requiredRecursive`. It works the same as `withDefault` but is
+necessary to avoid TypeScript's circular reference limitations.
+
+```typescript
+class TreeNode extends sf.objectRecursiveAlpha("TreeNode", {
+  value: sf.number,
+  label: SchemaFactoryAlpha.withDefaultRecursive(
+    sf.optional(sf.string),
+    "untitled",
+  ),
+  child: sf.optionalRecursive([() => TreeNode]),
+}) {}
+
+// `label` is optional in the constructor — the default is used when omitted
+const leaf = new TreeNode({ value: 1 });
+// leaf.label === "untitled"
+
+const root = new TreeNode({ value: 0, label: "root", child: leaf });
+// root.label === "root"
+// root.child.label === "untitled"
+```
+
+:::warning
+Be careful about using the recursive type itself as a default value — this is likely to cause
+infinite recursion at construction time, since creating the default value would trigger the same default again.
+Instead, use a primitive or a separate node type as the default:
+
+```typescript
+const DefaultTag = sf.objectRecursiveAlpha("Tag", {
+  id: sf.number,
+  child: sf.optionalRecursive([() => TreeNode]),
+});
+
+class TreeNode extends sf.objectRecursiveAlpha("TreeNode", {
+  value: sf.number,
+  // ✅ Safe: default is a non-recursive node
+  tag: SchemaFactoryAlpha.withDefaultRecursive(
+    sf.optional(DefaultTag),
+    () => new DefaultTag({ id: 0, child: new DefaultTag({ id: 1 }) }),
+  ),
+  child: sf.optionalRecursive([() => TreeNode]),
+}) {}
+```
+
+The following definition for `child` would cause infinite recursion at construction time:
+
+```typescript
+child: SchemaFactoryAlpha.withDefaultRecursive(
+  sf.optionalRecursive([() => TreeNode]),
+  () => new TreeNode({ value: 0 }),
+);
+```
+
+The infinite recursion can be solved by passing in `undefined` explicitly, but it is
+recommended to not use defaults in this case:
+
+```typescript
+child: SchemaFactoryAlpha.withDefaultRecursive(
+  sf.optionalRecursive([() => TreeNode]),
+  () => new TreeNode({ value: 0, child: undefined }),
+);
+```
+
+:::
+
+## Type Safety
+
+The default value (or the value returned by a generator function) must be of an allowed type for the field. TypeScript
+enforces this at compile time:
+
+```typescript
+// ✅ Valid: number default for number field
+sf.withDefault(sf.optional(sf.number), 8080);
+
+// ✅ Valid: generator returns string for string field
+sf.withDefault(sf.optional(sf.string), () => "localhost");
+
+// ❌ TypeScript error: string default for number field
+sf.withDefault(sf.optional(sf.number), "8080");
+
+// ❌ TypeScript error: generator returns number for string field
+sf.withDefault(sf.optional(sf.string), () => 8080);
+```
+
+## See Also
+
+- [Schema Definition](./index.mdx) — Overview of defining schemas with `SchemaFactory`
+- [Setting Properties as Optional](./index.mdx#setting-properties-as-optional) — Using `sf.optional()` for optional fields
+- [Recursive Schema](./index.mdx#recursive-schema) — Defining recursive types with `objectRecursive()`
+- [`SchemaFactoryAlpha` API](../../../api/fluid-framework/schemafactoryalpha-class) — API reference for `withDefault` and `withDefaultRecursive`
+- [Schema Evolution](../schema-evolution/index.mdx) — Safely updating schemas over time

--- a/docs/docs/data-structures/tree/schema-definition/index.mdx
+++ b/docs/docs/data-structures/tree/schema-definition/index.mdx
@@ -9,10 +9,10 @@ A schema is defined using a `SchemaFactory` object which is created by passing a
 The `SchemaFactory` class defines five primitive data types; `boolean`, `string`, `number`, `null`, and `handle` for specifying leaf nodes.
 It also has three methods for specifying internal nodes; `object()`, `array()`, and `map()`.
 Use the members of the class to build a schema.
-See [defining a schema](../../start/tree-start.mdx#defining-a-schema) for an example.
+See [defining a schema](../../../start/tree-start.mdx#defining-a-schema) for an example.
 
 :::note
-Once you have documents using your schema, see [Schema Evolution](./schema-evolution/index.mdx) for guidance on safely updating your schema over time.
+Once you have documents using your schema, see [Schema Evolution](../schema-evolution/index.mdx) for guidance on safely updating your schema over time.
 :::
 
 ## Object Schema
@@ -87,6 +87,10 @@ Do _not_ override the constructor of types that you derive from objects returned
 
 Create the schema for a group of notes. Note that the `array()` method is called inline, which means that the `Group.notes` property has the notional datatype of an array node. We'll change this to a genuine TypeScript type in the [Array schema](#array-schema) section.
 
+### Default Field Values
+
+Fields can be given default values using the `withDefault` API on `SchemaFactoryAlpha`, making them optional in the constructor even when they are required in the schema. See [Default Field Values](./default-field-values.mdx) for usage and examples.
+
 ```typescript
 class Group extends sf.object('Group', {
     id: sf.string,
@@ -97,7 +101,7 @@ class Group extends sf.object('Group', {
 
 ## Array Schema
 
-The app is going to need the type that is returned from `sf.array(Note)` in multiple places, including outside the context of `SchemaFactory`, so we create a TypeScript type for it as follows. Note that we include a method for adding a new note to the array of notes. The implementation is omitted, but it would wrap the constructor for the `Note` class and one or more methods in the [array node APIs](./reading-and-editing.mdx#array-node-apis).
+The app is going to need the type that is returned from `sf.array(Note)` in multiple places, including outside the context of `SchemaFactory`, so we create a TypeScript type for it as follows. Note that we include a method for adding a new note to the array of notes. The implementation is omitted, but it would wrap the constructor for the `Note` class and one or more methods in the [array node APIs](../reading-and-editing.mdx#array-node-apis).
 
 ```typescript
 class Notes extends sf.array("Notes", Note) {
@@ -141,7 +145,7 @@ class App extends sf.object("App", {
 }) {}
 ```
 
-The final step is to create a configuration object that will be used when a `SharedTree` object is created or loaded. See [creating a tree](../../start/tree-start.mdx#creating-a-tree). The following is an example of doing this.
+The final step is to create a configuration object that will be used when a `SharedTree` object is created or loaded. See [creating a tree](../../../start/tree-start.mdx#creating-a-tree). The following is an example of doing this.
 
 ```typescript
 export const appTreeConfiguration = new TreeViewConfiguration({
@@ -174,6 +178,8 @@ Due to limitations of TypeScript, recursive schema may not produce type errors w
 type _check = ValidateRecursiveSchema<typeof myRecursiveType>;
 ```
 
+To use [default field values](./default-field-values.mdx#recursive-types) within recursive schemas, use `withDefaultRecursive` and `objectRecursiveAlpha`.
+
 ## Setting Properties as Optional
 
 To specify that a property is not required, pass it to the `SchemaFactory.optional()` method inline. The following example shows a schema with an optional property.
@@ -184,6 +190,10 @@ class Proposal = sf.object('Proposal', {
     text: sf.optional(sf.string),
 });
 ```
+
+:::tip
+You can provide custom default values for both required and optional fields using the `withDefault` API on `SchemaFactoryAlpha`. This makes fields optional in the constructor while preserving their schema constraints. See [Default Field Values](./default-field-values.mdx) for details.
+:::
 
 ## Best Practices
 

--- a/docs/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
@@ -82,4 +82,4 @@ If you have a [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snap
 ## See Also
 
 - [`SchemaFactoryBeta.staged()` API](../../../api/fluid-framework/schemafactorybeta-class#staged-property) - API documentation
-- [Schema Definition](../schema-definition.mdx) - How to define schemas
+- [Schema Definition](../schema-definition/index.mdx) - How to define schemas

--- a/docs/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/index.mdx
@@ -6,7 +6,7 @@ sidebar_position: 8
 # Schema Evolution
 
 As your application (or library) grows and evolves, you may need to modify the structure of your [SharedTree](../index.mdx) data.
-SharedTree makes it possible to update your [schemas](../schema-definition.mdx) in ways that allow an app to load or upgrade documents created or edited by earlier versions of the app (see [understanding compatibility](./index.mdx#understanding-compatibility)).
+SharedTree makes it possible to update your [schemas](../schema-definition/index.mdx) in ways that allow an app to load or upgrade documents created or edited by earlier versions of the app (see [understanding compatibility](./index.mdx#understanding-compatibility)).
 To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions, write a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function).
 
 :::note
@@ -196,5 +196,5 @@ Even seemingly simple schema changes (for example, adding a new type of node to 
 
 - [Types of Schema Changes](./types-of-changes.mdx) - Detailed guide on safe vs breaking changes
 - [Rolling Out New Allowed Types](./allowed-types-rollout.mdx) - Guide on using staged to safely add new allowed types
-- [Schema Definition](../schema-definition.mdx) - How to define schemas
+- [Schema Definition](../schema-definition/index.mdx) - How to define schemas
 - [Node Types](../node-types.mdx) - Understanding different node types

--- a/docs/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
+++ b/docs/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
@@ -160,5 +160,5 @@ because those documents will only use the `string` type for the `id` field, whic
 ## See Also
 
 - [Schema Evolution](./index.mdx) - Overview and upgrade process
-- [Schema Definition](../schema-definition.mdx) - How to define schemas
+- [Schema Definition](../schema-definition/index.mdx) - How to define schemas
 - [Node Types](../node-types.mdx) - Understanding different node types

--- a/docs/docs/start/tree-start.mdx
+++ b/docs/docs/start/tree-start.mdx
@@ -69,7 +69,7 @@ const schemaFactory = new SchemaFactory("some-schema-id-prob-a-uuid");
 ```
 
 `SchemaFactory` provides some methods for specifying collection types including `object()`, `array()`, and `map()`; and five primitive data types for specifying leaf nodes: `boolean`, `string`, `number`, `null`, and `handle`.
-See [schema definition](../data-structures/tree/schema-definition.mdx) for more info on the provided types.
+See [schema definition](../data-structures/tree/schema-definition/index.mdx) for more info on the provided types.
 
 You can define a schema by extending one of the built-in object types.
 As an example, let's write a schema for a todo list:
@@ -197,7 +197,7 @@ class TodoList extends schemaFactory.object("TodoList", {
 ```
 
 These methods are designed to merge well in collaborative settings without you having to think much about it.
-See [schema definition](../data-structures/tree/schema-definition.mdx) for more details on the built-in editing methods.
+See [schema definition](../data-structures/tree/schema-definition/index.mdx) for more details on the built-in editing methods.
 You can also read more about how these editing operations work in collaborative settings [here](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/user-facing/merge-semantics.md).
 
 ### Grouping Edits into Transactions


### PR DESCRIPTION
## Description

Converts the schema definition page into a section and adds a new default field values page under it. The docs are mainly the same as what was published to the changelog when the API was released. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
