### PR TITLE
Exclude our scopes/packages from minReleaseAge during compat version installs

### DIFF
--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -134,7 +134,7 @@ const minimumReleaseAgeMinutes = 1 * 24 * 60;
 // We exclude our own scopes/packages so the installation of older FF versions for compat testing doesn't
 // fail due to young versions immediately after we ship a new release.
 // Ideally we shouldn't be installing the older versions "dynamically", but while we figure out an alternative
-// approach this is 
+// approach we can do this to make things a bit better.
 // See https://pnpm.io/supply-chain-security for context on the flags used here.
 const pnpmWorkspaceYamlContent = `
 minimumReleaseAge: ${minimumReleaseAgeMinutes}

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -131,9 +131,20 @@ const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const minimumReleaseAgeMinutes = 1 * 24 * 60;
 
 // Enforce reasonable security settings on compat package installs to mitigate risk of supply-chain attacks.
+// We exclude our own scopes/packages so the installation of older FF versions for compat testing doesn't
+// fail due to young versions immediately after we ship a new release.
+// Ideally we shouldn't be installing the older versions "dynamically", but while we figure out an alternative
+// approach this is 
 // See https://pnpm.io/supply-chain-security for context on the flags used here.
 const pnpmWorkspaceYamlContent = `
 minimumReleaseAge: ${minimumReleaseAgeMinutes}
+minimumReleaseAgeExclude:
+- '@fluidframework/*'
+- '@fluid-experimental/*'
+- '@fluid-internal/*'
+- '@fluid-private/*'
+- '@fluid-tools/*'
+- 'fluid-framework'
 
 # See: https://github.com/orgs/pnpm/discussions/11084 for some discussion.
 # Enabling this is additionally more complicated than coming up with a reasonable allow-list of packages, as Azure Artifact feeds don't seem to preserve trusted provenance metadata


### PR DESCRIPTION
## Description

Add exclusions to the minimum release age setting for our own packages/scopes (client release group only), during installation of older version for compat testing.

This is in response to the issue we hit after releasing a new legacy-breaking version, where pipelines immediately wanted to install the latest N-1 version which had just been published, and didn't meet the minimumReleaseAge requirements that we put in place recently to protect ourselves from supply-chain attacks like the recent axios incident.

Excluding our own packages from the policy seems reasonably safe. And we're discussing how to make it so we don't have to do these dynamic installs at all.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
