### PR TITLE
Disable test coverage in client build pipeline

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -198,7 +198,10 @@ extends:
     interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
-    testCoverage: ${{ eq(variables['System.TeamProject'], 'public' ) }} # disabling code coverage for internal project since we don't use it
+    # Disabled: coverage performance regressed in Node 22 and further in Node 24, causing test timeouts
+    # that need mitigation before coverage can be reenabled.
+    # testCoverage: ${{ eq(variables['System.TeamProject'], 'public' ) }} # disabling code coverage for internal project since we don't use it
+    testCoverage: false
     reportCodeCoverageComparison: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}
     tagName: client


### PR DESCRIPTION
[AB#71222](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71222)

## Summary

- Disables test coverage in the client build pipeline to mitigate test timeouts caused by coverage performance regressions in Node 22 and Node 24.
- The original `testCoverage` expression is preserved as a comment for easy restoration once the performance issues are addressed.

## Test plan

- [ ] Verify the client build pipeline runs successfully without coverage
- [ ] Confirm no errors from `reportCodeCoverageComparison` with coverage disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)