### PR TITLE
docs: strengthen tree API report guidance to prevent spurious diffs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,10 @@
 
 When writing asserts (from `@fluidframework/core-utils`), use a string literal for the error message, not a hex assert code. This applies only to newly added asserts, not existing ones.
 
+## API Reports (`*.api.md`)
+
+API report files are **generated artifacts** — never hand-edit them. If they need updating, rebuild and regenerate via `build:api-reports`. If you are working in `@fluidframework/tree` or its aggregator (`fluid-framework`) and encounter unexpected API report diffs, read `.claude/skills/ci-readiness-check/tree-api-checks.md` before attempting to fix them.
+
 ## Azure DevOps
 
 The ADO project for work items and pipelines is **`internal`** (not `FluidFramework`).

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -54,6 +54,8 @@ pnpm clean
 pnpm build
 ```
 
+The full build includes API report generation for all packages (including the `fluid-framework` aggregator), so no separate regeneration step is needed. Check the reports afterward — if only your intended changes appear, you're good.
+
 For other packages, a scoped clean may suffice:
 
 ```bash

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -46,13 +46,21 @@ The script detects changed packages, installs dependencies if needed, runs `flui
 
 Report to the user: packages changed, what was auto-fixed, any checks still failing, and uncommitted files. (Changeset guidance is handled by the `api-changes` skill if API reports changed; otherwise the script warning is sufficient.)
 
-If you see unexpected generated artifacts unrelated to the branch's changes, do a clean build first (set `PKG` to the package directory path):
+If you see unexpected generated artifacts unrelated to the branch's changes (especially in `*.api.md` files), stale build artifacts from a previous session or the incremental TypeScript bug are likely the cause. For `@fluidframework/tree` or its aggregator (`fluid-framework`), a scoped per-package clean is **not reliable** — you must do a full clean build from the repo root:
+
+```bash
+# From the repo root — no shortcuts
+pnpm clean
+pnpm build
+```
+
+For other packages, a scoped clean may suffice:
 
 ```bash
 cd $PKG && pnpm exec fluid-build . --task clean && pnpm exec fluid-build . --task compile
 ```
 
-Then re-run the CI readiness check. Stale build artifacts from a previous session are often the cause of false-positive diffs.
+Then re-run the CI readiness check. **Never hand-edit `*.api.md` files** — they are generated artifacts. If they're wrong, rebuild and regenerate.
 
 Check mode stops here — skip steps 4–8 entirely. Note what was skipped in the final report.
 
@@ -74,7 +82,7 @@ cd $PKG && pnpm exec fluid-build . -t eslint:fix
 
 Steps 6 and 7 only run if the public API surface changed. Proceed if: `src/index.ts` or any entry point (`src/alpha.ts`, `src/beta.ts`, `src/legacy.ts`, `src/internal.ts`) was modified; any exported type/interface/class/function signature changed; or `package.json` `exports` changed. Skip if only tests, internal implementation, comments, or function bodies (not signatures) changed.
 
-Running `build:api-reports` when nothing changed can introduce spurious diffs — specifically for the `@fluidframework/tree` and `fluid-framework` packages, which surface a known incremental TypeScript bug that non-deterministically reorders type unions. If you see only key-reorder diffs with no real API changes, do a clean build of the affected package and regenerate (see `tree-api-checks.md` for details).
+Running `build:api-reports` when nothing changed can introduce spurious diffs — specifically for the `@fluidframework/tree` and `fluid-framework` packages, which surface a known incremental TypeScript bug that non-deterministically reorders type unions and can cause other phantom changes. If you see any unexpected API report diffs, do a full clean build from the repo root (`pnpm clean && pnpm build`) and regenerate. Per-package cleans are not reliable for the tree package. See `tree-api-checks.md` for details.
 
 # Step 6: API reports and cross-package cascade (Build and Test only)
 

--- a/.claude/skills/ci-readiness-check/tree-api-checks.md
+++ b/.claude/skills/ci-readiness-check/tree-api-checks.md
@@ -39,6 +39,10 @@ There is a known incremental TypeScript compilation bug that affects `@fluidfram
 
 ### The fix: full clean build from the repo root
 
+**Before starting the clean build, tell the user what you're doing and why.** The build takes several minutes, so the user should not be left wondering. Example message:
+
+> I noticed some unexpected API report changes unrelated to your code. This is caused by a known incremental TypeScript build bug that affects the tree package. I need to do a full clean build from the repo root to get correct API reports — this will take a few minutes.
+
 ```bash
 # From the repo root — no shortcuts, no scoped cleans
 pnpm clean

--- a/.claude/skills/ci-readiness-check/tree-api-checks.md
+++ b/.claude/skills/ci-readiness-check/tree-api-checks.md
@@ -1,6 +1,6 @@
 # Tree-specific API check guidance
 
-This document is read by the `ci-readiness-check` skill when `@fluidframework/tree` is among the changed packages. Follow these instructions **in addition to** the general steps in `SKILL.md`.
+Guidance for working with API reports in `@fluidframework/tree` and its downstream aggregators (`fluid-framework`). Read this whenever you encounter unexpected API report diffs in these packages.
 
 ---
 
@@ -24,32 +24,27 @@ Verify the fix: `grep "from " lib/entrypoints/public.d.ts` should show `../index
 
 ---
 
-## After running `build:api-reports`: check for phantom key-reorder diffs
+## Handling unexpected API report diffs
 
