### PR TITLE
docs: improve OCE agent and Kusto skill for stress test investigations

### DIFF
--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -194,11 +194,11 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 - **Escalate to FRS**: For FRS performance/reliability issues, help create a Sev3 IcM ticket via `https://aka.ms/frs/escalate` with description, Tenant ID, Document ID, and approximate time.
 
-- **Finding FRS test tenant IDs for escalation**: The stress test FRS credentials are stored as JSON secrets in `prague-key-vault` with the prefix `automation-fluid-driver-frs-*`. The JSON shape is `{ "discoveryEndpoint", "host", "tenantId", "tenantSecret", "driverPolicies" }`. The `tenantId` field is what the FRS team needs.
-  - **`tools/getkeys` does NOT fetch these.** It explicitly skips secrets prefixed with `automation-` (line 89 of `tools/getkeys/index.js`).
+- **Finding FRS test tenant IDs for escalation**: The stress test FRS credentials are stored as JSON secrets in `prague-key-vault`. Each secret is a JSON object with fields `discoveryEndpoint`, `host`, `tenantId`, `tenantSecret`, and `driverPolicies`. The `tenantId` field is what the FRS team needs.
+  - **`tools/getkeys` does NOT fetch these.** It explicitly skips secrets whose names start with `automation` (line 89 of `tools/getkeys/index.js`).
   - To retrieve the tenant ID, someone with Key Vault access must run: `az keyvault secret show --vault-name prague-key-vault --name automation-fluid-driver-frs-canary-stress-test --query value -o tsv` (or use the Azure Portal). Parse the `tenantId` field from the returned JSON.
   - The tenant ID is NOT logged in Kusto automation telemetry — you cannot extract it from queries.
-  - Key secrets: `automation-fluid-test-driver-frs-stress-test` (FRS prod), `automation-fluid-driver-frs-canary-stress-test` (FRS canary).
+  - Key secrets: `automation-fluid-test-driver-frs-stress-test` (FRS prod), `automation-fluid-driver-frs-canary-stress-test` (FRS canary). Note: the naming convention is inconsistent between the two secrets.
 
 - **Update TSGs**: After resolution, help draft or update the relevant TSG on EngineeringHub.
 

--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -86,7 +86,7 @@ The OCE rotation covers **three IcM teams**. Always search all three when lookin
 |---|---|---|---|---|
 | Build - client packages | 12 | `fluidframework/internal` | `ado` | `build`, `run_checks`, `publish_npm_internal_*` |
 | E2E tests | 56 | `fluidframework/internal` | `ado` | `e2e_odsp`, `e2e_local_server`, `e2e_azure_client_frs`, `e2e_azure_client_local_server` |
-| Stress tests | 63 | `fluidframework/internal` | `ado` | `stress_tests_frs`, `stress_tests_tinylicious` |
+| Stress tests | 63 | `fluidframework/internal` | `ado` | `stress_tests_odsp`, `stress_tests_odspdf`, `stress_tests_tinylicious`, `stress_tests_frs`, `stress_tests_frs_canary` |
 | Loop-FF integration | 29163 | `office/OC` | `ado-office` | `Build And Run E2E Tests`, `Build And Run Unit Tests`, `Lint and Type Check` |
 
 **ADO MCP servers:** Two ADO MCP servers are configured — `ado` (for `fluidframework` org) and `ado-office` (for `office` org). When querying pipelines in `office/OC` (e.g., Loop-FF integration pipeline def 29163), use the `ado-office` MCP server tools. All other pipelines use the default `ado` tools.
@@ -188,11 +188,17 @@ This section covers the tasks you may perform. You are not limited to these — 
 
 ### Azure Fluid Relay (FRS) Support
 
-- **Monitor FRS pipelines**: Check Stress (def 63) and E2E (def 56) for `main` and `lts`, specifically the `stress_tests_frs` and `e2e_frs` stages.
+- **Monitor FRS pipelines**: Check Stress (def 63) and E2E (def 56) for `main` and `lts`, specifically the `stress_tests_frs`, `stress_tests_frs_canary`, and `e2e_frs` stages. The FRS Canary stage (`stress_tests_frs_canary`) uses a separate FRS deployment and has its own variable group (`stress-frs-canary`) and Key Vault secret.
 
 - **Handle Tier 3 customer escalations**: When the FRS OCE team escalates a client-side issue, review IcM details, assess client-side nature, and begin investigation. Only Sev2+ triggers phone escalation.
 
 - **Escalate to FRS**: For FRS performance/reliability issues, help create a Sev3 IcM ticket via `https://aka.ms/frs/escalate` with description, Tenant ID, Document ID, and approximate time.
