### PR TITLE
Remove feature flag SkipFailingIncorrectSummary after it has been rolled out.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4619,7 +4619,8 @@ export class ContainerRuntime
 
 	/**
 	 * This helper is called during summarization. If the container is dirty, it will return a failed summarize result
-	 * (IBaseSummarizeResult) unless this is the final summarize attempt and SkipFailingIncorrectSummary option is set.
+	 * (IBaseSummarizeResult) unless this is the final summarize attempt, in which case the summary is allowed to
+	 * proceed to make progress in documents where there are consistently pending ops in the summarizer.
 	 * @param logger - The logger to be used for sending telemetry.
 	 * @param referenceSequenceNumber - The reference sequence number of the summary attempt.
 	 * @param minimumSequenceNumber - The minimum sequence number of the summary attempt.
@@ -4638,13 +4639,9 @@ export class ContainerRuntime
 			return;
 		}
 
-		// If "SkipFailingIncorrectSummary" option is true, don't fail the summary in the last attempt.
-		// This is a fallback to make progress in documents where there are consistently pending ops in
-		// the summarizer.
-		if (
-			finalAttempt &&
-			this.mc.config.getBoolean("Fluid.Summarizer.SkipFailingIncorrectSummary") === true
-		) {
+		// Don't fail the summary in the last attempt. This is a fallback to make progress in
+		// documents where there are consistently pending ops in the summarizer.
+		if (finalAttempt) {
 			const error = DataProcessingError.create(
 				"Pending ops during summarization",
 				"submitSummary",

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4650,7 +4650,7 @@ export class ContainerRuntime
 			);
 			logger.sendErrorEvent(
 				{
-					eventName: "SkipFailingIncorrectSummary",
+					eventName: "PendingOpsDuringSummaryFinalAttempt",
 					referenceSequenceNumber,
 					minimumSequenceNumber,
 					beforeGenerate: beforeSummaryGeneration,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
@@ -498,7 +498,7 @@ describeCompat(
 		).timeout(standardTimeout * 2);
 
 		itExpects(
-			"All heuristics summary attempts should fail when ops are sent during summarize",
+			"Final summary attempt should succeed despite pending ops when ops are sent during summarize",
 			[
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
@@ -529,94 +529,8 @@ describeCompat(
 					error: "PendingOpsWhileSummarizing",
 				},
 				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-					clientType: "noninteractive/summarizer",
-					summaryAttempts: 5,
-					finalAttempt: true,
-					error: "PendingOpsWhileSummarizing",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:SummarizeFailed",
-					clientType: "noninteractive/summarizer",
-					error: "PendingOpsWhileSummarizing",
-				},
-			],
-			async () => {
-				const container = await createContainer(provider, false /* disableSummary */);
-				await waitForContainerConnection(container);
-
-				const rootDataObject = (await container.getEntryPoint()) as RootTestDataObject;
-				const containerRuntime = rootDataObject.containerRuntime as ContainerRuntime;
-
-				const summarizePromiseP = new Promise<ISummarizeEventProps>((resolve) => {
-					const handler = (eventProps: ISummarizeEventProps): void => {
-						if (eventProps.result !== "failure") {
-							containerRuntime.off("summarize", handler);
-							resolve(eventProps);
-						} else {
-							assert(
-								eventProps.error?.message === "PendingOpsWhileSummarizing",
-								"Unexpected summarization failure",
-							);
-							if (eventProps.currentAttempt === eventProps.maxAttempts) {
-								containerRuntime.off("summarize", handler);
-								resolve(eventProps);
-							}
-						}
-					};
-					containerRuntime.on("summarize", handler);
-				});
-
-				const dataObject2 = await dataStoreFactory2.createInstance(
-					rootDataObject.containerRuntime,
-				);
-				rootDataObject._root.set("dataStore2", dataObject2.handle);
-				dataObject2._root.set("op", "value");
-				await provider.ensureSynchronized();
-
-				const props = await summarizePromiseP;
-				assert.strictEqual(props.result, "failure", "Summarization did not fail as expected");
-				assert.strictEqual(
-					props.maxAttempts,
-					defaultMaxAttemptsForSubmitFailures,
-					`Unexpected summarize attempts`,
-				);
-			},
-		);
-
-		itExpects(
-			"Final summary attempt should pass when ops are sent during summarize",
-			[
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-					clientType: "noninteractive/summarizer",
-					summaryAttempts: 1,
-					finalAttempt: false,
-					error: "PendingOpsWhileSummarizing",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-					clientType: "noninteractive/summarizer",
-					summaryAttempts: 2,
-					finalAttempt: false,
-					error: "PendingOpsWhileSummarizing",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-					clientType: "noninteractive/summarizer",
-					summaryAttempts: 3,
-					finalAttempt: false,
-					error: "PendingOpsWhileSummarizing",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
-					clientType: "noninteractive/summarizer",
-					summaryAttempts: 4,
-					finalAttempt: false,
-					error: "PendingOpsWhileSummarizing",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:PendingOpsDuringSummaryFinalAttempt",
+					eventName:
+						"fluid:telemetry:Summarizer:Running:PendingOpsDuringSummaryFinalAttempt",
 					summaryAttempts: 5,
 					finalAttempt: true,
 					error: "Pending ops during summarization",

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
@@ -616,7 +616,7 @@ describeCompat(
 					error: "PendingOpsWhileSummarizing",
 				},
 				{
-					eventName: "fluid:telemetry:Summarizer:Running:SkipFailingIncorrectSummary",
+					eventName: "fluid:telemetry:Summarizer:Running:PendingOpsDuringSummaryFinalAttempt",
 					summaryAttempts: 5,
 					finalAttempt: true,
 					error: "Pending ops during summarization",

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
@@ -585,7 +585,7 @@ describeCompat(
 		);
 
 		itExpects(
-			"SkipFailingIncorrectSummary = true. Final summary attempt should pass when ops are sent during summarize",
+			"Final summary attempt should pass when ops are sent during summarize",
 			[
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:Summarize_cancel",
@@ -623,7 +623,6 @@ describeCompat(
 				},
 			],
 			async () => {
-				configProvider.set("Fluid.Summarizer.SkipFailingIncorrectSummary", true);
 				configProvider.set("Fluid.Summarizer.PendingOpsRetryDelayMs", 5);
 				const container = await createContainer(provider, false /* disableSummary */);
 				await waitForContainerConnection(container);

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
@@ -529,8 +529,7 @@ describeCompat(
 					error: "PendingOpsWhileSummarizing",
 				},
 				{
-					eventName:
-						"fluid:telemetry:Summarizer:Running:PendingOpsDuringSummaryFinalAttempt",
+					eventName: "fluid:telemetry:Summarizer:Running:PendingOpsDuringSummaryFinalAttempt",
 					summaryAttempts: 5,
 					finalAttempt: true,
 					error: "Pending ops during summarization",


### PR DESCRIPTION
## Description

 Removes the `Fluid.Summarizer.SkipFailingIncorrectSummary` feature flag from the summarization path. The behavior it gated — skipping summary failure on the final attempt when there are pending ops — is now unconditionally enabled.                                                                                                                                                                                                        
   
 This is a fallback to make progress in documents where there are consistently pending ops in the summarizer. The flag was used to control rollout of this behavior, and it is now safe to remove the gate and make it the default.                    