### PR TITLE
fix(tree): Don't apply nodeInDocument constraint to cell deletion when part of column deletion

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -792,7 +792,12 @@ export namespace System_TableSchema {
 
 							// First, remove all cells that correspond to each column from each row:
 							for (const column of columnsToRemove) {
-								this.#removeCells(column);
+								for (const row of this.table.rows) {
+									// TypeScript is unable to narrow the row type correctly here, hence the cast.
+									// See: https://github.com/microsoft/TypeScript/issues/52144
+									// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- This is currently how Record node entries are deleted.
+									delete (row as RowValueInternalType).cells[column.id];
+								}
 							}
 
 							// Second, remove the column nodes:
@@ -830,10 +835,8 @@ export namespace System_TableSchema {
 								for (const row of this.table.rows) {
 									// TypeScript is unable to narrow the row type correctly here, hence the cast.
 									// See: https://github.com/microsoft/TypeScript/issues/52144
-									this.removeCell({
-										column: columnToRemove,
-										row: row as RowValueType,
-									});
+									// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- This is currently how Record node entries are deleted.
+									delete (row as RowValueInternalType).cells[columnToRemove.id];
 								}
 
 								// We have already validated that all of the columns exist above, so this is safe.
@@ -930,37 +933,21 @@ export namespace System_TableSchema {
 
 				this.#applyEditsInBatch({
 					applyEdits: () => {
-						// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+						// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- This is currently how Record node entries are deleted.
 						delete row.cells[column.id];
 					},
-					// Relevant invariant: each cell corresponds to an existing row and column
-					// Prevents cell leaks from concurrently removed columns in earlier-sequenced edits when this cell removal is reverted.
-					// Example scenario: Client A removes a cell, then Client B removes the column for that cell.
-					// If A's cell removal is later reverted, the cell would be restored but B's column removal means there's no column for it.
-					// This constraint on revert ensures the column still exists, ensuring restored cells correspond to existing columns.
-					preconditionsOnRevert: [
-						{
-							type: "nodeInDocument",
-							node: column,
-						},
-					],
+					// Relevant invariant: each cell corresponds to an existing row and column.
+					// Prevents cell leaks from concurrently removed columns in earlier-sequenced
+					// edits when this cell removal is reverted.
+					// Example scenario: Client A removes a cell, then Client B removes the column
+					// for that cell. If A's cell removal is later reverted, the cell would be
+					// restored but B's column removal means there's no column for it.
+					// This constraint on revert ensures the column still exists, so restored cells
+					// always correspond to existing columns.
+					preconditionsOnRevert: [{ type: "nodeInDocument", node: column }],
 				});
 
 				return cell;
-			}
-
-			/**
-			 * Removes the cell corresponding with the specified column from each row in the table.
-			 */
-			#removeCells(column: ColumnValueType): void {
-				for (const row of this.table.rows) {
-					// TypeScript is unable to narrow the row type correctly here, hence the cast.
-					// See: https://github.com/microsoft/TypeScript/issues/52144
-					this.removeCell({
-						column,
-						row: row as RowValueType,
-					});
-				}
 			}
 
 			/**

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -936,14 +936,11 @@ export namespace System_TableSchema {
 						// eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- This is currently how Record node entries are deleted.
 						delete row.cells[column.id];
 					},
-					// Relevant invariant: each cell corresponds to an existing row and column.
-					// Prevents cell leaks from concurrently removed columns in earlier-sequenced
-					// edits when this cell removal is reverted.
-					// Example scenario: Client A removes a cell, then Client B removes the column
-					// for that cell. If A's cell removal is later reverted, the cell would be
-					// restored but B's column removal means there's no column for it.
-					// This constraint on revert ensures the column still exists, so restored cells
-					// always correspond to existing columns.
+					// Relevant invariant: each cell corresponds to an existing row and column
+					// Prevents cell leaks from concurrently removed columns in earlier-sequenced edits when this cell removal is reverted.
+					// Example scenario: Client A removes a cell, then Client B removes the column for that cell.
+					// If A's cell removal is later reverted, the cell would be restored but B's column removal means there's no column for it.
+					// This constraint on revert ensures the column still exists, ensuring restored cells correspond to existing columns.
 					preconditionsOnRevert: [{ type: "nodeInDocument", node: column }],
 				});
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -2313,6 +2313,194 @@ describe("TableFactory unit tests", () => {
 
 			unsubscribe();
 		});
+
+		// removeColumns internally calls removeCell for each populated cell in every row.
+		// Each removeCell call creates its own nested transaction carrying:
+		//   preconditionsOnRevert: [{ type: "nodeInDocument", node: column }]
+		// That constraint means: "when reverting this cell removal, the column must still
+		// be in the tree."
+		//
+		// This is correct for the concurrent case (you don't want to restore a cell whose
+		// column was removed by a peer), but it creates a problem for same-branch sequential
+		// undo: when the undo of removeColumns is rebased over any subsequent commit, the
+		// nodeInDocument check fires because the column is (correctly) absent at that point,
+		// and the undo is silently dropped.
+		//
+		// The key conditions required to hit this bug:
+		//   1. The removed column has at least one populated cell (triggering inner removeCell
+		//      transactions with nodeInDocument preconditionsOnRevert).
+		//   2. At least one other commit has been made after the removeColumns commit (causing
+		//      the undo to be rebased rather than applied directly).
+		//
+		// The tests below cover several combinations of interleaved operations to verify the
+		// undo works (or documents the known failure if it does not).
+		it("removeColumns (with cells) → insertRows → undo insertRows → undo removeColumns", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [new Column({ id: "column-0", props: {} })],
+					rows: [
+						new Row({
+							id: "row-0",
+							cells: { "column-0": { value: "Hello" } },
+						}),
+					],
+				}),
+			);
+
+			// Remove the column (also removes row-0's cell).
+			view.root.removeColumns(["column-0"]);
+			assert.equal(view.root.columns.length, 0);
+
+			// Insert an unrelated row after the column removal.
+			// This creates a subsequent commit that will force the removeColumns undo to rebase.
+			view.root.insertRows({ rows: [{ id: "row-1", cells: {} }] });
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo insertRows
+			assert.equal(view.root.rows.length, 1, "row-1 should have been removed");
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo removeColumns
+			assert.equal(view.root.columns.length, 1, "column-0 should be restored");
+			assert.equal(
+				view.root.getCell({ row: "row-0", column: "column-0" })?.value,
+				"Hello",
+				"cell should be restored along with the column",
+			);
+
+			unsubscribe();
+		});
+
+		// Same root cause as the insertRows variant above; any subsequent commit triggers
+		// the bug, not just insertRows specifically.
+		it("removeColumns (with cells) → insertColumns → undo insertColumns → undo removeColumns", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [new Column({ id: "column-0", props: {} })],
+					rows: [
+						new Row({
+							id: "row-0",
+							cells: { "column-0": { value: "Hello" } },
+						}),
+					],
+				}),
+			);
+
+			view.root.removeColumns(["column-0"]);
+			assert.equal(view.root.columns.length, 0);
+
+			// Insert an unrelated column to create the subsequent commit.
+			view.root.insertColumns({ columns: [{ id: "column-1", props: {} }] });
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo insertColumns
+			assert.equal(view.root.columns.length, 0, "column-1 should have been removed");
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo removeColumns
+			assert.equal(view.root.columns.length, 1, "column-0 should be restored");
+			assert.equal(
+				view.root.getCell({ row: "row-0", column: "column-0" })?.value,
+				"Hello",
+				"cell should be restored along with the column",
+			);
+
+			unsubscribe();
+		});
+
+		// Same root cause; a setCell on a different column is the subsequent commit.
+		it("removeColumns (with cells) → setCell → undo setCell → undo removeColumns", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [
+						new Column({ id: "column-0", props: {} }),
+						new Column({ id: "column-1", props: {} }),
+					],
+					rows: [
+						new Row({
+							id: "row-0",
+							cells: { "column-0": { value: "Hello" } },
+						}),
+					],
+				}),
+			);
+
+			view.root.removeColumns(["column-0"]);
+			assert.equal(view.root.columns.length, 1);
+
+			// Set a cell in the unrelated column to create the subsequent commit.
+			view.root.setCell({
+				key: { row: "row-0", column: "column-1" },
+				cell: { value: "World" },
+			});
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo setCell
+			assert.equal(
+				view.root.getCell({ row: "row-0", column: "column-1" }),
+				undefined,
+				"cell in column-1 should have been removed",
+			);
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo removeColumns
+			assert.equal(view.root.columns.length, 2, "both columns should be restored");
+			assert.equal(
+				view.root.getCell({ row: "row-0", column: "column-0" })?.value,
+				"Hello",
+				"cell should be restored along with column-0",
+			);
+
+			unsubscribe();
+		});
 	});
 
 	describe("Prevents orphan cells", () => {

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -2314,7 +2314,9 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		it("remove column (with cells) → removeColumn → undo → undo", () => {
+		// The below tests are regression tests which reproduce a bug where removing columns with associated cells caused constraints to be incorrectly applied. This caused subsequent undo operations to be dropped.
+		// The existence of cells associated with the first column being removed is what caused the constraints to be applied, so we need to test both with and without cells to ensure the bug is fully fixed and doesn't regress.
+		it("remove column (with cells) → remove column → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({
@@ -2369,9 +2371,7 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		// The below tests are regression tests reproing a bug where removing columns with associated cells caused constraints to be incorrectly applied and causing subsequent undo operations to be dropped.
-		// The existence of cells associated with the first column being removed is what caused the constraints to be applied, so we need to test both with and without cells to ensure the bug is fully fixed and doesn't regress.
-		it("removeColumns (with cells) → insertRows → undo insertRows → undo removeColumns", () => {
+		it("remove column (with cells) → insert row → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({
@@ -2424,58 +2424,7 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		it("removeColumns (with cells) → insertColumns → undo insertColumns → undo removeColumns", () => {
-			const provider = new TestTreeProviderLite(
-				1,
-				configuredSharedTree({
-					jsonValidator: FormatValidatorBasic,
-					minVersionForCollab: FluidClientVersion.v2_80,
-				}).getFactory(),
-			);
-			const config = new TreeViewConfiguration({
-				schema: Table,
-				enableSchemaValidation: true,
-			});
-			const tree = provider.trees[0];
-			const view = asAlpha(tree.viewWith(config));
-			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
-			view.initialize(
-				Table.create({
-					columns: [new Column({ id: "column-0", props: {} })],
-					rows: [
-						new Row({
-							id: "row-0",
-							cells: { "column-0": { value: "Hello" } },
-						}),
-					],
-				}),
-			);
-
-			view.root.removeColumns(["column-0"]);
-			assert.equal(view.root.columns.length, 0);
-
-			// Insert an unrelated column to create the subsequent commit.
-			view.root.insertColumns({ columns: [{ id: "column-1", props: {} }] });
-
-			let revertible = undoStack.pop();
-			assert(revertible !== undefined, "Missing revertible");
-			revertible.revert(); // undo insertColumns
-			assert.equal(view.root.columns.length, 0, "column-1 should have been removed");
-
-			revertible = undoStack.pop();
-			assert(revertible !== undefined, "Missing revertible");
-			revertible.revert(); // undo removeColumns
-			assert.equal(view.root.columns.length, 1, "column-0 should be restored");
-			assert.equal(
-				view.root.getCell({ row: "row-0", column: "column-0" })?.value,
-				"Hello",
-				"cell should be restored along with the column",
-			);
-
-			unsubscribe();
-		});
-
-		it("removeColumns (with cells) → setCell → undo setCell → undo removeColumns", () => {
+		it("remove column (with cells) → set cell → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -2043,6 +2043,278 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
+	describe("Undo/redo", () => {
+		it("multiple column inserts should be undoable if no concurrent modifications occurred", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [],
+					rows: [{ id: "row-0", cells: {} }],
+				}),
+			);
+
+			view.root.insertColumns({
+				columns: [{ id: "column-0", props: {} }],
+			});
+
+			view.root.insertColumns({
+				columns: [{ id: "column-1", props: {} }],
+			});
+
+			view.root.insertColumns({
+				columns: [{ id: "column-2", props: {} }],
+			});
+
+			// No changes happened concurrently, so we should be able to revert all of these changes.
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			assert.equal(view.root.columns.length, 3);
+			revertible.revert();
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			assert.equal(view.root.columns.length, 2);
+			revertible.revert();
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			assert.equal(view.root.columns.length, 1);
+			revertible.revert();
+
+			assert.equal(view.root.columns.length, 0);
+
+			unsubscribe();
+		});
+
+		it("multiple row inserts should be undoable if no concurrent modifications occurred", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(Table.create({ columns: [], rows: [] }));
+
+			view.root.insertRows({ rows: [{ id: "row-0", cells: {} }] });
+			view.root.insertRows({ rows: [{ id: "row-1", cells: {} }] });
+			assert.equal(view.root.rows.length, 2);
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.rows.length, 1);
+			assert.equal(view.root.rows[0].id, "row-0");
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.rows.length, 0);
+
+			unsubscribe();
+		});
+
+		it("remove column, remove column, undo, undo", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [
+						new Column({ id: "column-0", props: {} }),
+						new Column({ id: "column-1", props: {} }),
+					],
+					rows: [],
+				}),
+			);
+
+			view.root.removeColumns(["column-0"]);
+			assert.equal(view.root.columns.length, 1);
+			assert.equal(view.root.columns[0].id, "column-1");
+
+			view.root.removeColumns(["column-1"]);
+			assert.equal(view.root.columns.length, 0);
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.columns.length, 1);
+			assert.equal(view.root.columns[0].id, "column-1");
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.columns.length, 2);
+
+			unsubscribe();
+		});
+
+		it("remove row, remove row, undo, undo", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [],
+					rows: [new Row({ id: "row-0", cells: {} }), new Row({ id: "row-1", cells: {} })],
+				}),
+			);
+
+			view.root.removeRows(["row-0"]);
+			assert.equal(view.root.rows.length, 1);
+			assert.equal(view.root.rows[0].id, "row-1");
+
+			view.root.removeRows(["row-1"]);
+			assert.equal(view.root.rows.length, 0);
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.rows.length, 1);
+			assert.equal(view.root.rows[0].id, "row-1");
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.rows.length, 2);
+
+			unsubscribe();
+		});
+
+		it("insert column, remove different column, undo, undo", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [new Column({ id: "column-a", props: {} })],
+					rows: [],
+				}),
+			);
+
+			view.root.insertColumns({ columns: [{ id: "column-b", props: {} }] });
+			assert.equal(view.root.columns.length, 2);
+
+			view.root.removeColumns(["column-a"]);
+			assert.equal(view.root.columns.length, 1);
+			assert.equal(view.root.columns[0].id, "column-b");
+
+			// Undo the removal
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.columns.length, 2);
+
+			// Undo the insertion
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.columns.length, 1);
+			assert.equal(view.root.columns[0].id, "column-a");
+
+			unsubscribe();
+		});
+
+		it("insert row, remove different row, undo, undo", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [],
+					rows: [new Row({ id: "row-a", cells: {} })],
+				}),
+			);
+
+			view.root.insertRows({ rows: [{ id: "row-b", cells: {} }] });
+			assert.equal(view.root.rows.length, 2);
+
+			view.root.removeRows(["row-a"]);
+			assert.equal(view.root.rows.length, 1);
+			assert.equal(view.root.rows[0].id, "row-b");
+
+			// Undo the removal
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.rows.length, 2);
+
+			// Undo the insertion
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert();
+			assert.equal(view.root.rows.length, 1);
+			assert.equal(view.root.rows[0].id, "row-a");
+
+			unsubscribe();
+		});
+	});
+
 	describe("Prevents orphan cells", () => {
 		it("column removal does not orphan cells from concurrently added rows", () => {
 			// Create a provider with minimum version support for noChange constraints
@@ -2504,62 +2776,6 @@ describe("TableFactory unit tests", () => {
 			fork.rebaseOnto(view);
 			assert.equal(branchTable.columns.length, 0);
 			assert.equal(branchTable.getCell({ row: "row-0", column: "column-0" }), undefined);
-
-			unsubscribe();
-		});
-
-		it("multiple inserts should be undoable if no concurrent modifications occurred", () => {
-			const provider = new TestTreeProviderLite(
-				1,
-				configuredSharedTree({
-					jsonValidator: FormatValidatorBasic,
-					minVersionForCollab: FluidClientVersion.v2_80,
-				}).getFactory(),
-			);
-
-			const config = new TreeViewConfiguration({
-				schema: Table,
-				enableSchemaValidation: true,
-			});
-			const tree = provider.trees[0];
-			const view = asAlpha(tree.viewWith(config));
-			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
-			view.initialize(
-				Table.create({
-					columns: [],
-					rows: [{ id: "row-0", cells: {} }],
-				}),
-			);
-
-			view.root.insertColumns({
-				columns: [{ id: "column-0", props: {} }],
-			});
-
-			view.root.insertColumns({
-				columns: [{ id: "column-1", props: {} }],
-			});
-
-			view.root.insertColumns({
-				columns: [{ id: "column-2", props: {} }],
-			});
-
-			// No changes happened concurrently, so we should be able to revert all of these changes.
-			let revertible = undoStack.pop();
-			assert(revertible !== undefined, "Missing revertible");
-			assert.equal(view.root.columns.length, 3);
-			revertible.revert();
-
-			revertible = undoStack.pop();
-			assert(revertible !== undefined, "Missing revertible");
-			assert.equal(view.root.columns.length, 2);
-			revertible.revert();
-
-			revertible = undoStack.pop();
-			assert(revertible !== undefined, "Missing revertible");
-			assert.equal(view.root.columns.length, 1);
-			revertible.revert();
-
-			assert.equal(view.root.columns.length, 0);
 
 			unsubscribe();
 		});

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -2135,7 +2135,7 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		it("remove column, remove column, undo, undo", () => {
+		it("remove column → remove column → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({
@@ -2181,7 +2181,7 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		it("remove row, remove row, undo, undo", () => {
+		it("remove row → remove row → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({
@@ -2224,7 +2224,7 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		it("insert column, remove different column, undo, undo", () => {
+		it("insert column → remove different column → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({
@@ -2269,7 +2269,7 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		it("insert row, remove different row, undo, undo", () => {
+		it("insert row → remove different row → undo → undo", () => {
 			const provider = new TestTreeProviderLite(
 				1,
 				configuredSharedTree({
@@ -2369,26 +2369,8 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		// removeColumns internally calls removeCell for each populated cell in every row.
-		// Each removeCell call creates its own nested transaction carrying:
-		//   preconditionsOnRevert: [{ type: "nodeInDocument", node: column }]
-		// That constraint means: "when reverting this cell removal, the column must still
-		// be in the tree."
-		//
-		// This is correct for the concurrent case (you don't want to restore a cell whose
-		// column was removed by a peer), but it creates a problem for same-branch sequential
-		// undo: when the undo of removeColumns is rebased over any subsequent commit, the
-		// nodeInDocument check fires because the column is (correctly) absent at that point,
-		// and the undo is silently dropped.
-		//
-		// The key conditions required to hit this bug:
-		//   1. The removed column has at least one populated cell (triggering inner removeCell
-		//      transactions with nodeInDocument preconditionsOnRevert).
-		//   2. At least one other commit has been made after the removeColumns commit (causing
-		//      the undo to be rebased rather than applied directly).
-		//
-		// The tests below cover several combinations of interleaved operations to verify the
-		// undo works (or documents the known failure if it does not).
+		// The below tests are regression tests reproing a bug where removing columns with associated cells caused constraints to be incorrectly applied and causing subsequent undo operations to be dropped.
+		// The existence of cells associated with the first column being removed is what caused the constraints to be applied, so we need to test both with and without cells to ensure the bug is fully fixed and doesn't regress.
 		it("removeColumns (with cells) → insertRows → undo insertRows → undo removeColumns", () => {
 			const provider = new TestTreeProviderLite(
 				1,
@@ -2442,8 +2424,6 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		// Same root cause as the insertRows variant above; any subsequent commit triggers
-		// the bug, not just insertRows specifically.
 		it("removeColumns (with cells) → insertColumns → undo insertColumns → undo removeColumns", () => {
 			const provider = new TestTreeProviderLite(
 				1,
@@ -2495,7 +2475,6 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
-		// Same root cause; a setCell on a different column is the subsequent commit.
 		it("removeColumns (with cells) → setCell → undo setCell → undo removeColumns", () => {
 			const provider = new TestTreeProviderLite(
 				1,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -2314,6 +2314,61 @@ describe("TableFactory unit tests", () => {
 			unsubscribe();
 		});
 
+		it("remove column (with cells) → removeColumn → undo → undo", () => {
+			const provider = new TestTreeProviderLite(
+				1,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					minVersionForCollab: FluidClientVersion.v2_80,
+				}).getFactory(),
+			);
+			const config = new TreeViewConfiguration({
+				schema: Table,
+				enableSchemaValidation: true,
+			});
+			const tree = provider.trees[0];
+			const view = asAlpha(tree.viewWith(config));
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+			view.initialize(
+				Table.create({
+					columns: [
+						new Column({ id: "column-0", props: {} }),
+						new Column({ id: "column-1", props: {} }),
+					],
+					rows: [
+						new Row({
+							id: "row-0",
+							cells: { "column-0": { value: "Hello" } },
+						}),
+					],
+				}),
+			);
+
+			// Remove column-0 (also removes corresponding cell in row-0).
+			view.root.removeColumns(["column-0"]);
+			assert.equal(view.root.columns.length, 1);
+
+			// Remove column-1
+			view.root.removeColumns(["column-1"]);
+
+			let revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo removeColumns
+			assert.equal(view.root.columns.length, 1, "column-1 should have been restored");
+
+			revertible = undoStack.pop();
+			assert(revertible !== undefined, "Missing revertible");
+			revertible.revert(); // undo removeColumns
+			assert.equal(view.root.columns.length, 2, "column-0 should be restored");
+			assert.equal(
+				view.root.getCell({ row: "row-0", column: "column-0" })?.value,
+				"Hello",
+				"cell should be restored along with the column",
+			);
+
+			unsubscribe();
+		});
+
 		// removeColumns internally calls removeCell for each populated cell in every row.
 		// Each removeCell call creates its own nested transaction carrying:
 		//   preconditionsOnRevert: [{ type: "nodeInDocument", node: column }]


### PR DESCRIPTION
There is a known issue with nested transactions that causes constraints to not compose correctly ([AB#55763](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/55763)).

In the case of table cell removal, we apply an on-revert constraint requiring the associated column still exist in the document in order to restore the cell. This prevents cells from becoming "orphaned" nodes within their row. This is important for individual cell removal via the `removeCell` API.

But when deleting cells as a part of a column deletion operation (via the `removeColumns` API), applying this on-revert constraint currently causes reverts to be dropped, despite the fact that the associated column would be restored as a part of the same transaction.

To mitigate this, cell deletion has been refactored to not apply this on-revert constraint when occurring as part of column deletion. This is fundamentally safe, and also likely yields a performance win, since we no longer need to incur needless constraint validation overhead.