### PR TITLE
docs(devcontainer): update welcome tour to align with current agent aliases

### DIFF
--- a/.tours/welcome.tour
+++ b/.tours/welcome.tour
@@ -20,7 +20,7 @@
       "file": "scripts/codespace-setup/agent-aliases.sh",
       "line": 8,
       "title": "Claude Aliases",
-      "description": "These aliases launch Claude Code via agency:\n\n- **`claude`** — Normal Claude Code\n- **`dev`** - Claude Code with Nori overlay\n\nBoth aliases use `agency claude` under the hood, which ensures consistent configuration and context."
+      "description": "These aliases launch Claude Code via agency:\n\n- **`claude`** - Normal Claude Code\n- **`dev`** - Claude Code with Nori overlay\n\nBoth aliases use `agency claude` under the hood, which ensures consistent configuration and context."
     },
     {
       "file": "scripts/codespace-setup/agent-aliases.sh",
@@ -44,7 +44,7 @@
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
       "line": 1,
       "title": "Next Steps",
-      "description": "You're all set! Here's what to do:\n\n1. Run `pnpm install:agency` and open a new terminal\n2. Try `claude` or `copilot` to start an AI-assisted session\n3. Check [DEV.md](./DEV.md) for the full development workflow\n\nFor more info, see the [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace)."
+      "description": "You're all set! Here's what to do:\n\n1. Run `pnpm install:agency` and open a new terminal\n2. Try `dev`, `claude`, or `copilot` to start an AI-assisted session\n3. Check [DEV.md](./DEV.md) for the full development workflow\n\nFor more info, see the [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace)."
     }
   ]
 }

--- a/.tours/welcome.tour
+++ b/.tours/welcome.tour
@@ -26,7 +26,7 @@
       "file": "scripts/codespace-setup/agent-aliases.sh",
       "line": 37,
       "title": "Copilot Aliases",
-      "description": "These aliases launch GitHub Copilot:\n\n- **`copilot`** — Standard GitHub Copilot\n- **`copilot-oce`** — On-Call Engineer workflow (switches to ff-oce overlay)"
+      "description": "These aliases launch GitHub Copilot:\n\n- **`copilot`** — Standard GitHub Copilot\n- **`oce`** — On-Call Engineer workflow (switches to ff-oce agent)"
     },
     {
       "file": "scripts/codespace-setup/agent-aliases.sh",

--- a/.tours/welcome.tour
+++ b/.tours/welcome.tour
@@ -20,23 +20,17 @@
       "file": "scripts/codespace-setup/agent-aliases.sh",
       "line": 8,
       "title": "Claude Aliases",
-      "description": "These aliases launch Claude Code via agency:\n\n- **`claude`** — Default model\n- **`haiku`** — Fastest, cheapest option\n- **`sonnet`** — Balanced capabilities\n- **`opus`** — Most capable model\n\nAll aliases use `agency claude` under the hood, which ensures consistent configuration and context."
+      "description": "These aliases launch Claude Code via agency:\n\n- **`claude`** — Normal Claude Code\n- **`dev`** - Claude Code with Nori overlay\n\nBoth aliases use `agency claude` under the hood, which ensures consistent configuration and context."
     },
     {
       "file": "scripts/codespace-setup/agent-aliases.sh",
-      "line": 13,
-      "title": "Nori",
-      "description": "**`nori`** switches to the nori repoverlay and launches Claude.\n\nRepoverlay is an overlay system that layers context files (agent configurations, skills, prompt templates) on top of the repository. The `nori` overlay provides a curated set of skills for feature development, debugging, and bug fixing.\n\nRecommended for feature work, debugging, and bug fixing."
-    },
-    {
-      "file": "scripts/codespace-setup/agent-aliases.sh",
-      "line": 15,
+      "line": 37,
       "title": "Copilot Aliases",
-      "description": "These aliases launch GitHub Copilot with various MCP (Model Context Protocol) integrations:\n\n- **`copilot`** — Standard GitHub Copilot\n- **`copilot-ado`** — With Azure DevOps integration\n- **`copilot-kusto`** — With telemetry query capabilities\n- **`copilot-oce`** — On-Call Engineer workflow (switches to ff-oce overlay)\n- **`copilot-work`** — With WorkIQ integration"
+      "description": "These aliases launch GitHub Copilot:\n\n- **`copilot`** — Standard GitHub Copilot\n- **`copilot-oce`** — On-Call Engineer workflow (switches to ff-oce overlay)"
     },
     {
       "file": "scripts/codespace-setup/agent-aliases.sh",
-      "line": 21,
+      "line": 49,
       "title": "Resetting Overlays",
       "description": "If you need to reset your repoverlay state (remove all overlays and return to a clean repo state), run `ai-reset` in the terminal.\n\nThis runs `repoverlay remove --all` and is useful when switching between different workflows or troubleshooting overlay issues."
     },
@@ -50,7 +44,7 @@
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
       "line": 1,
       "title": "Next Steps",
-      "description": "You're all set! Here's what to do:\n\n1. Run `pnpm install:agency` and open a new terminal\n2. Try `claude` or `nori` to start an AI-assisted session\n3. Check [DEV.md](../DEV.md) for the full development workflow\n\nFor more info, see the [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace)."
+      "description": "You're all set! Here's what to do:\n\n1. Run `pnpm install:agency` and open a new terminal\n2. Try `claude` or `copilot` to start an AI-assisted session\n3. Check [DEV.md](./DEV.md) for the full development workflow\n\nFor more info, see the [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace)."
     }
   ]
 }


### PR DESCRIPTION
## Description

Following the welcome CodeTour when I set up my codespace I noticed a few outdated aliases (removal of the nori alias, removal of model-specific aliases) being pointed out in some of the steps. They have been updated along with some line numbers to align with the current aliases.
