### PR TITLE
fix(build-cli): fix flub ai Copilot auth and launch in Codespaces

### DIFF
--- a/.devcontainer/ai-agent/launcher-prompt.md
+++ b/.devcontainer/ai-agent/launcher-prompt.md
@@ -1,15 +1,16 @@
 ---
-model: claude-haiku-4-5-20251001
+model: claude-haiku-4.5
 ---
 
 You are a launcher assistant for the Fluid Framework. Your job is to help the user pick the right AI agent alias and MCP server configuration for their task.
 
 ## Your Behavior
-1. Greet the user briefly and ask what they want to accomplish today.
-2. Ask clarifying questions if needed to understand their task, one question at a time.
-3. Once you know enough, call select_alias with your recommendation.
+1. Greet the user briefly and use the `ask_user` tool to ask what they want to accomplish today.
+2. Use `ask_user` for any clarifying questions — one question at a time.
+3. Once you know enough, call `select_alias` with your recommendation.
 4. NEVER recommend aliases that don't exist in the alias definitions below.
 5. Keep the conversation short — usually 1-2 questions is enough.
+6. **Important:** Always use the `ask_user` tool when you need input from the user. Do NOT write questions as plain text — use `ask_user` so the user can respond.
 
 ## Alias Definitions (source of truth)
 

