### PR TITLE
fix(codespace): show welcome notice on every terminal and GETTING_STARTED on every VS Code open

### DIFF
--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -44,12 +44,14 @@
 		"node-setup": "bash scripts/codespace-setup/on-create.sh"
 	},
 	"postCreateCommand": {
-		"ai-setup": "bash scripts/codespace-setup/ai-setup.sh",
-		"welcome-notice": "sudo cp .devcontainer/ai-agent/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
+		"ai-setup": "bash scripts/codespace-setup/ai-setup.sh"
 	},
 	"postStartCommand": {
 		"bwrap-setup": "sudo mount --make-rshared /",
 		"sandbox-tmpdir": "mkdir -p /tmp/claude"
+	},
+	"postAttachCommand": {
+		"open-getting-started": "code .devcontainer/ai-agent/GETTING_STARTED.md"
 	},
 	"remoteUser": "node",
 	"features": {

--- a/scripts/codespace-setup/ai-setup.sh
+++ b/scripts/codespace-setup/ai-setup.sh
@@ -38,4 +38,25 @@ elif [ -f /etc/zshrc ] && ! sudo grep -qxF 'source /usr/local/lib/agent-aliases.
   echo "source /usr/local/lib/agent-aliases.sh" | sudo tee -a /etc/zshrc > /dev/null
 fi
 
+# Install welcome notice so it displays in every interactive terminal session,
+# using the same shell-init strategy as agent-aliases above.
+sudo install -Dm644 "$SCRIPT_DIR/../../.devcontainer/ai-agent/first-run-notice.txt" /usr/local/etc/fluid-welcome-notice.txt
+sudo install -Dm644 "$SCRIPT_DIR/welcome-notice.sh" /usr/local/lib/welcome-notice.sh
+
+sudo ln -sf /usr/local/lib/welcome-notice.sh /etc/profile.d/welcome-notice.sh
+
+if [ -d /etc/bash/bashrc.d ]; then
+  sudo ln -sf /usr/local/lib/welcome-notice.sh /etc/bash/bashrc.d/welcome-notice.sh
+elif ! sudo grep -qxF 'source /usr/local/lib/welcome-notice.sh' /etc/bash.bashrc 2>/dev/null; then
+  echo "source /usr/local/lib/welcome-notice.sh" | sudo tee -a /etc/bash.bashrc > /dev/null
+fi
+
+if [ -d /etc/zsh/zshrc.d ]; then
+  sudo ln -sf /usr/local/lib/welcome-notice.sh /etc/zsh/zshrc.d/welcome-notice.sh
+elif [ -f /etc/zsh/zshrc ] && ! sudo grep -qxF 'source /usr/local/lib/welcome-notice.sh' /etc/zsh/zshrc 2>/dev/null; then
+  echo "source /usr/local/lib/welcome-notice.sh" | sudo tee -a /etc/zsh/zshrc > /dev/null
+elif [ -f /etc/zshrc ] && ! sudo grep -qxF 'source /usr/local/lib/welcome-notice.sh' /etc/zshrc 2>/dev/null; then
+  echo "source /usr/local/lib/welcome-notice.sh" | sudo tee -a /etc/zshrc > /dev/null
+fi
+
 bash "$SCRIPT_DIR/playwright-setup.sh"

--- a/scripts/codespace-setup/welcome-notice.sh
+++ b/scripts/codespace-setup/welcome-notice.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Display welcome notice in every interactive terminal session.
+# Sourced from /etc/profile.d, /etc/bash/bashrc.d, or /etc/zsh/zshrc.d.
+
+# Only display in interactive shells
+case $- in
+  *i*) ;;
+  *) return 0 ;;
+esac
+
+if [ -f /usr/local/etc/fluid-welcome-notice.txt ]; then
+  cat /usr/local/etc/fluid-welcome-notice.txt
+fi


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

The welcome notice (`first-run-notice.txt`) and `GETTING_STARTED.md` were only displayed on initial codespace creation — if you opened the codespace in the browser first and then switched to VS Code, you'd miss both.

- **Welcome notice**: Replaced the VS Code `first-run-notice.txt` one-time mechanism with a shell init script installed into `/etc/profile.d/`, `/etc/bash/bashrc.d/`, and `/etc/zsh/zshrc.d/` (same approach as agent-aliases). Now displays in every new interactive terminal session.
- **GETTING_STARTED.md**: Added `postAttachCommand` to open the file via `code` CLI every time VS Code attaches to the container, not just on first creation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).