### PR TITLE
test(tree): add buildRegistry to compat test config and validate custom factories in convertRegistry, tests for incremental summary bug

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -11,14 +11,14 @@ import {
 	describeCompat,
 	describeInstallVersions,
 	getVersionedTestObjectProvider,
+	type CompatApis,
 } from "@fluid-private/test-version-utils";
 import {
 	CompressionAlgorithms,
 	type IContainerRuntimeOptions,
 	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
-// TODO:AB#6558: This should be provided based on the compatibility configuration.
-import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
+import type { ISharedMap } from "@fluidframework/map/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {
 	DataObjectFactoryType,
@@ -30,7 +30,10 @@ import {
 
 import { pkgVersion } from "../packageVersion.js";
 
-const compressionSuite = (getProvider, apis?): void => {
+const compressionSuite = (
+	getProvider: () => Promise<ITestObjectProvider>,
+	apis: Pick<CompatApis, "dds" | "containerRuntime" | "containerRuntimeForLoading">,
+): void => {
 	describe("Compression", () => {
 		let provider: ITestObjectProvider;
 		let localDataObject: ITestFluidObject;
@@ -51,7 +54,7 @@ const compressionSuite = (getProvider, apis?): void => {
 			// If the runtime version for the local or remote container runtime is 1.4.0, then we need to skip the tests as a lot of the options being tested fail in this version.
 			if (provider.type === "TestObjectProviderWithVersionedLoad") {
 				compatLocalVersionIsOld = apis.containerRuntime.version === "1.4.0";
-				compatOldRemoteVersionIsOld = apis.containerRuntimeForLoading.version === "1.4.0";
+				compatOldRemoteVersionIsOld = apis.containerRuntimeForLoading?.version === "1.4.0";
 			}
 		});
 
@@ -59,6 +62,7 @@ const compressionSuite = (getProvider, apis?): void => {
 			runtimeOptions: IContainerRuntimeOptionsInternal = defaultRuntimeOptions,
 			minVersionForCollab: MinimumVersionForCollab | undefined = undefined,
 		): Promise<void> {
+			const { SharedMap } = apis.dds;
 			const containerConfig: ITestContainerConfig = {
 				registry: [["mapKey", SharedMap.getFactory()]],
 				runtimeOptions,
@@ -178,7 +182,7 @@ describeInstallVersions(
 		requestAbsoluteVersions: [loaderWithoutCompressionField],
 	},
 	/* timeoutMs: 3 minutes */ 180000,
-)("Op Compression self-healing with old loader", (getProvider) =>
+)("Op Compression self-healing with old loader", (getProvider, apis) =>
 	compressionSuite(async () => {
 		const provider = getProvider();
 		// Ensure support for endpoint names for r11s driver. ODSP might need similar help at some point if we have
@@ -200,7 +204,7 @@ describeInstallVersions(
 			pkgVersion, // runtime version
 			pkgVersion, // datastore runtime version
 		);
-	}),
+	}, apis),
 );
 
 const generateRandomStringOfSize = (sizeInBytes: number): string =>

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -9,13 +9,8 @@ import {
 	describeCompat,
 	describeInstallVersions,
 	getVersionedTestObjectProvider,
+	type CompatApis,
 } from "@fluid-private/test-version-utils";
-// TODO:AB#6558: describeInstallVersions doesn't support dynamically providing package APIs.
-import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
-	DataObject,
-	DataObjectFactory,
-} from "@fluidframework/aqueduct/internal";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
@@ -28,21 +23,24 @@ import { pkgVersion } from "../packageVersion.js";
 describe("entryPoint compat", () => {
 	let provider: ITestObjectProvider;
 
-	class TestDataObject extends DataObject {
-		public get _root(): IDirectory {
-			return this.root;
-		}
-		public get _context(): IFluidDataStoreContext {
-			return this.context;
-		}
-	}
-
 	async function getDefaultFluidObject(runtime: IContainerRuntime): Promise<FluidObject> {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		return (await runtime.getAliasedDataStoreEntryPoint?.("default"))!.get();
 	}
 
-	async function createContainer(): Promise<IContainer> {
+	async function createContainer(apis: CompatApis): Promise<IContainer> {
+		const { DataObject, DataObjectFactory } = apis.dataRuntime;
+		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+
+		class TestDataObject extends DataObject {
+			public get _root(): IDirectory {
+				return this.root;
+			}
+			public get _context(): IFluidDataStoreContext {
+				return this.context;
+			}
+		}
+
 		const dataObjectFactory = new DataObjectFactory({
 			type: "TestDataObject",
 			ctor: TestDataObject,
@@ -56,13 +54,13 @@ describe("entryPoint compat", () => {
 		return provider.createContainer(runtimeFactory);
 	}
 
-	describeCompat("no compat", "NoCompat", (getTestObjectProvider) => {
+	describeCompat("no compat", "NoCompat", (getTestObjectProvider, apis) => {
 		beforeEach("getTestObjectProvider", async () => {
 			provider = getTestObjectProvider();
 		});
 
 		it("entryPoint pattern", async () => {
-			const container = await createContainer();
+			const container = await createContainer(apis);
 			const entryPoint = await container.getEntryPoint?.();
 			assert.notStrictEqual(entryPoint, undefined, "entryPoint was undefined");
 		});
@@ -71,7 +69,7 @@ describe("entryPoint compat", () => {
 	const loaderWithRequest = "2.0.0-internal.7.0.0";
 	describeInstallVersions({
 		requestAbsoluteVersions: [loaderWithRequest],
-	})("loader compat", (_) => {
+	})("loader compat", (_, apis) => {
 		beforeEach("getVersionedTestObjectProvider", async () => {
 			provider = await getVersionedTestObjectProvider(
 				pkgVersion, // base version
@@ -84,7 +82,7 @@ describe("entryPoint compat", () => {
 		});
 
 		it("request pattern works", async () => {
-			const container = await createContainer();
+			const container = await createContainer(apis);
 			const requestResult = await (container as any).request({ url: "/" });
 
 			assert.strictEqual(requestResult.status, 200, requestResult.value);
@@ -92,7 +90,7 @@ describe("entryPoint compat", () => {
 		});
 
 		it("request pattern works when entryPoint is available", async () => {
-			const container = await createContainer();
+			const container = await createContainer(apis);
 			const requestResult = await (container as any).request({ url: "/" });
 
 			// Verify request pattern still works for older loaders (even with entryPoint available)

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -11,8 +11,7 @@ import {
 	getDataRuntimeApi,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-// TODO:AB#6558: This should be provided based on the compatibility configuration.
-import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
+import type { ISharedMap } from "@fluidframework/map/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 import {
 	ChannelFactoryRegistry,
@@ -30,7 +29,7 @@ describeInstallVersions(
 		requestAbsoluteVersions: [versionWithChunking],
 	},
 	/* timeoutMs: 3 minutes */ 180000,
-)("Legacy chunking", (getTestObjectProvider) => {
+)("Legacy chunking", (getTestObjectProvider, apis) => {
 	let provider: ITestObjectProvider;
 	let oldMap: ISharedMap;
 	let newMap: ISharedMap;
@@ -40,7 +39,7 @@ describeInstallVersions(
 	afterEach(async () => provider.reset());
 
 	const mapId = "map";
-	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
+	const registry: ChannelFactoryRegistry = [[mapId, apis.dds.SharedMap.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
 		registry,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -21,6 +21,7 @@ import type { ITree, TreeView } from "@fluidframework/tree";
 import {
 	configuredSharedTree,
 	FluidClientVersion,
+	ForestTypeOptimized,
 	incrementalEncodingPolicyForAllowedTypes,
 	incrementalSummaryHint,
 	SchemaFactoryAlpha,
@@ -58,6 +59,7 @@ const viewConfig = new TreeViewConfigurationAlpha({ schema: Workspace });
 // Factory configured for incremental summarization
 // ---------------------------------------------------------------------------
 const ConfiguredSharedTree = configuredSharedTree({
+	forest: ForestTypeOptimized,
 	treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
 	minVersionForCollab: FluidClientVersion.v2_74,
 	shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(viewConfig),

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -1,0 +1,220 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { describeCompat } from "@fluid-private/test-version-utils";
+import type { IContainer } from "@fluidframework/container-definitions/internal";
+import type { ISummarizer } from "@fluidframework/container-runtime/internal";
+import {
+	DataObjectFactoryType,
+	getContainerEntryPointBackCompat,
+	type ITestContainerConfig,
+	type ITestFluidObject,
+	type ITestObjectProvider,
+	createSummarizer,
+	summarizeNow,
+} from "@fluidframework/test-utils/internal";
+import type { ITree, TreeView } from "@fluidframework/tree";
+import {
+	configuredSharedTree,
+	FluidClientVersion,
+	incrementalEncodingPolicyForAllowedTypes,
+	incrementalSummaryHint,
+	SchemaFactoryAlpha,
+	TreeCompressionStrategy,
+	TreeViewConfiguration,
+	TreeViewConfigurationAlpha,
+} from "@fluidframework/tree/internal";
+
+// ---------------------------------------------------------------------------
+// Schema: 3-depth nested structure with incrementalSummaryHint at depths 1 & 2
+// ---------------------------------------------------------------------------
+const sf = new SchemaFactoryAlpha("incrementalSummaryE2E");
+
+class Tag extends sf.object("Tag", {
+	name: sf.string,
+}) {}
+
+class Item extends sf.object("Item", {
+	itemName: sf.string,
+	tags: sf.types([{ type: sf.map(Tag), metadata: {} }], {
+		custom: { [incrementalSummaryHint]: true },
+	}),
+}) {}
+
+class Workspace extends sf.object("Workspace", {
+	label: sf.string,
+	items: sf.types([{ type: sf.map(Item), metadata: {} }], {
+		custom: { [incrementalSummaryHint]: true },
+	}),
+}) {}
+
+const viewConfig = new TreeViewConfigurationAlpha({ schema: Workspace });
+
+// ---------------------------------------------------------------------------
+// Factory configured for incremental summarization
+// ---------------------------------------------------------------------------
+const ConfiguredSharedTree = configuredSharedTree({
+	treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
+	minVersionForCollab: FluidClientVersion.v2_74,
+	shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(viewConfig),
+});
+
+const treeId = "sharedTree";
+
+describeCompat(
+	"SharedTree incremental summary handle paths",
+	"NoCompat",
+	(getTestObjectProvider) => {
+		let provider: ITestObjectProvider;
+
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			runtimeOptions: {
+				enableRuntimeIdCompressor: "on",
+			},
+			registry: [[treeId, ConfiguredSharedTree.getFactory()]],
+		};
+
+		async function createContainerAndTree(): Promise<{
+			container: IContainer;
+			view: TreeView<typeof Workspace>;
+		}> {
+			const container = await provider.makeTestContainer(testContainerConfig);
+			const dataObject =
+				await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+			const tree = await dataObject.getSharedObject<ITree>(treeId);
+			const view = tree.viewWith(new TreeViewConfiguration({ schema: Workspace }));
+			view.initialize(
+				new Workspace({
+					label: "v1",
+					items: {
+						item1: new Item({
+							itemName: "Item 1",
+							tags: {
+								tag1: new Tag({ name: "tag1" }),
+							},
+						}),
+					},
+				}),
+			);
+			return { container, view };
+		}
+
+		async function createTestSummarizer(
+			container: IContainer,
+		): Promise<ISummarizer> {
+			const { summarizer } = await createSummarizer(
+				provider,
+				container,
+				testContainerConfig,
+			);
+			return summarizer;
+		}
+
+		beforeEach("getTestObjectProvider", async () => {
+			provider = getTestObjectProvider({ syncSummarizer: true });
+		});
+
+		/**
+		 * Regression test for the stale incremental summary handle path bug fixed
+		 * in PR #26990.
+		 *
+		 * The bug: when a parent incremental chunk was re-encoded with a new
+		 * referenceId, child chunks that became handles still held a summaryPath
+		 * string referencing the old referenceId. On the next summary those handle
+		 * URLs pointed to keys that no longer existed in the preceding summary tree,
+		 * causing a storage error (e.g. `TypeError: Cannot read properties of
+		 * undefined (reading 'trees')`).
+		 *
+		 * To reproduce we need:
+		 * 1. A schema with incrementalSummaryHint at 2+ levels deep.
+		 * 2. CompressedIncremental encoding + ForestSummaryFormatVersion.v3.
+		 * 3. Multiple summaries where the parent chunk changes but the child does
+		 *    not — the child's handle path must be recomputed against the new parent
+		 *    referenceId each time.
+		 */
+		it("handles remain valid across multiple incremental summaries when parent chunks change", async () => {
+			const { container, view } = await createContainerAndTree();
+			const summarizer = await createTestSummarizer(container);
+
+			// 1. Initial summary — everything is encoded as full trees, no handles.
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			// 2. Mutate the "items" map (depth 1) — this re-encodes the outer chunk.
+			//    The "tags" map (depth 2) is unchanged → becomes a handle pointing into
+			//    the first summary.
+			const item1 = view.root.items.get("item1");
+			assert(item1 !== undefined, "item1 not found");
+			item1.itemName = "Item 1 - updated";
+
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			// 3. Mutate the "items" map again — the outer chunk gets a NEW referenceId.
+			//    The child "tags" handle must point into the second summary (not the
+			//    first). Before the fix, the stale summaryPath would cause a failure here.
+			item1.itemName = "Item 1 - updated again";
+
+			await provider.ensureSynchronized();
+			// This is the critical summary — it would fail before the fix because the
+			// child handle's path referenced the old parent referenceId.
+			await assert.doesNotReject(
+				summarizeNow(summarizer),
+				"Third summary should succeed — handle paths must be recomputed correctly",
+			);
+
+			// 4. Verify the document can still be loaded from the latest summary.
+			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const dataObject2 =
+				await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
+			const tree2 = await dataObject2.getSharedObject<ITree>(treeId);
+			const view2 = tree2.viewWith(new TreeViewConfiguration({ schema: Workspace }));
+			assert.strictEqual(
+				view2.root.items.get("item1")?.itemName,
+				"Item 1 - updated again",
+				"Loaded document should reflect the latest mutation",
+			);
+		});
+
+		it("handles remain valid when depth-0 changes cause copy propagation of tracking entries", async () => {
+			const { container, view } = await createContainerAndTree();
+			const summarizer = await createTestSummarizer(container);
+
+			// 1. Initial summary.
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			// 2. Change at depth 1 — re-encodes items chunk, tags becomes a handle.
+			const item1 = view.root.items.get("item1");
+			assert(item1 !== undefined, "item1 not found");
+			item1.itemName = "changed-1";
+
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			// 3. Change at depth 0 only (non-incremental root field) — ALL incremental
+			//    chunks become handles. completeSummary copies their tracking entries
+			//    forward, including parentReferenceId values.
+			view.root.label = "v2";
+
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			// 4. Change at depth 1 again — the parent chunk gets a new referenceId.
+			//    Child handles whose tracking entries were copied forward in step 3 must
+			//    resolve correctly against the latest summary.
+			item1.itemName = "changed-2";
+
+			await provider.ensureSynchronized();
+			await assert.doesNotReject(
+				summarizeNow(summarizer),
+				"Summary after copy-propagated tracking entries should succeed",
+			);
+		});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -30,9 +30,6 @@ import {
 	TreeViewConfigurationAlpha,
 } from "@fluidframework/tree/internal";
 
-// ---------------------------------------------------------------------------
-// Schema: 3-depth nested structure with incrementalSummaryHint at depths 1 & 2
-// ---------------------------------------------------------------------------
 const sf = new SchemaFactoryAlpha("incrementalSummaryE2E");
 
 class Tag extends sf.object("Tag", {
@@ -55,9 +52,6 @@ class Workspace extends sf.object("Workspace", {
 
 const viewConfig = new TreeViewConfigurationAlpha({ schema: Workspace });
 
-// ---------------------------------------------------------------------------
-// Factory configured for incremental summarization
-// ---------------------------------------------------------------------------
 const ConfiguredSharedTree = configuredSharedTree({
 	forest: ForestTypeOptimized,
 	treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
@@ -118,13 +112,11 @@ describeCompat(
 			const { container, view } = await createContainerAndTree();
 			const summarizer = await createTestSummarizer(container);
 
-			// 1. Initial summary — everything is encoded as full trees, no handles.
 			await provider.ensureSynchronized();
 			await summarizeNow(summarizer);
 
-			// 2. Mutate the "items" map (depth 1) — this re-encodes the outer chunk.
-			//    The "tags" map (depth 2) is unchanged → becomes a handle pointing into
-			//    the first summary.
+			// Mutate the "items" map (depth 1) — re-encodes the outer chunk.
+			// The "tags" map (depth 2) is unchanged and becomes a handle.
 			const item1 = view.root.items.get("item1");
 			assert(item1 !== undefined, "item1 not found");
 			item1.itemName = "Item 1 - updated";
@@ -132,20 +124,17 @@ describeCompat(
 			await provider.ensureSynchronized();
 			await summarizeNow(summarizer);
 
-			// 3. Mutate the "items" map again — the outer chunk gets a NEW referenceId.
-			//    The child "tags" handle must point into the second summary (not the
-			//    first). Before the fix, the stale summaryPath would cause a failure here.
+			// Mutate again — the outer chunk gets a new referenceId. The child "tags"
+			// handle must now point into the second summary. Before the fix the stale
+			// summaryPath caused "Cannot read properties of undefined (reading 'trees')".
 			item1.itemName = "Item 1 - updated again";
 
 			await provider.ensureSynchronized();
-			// This is the critical summary — it would fail before the fix because the
-			// child handle's path referenced the old parent referenceId.
 			await assert.doesNotReject(
 				summarizeNow(summarizer),
 				"Third summary should succeed — handle paths must be recomputed correctly",
 			);
 
-			// 4. Verify the document can still be loaded from the latest summary.
 			const container2 = await provider.loadTestContainer(testContainerConfig);
 			const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 			const tree2 = await dataObject2.getSharedObject<ITree>(treeId);
@@ -161,11 +150,10 @@ describeCompat(
 			const { container, view } = await createContainerAndTree();
 			const summarizer = await createTestSummarizer(container);
 
-			// 1. Initial summary.
 			await provider.ensureSynchronized();
 			await summarizeNow(summarizer);
 
-			// 2. Change at depth 1 — re-encodes items chunk, tags becomes a handle.
+			// Change at depth 1 — re-encodes items chunk, tags becomes a handle.
 			const item1 = view.root.items.get("item1");
 			assert(item1 !== undefined, "item1 not found");
 			item1.itemName = "changed-1";
@@ -173,17 +161,15 @@ describeCompat(
 			await provider.ensureSynchronized();
 			await summarizeNow(summarizer);
 
-			// 3. Change at depth 0 only (non-incremental root field) — ALL incremental
-			//    chunks become handles. completeSummary copies their tracking entries
-			//    forward, including parentReferenceId values.
+			// Change at depth 0 only — all incremental chunks become handles and
+			// completeSummary copies their tracking entries forward.
 			view.root.label = "v2";
 
 			await provider.ensureSynchronized();
 			await summarizeNow(summarizer);
 
-			// 4. Change at depth 1 again — the parent chunk gets a new referenceId.
-			//    Child handles whose tracking entries were copied forward in step 3 must
-			//    resolve correctly against the latest summary.
+			// Change at depth 1 again — the parent chunk gets a new referenceId.
+			// Child handles copied forward in the previous summary must still resolve.
 			item1.itemName = "changed-2";
 
 			await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -111,72 +111,83 @@ describeCompat(
 		it("handles remain valid across multiple incremental summaries when parent chunks change", async () => {
 			const { container, view } = await createContainerAndTree();
 			const summarizer = await createTestSummarizer(container);
+			let container2: IContainer | undefined;
+			try {
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Mutate the "items" map (depth 1) — re-encodes the outer chunk.
+				// The "tags" map (depth 2) is unchanged and becomes a handle.
+				const item1 = view.root.items.get("item1");
+				assert(item1 !== undefined, "item1 not found");
+				item1.itemName = "Item 1 - updated";
 
-			// Mutate the "items" map (depth 1) — re-encodes the outer chunk.
-			// The "tags" map (depth 2) is unchanged and becomes a handle.
-			const item1 = view.root.items.get("item1");
-			assert(item1 !== undefined, "item1 not found");
-			item1.itemName = "Item 1 - updated";
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Mutate again — the outer chunk gets a new referenceId. The child "tags"
+				// handle must now point into the second summary. Before the fix the stale
+				// summaryPath caused "Cannot read properties of undefined (reading 'trees')".
+				item1.itemName = "Item 1 - updated again";
 
-			// Mutate again — the outer chunk gets a new referenceId. The child "tags"
-			// handle must now point into the second summary. Before the fix the stale
-			// summaryPath caused "Cannot read properties of undefined (reading 'trees')".
-			item1.itemName = "Item 1 - updated again";
+				await provider.ensureSynchronized();
+				await assert.doesNotReject(
+					summarizeNow(summarizer),
+					"Third summary should succeed — handle paths must be recomputed correctly",
+				);
 
-			await provider.ensureSynchronized();
-			await assert.doesNotReject(
-				summarizeNow(summarizer),
-				"Third summary should succeed — handle paths must be recomputed correctly",
-			);
-
-			const container2 = await provider.loadTestContainer(testContainerConfig);
-			const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
-			const tree2 = await dataObject2.getSharedObject<ITree>(treeId);
-			const view2 = tree2.viewWith(new TreeViewConfiguration({ schema: Workspace }));
-			assert.strictEqual(
-				view2.root.items.get("item1")?.itemName,
-				"Item 1 - updated again",
-				"Loaded document should reflect the latest mutation",
-			);
+				container2 = await provider.loadTestContainer(testContainerConfig);
+				const dataObject2 =
+					await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
+				const tree2 = await dataObject2.getSharedObject<ITree>(treeId);
+				const view2 = tree2.viewWith(new TreeViewConfiguration({ schema: Workspace }));
+				assert.strictEqual(
+					view2.root.items.get("item1")?.itemName,
+					"Item 1 - updated again",
+					"Loaded document should reflect the latest mutation",
+				);
+			} finally {
+				container2?.close();
+				summarizer.close();
+				container.close();
+			}
 		});
 
 		it("handles remain valid when depth-0 changes cause copy propagation of tracking entries", async () => {
 			const { container, view } = await createContainerAndTree();
 			const summarizer = await createTestSummarizer(container);
+			try {
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Change at depth 1 — re-encodes items chunk, tags becomes a handle.
+				const item1 = view.root.items.get("item1");
+				assert(item1 !== undefined, "item1 not found");
+				item1.itemName = "changed-1";
 
-			// Change at depth 1 — re-encodes items chunk, tags becomes a handle.
-			const item1 = view.root.items.get("item1");
-			assert(item1 !== undefined, "item1 not found");
-			item1.itemName = "changed-1";
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Change at depth 0 only — all incremental chunks become handles and
+				// completeSummary copies their tracking entries forward.
+				view.root.label = "v2";
 
-			// Change at depth 0 only — all incremental chunks become handles and
-			// completeSummary copies their tracking entries forward.
-			view.root.label = "v2";
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Change at depth 1 again — the parent chunk gets a new referenceId.
+				// Child handles copied forward in the previous summary must still resolve.
+				item1.itemName = "changed-2";
 
-			// Change at depth 1 again — the parent chunk gets a new referenceId.
-			// Child handles copied forward in the previous summary must still resolve.
-			item1.itemName = "changed-2";
-
-			await provider.ensureSynchronized();
-			await assert.doesNotReject(
-				summarizeNow(summarizer),
-				"Summary after copy-propagated tracking entries should succeed",
-			);
+				await provider.ensureSynchronized();
+				await assert.doesNotReject(
+					summarizeNow(summarizer),
+					"Summary after copy-propagated tracking entries should succeed",
+				);
+			} finally {
+				summarizer.close();
+				container.close();
+			}
 		});
 	},
 );

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -86,8 +86,7 @@ describeCompat(
 			view: TreeView<typeof Workspace>;
 		}> {
 			const container = await provider.makeTestContainer(testContainerConfig);
-			const dataObject =
-				await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+			const dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
 			const tree = await dataObject.getSharedObject<ITree>(treeId);
 			const view = tree.viewWith(new TreeViewConfiguration({ schema: Workspace }));
 			view.initialize(
@@ -106,14 +105,8 @@ describeCompat(
 			return { container, view };
 		}
 
-		async function createTestSummarizer(
-			container: IContainer,
-		): Promise<ISummarizer> {
-			const { summarizer } = await createSummarizer(
-				provider,
-				container,
-				testContainerConfig,
-			);
+		async function createTestSummarizer(container: IContainer): Promise<ISummarizer> {
+			const { summarizer } = await createSummarizer(provider, container, testContainerConfig);
 			return summarizer;
 		}
 
@@ -121,24 +114,6 @@ describeCompat(
 			provider = getTestObjectProvider({ syncSummarizer: true });
 		});
 
-		/**
-		 * Regression test for the stale incremental summary handle path bug fixed
-		 * in PR #26990.
-		 *
-		 * The bug: when a parent incremental chunk was re-encoded with a new
-		 * referenceId, child chunks that became handles still held a summaryPath
-		 * string referencing the old referenceId. On the next summary those handle
-		 * URLs pointed to keys that no longer existed in the preceding summary tree,
-		 * causing a storage error (e.g. `TypeError: Cannot read properties of
-		 * undefined (reading 'trees')`).
-		 *
-		 * To reproduce we need:
-		 * 1. A schema with incrementalSummaryHint at 2+ levels deep.
-		 * 2. CompressedIncremental encoding + ForestSummaryFormatVersion.v3.
-		 * 3. Multiple summaries where the parent chunk changes but the child does
-		 *    not — the child's handle path must be recomputed against the new parent
-		 *    referenceId each time.
-		 */
 		it("handles remain valid across multiple incremental summaries when parent chunks change", async () => {
 			const { container, view } = await createContainerAndTree();
 			const summarizer = await createTestSummarizer(container);
@@ -172,8 +147,7 @@ describeCompat(
 
 			// 4. Verify the document can still be loaded from the latest summary.
 			const container2 = await provider.loadTestContainer(testContainerConfig);
-			const dataObject2 =
-				await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
+			const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 			const tree2 = await dataObject2.getSharedObject<ITree>(treeId);
 			const view2 = tree2.viewWith(new TreeViewConfiguration({ schema: Workspace }));
 			assert.strictEqual(

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -5,13 +5,15 @@
 
 import { strict as assert } from "assert";
 
-import { describeCompat, type CompatApis } from "@fluid-private/test-version-utils";
+import {
+	describeCompat,
+	type ICompatTestContainerConfig,
+} from "@fluid-private/test-version-utils";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
 import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import {
 	DataObjectFactoryType,
 	getContainerEntryPointBackCompat,
-	type ITestContainerConfig,
 	type ITestFluidObject,
 	type ITestObjectProvider,
 	createSummarizer,
@@ -53,29 +55,27 @@ const viewConfig = new TreeViewConfigurationAlpha({ schema: Workspace });
 
 const treeId = "sharedTree";
 
-function buildTestContainerConfig(apis: CompatApis): ITestContainerConfig {
-	const { configuredSharedTree } = apis.dataRuntime.packages.tree;
-	const ConfiguredSharedTree = configuredSharedTree({
-		forest: ForestTypeOptimized,
-		treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
-		minVersionForCollab: FluidClientVersion.v2_74,
-		shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(viewConfig),
-	});
-	return {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		runtimeOptions: {
-			enableRuntimeIdCompressor: "on",
-		},
-		registry: [[treeId, ConfiguredSharedTree.getFactory()]],
-	};
-}
+const testContainerConfig: ICompatTestContainerConfig = {
+	fluidDataObjectType: DataObjectFactoryType.Test,
+	runtimeOptions: {
+		enableRuntimeIdCompressor: "on",
+	},
+	buildRegistry: (dataRuntime) => {
+		const ConfiguredSharedTree = dataRuntime.packages.tree.configuredSharedTree({
+			forest: ForestTypeOptimized,
+			treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
+			minVersionForCollab: FluidClientVersion.v2_74,
+			shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(viewConfig),
+		});
+		return [[treeId, ConfiguredSharedTree.getFactory()]];
+	},
+};
 
 describeCompat(
 	"SharedTree incremental summary handle paths",
 	"NoCompat",
-	(getTestObjectProvider, apis) => {
+	(getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
-		const testContainerConfig = buildTestContainerConfig(apis);
 
 		async function createContainerAndTree(): Promise<{
 			container: IContainer;

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementalSharedTree.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { describeCompat } from "@fluid-private/test-version-utils";
+import { describeCompat, type CompatApis } from "@fluid-private/test-version-utils";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
 import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import {
@@ -19,7 +19,6 @@ import {
 } from "@fluidframework/test-utils/internal";
 import type { ITree, TreeView } from "@fluidframework/tree";
 import {
-	configuredSharedTree,
 	FluidClientVersion,
 	ForestTypeOptimized,
 	incrementalEncodingPolicyForAllowedTypes,
@@ -52,28 +51,31 @@ class Workspace extends sf.object("Workspace", {
 
 const viewConfig = new TreeViewConfigurationAlpha({ schema: Workspace });
 
-const ConfiguredSharedTree = configuredSharedTree({
-	forest: ForestTypeOptimized,
-	treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
-	minVersionForCollab: FluidClientVersion.v2_74,
-	shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(viewConfig),
-});
-
 const treeId = "sharedTree";
+
+function buildTestContainerConfig(apis: CompatApis): ITestContainerConfig {
+	const { configuredSharedTree } = apis.dataRuntime.packages.tree;
+	const ConfiguredSharedTree = configuredSharedTree({
+		forest: ForestTypeOptimized,
+		treeEncodeType: TreeCompressionStrategy.CompressedIncremental,
+		minVersionForCollab: FluidClientVersion.v2_74,
+		shouldEncodeIncrementally: incrementalEncodingPolicyForAllowedTypes(viewConfig),
+	});
+	return {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		runtimeOptions: {
+			enableRuntimeIdCompressor: "on",
+		},
+		registry: [[treeId, ConfiguredSharedTree.getFactory()]],
+	};
+}
 
 describeCompat(
 	"SharedTree incremental summary handle paths",
 	"NoCompat",
-	(getTestObjectProvider) => {
+	(getTestObjectProvider, apis) => {
 		let provider: ITestObjectProvider;
-
-		const testContainerConfig: ITestContainerConfig = {
-			fluidDataObjectType: DataObjectFactoryType.Test,
-			runtimeOptions: {
-				enableRuntimeIdCompressor: "on",
-			},
-			registry: [[treeId, ConfiguredSharedTree.getFactory()]],
-		};
+		const testContainerConfig = buildTestContainerConfig(apis);
 
 		async function createContainerAndTree(): Promise<{
 			container: IContainer;

--- a/packages/test/test-end-to-end-tests/src/test/treeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/treeCompat.spec.ts
@@ -5,12 +5,15 @@
 
 import { strict as assert } from "assert";
 
-import { describeCompat, type CompatApis } from "@fluid-private/test-version-utils";
+import {
+	describeCompat,
+	type CompatApis,
+	type ICompatTestContainerConfig,
+} from "@fluid-private/test-version-utils";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
 import {
 	DataObjectFactoryType,
 	getContainerEntryPointBackCompat,
-	type ITestContainerConfig,
 	type ITestFluidObject,
 	type ITestObjectProvider,
 } from "@fluidframework/test-utils/internal";
@@ -18,11 +21,12 @@ import type { ITree } from "@fluidframework/tree";
 import { lt } from "semver";
 
 const treeId = "sharedTree";
-const baseTestContainerConfig: ITestContainerConfig = {
+const testContainerConfig: ICompatTestContainerConfig = {
 	fluidDataObjectType: DataObjectFactoryType.Test,
 	runtimeOptions: {
 		enableRuntimeIdCompressor: "on",
 	},
+	buildRegistry: (dataRuntime) => [[treeId, dataRuntime.dds.SharedTree.getFactory()]],
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- TODO: extract schema definition and provide explicit return type
@@ -45,12 +49,6 @@ async function createTreeView(
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- TODO: extract schema definition and provide explicit return type
 async function createContainerAndGetTreeView(provider: ITestObjectProvider, apis: CompatApis) {
-	const { SharedTree } = apis.dataRuntime.dds;
-	const testContainerConfig: ITestContainerConfig = {
-		...baseTestContainerConfig,
-		registry: [[treeId, SharedTree.getFactory()]],
-	};
-
 	const container = await provider.makeTestContainer(testContainerConfig);
 	return createTreeView(container, apis.dataRuntime);
 }
@@ -58,12 +56,6 @@ async function createContainerAndGetTreeView(provider: ITestObjectProvider, apis
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- TODO: extract schema definition and provide explicit return type
 async function loadContainerAndGetTreeView(provider: ITestObjectProvider, apis: CompatApis) {
 	const dataRuntimeApi = apis.dataRuntimeForLoading ?? apis.dataRuntime;
-	const { SharedTree } = dataRuntimeApi.dds;
-	const testContainerConfig: ITestContainerConfig = {
-		...baseTestContainerConfig,
-		registry: [[treeId, SharedTree.getFactory()]],
-	};
-
 	const container = await provider.loadTestContainer(testContainerConfig);
 	return createTreeView(container, dataRuntimeApi);
 }

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -105,9 +105,30 @@ export interface ITestDataObject extends IFluidLoadable {
 	_root: ISharedDirectory;
 }
 
+/**
+ * Extension of {@link ITestContainerConfig} that lets a test build its channel factory registry
+ * from a per-side data-runtime api rather than passing a pre-built one.
+ *
+ * @remarks
+ * Prefer `buildRegistry` over `registry` when the registry contains factories that encode more
+ * than a DDS kind (e.g. `configuredSharedTree`, which bakes options into the factory class). In
+ * cross-client compat tests the framework invokes the builder once per side with that side's
+ * api, producing per-version factories directly and bypassing the type-based remap in
+ * `convertRegistry`. This prevents the silent-drop footgun where custom factory configuration
+ * gets discarded when the load side remaps by type string alone.
+ *
+ * `registry` and `buildRegistry` are mutually exclusive; setting both will throw.
+ *
+ * @internal
+ */
+export interface ICompatTestContainerConfig extends ITestContainerConfig {
+	buildRegistry?: (
+		dataRuntime: ReturnType<typeof getDataRuntimeApi>,
+	) => ChannelFactoryRegistry;
+}
+
 function createGetDataStoreFactoryFunction(
 	api: ReturnType<typeof getDataRuntimeApi>,
-	isCrossClientLoadPath = false,
 ): (containerOptions?: ITestContainerConfig) => IFluidDataStoreFactory {
 	class TestDataObject extends api.DataObject implements ITestDataObject {
 		public get _context(): IFluidDataStoreContext {
@@ -134,27 +155,19 @@ function createGetDataStoreFactoryFunction(
 	}
 
 	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
-		// When the api already matches pkg version, the registry needs no remap; short-circuit
-		// to preserve custom-configured factories (e.g. configuredSharedTree). The cross-client
-		// load path bypasses this — its registry is from the create version and must be remapped.
-		if (!isCrossClientLoadPath && api.version === pkgVersion) {
-			return registry;
-		}
-
 		const oldRegistry: [string | undefined, IChannelFactory][] = [];
 		for (const [key, factory] of registry) {
 			const oldFactory = registryMapping[factory.type];
 			if (oldFactory === undefined) {
 				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
 			}
-			// On the cross-client load path, factories legitimately come from the create version,
-			// so a ctor mismatch is by design rather than a test author mistake.
-			if (!isCrossClientLoadPath && factory.constructor !== oldFactory.constructor) {
+			// The factory must be a default factory. A custom wrapper (e.g.
+			// configuredSharedTree) would have its config silently dropped by the remap
+			// below.
+			if (factory.constructor !== oldFactory.constructor) {
 				throw Error(
-					`Non-default factory for "${factory.type}" cannot run in cross-version compat ` +
-						`(api=${api.version}, pkg=${pkgVersion}) — its configuration would be silently ` +
-						`dropped. Use the default factory, or pull the factory from apis.dds (or ` +
-						`apis.dataRuntime.dds) provided by describeCompat instead of importing it directly.`,
+					`Custom factory for "${factory.type}" would lose its configuration during compat ` +
+						`remap. Use buildRegistry or pull the factory from apis.dds instead.`,
 				);
 			}
 			oldRegistry.push([key, oldFactory]);
@@ -162,8 +175,22 @@ function createGetDataStoreFactoryFunction(
 		return oldRegistry;
 	}
 
-	return function (containerOptions?: ITestContainerConfig): IFluidDataStoreFactory {
-		const registry = convertRegistry(containerOptions?.registry);
+	return function (containerOptions?: ICompatTestContainerConfig): IFluidDataStoreFactory {
+		if (
+			containerOptions?.buildRegistry !== undefined &&
+			containerOptions.registry !== undefined
+		) {
+			throw new Error(
+				"ITestContainerConfig: `registry` and `buildRegistry` are mutually exclusive.",
+			);
+		}
+		// buildRegistry receives the side's own api, so its factories are already correct for
+		// this side — no type-based remap needed. Fall back to convertRegistry for the legacy
+		// `registry` field.
+		const registry =
+			containerOptions?.buildRegistry !== undefined
+				? containerOptions.buildRegistry(api)
+				: convertRegistry(containerOptions?.registry);
 		const fluidDataObjectType = containerOptions?.fluidDataObjectType;
 		switch (fluidDataObjectType) {
 			case undefined:
@@ -294,11 +321,8 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 		).IFluidHandleContext.resolveHandle(request);
 
 	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
-	// Cross-client load path: the registry comes from the create version's apis.dds, so
-	// factories must be remapped to the load version's equivalents even at pkgVersion.
 	const getDataStoreFactoryFnForLoading = createGetDataStoreFactoryFunction(
 		apis.dataRuntimeForLoading,
-		true,
 	);
 
 	// We want to ensure that we are testing all latest runtime features, but only if both runtimes

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -129,6 +129,7 @@ export interface ICompatTestContainerConfig extends ITestContainerConfig {
 
 function createGetDataStoreFactoryFunction(
 	api: ReturnType<typeof getDataRuntimeApi>,
+	otherApi?: ReturnType<typeof getDataRuntimeApi>,
 ): (containerOptions?: ITestContainerConfig) => IFluidDataStoreFactory {
 	class TestDataObject extends api.DataObject implements ITestDataObject {
 		public get _context(): IFluidDataStoreContext {
@@ -142,17 +143,26 @@ function createGetDataStoreFactoryFunction(
 		}
 	}
 
-	const registryMapping = {};
-	for (const value of Object.values(api.dds)) {
-		/**
-		 * Skip dds that may not be available in this version of the api.
-		 * Not all versions have all dds. See {@link PackageToInstall} for details.
-		 */
-		if (value?.getFactory === undefined) {
-			continue;
+	const buildRegistryMapping = (
+		a: ReturnType<typeof getDataRuntimeApi>,
+	): Record<string, IChannelFactory> => {
+		const mapping: Record<string, IChannelFactory> = {};
+		for (const value of Object.values(a.dds)) {
+			/**
+			 * Skip dds that may not be available in this version of the api.
+			 * Not all versions have all dds. See {@link PackageToInstall} for details.
+			 */
+			if (value?.getFactory === undefined) {
+				continue;
+			}
+			mapping[value.getFactory().type] = value.getFactory();
 		}
-		registryMapping[value.getFactory().type] = value.getFactory();
-	}
+		return mapping;
+	};
+
+	const registryMapping = buildRegistryMapping(api);
+	const otherRegistryMapping =
+		otherApi === undefined ? undefined : buildRegistryMapping(otherApi);
 
 	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
 		const oldRegistry: [string | undefined, IChannelFactory][] = [];
@@ -161,10 +171,11 @@ function createGetDataStoreFactoryFunction(
 			if (oldFactory === undefined) {
 				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
 			}
-			// The factory must be a default factory. A custom wrapper (e.g.
-			// configuredSharedTree) would have its config silently dropped by the remap
-			// below.
-			if (factory.constructor !== oldFactory.constructor) {
+			// Reject custom wrappers (e.g. configuredSharedTree) — the remap below would drop their config.
+			const matchesOwnDefault = factory.constructor === oldFactory.constructor;
+			const matchesOtherDefault =
+				otherRegistryMapping?.[factory.type]?.constructor === factory.constructor;
+			if (!matchesOwnDefault && !matchesOtherDefault) {
 				throw Error(
 					`Custom factory for "${factory.type}" would lose its configuration during compat ` +
 						`remap. Use buildRegistry or pull the factory from apis.dds instead.`,
@@ -320,9 +331,13 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 			runtime as any as Required<FluidObject<IFluidHandleContext>>
 		).IFluidHandleContext.resolveHandle(request);
 
-	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
+	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(
+		apis.dataRuntime,
+		apis.dataRuntimeForLoading,
+	);
 	const getDataStoreFactoryFnForLoading = createGetDataStoreFactoryFunction(
 		apis.dataRuntimeForLoading,
+		apis.dataRuntime,
 	);
 
 	// We want to ensure that we are testing all latest runtime features, but only if both runtimes

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -106,14 +106,11 @@ export interface ITestDataObject extends IFluidLoadable {
 }
 
 /**
- * Map from DDS type string to the constructor of the current package version's default factory
- * for that type. Used by {@link convertRegistry} to distinguish default factories (which should
- * be swapped to the compat version) from custom-configured factories (which should be preserved).
- *
- * For example, `SharedTree.getFactory()` produces an instance whose constructor is recorded here.
- * A factory returned by `configuredSharedTree(options).getFactory()` has a *different* constructor
- * (because `makeChannelFactory` creates a new class per `SharedObjectKind`), so it won't match and
- * will be passed through without conversion.
+ * Maps DDS type string to the constructor of the current version's default factory.
+ * `makeSharedObjectKind` creates a new class per `SharedObjectKind`, so
+ * custom-configured variants have a different constructor than the default. The identity
+ * check in {@link convertRegistry} uses this to let those factories pass through
+ * without being swapped to the compat version.
  */
 const currentDefaultFactoryCtors: Map<string, unknown> = new Map();
 {
@@ -153,14 +150,6 @@ function createGetDataStoreFactoryFunction(
 		registryMapping[value.getFactory().type] = value.getFactory();
 	}
 
-	/**
-	 * Maps user-provided channel factory registry entries to the version-appropriate factories.
-	 *
-	 * Default factories (whose constructor matches the current package version's default for that
-	 * DDS type) are replaced with the compat version's factory so that cross-version tests use the
-	 * correct implementation. Custom-configured factories (e.g. from `configuredSharedTree(options)`)
-	 * have a different constructor and are passed through unchanged, preserving their options.
-	 */
 	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
 		const oldRegistry: [string | undefined, IChannelFactory][] = [];
 		for (const [key, factory] of registry) {

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -105,6 +105,27 @@ export interface ITestDataObject extends IFluidLoadable {
 	_root: ISharedDirectory;
 }
 
+/**
+ * Map from DDS type string to the constructor of the current package version's default factory
+ * for that type. Used by {@link convertRegistry} to distinguish default factories (which should
+ * be swapped to the compat version) from custom-configured factories (which should be preserved).
+ *
+ * For example, `SharedTree.getFactory()` produces an instance whose constructor is recorded here.
+ * A factory returned by `configuredSharedTree(options).getFactory()` has a *different* constructor
+ * (because `makeChannelFactory` creates a new class per `SharedObjectKind`), so it won't match and
+ * will be passed through without conversion.
+ */
+const currentDefaultFactoryCtors: Map<string, Function> = new Map();
+{
+	const currentApi = getDataRuntimeApi(pkgVersion);
+	for (const value of Object.values(currentApi.dds)) {
+		if (value?.getFactory !== undefined) {
+			const f = value.getFactory();
+			currentDefaultFactoryCtors.set(f.type, f.constructor);
+		}
+	}
+}
+
 function createGetDataStoreFactoryFunction(
 	api: ReturnType<typeof getDataRuntimeApi>,
 ): (containerOptions?: ITestContainerConfig) => IFluidDataStoreFactory {
@@ -132,6 +153,14 @@ function createGetDataStoreFactoryFunction(
 		registryMapping[value.getFactory().type] = value.getFactory();
 	}
 
+	/**
+	 * Maps user-provided channel factory registry entries to the version-appropriate factories.
+	 *
+	 * Default factories (whose constructor matches the current package version's default for that
+	 * DDS type) are replaced with the compat version's factory so that cross-version tests use the
+	 * correct implementation. Custom-configured factories (e.g. from `configuredSharedTree(options)`)
+	 * have a different constructor and are passed through unchanged, preserving their options.
+	 */
 	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
 		const oldRegistry: [string | undefined, IChannelFactory][] = [];
 		for (const [key, factory] of registry) {
@@ -139,7 +168,17 @@ function createGetDataStoreFactoryFunction(
 			if (oldFactory === undefined) {
 				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
 			}
-			oldRegistry.push([key, oldFactory]);
+			const currentDefaultCtor = currentDefaultFactoryCtors.get(factory.type);
+			if (
+				currentDefaultCtor !== undefined &&
+				factory.constructor === currentDefaultCtor
+			) {
+				// Factory matches a known current-version default — convert to compat version.
+				oldRegistry.push([key, oldFactory]);
+			} else {
+				// Custom-configured factory — preserve as-is.
+				oldRegistry.push([key, factory]);
+			}
 		}
 		return oldRegistry;
 	}

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -115,7 +115,7 @@ export interface ITestDataObject extends IFluidLoadable {
  * (because `makeChannelFactory` creates a new class per `SharedObjectKind`), so it won't match and
  * will be passed through without conversion.
  */
-const currentDefaultFactoryCtors: Map<string, Function> = new Map();
+const currentDefaultFactoryCtors: Map<string, unknown> = new Map();
 {
 	const currentApi = getDataRuntimeApi(pkgVersion);
 	for (const value of Object.values(currentApi.dds)) {

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -169,10 +169,7 @@ function createGetDataStoreFactoryFunction(
 				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
 			}
 			const currentDefaultCtor = currentDefaultFactoryCtors.get(factory.type);
-			if (
-				currentDefaultCtor !== undefined &&
-				factory.constructor === currentDefaultCtor
-			) {
+			if (currentDefaultCtor !== undefined && factory.constructor === currentDefaultCtor) {
 				// Factory matches a known current-version default — convert to compat version.
 				oldRegistry.push([key, oldFactory]);
 			} else {

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -106,7 +106,7 @@ export interface ITestDataObject extends IFluidLoadable {
 }
 
 /**
- * Extension of {@link ITestContainerConfig} that lets a test build its channel factory registry
+ * Extension of `ITestContainerConfig` that lets a test build its channel factory registry
  * from a per-side data-runtime api rather than passing a pre-built one.
  *
  * @remarks

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -107,6 +107,7 @@ export interface ITestDataObject extends IFluidLoadable {
 
 function createGetDataStoreFactoryFunction(
 	api: ReturnType<typeof getDataRuntimeApi>,
+	isCrossClientLoadPath = false,
 ): (containerOptions?: ITestContainerConfig) => IFluidDataStoreFactory {
 	class TestDataObject extends api.DataObject implements ITestDataObject {
 		public get _context(): IFluidDataStoreContext {
@@ -133,9 +134,10 @@ function createGetDataStoreFactoryFunction(
 	}
 
 	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
-		// No conversion needed when already on the current version — preserves
-		// custom-configured factories that would otherwise be replaced with defaults.
-		if (api.version === pkgVersion) {
+		// When the api already matches pkg version, the registry needs no remap; short-circuit
+		// to preserve custom-configured factories (e.g. configuredSharedTree). The cross-client
+		// load path bypasses this — its registry is from the create version and must be remapped.
+		if (!isCrossClientLoadPath && api.version === pkgVersion) {
 			return registry;
 		}
 
@@ -144,6 +146,16 @@ function createGetDataStoreFactoryFunction(
 			const oldFactory = registryMapping[factory.type];
 			if (oldFactory === undefined) {
 				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
+			}
+			// On the cross-client load path, factories legitimately come from the create version,
+			// so a ctor mismatch is by design rather than a test author mistake.
+			if (!isCrossClientLoadPath && factory.constructor !== oldFactory.constructor) {
+				throw Error(
+					`Non-default factory for "${factory.type}" cannot run in cross-version compat ` +
+						`(api=${api.version}, pkg=${pkgVersion}) — its configuration would be silently ` +
+						`dropped. Use the default factory, or pull the factory from apis.dds (or ` +
+						`apis.dataRuntime.dds) provided by describeCompat instead of importing it directly.`,
+				);
 			}
 			oldRegistry.push([key, oldFactory]);
 		}
@@ -282,8 +294,11 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 		).IFluidHandleContext.resolveHandle(request);
 
 	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
+	// Cross-client load path: the registry comes from the create version's apis.dds, so
+	// factories must be remapped to the load version's equivalents even at pkgVersion.
 	const getDataStoreFactoryFnForLoading = createGetDataStoreFactoryFunction(
 		apis.dataRuntimeForLoading,
+		true,
 	);
 
 	// We want to ensure that we are testing all latest runtime features, but only if both runtimes

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -105,24 +105,6 @@ export interface ITestDataObject extends IFluidLoadable {
 	_root: ISharedDirectory;
 }
 
-/**
- * Maps DDS type string to the constructor of the current version's default factory.
- * `makeSharedObjectKind` creates a new class per `SharedObjectKind`, so
- * custom-configured variants have a different constructor than the default. The identity
- * check in {@link convertRegistry} uses this to let those factories pass through
- * without being swapped to the compat version.
- */
-const currentDefaultFactoryCtors: Map<string, unknown> = new Map();
-{
-	const currentApi = getDataRuntimeApi(pkgVersion);
-	for (const value of Object.values(currentApi.dds)) {
-		if (value?.getFactory !== undefined) {
-			const f = value.getFactory();
-			currentDefaultFactoryCtors.set(f.type, f.constructor);
-		}
-	}
-}
-
 function createGetDataStoreFactoryFunction(
 	api: ReturnType<typeof getDataRuntimeApi>,
 ): (containerOptions?: ITestContainerConfig) => IFluidDataStoreFactory {
@@ -151,20 +133,19 @@ function createGetDataStoreFactoryFunction(
 	}
 
 	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
+		// No conversion needed when already on the current version — preserves
+		// custom-configured factories that would otherwise be replaced with defaults.
+		if (api.version === pkgVersion) {
+			return registry;
+		}
+
 		const oldRegistry: [string | undefined, IChannelFactory][] = [];
 		for (const [key, factory] of registry) {
 			const oldFactory = registryMapping[factory.type];
 			if (oldFactory === undefined) {
 				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
 			}
-			const currentDefaultCtor = currentDefaultFactoryCtors.get(factory.type);
-			if (currentDefaultCtor !== undefined && factory.constructor === currentDefaultCtor) {
-				// Factory matches a known current-version default — convert to compat version.
-				oldRegistry.push([key, oldFactory]);
-			} else {
-				// Custom-configured factory — preserve as-is.
-				oldRegistry.push([key, factory]);
-			}
+			oldRegistry.push([key, oldFactory]);
 		}
 		return oldRegistry;
 	}

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -13,7 +13,15 @@ import { driver, odspEndpointName, r11sEndpointName, tenantIndex } from "./compa
 import { getVersionedTestObjectProvider } from "./compatUtils.js";
 import { ITestObjectProviderOptions } from "./describeCompat.js";
 import { pkgVersion } from "./packageVersion.js";
-import { ensurePackageInstalled, InstalledPackage } from "./testApi.js";
+import {
+	type CompatApis,
+	ensurePackageInstalled,
+	getContainerRuntimeApi,
+	getDataRuntimeApi,
+	getDriverApi,
+	getLoaderApi,
+	InstalledPackage,
+} from "./testApi.js";
 
 /**
  * Interface to hold the requested versions which should be installed
@@ -69,13 +77,22 @@ const defaultTimeoutMs = 180000; // 3 minutes
 const defaultRequestedVersions: IRequestedFluidVersions = { requestRelativeVersions: -2 };
 
 function createTestSuiteWithInstalledVersion(
-	tests: (this: Mocha.Suite, provider: () => ITestObjectProvider) => void,
+	tests: (this: Mocha.Suite, provider: () => ITestObjectProvider, apis: CompatApis) => void,
 	requiredVersions: IRequestedFluidVersions = defaultRequestedVersions,
 	timeoutMs: number = defaultTimeoutMs,
 ) {
 	return function (this: Mocha.Suite) {
 		let provider: TestObjectProvider | undefined;
 		let resetAfterEach: boolean;
+		const dataRuntime = getDataRuntimeApi(pkgVersion);
+		const apis: CompatApis = {
+			mode: "None",
+			containerRuntime: getContainerRuntimeApi(pkgVersion),
+			dataRuntime,
+			dds: dataRuntime.dds,
+			driver: getDriverApi(pkgVersion),
+			loader: getLoaderApi(pkgVersion),
+		};
 		before("Create TestObjectProvider", async function () {
 			this.timeout(Math.max(defaultTimeoutMs, timeoutMs));
 
@@ -112,7 +129,7 @@ function createTestSuiteWithInstalledVersion(
 			}
 
 			return provider;
-		});
+		}, apis);
 
 		afterEach("Reset TestObjectProvider", () => {
 			if (provider === undefined) {
@@ -162,6 +179,7 @@ export type DescribeSuiteWithVersions = (
 	tests: (
 		this: Mocha.Suite,
 		provider: (options?: ITestObjectProviderOptions) => ITestObjectProvider,
+		apis: CompatApis,
 	) => void,
 ) => Mocha.Suite | void;
 

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -9,6 +9,7 @@ export {
 	getDataStoreFactory,
 	getVersionedTestObjectProvider,
 	getVersionedTestObjectProviderFromApis,
+	type ICompatTestContainerConfig,
 	ITestDataObject,
 	TestDataObjectType,
 } from "./compatUtils.js";


### PR DESCRIPTION
## Description

In cross-version compat tests, `convertRegistry` remaps channel factories by type string. When a test uses a custom/configured factory (e.g. `configuredSharedTree`),
  the remap silently drops the custom configuration — the test runs with a default factory without any indication that something is wrong.

  This PR:
  - Adds `ICompatTestContainerConfig` with a `buildRegistry` callback that receives the per-side data-runtime API, letting tests with custom factory config produce
  correct factories without going through the type-based remap.
  - Adds a constructor identity check in `convertRegistry` that throws when a non-default factory is passed via the legacy `registry` field, instead of silently dropping
  config.
  - Passes `CompatApis` to `describeInstallVersions` test suites, matching `describeCompat` behavior.
  - Migrates several tests (`compression`, `entryPointCompat`, `treeCompat`, `legacyChunking`) to pull factories from `apis.dds`/`apis.dataRuntime` instead of direct
  imports.
  - Adds `summarizeIncrementalSharedTree.spec.ts` — validates that SharedTree incremental summary handle paths remain valid across multiple summaries, using
  `buildRegistry` with `configuredSharedTree`.

  ## Reviewer Guidance

  The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

  The core logic change is in `compatUtils.ts` — the constructor identity check in `convertRegistry` and the new `buildRegistry` path. The test file changes are mostly
  mechanical (switching from direct imports to `apis.dds`). The new `summarizeIncrementalSharedTree.spec.ts` is the motivating test that requires `buildRegistry` with
  `configuredSharedTree`.'