### PR TITLE
Clarify tree API report reorder diffs as incremental TS bug

### DIFF
--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -74,7 +74,7 @@ cd $PKG && pnpm exec fluid-build . -t eslint:fix
 
 Steps 6 and 7 only run if the public API surface changed. Proceed if: `src/index.ts` or any entry point (`src/alpha.ts`, `src/beta.ts`, `src/legacy.ts`, `src/internal.ts`) was modified; any exported type/interface/class/function signature changed; or `package.json` `exports` changed. Skip if only tests, internal implementation, comments, or function bodies (not signatures) changed.
 
-Running `build:api-reports` when nothing changed can introduce spurious diffs — especially for `@fluidframework/tree` and `fluid-framework`, which have a known API Extractor bug with non-deterministic type ordering.
+Running `build:api-reports` when nothing changed can introduce spurious diffs — specifically for the `@fluidframework/tree` and `fluid-framework` packages, which surface a known incremental TypeScript bug that non-deterministically reorders type unions. If you see only key-reorder diffs with no real API changes, do a clean build of the affected package and regenerate (see `tree-api-checks.md` for details).
 
 # Step 6: API reports and cross-package cascade (Build and Test only)
 

--- a/.claude/skills/ci-readiness-check/tree-api-checks.md
+++ b/.claude/skills/ci-readiness-check/tree-api-checks.md
@@ -26,17 +26,18 @@ Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index
 
 ## After running `build:api-reports`: check for phantom key-reorder diffs
 
-There is a known bug in API Extractor that non-deterministically reorders union key strings within `Omit<>` type signatures in this package — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. The ordering is stable within a single fresh compilation (local and CI agree), but it can silently flip between compilations after clearing `tsbuildinfo` or after TypeScript version changes.
+There is a known incremental TypeScript compilation bug that non-deterministically reorders union key strings within `Omit<>` type signatures in this package — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. This is a bug in TypeScript's incremental build and flows downstream to API extractor. It only occurs with incremental builds; clean builds produce deterministic, stable output that matches CI.
 
 A diff is a phantom key-reorder if: only the order of string literal keys in an `Omit<>` changes; nothing is added or removed.
 
-**Always commit the file that `build:api-reports` produces.** Do not manually flip key order or restore from git. The local fresh build and CI agree on the same ordering, so the build output is exactly what CI expects. If you restore the old order, CI will fail.
+**If you see phantom key-reorder diffs, do a clean build and regenerate:**
 
-There are two situations:
+```bash
+cd packages/dds/tree && pnpm exec fluid-build . --task clean && pnpm exec fluid-build . --task compile
+pnpm exec fluid-build . -t build:api-reports
+```
 
-1. **The only diff is key reorderings** (no real API additions/removals): Commit the updated file. The reordering is spurious but CI requires it.
-
-2. **The diff contains both real API changes and key reorderings:** Commit the entire file as-is. Both the real changes and the reorderings match what CI will produce.
+CI always runs clean builds, so a local clean build will produce the same output CI expects. After the clean rebuild, the spurious reorderings will be gone.
 
 ---
 
@@ -51,4 +52,4 @@ cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api
 
 If the tree reports are unchanged, skip this — the aggregator reports won't change either.
 
-After running either of these, apply the same phantom key-reorder check above — the same bug affects their reports for the same reason.
+After running either of these, check for phantom key-reorder diffs — the same incremental TypeScript bug can affect their reports. If you see any, do a clean build of the affected aggregator package and regenerate its API reports (same approach as above).


### PR DESCRIPTION
## Description

The CI readiness and tree API check skills incorrectly attributed phantom key-reorder diffs in API reports to "a known bug in API Extractor." This is actually an incremental TypeScript compilation bug — clean builds produce deterministic output that matches CI.

Updated the skill instructions to:
- Correctly identify the root cause as an incremental TypeScript bug, not an API Extractor bug
- Simplify the mitigation: do a clean build and regenerate, rather than committing potentially non-deterministic output
- Apply the same correction to the aggregator cascade guidance

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).