### PR TITLE
refactor: extract shared ts-morph Node16 Project configuration

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -20,15 +20,14 @@ import { readJson } from "fs-extra/esm";
 import { major, minor, patch } from "semver";
 import {
 	type JSDoc,
-	ModuleKind,
 	type NameableNodeSpecific,
 	type NamedNodeSpecificBase,
 	Node,
-	Project,
 	type SourceFile,
 	SyntaxKind,
 } from "ts-morph";
 import { PackageCommand } from "../../BasePackageCommand.js";
+import { createNode16TsMorphProject } from "../../library/tsMorphProject.js";
 import { unscopedPackageNameString } from "../../library/commands/constants.js";
 import { ensureDevDependencyExists } from "../../library/package.js";
 import { getTypesPathFromPackage } from "../../library/packageExports.js";
@@ -561,13 +560,7 @@ function getTags(docs: JSDoc[]): ReadonlySet<string> {
  * @returns The loaded source file.
  */
 export function loadTypesSourceFile(typesPath: string): SourceFile {
-	// Note that this does NOT load anything from tsconfig.
-	const project = new Project({
-		skipAddingFilesFromTsConfig: true,
-		compilerOptions: {
-			module: ModuleKind.Node16,
-		},
-	});
+	const project = createNode16TsMorphProject();
 
 	// The typesPath may be a symlink or junction, so resolve the real path
 	// before adding it to the project to ensure correct module resolutions.

--- a/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
@@ -9,8 +9,9 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { Flags } from "@oclif/core";
 import * as JSON5 from "json5";
-import { type ImportDeclaration, ModuleKind, Project, type SourceFile } from "ts-morph";
+import { type ImportDeclaration, Project, type SourceFile } from "ts-morph";
 import { ApiLevel, isKnownApiLevel } from "../../library/apiLevel.js";
+import { createNode16TsMorphProject } from "../../library/tsMorphProject.js";
 import { BaseCommand } from "../../library/commands/base.js";
 import { getApiExports } from "../../library/typescriptApi.js";
 import type { CommandLogger } from "../../logging.js";
@@ -624,12 +625,7 @@ type NamedExportToPath = Map<string, ExportPath>;
 type MapData = Map<PackageName, NamedExportToPath>;
 
 class ApiLevelReader {
-	private readonly project = new Project({
-		skipAddingFilesFromTsConfig: true,
-		compilerOptions: {
-			module: ModuleKind.Node16,
-		},
-	});
+	private readonly project = createNode16TsMorphProject();
 
 	private readonly tempSource = this.project.createSourceFile("flub-fluid-importer-temp.ts");
 	private readonly map: Map<PackageName, NamedExportToPath | undefined>;

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -8,12 +8,13 @@ import type { PackageJson } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import fs from "fs-extra";
 import type { ExportSpecifierStructure, Node } from "ts-morph";
-import { ModuleKind, Project, ScriptKind } from "ts-morph";
+import { ScriptKind } from "ts-morph";
 
 import type { CommandLogger } from "../../logging.js";
 import { ApiLevel, isLegacy } from "../apiLevel.js";
 import type { ExportData, Node10CompatExportData } from "../packageExports.js";
 import { queryTypesResolutionPathsFromPackageExports } from "../packageExports.js";
+import { createNode16TsMorphProject } from "../tsMorphProject.js";
 import { getApiExports, getPackageDocumentationText } from "../typescriptApi.js";
 import { BaseCommand } from "./base.js";
 
@@ -540,19 +541,11 @@ async function generateEntrypoints(
 
 	log.info(`Processing: ${mainEntrypoint}`);
 
-	const project = new Project({
-		skipAddingFilesFromTsConfig: true,
-		// Note: it is likely better to leverage a tsconfig file from package rather than
-		// assume Node16 and no other special setup. However, currently configs are pretty
-		// standard with simple Node16 module specification and using a tsconfig for just
-		// part of its setting may be confusing to document and keep tidy with dual-emit.
-		compilerOptions: {
-			module: ModuleKind.Node16,
-			// Without this, JSX files are not properly handled by ts-morph. "React" is the
-			// value we use in our base config, so it should be a safe value.
-			jsx: 2 /* JSXEmit.React */,
-			customConditions,
-		},
+	const project = createNode16TsMorphProject({
+		// Without this, JSX files are not properly handled by ts-morph. "React" is the
+		// value we use in our base config, so it should be a safe value.
+		jsx: 2 /* JSXEmit.React */,
+		customConditions,
 	});
 	const mainSourceFile = project.addSourceFileAtPath(mainEntrypoint);
 	const exports = getApiExports(mainSourceFile, "throwForMissing", log);

--- a/build-tools/packages/build-cli/src/library/tsMorphProject.ts
+++ b/build-tools/packages/build-cli/src/library/tsMorphProject.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { type CompilerOptions, ModuleKind, Project } from "ts-morph";
+
+/**
+ * Creates a ts-morph {@link Project} configured with Node16 module resolution and no tsconfig file loading.
+ *
+ * @param compilerOptionOverrides - Additional compiler options to merge with the base Node16 configuration.
+ * @returns A new ts-morph {@link Project}.
+ */
+export function createNode16TsMorphProject(
+	compilerOptionOverrides?: CompilerOptions,
+): Project {
+	return new Project({
+		skipAddingFilesFromTsConfig: true,
+		// Note: it is likely better to leverage a tsconfig file from package rather than
+		// assume Node16 and no other special setup. However, currently configs are pretty
+		// standard with simple Node16 module specification and using a tsconfig for just
+		// part of its setting may be confusing to document and keep tidy with dual-emit.
+		compilerOptions: {
+			module: ModuleKind.Node16,
+			...compilerOptionOverrides,
+		},
+	});
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `createNode16TsMorphProject()` helper into `build-tools/packages/build-cli/src/library/tsMorphProject.ts`
- Replaces 3 duplicate `new Project({ skipAddingFilesFromTsConfig: true, compilerOptions: { module: ModuleKind.Node16 } })` call sites with the shared helper
- Pure refactor — no behavior change

Fixes #26734

## Test plan

- [ ] Verify `pnpm build` passes in `build-tools/packages/build-cli`
- [ ] Verify `pnpm test` passes in `build-tools/packages/build-cli`
- [ ] Verify `flub generate typetests`, `flub modify fluid-imports`, and `flub generate entrypoints` commands still work correctly