+
+- **Finding FRS test tenant IDs for escalation**: The stress test FRS credentials are stored as JSON secrets in `prague-key-vault` with the prefix `automation-fluid-driver-frs-*`. The JSON shape is `{ "discoveryEndpoint", "host", "tenantId", "tenantSecret", "driverPolicies" }`. The `tenantId` field is what the FRS team needs.
+  - **`tools/getkeys` does NOT fetch these.** It explicitly skips secrets prefixed with `automation-` (line 89 of `tools/getkeys/index.js`).
+  - To retrieve the tenant ID, someone with Key Vault access must run: `az keyvault secret show --vault-name prague-key-vault --name automation-fluid-driver-frs-canary-stress-test --query value -o tsv` (or use the Azure Portal). Parse the `tenantId` field from the returned JSON.
+  - The tenant ID is NOT logged in Kusto automation telemetry — you cannot extract it from queries.
+  - Key secrets: `automation-fluid-test-driver-frs-stress-test` (FRS prod), `automation-fluid-driver-frs-canary-stress-test` (FRS canary).
 
 - **Update TSGs**: After resolution, help draft or update the relevant TSG on EngineeringHub.
 

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/SKILL.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/SKILL.md
@@ -15,6 +15,8 @@ This skill provides a comprehensive reference for Fluid Framework telemetry inve
 - **Cluster:** `https://kusto.aria.microsoft.com`
 - **Primary database:** `Office Fluid`
 - **Database ID:** `6a8929bcfc6d44e9b13fee392ada9cf0` (use this, not the pretty name, as the `database` parameter in `kusto_query`)
+- **Automation/stress test database:** `Office Fluid Test`
+- **Database ID:** `742fa5a288b045e5beab1a2b8e445a71` — contains `office_fluid_ffautomation_*` tables used for stress test / pipeline telemetry. **These tables are NOT in the primary "Office Fluid" database.**
 - **Retention:** ~28 days
 - **VPN:** Required (Microsoft internal network)
 - **Access requirement:** M365HeartbeatTenantUsers group membership

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md
@@ -1428,7 +1428,7 @@ office_fluid_ffautomation_error
 ```kusto
 // CompareBuildHealth: Compare event volume, duration, and errors across builds per stage
 // Use to diagnose "pipeline suddenly started failing" — shows which stage regressed
-union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
+union withsource=TableName office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Event_Time between(datetime(2026-04-10) .. datetime(2026-04-17)) // adjust range
     and Data_hostName == "@fluid-internal/test-service-load"
     and Data_buildId in ("392069", "392243") // passing vs failing build IDs
@@ -1438,7 +1438,7 @@ union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, of
     MaxTime=max(Event_Time),
     Duration_minutes=datetime_diff('minute', max(Event_Time), min(Event_Time)),
     DistinctDocs=dcount(Data_docId),
-    ErrorCount=countif(Event_Name has "Error")
+    ErrorCount=countif(TableName == "office_fluid_ffautomation_error")
     by Data_buildId, Data_driverType, Data_driverEndpointName
 | order by Data_buildId asc, Data_driverType asc
 ```
