### PR TITLE
docs(devcontainer): Clarify Kusto MCP compliance and update examples

### DIFF
--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -56,12 +56,15 @@ You can also launch an agent with your own combination of MCP servers using the 
 Stack as many as you need (and watch for browser authentication popups).
 
 ```bash
-# Claude with an additional Kusto MCP server (ADO, WorkIQ, and EngHub are always included)
-claude --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'
+# Copilot with the Kusto MCP server
+copilot --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'
 
-# Copilot with an additional MCP server
-copilot --mcp 'workiq'
+# Claude with an additional MCP server
+claude --mcp 'workiq'
 ```
+
+> [!IMPORTANT]
+> The **Kusto** MCP server must only be used with **Copilot**, not Claude, for compliance reasons.
 
 > Run `agency mcp --help` to see all available MCP servers and their options.
 

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -60,7 +60,7 @@ Stack as many as you need (and watch for browser authentication popups).
 copilot --mcp 'kusto --service-uri https://kusto.aria.microsoft.com'
 
 # Claude with an additional MCP server
-claude --mcp 'workiq'
+claude --mcp 'sharepoint'
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Description

The Kusto MCP server example in GETTING_STARTED.md previously showed it being used with Claude. For compliance reasons, Kusto must only be used with Copilot. This PR:

- Moves the Kusto example to use `copilot` instead of `claude`
- Adds an `[\!IMPORTANT]` callout about the compliance requirement
- Uses `sharepoint` instead of `workiq` as the Claude example, since WorkIQ is already included by default

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).