### PR TITLE
test(client-fluid-telemetry): support build-and-test:unit:*

### DIFF
--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -81,10 +81,12 @@
 		"test": "start-server-and-test start:tinylicious:test 7070 test:mocha:all",
 		"test:mocha": "npm run test:mocha:esm:unit && echo skipping cjs to avoid overhead - npm run test:mocha:cjs:unit",
 		"test:mocha:all": "npm run test:mocha:esm:all && echo skipping cjs to avoid overhead - npm run test:mocha:cjs:all",
+		"test:mocha:cjs": "npm run test:mocha:cjs:unit && echo note: not running end-to-end tests",
 		"test:mocha:cjs:all": "mocha \"dist/test/**/*.spec*.js\"",
 		"test:mocha:cjs:end-to-end": "mocha \"dist/test/**/*.spec.realsvc.js\"",
 		"test:mocha:cjs:unit": "mocha \"dist/test/**/*.spec.js\"",
 		"test:mocha:end-to-end": "npm run test:mocha:esm:end-to-end && echo skipping cjs to avoid overhead - npm run test:mocha:cjs:end-to-end",
+		"test:mocha:esm": "npm run test:mocha:esm:unit && echo note: not running end-to-end tests",
 		"test:mocha:esm:all": "mocha \"lib/test/**/*.spec*.js\"",
 		"test:mocha:esm:end-to-end": "mocha \"lib/test/**/*.spec.realsvc.js\"",
 		"test:mocha:esm:unit": "mocha \"lib/test/**/*.spec.js\"",
@@ -127,6 +129,16 @@
 		"tinylicious": "^7.0.0",
 		"tslib": "^1.10.0",
 		"typescript": "~5.4.5"
+	},
+	"fluidBuild": {
+		"tasks": {
+			"test:mocha:cjs:all": ["build:test:cjs"],
+			"test:mocha:cjs:end-to-end": ["build:test:cjs"],
+			"test:mocha:cjs:unit": ["build:test:cjs"],
+			"test:mocha:esm:all": ["build:test:esm"],
+			"test:mocha:esm:end-to-end": ["build:test:esm"],
+			"test:mocha:esm:unit": ["build:test:esm"]
+		}
 	},
 	"typeValidation": {
 		"disabled": true

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -132,12 +132,24 @@
 	},
 	"fluidBuild": {
 		"tasks": {
-			"test:mocha:cjs:all": ["build:test:cjs"],
-			"test:mocha:cjs:end-to-end": ["build:test:cjs"],
-			"test:mocha:cjs:unit": ["build:test:cjs"],
-			"test:mocha:esm:all": ["build:test:esm"],
-			"test:mocha:esm:end-to-end": ["build:test:esm"],
-			"test:mocha:esm:unit": ["build:test:esm"]
+			"test:mocha:cjs:all": [
+				"build:test:cjs"
+			],
+			"test:mocha:cjs:end-to-end": [
+				"build:test:cjs"
+			],
+			"test:mocha:cjs:unit": [
+				"build:test:cjs"
+			],
+			"test:mocha:esm:all": [
+				"build:test:esm"
+			],
+			"test:mocha:esm:end-to-end": [
+				"build:test:esm"
+			],
+			"test:mocha:esm:unit": [
+				"build:test:esm"
+			]
 		}
 	},
 	"typeValidation": {


### PR DESCRIPTION
fluid-telemetry has specialized unit tests with no entry that allows `build-and-test:unit:esm` to build or test.
1. Add `test:mocha:esm` pointing to `test:mocha:esm:unit`.
2. Update task deps such that any of the mocha tests can be fluid-build tasks (get automatic build before test run).