### PR TITLE
fix(fluid-telemetry,app-insights-logger): Fix flaky ApplicationInsights test timeouts

### DIFF
--- a/packages/framework/client-logger/app-insights-logger/eslint.config.mts
+++ b/packages/framework/client-logger/app-insights-logger/eslint.config.mts
@@ -6,6 +6,16 @@
 import type { Linter } from "eslint";
 import { strict } from "@fluidframework/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		files: ["src/test/**/*.spec.ts"],
+		rules: {
+			// Allow named functions in mocha hooks (before, beforeEach, etc.) so that
+			// the function name appears in error output and stack traces.
+			"prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -23,7 +23,7 @@ describe("FluidAppInsightsLogger", () => {
 	// Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
 	// initialization path (~250ms locally, potentially much worse in CI). Calling
 	// loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
-	before(() => {
+	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -34,11 +34,11 @@ describe("FluidAppInsightsLogger", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(() => {
+	beforeEach(function createTrackEventSpy() {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	afterEach(() => {
+	afterEach(function restoreSpy() {
 		trackEventSpy.restore();
 	});
 
@@ -125,7 +125,7 @@ describe("Telemetry Filter - filter mode", () => {
 	let appInsightsClient: ApplicationInsights;
 	let trackEventSpy: Sinon.SinonSpy;
 
-	before(() => {
+	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -136,11 +136,11 @@ describe("Telemetry Filter - filter mode", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(() => {
+	beforeEach(function createTrackEventSpy() {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	afterEach(() => {
+	afterEach(function restoreSpy() {
 		trackEventSpy.restore();
 	});
 
@@ -202,7 +202,7 @@ describe("Telemetry Filter - Category Filtering", () => {
 		},
 	};
 
-	before(() => {
+	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -213,11 +213,11 @@ describe("Telemetry Filter - Category Filtering", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(() => {
+	beforeEach(function createTrackEventSpy() {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	afterEach(() => {
+	afterEach(function restoreSpy() {
 		trackEventSpy.restore();
 	});
 
@@ -376,7 +376,7 @@ describe("Telemetry Filter - Namespace Filtering", () => {
 		},
 	};
 
-	before(() => {
+	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -387,11 +387,11 @@ describe("Telemetry Filter - Namespace Filtering", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(() => {
+	beforeEach(function createTrackEventSpy() {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	afterEach(() => {
+	afterEach(function restoreSpy() {
 		trackEventSpy.restore();
 	});
 
@@ -614,7 +614,7 @@ describe("Telemetry Filter - Category & Namespace Combination Filtering", () => 
 		},
 	};
 
-	before(() => {
+	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -625,11 +625,11 @@ describe("Telemetry Filter - Category & Namespace Combination Filtering", () => 
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(() => {
+	beforeEach(function createTrackEventSpy() {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	afterEach(() => {
+	afterEach(function restoreSpy() {
 		trackEventSpy.restore();
 	});
 

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -19,7 +19,11 @@ describe("FluidAppInsightsLogger", () => {
 	let appInsightsClient: ApplicationInsights;
 	let trackEventSpy: Sinon.SinonSpy;
 
-	beforeEach(() => {
+	// Create the ApplicationInsights instance once for the suite and eagerly initialize it.
+	// Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
+	// initialization path (~250ms locally, potentially much worse in CI). Calling
+	// loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
+	before(() => {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -27,11 +31,18 @@ describe("FluidAppInsightsLogger", () => {
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		appInsightsClient.loadAppInsights();
+	});
+
+	beforeEach(() => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 	});
 
-	// AB#69025 - fix the flakiness for this test, if we don't sunset the feature/package before that
-	it.skip("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
+	afterEach(() => {
+		trackEventSpy.restore();
+	});
+
+	it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
 		const logger = createLogger(appInsightsClient);
 
 		const mockTelemetryEvent = {
@@ -114,7 +125,7 @@ describe("Telemetry Filter - filter mode", () => {
 	let appInsightsClient: ApplicationInsights;
 	let trackEventSpy: Sinon.SinonSpy;
 
-	beforeEach(() => {
+	before(() => {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -122,7 +133,15 @@ describe("Telemetry Filter - filter mode", () => {
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		appInsightsClient.loadAppInsights();
+	});
+
+	beforeEach(() => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
+
+	afterEach(() => {
+		trackEventSpy.restore();
 	});
 
 	it("exclusive filter mode sends all events when no filters are defined", () => {
@@ -183,7 +202,7 @@ describe("Telemetry Filter - Category Filtering", () => {
 		},
 	};
 
-	beforeEach(() => {
+	before(() => {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -191,7 +210,15 @@ describe("Telemetry Filter - Category Filtering", () => {
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		appInsightsClient.loadAppInsights();
+	});
+
+	beforeEach(() => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
+
+	afterEach(() => {
+		trackEventSpy.restore();
 	});
 
 	it("exclusive filtering mode DOES NOT SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
@@ -349,7 +376,7 @@ describe("Telemetry Filter - Namespace Filtering", () => {
 		},
 	};
 
-	beforeEach(() => {
+	before(() => {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -357,7 +384,15 @@ describe("Telemetry Filter - Namespace Filtering", () => {
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		appInsightsClient.loadAppInsights();
+	});
+
+	beforeEach(() => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
+
+	afterEach(() => {
+		trackEventSpy.restore();
 	});
 
 	it("exclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters", () => {
@@ -579,7 +614,7 @@ describe("Telemetry Filter - Category & Namespace Combination Filtering", () => 
 		},
 	};
 
-	beforeEach(() => {
+	before(() => {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -587,7 +622,15 @@ describe("Telemetry Filter - Category & Namespace Combination Filtering", () => 
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		appInsightsClient.loadAppInsights();
+	});
+
+	beforeEach(() => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
+
+	afterEach(() => {
+		trackEventSpy.restore();
 	});
 
 	it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {

--- a/packages/framework/client-logger/fluid-telemetry/eslint.config.mts
+++ b/packages/framework/client-logger/fluid-telemetry/eslint.config.mts
@@ -6,6 +6,16 @@
 import type { Linter } from "eslint";
 import { strict } from "@fluidframework/eslint-config-fluid/flat.mts";
 
-const config: Linter.Config[] = [...strict];
+const config: Linter.Config[] = [
+	...strict,
+	{
+		files: ["src/test/**/*.spec.ts"],
+		rules: {
+			// Allow named functions in mocha hooks (before, beforeEach, etc.) so that
+			// the function name appears in error output and stack traces.
+			"prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
+		},
+	},
+];
 
 export default config;

--- a/packages/framework/client-logger/fluid-telemetry/src/test/containerTelemetry.spec.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/test/containerTelemetry.spec.ts
@@ -49,7 +49,11 @@ describe("container telemetry via", () => {
 	let trackEventSpy: Sinon.SinonSpy;
 	let telemetryConfig: TelemetryConfig;
 
-	beforeEach(() => {
+	// Create the ApplicationInsights instance once for the suite and eagerly initialize it.
+	// Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
+	// initialization path (~250ms locally, potentially much worse in CI). Calling
+	// loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
+	before(() => {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -57,7 +61,10 @@ describe("container telemetry via", () => {
 					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
 			},
 		});
+		appInsightsClient.loadAppInsights();
+	});
 
+	beforeEach(() => {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 		mockFluidContainer = new MockFluidContainer();
 
@@ -66,6 +73,10 @@ describe("container telemetry via", () => {
 			containerId: mockContainerId,
 			consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
 		};
+	});
+
+	afterEach(() => {
+		trackEventSpy.restore();
 	});
 
 	it("Emitting 'connected' container system event produces expected ContainerConnectedTelemetry using Azure App Insights", () => {

--- a/packages/framework/client-logger/fluid-telemetry/src/test/containerTelemetry.spec.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/test/containerTelemetry.spec.ts
@@ -53,7 +53,7 @@ describe("container telemetry via", () => {
 	// Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
 	// initialization path (~250ms locally, potentially much worse in CI). Calling
 	// loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
-	before(() => {
+	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
 			config: {
 				connectionString:
@@ -64,7 +64,7 @@ describe("container telemetry via", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(() => {
+	beforeEach(function createSpiesAndConfig() {
 		trackEventSpy = spy(appInsightsClient, "trackEvent");
 		mockFluidContainer = new MockFluidContainer();
 
@@ -75,7 +75,7 @@ describe("container telemetry via", () => {
 		};
 	});
 
-	afterEach(() => {
+	afterEach(function restoreSpy() {
 		trackEventSpy.restore();
 	});
 


### PR DESCRIPTION
[AB#71221](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71221)

## Description

Tests in `@fluidframework/fluid-telemetry` and `@fluidframework/app-insights-logger` were
intermittently timing out in CI. Both had the same root cause.

Without calling `loadAppInsights()`, the first `trackEvent` call on an `ApplicationInsights`
instance triggers an expensive fallback initialization path (~250ms locally, potentially much
worse under CI resource contention). Previously, `beforeEach` created a new instance per test,
so every test paid this cost within its own timeout budget.

The fix for both packages:
- Moves `ApplicationInsights` construction from `beforeEach` to `before` (suite-level)
- Calls `loadAppInsights()` to eagerly initialize the SDK, avoiding the expensive fallback
  path entirely (reduces first `trackEvent` from ~250ms to ~1ms)
- Adds `afterEach` to restore the sinon spy between tests (necessary since the instance is
  now shared)
- Uses named functions for mocha hooks for better debuggability in stack traces, with an
  eslint override (`allowNamedFunctions`) scoped to `*.spec.ts` files

The `app-insights-logger` change also unskips the test that was skipped in #27007 ([AB#69025](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/69025)).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).