### PR TITLE
Fix lint config for @fluidframework/type-factory

### DIFF
--- a/packages/framework/type-factory/eslint.config.mts
+++ b/packages/framework/type-factory/eslint.config.mts
@@ -4,7 +4,7 @@
  */
 
 import type { Linter } from "eslint";
-import { strict } from "../../../common/build/eslint-config-fluid/flat.mts";
+import { strict } from "@fluidframework/eslint-config-fluid/flat.mts";
 
 const config: Linter.Config[] = [
 	...strict,


### PR DESCRIPTION
## Description

type-factory was extending its lint config from eslint-config-fluid by path in the repo instead of through the installed dev dependency, causing issues unless dependencies were installed in that package first, which shouldn't be necessary to work on the client release group.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
