### PR TITLE
feat(build-cli): make flub ai launcher aliases configurable

### DIFF
--- a/.devcontainer/ai-agent-insiders/devcontainer.json
+++ b/.devcontainer/ai-agent-insiders/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "AI-enabled (Insiders)",
 	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.1
+	// prebuild-version: 1.0.2
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/ai-agent/launcher-prompt.md
+++ b/.devcontainer/ai-agent/launcher-prompt.md
@@ -1,5 +1,11 @@
 ---
 model: claude-haiku-4.5
+aliases:
+  - claude
+  - dev
+  - copilot
+  - oce
+  - ai-reset
 ---
 
 You are a launcher assistant for the Fluid Framework. Your job is to help the user pick the right AI agent alias and MCP server configuration for their task.

--- a/.devcontainer/ai-agent/launcher-prompt.md
+++ b/.devcontainer/ai-agent/launcher-prompt.md
@@ -38,9 +38,7 @@ Use it to understand the aliases, MCP server options, and recommended workflows.
 {{gettingStartedContent}}
 
 ## Guidelines
-- ONLY recommend aliases that appear in the allowed alias list for this session.
-- ONLY recommend aliases that exist as functions in the alias definitions above.
-- When calling select_alias, the alias value must exactly match a function name from the script.
+- ONLY recommend aliases that appear in the allowed alias list for this session. When calling select_alias, the value must exactly match a function name from the alias definitions script.
 - Most developers doing feature work should use `dev`.
 - For OCE/incident work, always recommend `oce`.
 - For general questions or exploration without a specific workflow, recommend `claude`.

--- a/.devcontainer/ai-agent/launcher-prompt.md
+++ b/.devcontainer/ai-agent/launcher-prompt.md
@@ -1,11 +1,5 @@
 ---
 model: claude-haiku-4.5
-aliases:
-  - claude
-  - dev
-  - copilot
-  - oce
-  - ai-reset
 ---
 
 You are a launcher assistant for the Fluid Framework. Your job is to help the user pick the right AI agent alias and MCP server configuration for their task.
@@ -30,8 +24,9 @@ which overlays it applies, which MCP servers it includes by default).
 
 ## Allowed Aliases for This Session
 
-Only recommend aliases from this configured allowlist. If an alias exists in the shell
-script but is not listed here, treat it as unavailable for this launcher session.
+This list is injected from `agent-aliases.sh`, which is the source of truth for
+the selectable aliases in the current environment. Do not infer additional
+aliases from the shell script beyond the list below.
 
 {{allowedAliasesContent}}
 

