### PR TITLE
ci: Skip reporting pipeline stage telemetry for manual runs of test pipelines

### DIFF
--- a/tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+++ b/tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
@@ -27,7 +27,9 @@ parameters:
 stages:
 - stage: upload_telemetry_${{ parameters.stageIdFilter }}
   displayName: Upload telemetry to Kusto ('${{ parameters.stageIdFilter }}')
-  condition: succeededOrFailed()
+  # Run for all possible pipeline triggers except manual
+  # (manual runs tend to be for testing and can fail repeatedly, we don't want that creating incidents)
+  condition: and(succeededOrFailed(), ne(variables['Build.Reason'], 'Manual'))
   dependsOn:
     - ${{ if ne(parameters.stageIdFilter, 'all') }}:
       - ${{ parameters.stageIdFilter }}

--- a/tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
+++ b/tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
@@ -24,6 +24,9 @@ steps:
     BUILD_ID: $(Build.BuildId)
     ADO_API_TOKEN: $(System.AccessToken)
     WORK_FOLDER: $(Agent.TempDirectory)/stageTimingAndResult
+  # Run for all possible pipeline triggers except manual
+  # (manual runs tend to be for testing and can fail repeatedly, we don't want that creating incidents)
+  condition: ne(variables['Build.Reason'], 'Manual')
   inputs:
     targetType: 'inline'
     script: |
@@ -45,6 +48,9 @@ steps:
       STAGE_ID: ${{ parameters.stageIdFilter }}
     PIPELINE: ${{ parameters.pipelineIdentifierForTelemetry }}
     WORK_FOLDER: $(Agent.TempDirectory)/stageTimingAndResult
+  # Run for all possible pipeline triggers except manual
+  # (manual runs tend to be for testing and can fail repeatedly, we don't want that creating incidents)
+  condition: ne(variables['Build.Reason'], 'Manual')
   inputs:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)

--- a/tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
+++ b/tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
@@ -24,9 +24,6 @@ steps:
     BUILD_ID: $(Build.BuildId)
     ADO_API_TOKEN: $(System.AccessToken)
     WORK_FOLDER: $(Agent.TempDirectory)/stageTimingAndResult
-  # Run for all possible pipeline triggers except manual
-  # (manual runs tend to be for testing and can fail repeatedly, we don't want that creating incidents)
-  condition: ne(variables['Build.Reason'], 'Manual')
   inputs:
     targetType: 'inline'
     script: |
@@ -48,9 +45,6 @@ steps:
       STAGE_ID: ${{ parameters.stageIdFilter }}
     PIPELINE: ${{ parameters.pipelineIdentifierForTelemetry }}
     WORK_FOLDER: $(Agent.TempDirectory)/stageTimingAndResult
-  # Run for all possible pipeline triggers except manual
-  # (manual runs tend to be for testing and can fail repeatedly, we don't want that creating incidents)
-  condition: ne(variables['Build.Reason'], 'Manual')
   inputs:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)


### PR DESCRIPTION
## Description

Manual pipeline runs tend to be for testing and are thus more prone to having issues. We don't want consecutive failures of manual runs of our test pipelines to create incidents for OCEs, so this PR makes it so we skip the stage telemetry reporting for manual runs.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
