### PR TITLE
Add `after` to `MemoryUseModifier`

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.56.0
 
+-   Add `after` to `MemoryUseModifier`.
+
 ## 0.55.0
 
 -   Added `memoryUseOfValue` and `memoryAddedBy` helper functions for constructing common `MemoryUseBenchmark` cases without hand-writing the callback loop.

--- a/tools/benchmark/api-report/benchmark.public.api.md
+++ b/tools/benchmark/api-report/benchmark.public.api.md
@@ -172,6 +172,7 @@ export interface MemoryUseCallbacks {
 
 // @public @input
 export interface MemoryUseModifier<TIn> {
+    after?: (input: TIn) => void | Promise<void>;
     modify(input: TIn): void | Promise<void>;
     setup(): TIn | Promise<TIn>;
 }

--- a/tools/benchmark/api-report/benchmark.public.api.md
+++ b/tools/benchmark/api-report/benchmark.public.api.md
@@ -172,7 +172,7 @@ export interface MemoryUseCallbacks {
 
 // @public @input
 export interface MemoryUseModifier<TIn> {
-    after?: (input: TIn) => void | Promise<void>;
+    after?(input: TIn): void | Promise<void>;
     modify(input: TIn): void | Promise<void>;
     setup(): TIn | Promise<TIn>;
 }

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -27,7 +27,7 @@
 		"format": "npm run prettier:fix",
 		"lint": "npm run prettier && npm run eslint",
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
-		"perf": "cross-env FLUID_TEST_VERBOSE=1 mocha --v8-expose-gc --timeout 999999 --perfMode --fgrep @Benchmark --reporter ./dist/mocha/Reporter.js",
+		"perf": "cross-env FLUID_TEST_VERBOSE=1 FLUID_TEST_PERF_MODE=1 mocha --v8-expose-gc --timeout 999999 --fgrep @Benchmark --reporter ./dist/mocha/Reporter.js",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
 		"test": "npm run test:mocha",

--- a/tools/benchmark/src/memoryBenchmarking/memoryUtils.ts
+++ b/tools/benchmark/src/memoryBenchmarking/memoryUtils.ts
@@ -24,6 +24,12 @@ export interface MemoryUseModifier<TIn> {
 	 * The additional memory retained by `input` after this operation will be measured.
 	 */
 	modify(input: TIn): void | Promise<void>;
+
+	/**
+	 * Optional callback to run after the value has been modified.
+	 * @param input - The value that was created by `setup` and modified by `modify`.
+	 */
+	after?: (input: TIn) => void | Promise<void>;
 }
 
 /**
@@ -111,6 +117,7 @@ export function memoryAddedBy<TIn extends NonNullable<unknown>>(
 				await state.beforeAllocation();
 				await options.modify(box.value);
 				await state.whileAllocated();
+				await options.after?.(box.value);
 				box.clear();
 				// afterDeallocation must not be called here:
 				// box.clear() frees the whole object not just what was added by the modifications,

--- a/tools/benchmark/src/memoryBenchmarking/memoryUtils.ts
+++ b/tools/benchmark/src/memoryBenchmarking/memoryUtils.ts
@@ -26,10 +26,14 @@ export interface MemoryUseModifier<TIn> {
 	modify(input: TIn): void | Promise<void>;
 
 	/**
-	 * Optional callback to run after the value has been modified.
+	 * Optional callback to run after the value has been modified and after the
+	 * `whileAllocated` measurement snapshot has been taken.
+	 * @remarks
+	 * Any allocations or mutations performed here are not reflected in the measured "while allocated" memory usage.
+	 * This hook is intended for cleanup or resetting state between benchmark iterations.
 	 * @param input - The value that was created by `setup` and modified by `modify`.
 	 */
-	after?: (input: TIn) => void | Promise<void>;
+	after?(input: TIn): void | Promise<void>;
 }
 
 /**

--- a/tools/benchmark/src/test/memoryBenchmarking/memoryUtils.spec.ts
+++ b/tools/benchmark/src/test/memoryBenchmarking/memoryUtils.spec.ts
@@ -52,6 +52,50 @@ describe("memoryUtils", () => {
 	});
 
 	describe("memoryAddedBy", () => {
+		it("everything called in expected order", async () => {
+			const log: string[] = [];
+			const benchmark = memoryAddedBy({
+				setup() {
+					log.push("setup");
+					return {};
+				},
+				modify() {
+					log.push("modify");
+				},
+				after() {
+					log.push("after");
+				},
+			});
+			const iterations = 2;
+			let count = 0;
+			await benchmark.benchmarkFn({
+				continue() {
+					return count++ < iterations;
+				},
+				async beforeAllocation() {
+					log.push("beforeAllocation");
+				},
+				async whileAllocated() {
+					log.push("whileAllocated");
+				},
+				async afterDeallocation() {
+					log.push("afterDeallocation");
+				},
+			});
+			assert.deepEqual(log, [
+				"setup",
+				"beforeAllocation",
+				"modify",
+				"whileAllocated",
+				"after",
+				"setup",
+				"beforeAllocation",
+				"modify",
+				"whileAllocated",
+				"after",
+			]);
+		});
+
 		benchmarkIt({
 			title: "sync setup and modify",
 			...benchmarkMemoryUse(


### PR DESCRIPTION
## Description

Add `after` to `MemoryUseModifier`

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