--- a/.devcontainer/ai-agent/launcher-prompt.md
+++ b/.devcontainer/ai-agent/launcher-prompt.md
@@ -28,6 +28,13 @@ which overlays it applies, which MCP servers it includes by default).
 {{aliasFileContent}}
 ```
 
+## Allowed Aliases for This Session
+
+Only recommend aliases from this configured allowlist. If an alias exists in the shell
+script but is not listed here, treat it as unavailable for this launcher session.
+
+{{allowedAliasesContent}}
+
 ## Getting Started Guide
 
 The following guide is shown to users when they first start working.
@@ -36,6 +43,7 @@ Use it to understand the aliases, MCP server options, and recommended workflows.
 {{gettingStartedContent}}
 
 ## Guidelines
+- ONLY recommend aliases that appear in the allowed alias list for this session.
 - ONLY recommend aliases that exist as functions in the alias definitions above.
 - When calling select_alias, the alias value must exactly match a function name from the script.
 - Most developers doing feature work should use `dev`.

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -77,15 +77,18 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 			`Model: ${model} (source: ${flags.model ? "flag" : promptFile.model ? "frontmatter" : "fallback"})`,
 		);
 
-		const aliases = promptFile.aliases ?? FALLBACK_ALIASES;
+		const aliases = resolveAllowedAliases(promptFile.aliases);
 		const allowedAliasSet = new Set(aliases);
 		this.verbose(
 			`Aliases: ${aliases.join(", ")} (source: ${promptFile.aliases ? "frontmatter" : "fallback"})`,
 		);
 
-		const prompt = promptFile.template
-			.replaceAll("{{aliasFileContent}}", aliasFile.content)
-			.replaceAll("{{gettingStartedContent}}", gettingStartedContent ?? "");
+		const prompt = buildLauncherPrompt({
+			template: promptFile.template,
+			aliasFileContent: aliasFile.content,
+			gettingStartedContent,
+			allowedAliases: aliases,
+		});
 		const githubToken =
 			flags.githubToken ??
 			process.env.GH_TOKEN ??
@@ -307,7 +310,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 				return {
 					template: content.trim(),
 					model: typeof data.model === "string" ? data.model : undefined,
-					aliases: Array.isArray(data.aliases) ? (data.aliases as string[]) : undefined,
+					aliases: normalizeFrontmatterAliases(data.aliases),
 				};
 			} catch (error) {
 				this.warning(
@@ -338,6 +341,36 @@ export function assertSafeAliasSelection(
 			`Unsupported AI alias selection: ${proposal.alias}. Allowed aliases: ${[...aliasSet].join(", ")}`,
 		);
 	}
+}
+
+export function resolveAllowedAliases(configuredAliases?: readonly string[]): string[] {
+	return configuredAliases !== undefined && configuredAliases.length > 0
+		? [...configuredAliases]
+		: [...FALLBACK_ALIASES];
+}
+
+export function buildLauncherPrompt({
+	template,
+	aliasFileContent,
+	gettingStartedContent,
+	allowedAliases,
+}: {
+	template: string;
+	aliasFileContent: string;
+	gettingStartedContent?: string;
+	allowedAliases: readonly string[];
+}): string {
+	const allowedAliasesContent = allowedAliases.map((alias) => `- \`${alias}\``).join("\n");
+	const prompt = template
+		.replaceAll("{{aliasFileContent}}", aliasFileContent)
+		.replaceAll("{{gettingStartedContent}}", gettingStartedContent ?? "")
+		.replaceAll("{{allowedAliasesContent}}", allowedAliasesContent);
+
+	if (template.includes("{{allowedAliasesContent}}")) {
+		return prompt;
+	}
+
+	return `${prompt}\n\n## Allowed Aliases for This Session\n\nOnly recommend aliases from this configured allowlist. If an alias exists in the shell script but is not listed here, treat it as unavailable.\n\n${allowedAliasesContent}`;
 }
 
 function formatAliasCommand(proposal: AliasProposal): string {
@@ -372,6 +405,16 @@ export function normalizePromptAnswer(answer: string, choices?: string[]): strin
 	}
 
 	return trimmed;
+}
+
+function normalizeFrontmatterAliases(aliases: unknown): string[] | undefined {
+	if (!Array.isArray(aliases)) {
+		return undefined;
+	}
+
+	return aliases.filter(
+		(alias): alias is string => typeof alias === "string" && alias.length > 0,
+	);
 }
 
 function isUserCancellation(error: unknown): boolean {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -17,6 +17,7 @@ import { BaseCommand } from "../library/commands/base.js";
 
 const FALLBACK_MODEL = "claude-haiku-4.5";
 export const FALLBACK_ALIASES = ["claude", "dev", "copilot", "oce", "ai-reset"] as const;
+const FALLBACK_ALIAS_SET = new Set<string>(FALLBACK_ALIASES);
 
 export default class AiCommand extends BaseCommand<typeof AiCommand> {
 	static readonly description =
@@ -76,7 +77,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 			`Model: ${model} (source: ${flags.model ? "flag" : promptFile.model ? "frontmatter" : "fallback"})`,
 		);
 
-		const aliases = promptFile.aliases ?? [...FALLBACK_ALIASES];
+		const aliases = promptFile.aliases ?? FALLBACK_ALIASES;
 		const allowedAliasSet = new Set(aliases);
 		this.verbose(
 			`Aliases: ${aliases.join(", ")} (source: ${promptFile.aliases ? "frontmatter" : "fallback"})`,
@@ -309,14 +310,14 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 					aliases: Array.isArray(data.aliases) ? (data.aliases as string[]) : undefined,
 				};
 			} catch (error) {
-				this.warn(
+				this.warning(
 					`Failed to parse launcher-prompt.md frontmatter; using raw file contents instead: ${String(error)}`,
 				);
 				return { template: raw.trim() };
 			}
 		}
 