@@ -1457,14 +1457,14 @@ office_fluid_ffautomation_error
 
 ```kusto
 // StageHealthTrend: Track a specific stage's health across all recent builds
-union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
+union withsource=TableName office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Event_Time > ago(7d)
     and Data_hostName == "@fluid-internal/test-service-load"
     and Data_driverEndpointName == "frsCanary" // change to stage of interest
 | summarize
     TotalEvents=count(),
     Duration_minutes=datetime_diff('minute', max(Event_Time), min(Event_Time)),
-    ErrorCount=countif(Event_Name has "Error"),
+    ErrorCount=countif(TableName == "office_fluid_ffautomation_error"),
     DistinctDocs=dcount(Data_docId)
     by Data_buildId
 | order by TotalEvents asc

--- a/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md
+++ b/.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md
@@ -36,8 +36,10 @@ This document is a comprehensive reference for Fluid Framework telemetry investi
 | `Office_Fluid_Video_Activity_GetPersonalOdbUrl` | ODB URL fetch events. `Activity_Success == false` signals failures. `Data_isExpected` marks expected failures (e.g. 404 for users without ODB). |
 | `Office_Fluid_Video_Activity_CreateRedeemableSharingLink` | Sharing link creation events for video. `Activity_Success == 'false'` for failures. |
 | `Office_Fluid_Video_Generic_Request` | Raw HTTP request events from the video component. Fields: `Data_status` (HTTP status code), `Data_clientRequestId`, `Data_requestId`, `Data_spRequestGuid`. |
-| `office_fluid_ffautomation_error` | Errors from stress test / automation runs. Fields: `Data_buildId`, `Data_driverType`, `Data_driverEndpointName`, `Data_profile`, `Data_branch`. Key field: `Data_hostName == "@fluid-internal/test-service-load"`. |
-| `union office_fluid_ffautomation*` | All automation tables — used for summarizer investigation in stress test runs (`DidSummarizerRecover`, `SummarizerView` queries). |
+| `office_fluid_ffautomation_error` | **Database: "Office Fluid Test" (ID `742fa5a288b045e5beab1a2b8e445a71`)** — NOT in the primary "Office Fluid" database. Errors from stress test / automation runs. Key columns: `Data_buildId`, `Data_driverType`, `Data_driverEndpointName` (values: `frs`, `frsCanary`, `odsp`, `odsp-df`, `local`), `Data_profile`, `Data_branch`, `Data_docId`, `Data_containerId`, `Data_eventName`, `Data_error`, `Data_errorType`, `Data_message`, `Data_stack`. Filter: `Data_hostName == "@fluid-internal/test-service-load"`. Note: tenant ID and service endpoint URLs are NOT logged in telemetry. |
+| `office_fluid_ffautomation_performance` | Same database as above. Performance/timing events from automation runs. Same key columns as `_error`. |
+| `office_fluid_ffautomation_generic` | Same database as above. Informational events from automation runs. Same key columns as `_error`. |
+| `union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic` | All automation tables. **Do NOT use wildcard `office_fluid_ffautomation*`** — the wildcard syntax does not resolve in this database. Always enumerate the three tables explicitly. |
 | `cluster('https://stream.eastus2.kusto.windows.net').database("OnePlayer").*` | OnePlayer (Stream video player) telemetry. Key fields: `playbackSessionId`, `userId`, `odspItemId`, `hostComponent`, `hostApp`, `result` (`"Fatal"` = error), `name`, `message`. EU cluster: `cluster('https://streameu.northeurope.kusto.windows.net')`. |
 
 **Shorthand for all FluidRuntime tables:**
@@ -1397,7 +1399,13 @@ union Office_Fluid_FluidRuntime_*
 
 ### 4.6 Stress Test Automation Queries
 
-**Source:** `summaryinvestigations` page, EngineeringHub. These queries run against `office_fluid_ffautomation*` tables (not `Office_Fluid_FluidRuntime_*`).
+**Database:** `Office Fluid Test` (ID `742fa5a288b045e5beab1a2b8e445a71`). These tables are **NOT** in the primary "Office Fluid" database.
+
+**Tables:** `office_fluid_ffautomation_error`, `office_fluid_ffautomation_performance`, `office_fluid_ffautomation_generic`. The wildcard `office_fluid_ffautomation*` does **NOT** resolve — always enumerate tables explicitly.
+
+**Key columns** (shared across all three tables): `Data_buildId`, `Data_driverType` (`odsp`, `routerlicious`, `tinylicious`), `Data_driverEndpointName` (`odsp`, `odsp-df`, `frs`, `frsCanary`, `local`), `Data_profile`, `Data_branch`, `Data_hostName`, `Data_docId`, `Data_containerId`, `Data_eventName`. Error table additionally has: `Data_error`, `Data_errorType`, `Data_message`, `Data_stack`.
+
+**Note:** Tenant IDs and service endpoint URLs are **not** logged in automation telemetry. To find the FRS Canary tenant ID, you must read the Key Vault secret `automation-fluid-driver-frs-canary-stress-test` from `prague-key-vault` (see OCE agent prompt for details).
 
 ```kusto
 // FindBuildErrors: All errors for a specific stress test run
