### PR TITLE
fix(codespace): broaden fluid-pr-guide skill description for better trigger matching

### DIFF
--- a/.claude/skills/fluid-pr-guide/SKILL.md
+++ b/.claude/skills/fluid-pr-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fluid-pr-guide
-description: Use when composing or reviewing a PR in Fluid Framework — provides title style, body template, and section guidance.
+description: Use when composing, writing, drafting, or reviewing a PR title, PR description, or PR body in Fluid Framework — provides title style, body template, and section guidance.
 ---
 
 There is no enforced title policy in this repo. Two styles appear in roughly equal proportion — use whichever fits the change. Do not mix them (e.g., don't add a `fix:` prefix to an otherwise plain-imperative title just because it's a bug fix).


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

The `fluid-pr-guide` skill description only mentioned "composing or reviewing a PR", which was too narrow for Claude Code to auto-detect when a user asks to write, draft, or review a PR title or description. This adds explicit trigger phrases (`writing`, `drafting`, `PR title`, `PR description`, `PR body`) so the skill loads reliably in those contexts.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).