-		this.warn("launcher-prompt.md not found; using hardcoded fallback prompt.");
+		this.warning("launcher-prompt.md not found; using hardcoded fallback prompt.");
 		return {
 			template:
 				"You are a launcher assistant. Ask the user what they want to do, " +
@@ -331,7 +332,7 @@ export function assertSafeAliasSelection(
 	proposal: AliasProposal,
 	allowedAliases?: Set<string>,
 ): void {
-	const aliasSet = allowedAliases ?? new Set<string>(FALLBACK_ALIASES);
+	const aliasSet = allowedAliases ?? FALLBACK_ALIAS_SET;
 	if (!aliasSet.has(proposal.alias)) {
 		throw new Error(
 			`Unsupported AI alias selection: ${proposal.alias}. Allowed aliases: ${[...aliasSet].join(", ")}`,
@@ -395,7 +396,6 @@ async function resolveGhAuthToken(): Promise<string | undefined> {
 		return undefined;
 	}
 }
-
 
 async function tryReadFile(filePath: string): Promise<string | undefined> {
 	try {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -306,7 +306,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 				return {
 					template: content.trim(),
 					model: typeof data.model === "string" ? data.model : undefined,
-					aliases: parseAliasesFromFrontmatter(data.aliases),
+					aliases: Array.isArray(data.aliases) ? (data.aliases as string[]) : undefined,
 				};
 			} catch (error) {
 				this.warn(
@@ -396,17 +396,6 @@ async function resolveGhAuthToken(): Promise<string | undefined> {
 	}
 }
 
-/**
- * Parses and validates the `aliases` field from launcher-prompt.md frontmatter.
- * Returns undefined if the field is missing or not a valid string array.
- */
-function parseAliasesFromFrontmatter(value: unknown): string[] | undefined {
-	if (!Array.isArray(value)) {
-		return undefined;
-	}
-	const strings = value.filter((item): item is string => typeof item === "string");
-	return strings.length > 0 ? strings : undefined;
-}
 
 async function tryReadFile(filePath: string): Promise<string | undefined> {
 	try {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -16,8 +16,7 @@ import { type AliasProposal, runAiSession } from "../library/ai/copilotSession.j
 import { BaseCommand } from "../library/commands/base.js";
 
 const FALLBACK_MODEL = "claude-haiku-4.5";
-export const supportedAliases = ["claude", "dev", "copilot", "oce", "ai-reset"] as const;
-const supportedAliasSet = new Set<string>(supportedAliases);
+export const FALLBACK_ALIASES = ["claude", "dev", "copilot", "oce", "ai-reset"] as const;
 
 export default class AiCommand extends BaseCommand<typeof AiCommand> {
 	static readonly description =
@@ -75,6 +74,12 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		const model = flags.model ?? promptFile.model ?? FALLBACK_MODEL;
 		this.verbose(
 			`Model: ${model} (source: ${flags.model ? "flag" : promptFile.model ? "frontmatter" : "fallback"})`,
+		);
+
+		const aliases = promptFile.aliases ?? [...FALLBACK_ALIASES];
+		const allowedAliasSet = new Set(aliases);
+		this.verbose(
+			`Aliases: ${aliases.join(", ")} (source: ${promptFile.aliases ? "frontmatter" : "fallback"})`,
 		);
 
 		const prompt = promptFile.template
@@ -144,7 +149,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		}
 
 		try {
-			assertSafeAliasSelection(proposal);
+			assertSafeAliasSelection(proposal, allowedAliasSet);
 		} catch (error: unknown) {
 			this.error(error instanceof Error ? error.message : String(error), { exit: 1 });
 		}
@@ -293,7 +298,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 	 */
 	private async loadPromptFile(
 		repoRoot: string | undefined,
-	): Promise<{ template: string; model?: string }> {
+	): Promise<{ template: string; model?: string; aliases?: string[] }> {
 		const raw = await this.readDevcontainerFile(repoRoot, "launcher-prompt.md");
 		if (raw !== undefined) {
 			try {
@@ -301,6 +306,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 				return {
 					template: content.trim(),
 					model: typeof data.model === "string" ? data.model : undefined,
+					aliases: parseAliasesFromFrontmatter(data.aliases),
 				};
 			} catch (error) {
 				this.warn(
@@ -321,10 +327,14 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 	}
 }
 
-export function assertSafeAliasSelection(proposal: AliasProposal): void {
-	if (!supportedAliasSet.has(proposal.alias)) {
+export function assertSafeAliasSelection(
+	proposal: AliasProposal,
+	allowedAliases?: Set<string>,
+): void {
+	const aliasSet = allowedAliases ?? new Set<string>(FALLBACK_ALIASES);
+	if (!aliasSet.has(proposal.alias)) {
 		throw new Error(
-			`Unsupported AI alias selection: ${proposal.alias}. Allowed aliases: ${supportedAliases.join(", ")}`,
+			`Unsupported AI alias selection: ${proposal.alias}. Allowed aliases: ${[...aliasSet].join(", ")}`,
 		);
 	}
 }
@@ -384,6 +394,18 @@ async function resolveGhAuthToken(): Promise<string | undefined> {
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * Parses and validates the `aliases` field from launcher-prompt.md frontmatter.
+ * Returns undefined if the field is missing or not a valid string array.
+ */
+function parseAliasesFromFrontmatter(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const strings = value.filter((item): item is string => typeof item === "string");
+	return strings.length > 0 ? strings : undefined;
 }
 
 async function tryReadFile(filePath: string): Promise<string | undefined> {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -18,6 +18,7 @@ import { BaseCommand } from "../library/commands/base.js";
 const FALLBACK_MODEL = "claude-haiku-4.5";
 export const FALLBACK_ALIASES = ["claude", "dev", "copilot", "oce", "ai-reset"] as const;
 const FALLBACK_ALIAS_SET = new Set<string>(FALLBACK_ALIASES);
+const SELECTABLE_ALIASES_FUNCTION = "list_aliases_json";
 
 export default class AiCommand extends BaseCommand<typeof AiCommand> {
 	static readonly description =
@@ -77,11 +78,9 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 			`Model: ${model} (source: ${flags.model ? "flag" : promptFile.model ? "frontmatter" : "fallback"})`,
 		);
 
-		const aliases = resolveAllowedAliases(promptFile.aliases);
+		const { aliases, source } = await this.loadAllowedAliases(aliasFile.path);
 		const allowedAliasSet = new Set(aliases);
-		this.verbose(
-			`Aliases: ${aliases.join(", ")} (source: ${promptFile.aliases ? "frontmatter" : "fallback"})`,
-		);
+		this.verbose(`Aliases: ${aliases.join(", ")} (source: ${source})`);
 
 		const prompt = buildLauncherPrompt({
 			template: promptFile.template,
@@ -302,7 +301,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 	 */
 	private async loadPromptFile(
 		repoRoot: string | undefined,
-	): Promise<{ template: string; model?: string; aliases?: string[] }> {
+	): Promise<{ template: string; model?: string }> {
 		const raw = await this.readDevcontainerFile(repoRoot, "launcher-prompt.md");
 		if (raw !== undefined) {
 			try {
@@ -310,7 +309,6 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 				return {
 					template: content.trim(),
 					model: typeof data.model === "string" ? data.model : undefined,
-					aliases: normalizeFrontmatterAliases(data.aliases),
 				};
 			} catch (error) {
 				this.warning(
@@ -326,8 +324,34 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 				"You are a launcher assistant. Ask the user what they want to do, " +
 				"then call select_alias with the best alias from the alias definitions.\n\n" +
 				"## Alias Definitions\n\n```bash\n{{aliasFileContent}}\n```\n\n" +
+				"## Allowed Aliases for This Session\n\n{{allowedAliasesContent}}\n\n" +
 				"## Getting Started Guide\n\n{{gettingStartedContent}}",
 		};
+	}
+
+	/**
+	 * Reads the machine-readable alias manifest from agent-aliases.sh.
+	 * This keeps the shell script as the source of truth without scraping bash.
+	 */
+	private async loadAllowedAliases(
+		aliasFilePath: string,
+	): Promise<{ aliases: string[]; source: "agent-aliases.sh" | "fallback" }> {
+		try {
+			const { stdout } = await execa("bash", [
+				"-c",
+				`source ${shellQuote(aliasFilePath)} && ${SELECTABLE_ALIASES_FUNCTION}`,
+			]);
+			const aliases = parseSelectableAliasesJson(stdout);
+			if (aliases !== undefined) {
+				return { aliases, source: "agent-aliases.sh" };
+			}
+			this.verbose(`Alias manifest from ${aliasFilePath} was not valid JSON.`);
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.verbose(`Failed to load aliases from ${aliasFilePath}: ${message}`);
+		}
+
+		return { aliases: [...FALLBACK_ALIASES], source: "fallback" };
 	}
 }
 
@@ -343,10 +367,15 @@ export function assertSafeAliasSelection(
 	}
 }
 
-export function resolveAllowedAliases(configuredAliases?: readonly string[]): string[] {
-	return configuredAliases !== undefined && configuredAliases.length > 0
-		? [...configuredAliases]
-		: [...FALLBACK_ALIASES];
+export function resolveAllowedAliases(allowedAliases?: readonly string[]): string[] {
+	if (allowedAliases === undefined || allowedAliases.length === 0) {
+		return [...FALLBACK_ALIASES];
+	}
+
+	const normalizedAliases = Array.from(
+		new Set(allowedAliases.filter((alias) => alias.trim().length > 0)),
+	);
+	return normalizedAliases.length > 0 ? normalizedAliases : [...FALLBACK_ALIASES];
 }
 
 export function buildLauncherPrompt({
@@ -370,7 +399,7 @@ export function buildLauncherPrompt({
 		return prompt;
 	}
 
-	return `${prompt}\n\n## Allowed Aliases for This Session\n\nOnly recommend aliases from this configured allowlist. If an alias exists in the shell script but is not listed here, treat it as unavailable.\n\n${allowedAliasesContent}`;
+	return `${prompt}\n\n## Allowed Aliases for This Session\n\nOnly recommend aliases from this list derived from agent-aliases.sh for the current session.\n\n${allowedAliasesContent}`;
 }
 
 function formatAliasCommand(proposal: AliasProposal): string {
@@ -407,14 +436,20 @@ export function normalizePromptAnswer(answer: string, choices?: string[]): strin
 	return trimmed;
 }
 
-function normalizeFrontmatterAliases(aliases: unknown): string[] | undefined {
-	if (!Array.isArray(aliases)) {
+function parseSelectableAliasesJson(raw: string): string[] | undefined {
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) {
+			return undefined;
+		}
+
+		const aliases = parsed.filter(
+			(alias): alias is string => typeof alias === "string" && alias.trim().length > 0,
+		);
+		return resolveAllowedAliases(aliases);
+	} catch {
 		return undefined;
 	}
-
-	return aliases.filter(
-		(alias): alias is string => typeof alias === "string" && alias.length > 0,
-	);
 }
 
 function isUserCancellation(error: unknown): boolean {

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -17,7 +17,6 @@ import { BaseCommand } from "../library/commands/base.js";
 
 const FALLBACK_MODEL = "claude-haiku-4.5";
 export const FALLBACK_ALIASES = ["claude", "dev", "copilot", "oce", "ai-reset"] as const;
-const FALLBACK_ALIAS_SET = new Set<string>(FALLBACK_ALIASES);
 const SELECTABLE_ALIASES_FUNCTION = "list_aliases_json";
 
 export default class AiCommand extends BaseCommand<typeof AiCommand> {
@@ -329,10 +328,6 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		};
 	}
 
-	/**
-	 * Reads the machine-readable alias manifest from agent-aliases.sh.
-	 * This keeps the shell script as the source of truth without scraping bash.
-	 */
 	private async loadAllowedAliases(
 		aliasFilePath: string,
 	): Promise<{ aliases: string[]; source: "agent-aliases.sh" | "fallback" }> {
@@ -357,12 +352,11 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 
 export function assertSafeAliasSelection(
 	proposal: AliasProposal,
-	allowedAliases?: Set<string>,
+	allowedAliases: Set<string>,
 ): void {
-	const aliasSet = allowedAliases ?? FALLBACK_ALIAS_SET;
-	if (!aliasSet.has(proposal.alias)) {
+	if (!allowedAliases.has(proposal.alias)) {
 		throw new Error(
-			`Unsupported AI alias selection: ${proposal.alias}. Allowed aliases: ${[...aliasSet].join(", ")}`,
+			`Unsupported AI alias selection: ${proposal.alias}. Allowed aliases: ${[...allowedAliases].join(", ")}`,
 		);
 	}
 }
@@ -390,16 +384,10 @@ export function buildLauncherPrompt({
 	allowedAliases: readonly string[];
 }): string {
 	const allowedAliasesContent = allowedAliases.map((alias) => `- \`${alias}\``).join("\n");
-	const prompt = template
+	return template
 		.replaceAll("{{aliasFileContent}}", aliasFileContent)
 		.replaceAll("{{gettingStartedContent}}", gettingStartedContent ?? "")
 		.replaceAll("{{allowedAliasesContent}}", allowedAliasesContent);
-
-	if (template.includes("{{allowedAliasesContent}}")) {
-		return prompt;
-	}
-
-	return `${prompt}\n\n## Allowed Aliases for This Session\n\nOnly recommend aliases from this list derived from agent-aliases.sh for the current session.\n\n${allowedAliasesContent}`;
 }
 
 function formatAliasCommand(proposal: AliasProposal): string {
@@ -443,10 +431,10 @@ function parseSelectableAliasesJson(raw: string): string[] | undefined {
 			return undefined;
 		}
 
-		const aliases = parsed.filter(
-			(alias): alias is string => typeof alias === "string" && alias.trim().length > 0,
+		const strings = parsed.filter(
+			(alias): alias is string => typeof alias === "string",
 		);
-		return resolveAllowedAliases(aliases);
+		return resolveAllowedAliases(strings);
 	} catch {
 		return undefined;
 	}

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -328,6 +328,10 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 		};
 	}
 
+	/**
+	 * Reads the machine-readable alias manifest from agent-aliases.sh.
+	 * This keeps the shell script as the source of truth without scraping bash.
+	 */
 	private async loadAllowedAliases(
 		aliasFilePath: string,
 	): Promise<{ aliases: string[]; source: "agent-aliases.sh" | "fallback" }> {
@@ -431,9 +435,7 @@ function parseSelectableAliasesJson(raw: string): string[] | undefined {
 			return undefined;
 		}
 
-		const strings = parsed.filter(
-			(alias): alias is string => typeof alias === "string",
-		);
+		const strings = parsed.filter((alias): alias is string => typeof alias === "string");
 		return resolveAllowedAliases(strings);
 	} catch {
 		return undefined;

--- a/build-tools/packages/build-cli/src/test/commands/ai.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/ai.test.ts
@@ -15,33 +15,19 @@ import {
 } from "../../commands/ai.js";
 
 describe("ai command", () => {
-	it("allows fallback aliases when no custom set provided", () => {
-		for (const alias of FALLBACK_ALIASES) {
-			expect(() =>
-				assertSafeAliasSelection({ alias, explanation: `launch ${alias}` }),
-			).to.not.throw();
-		}
-	});
-
-	it("rejects unsupported aliases when no custom set provided", () => {
+	it("allows aliases present in the provided set", () => {
+		const aliasSet = new Set(["my-alias", "other-alias"]);
 		expect(() =>
-			assertSafeAliasSelection({ alias: "bash", explanation: "definitely not safe" }),
-		).to.throw(/Unsupported AI alias selection: bash/);
-	});
-
-	it("accepts aliases in a custom set", () => {
-		const customSet = new Set(["my-alias", "other-alias"]);
-		expect(() =>
-			assertSafeAliasSelection({ alias: "my-alias", explanation: "custom alias" }, customSet),
+			assertSafeAliasSelection({ alias: "my-alias", explanation: "custom alias" }, aliasSet),
 		).to.not.throw();
 	});
 
-	it("rejects aliases not in a custom set", () => {
-		const customSet = new Set(["my-alias", "other-alias"]);
+	it("rejects aliases not in the provided set", () => {
+		const aliasSet = new Set(["my-alias", "other-alias"]);
 		expect(() =>
 			assertSafeAliasSelection(
-				{ alias: "claude", explanation: "not in custom set" },
-				customSet,
+				{ alias: "claude", explanation: "not in set" },
+				aliasSet,
 			),
 		).to.throw(/Unsupported AI alias selection: claude/);
 	});
@@ -72,17 +58,6 @@ describe("ai command", () => {
 
 		expect(prompt).to.include("- `copilot`");
 		expect(prompt).to.not.include("{{allowedAliasesContent}}");
-	});
-
-	it("appends the configured alias list when the template lacks a placeholder", () => {
-		const prompt = buildLauncherPrompt({
-			template: "## Alias Definitions\n{{aliasFileContent}}",
-			aliasFileContent: "dev() {}",
-			allowedAliases: ["dev"],
-		});
-
-		expect(prompt).to.include("## Allowed Aliases for This Session");
-		expect(prompt).to.include("- `dev`");
 	});
 
 	it("maps numbered prompt selections to the selected choice", () => {

--- a/build-tools/packages/build-cli/src/test/commands/ai.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/ai.test.ts
@@ -32,10 +32,7 @@ describe("ai command", () => {
 	it("accepts aliases in a custom set", () => {
 		const customSet = new Set(["my-alias", "other-alias"]);
 		expect(() =>
-			assertSafeAliasSelection(
-				{ alias: "my-alias", explanation: "custom alias" },
-				customSet,
-			),
+			assertSafeAliasSelection({ alias: "my-alias", explanation: "custom alias" }, customSet),
 		).to.not.throw();
 	});
 
@@ -55,6 +52,13 @@ describe("ai command", () => {
 
 	it("uses the configured aliases when provided", () => {
 		expect(resolveAllowedAliases(["copilot", "oce"])).to.deep.equal(["copilot", "oce"]);
+	});
+
+	it("normalizes parsed alias lists", () => {
+		expect(resolveAllowedAliases(["dev", "copilot", "dev", ""])).to.deep.equal([
+			"dev",
+			"copilot",
+		]);
 	});
 
 	it("renders the configured alias list into the launcher prompt", () => {

--- a/build-tools/packages/build-cli/src/test/commands/ai.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/ai.test.ts
@@ -8,8 +8,10 @@ import { describe, it } from "mocha";
 
 import {
 	assertSafeAliasSelection,
+	buildLauncherPrompt,
 	FALLBACK_ALIASES,
 	normalizePromptAnswer,
+	resolveAllowedAliases,
 } from "../../commands/ai.js";
 
 describe("ai command", () => {
@@ -45,6 +47,38 @@ describe("ai command", () => {
 				customSet,
 			),
 		).to.throw(/Unsupported AI alias selection: claude/);
+	});
+
+	it("falls back to the default aliases when the configured list is empty", () => {
+		expect(resolveAllowedAliases([])).to.deep.equal([...FALLBACK_ALIASES]);
+	});
+
+	it("uses the configured aliases when provided", () => {
+		expect(resolveAllowedAliases(["copilot", "oce"])).to.deep.equal(["copilot", "oce"]);
+	});
+
+	it("renders the configured alias list into the launcher prompt", () => {
+		const prompt = buildLauncherPrompt({
+			template:
+				"## Alias Definitions\n{{aliasFileContent}}\n\n## Allowed Aliases\n{{allowedAliasesContent}}\n\n## Getting Started\n{{gettingStartedContent}}",
+			aliasFileContent: "dev() {}",
+			gettingStartedContent: "start here",
+			allowedAliases: ["copilot"],
+		});
+
+		expect(prompt).to.include("- `copilot`");
+		expect(prompt).to.not.include("{{allowedAliasesContent}}");
+	});
+
+	it("appends the configured alias list when the template lacks a placeholder", () => {
+		const prompt = buildLauncherPrompt({
+			template: "## Alias Definitions\n{{aliasFileContent}}",
+			aliasFileContent: "dev() {}",
+			allowedAliases: ["dev"],
+		});
+
+		expect(prompt).to.include("## Allowed Aliases for This Session");
+		expect(prompt).to.include("- `dev`");
 	});
 
 	it("maps numbered prompt selections to the selected choice", () => {

--- a/build-tools/packages/build-cli/src/test/commands/ai.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/ai.test.ts
@@ -25,10 +25,7 @@ describe("ai command", () => {
 	it("rejects aliases not in the provided set", () => {
 		const aliasSet = new Set(["my-alias", "other-alias"]);
 		expect(() =>
-			assertSafeAliasSelection(
-				{ alias: "claude", explanation: "not in set" },
-				aliasSet,
-			),
+			assertSafeAliasSelection({ alias: "claude", explanation: "not in set" }, aliasSet),
 		).to.throw(/Unsupported AI alias selection: claude/);
 	});
 

--- a/build-tools/packages/build-cli/src/test/commands/ai.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/ai.test.ts
@@ -8,23 +8,43 @@ import { describe, it } from "mocha";
 
 import {
 	assertSafeAliasSelection,
+	FALLBACK_ALIASES,
 	normalizePromptAnswer,
-	supportedAliases,
 } from "../../commands/ai.js";
 
 describe("ai command", () => {
-	it("allows known agent aliases", () => {
-		for (const alias of supportedAliases) {
+	it("allows fallback aliases when no custom set provided", () => {
+		for (const alias of FALLBACK_ALIASES) {
 			expect(() =>
 				assertSafeAliasSelection({ alias, explanation: `launch ${alias}` }),
 			).to.not.throw();
 		}
 	});
 
-	it("rejects unsupported aliases", () => {
+	it("rejects unsupported aliases when no custom set provided", () => {
 		expect(() =>
 			assertSafeAliasSelection({ alias: "bash", explanation: "definitely not safe" }),
 		).to.throw(/Unsupported AI alias selection: bash/);
+	});
+
+	it("accepts aliases in a custom set", () => {
+		const customSet = new Set(["my-alias", "other-alias"]);
+		expect(() =>
+			assertSafeAliasSelection(
+				{ alias: "my-alias", explanation: "custom alias" },
+				customSet,
+			),
+		).to.not.throw();
+	});
+
+	it("rejects aliases not in a custom set", () => {
+		const customSet = new Set(["my-alias", "other-alias"]);
+		expect(() =>
+			assertSafeAliasSelection(
+				{ alias: "claude", explanation: "not in custom set" },
+				customSet,
+			),
+		).to.throw(/Unsupported AI alias selection: claude/);
 	});
 
 	it("maps numbered prompt selections to the selected choice", () => {

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -9,6 +9,7 @@ _ensure_agency() {
 		echo "Agency is not installed. Installing now..."
 		echo "  A browser window will open for authentication!"
 		pnpm install:agency || return 1
+		echo "Please wait..."
 	fi
 	if [[ ! -x "$AGENCY_DIR/agency" ]]; then
 		echo "Agency is still not available at $AGENCY_DIR/agency after installation." >&2

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -20,6 +20,21 @@ _ensure_agency() {
 	fi
 }
 
+# Machine-readable source of truth for the aliases that `flub ai` may recommend.
+# Keep this side-effect free and in sync with the user-selectable shell functions
+# below. Helpers like `start`, `obiwan`, and `flub-ai` are intentionally omitted.
+alias_manifest() {
+	cat <<'JSON'
+["claude","dev","copilot","oce","ai-reset"]
+JSON
+}
+
+# Emit just the selectable alias list so tooling can safely parse it without
+# scraping bash function bodies.
+list_aliases_json() {
+	alias_manifest
+}
+
 # Agent launcher functions. Extra args (e.g. --mcp 'kusto ...') are inserted
 # before the -- separator so they reach agency, not Claude/Copilot directly.
 claude() {

--- a/scripts/codespace-setup/agent-aliases.sh
+++ b/scripts/codespace-setup/agent-aliases.sh
@@ -23,16 +23,10 @@ _ensure_agency() {
 # Machine-readable source of truth for the aliases that `flub ai` may recommend.
 # Keep this side-effect free and in sync with the user-selectable shell functions
 # below. Helpers like `start`, `obiwan`, and `flub-ai` are intentionally omitted.
-alias_manifest() {
+list_aliases_json() {
 	cat <<'JSON'
 ["claude","dev","copilot","oce","ai-reset"]
 JSON
-}
-
-# Emit just the selectable alias list so tooling can safely parse it without
-# scraping bash function bodies.
-list_aliases_json() {
-	alias_manifest
 }
 
 # Agent launcher functions. Extra args (e.g. --mcp 'kusto ...') are inserted


### PR DESCRIPTION
## Description

Makes `flub ai` load its allowed aliases at runtime from `agent-aliases.sh` instead of a hardcoded list in the CLI source.

- Adds a `list_aliases_json` function to `agent-aliases.sh` as the machine-readable source of truth for selectable aliases.
- `flub ai` sources the shell script and calls that function to discover which aliases are available; falls back to the previous hardcoded list on failure.
- Injects the allowed-alias list into the launcher prompt via a new `{{allowedAliasesContent}}` template variable so the LLM only recommends valid aliases.
- Extracts `buildLauncherPrompt` and `resolveAllowedAliases` helpers; updates `assertSafeAliasSelection` to accept a dynamic alias set.
- Replaces `this.warn` with `this.warning` (oclif deprecation).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).