### PR TITLE
test(client-test-version--utils): import SharedTee via /internal

### DIFF
--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -73,7 +73,7 @@ export interface PackageToInstall {
 	/**
 	 * Entrypoint to load from, if available. Otherwise, root entrypoint will be used.
 	 */
-	preferredEnrypoint?: "." | `./${string}`;
+	preferredEntrypoint?: "." | `./${string}`;
 }
 
 // List of driver API packages to install.
@@ -107,7 +107,7 @@ const dataRuntimePackageEntries = [
 	{ pkgName: "@fluidframework/register-collection", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/sequence", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/agent-scheduler", minVersion: "0.56.0" },
-	{ pkgName: "@fluidframework/tree", minVersion: "2.0.0", preferredEnrypoint: "./internal" },
+	{ pkgName: "@fluidframework/tree", minVersion: "2.0.0", preferredEntrypoint: "./internal" },
 ] satisfies PackageToInstall[];
 
 /**
@@ -248,7 +248,7 @@ async function loadIfCompatible(
 ): Promise<any> {
 	// Check if the requested version satisfies the minVersion requirement
 	if (semver.gte(versionToInstall, pkgEntry.minVersion)) {
-		return loadPackage(modulePath, pkgEntry.pkgName, pkgEntry.preferredEnrypoint);
+		return loadPackage(modulePath, pkgEntry.pkgName, pkgEntry.preferredEntrypoint);
 	}
 	return undefined;
 }

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -59,6 +59,7 @@ import {
 export interface PackageToInstall {
 	/** The name of the package to install. */
 	pkgName: string;
+
 	/**
 	 * The minimum version where the package should be installed.
 	 * If the requested version is lower than this, the package will not be installed. This enables certain level of
@@ -68,28 +69,33 @@ export interface PackageToInstall {
 	 * versions prior to that, the package will not be installed and the test should skip testing these versions.
 	 */
 	minVersion: string;
+
+	/**
+	 * Entrypoint to load from, if available. Otherwise, root entrypoint will be used.
+	 */
+	preferredEnrypoint?: "." | `./${string}`;
 }
 
 // List of driver API packages to install.
-const driverPackageEntries: PackageToInstall[] = [
+const driverPackageEntries = [
 	{ pkgName: "@fluidframework/local-driver", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/odsp-driver", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/routerlicious-driver", minVersion: "0.56.0" },
-];
+] satisfies PackageToInstall[];
 
 // List of loader API packages to install.
-const loaderPackageEntries: PackageToInstall[] = [
+const loaderPackageEntries = [
 	{ pkgName: "@fluidframework/container-loader", minVersion: "0.56.0" },
-];
+] satisfies PackageToInstall[];
 
 // List of container runtime API packages to install.