--- a/build-tools/packages/build-cli/docs/ai.md
+++ b/build-tools/packages/build-cli/docs/ai.md
@@ -11,13 +11,16 @@ AI-powered assistant that helps you launch the right AI agent.
 
 ```
 USAGE
-  $ flub ai [-v | --quiet] [--aliasFile <value>] [--githubToken <value>] [--model <value>]
+  $ flub ai [-v | --quiet] [--aliasFile <value>] [--githubToken <value>] [--launchFile <value>] [--model
+    <value>]
 
 FLAGS
   --aliasFile=<value>    [env: FLUB_AI_ALIAS_FILE] Path to the agent-aliases.sh file. Defaults to the AI-enabled
                          Codespace locations.
   --githubToken=<value>  [env: COPILOT_GITHUB_TOKEN] GitHub token for the launcher assistant. Defaults to
                          COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN.
+  --launchFile=<value>   Write the launch command to this file instead of executing it. Used by shell wrappers to run
+                         the alias as a separate process.
   --model=<value>        The AI model to use for the launcher assistant. Defaults to the model specified in
                          launcher-prompt.md frontmatter.
 

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -175,7 +175,14 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		// When --launch-file is provided, write the command to that file and exit
 		// so a shell wrapper can run it as a separate, independent process.
 		if (flags.launchFile !== undefined) {
-			await writeFile(flags.launchFile, shellCommand, "utf8");
+			try {
+				await writeFile(flags.launchFile, shellCommand, "utf8");
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				this.error(`Failed to write launch file ${flags.launchFile}: ${message}`, {
+					exit: 1,
+				});
+			}
 			return;
 		}
 

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import * as readline from "node:readline/promises";
 import { getResolvedFluidRoot } from "@fluidframework/build-tools";
@@ -15,7 +15,7 @@ import chalk from "picocolors";
 import { type AliasProposal, runAiSession } from "../library/ai/copilotSession.js";
 import { BaseCommand } from "../library/commands/base.js";
 
-const FALLBACK_MODEL = "claude-haiku-4-5-20251001";
+const FALLBACK_MODEL = "claude-haiku-4.5";
 export const supportedAliases = ["claude", "dev", "copilot", "oce", "ai-reset"] as const;
 const supportedAliasSet = new Set<string>(supportedAliases);
 
@@ -45,6 +45,11 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 			description:
 				"GitHub token for the launcher assistant. Defaults to COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN.",
 			env: "COPILOT_GITHUB_TOKEN",
+		}),
+		launchFile: Flags.file({
+			description:
+				"Write the launch command to this file instead of executing it. " +
+				"Used by shell wrappers to run the alias as a separate process.",
 		}),
 		model: Flags.string({
 			description:
@@ -167,6 +172,15 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 
 		const shellCommand = `source ${shellQuote(aliasFile.path)} && ${formattedCommand}`;
 		this.verbose(`Shell command: ${shellCommand}`);
+
+		// When --launch-file is provided, write the command to that file and exit
+		// so a shell wrapper can run it as a separate, independent process.
+		if (flags.launchFile !== undefined) {
+			await writeFile(flags.launchFile, shellCommand, "utf8");
+			this.log(`\nLaunching ${chalk.green(proposal.alias)}...\n`);
+			return;
+		}
+
 		this.log(`\nLaunching ${chalk.green(proposal.alias)}...\n`);
 
 		try {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -75,7 +75,16 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		const prompt = promptFile.template
 			.replaceAll("{{aliasFileContent}}", aliasFile.content)
 			.replaceAll("{{gettingStartedContent}}", gettingStartedContent ?? "");
-		const githubToken = flags.githubToken ?? process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+		const githubToken =
+			// Explicit flag or COPILOT_GITHUB_TOKEN env var (via oclif flag config)
+			flags.githubToken ??
+			// GH_TOKEN is the conventional override for GitHub CLI tools
+			process.env.GH_TOKEN ??
+			// The user's OAuth token from `gh auth login` — preferred over GITHUB_TOKEN
+			// because in Codespaces GITHUB_TOKEN is a repo-scoped token that lacks Copilot permissions.
+			(await resolveGhAuthToken()) ??
+			// GITHUB_TOKEN as a last resort (may be the limited Codespace token)
+			process.env.GITHUB_TOKEN;
 
 		const rl = readline.createInterface({
 			input: process.stdin,
@@ -338,6 +347,20 @@ function isUserCancellation(error: unknown): boolean {
 			error.name === "AbortError" ||
 			/cancel|canceled|cancelled|aborted|sigint/i.test(error.message))
 	);
+}
+
+/**
+ * Attempts to resolve a GitHub token from the GitHub CLI (`gh auth token`).
+ * Returns undefined if `gh` is not installed or not authenticated.
+ */
+async function resolveGhAuthToken(): Promise<string | undefined> {
+	try {
+		const { stdout } = await execa("gh", ["auth", "token"]);
+		const token = stdout.trim();
+		return token.length > 0 ? token : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 async function tryReadFile(filePath: string): Promise<string | undefined> {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -81,14 +81,11 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 			.replaceAll("{{aliasFileContent}}", aliasFile.content)
 			.replaceAll("{{gettingStartedContent}}", gettingStartedContent ?? "");
 		const githubToken =
-			// Explicit flag or COPILOT_GITHUB_TOKEN env var (via oclif flag config)
 			flags.githubToken ??
-			// GH_TOKEN is the conventional override for GitHub CLI tools
 			process.env.GH_TOKEN ??
-			// The user's OAuth token from `gh auth login` — preferred over GITHUB_TOKEN
-			// because in Codespaces GITHUB_TOKEN is a repo-scoped token that lacks Copilot permissions.
+			// Preferred over GITHUB_TOKEN because in Codespaces GITHUB_TOKEN is a
+			// repo-scoped token that lacks Copilot permissions.
 			(await resolveGhAuthToken()) ??
-			// GITHUB_TOKEN as a last resort (may be the limited Codespace token)
 			process.env.GITHUB_TOKEN;
 
 		const rl = readline.createInterface({
@@ -173,15 +170,14 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		const shellCommand = `source ${shellQuote(aliasFile.path)} && ${formattedCommand}`;
 		this.verbose(`Shell command: ${shellCommand}`);
 
+		this.log(`\nLaunching ${chalk.green(proposal.alias)}...\n`);
+
 		// When --launch-file is provided, write the command to that file and exit
 		// so a shell wrapper can run it as a separate, independent process.
 		if (flags.launchFile !== undefined) {
 			await writeFile(flags.launchFile, shellCommand, "utf8");
-			this.log(`\nLaunching ${chalk.green(proposal.alias)}...\n`);
 			return;
 		}
-
-		this.log(`\nLaunching ${chalk.green(proposal.alias)}...\n`);
 
 		try {
 			const result = await execa("bash", ["-c", shellCommand], {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -188,7 +188,10 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 				stdio: "inherit",
 				cwd: process.cwd(),
 			});
-			this.exit(result.exitCode ?? 0);
+			// Don't use this.exit() here — it throws an EEXIT error that would be
+			// caught by the catch block below and reported as a launch failure.
+			process.exitCode = result.exitCode ?? 0;
+			return;
 		} catch (error: unknown) {
 			const execError = error as execa.ExecaError;
 			const exitCode = execError.exitCode ?? 1;

--- a/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
+++ b/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
@@ -141,6 +141,9 @@ const AUTH_REMEDIATION =
 
 async function preflight(client: CopilotClient): Promise<void> {
 	try {
+		// start() must be called before ping() — the connection to the CLI server
+		// is not established until start() (or createSession with autoStart) runs.
+		await client.start();
 		await client.ping();
 	} catch (cause) {
 		throw new Error(

--- a/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
+++ b/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
@@ -142,7 +142,7 @@ const AUTH_REMEDIATION =
 async function preflight(client: CopilotClient): Promise<void> {
 	try {
 		// start() must be called before ping() — the connection to the CLI server
-		// is not established until start() (or createSession with autoStart) runs.
+		// is not established until start() runs.
 		await client.start();
 		await client.ping();
 	} catch (cause) {

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -60,7 +60,7 @@ flub-ai() {
 	local rc=$?
 	if [ $rc -eq 0 ] && [ -s "$launch_file" ]; then
 		local cmd
-		cmd=$(cat "$launch_file")
+		cmd=$(<"$launch_file")
 		rm -f "$launch_file"
 		eval "$cmd"
 	else

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -55,10 +55,13 @@ ai-reset() {
 # before the alias starts).
 flub-ai() {
 	local launch_file
-	launch_file=$(mktemp "${TMPDIR:-/tmp}/flub-ai-XXXXXX")
+	launch_file=$(mktemp "${TMPDIR:-/tmp}/flub-ai-XXXXXX") || {
+		echo "Failed to create a temporary launch file." >&2
+		return 1
+	}
 	flub ai --launch-file "$launch_file" "$@"
 	local rc=$?
-	if [ $rc -eq 0 ] && [ -s "$launch_file" ]; then
+	if [ "$rc" -eq 0 ] && [ -s "$launch_file" ]; then
 		local cmd
 		cmd=$(<"$launch_file")
 		rm -f "$launch_file"

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -49,3 +49,22 @@ oce() {
 ai-reset() {
 	repoverlay remove --all
 }
+
+# Interactive launcher: runs `flub ai` to pick an alias, then executes it as a
+# separate top-level process (flub and the Copilot CLI server are fully stopped
+# before the alias starts).
+flub-ai() {
+	local launch_file
+	launch_file=$(mktemp "${TMPDIR:-/tmp}/flub-ai-XXXXXX")
+	flub ai --launch-file "$launch_file" "$@"
+	local rc=$?
+	if [ $rc -eq 0 ] && [ -s "$launch_file" ]; then
+		local cmd
+		cmd=$(cat "$launch_file")
+		rm -f "$launch_file"
+		eval "$cmd"
+	else
+		rm -f "$launch_file"
+		return $rc
+	fi
+}


### PR DESCRIPTION
## Description

Fixes several issues preventing `flub ai` from working correctly in GitHub Codespaces:

- **Copilot auth in Codespaces**: In Codespaces, `GITHUB_TOKEN` is a repo-scoped token that lacks Copilot permissions. Added `gh auth token` as a fallback so the user's OAuth token is preferred for Copilot SDK authentication.
- **Server startup ordering**: `CopilotClient` from `@github/copilot-sdk` requires `start()` before `ping()` — calling `ping()` on an unstarted client always fails with "Client not connected".
- **Copilot model names**: Switched from Anthropic API naming (`claude-haiku-4-5-20251001`) to Copilot naming (`claude-haiku-4.5`).
- **`ask_user` tool prompt**: Instructed the launcher prompt to use the `ask_user` tool for interactive questions so sessions wait for user input.
- **`--launch-file` flag**: Added support for writing the shell command to a file instead of executing it directly, enabling the `flub-ai` shell wrapper to run the alias as a fully independent process.
- **oclif EEXIT error**: Replaced `this.exit()` with `process.exitCode` in the execa success path. oclif's `this.exit()` throws an EEXIT error that was caught by the surrounding catch block and reported as a launch failure even on clean exit.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).