@@ -1418,9 +1426,55 @@ office_fluid_ffautomation_error
 *Get the RunId from the failing ADO pipeline run. The pipeline logs show the buildId, driverType, and profile used.*
 
 ```kusto
+// CompareBuildHealth: Compare event volume, duration, and errors across builds per stage
+// Use to diagnose "pipeline suddenly started failing" — shows which stage regressed
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
+| where Event_Time between(datetime(2026-04-10) .. datetime(2026-04-17)) // adjust range
+    and Data_hostName == "@fluid-internal/test-service-load"
+    and Data_buildId in ("392069", "392243") // passing vs failing build IDs
+| summarize
+    TotalEvents=count(),
+    MinTime=min(Event_Time),
+    MaxTime=max(Event_Time),
+    Duration_minutes=datetime_diff('minute', max(Event_Time), min(Event_Time)),
+    DistinctDocs=dcount(Data_docId),
+    ErrorCount=countif(Event_Name has "Error")
+    by Data_buildId, Data_driverType, Data_driverEndpointName
+| order by Data_buildId asc, Data_driverType asc
+```
+*Healthy stages typically show 100K–800K events in 20–45 min. A degraded stage shows dramatically fewer events (e.g. 6K) over a much longer duration (60+ min) with many errors.*
+
+```kusto
+// CompareBuildErrors: Side-by-side error breakdown for passing vs failing builds
+office_fluid_ffautomation_error
+| where Event_Time between(datetime(2026-04-10) .. datetime(2026-04-17)) // adjust range
+    and Data_hostName == "@fluid-internal/test-service-load"
+    and Data_buildId in ("392069", "392243") // passing vs failing build IDs
+| summarize ErrorCount=count(), DistinctDocs=dcount(Data_docId)
+    by Data_buildId, Data_eventName, Data_error, Data_errorType
+| order by Data_buildId asc, ErrorCount desc
+```
+
+```kusto
+// StageHealthTrend: Track a specific stage's health across all recent builds
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
+| where Event_Time > ago(7d)
+    and Data_hostName == "@fluid-internal/test-service-load"
+    and Data_driverEndpointName == "frsCanary" // change to stage of interest
+| summarize
+    TotalEvents=count(),
+    Duration_minutes=datetime_diff('minute', max(Event_Time), min(Event_Time)),
+    ErrorCount=countif(Event_Name has "Error"),
+    DistinctDocs=dcount(Data_docId)
+    by Data_buildId
+| order by TotalEvents asc
+```
+*Sort by TotalEvents ascending to quickly spot degraded builds (low event count = test couldn't make progress).*
+
+```kusto
 // DidSummarizerRecover: Determine if the summarizer recovered after errors
 // Returns "true" if a successful summarize_end happened after the last error
-union office_fluid_ffautomation*
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Data_docId == "<docId>"
 | where Data_eventName in (
     "fluid:telemetry:Summarizer:Running:Summarize_end",
@@ -1440,7 +1494,7 @@ union office_fluid_ffautomation*
 
 ```kusto
 // SummarizerView: Full timeline of summarizer events for a document
-union office_fluid_ffautomation*
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Event_Time > ago(30d)
     and Data_clientType == 'noninteractive/summarizer'
     and Data_eventName contains "Summarizer:Running:"
@@ -1453,7 +1507,7 @@ union office_fluid_ffautomation*
 
 ```kusto
 // SummarizerLaunchRunView: Full summarizer manager + runner timeline
-union office_fluid_ffautomation*
+union office_fluid_ffautomation_error, office_fluid_ffautomation_performance, office_fluid_ffautomation_generic
 | where Event_Time > ago(30d)
     and (Data_eventName contains "fluid:telemetry:SummaryManager:"
         or Data_eventName contains "fluid:telemetry:Summarizer:Running")


### PR DESCRIPTION
## Description

Indexes learnings from a real FRS Canary stress test pipeline investigation into the OCE agent prompt and Kusto skill reference. During the investigation, the agent wasted ~5 failed queries and multiple round-trips due to incorrect database references, broken wildcard syntax, and missing documentation. These changes prevent that for future investigations.

### Changes

**`.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/SKILL.md`**
- Added the "Office Fluid Test" database (ID `742fa5a288b045e5beab1a2b8e445a71`) to Cluster & Access — the automation/stress test tables live here, not in the primary "Office Fluid" database.

**`.repoverlay/library/ff-oce/.claude/skills/ff-oce-kusto/references/kusto-query-reference.md`**
- **§1.1 Table Overview**: Replaced 2 vague automation table entries with 4 detailed entries documenting the correct database, all key columns, the 3 explicit table names, and a warning against wildcard `office_fluid_ffautomation*` syntax (which does not resolve).
- **§4.6 Stress Test Automation Queries**: Added database/table/column callout header; fixed all `union office_fluid_ffautomation*` → explicit table enumeration; added 3 new queries (`CompareBuildHealth`, `CompareBuildErrors`, `StageHealthTrend`) for cross-build pipeline regression analysis.

**`.repoverlay/library/ff-oce/.claude/agents/ff-oce.md`**
- **Pipeline table**: Listed all 5 stress test stages (was missing `stress_tests_odsp`, `stress_tests_odspdf`, `stress_tests_frs_canary`).
- **FRS Support section**: Added `stress_tests_frs_canary` to monitoring guidance; added "Finding FRS test tenant IDs for escalation" documenting Key Vault secret names, JSON shape, `getKeys` exclusion, and `az keyvault` retrieval command.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

These are repoverlay profile files — they get copied into `.claude/` when the OCE profile is loaded. The changes are documentation/configuration only with no code impact.