### PR TITLE
test(app-insights-logger): Skip flaky test

### DIFF
--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -30,7 +30,9 @@ describe("FluidAppInsightsLogger", () => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
+
+	// AB#69025 - fix the flakiness for this test, if we don't sunset the feature/package before that
+	it.skip("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
 		const logger = createLogger(appInsightsClient);
 
 		const mockTelemetryEvent = {

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -30,7 +30,6 @@ describe("FluidAppInsightsLogger", () => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-
 	// AB#69025 - fix the flakiness for this test, if we don't sunset the feature/package before that
 	it.skip("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
 		const logger = createLogger(appInsightsClient);


### PR DESCRIPTION
## Description

Skips a test that's been timing out in PR builds lately. Opened [AB#69025](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/69025) to track it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
