### PR TITLE
Reduce number of intervals in endpointInRangeIndex.spec.ts fuzz test

### DIFF
--- a/packages/dds/sequence/src/test/endpointInRangeIndex.spec.ts
+++ b/packages/dds/sequence/src/test/endpointInRangeIndex.spec.ts
@@ -229,7 +229,7 @@ describe("findIntervalsWithEndpointInRange", () => {
 		it("when given massive random inputs", () => {
 			const testIndex = new TestEndpointInRangeIndex(sharedString);
 			const random = makeRandom(0);
-			const count = 800;
+			const count = 400;
 			const min = 1;
 			const max = sharedString.getLength() - 1;
 


### PR DESCRIPTION
## Description

This test regularly hovers near the timeout, and recently caused a PR failure due to going over it.

Given the test config, it roughly makes sense that it would take a while: pre-PR, it adds 800 intervals to a SharedString with 1k characters, then performs 100 queries at random positions comparing the actual API with a brute-force test implementation which isn't guaranteed to be particularly fast. I'd estimate the original test calls `localReferencePositionToPosition` on this sharedstring somewhere on the order of 500k times among other bookkeeping. Additionally, the API cannot hope to ever be more efficient than O(# of intervals in overlap), which will tend to be rather large given the density of intervals in the string and the test strategy of generating random positions.

I've reduced the number of intervals in the string by a factor of 2 to reduce test time. This should still provide some decent smoke coverage.