### PR TITLE
Increase timeout of end to end test to fix CI errors

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -58,7 +58,7 @@ describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObject
 	benchmarkIt({
 		title: "Create loader",
 		...benchmarkMemoryUse(memoryUseOfValue(() => createLoader())),
-	});
+	}).timeout(60000);
 
 	benchmarkIt({
 		title: "Create detached container",


### PR DESCRIPTION
Increase timeout for `Create Loader` end to end test to fix CI errors