### PR TITLE
feat(codespace): overhaul AI-enabled codespace startup experience

### DIFF
--- a/.claude/skills/fluid-pr/SKILL.md
+++ b/.claude/skills/fluid-pr/SKILL.md
@@ -10,8 +10,8 @@ description: Use when creating a pull request in the Fluid Framework repo. Compo
 
 1. Confirm you are NOT on `main` or any release branch. If you are, stop and tell the user: you cannot create a PR from a protected branch — they need to create or switch to a feature branch first.
 2. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead.
-3. Compose the PR title following Fluid Framework conventions using the `fluid-pr-guide` skill.
-4. Compose the PR body following the official template using the `fluid-pr-guide` skill.
+3. **Load the `fluid-pr-guide` skill NOW** (via the Skill tool) before composing anything. It contains the title conventions, body template, and section guidance you need. Do NOT skip this step or rely on memory.
+4. Using the loaded `fluid-pr-guide`, compose the PR title and body following its conventions and template.
 5. Print the proposed title and body as text, then immediately use the `AskUserQuestion` tool to let the user choose what to do next. Use these exact options:
    - "Create PR" — Push the branch and open the pull request
    - "Create draft PR" — Push the branch and open a draft pull request

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -6,14 +6,16 @@ This codespace is pre-configured for AI-agent-assisted development of the Fluid 
 
 ## First-time Setup
 
-Agency **must** be installed manually after the Codespace starts. Run `pnpm install:agency` in the terminal — this requires Azure authentication and will open a browser window for sign-in.
+Agency is installed automatically the first time you run `dev`, `claude`, or any agent alias - watch for a browser authentication popup.
+If automatic installation fails, you can install agency manually via `pnpm install:agency`.
 
 > [!NOTE]
-> `pnpm install:agency` is supported in **VS Code** (desktop or SSH). It may not work in a
-> browser-based Codespace because the OAuth redirect requires a local browser and authentication may
-> not complete correctly.
+> Agency installation is supported in **VS Code** (desktop or SSH).
+> It may not work in a browser-based Codespace because the OAuth redirect requires a local browser and authentication may not complete correctly.
 
-Then open a **new terminal** for the agent aliases to be available.
+> [!TIP]
+> After creating a new AI-enabled Codespace you may be prompted to authenticate several times.
+> It may seem excessive, but is expected - just keep clicking through each prompt until they stop.
 
 ## Quick Start
 
@@ -37,21 +39,31 @@ These aliases are available in all terminal sessions (after installing agency):
 
 | Alias | Command | Purpose |
 |---|---|---|
-| `claude` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework'` | Default Claude Code model |
-| `haiku` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model haiku` | Fastest, cheapest option |
-| `sonnet` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model sonnet` | Balanced capabilities |
-| `opus` | `repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model opus` | Most capable model |
-| `nori` | `repoverlay switch --copy nori && agency claude --mcp 'ado --org fluidframework'` | Switch to nori overlay and launch Claude |
+| `dev` | `repoverlay switch --copy nori && agency claude ... -- --model opus` | Launch Claude optimized for feature work and debugging |
+| `claude` | `repoverlay switch --copy ff-claude && agency claude ... -- --model opus` | General purpose Claude Code agent |
 
 ### Copilot
 
 | Alias | Command | Purpose |
 |---|---|---|
 | `copilot` | `agency copilot` | Standard GitHub Copilot |
-| `copilot-ado` | `agency copilot --mcp 'ado --org fluidframework'` | Azure DevOps integration |
-| `copilot-kusto` | `agency copilot --mcp 'kusto ...'` | Telemetry queries |
-| `copilot-oce` | `repoverlay switch --copy ff-oce && copilot -- --agent ff-oce` | On-Call Engineer workflows |
-| `copilot-work` | `agency copilot --mcp 'workiq'` | WorkIQ integration |
+| `oce` | `repoverlay switch --copy ff-oce && copilot -- --agent ff-oce` | On-Call Engineer workflows |
+
+### Custom MCP Servers
+
+The built-in aliases include at least ADO, WorkIQ, and EngHub MCP servers.
+You can also launch an agent with your own combination of MCP servers using the `--mcp` flag.
+Stack as many as you need (and watch for browser authentication popups):
+
+```bash
+# Claude with ADO and Kusto
+agency claude --mcp 'ado --org fluidframework' --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'
+
+# Copilot with WorkIQ
+agency copilot --mcp 'workiq'
+```
+
+> Run `agency mcp --help` to see all available MCP servers and their options.
 
 ### Utility
 

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -47,7 +47,7 @@ These aliases are available in all terminal sessions (after installing agency):
 | Alias | Command | Purpose |
 |---|---|---|
 | `copilot` | `agency copilot` | Standard GitHub Copilot |
