### PR TITLE
feat(client-presence): promote to public

### DIFF
--- a/.changeset/beige-candles-sleep.md
+++ b/.changeset/beige-candles-sleep.md
@@ -10,7 +10,7 @@ Now `getPresence` is available for import from the `fluid-framework` package.
 To prepare, make changes following this pattern:
 ```diff
 -import { getPresence } from "@fluidframework/presence/beta";
-+import { getPresence } from "fluid-framework/beta";
++import { getPresence } from "fluid-framework";
 ```
 
 See [issue #26397](https://github.com/microsoft/FluidFramework/issues/26397) for more details.

--- a/.changeset/humble-pants-love.md
+++ b/.changeset/humble-pants-love.md
@@ -4,4 +4,6 @@
 ---
 presence API set now at public support level
 
-All `@fluidframework/presence` APIs that had been `@beta` have been promoted to `@public` support with the exception of `getPresence` which has been relocated to `fluid-framework`. See [issue #26397](https://github.com/microsoft/FluidFramework/issues/26397) for more `getPresence` details.
+All `@fluidframework/presence` APIs that had been `@beta` have been promoted to `@public` support with the exception of `getPresence` which has been relocated to `fluid-framework`. (See [issue #26397](https://github.com/microsoft/FluidFramework/issues/26397) for more `getPresence` details.)
+
+See [Presence API overview](https://fluidframework.com/docs/build/presence) and [Presence package API details](https://fluidframework.com/docs/api/presence/) with [getPresence API](https://fluidframework.com/docs/api/fluid-framework/#getPresence) to get started.

--- a/.changeset/humble-pants-love.md
+++ b/.changeset/humble-pants-love.md
@@ -4,4 +4,4 @@
 ---
 presence API set now at public support level
 
-All `@fluidframework/presence` APIs that had been `@beta` have been promoted to `@public` support with the exception of `getPresence` which is being relocated.
+All `@fluidframework/presence` APIs that had been `@beta` have been promoted to `@public` support with the exception of `getPresence` which has been relocated to `fluid-framework`. See [issue #26397](https://github.com/microsoft/FluidFramework/issues/26397) for more `getPresence` details.

--- a/.changeset/humble-pants-love.md
+++ b/.changeset/humble-pants-love.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/presence": minor
+"__section": feature
+---
+presence API set now at public support level
+
+All `@fluidframework/presence` APIs that had been `@beta` have been promoted to `@public` support with the exception of `getPresence` which is being relocated.

--- a/docs/docs/build/presence.mdx
+++ b/docs/docs/build/presence.mdx
@@ -183,8 +183,8 @@ function usePresence(container: IFluidContainer): void {
 #### Schema Definition and Workspace
 
 ```typescript
-import type { Latest, LatestMap, Presence, StatesWorkspaceSchema } from "@fluidframework/presence/beta";
-import { StateFactory } from "@fluidframework/presence/beta";
+import type { Latest, LatestMap, Presence, StatesWorkspaceSchema } from "@fluidframework/presence";
+import { StateFactory } from "@fluidframework/presence";
 
 interface PointXY { x: number; y: number }
 

--- a/docs/docs/build/presence.mdx
+++ b/docs/docs/build/presence.mdx
@@ -173,7 +173,7 @@ function logOthersCounters(counterTracker: LatestMap<number, string>): void {
 To access Presence APIs, use `getPresence()` with any `IFluidContainer`.
 
 ```typescript
-import { getPresence } from "fluid-framework/beta";
+import { getPresence } from "fluid-framework";
 
 function usePresence(container: IFluidContainer): void {
    const presence = getPresence(container);

--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -5,13 +5,8 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IEvent } from "@fluidframework/core-interfaces";
-import type {
-	Attendee,
-	LatestRaw,
-	Presence,
-	StatesWorkspace,
-} from "@fluidframework/presence/beta";
-import { AttendeeStatus, StateFactory } from "@fluidframework/presence/beta";
+import type { Attendee, LatestRaw, Presence, StatesWorkspace } from "@fluidframework/presence";
+import { AttendeeStatus, StateFactory } from "@fluidframework/presence";
 
 /**
  * IFocusState is the data that individual session clients share via presence.

--- a/examples/apps/presence-tracker/src/MouseTracker.ts
+++ b/examples/apps/presence-tracker/src/MouseTracker.ts
@@ -5,13 +5,8 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IEvent } from "@fluidframework/core-interfaces";
-import type {
-	Presence,
-	Attendee,
-	LatestRaw,
-	StatesWorkspace,
-} from "@fluidframework/presence/beta";
-import { AttendeeStatus, StateFactory } from "@fluidframework/presence/beta";
+import type { Presence, Attendee, LatestRaw, StatesWorkspace } from "@fluidframework/presence";
+import { AttendeeStatus, StateFactory } from "@fluidframework/presence";
 
 /**
  * IMousePosition is the data that individual session clients share via presence.

--- a/examples/apps/presence-tracker/src/app.ts
+++ b/examples/apps/presence-tracker/src/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { AttendeeId, AttendeeStatus } from "@fluidframework/presence/beta";
+import type { AttendeeId, AttendeeStatus } from "@fluidframework/presence";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 import type { ContainerSchema, IFluidContainer } from "fluid-framework";
 import { getPresence } from "fluid-framework/beta";

--- a/examples/apps/presence-tracker/src/app.ts
+++ b/examples/apps/presence-tracker/src/app.ts
@@ -6,7 +6,7 @@
 import type { AttendeeId, AttendeeStatus } from "@fluidframework/presence";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 import type { ContainerSchema, IFluidContainer } from "fluid-framework";
-import { getPresence } from "fluid-framework/beta";
+import { getPresence } from "fluid-framework";
 
 import { FocusTracker } from "./FocusTracker.js";
 import { MouseTracker } from "./MouseTracker.js";

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -7,7 +7,7 @@ import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-
 import { createDevtoolsLogger, initializeDevtools } from "@fluidframework/devtools/beta";
 import { createChildLogger } from "@fluidframework/telemetry-utils/legacy";
 import type { IFluidContainer } from "fluid-framework";
-import { getPresence } from "fluid-framework/beta";
+import { getPresence } from "fluid-framework";
 
 import { DiceRollerController, type DieValue } from "./controller.js";
 import {

--- a/examples/service-clients/azure-client/external-controller/src/presence.ts
+++ b/examples/service-clients/azure-client/external-controller/src/presence.ts
@@ -8,7 +8,7 @@ import {
 	StateFactory,
 	type StatesWorkspace,
 	type StatesWorkspaceSchema,
-} from "@fluidframework/presence/beta";
+} from "@fluidframework/presence";
 
 import type { DieValue } from "./controller.js";
 

--- a/examples/service-clients/azure-client/external-controller/src/view.ts
+++ b/examples/service-clients/azure-client/external-controller/src/view.ts
@@ -4,7 +4,7 @@
  */
 
 import type { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
-import type { LatestRaw, Presence } from "@fluidframework/presence/beta";
+import type { LatestRaw, Presence } from "@fluidframework/presence";
 
 import type { IDiceRollerController } from "./controller.js";
 import type { ICustomUserDetails } from "./fluid.js";

--- a/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
@@ -5,6 +5,13 @@
 ```ts
 
 // @public
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
+// @public
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 // @public @sealed

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @beta
+// @public
 export class BrandedType<out Brand> {
     static [Symbol.hasInstance](value: never): value is never;
     protected constructor();

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @beta
+// @public
 export class BrandedType<out Brand> {
     static [Symbol.hasInstance](value: never): value is never;
     protected constructor();

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.public.api.md
@@ -5,6 +5,13 @@
 ```ts
 
 // @public
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
+// @public
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 // @public @sealed

--- a/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
@@ -5,6 +5,13 @@
 ```ts
 
 // @public
+export class BrandedType<out Brand> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected constructor();
+    protected readonly brand: (dummy: never) => Brand;
+}
+
+// @public
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 // @public @sealed

--- a/packages/common/core-interfaces/src/brandedType.ts
+++ b/packages/common/core-interfaces/src/brandedType.ts
@@ -82,7 +82,7 @@
  * }
  * ```
  *
- * @beta
+ * @public
  */
 export declare class BrandedType<out Brand> {
 	/**

--- a/packages/common/core-interfaces/src/deepReadonly.ts
+++ b/packages/common/core-interfaces/src/deepReadonly.ts
@@ -16,7 +16,7 @@ import type {
  * @privateRemarks
  * WeakRef should be added when lib is updated to ES2021 or later.
  *
- * @beta
+ * @public
  * @system
  */
 export type DeepReadonlySupportedGenericsDefault =
@@ -29,7 +29,7 @@ export type DeepReadonlySupportedGenericsDefault =
 /**
  * Options for {@link DeepReadonly}.
  *
- * @beta
+ * @public
  */
 export interface DeepReadonlyOptions {
 	/**
@@ -58,7 +58,7 @@ export interface DeepReadonlyOptions {
  * {@link DeepReadonlySupportedGenericsDefault} for generics that have
  * immutability applied to generic type by default.
  *
- * @beta
+ * @public
  */
 export type DeepReadonly<
 	T,

--- a/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
@@ -27,7 +27,7 @@ const RecursionMarkerSymbol: unique symbol = Symbol("recursion here");
  * @privateRemarks
  * WeakRef should be added when lib is updated to ES2021 or later.
  *
- * @beta
+ * @public
  */
 export type ReadonlySupportedGenerics =
 	| IFluidHandle
@@ -46,7 +46,7 @@ export type ReadonlySupportedGenerics =
  * depth limit when a recursive type is found. Use of `0` will stop applying
  * `DeepReadonly` at the first point recursion is detected.
  *
- * @beta
+ * @public
  * @system
  */
 export type DeepReadonlyRecursionLimit = "NoLimit" | 0 | `+${string}`;
@@ -67,7 +67,7 @@ export type DeepReadonlyRecursionLimit = "NoLimit" | 0 | `+${string}`;
  * exported anyway. All in namespace are left exported to avoid api-extractor
  * potentially failing to validate other modules correctly.
  *
- * @beta
+ * @public
  * @system
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/common/core-interfaces/src/jsonDeserialized.ts
+++ b/packages/common/core-interfaces/src/jsonDeserialized.ts
@@ -8,7 +8,7 @@ import type { InternalUtilityTypes } from "./exposedInternalUtilityTypes.js";
 /**
  * Options for {@link JsonDeserialized}.
  *
- * @beta
+ * @public
  */
 export interface JsonDeserializedOptions {
 	/**
@@ -107,7 +107,7 @@ export interface JsonDeserializedOptions {
  * function foo<T>(): JsonDeserialized<T> { ... }
  * ```
  *
- * @beta
+ * @public
  */
 export type JsonDeserialized<
 	T,

--- a/packages/common/core-interfaces/src/jsonSerializable.ts
+++ b/packages/common/core-interfaces/src/jsonSerializable.ts
@@ -8,7 +8,7 @@ import type { InternalUtilityTypes } from "./exposedInternalUtilityTypes.js";
 /**
  * Options for {@link JsonSerializable}.
  *
- * @beta
+ * @public
  */
 export interface JsonSerializableOptions {
 	/**
@@ -130,7 +130,7 @@ export interface JsonSerializableOptions {
  * proper use, that will never be an issue as any filtering of types will happen
  * before T recursion.
  *
- * @beta
+ * @public
  */
 export type JsonSerializable<
 	T,

--- a/packages/common/core-interfaces/src/jsonSerializationErrors.ts
+++ b/packages/common/core-interfaces/src/jsonSerializationErrors.ts
@@ -10,7 +10,7 @@
  * @privateRemarks type is used over interface; so inspection of type
  * result can be more informative than just the type name.
  *
- * @beta
+ * @public
  * @system
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -25,7 +25,7 @@ export type SerializationErrorPerUndefinedArrayElement = {
  * @privateRemarks type is used over interface; so inspection of type
  * result can be more informative than just the type name.
  *
- * @beta
+ * @public
  * @system
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/packages/common/core-interfaces/src/jsonType.ts
+++ b/packages/common/core-interfaces/src/jsonType.ts
@@ -15,7 +15,7 @@
  * Prefer using `JsonSerializable<unknown>` or `JsonDeserialized<unknown>` over this type that
  * is an implementation detail.
  *
- * @beta
+ * @public
  */
 export type JsonTypeWith<T> =
 	// eslint-disable-next-line @rushstack/no-new-null
@@ -30,7 +30,7 @@ export type JsonTypeWith<T> =
 /**
  * Portion of {@link JsonTypeWith} that is an object (including array) and not null.
  *
- * @beta
+ * @public
  */
 export type NonNullJsonObjectWith<T> =
 	| { [key: string | number]: JsonTypeWith<T> }
@@ -51,7 +51,7 @@ export type NonNullJsonObjectWith<T> =
  * ```
  * does not prevent later `x = 5`. (Does prevent `x.a = 2`.)
  *
- * @beta
+ * @public
  */
 export type ReadonlyJsonTypeWith<TReadonlyAlternates> =
 	// eslint-disable-next-line @rushstack/no-new-null

--- a/packages/common/core-interfaces/src/opaqueJson.ts
+++ b/packages/common/core-interfaces/src/opaqueJson.ts
@@ -19,7 +19,7 @@ import { BrandedType } from "./brandedType.js";
  * be read.
  *
  * @sealed
- * @beta
+ * @public
  */
 export declare class OpaqueJsonDeserialized<
 	T,
@@ -59,7 +59,7 @@ export declare class OpaqueJsonDeserialized<
  * when "instance" will be forwarded along.
  *
  * @sealed
- * @beta
+ * @public
  */
 export declare class OpaqueJsonSerializable<
 	T,

--- a/packages/common/core-interfaces/src/test/brandedType.spec.ts
+++ b/packages/common/core-interfaces/src/test/brandedType.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { BrandedType } from "@fluidframework/core-interfaces/internal";
+import type { BrandedType } from "@fluidframework/core-interfaces";
 
 import { createInstanceOf } from "./testUtils.js";
 import type { BrandedString } from "./testValues.js";

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -592,7 +592,7 @@ export function generateSchemaFromSimpleSchema(simple: SimpleTreeSchema): TreeSc
 // @alpha
 export function getJsonSchema(schema: ImplicitAllowedTypes, options: Required<TreeSchemaEncodingOptions>): JsonTreeSchema;
 
-// @beta
+// @public
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @alpha

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -303,7 +303,7 @@ export const ForestTypeOptimized: ForestType;
 // @beta
 export const ForestTypeReference: ForestType;
 
-// @beta
+// @public
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -306,7 +306,7 @@ export const ForestTypeOptimized: ForestType;
 // @beta
 export const ForestTypeReference: ForestType;
 
-// @beta
+// @public
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @beta @legacy

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -144,6 +144,9 @@ export type FluidObject<T = unknown> = {
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
 // @public
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
+
+// @public
 export interface IConnection {
     readonly id: string;
     readonly mode: "write" | "read";

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -144,6 +144,9 @@ export type FluidObject<T = unknown> = {
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
 // @public
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
+
+// @public
 export interface IConnection {
     readonly id: string;
     readonly mode: "write" | "read";

--- a/packages/framework/fluid-static/README.md
+++ b/packages/framework/fluid-static/README.md
@@ -30,8 +30,6 @@ For more information on the related support guarantees, see [API Support Levels]
 
 To access the `public` ([SemVer](https://semver.org/)) APIs, import via `@fluidframework/fluid-static` like normal.
 
-To access the `beta` APIs, import via `@fluidframework/fluid-static/beta`.
-
 To access the `alpha` APIs, import via `@fluidframework/fluid-static/alpha`.
 
 To access the `legacy` APIs, import via `@fluidframework/fluid-static/legacy`.

--- a/packages/framework/fluid-static/api-extractor/api-extractor-lint-beta.cjs.json
+++ b/packages/framework/fluid-static/api-extractor/api-extractor-lint-beta.cjs.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/dist/beta.d.ts"
-}

--- a/packages/framework/fluid-static/api-extractor/api-extractor-lint-beta.esm.json
+++ b/packages/framework/fluid-static/api-extractor/api-extractor-lint-beta.esm.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/lib/beta.d.ts"
-}

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -16,7 +16,7 @@ export interface ContainerSchema {
     readonly initialObjects: Record<string, SharedObjectKind>;
 }
 
-// @beta
+// @public
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @alpha

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -16,7 +16,7 @@ export interface ContainerSchema {
     readonly initialObjects: Record<string, SharedObjectKind>;
 }
 
-// @beta
+// @public
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @public

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
@@ -25,7 +25,7 @@ export function createTreeContainerRuntimeFactory(props: {
     readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory;
 
-// @beta
+// @public
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
 // @public

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
@@ -17,6 +17,9 @@ export interface ContainerSchema {
 }
 
 // @public
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
+
+// @public
 export interface IConnection {
     readonly id: string;
     readonly mode: "write" | "read";

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -17,6 +17,9 @@ export interface ContainerSchema {
 }
 
 // @public
+export const getPresence: (fluidContainer: IFluidContainer) => Presence;
+
+// @public
 export interface IConnection {
     readonly id: string;
     readonly mode: "write" | "read";

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -23,16 +23,6 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./beta": {
-			"import": {
-				"types": "./lib/beta.d.ts",
-				"default": "./lib/index.js"
-			},
-			"require": {
-				"types": "./dist/beta.d.ts",
-				"default": "./dist/index.js"
-			}
-		},
 		"./alpha": {
 			"import": {
 				"types": "./lib/alpha.d.ts",
@@ -86,11 +76,9 @@
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.cjs.json",
-		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
 		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
 		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
 		"check:exports:esm:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.esm.json",
-		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
 		"check:exports:esm:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json",
 		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",

--- a/packages/framework/fluid-static/src/getPresence.ts
+++ b/packages/framework/fluid-static/src/getPresence.ts
@@ -22,7 +22,7 @@ import { isInternalFluidContainer } from "./fluidContainer.js";
  * @param fluidContainer - Fluid Container to acquire the map from
  * @returns the {@link @fluidframework/presence#Presence}
  *
- * @beta
+ * @public
  */
 export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPresenceAlpha;
 

--- a/packages/framework/presence-definitions/api-report/presence-definitions.alpha.api.md
+++ b/packages/framework/presence-definitions/api-report/presence-definitions.alpha.api.md
@@ -4,22 +4,22 @@
 
 ```ts
 
-// @beta @system
+// @public @system
 export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
 
-// @beta @sealed
+// @public @sealed
 export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
     readonly attendeeId: SpecificAttendeeId;
     getConnectionId(): ClientConnectionId;
     getConnectionStatus(): AttendeeStatus;
 }
 
-// @beta
+// @public
 export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed
+// @public @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -27,29 +27,29 @@ export interface AttendeesEvents {
     attendeeDisconnected: (attendee: Attendee) => void;
 }
 
-// @beta
+// @public
 export const AttendeeStatus: {
     readonly Connected: "Connected";
     readonly Disconnected: "Disconnected";
 };
 
-// @beta
+// @public
 export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
 
-// @beta @sealed
+// @public @sealed
 export interface BroadcastControls {
     allowableUpdateLatencyMs: number | undefined;
 }
 
-// @beta
+// @public
 export interface BroadcastControlSettings {
     readonly allowableUpdateLatencyMs?: number;
 }
 
-// @beta
+// @public
 export type ClientConnectionId = string;
 
-// @beta @system
+// @public @system
 export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
@@ -141,10 +141,10 @@ export namespace InternalPresenceUtilityTypes {
     export type NotificationParametersSignatureFromSubscriberSignature<Event> = Event extends (sender: Attendee, ...args: infer P) => void ? (...args: P) => void : never;
 }
 
-// @beta
+// @public
 export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
 
-// @beta @sealed
+// @public @sealed
 export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
@@ -156,32 +156,32 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
     attendee: Attendee;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localUpdated: (update: {
@@ -191,13 +191,13 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
     remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestFactory {
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -208,13 +208,13 @@ export interface LatestMap<T, Keys extends string = string, TRemoteAccessor exte
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
     keyValidator?: KeySchemaValidator<Keys>;
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     local?: {
         [K in Keys]: JsonSerializable<T>;
@@ -222,16 +222,16 @@ export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
     items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -250,46 +250,46 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapFactory {
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemRemovedClientData<K extends string> {
     attendee: Attendee;
     key: K;
     metadata: LatestMetadata;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
     key: K;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMetadata {
     revision: number;
     timestamp: number;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
 // @alpha @sealed
@@ -341,7 +341,7 @@ export type NotificationsWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
 };
 
-// @beta @sealed
+// @public @sealed
 export interface Presence {
     readonly attendees: {
         readonly events: Listenable<AttendeesEvents>;
@@ -355,7 +355,7 @@ export interface Presence {
     };
 }
 
-// @beta @sealed
+// @public @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
@@ -368,7 +368,7 @@ export interface PresenceWithNotifications extends Presence {
     };
 }
 
-// @beta @system
+// @public @system
 export interface ProxiedValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -376,7 +376,7 @@ export interface ProxiedValueAccessor<T> {
     readonly kind: "proxied";
 }
 
-// @beta @system
+// @public @system
 export interface RawValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -384,7 +384,7 @@ export interface RawValueAccessor<T> {
     readonly kind: "raw";
 }
 
-// @beta @sealed
+// @public @sealed
 export interface StateMap<K extends string, V> {
     clear(): void;
     delete(key: K): boolean;
@@ -396,11 +396,11 @@ export interface StateMap<K extends string, V> {
     readonly size: number;
 }
 
-// @beta
+// @public
 export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
-// @beta @sealed
+// @public @sealed
 export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
@@ -408,7 +408,7 @@ export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<T
     readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
@@ -416,18 +416,18 @@ export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema
     readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
-// @beta
+// @public
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
-// @beta
+// @public
 export type StatesWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 };
 
-// @beta @system
+// @public @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
 
-// @beta
+// @public
 export type WorkspaceAddress = `${string}:${string}`;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/framework/presence-definitions/api-report/presence-definitions.beta.api.md
+++ b/packages/framework/presence-definitions/api-report/presence-definitions.beta.api.md
@@ -4,22 +4,22 @@
 
 ```ts
 
-// @beta @system
+// @public @system
 export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
 
-// @beta @sealed
+// @public @sealed
 export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
     readonly attendeeId: SpecificAttendeeId;
     getConnectionId(): ClientConnectionId;
     getConnectionStatus(): AttendeeStatus;
 }
 
-// @beta
+// @public
 export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed
+// @public @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -27,29 +27,29 @@ export interface AttendeesEvents {
     attendeeDisconnected: (attendee: Attendee) => void;
 }
 
-// @beta
+// @public
 export const AttendeeStatus: {
     readonly Connected: "Connected";
     readonly Disconnected: "Disconnected";
 };
 
-// @beta
+// @public
 export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
 
-// @beta @sealed
+// @public @sealed
 export interface BroadcastControls {
     allowableUpdateLatencyMs: number | undefined;
 }
 
-// @beta
+// @public
 export interface BroadcastControlSettings {
     readonly allowableUpdateLatencyMs?: number;
 }
 
-// @beta
+// @public
 export type ClientConnectionId = string;
 
-// @beta @system
+// @public @system
 export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
@@ -115,10 +115,10 @@ export namespace InternalPresenceTypes {
     }
 }
 
-// @beta
+// @public
 export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
 
-// @beta @sealed
+// @public @sealed
 export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
@@ -130,32 +130,32 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
     attendee: Attendee;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localUpdated: (update: {
@@ -165,13 +165,13 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
     remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestFactory {
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -182,13 +182,13 @@ export interface LatestMap<T, Keys extends string = string, TRemoteAccessor exte
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
     keyValidator?: KeySchemaValidator<Keys>;
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     local?: {
         [K in Keys]: JsonSerializable<T>;
@@ -196,16 +196,16 @@ export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
     items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -224,49 +224,49 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapFactory {
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemRemovedClientData<K extends string> {
     attendee: Attendee;
     key: K;
     metadata: LatestMetadata;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
     key: K;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMetadata {
     revision: number;
     timestamp: number;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface Presence {
     readonly attendees: {
         readonly events: Listenable<AttendeesEvents>;
@@ -280,12 +280,12 @@ export interface Presence {
     };
 }
 
-// @beta @sealed
+// @public @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
 
-// @beta @system
+// @public @system
 export interface ProxiedValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -293,7 +293,7 @@ export interface ProxiedValueAccessor<T> {
     readonly kind: "proxied";
 }
 
-// @beta @system
+// @public @system
 export interface RawValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -301,7 +301,7 @@ export interface RawValueAccessor<T> {
     readonly kind: "raw";
 }
 
-// @beta @sealed
+// @public @sealed
 export interface StateMap<K extends string, V> {
     clear(): void;
     delete(key: K): boolean;
@@ -313,11 +313,11 @@ export interface StateMap<K extends string, V> {
     readonly size: number;
 }
 
-// @beta
+// @public
 export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
-// @beta @sealed
+// @public @sealed
 export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
@@ -325,7 +325,7 @@ export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<T
     readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
@@ -333,18 +333,18 @@ export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema
     readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
-// @beta
+// @public
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
-// @beta
+// @public
 export type StatesWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 };
 
-// @beta @system
+// @public @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
 
-// @beta
+// @public
 export type WorkspaceAddress = `${string}:${string}`;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/framework/presence-definitions/api-report/presence-definitions.public.api.md
+++ b/packages/framework/presence-definitions/api-report/presence-definitions.public.api.md
@@ -4,6 +4,349 @@
 
 ```ts
 
+// @public @system
+export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
+
+// @public @sealed
+export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    readonly attendeeId: SpecificAttendeeId;
+    getConnectionId(): ClientConnectionId;
+    getConnectionStatus(): AttendeeStatus;
+}
+
+// @public
+export type AttendeeId = SessionId & {
+    readonly AttendeeId: "AttendeeId";
+};
+
+// @public @sealed
+export interface AttendeesEvents {
+    // @eventProperty
+    attendeeConnected: (attendee: Attendee) => void;
+    // @eventProperty
+    attendeeDisconnected: (attendee: Attendee) => void;
+}
+
+// @public
+export const AttendeeStatus: {
+    readonly Connected: "Connected";
+    readonly Disconnected: "Disconnected";
+};
+
+// @public
+export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
+
+// @public @sealed
+export interface BroadcastControls {
+    allowableUpdateLatencyMs: number | undefined;
+}
+
+// @public
+export interface BroadcastControlSettings {
+    readonly allowableUpdateLatencyMs?: number;
+}
+
+// @public
+export type ClientConnectionId = string;
+
+// @public @system
+export namespace InternalPresenceTypes {
+    // @system
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
+    } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
+        initialData?: {
+            value: TValue;
+            allowableUpdateLatencyMs: number | undefined;
+        };
+        manager: StateValue<TManager>;
+    });
+    // @system
+    export interface MapValueState<T, Keys extends string> {
+        // (undocumented)
+        items: {
+            [name in Keys]: ValueOptionalState<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export interface NotificationType {
+        // (undocumented)
+        args: unknown[];
+        // (undocumented)
+        name: string;
+    }
+    // @system
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
+    }
+    // @system
+    export type StateValue<T> = T & StateValueBrand<T>;
+    // @system
+    export class StateValueBrand<T> {
+    }
+    // @system
+    export interface ValueDirectory<T> {
+        // (undocumented)
+        items: {
+            [name: string | number]: ValueOptionalState<T> | ValueDirectory<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export type ValueDirectoryOrState<T> = ValueRequiredState<T> | ValueDirectory<T>;
+    // @system
+    export interface ValueOptionalState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value?: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueRequiredState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueStateMetadata {
+        // (undocumented)
+        rev: number;
+        // (undocumented)
+        timestamp: number;
+    }
+}
+
+// @public
+export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
+
+// @public @sealed
+export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    readonly controls: BroadcastControls;
+    readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
+    getRemote(attendee: Attendee): LatestData<T, TRemoteAccessor>;
+    getRemotes(): IterableIterator<LatestClientData<T, TRemoteAccessor>>;
+    getStateAttendees(): Attendee[];
+    get local(): DeepReadonly<JsonDeserialized<T>>;
+    set local(value: JsonSerializable<T>);
+    readonly presence: Presence;
+}
+
+// @public @input
+export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
+    validator: StateSchemaValidator<T>;
+}
+
+// @public @input
+export interface LatestArgumentsRaw<T extends object | null> {
+    local: JsonSerializable<T>;
+    settings?: BroadcastControlSettings | undefined;
+}
+
+// @public @sealed
+export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
+    attendee: Attendee;
+}
+
+// @public @sealed
+export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+
+// @public @sealed
+export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
+    metadata: LatestMetadata;
+    value: Accessor<T, TValueAccessor>;
+}
+
+// @public @sealed
+export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    // @eventProperty
+    localUpdated: (update: {
+        value: DeepReadonly<JsonSerializable<T>>;
+    }) => void;
+    // @eventProperty
+    remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
+}
+
+// @public @sealed
+export interface LatestFactory {
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
+}
+
+// @public @sealed
+export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    readonly controls: BroadcastControls;
+    readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
+    getRemote(attendee: Attendee): ReadonlyMap<Keys, LatestData<T, TRemoteAccessor>>;
+    getRemotes(): IterableIterator<LatestMapClientData<T, Keys, TRemoteAccessor>>;
+    getStateAttendees(): Attendee[];
+    readonly local: StateMap<Keys, T>;
+    readonly presence: Presence;
+}
+
+// @public @input
+export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
+    keyValidator?: KeySchemaValidator<Keys>;
+    validator: StateSchemaValidator<T>;
+}
+
+// @public @input
+export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
+    local?: {
+        [K in Keys]: JsonSerializable<T>;
+    };
+    settings?: BroadcastControlSettings | undefined;
+}
+
+// @public @sealed
+export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    attendee: Attendee<SpecificAttendeeId>;
+    items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
+}
+
+// @public @sealed
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+
+// @public @sealed
+export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    // @eventProperty
+    localItemRemoved: (removedItem: {
+        key: K;
+    }) => void;
+    // @eventProperty
+    localItemUpdated: (updatedItem: {
+        value: DeepReadonly<JsonSerializable<T>>;
+        key: K;
+    }) => void;
+    // @eventProperty
+    remoteItemRemoved: (removedItem: LatestMapItemRemovedClientData<K>) => void;
+    // @eventProperty
+    remoteItemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K, TRemoteValueAccessor>) => void;
+    // @eventProperty
+    remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
+}
+
+// @public @sealed
+export interface LatestMapFactory {
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
+}
+
+// @public @sealed
+export interface LatestMapItemRemovedClientData<K extends string> {
+    attendee: Attendee;
+    key: K;
+    metadata: LatestMetadata;
+}
+
+// @public @sealed
+export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
+    key: K;
+}
+
+// @public @sealed
+export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
+
+// @public @sealed
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+
+// @public @sealed
+export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
+
+// @public @sealed
+export interface LatestMetadata {
+    revision: number;
+    timestamp: number;
+}
+
+// @public @sealed
+export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
+
+// @public @sealed
+export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+
+// @public @sealed
+export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
+
+// @public @sealed
+export interface Presence {
+    readonly attendees: {
+        readonly events: Listenable<AttendeesEvents>;
+        getAttendees(): ReadonlySet<Attendee>;
+        getAttendee(clientId: ClientConnectionId | AttendeeId): Attendee;
+        getMyself(): Attendee;
+    };
+    readonly events: Listenable<PresenceEvents>;
+    readonly states: {
+        getWorkspace<StatesSchema extends Partial<StatesWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema, unknown, SchemaKeys>;
+    };
+}
+
+// @public @sealed
+export interface PresenceEvents {
+    workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
+}
+
+// @public @system
+export interface ProxiedValueAccessor<T> {
+    // (undocumented)
+    readonly data: T;
+    // (undocumented)
+    readonly kind: "proxied";
+}
+
+// @public @system
+export interface RawValueAccessor<T> {
+    // (undocumented)
+    readonly data: T;
+    // (undocumented)
+    readonly kind: "raw";
+}
+
+// @public @sealed
+export interface StateMap<K extends string, V> {
+    clear(): void;
+    delete(key: K): boolean;
+    forEach(callbackfn: (value: DeepReadonly<JsonDeserialized<V>>, key: K, map: StateMap<K, V>) => void, thisArg?: unknown): void;
+    get(key: K): DeepReadonly<JsonDeserialized<V>> | undefined;
+    has(key: K): boolean;
+    keys(): IterableIterator<K>;
+    set(key: K, value: JsonSerializable<V>): this;
+    readonly size: number;
+}
+
+// @public
+export type StateSchemaValidator<T> = (
+unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
+
+// @public @sealed
+export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    readonly controls: BroadcastControls;
+    readonly presence: Presence;
+    readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
+}
+
+// @public @sealed
+export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
+    /**
+    * Registered State objects.
+    */
+    readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+};
+
+// @public
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
+
+// @public
+export type StatesWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+};
+
+// @public @system
+export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
+
+// @public
+export type WorkspaceAddress = `${string}:${string}`;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/framework/presence-definitions/src/baseTypes.ts
+++ b/packages/framework/presence-definitions/src/baseTypes.ts
@@ -19,6 +19,6 @@
  * strings. Branding broadly is likely a breaking change and may take decent
  * effort to manage.
  *
- * @beta
+ * @public
  */
 export type ClientConnectionId = string;

--- a/packages/framework/presence-definitions/src/broadcastControlsTypes.ts
+++ b/packages/framework/presence-definitions/src/broadcastControlsTypes.ts
@@ -7,7 +7,7 @@
  * Common controls for States objects.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface BroadcastControls {
 	/**
@@ -40,7 +40,7 @@ export interface BroadcastControls {
 /**
  * Value set to configure {@link BroadcastControls}.
  *
- * @beta
+ * @public
  */
 export interface BroadcastControlSettings {
 	/**

--- a/packages/framework/presence-definitions/src/exposedInternalTypes.ts
+++ b/packages/framework/presence-definitions/src/exposedInternalTypes.ts
@@ -9,7 +9,7 @@ import type { OpaqueJsonDeserialized } from "@fluidframework/core-interfaces/int
  * Collection of value types that are not intended to be used/imported
  * directly outside of this package.
  *
- * @beta
+ * @public
  * @system
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/framework/presence-definitions/src/latestMapTypes.ts
+++ b/packages/framework/presence-definitions/src/latestMapTypes.ts
@@ -31,7 +31,7 @@ import type { Attendee, AttendeeId, Presence } from "./presence.js";
  *
  * @returns True if the key is valid.
  *
- * @beta
+ * @public
  */
 export type KeySchemaValidator<Keys extends string> = (
 	unvalidatedKey: string,
@@ -41,7 +41,7 @@ export type KeySchemaValidator<Keys extends string> = (
  * Collection of latest known values for a specific {@link Attendee}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestMapClientData<
 	T,
@@ -67,7 +67,7 @@ export interface LatestMapClientData<
  * State of a single item value, its key, and its metadata.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestMapItemUpdatedClientData<
 	T,
@@ -84,7 +84,7 @@ export interface LatestMapItemUpdatedClientData<
  * Identifier and metadata for a removed item.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestMapItemRemovedClientData<K extends string> {
 	/**
@@ -107,7 +107,7 @@ export interface LatestMapItemRemovedClientData<K extends string> {
  * Events from {@link LatestMapRaw}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestMapEvents<
 	T,
@@ -166,7 +166,7 @@ export interface LatestMapEvents<
  * Events from {@link LatestMapRaw}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<
 	T,
@@ -178,7 +178,7 @@ export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<
  * Map of local client's values. Modifications are transmitted to all other connected clients.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface StateMap<K extends string, V> {
 	/**
@@ -270,7 +270,7 @@ export interface StateMap<K extends string, V> {
  * @remarks Create using {@link @fluidframework/presence#StateFactory.latestMap} registered to {@link StatesWorkspace}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestMap<
 	T,
@@ -322,7 +322,7 @@ export interface LatestMap<
  * @remarks Create using {@link @fluidframework/presence#StateFactory.latestMap} registered to {@link StatesWorkspace}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<
 	T,
@@ -334,7 +334,7 @@ export type LatestMapRaw<T, Keys extends string = string> = LatestMap<
  * Arguments that are passed to the {@link @fluidframework/presence#StateFactory|StateFactory}.{@link LatestMapFactory|latestMap} function.
  *
  * @input
- * @beta
+ * @public
  */
 export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
 	/**
@@ -354,7 +354,7 @@ export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
  * Arguments that are passed to the {@link @fluidframework/presence#StateFactory|StateFactory}.{@link LatestMapFactory|latestMap} function.
  *
  * @input
- * @beta
+ * @public
  */
 export interface LatestMapArguments<T, Keys extends string = string>
 	extends LatestMapArgumentsRaw<T, Keys> {
@@ -387,7 +387,7 @@ export interface LatestMapArguments<T, Keys extends string = string>
  * Specification is recommended to highlight connection between schema and
  * factory when spread across modules.
  *
- * @beta
+ * @public
  * @sealed
  */
 export type LatestMapConfiguration<
@@ -413,7 +413,7 @@ export type LatestMapConfiguration<
  * Specification is recommended to highlight connection between schema and
  * factory when spread across modules.
  *
- * @beta
+ * @public
  * @sealed
  */
 export type LatestMapRawConfiguration<
@@ -429,7 +429,7 @@ export type LatestMapRawConfiguration<
 /**
  * Factory for creating a {@link LatestMap} or {@link LatestMapRaw} State object.
  *
- * @beta
+ * @public
  * @sealed
  */
 export interface LatestMapFactory {

--- a/packages/framework/presence-definitions/src/latestTypes.ts
+++ b/packages/framework/presence-definitions/src/latestTypes.ts
@@ -26,7 +26,7 @@ import type { Attendee, Presence } from "./presence.js";
  * Events from {@link LatestRaw}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestEvents<
 	T,
@@ -51,7 +51,7 @@ export interface LatestEvents<
  * Events from {@link LatestRaw}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
@@ -62,7 +62,7 @@ export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
  * @remarks Create using {@link @fluidframework/presence#StateFactory|StateFactory}.{@link LatestFactory|latest} registered to {@link StatesWorkspace}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
@@ -73,7 +73,7 @@ export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
  * @remarks Create using {@link @fluidframework/presence#StateFactory|StateFactory}.{@link LatestFactory|latest} registered to {@link StatesWorkspace}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface Latest<
 	T,
@@ -123,7 +123,7 @@ export interface Latest<
  * Arguments that are passed to the {@link @fluidframework/presence#StateFactory.latest} function to create a {@link LatestRaw} State object.
  *
  * @input
- * @beta
+ * @public
  */
 export interface LatestArgumentsRaw<T extends object | null> {
 	/**
@@ -145,7 +145,7 @@ export interface LatestArgumentsRaw<T extends object | null> {
  * Arguments that are passed to the {@link @fluidframework/presence#StateFactory.latest} function to create a {@link Latest} State object.
  *
  * @input
- * @beta
+ * @public
  */
 export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
 	/**
@@ -167,7 +167,7 @@ export interface LatestArguments<T extends object | null> extends LatestArgument
  * Specification is recommended to highlight connection between schema and
  * factory when spread across modules.
  *
- * @beta
+ * @public
  * @sealed
  */
 export type LatestConfiguration<
@@ -193,7 +193,7 @@ export type LatestConfiguration<
  * Specification is recommended to highlight connection between schema and
  * factory when spread across modules.
  *
- * @beta
+ * @public
  * @sealed
  */
 export type LatestRawConfiguration<
@@ -209,7 +209,7 @@ export type LatestRawConfiguration<
 /**
  * Factory for creating a {@link Latest} or {@link LatestRaw} State object.
  *
- * @beta
+ * @public
  * @sealed
  */
 export interface LatestFactory {

--- a/packages/framework/presence-definitions/src/latestValueTypes.ts
+++ b/packages/framework/presence-definitions/src/latestValueTypes.ts
@@ -14,7 +14,7 @@ import type { Attendee } from "./presence.js";
  * Metadata for the value state.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestMetadata {
 	/**
@@ -32,7 +32,7 @@ export interface LatestMetadata {
  * Represents a value that is accessed directly.
  *
  * @system
- * @beta
+ * @public
  */
 export interface RawValueAccessor<T> {
 	readonly kind: "raw";
@@ -43,7 +43,7 @@ export interface RawValueAccessor<T> {
  * Represents a value that is accessed via a function call, which may result in no value.
  *
  * @system
- * @beta
+ * @public
  */
 export interface ProxiedValueAccessor<T> {
 	readonly kind: "proxied";
@@ -54,7 +54,7 @@ export interface ProxiedValueAccessor<T> {
  * Union of possible accessor types for a value.
  *
  * @system
- * @beta
+ * @public
  */
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
 
@@ -62,7 +62,7 @@ export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
  * Utility type that conditionally represents an accessor type based on the base accessor type.
  *
  * @system
- * @beta
+ * @public
  */
 export type Accessor<T, BaseAccessor extends ValueAccessor<T>> =
 	BaseAccessor extends ProxiedValueAccessor<T>
@@ -75,7 +75,7 @@ export type Accessor<T, BaseAccessor extends ValueAccessor<T>> =
  * State of a value and its metadata.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
 	/**
@@ -100,7 +100,7 @@ export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
  * State of a specific {@link Attendee}'s value and its metadata.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface LatestClientData<
 	T,
@@ -120,7 +120,7 @@ export interface LatestClientData<
  *
  * @returns The validated data, or `undefined` if the data is invalid.
  *
- * @beta
+ * @public
  */
 export type StateSchemaValidator<T> = (
 	/**

--- a/packages/framework/presence-definitions/src/presence.ts
+++ b/packages/framework/presence-definitions/src/presence.ts
@@ -26,14 +26,14 @@ import type {
  * identify clients in a session. {@link Attendee.attendeeId} will provide
  * the session ID.
  *
- * @beta
+ * @public
  */
 export type AttendeeId = SessionId & { readonly AttendeeId: "AttendeeId" };
 
 /**
  * The connection status of the {@link Attendee}.
  *
- * @beta
+ * @public
  */
 export const AttendeeStatus = {
 	/**
@@ -57,7 +57,7 @@ export const AttendeeStatus = {
  * - State changes are kept locally and communicated to others upon reconnect.
  * - Notification requests are discarded (silently).
  *
- * @beta
+ * @public
  */
 export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
 
@@ -77,7 +77,7 @@ export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus
  * Audience, and Quorum representations of clients and users.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
 	/**
@@ -110,7 +110,7 @@ export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
  * Events from {@link Presence.attendees}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface AttendeesEvents {
 	/**
@@ -132,7 +132,7 @@ export interface AttendeesEvents {
  * Events from {@link Presence}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface PresenceEvents {
 	/**
@@ -159,7 +159,7 @@ export interface PresenceEvents {
  * under {@link StatesWorkspace}s.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface Presence {
 	/**

--- a/packages/framework/presence-definitions/src/types.ts
+++ b/packages/framework/presence-definitions/src/types.ts
@@ -23,14 +23,14 @@ import type { Presence, PresenceWithNotifications } from "./presence.js";
  *   "address:object0/sub-object2:pointers"
  * ```
  *
- * @beta
+ * @public
  */
 export type WorkspaceAddress = `${string}:${string}`;
 
 /**
  * Single entry in {@link StatesWorkspaceSchema} or  {@link NotificationsWorkspaceSchema}.
  *
- * @beta
+ * @public
  */
 export type StatesWorkspaceEntry<
 	TKey extends string,
@@ -45,7 +45,7 @@ export type StatesWorkspaceEntry<
  *
  * Keys of schema are the keys of the {@link StatesWorkspace} providing access to State objects.
  *
- * @beta
+ * @public
  */
 export type StatesWorkspaceSchema<Keys extends string = string> = {
 	/**
@@ -58,7 +58,7 @@ export type StatesWorkspaceSchema<Keys extends string = string> = {
  * Map of State objects registered with {@link StatesWorkspace}.
  *
  * @sealed
- * @beta
+ * @public
  */
 export type StatesWorkspaceEntries<
 	TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>,
@@ -82,7 +82,7 @@ export type StatesWorkspaceEntries<
  * each client's state is independent and may only be updated by originating client.
  *
  * @sealed
- * @beta
+ * @public
  */
 export interface StatesWorkspace<
 	TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>,

--- a/packages/framework/presence-runtime/src/states/stateFactory.ts
+++ b/packages/framework/presence-runtime/src/states/stateFactory.ts
@@ -22,7 +22,7 @@ import { latest } from "./latestValueManager.js";
  * Use `latest` to create a {@link @fluidframework/presence#LatestRaw} State object.
  * Use `latestMap` to create a {@link @fluidframework/presence#LatestMapRaw} State object.
  *
- * @beta
+ * @public
  */
 export const StateFactory = {
 	latest,

--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -203,7 +203,7 @@ function logOthersCounters(counterTracker: LatestMap<number, string>): void {
 To access Presence APIs, use `getPresence()` with any `IFluidContainer`.
 
 ```typescript
-import { getPresence } from "fluid-framework/beta";
+import { getPresence } from "fluid-framework";
 
 function usePresence(container: IFluidContainer): void {
    const presence = getPresence(container);

--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -213,8 +213,8 @@ function usePresence(container: IFluidContainer): void {
 #### Schema Definition and Workspace
 
 ```typescript
-import type { Latest, LatestMap, Presence, StatesWorkspaceSchema } from "@fluidframework/presence/beta";
-import { StateFactory } from "@fluidframework/presence/beta";
+import type { Latest, LatestMap, Presence, StatesWorkspaceSchema } from "@fluidframework/presence";
+import { StateFactory } from "@fluidframework/presence";
 
 interface PointXY { x: number; y: number }
 

--- a/packages/framework/presence/api-extractor/api-extractor-lint-public.cjs.json
+++ b/packages/framework/presence/api-extractor/api-extractor-lint-public.cjs.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/dist/public.d.ts"
+}

--- a/packages/framework/presence/api-extractor/api-extractor-lint-public.esm.json
+++ b/packages/framework/presence/api-extractor/api-extractor-lint-public.esm.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/public.d.ts"
+}

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -4,22 +4,22 @@
 
 ```ts
 
-// @beta @system
+// @public @system
 export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
 
-// @beta @sealed
+// @public @sealed
 export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
     readonly attendeeId: SpecificAttendeeId;
     getConnectionId(): ClientConnectionId;
     getConnectionStatus(): AttendeeStatus;
 }
 
-// @beta
+// @public
 export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed
+// @public @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -27,32 +27,32 @@ export interface AttendeesEvents {
     attendeeDisconnected: (attendee: Attendee) => void;
 }
 
-// @beta
+// @public
 export const AttendeeStatus: {
     readonly Connected: "Connected";
     readonly Disconnected: "Disconnected";
 };
 
-// @beta
+// @public
 export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
 
-// @beta @sealed
+// @public @sealed
 export interface BroadcastControls {
     allowableUpdateLatencyMs: number | undefined;
 }
 
-// @beta
+// @public
 export interface BroadcastControlSettings {
     readonly allowableUpdateLatencyMs?: number;
 }
 
-// @beta
+// @public
 export type ClientConnectionId = string;
 
 // @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
-// @beta @system
+// @public @system
 export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
@@ -144,10 +144,10 @@ export namespace InternalPresenceUtilityTypes {
     export type NotificationParametersSignatureFromSubscriberSignature<Event> = Event extends (sender: Attendee, ...args: infer P) => void ? (...args: P) => void : never;
 }
 
-// @beta
+// @public
 export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
 
-// @beta @sealed
+// @public @sealed
 export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
@@ -159,32 +159,32 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
     attendee: Attendee;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localUpdated: (update: {
@@ -194,13 +194,13 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
     remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestFactory {
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -211,13 +211,13 @@ export interface LatestMap<T, Keys extends string = string, TRemoteAccessor exte
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
     keyValidator?: KeySchemaValidator<Keys>;
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     local?: {
         [K in Keys]: JsonSerializable<T>;
@@ -225,16 +225,16 @@ export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
     items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -253,46 +253,46 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapFactory {
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemRemovedClientData<K extends string> {
     attendee: Attendee;
     key: K;
     metadata: LatestMetadata;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
     key: K;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMetadata {
     revision: number;
     timestamp: number;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
 // @alpha @sealed
@@ -350,7 +350,7 @@ export type NotificationsWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
 };
 
-// @beta @sealed
+// @public @sealed
 export interface Presence {
     readonly attendees: {
         readonly events: Listenable<AttendeesEvents>;
@@ -364,7 +364,7 @@ export interface Presence {
     };
 }
 
-// @beta @sealed
+// @public @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
@@ -377,7 +377,7 @@ export interface PresenceWithNotifications extends Presence {
     };
 }
 
-// @beta @system
+// @public @system
 export interface ProxiedValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -385,7 +385,7 @@ export interface ProxiedValueAccessor<T> {
     readonly kind: "proxied";
 }
 
-// @beta @system
+// @public @system
 export interface RawValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -393,13 +393,13 @@ export interface RawValueAccessor<T> {
     readonly kind: "raw";
 }
 
-// @beta
+// @public
 export const StateFactory: {
     readonly latest: LatestFactory_2;
     readonly latestMap: LatestMapFactory_2;
 };
 
-// @beta @sealed
+// @public @sealed
 export interface StateMap<K extends string, V> {
     clear(): void;
     delete(key: K): boolean;
@@ -411,11 +411,11 @@ export interface StateMap<K extends string, V> {
     readonly size: number;
 }
 
-// @beta
+// @public
 export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
-// @beta @sealed
+// @public @sealed
 export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
@@ -423,7 +423,7 @@ export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<T
     readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
@@ -431,18 +431,18 @@ export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema
     readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
-// @beta
+// @public
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
-// @beta
+// @public
 export type StatesWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 };
 
-// @beta @system
+// @public @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
 
-// @beta
+// @public
 export type WorkspaceAddress = `${string}:${string}`;
 
 ```

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -4,22 +4,22 @@
 
 ```ts
 
-// @beta @system
+// @public @system
 export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
 
-// @beta @sealed
+// @public @sealed
 export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
     readonly attendeeId: SpecificAttendeeId;
     getConnectionId(): ClientConnectionId;
     getConnectionStatus(): AttendeeStatus;
 }
 
-// @beta
+// @public
 export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed
+// @public @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -27,32 +27,32 @@ export interface AttendeesEvents {
     attendeeDisconnected: (attendee: Attendee) => void;
 }
 
-// @beta
+// @public
 export const AttendeeStatus: {
     readonly Connected: "Connected";
     readonly Disconnected: "Disconnected";
 };
 
-// @beta
+// @public
 export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
 
-// @beta @sealed
+// @public @sealed
 export interface BroadcastControls {
     allowableUpdateLatencyMs: number | undefined;
 }
 
-// @beta
+// @public
 export interface BroadcastControlSettings {
     readonly allowableUpdateLatencyMs?: number;
 }
 
-// @beta
+// @public
 export type ClientConnectionId = string;
 
 // @beta @deprecated
 export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 
-// @beta @system
+// @public @system
 export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
@@ -118,10 +118,10 @@ export namespace InternalPresenceTypes {
     }
 }
 
-// @beta
+// @public
 export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
 
-// @beta @sealed
+// @public @sealed
 export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
@@ -133,32 +133,32 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
     attendee: Attendee;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localUpdated: (update: {
@@ -168,13 +168,13 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
     remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestFactory {
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -185,13 +185,13 @@ export interface LatestMap<T, Keys extends string = string, TRemoteAccessor exte
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
     keyValidator?: KeySchemaValidator<Keys>;
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     local?: {
         [K in Keys]: JsonSerializable<T>;
@@ -199,16 +199,16 @@ export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
     items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -227,49 +227,49 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapFactory {
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemRemovedClientData<K extends string> {
     attendee: Attendee;
     key: K;
     metadata: LatestMetadata;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
     key: K;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMetadata {
     revision: number;
     timestamp: number;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface Presence {
     readonly attendees: {
         readonly events: Listenable<AttendeesEvents>;
@@ -283,12 +283,12 @@ export interface Presence {
     };
 }
 
-// @beta @sealed
+// @public @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
 
-// @beta @system
+// @public @system
 export interface ProxiedValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -296,7 +296,7 @@ export interface ProxiedValueAccessor<T> {
     readonly kind: "proxied";
 }
 
-// @beta @system
+// @public @system
 export interface RawValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -304,13 +304,13 @@ export interface RawValueAccessor<T> {
     readonly kind: "raw";
 }
 
-// @beta
+// @public
 export const StateFactory: {
     readonly latest: LatestFactory_2;
     readonly latestMap: LatestMapFactory_2;
 };
 
-// @beta @sealed
+// @public @sealed
 export interface StateMap<K extends string, V> {
     clear(): void;
     delete(key: K): boolean;
@@ -322,11 +322,11 @@ export interface StateMap<K extends string, V> {
     readonly size: number;
 }
 
-// @beta
+// @public
 export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
-// @beta @sealed
+// @public @sealed
 export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
@@ -334,7 +334,7 @@ export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<T
     readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
@@ -342,18 +342,18 @@ export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema
     readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
-// @beta
+// @public
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
-// @beta
+// @public
 export type StatesWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 };
 
-// @beta @system
+// @public @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
 
-// @beta
+// @public
 export type WorkspaceAddress = `${string}:${string}`;
 
 ```

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -4,22 +4,22 @@
 
 ```ts
 
-// @beta @system
+// @public @system
 export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
 
-// @beta @sealed
+// @public @sealed
 export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
     readonly attendeeId: SpecificAttendeeId;
     getConnectionId(): ClientConnectionId;
     getConnectionStatus(): AttendeeStatus;
 }
 
-// @beta
+// @public
 export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed
+// @public @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -27,26 +27,26 @@ export interface AttendeesEvents {
     attendeeDisconnected: (attendee: Attendee) => void;
 }
 
-// @beta
+// @public
 export const AttendeeStatus: {
     readonly Connected: "Connected";
     readonly Disconnected: "Disconnected";
 };
 
-// @beta
+// @public
 export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
 
-// @beta @sealed
+// @public @sealed
 export interface BroadcastControls {
     allowableUpdateLatencyMs: number | undefined;
 }
 
-// @beta
+// @public
 export interface BroadcastControlSettings {
     readonly allowableUpdateLatencyMs?: number;
 }
 
-// @beta
+// @public
 export type ClientConnectionId = string;
 
 // @beta @deprecated
@@ -55,7 +55,7 @@ export const getPresence: (fluidContainer: IFluidContainer) => Presence;
 // @alpha @legacy
 export function getPresenceFromDataStoreContext(context: IFluidDataStoreContext): Presence;
 
-// @beta @system
+// @public @system
 export namespace InternalPresenceTypes {
     // @system
     export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
@@ -147,10 +147,10 @@ export namespace InternalPresenceUtilityTypes {
     export type NotificationParametersSignatureFromSubscriberSignature<Event> = Event extends (sender: Attendee, ...args: infer P) => void ? (...args: P) => void : never;
 }
 
-// @beta
+// @public
 export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
 
-// @beta @sealed
+// @public @sealed
 export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
@@ -162,32 +162,32 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
     attendee: Attendee;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
     metadata: LatestMetadata;
     value: Accessor<T, TValueAccessor>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localUpdated: (update: {
@@ -197,13 +197,13 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
     remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestFactory {
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
     <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -214,13 +214,13 @@ export interface LatestMap<T, Keys extends string = string, TRemoteAccessor exte
     readonly presence: Presence;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
     keyValidator?: KeySchemaValidator<Keys>;
     validator: StateSchemaValidator<T>;
 }
 
-// @beta @input
+// @public @input
 export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     local?: {
         [K in Keys]: JsonSerializable<T>;
@@ -228,16 +228,16 @@ export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
     settings?: BroadcastControlSettings | undefined;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
     items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -256,46 +256,46 @@ export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor exten
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapFactory {
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
     <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemRemovedClientData<K extends string> {
     attendee: Attendee;
     key: K;
     metadata: LatestMetadata;
 }
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
     key: K;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export interface LatestMetadata {
     revision: number;
     timestamp: number;
 }
 
-// @beta @sealed
+// @public @sealed
 export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
 
-// @beta @sealed
+// @public @sealed
 export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
 
 // @alpha @sealed
@@ -353,7 +353,7 @@ export type NotificationsWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: InternalPresenceTypes.ManagerFactory<Key, InternalPresenceTypes.ValueRequiredState<InternalPresenceTypes.NotificationType>, NotificationsManager<InternalPresenceUtilityTypes.NotificationListeners<unknown>>>;
 };
 
-// @beta @sealed
+// @public @sealed
 export interface Presence {
     readonly attendees: {
         readonly events: Listenable<AttendeesEvents>;
@@ -367,7 +367,7 @@ export interface Presence {
     };
 }
 
-// @beta @sealed
+// @public @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
@@ -380,7 +380,7 @@ export interface PresenceWithNotifications extends Presence {
     };
 }
 
-// @beta @system
+// @public @system
 export interface ProxiedValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -388,7 +388,7 @@ export interface ProxiedValueAccessor<T> {
     readonly kind: "proxied";
 }
 
-// @beta @system
+// @public @system
 export interface RawValueAccessor<T> {
     // (undocumented)
     readonly data: T;
@@ -396,13 +396,13 @@ export interface RawValueAccessor<T> {
     readonly kind: "raw";
 }
 
-// @beta
+// @public
 export const StateFactory: {
     readonly latest: LatestFactory_2;
     readonly latestMap: LatestMapFactory_2;
 };
 
-// @beta @sealed
+// @public @sealed
 export interface StateMap<K extends string, V> {
     clear(): void;
     delete(key: K): boolean;
@@ -414,11 +414,11 @@ export interface StateMap<K extends string, V> {
     readonly size: number;
 }
 
-// @beta
+// @public
 export type StateSchemaValidator<T> = (
 unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
 
-// @beta @sealed
+// @public @sealed
 export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
     add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
@@ -426,7 +426,7 @@ export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<T
     readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
 }
 
-// @beta @sealed
+// @public @sealed
 export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
     /**
     * Registered State objects.
@@ -434,18 +434,18 @@ export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema
     readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
 };
 
-// @beta
+// @public
 export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
 
-// @beta
+// @public
 export type StatesWorkspaceSchema<Keys extends string = string> = {
     [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
 };
 
-// @beta @system
+// @public @system
 export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
 
-// @beta
+// @public
 export type WorkspaceAddress = `${string}:${string}`;
 
 ```

--- a/packages/framework/presence/api-report/presence.public.api.md
+++ b/packages/framework/presence/api-report/presence.public.api.md
@@ -4,4 +4,353 @@
 
 ```ts
 
+// @public @system
+export type Accessor<T, BaseAccessor extends ValueAccessor<T>> = BaseAccessor extends ProxiedValueAccessor<T> ? () => DeepReadonly<JsonDeserialized<T>> | undefined : BaseAccessor extends RawValueAccessor<T> ? DeepReadonly<JsonDeserialized<T>> : never;
+
+// @public @sealed
+export interface Attendee<SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    readonly attendeeId: SpecificAttendeeId;
+    getConnectionId(): ClientConnectionId;
+    getConnectionStatus(): AttendeeStatus;
+}
+
+// @public
+export type AttendeeId = SessionId & {
+    readonly AttendeeId: "AttendeeId";
+};
+
+// @public @sealed
+export interface AttendeesEvents {
+    // @eventProperty
+    attendeeConnected: (attendee: Attendee) => void;
+    // @eventProperty
+    attendeeDisconnected: (attendee: Attendee) => void;
+}
+
+// @public
+export const AttendeeStatus: {
+    readonly Connected: "Connected";
+    readonly Disconnected: "Disconnected";
+};
+
+// @public
+export type AttendeeStatus = (typeof AttendeeStatus)[keyof typeof AttendeeStatus];
+
+// @public @sealed
+export interface BroadcastControls {
+    allowableUpdateLatencyMs: number | undefined;
+}
+
+// @public
+export interface BroadcastControlSettings {
+    readonly allowableUpdateLatencyMs?: number;
+}
+
+// @public
+export type ClientConnectionId = string;
+
+// @public @system
+export namespace InternalPresenceTypes {
+    // @system
+    export type ManagerFactory<TKey extends string, TValue extends ValueDirectoryOrState<unknown>, TManager> = {
+        instanceBase: new (...args: any[]) => unknown;
+    } & ((key: TKey, datastoreHandle: StateDatastoreHandle<TKey, TValue>) => {
+        initialData?: {
+            value: TValue;
+            allowableUpdateLatencyMs: number | undefined;
+        };
+        manager: StateValue<TManager>;
+    });
+    // @system
+    export interface MapValueState<T, Keys extends string> {
+        // (undocumented)
+        items: {
+            [name in Keys]: ValueOptionalState<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export interface NotificationType {
+        // (undocumented)
+        args: unknown[];
+        // (undocumented)
+        name: string;
+    }
+    // @system
+    export class StateDatastoreHandle<TKey, TValue extends ValueDirectoryOrState<unknown>> {
+    }
+    // @system
+    export type StateValue<T> = T & StateValueBrand<T>;
+    // @system
+    export class StateValueBrand<T> {
+    }
+    // @system
+    export interface ValueDirectory<T> {
+        // (undocumented)
+        items: {
+            [name: string | number]: ValueOptionalState<T> | ValueDirectory<T>;
+        };
+        // (undocumented)
+        rev: number;
+    }
+    // @system
+    export type ValueDirectoryOrState<T> = ValueRequiredState<T> | ValueDirectory<T>;
+    // @system
+    export interface ValueOptionalState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value?: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueRequiredState<TValue> extends ValueStateMetadata {
+        // (undocumented)
+        value: OpaqueJsonDeserialized<TValue>;
+    }
+    // @system
+    export interface ValueStateMetadata {
+        // (undocumented)
+        rev: number;
+        // (undocumented)
+        timestamp: number;
+    }
+}
+
+// @public
+export type KeySchemaValidator<Keys extends string> = (unvalidatedKey: string) => unvalidatedKey is Keys;
+
+// @public @sealed
+export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    readonly controls: BroadcastControls;
+    readonly events: Listenable<LatestEvents<T, TRemoteAccessor>>;
+    getRemote(attendee: Attendee): LatestData<T, TRemoteAccessor>;
+    getRemotes(): IterableIterator<LatestClientData<T, TRemoteAccessor>>;
+    getStateAttendees(): Attendee[];
+    get local(): DeepReadonly<JsonDeserialized<T>>;
+    set local(value: JsonSerializable<T>);
+    readonly presence: Presence;
+}
+
+// @public @input
+export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
+    validator: StateSchemaValidator<T>;
+}
+
+// @public @input
+export interface LatestArgumentsRaw<T extends object | null> {
+    local: JsonSerializable<T>;
+    settings?: BroadcastControlSettings | undefined;
+}
+
+// @public @sealed
+export interface LatestClientData<T, TValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> extends LatestData<T, TValueAccessor> {
+    attendee: Attendee;
+}
+
+// @public @sealed
+export type LatestConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, Latest<T>>;
+
+// @public @sealed
+export interface LatestData<T, TValueAccessor extends ValueAccessor<T>> {
+    metadata: LatestMetadata;
+    value: Accessor<T, TValueAccessor>;
+}
+
+// @public @sealed
+export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    // @eventProperty
+    localUpdated: (update: {
+        value: DeepReadonly<JsonSerializable<T>>;
+    }) => void;
+    // @eventProperty
+    remoteUpdated: (update: LatestClientData<T, TRemoteValueAccessor>) => void;
+}
+
+// @public @sealed
+export interface LatestFactory {
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArguments<T>): LatestConfiguration<T, RegistrationKeyRestrictions>;
+    <T extends object | null, RegistrationKeyRestrictions extends string = string>(args: LatestArgumentsRaw<T>): LatestRawConfiguration<T, RegistrationKeyRestrictions>;
+}
+
+// @public @sealed
+export interface LatestMap<T, Keys extends string = string, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    readonly controls: BroadcastControls;
+    readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
+    getRemote(attendee: Attendee): ReadonlyMap<Keys, LatestData<T, TRemoteAccessor>>;
+    getRemotes(): IterableIterator<LatestMapClientData<T, Keys, TRemoteAccessor>>;
+    getStateAttendees(): Attendee[];
+    readonly local: StateMap<Keys, T>;
+    readonly presence: Presence;
+}
+
+// @public @input
+export interface LatestMapArguments<T, Keys extends string = string> extends LatestMapArgumentsRaw<T, Keys> {
+    keyValidator?: KeySchemaValidator<Keys>;
+    validator: StateSchemaValidator<T>;
+}
+
+// @public @input
+export interface LatestMapArgumentsRaw<T, Keys extends string = string> {
+    local?: {
+        [K in Keys]: JsonSerializable<T>;
+    };
+    settings?: BroadcastControlSettings | undefined;
+}
+
+// @public @sealed
+export interface LatestMapClientData<T, Keys extends string, TValueAccessor extends ValueAccessor<T>, SpecificAttendeeId extends AttendeeId = AttendeeId> {
+    attendee: Attendee<SpecificAttendeeId>;
+    items: ReadonlyMap<Keys, LatestData<T, TValueAccessor>>;
+}
+
+// @public @sealed
+export type LatestMapConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
+
+// @public @sealed
+export interface LatestMapEvents<T, K extends string, TRemoteValueAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
+    // @eventProperty
+    localItemRemoved: (removedItem: {
+        key: K;
+    }) => void;
+    // @eventProperty
+    localItemUpdated: (updatedItem: {
+        value: DeepReadonly<JsonSerializable<T>>;
+        key: K;
+    }) => void;
+    // @eventProperty
+    remoteItemRemoved: (removedItem: LatestMapItemRemovedClientData<K>) => void;
+    // @eventProperty
+    remoteItemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K, TRemoteValueAccessor>) => void;
+    // @eventProperty
+    remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
+}
+
+// @public @sealed
+export interface LatestMapFactory {
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args: LatestMapArguments<T, Keys>): LatestMapConfiguration<T, Keys, RegistrationKeyRestrictions>;
+    <T, Keys extends string = string, RegistrationKeyRestrictions extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): LatestMapRawConfiguration<T, Keys, RegistrationKeyRestrictions>;
+}
+
+// @public @sealed
+export interface LatestMapItemRemovedClientData<K extends string> {
+    attendee: Attendee;
+    key: K;
+    metadata: LatestMetadata;
+}
+
+// @public @sealed
+export interface LatestMapItemUpdatedClientData<T, K extends string, TValueAccessor extends ValueAccessor<T>> extends LatestClientData<T, TValueAccessor> {
+    key: K;
+}
+
+// @public @sealed
+export type LatestMapRaw<T, Keys extends string = string> = LatestMap<T, Keys, RawValueAccessor<T>>;
+
+// @public @sealed
+export type LatestMapRawConfiguration<T, Keys extends string, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
+
+// @public @sealed
+export type LatestMapRawEvents<T, K extends string> = LatestMapEvents<T, K, RawValueAccessor<T>>;
+
+// @public @sealed
+export interface LatestMetadata {
+    revision: number;
+    timestamp: number;
+}
+
+// @public @sealed
+export type LatestRaw<T> = Latest<T, RawValueAccessor<T>>;
+
+// @public @sealed
+export type LatestRawConfiguration<T extends object | null, RegistrationKeyRestrictions extends string = string> = InternalPresenceTypes.ManagerFactory<RegistrationKeyRestrictions, InternalPresenceTypes.ValueRequiredState<T>, LatestRaw<T>>;
+
+// @public @sealed
+export type LatestRawEvents<T> = LatestEvents<T, RawValueAccessor<T>>;
+
+// @public @sealed
+export interface Presence {
+    readonly attendees: {
+        readonly events: Listenable<AttendeesEvents>;
+        getAttendees(): ReadonlySet<Attendee>;
+        getAttendee(clientId: ClientConnectionId | AttendeeId): Attendee;
+        getMyself(): Attendee;
+    };
+    readonly events: Listenable<PresenceEvents>;
+    readonly states: {
+        getWorkspace<StatesSchema extends Partial<StatesWorkspaceSchema<SchemaKeys>>, SchemaKeys extends string & keyof StatesSchema = string & keyof StatesSchema>(workspaceAddress: WorkspaceAddress, requestedStates: StatesSchema, controls?: BroadcastControlSettings): StatesWorkspace<StatesSchema, unknown, SchemaKeys>;
+    };
+}
+
+// @public @sealed
+export interface PresenceEvents {
+    workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
+}
+
+// @public @system
+export interface ProxiedValueAccessor<T> {
+    // (undocumented)
+    readonly data: T;
+    // (undocumented)
+    readonly kind: "proxied";
+}
+
+// @public @system
+export interface RawValueAccessor<T> {
+    // (undocumented)
+    readonly data: T;
+    // (undocumented)
+    readonly kind: "raw";
+}
+
+// @public
+export const StateFactory: {
+    readonly latest: LatestFactory_2;
+    readonly latestMap: LatestMapFactory_2;
+};
+
+// @public @sealed
+export interface StateMap<K extends string, V> {
+    clear(): void;
+    delete(key: K): boolean;
+    forEach(callbackfn: (value: DeepReadonly<JsonDeserialized<V>>, key: K, map: StateMap<K, V>) => void, thisArg?: unknown): void;
+    get(key: K): DeepReadonly<JsonDeserialized<V>> | undefined;
+    has(key: K): boolean;
+    keys(): IterableIterator<K>;
+    set(key: K, value: JsonSerializable<V>): this;
+    readonly size: number;
+}
+
+// @public
+export type StateSchemaValidator<T> = (
+unvalidatedData: unknown) => JsonDeserialized<T> | undefined;
+
+// @public @sealed
+export interface StatesWorkspace<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TManagerConstraints = unknown, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> {
+    add<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager extends TManagerConstraints>(key: TKey, configuration: InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    readonly controls: BroadcastControls;
+    readonly presence: Presence;
+    readonly states: StatesWorkspaceEntries<TSchema, TSchemaKeys>;
+}
+
+// @public @sealed
+export type StatesWorkspaceEntries<TSchema extends Partial<StatesWorkspaceSchema<TSchemaKeys>>, TSchemaKeys extends string & keyof TSchema = string & keyof TSchema> = {
+    /**
+    * Registered State objects.
+    */
+    readonly [Key in keyof TSchema]: ReturnType<Exclude<TSchema[Key], undefined>>["manager"] extends InternalPresenceTypes.StateValue<infer TManager> ? TManager : never;
+};
+
+// @public
+export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalPresenceTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalPresenceTypes.ManagerFactory<TKey, TValue, TManager>;
+
+// @public
+export type StatesWorkspaceSchema<Keys extends string = string> = {
+    [Key in Keys]: StatesWorkspaceEntry<Key, InternalPresenceTypes.ValueDirectoryOrState<unknown>>;
+};
+
+// @public @system
+export type ValueAccessor<T> = RawValueAccessor<T> | ProxiedValueAccessor<T>;
+
+// @public
+export type WorkspaceAddress = `${string}:${string}`;
+
 ```

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -13,6 +13,16 @@
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/public.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/public.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
 		"./beta": {
 			"import": {
 				"types": "./lib/beta.d.ts",
@@ -69,9 +79,11 @@
 		"check:exports:cjs:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.cjs.json",
 		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
 		"check:exports:cjs:legacy.alpha": "api-extractor run --config api-extractor/api-extractor-lint-legacy.alpha.cjs.json",
+		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
 		"check:exports:esm:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.esm.json",
 		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
 		"check:exports:esm:legacy.alpha": "api-extractor run --config api-extractor/api-extractor-lint-legacy.alpha.esm.json",
+		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -23,7 +23,7 @@ import type {
  *
  * @beta
  *
- * @deprecated Import from `fluid-framework/beta` instead. This export will be removed in the 2.110.0 release.
+ * @deprecated Import from `fluid-framework` instead. This export will be removed in the 2.110.0 release.
  * See {@link https://github.com/microsoft/FluidFramework/issues/26397}
  */
 export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPresenceAlpha;

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -26,7 +26,7 @@ import {
 	type LatestRaw,
 	type LatestMapRaw,
 	type StatesWorkspace,
-} from "@fluidframework/presence/beta";
+} from "@fluidframework/presence";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.tool.ts
@@ -18,7 +18,7 @@ import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { LogLevel } from "@fluidframework/core-interfaces";
 import type { ScopeType } from "@fluidframework/driver-definitions/legacy";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
-import { getPresence } from "@fluidframework/fluid-static/beta";
+import { getPresence } from "@fluidframework/fluid-static";
 import {
 	type Attendee,
 	type Presence,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -6,7 +6,7 @@
 // eslint-disable-next-line import-x/no-internal-modules
 import type { JsonSerializable } from "@fluidframework/core-interfaces/internal";
 import type { ScopeType } from "@fluidframework/driver-definitions/legacy";
-import type { AttendeeId } from "@fluidframework/presence/beta";
+import type { AttendeeId } from "@fluidframework/presence";
 
 export interface UserIdAndName {
 	id: string;

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/orchestratorUtils.ts
@@ -7,7 +7,7 @@ import { fork } from "node:child_process";
 import type { ChildProcess as AnyChildProcess } from "node:child_process";
 
 import { ScopeType } from "@fluidframework/driver-definitions/legacy";
-import type { AttendeeId } from "@fluidframework/presence/beta";
+import type { AttendeeId } from "@fluidframework/presence";
 import { timeoutAwait, timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import type {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "node:assert";
 import type { ChildProcess } from "node:child_process";
 import inspector from "node:inspector";
 
-import type { AttendeeId } from "@fluidframework/presence/beta";
+import type { AttendeeId } from "@fluidframework/presence";
 import { timeoutAwait, timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import type { MessageFromChild } from "./messageTypes.js";


### PR DESCRIPTION
- Retag all `@beta` presence APIs and their supporting types with `@public`.
  - The `getPresence` from `@fluidframework/presence` remains at `@beta+@deprecated`. The not deprecated `getPresence` from `fluid-framework` is retagged to `@public`.
- Add public entrypoint to `@fluidframework/presence` package.
- Update documentation to note public support (no /beta import spec).
- Update internal presence/beta imports to public.
- Remove `/beta` exports from `fluid-static` as unused (never released #26399 independently)

The are no logic changes.