### PR TITLE
chore(server): Upgrade server Dockerfiles to Node 22

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -5,7 +5,7 @@
 # Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
 # That version of the base image must also be baked into the CI build agent by a repo maintainer.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
+FROM node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -6,7 +6,7 @@
 # Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
 # That version of the base image must also be baked into the CI build agent by a repo maintainer.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
+FROM node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -6,7 +6,7 @@
 # Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
 # That version of the base image must also be baked into the CI build agent by a repo maintainer.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
+FROM node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION


### PR DESCRIPTION
[AB#71225](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71225)

## Description

Updates the base image in the routerlicious, historian, and gitrest Dockerfiles from
`node:20.19.0-bookworm-slim` to `node:22.22.2-bookworm-slim` with a pinned sha256 digest.

This is a re-land of #26998, which was reverted due to a startup race condition between
riddler and gitrest. That issue has been fixed in #27069 by adding retry logic to riddler's
`getOrCreateRepository` call.

The gitssh Dockerfile uses Alpine (no Node) and does not require changes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The Node 22.22.2 base image must be baked into CI build agents before this PR can merge.
- The riddler retry fix (#27069) must be merged first (already merged).