-| `oce` | `repoverlay switch --copy ff-oce && copilot -- --agent ff-oce` | On-Call Engineer workflows |
+| `oce` | `repoverlay switch --copy ff-oce && agency copilot -- --agent ff-oce` | On-Call Engineer workflows |
 
 ### Custom MCP Servers
 

--- a/.devcontainer/ai-agent/first-run-notice.txt
+++ b/.devcontainer/ai-agent/first-run-notice.txt
@@ -1,35 +1,29 @@
-Welcome to Fluid Framework's AI-enabled codespace!
+ _________   _____       __    __    _____   ______       ________    ________
+(_   _____) (_   _)      ) )  ( (   (_   _) (_  __ \     /_______/\  /_______/\
+  ) (___      | |       ( (    ) )    | |     ) ) \ \    \::: _  \ \ \__.::._\/
+ (   ___)     | |        ) )  ( (     | |    ( (   ) )    \::(_)  \ \   \::\ \
+  ) (         | |   __  ( (    ) )    | |     ) )  ) )     \:: __  \ \  _\::\ \__
+ (   )      __| |___) )  ) \__/ (    _| |__  / /__/ /       \:.\ \  \ \/__\::\__/\
+  \_/       \________/   \______/   /_____( (______/         \__\/\__\/\________\/
 
-This codespace is configured for AI-agent-assisted workflows with 32 CPUs and
-64 GB RAM. It includes additional CLI tooling (GitHub CLI, SSH, agency, repoverlay).
+GET STARTED: Run one of the commands below:
+  dev                    Launch an agent for feature work/testing/debugging
+  claude                 Launch an agent for general purpose work
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!  To use AI agents, run the following command first:                        !!
-!!                                                                            !!
-!!      pnpm install:agency                                                   !!
-!!                                                                            !!
-!!  Then open a NEW terminal for the agent aliases to be available.           !!
-!!                                                                            !!
-!!  NOTE: pnpm install:agency requires VS Code (desktop or SSH).              !!
-!!  It may not work in a browser-based Codespace.                             !!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Other agent aliases:
+  copilot                Launch GitHub Copilot via agency
+  oce                    Launch Copilot for on-call engineer workflows
 
-AI agent aliases (provided by agency):
-  claude                Launch Claude Code via agency
-  haiku / sonnet / opus Launch Claude with a specific model
-  nori                  Switch to nori overlay and launch Claude
-                        Recommended for feature work, debugging, and bug fixing.
-  copilot               Launch GitHub Copilot via agency
-  copilot-ado           Copilot with Azure DevOps MCP
-  copilot-kusto         Copilot with Kusto MCP
-  copilot-oce           Copilot for On-Call Engineer workflows
-  copilot-work          Copilot with WorkIQ MCP
+Choose your own MCP servers:
+  Use --mcp to launch an agent with specific MCP servers. Stack as many as you need:
+    agency claude --mcp 'ado --org fluidframework' --mcp 'kusto --service-uri ...'
+    agency copilot --mcp 'workiq'
+  Run `agency mcp --help` to see all available MCP servers.
 
-Getting started:
-  pnpm install:agency   Install agency (required for AI agents)
-  pnpm install          Install all dependencies
-  pnpm build            Build all packages
-  pnpm test             Run tests
-  pnpm fluid-build .    Build only the current package and its dependencies
+Other commands:
+  pnpm install           Install all dependencies
+  pnpm build             Build all packages
+  pnpm test              Run tests
+  pnpm fluid-build .     Build only the current package and its dependencies
 
 More information on this codespace: https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -11,7 +11,11 @@ _ensure_agency() {
 	if [[ ! -x "$AGENCY_DIR/agency" ]]; then
 		echo "Agency is not installed. Installing now..."
 		echo "  A browser window will open for authentication!"
-		pnpm install:agency
+		pnpm install:agency || return 1
+	fi
+	if [[ ! -x "$AGENCY_DIR/agency" ]]; then
+		echo "Agency is still not available at $AGENCY_DIR/agency after installation." >&2
+		return 1
 	fi
 	# Always ensure agency is in PATH (whether just installed or pre-existing).
 	if [[ ":$PATH:" != *":$AGENCY_DIR:"* ]]; then
@@ -22,6 +26,6 @@ _ensure_agency() {
 alias claude="_ensure_agency && repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' --mcp 'workiq' --mcp 'enghub' -- --model opus"
 alias dev="_ensure_agency && repoverlay switch --copy nori && agency claude --mcp 'ado --org fluidframework' --mcp 'workiq' --mcp 'enghub' -- --model opus"
 alias copilot="_ensure_agency && agency copilot"
-alias oce="_ensure_agency && repoverlay switch --copy ff-oce && copilot -- --agent ff-oce"
+alias oce="_ensure_agency && repoverlay switch --copy ff-oce && agency copilot -- --agent ff-oce"
 
 alias ai-reset="repoverlay remove --all"

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -5,17 +5,23 @@
 # shopt -s expand_aliases is bash-only; zsh expands aliases by default in interactive shells.
 [ -n "${BASH_VERSION:-}" ] && shopt -s expand_aliases
 
-alias claude="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework'"
-alias haiku="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model haiku"
-alias sonnet="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model sonnet"
-alias opus="repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' -- --model opus"
+# Ensures agency is installed and in PATH; installs it (via the repo-approved pnpm script) if not.
+_ensure_agency() {
+	local AGENCY_DIR="$HOME/.config/agency/CurrentVersion"
+	if [[ ! -x "$AGENCY_DIR/agency" ]]; then
+		echo "Agency is not installed. Installing now..."
+		echo "  A browser window will open for authentication!"
+		pnpm install:agency
+	fi
+	# Always ensure agency is in PATH (whether just installed or pre-existing).
+	if [[ ":$PATH:" != *":$AGENCY_DIR:"* ]]; then
+		export PATH="$AGENCY_DIR:$PATH"
+	fi
+}
 
-alias nori="repoverlay switch --copy nori && agency claude --mcp 'ado --org fluidframework'"
-
-alias copilot="agency copilot"
-alias copilot-ado="agency copilot --mcp 'ado --org fluidframework'"
-alias copilot-kusto="agency copilot --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'"
-alias copilot-oce="repoverlay switch --copy ff-oce && copilot -- --agent ff-oce"
-alias copilot-work="agency copilot --mcp 'workiq'"
+alias claude="_ensure_agency && repoverlay switch --copy ff-claude && agency claude --mcp 'ado --org fluidframework' --mcp 'workiq' --mcp 'enghub' -- --model opus"
+alias dev="_ensure_agency && repoverlay switch --copy nori && agency claude --mcp 'ado --org fluidframework' --mcp 'workiq' --mcp 'enghub' -- --model opus"
+alias copilot="_ensure_agency && agency copilot"
+alias oce="_ensure_agency && repoverlay switch --copy ff-oce && copilot -- --agent ff-oce"
 
 alias ai-reset="repoverlay remove --all"


### PR DESCRIPTION
## Description

Overhauls the AI-enabled codespace first-run experience:

- **Auto-install agency**: Adds `_ensure_agency` helper to shell aliases that automatically installs agency and ensures it's in PATH on first use — no manual `pnpm install:agency` step needed.
- **Simplified aliases**: Consolidates from 11 aliases down to 5: `dev`, `claude`, `copilot`, `oce`, `ai-reset`.
- **MCP servers**: Claude aliases (`dev`, `claude`) now include ADO, WorkIQ, and EngHub MCP servers by default.
- **First-run notice**: Replaces the old install-instructions banner with ASCII art header and a streamlined command list, including guidance on custom MCP server usage.
- **GETTING_STARTED.md**: Updated to reflect auto-install, new alias set, auth popup warning, and a custom MCP servers section.
- Updated PR skill to more strongly ask to use the pr formatting instructions

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Testing: create a fresh AI-enabled codespace from this branch and verify the first-run notice displays correctly, then run `dev` or `claude` to confirm auto-install and agent launch work end-to-end.