### PR TITLE
fix: correct spelling typos across the repo

### DIFF
--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -54,7 +54,7 @@ export interface IUrlResolver {
 }
 
 /**
- * Information that can be returned by a lightweight, seperately exported driver function. Used to preanalyze a URL
+ * Information that can be returned by a lightweight, separately exported driver function. Used to preanalyze a URL
  * for driver compatibility and preload information.
  * @legacy @beta
  */

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -137,7 +137,7 @@ export class EpochTracker implements IPersistedFileCache {
 			const value = (await this.cache.get(
 				this.fileEntryFromEntry(entry),
 			)) as IVersionedValueWithEpoch;
-			// Version mismatch between what the runtime expects and what it recieved.
+			// Version mismatch between what the runtime expects and what it received.
 			// The cached value should not be used
 			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
 			if (value === undefined || value.version !== persistedCacheValueVersion) {

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -174,7 +174,7 @@ export async function prefetchLatestSnapshot(
 					}, 5000);
 				})
 				.catch((error) => {
-					// Remove it from the non persistent cache if an error occured.
+					// Remove it from the non persistent cache if an error occurred.
 					snapshotNonPersistentCache?.remove(nonPersistentCacheKey);
 					snapshotContentsWithEpochP.reject(error);
 					throw error;

--- a/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
@@ -203,7 +203,7 @@ describe("Tree Representation tests", () => {
 		} catch {
 			success = false;
 		}
-		assert(!success, "Error should have occured");
+		assert(!success, "Error should have occurred");
 	});
 
 	it("node instance test", async () => {
@@ -217,7 +217,7 @@ describe("Tree Representation tests", () => {
 		} catch {
 			success = false;
 		}
-		assert(!success, "Error should have occured");
+		assert(!success, "Error should have occurred");
 	});
 
 	it("number instance test", async () => {
@@ -231,7 +231,7 @@ describe("Tree Representation tests", () => {
 		} catch {
 			success = false;
 		}
-		assert(!success, "Error should have occured");
+		assert(!success, "Error should have occurred");
 	});
 
 	it("bool instance test", async () => {
@@ -245,6 +245,6 @@ describe("Tree Representation tests", () => {
 		} catch {
 			success = false;
 		}
-		assert(!success, "Error should have occured");
+		assert(!success, "Error should have occurred");
 	});
 });

--- a/packages/framework/client-logger/fluid-telemetry/src/test/containerTelemetry.spec.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/test/containerTelemetry.spec.ts
@@ -168,7 +168,7 @@ describe("container telemetry via", () => {
 
 		const containerError: ICriticalContainerError = {
 			errorType: "unknown error",
-			message: "An unknown error occured",
+			message: "An unknown error occurred",
 			stack: "example stack error at line 52 of Container.ts",
 		};
 

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -849,7 +849,7 @@ describe("ConnectionStateHandler Tests", () => {
 		assert.strictEqual(
 			connectionStateHandler.connectionState,
 			ConnectionState.CatchingUp,
-			"Client 3 should still be in connecting state as timeout has not occured",
+			"Client 3 should still be in connecting state as timeout has not occurred",
 		);
 
 		await tickClock(1);
@@ -919,7 +919,7 @@ describe("ConnectionStateHandler Tests", () => {
 		assert.strictEqual(
 			connectionStateHandler.connectionState,
 			ConnectionState.CatchingUp,
-			"Client 3 should still be in connecting state as timeout has not occured",
+			"Client 3 should still be in connecting state as timeout has not occurred",
 		);
 
 		connectionStateHandler.containerSaved();
@@ -1061,7 +1061,7 @@ describe("ConnectionStateHandler Tests", () => {
 			assert.strictEqual(
 				connectionStateHandler.connectionState,
 				ConnectionState.CatchingUp,
-				"Client 3 should still be in connecting state as timeout has not occured",
+				"Client 3 should still be in connecting state as timeout has not occurred",
 			);
 
 			await tickClock(1);

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
@@ -147,7 +147,7 @@ for (const testOpts of testMatrix) {
 		 * Scenario: Client sends a signal and connected clients receive it.
 		 *
 		 * Expected behavior: While 2 clients are connected to a container,
-		 * a signal sent by 1 client should be recieved by both clients.
+		 * a signal sent by 1 client should be received by both clients.
 		 */
 		it("can send and receive signals", async () => {
 			const { signaler, containerId } = await getOrCreateSignalerContainer(undefined, user1);
@@ -189,7 +189,7 @@ for (const testOpts of testMatrix) {
 		 * Scenario: Read and Write clients send signals and connected clients receive them.
 		 *
 		 * Expected behavior: While 2 clients are connected (1 writer, 2 readers) to a container,
-		 * a signal sent by any 1 client should be recieved by all 3 clients, regardless of read/write permissions.
+		 * a signal sent by any 1 client should be received by all 3 clients, regardless of read/write permissions.
 		 */
 		it("can send and receive read-only client signals", async function () {
 			const { signaler: writeSignaler, containerId } = await getOrCreateSignalerContainer(

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -122,7 +122,7 @@ export class CheckpointManager {
 	 */
 	public async flush(): Promise<void> {
 		if (this.lastCheckpoint) {
-			Lumberjack.info(`Checkpointing last recieved offset: ${this.lastCheckpoint.offset}`, {
+			Lumberjack.info(`Checkpointing last received offset: ${this.lastCheckpoint.offset}`, {
 				offset: this.lastCheckpoint.offset,
 				partition: this.lastCheckpoint.partition,
 			});


### PR DESCRIPTION
## Summary

- Fix `seperately` → `separately` in a public API doc comment (`DriverPreCheckInfo`)
- Fix `occured` → `occurred` in comments, test assertions, and error messages (7 instances)
- Fix `recieved` → `received` in comments, log messages, and test descriptions (4 instances)

13 typo corrections across 8 files. No behavioral changes.

> **Note:** This change is mostly just for the purpose of testing out the AI-enabled Codespace.

## Test plan

- [ ] Existing tests pass (string-only changes in assertions/comments, no logic affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)