### PR TITLE
ci(codespaces): add prebuild drift detection for setup script changes

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -35,8 +35,19 @@ The devcontainer lifecycle hooks are structured for prebuild optimization:
 | --- | --- | --- |
 | `onCreateCommand` | Node.js setup (nvm install, corepack enable) | Yes |
 | `postCreateCommand` | Welcome notice (all profiles); AI tooling setup (AI-enabled profiles) | Yes |
+| `postStartCommand` | bwrap/sandbox setup (AI profiles only) | No |
 
 Heavy setup work runs in `onCreateCommand` so it is captured by Codespace prebuilds, making the user-connect experience faster.
+
+## Prebuild configuration
+
+Prebuilds use the **"on configuration change"** trigger, which only fires when `devcontainer.json` or the referenced `Dockerfile` changes. It does **not** detect changes to files those configs depend on, such as scripts in `scripts/codespace-setup/`.
+
+### The `prebuild-version` comment
+
+Each `devcontainer.json` contains a `// prebuild-version: N` comment. **Bump this value whenever you change files in `scripts/codespace-setup/`** — this ensures the devcontainer.json file is modified, which triggers a prebuild rebuild.
+
+A CI check (`devcontainer-prebuild-check.yml`) enforces this: PRs that modify `scripts/codespace-setup/**` without also modifying a `devcontainer.json` will fail.
 
 ## AI-enabled vs. AI-enabled (Insiders)
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -45,9 +45,9 @@ Prebuilds use the **"on configuration change"** trigger, which only fires when `
 
 ### The `prebuild-version` comment
 
-Each `devcontainer.json` contains a `// prebuild-version: N` comment. **Bump this value whenever you change files in `scripts/codespace-setup/`** — this ensures the devcontainer.json file is modified, which triggers a prebuild rebuild.
+Each `devcontainer.json` contains a `// prebuild-version: N` comment. **Bump this value whenever you change files in `scripts/codespace-setup/`** and your PR doesn't already modify a `devcontainer.json` or the `Dockerfile` — this ensures a prebuild-triggering file is modified, which forces a rebuild.
 
-A CI check (`devcontainer-prebuild-check.yml`) enforces this: PRs that modify `scripts/codespace-setup/**` without also modifying a `devcontainer.json` will fail.
+A CI check (`devcontainer-prebuild-check.yml`) enforces this: PRs that modify `scripts/codespace-setup/**` without also modifying a `devcontainer.json` or the `Dockerfile` will fail.
 
 ## AI-enabled vs. AI-enabled (Insiders)
 