-There is a known incremental TypeScript compilation bug that non-deterministically reorders union key strings within `Omit<>` type signatures in this package — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — with no real API change. This is a bug in TypeScript's incremental build and flows downstream to API extractor. It only occurs with incremental builds; clean builds produce deterministic, stable output that matches CI.
+There is a known incremental TypeScript compilation bug that affects `@fluidframework/tree` and its downstream aggregator packages (`fluid-framework`). It non-deterministically reorders union key strings within `Omit<>` type signatures — e.g. `"keyA" | "keyB"` swapped to `"keyB" | "keyA"` — and can also cause spurious additions or removals of unrelated API entries. This is a bug in TypeScript's incremental build that flows downstream to API Extractor. It **only** occurs with incremental builds; full clean builds produce deterministic, stable output that matches CI.
 
-A diff is a phantom key-reorder if: only the order of string literal keys in an `Omit<>` changes; nothing is added or removed.
+**The golden rule: if you see ANY unexpected API report changes that are not directly related to your code changes, you must do a full clean build from the repo root.** Do not attempt to fix API reports by hand-editing, by checking them out from another branch, or by doing scoped per-package cleans. These approaches are unreliable because stale artifacts in *dependency* packages can cause wrong output even if the target package itself is clean.
 
-**If you see phantom key-reorder diffs, do a clean build and regenerate:**
+### What "unexpected" looks like
 
-```bash
-cd packages/dds/tree && pnpm exec fluid-build . --task clean && pnpm exec fluid-build . --task compile
-pnpm exec fluid-build . -t build:api-reports
-```
+- Union member reordering (e.g. `A | B` changed to `B | A`) with nothing added or removed
+- Entire APIs appearing or disappearing from reports for packages you didn't change
+- Beta/legacy.beta reports changing when you only made alpha-level changes
+- Aggregator package reports (`fluid-framework`) picking up unrelated diffs
 
-CI always runs clean builds, so a local clean build will produce the same output CI expects. After the clean rebuild, the spurious reorderings will be gone.
-
----
-
-## After tree reports updated: cascade to aggregator packages
-
-If `@fluidframework/tree`'s API reports actually changed (check `git diff` on `packages/dds/tree/api-report/`), also regenerate the reports for packages that re-export from it:
+### The fix: full clean build from the repo root
 
 ```bash
-cd packages/framework/fluid-framework && pnpm exec fluid-build . -t build:api-reports
-cd packages/service-clients/azure-client && pnpm exec fluid-build . -t build:api-reports
+# From the repo root — no shortcuts, no scoped cleans
+pnpm clean
+pnpm build
 ```
 
-If the tree reports are unchanged, skip this — the aggregator reports won't change either.
+This takes longer but is the **only** reliable way to produce API reports that match CI. The full build includes API report generation for all packages (including the `fluid-framework` aggregator), so no separate regeneration step is needed. Check the reports afterward — if only your intended changes appear, you're good.
 
-After running either of these, check for phantom key-reorder diffs — the same incremental TypeScript bug can affect their reports. If you see any, do a clean build of the affected aggregator package and regenerate its API reports (same approach as above).
+**Never hand-edit `*.api.md` files** — they are generated artifacts. If they're wrong, the fix is always to rebuild and regenerate, not to edit them directly.

--- a/.claude/skills/fluid-pr/SKILL.md
+++ b/.claude/skills/fluid-pr/SKILL.md
@@ -55,3 +55,15 @@ EOF
 ```
 
 After creating the PR, output the PR URL so the user can navigate to it.
+
+# Updating an existing PR description
+
+You do not have permissions to edit PRs on the upstream `microsoft/FluidFramework` repo via the API. If you need to update an existing PR's title or body, write the new content to a temp file and tell the user to copy-paste it into GitHub:
+
+```bash
+cat <<'EOF' > "$TMPDIR/pr-body.md"
+<new body content>
+EOF
+```
+
+Then tell the user: "I can't edit the PR directly — I've written the updated description to `$TMPDIR/pr-body.md`. Please copy-paste it into the PR on GitHub."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,10 @@
 
 When writing asserts (from `@fluidframework/core-utils`), use a string literal for the error message, not a hex assert code. This applies only to newly added asserts, not existing ones.
 
+## API Reports (`*.api.md`)
+
+API report files are **generated artifacts** — never hand-edit them. If they need updating, rebuild and regenerate via `build:api-reports`. If you are working in `@fluidframework/tree` or its aggregator (`fluid-framework`) and encounter unexpected API report diffs, read `.claude/skills/ci-readiness-check/tree-api-checks.md` before attempting to fix them.
+
 ## Azure DevOps
 
 The ADO project for work items and pipelines is **`internal`** (not `FluidFramework`).


### PR DESCRIPTION
## Description

Strengthens documentation around handling unexpected API report diffs in `@fluidframework/tree`. The existing docs recommended per-package clean builds, but these are unreliable due to an incremental TypeScript bug that leaves stale artifacts in dependency packages. All relevant docs now prescribe a full root-level `pnpm clean && pnpm build` as the only reliable fix.

Also adds a note to the `fluid-pr` skill about the workaround for editing existing PR descriptions (write to a temp file for the user to copy-paste, since the agent lacks upstream write access).

**Changes:**
- **CLAUDE.md / copilot-instructions.md**: Add short "never hand-edit api.md" rule with pointer to `tree-api-checks.md`
- **tree-api-checks.md**: Rewrite phantom-diff section with explicit "golden rule", anti-pattern list, full root clean commands, and guidance to inform the user before starting long builds. Remove incorrect `azure-client` references and redundant cascade section (full build already covers aggregators).
- **ci-readiness-check SKILL.md**: Distinguish tree (needs root clean) from other packages (scoped clean OK); add never-hand-edit warning
- **fluid-pr SKILL.md**: Add section on updating existing PR descriptions via temp file

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Documentation-only change — no functional code affected.