-const containerRuntimePackageEntries: PackageToInstall[] = [
+const containerRuntimePackageEntries = [
 	{ pkgName: "@fluidframework/container-runtime", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/aqueduct", minVersion: "0.56.0" },
-];
+] satisfies PackageToInstall[];
 
 // List of data runtime API packages to install.
-const dataRuntimePackageEntries: PackageToInstall[] = [
+const dataRuntimePackageEntries = [
 	{ pkgName: "@fluidframework/aqueduct", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/datastore", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/test-utils", minVersion: "0.56.0" },
@@ -101,20 +107,20 @@ const dataRuntimePackageEntries: PackageToInstall[] = [
 	{ pkgName: "@fluidframework/register-collection", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/sequence", minVersion: "0.56.0" },
 	{ pkgName: "@fluidframework/agent-scheduler", minVersion: "0.56.0" },
-	{ pkgName: "@fluidframework/tree", minVersion: "2.0.0" },
-];
+	{ pkgName: "@fluidframework/tree", minVersion: "2.0.0", preferredEnrypoint: "./internal" },
+] satisfies PackageToInstall[];
 
 /**
  * The list of all the packages to install for compatibility testing.
  * If this list is changed, the {@link revision} in `versionUtils.ts`should be incremented to force re-installation. If
  * not, the pipelines that run the compatibility tests may fail as the packages may be fetched from the cache.
  */
-const packageListToInstall: PackageToInstall[] = [
+const packageListToInstall = [
 	...driverPackageEntries,
 	...loaderPackageEntries,
 	...containerRuntimePackageEntries,
 	...dataRuntimePackageEntries,
-];
+] satisfies PackageToInstall[];
 
 /**
  * @internal
@@ -188,7 +194,6 @@ export const DataRuntimeApi = {
 	DataObjectFactory,
 	FluidDataStoreRuntime,
 	TestFluidObjectFactory,
-	// TODO: SharedTree is not included included here. Perhaps it should be added?
 	dds: {
 		SharedCell,
 		SharedCounter,
@@ -243,7 +248,7 @@ async function loadIfCompatible(
 ): Promise<any> {
 	// Check if the requested version satisfies the minVersion requirement
 	if (semver.gte(versionToInstall, pkgEntry.minVersion)) {
-		return loadPackage(modulePath, pkgEntry.pkgName);
+		return loadPackage(modulePath, pkgEntry.pkgName, pkgEntry.preferredEnrypoint);
 	}
 	return undefined;
 }

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -427,7 +427,7 @@ export const loadPackage = async (
 						? exp.require.default
 						: exp.default;
 			if (typeof primaryExport !== "string") {
-				// eslint-disable-next-line unicorn/prefer-type-error -- this isn't a TypeError really; it is an internal logic short-coming; entry might not be a string
+				// eslint-disable-next-line unicorn/prefer-type-error -- this isn't a TypeError really; it is an internal logic shortcoming; entry might not be a string
 				throw new Error(
 					`Package ${pkg} defined subpath exports but no recognizable ${importPath} entry.`,
 				);

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -390,7 +390,11 @@ export function checkInstalled(requested: string): { version: string; modulePath
  *
  * @internal
  */
-export const loadPackage = async (modulePath: string, pkg: string): Promise<any> => {
+export const loadPackage = async (
+	modulePath: string,
+	pkg: string,
+	importPath: "." | `./${string}` = ".",
+): Promise<any> => {
 	const pkgPath = path.join(modulePath, "node_modules", pkg);
 	// Because we put legacy versions in a specific subfolder of node_modules (.legacy/<version>), we need to reimplement
 	// some of Node's module loading logic here.
@@ -415,20 +419,28 @@ export const loadPackage = async (modulePath: string, pkg: string): Promise<any>
 		if (typeof pkgJson.exports === "string") {
 			primaryExport = pkgJson.exports;
 		} else {
-			const exp: any | undefined = pkgJson.exports["."];
+			const exp: any | undefined = pkgJson.exports[importPath] ?? pkgJson.exports["."];
 			primaryExport =
 				typeof exp === "string"
 					? exp
 					: exp.require !== undefined
 						? exp.require.default
 						: exp.default;
-			if (primaryExport === undefined) {
-				throw new Error(`Package ${pkg} defined subpath exports but no '.' entry.`);
+			if (typeof primaryExport !== "string") {
+				// eslint-disable-next-line unicorn/prefer-type-error -- this isn't a TypeError really; it is an internal logic short-coming; entry might not be a string
+				throw new Error(
+					`Package ${pkg} defined subpath exports but no recognizable ${importPath} entry.`,
+				);
 			}
 		}
 	} else {
 		if (pkgJson.main === undefined) {
 			throw new Error(`No main or exports in package.json for ${pkg}`);
+		}
+		if (importPath !== ".") {
+			console.warn(
+				`Package ${pkg} main used despite request for ${importPath} entry (no "exports" property found).`,
+			);
 		}
 		primaryExport = pkgJson.main;
 	}


### PR DESCRIPTION
- add preferred import entrypoint to loading logic
- set "./internal" as tree packages preferred import which preserves prior behavior of runtime imports. (In 2.92.0 tree removed the non-internal runtime APIs from non-internal entrypoints.)

[AB#69118](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/69118)