--- a/.devcontainer/ai-agent-insiders/devcontainer.json
+++ b/.devcontainer/ai-agent-insiders/devcontainer.json
@@ -1,6 +1,8 @@
 // AI-enabled (Insiders) — everything in AI-enabled, plus the flub AI launcher command.
 {
 	"name": "AI-enabled (Insiders)",
+	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
+	// prebuild-version: 1
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -1,6 +1,8 @@
 // Codespaces profile optimized for AI-agent workflows with extra CLI tooling.
 {
 	"name": "AI-enabled",
+	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
+	// prebuild-version: 1
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
 	"name": "Standard",
+	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
+	// prebuild-version: 1
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'NODE_VERSION' to pick the desired Node.js version (default: 24)
@@ -30,7 +32,6 @@
 	"postCreateCommand": {
 		"welcome-notice": "sudo cp .devcontainer/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
 	},
-
 	// Forward port for Tinylicious
 	"forwardPorts": [7070],
 

--- a/.devcontainer/lightweight/devcontainer.json
+++ b/.devcontainer/lightweight/devcontainer.json
@@ -1,6 +1,8 @@
 // Lightweight Codespaces profile for docs, API review, and focused package edits.
 {
 	"name": "Lightweight (Review/Docs)",
+	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
+	// prebuild-version: 1
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.github/workflows/devcontainer-prebuild-check.yml
+++ b/.github/workflows/devcontainer-prebuild-check.yml
@@ -25,21 +25,21 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Check if devcontainer.json was also modified
+      - name: Check if a prebuild-triggering file was also modified
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
 
-          if echo "$CHANGED_FILES" | grep -q 'devcontainer.json'; then
-            echo "A devcontainer.json file was modified — prebuild will be triggered."
+          if echo "$CHANGED_FILES" | grep -qE '(devcontainer\.json|Dockerfile)'; then
+            echo "A devcontainer.json or Dockerfile was modified — prebuild will be triggered."
           else
-            echo "::error::Setup scripts in scripts/codespace-setup/ were modified but no devcontainer.json was updated."
+            echo "::error::Setup scripts in scripts/codespace-setup/ were modified but no devcontainer.json or Dockerfile was updated."
             echo ""
             echo "Codespace prebuilds only trigger on devcontainer.json or Dockerfile changes."
-            echo "Bump the _prebuildVersion field in the relevant devcontainer.json file(s) to"
-            echo "ensure the prebuild is regenerated."
+            echo "Bump the // prebuild-version: N comment in the relevant devcontainer.json"
+            echo "file(s) to ensure the prebuild is regenerated."
             echo ""
             echo "Files to consider:"
             echo "  .devcontainer/devcontainer.json"

--- a/.github/workflows/devcontainer-prebuild-check.yml
+++ b/.github/workflows/devcontainer-prebuild-check.yml
@@ -1,0 +1,50 @@
+name: "Devcontainer prebuild check"
+
+# Codespace prebuilds in "on configuration change" mode only trigger when
+# devcontainer.json or the Dockerfile change. This job catches PRs that modify
+# the setup scripts the devcontainer depends on WITHOUT also bumping a
+# devcontainer.json file, which would leave prebuilds stale.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "scripts/codespace-setup/**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-prebuild-version:
+    name: Check prebuild version bump
+    runs-on: ubuntu-latest
+    steps:
+      # release notes: https://github.com/actions/checkout/releases/tag/v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check if devcontainer.json was also modified
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+
+          if echo "$CHANGED_FILES" | grep -q 'devcontainer.json'; then
+            echo "A devcontainer.json file was modified — prebuild will be triggered."
+          else
+            echo "::error::Setup scripts in scripts/codespace-setup/ were modified but no devcontainer.json was updated."
+            echo ""
+            echo "Codespace prebuilds only trigger on devcontainer.json or Dockerfile changes."
+            echo "Bump the _prebuildVersion field in the relevant devcontainer.json file(s) to"
+            echo "ensure the prebuild is regenerated."
+            echo ""
+            echo "Files to consider:"
+            echo "  .devcontainer/devcontainer.json"
+            echo "  .devcontainer/lightweight/devcontainer.json"
+            echo "  .devcontainer/ai-agent/devcontainer.json"
+            echo "  .devcontainer/ai-agent-insiders/devcontainer.json"
+            exit 1
+          fi


### PR DESCRIPTION
## Description

Codespace prebuilds in "on configuration change" mode only watch `devcontainer.json` and the `Dockerfile` — not the setup scripts they reference (`scripts/codespace-setup/`). This means setup script changes silently drift, leaving users with stale prebuilt environments.

This PR adds:

1. **`// prebuild-version: N` comments** in each `devcontainer.json`. Bumping the version forces a byte change that triggers a prebuild rebuild.
2. **A CI workflow** (`devcontainer-prebuild-check.yml`) that fails PRs touching `scripts/codespace-setup/**` without also modifying a `devcontainer.json` or `Dockerfile`.

The convention is documented in `.devcontainer/README.md`.

## Reviewer Guidance

- The approach uses a JSONC comment rather than a JSON field — any byte change to `devcontainer.json` triggers the prebuild, so comments work fine.
- The CI workflow is lightweight and read-only, following the same pattern as other validation workflows.
- No breaking changes or code changes — only devcontainer config, a CI workflow, and docs.