### PR TITLE
fix(routerlicious): Retry getOrCreateRepository on startup

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -171,7 +171,7 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 							);
 						} else {
 							// This is okay to fail since the repos are already created in production.
-							winston.error(`Error creating repos after ${maxAttempts} retries, giving up`);
+							winston.error(`Error creating repos after ${maxAttempts} attempts, giving up`);
 							Lumberjack.error(
 								`Error creating repos`,
 								{ [BaseTelemetryProperties.tenantId]: tenant._id },

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -170,7 +170,8 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 							);
 							await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 						} else {
-							// This is okay to fail since the repos are already created in production.
+							// Production (e.g. AFR) doesn't hit this path because tenantConfig
+							// is empty. This repo creation is only used in local/test environments.
 							winston.error(
 								`Error creating repos after ${attempt} attempts, giving up`,
 							);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -166,12 +166,12 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 							winston.info(
 								`Error creating repos, retrying in ${retryDelayMs}ms (attempt ${attempt}/${maxAttempts})`,
 							);
-							await new Promise((resolve) =>
-								setTimeout(resolve, retryDelayMs),
-							);
+							await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 						} else {
 							// This is okay to fail since the repos are already created in production.
-							winston.error(`Error creating repos after ${maxAttempts} attempts, giving up`);
+							winston.error(
+								`Error creating repos after ${maxAttempts} attempts, giving up`,
+							);
 							Lumberjack.error(
 								`Error creating repos`,
 								{ [BaseTelemetryProperties.tenantId]: tenant._id },

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -146,21 +146,39 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 			// Skip creating anything with credentials - we assume this is external to us and something we can't
 			// or don't want to automatically create (i.e. GitHub)
 			if (!tenant.storage.credentials) {
-				try {
-					const storageUrl = config.get("storage:storageUrl");
-					await getOrCreateRepository(
-						storageUrl,
-						tenant.storage.owner,
-						tenant.storage.repository,
-					);
-				} catch (err) {
-					// This is okay to fail since the repos are alreay created in production.
-					winston.error(`Error creating repos`);
-					Lumberjack.error(
-						`Error creating repos`,
-						{ [BaseTelemetryProperties.tenantId]: tenant._id },
-						err,
-					);
+				// Retry repo creation because gitrest may not be ready yet when riddler starts.
+				// If gitrest is unavailable, getOrCreateRepository throws ECONNREFUSED. Without
+				// retries, the error is swallowed and repos are never created, causing all
+				// subsequent operations to fail with "Repo does not exist".
+				const maxAttempts = 5;
+				const retryDelayMs = 2000;
+				for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+					try {
+						const storageUrl = config.get("storage:storageUrl");
+						await getOrCreateRepository(
+							storageUrl,
+							tenant.storage.owner,
+							tenant.storage.repository,
+						);
+						break;
+					} catch (err) {
+						if (attempt < maxAttempts) {
+							winston.info(
+								`Error creating repos, retrying in ${retryDelayMs}ms (attempt ${attempt}/${maxAttempts})`,
+							);
+							await new Promise((resolve) =>
+								setTimeout(resolve, retryDelayMs),
+							);
+						} else {
+							// This is okay to fail since the repos are already created in production.
+							winston.error(`Error creating repos after ${maxAttempts} retries, giving up`);
+							Lumberjack.error(
+								`Error creating repos`,
+								{ [BaseTelemetryProperties.tenantId]: tenant._id },
+								err,
+							);
+						}
+					}
 				}
 			}
 		});

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -161,8 +161,10 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 							tenant.storage.repository,
 						);
 						break;
-					} catch (err) {
-						if (attempt < maxAttempts) {
+					} catch (err: unknown) {
+						const isConnectionRefusedError =
+							err instanceof Error && "code" in err && err.code === "ECONNREFUSED";
+						if (isConnectionRefusedError && attempt < maxAttempts) {
 							winston.info(
 								`Error creating repos, retrying in ${retryDelayMs}ms (attempt ${attempt}/${maxAttempts})`,
 							);
@@ -170,13 +172,14 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 						} else {
 							// This is okay to fail since the repos are already created in production.
 							winston.error(
-								`Error creating repos after ${maxAttempts} attempts, giving up`,
+								`Error creating repos after ${attempt} attempts, giving up`,
 							);
 							Lumberjack.error(
 								`Error creating repos`,
 								{ [BaseTelemetryProperties.tenantId]: tenant._id },
 								err,
 							);
+							break;
 						}
 					}
 				}


### PR DESCRIPTION
[AB#71224](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71224)

## Description

Riddler calls `getOrCreateRepository` during startup to ensure git repos exist on gitrest.
If gitrest hasn't started yet, the request fails with `ECONNREFUSED` and the error is
swallowed, leaving repos uncreated. All subsequent operations then fail with
"Repo does not exist".

This was exposed by the Node 22 Dockerfile upgrade (#26998), which changed gitrest's startup
timing enough to consistently trigger this failure in CI.

The fix adds retry logic (5 attempts, 2s delay) to riddler's repo creation so it waits for
gitrest to become available. When repos already exist (production), the first attempt
succeeds immediately via the GET check in `getOrCreateRepository`, so there is no added
delay in production.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The change is in `server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts`.
- This is a prerequisite for re-landing the Node 22 Dockerfile upgrade (#26998, which was
  reverted due to this issue).
- Tested locally by adding a synthetic startup delay to gitrest in docker-compose and
  verifying that the retry logic successfully waits for gitrest and creates the repos.