### PR TITLE
fix(tree): track chunkIndex on field entry so getField finds parent

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -555,14 +555,16 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 	}
 
 	/**
-	 * Returns the chunks that make up the field the cursor is currently in.
+	 * Resolves the chunks that make up the field the cursor is currently in. At the root, this is
+	 * {@link root} directly. Otherwise, the cursor must be in {@link CursorLocationType.Fields} mode,
+	 * and the result is looked up on the parent node using the current field key.
 	 *
-	 * @remarks At the root, this is {@link root} directly. Otherwise, the cursor must be in
-	 * {@link CursorLocationType.Fields} mode, and the result is looked up on the parent node using
-	 * the current field key. The parent node is the {@link BasicChunk} in the node array at the top
-	 * of {@link siblingStack} while we are in {@link CursorLocationType.Fields} mode. We need the
-	 * parent since a field's chunks are stored on the parent node's {@link BasicChunk.fields} map,
-	 * not on the cursor itself.
+	 * @remarks The parent node is the {@link BasicChunk} in the node array at the top of
+	 * {@link siblingStack} while we are in {@link CursorLocationType.Fields} mode. We need the parent
+	 * since a field's chunks are stored on the parent node's {@link BasicChunk.fields} map, not on
+	 * the cursor itself.
+	 *
+	 * @returns The chunks that make up the field the cursor is currently in.
 	 */
 	private getField(): readonly TreeChunk[] {
 		if (this.siblingStack.length === 0) {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -220,7 +220,15 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		return (this.siblingStack[height] as readonly TreeChunk[])[index] as BasicChunk;
 	}
 
-	// Returns the floor of half the height passed in, or half of `siblingStack.length` if no height is provided.
+	/**
+	 * Converts a {@link height}, which contains field and node levels, into the corresponding depth/index
+	 * for the node-only stacks ({@link indexOfChunkStack} and {@link indexWithinChunkStack}), which are
+	 * only pushed on node-level transitions.
+	 *
+	 * @param height - A depth in {@link siblingStack} to convert. Defaults to {@link siblingStack}'s
+	 * current length, which gives the current depth of the node-only stacks.
+	 * @returns `floor(height / 2)` — the number of node levels at or below the given stack height.
+	 */
 	private getNodeOnlyHeightFromHeight(height: number = this.siblingStack.length): number {
 		// The bitwise shift computes the floor, which is valid assuming the depth is less than 2^31, which seems safe.
 		// eslint-disable-next-line no-bitwise
@@ -546,6 +554,16 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		return (this.siblings as TreeChunk[])[this.indexOfChunk] as BasicChunk;
 	}
 
+	/**
+	 * Returns the chunks that make up the field the cursor is currently in.
+	 *
+	 * @remarks At the root, this is {@link root} directly. Otherwise, the cursor must be in
+	 * {@link CursorLocationType.Fields} mode, and the result is looked up on the parent node using
+	 * the current field key. The parent node is the {@link BasicChunk} in the node array at the top
+	 * of {@link siblingStack} while we are in {@link CursorLocationType.Fields} mode. We need the
+	 * parent since a field's chunks are stored on the parent node's {@link BasicChunk.fields} map,
+	 * not on the cursor itself.
+	 */
 	private getField(): readonly TreeChunk[] {
 		if (this.siblingStack.length === 0) {
 			return this.root;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob, fail } from "@fluidframework/core-utils/internal";
+import { assert, oob, fail, debugAssert } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -217,7 +217,9 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 
 	private getStackedChunk(height: number): BasicChunk {
 		const index = this.getStackedChunkIndex(height);
-		return (this.siblingStack[height] as readonly TreeChunk[])[index] as BasicChunk;
+		const chunk = (this.siblingStack[height] as readonly TreeChunk[])[index];
+		debugAssert(() => chunk instanceof BasicChunk || "only basic chunks are expected");
+		return chunk as BasicChunk;
 	}
 
 	/**
@@ -551,18 +553,15 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 
 	private getNode(): BasicChunk {
 		assert(this.mode === CursorLocationType.Nodes, 0x52f /* can only get node when in node */);
-		return (this.siblings as TreeChunk[])[this.indexOfChunk] as BasicChunk;
+		const chunk = (this.siblings as TreeChunk[])[this.indexOfChunk];
+		debugAssert(() => chunk instanceof BasicChunk || "only basic chunks are expected");
+		return chunk as BasicChunk;
 	}
 
 	/**
 	 * Resolves the chunks that make up the field the cursor is currently in. At the root, this is
 	 * {@link root} directly. Otherwise, the cursor must be in {@link CursorLocationType.Fields} mode,
 	 * and the result is looked up on the parent node using the current field key.
-	 *
-	 * @remarks The parent node is the {@link BasicChunk} in the node array at the top of
-	 * {@link siblingStack} while we are in {@link CursorLocationType.Fields} mode. We need the parent
-	 * since a field's chunks are stored on the parent node's {@link BasicChunk.fields} map, not on
-	 * the cursor itself.
 	 *
 	 * @returns The chunks that make up the field the cursor is currently in.
 	 */
@@ -574,6 +573,10 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 			this.mode === CursorLocationType.Fields,
 			0x530 /* can only get field when in fields */,
 		);
+		// The parent node is the `BasicChunk` in the node array at the top of
+		// `siblingStack` while we are in `CursorLocationType.Fields` mode. We need the parent
+		// since a field's chunks are stored on the parent node's `BasicChunk.fields` map, not on
+		// the cursor itself.
 		const parent = this.getStackedChunk(this.siblingStack.length - 1);
 		const key: FieldKey = this.getFieldKey();
 		const field = parent.fields.get(key) ?? [];

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -169,7 +169,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		// Compute the number of nodes deep the current depth is.
 		// We want the floor of the result, which can computed using a bitwise shift assuming the depth is less than 2^31, which seems safe.
 		// eslint-disable-next-line no-bitwise
-		const halfHeight = (this.siblingStack.length + 1) >> 1;
+		const halfHeight = this.siblingStack.length >> 1;
 		assert(
 			this.indexOfChunkStack.length === halfHeight,
 			0x51c /* unexpected indexOfChunkStack */,
@@ -203,8 +203,15 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		return this.indexStack[height] ?? oob();
 	}
 
-	private getStackedNode(height: number): BasicChunk {
-		const index = this.getStackedNodeIndex(height);
+	private getStackedChunkIndex(height: number): number {
+		assert(height % 2 === 1, "must be node height");
+		assert(height >= 0, "must not be above root");
+		// eslint-disable-next-line no-bitwise
+		return this.indexOfChunkStack[height >> 1] ?? oob();
+	}
+
+	private getStackedChunk(height: number): BasicChunk {
+		const index = this.getStackedChunkIndex(height);
 		return (this.siblingStack[height] as readonly TreeChunk[])[index] as BasicChunk;
 	}
 
@@ -322,6 +329,11 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		assert(this.mode === CursorLocationType.Nodes, 0x528 /* must be in nodes mode */);
 		this.siblingStack.push(this.siblings);
 		this.indexStack.push(this.index);
+		// Save the chunk array position of the current node. When siblings contain
+		// multi node chunks, the flat node index diverges from the array position,
+		// so getField needs this to locate the parent in the sibling array.
+		this.indexOfChunkStack.push(this.indexOfChunk);
+		this.indexWithinChunkStack.push(this.indexWithinChunk);
 
 		// For fields, siblings are only used for key lookup and
 		// nextField and which has arbitrary iteration order,
@@ -355,6 +367,8 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 
 		this.siblingStack.push(this.siblings);
 		this.indexStack.push(this.index);
+		this.indexOfChunkStack.push(this.indexOfChunk);
+		this.indexWithinChunkStack.push(this.indexWithinChunk);
 		this.index = 0;
 		this.siblings = [...fields.keys()]; // TODO: avoid this copy
 		return true;
@@ -422,8 +436,6 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		}
 		this.siblingStack.push(this.siblings);
 		this.indexStack.push(this.index);
-		this.indexOfChunkStack.push(this.indexOfChunk);
-		this.indexWithinChunkStack.push(this.indexWithinChunk);
 		this.index = 0;
 		this.siblings = siblings;
 		this.indexOfChunk = 0;
@@ -486,6 +498,10 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		this.siblings =
 			this.siblingStack.pop() ?? fail(0xaf0 /* Unexpected siblingStack.length */);
 		this.index = this.indexStack.pop() ?? fail(0xaf1 /* Unexpected indexStack.length */);
+		this.indexOfChunk =
+			this.indexOfChunkStack.pop() ?? fail("Unexpected indexOfChunkStack.length");
+		this.indexWithinChunk =
+			this.indexWithinChunkStack.pop() ?? fail("Unexpected indexWithinChunkStack.length");
 	}
 
 	public exitNode(): void {
@@ -502,16 +518,15 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		this.siblings =
 			this.siblingStack.pop() ?? fail(0xaf2 /* Unexpected siblingStack.length */);
 		this.index = this.indexStack.pop() ?? fail(0xaf3 /* Unexpected indexStack.length */);
-		this.indexOfChunk =
-			this.indexOfChunkStack.pop() ?? fail(0xaf4 /* Unexpected indexOfChunkStack.length */);
-		this.indexWithinChunk =
-			this.indexWithinChunkStack.pop() ??
-			fail(0xaf5 /* Unexpected indexWithinChunkStack.length */);
+		// At the Fields level these aren't semantically used, but reset for consistent state
+		// (so a fully-iterated cursor matches a fresh cursor at the same logical position).
+		this.indexOfChunk = 0;
+		this.indexWithinChunk = 0;
 	}
 
 	private getNode(): BasicChunk {
 		assert(this.mode === CursorLocationType.Nodes, 0x52f /* can only get node when in node */);
-		return (this.siblings as TreeChunk[])[this.index] as BasicChunk;
+		return (this.siblings as TreeChunk[])[this.indexOfChunk] as BasicChunk;
 	}
 
 	private getField(): readonly TreeChunk[] {
@@ -522,7 +537,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 			this.mode === CursorLocationType.Fields,
 			0x530 /* can only get field when in fields */,
 		);
-		const parent = this.getStackedNode(this.indexStack.length - 1);
+		const parent = this.getStackedChunk(this.siblingStack.length - 1);
 		const key: FieldKey = this.getFieldKey();
 		const field = parent.fields.get(key) ?? [];
 		return field;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -166,10 +166,19 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		if (this.nestedCursor !== undefined) {
 			return this.nestedCursor.mode;
 		}
-		// Compute the number of nodes deep the current depth is.
-		// We want the floor of the result, which can computed using a bitwise shift assuming the depth is less than 2^31, which seems safe.
-		// eslint-disable-next-line no-bitwise
-		const halfHeight = this.siblingStack.length >> 1;
+		this.assertChunkStacksMatchNodeDepth();
+		return this.siblingStack.length % 2 === 0
+			? CursorLocationType.Fields
+			: CursorLocationType.Nodes;
+	}
+
+	/**
+	 * Asserts that the node-only stacks (`indexOfChunkStack` and `indexWithinChunkStack`) are in sync with `siblingStack`.
+	 * Since `siblingStack` interleaves field and node levels while the node-only stacks are pushed/popped only on node-level transitions,
+	 * their length should always equal the number of node levels traversed.
+	 */
+	private assertChunkStacksMatchNodeDepth(): void {
+		const halfHeight = this.getNodeOnlyHeightFromHeight();
 		assert(
 			this.indexOfChunkStack.length === halfHeight,
 			0x51c /* unexpected indexOfChunkStack */,
@@ -178,9 +187,6 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 			this.indexWithinChunkStack.length === halfHeight,
 			0x51d /* unexpected indexWithinChunkStack */,
 		);
-		return this.siblingStack.length % 2 === 0
-			? CursorLocationType.Fields
-			: CursorLocationType.Nodes;
 	}
 
 	public getFieldKey(): FieldKey {
@@ -206,13 +212,19 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 	private getStackedChunkIndex(height: number): number {
 		assert(height % 2 === 1, "must be node height");
 		assert(height >= 0, "must not be above root");
-		// eslint-disable-next-line no-bitwise
-		return this.indexOfChunkStack[height >> 1] ?? oob();
+		return this.indexOfChunkStack[this.getNodeOnlyHeightFromHeight(height)] ?? oob();
 	}
 
 	private getStackedChunk(height: number): BasicChunk {
 		const index = this.getStackedChunkIndex(height);
 		return (this.siblingStack[height] as readonly TreeChunk[])[index] as BasicChunk;
+	}
+
+	// Returns the floor of half the height passed in, or half of `siblingStack.length` if no height is provided.
+	private getNodeOnlyHeightFromHeight(height: number = this.siblingStack.length): number {
+		// The bitwise shift computes the floor, which is valid assuming the depth is less than 2^31, which seems safe.
+		// eslint-disable-next-line no-bitwise
+		return height >> 1;
 	}
 
 	public getFieldLength(): number {
@@ -342,6 +354,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		// at the cost of an allocation here.
 		this.index = 0;
 		this.siblings = [key];
+		this.assertChunkStacksMatchNodeDepth();
 	}
 
 	public nextField(): boolean {
@@ -371,6 +384,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		this.indexWithinChunkStack.push(this.indexWithinChunk);
 		this.index = 0;
 		this.siblings = [...fields.keys()]; // TODO: avoid this copy
+		this.assertChunkStacksMatchNodeDepth();
 		return true;
 	}
 
@@ -440,6 +454,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		this.siblings = siblings;
 		this.indexOfChunk = 0;
 		this.indexWithinChunk = 0;
+		this.assertChunkStacksMatchNodeDepth();
 		this.initNestedCursor();
 		return true;
 	}
@@ -502,6 +517,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 			this.indexOfChunkStack.pop() ?? fail("Unexpected indexOfChunkStack.length");
 		this.indexWithinChunk =
 			this.indexWithinChunkStack.pop() ?? fail("Unexpected indexWithinChunkStack.length");
+		this.assertChunkStacksMatchNodeDepth();
 	}
 
 	public exitNode(): void {
@@ -522,6 +538,7 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 		// (so a fully-iterated cursor matches a fresh cursor at the same logical position).
 		this.indexOfChunk = 0;
 		this.indexWithinChunk = 0;
+		this.assertChunkStacksMatchNodeDepth();
 	}
 
 	private getNode(): BasicChunk {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -7,13 +7,17 @@ import { strict as assert } from "node:assert";
 
 import {
 	EmptyKey,
+	type FieldKey,
 	type ITreeCursor,
 	type ITreeCursorSynchronous,
 	type JsonableTree,
 	type ChunkedCursor,
 } from "../../../core/index.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { BasicChunk } from "../../../feature-libraries/chunked-forest/basicChunk.js";
+import {
+	BasicChunk,
+	BasicChunkCursor,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../../feature-libraries/chunked-forest/basicChunk.js";
 import {
 	basicChunkTree,
 	basicOnlyChunkPolicy,
@@ -22,9 +26,14 @@ import {
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import { uniformChunk } from "../../../feature-libraries/chunked-forest/index.js";
+import { dummyRoot, uniformChunk } from "../../../feature-libraries/chunked-forest/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { SequenceChunk } from "../../../feature-libraries/chunked-forest/sequenceChunk.js";
+import {
+	TreeShape,
+	UniformChunk,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../../feature-libraries/chunked-forest/uniformChunk.js";
 import {
 	type TreeChunk,
 	chunkTree,
@@ -153,6 +162,75 @@ describe("basic chunk", () => {
 		assert(cursor.atChunkRoot());
 		cursor.enterField(EmptyKey);
 		assert(!cursor.atChunkRoot());
+	});
+
+	it("getField resolves parent via chunk array index when preceded by a multi-node chunk", () => {
+		// A root field with 3 logical nodes split across 2 chunks:
+		// chunks[0]: UniformChunk with 2 number nodes.
+		// chunks[1]: BasicChunk holding a single subField leaf.
+		const numberShape = new TreeShape(brand(numberSchema.identifier), true, []);
+		const uniform = new UniformChunk(numberShape.withTopLevelLength(2), [10, 20]);
+
+		const subField: FieldKey = brand("subField");
+		const subLeaf = new BasicChunk(brand(numberSchema.identifier), new Map(), 42);
+		const trailingBasic = new BasicChunk(brand("Trailing"), new Map([[subField, [subLeaf]]]));
+
+		const cursor = new BasicChunkCursor(
+			[uniform, trailingBasic],
+			// siblingStack, indexStack, indexOfChunkStack, indexWithinChunkStack
+			[],
+			[],
+			[],
+			[],
+			[dummyRoot],
+			// index, indexOfChunk, indexWithinChunk
+			0,
+			0,
+			0,
+			undefined,
+		);
+
+		// Logical node index 2 maps to chunk array index 1 (the trailing BasicChunk).
+		cursor.enterNode(2);
+
+		// enterField drives getField, which on main looks up the parent at the
+		// logical node index (2) instead of the chunk array index (1). siblings[2]
+		// is out of bounds in the 2-chunk array, so the cast returns undefined and
+		// the subsequent field read throws.
+		cursor.enterField(subField);
+		assert.doesNotThrow(() => cursor.getFieldLength());
+	});
+
+	it("getField resolves parent via chunk array index when preceded by two multi-node chunks", () => {
+		// Root field with 5 logical nodes across 3 chunks:
+		// chunks[0]: UniformChunk with 2 number nodes.
+		// chunks[1]: UniformChunk with 2 number nodes.
+		// chunks[2]: BasicChunk with a single subField leaf.
+		const numberShape = new TreeShape(brand(numberSchema.identifier), true, []);
+		const uniformA = new UniformChunk(numberShape.withTopLevelLength(2), [10, 20]);
+		const uniformB = new UniformChunk(numberShape.withTopLevelLength(2), [30, 40]);
+
+		const subField: FieldKey = brand("subField");
+		const subLeaf = new BasicChunk(brand(numberSchema.identifier), new Map(), 99);
+		const trailingBasic = new BasicChunk(brand("Trailing"), new Map([[subField, [subLeaf]]]));
+
+		const cursor = new BasicChunkCursor(
+			[uniformA, uniformB, trailingBasic],
+			[],
+			[],
+			[],
+			[],
+			[dummyRoot],
+			0,
+			0,
+			0,
+			undefined,
+		);
+
+		// Logical node index 4 maps to chunk array index 2 (the trailing BasicChunk).
+		cursor.enterNode(4);
+		cursor.enterField(subField);
+		assert.doesNotThrow(() => cursor.getFieldLength());
 	});
 
 	describe("SequenceChunk", () => {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -190,15 +190,21 @@ describe("basic chunk", () => {
 			undefined,
 		);
 
-		// Logical node index 2 maps to chunk array index 1 (the trailing BasicChunk).
+		// Transitions from field to firstNode and then increments to nodeIndex 2,
+		// which maps to chunk array index 1 (the trailing BasicChunk).
 		cursor.enterNode(2);
 
-		// enterField drives getField, which on main looks up the parent at the
-		// logical node index (2) instead of the chunk array index (1). siblings[2]
-		// is out of bounds in the 2-chunk array, so the cast returns undefined and
-		// the subsequent field read throws.
+		// Entering the subfield of the trailing BasicChunk calls enterField, which is followed by
+		// getField, which looks up the current node (whose field we should get). This must
+		// handle the case where the index of the node does not match the index of the chunk
+		// containing the node in the siblings array held at the top of `siblingStack`.
+		// In this test, the node index is 2 and the chunk index is 1.
 		cursor.enterField(subField);
-		assert.doesNotThrow(() => cursor.getFieldLength());
+		// Validates the cursor is positioned on the subField holding the subLeaf,
+		// then enters it to confirm its value (42).
+		assert.equal(cursor.getFieldLength(), 1);
+		cursor.firstNode();
+		assert.equal(cursor.value, 42);
 	});
 
 	it("getField resolves parent via chunk array index when preceded by two multi-node chunks", () => {
@@ -227,10 +233,21 @@ describe("basic chunk", () => {
 			undefined,
 		);
 
-		// Logical node index 4 maps to chunk array index 2 (the trailing BasicChunk).
+		// Transitions from field to firstNode and then increments to nodeIndex 4,
+		// which maps to chunk array index 2 (the trailing BasicChunk).
 		cursor.enterNode(4);
+
+		// Entering the subfield of the trailing BasicChunk calls enterField, which is followed by
+		// getField, which looks up the current node (whose field we should get). This must
+		// handle the case where the index of the node does not match the index of the chunk
+		// containing the node in the siblings array held at the top of `siblingStack`.
+		// In this test, the node index is 4 and the chunk index is 2.
 		cursor.enterField(subField);
-		assert.doesNotThrow(() => cursor.getFieldLength());
+		// Validates the cursor is positioned on the subField holding the subLeaf,
+		// then enters it to confirm its value (99).
+		assert.equal(cursor.getFieldLength(), 1);
+		cursor.firstNode();
+		assert.equal(cursor.value, 99);
 	});
 
 	describe("SequenceChunk", () => {


### PR DESCRIPTION
# Summary

basicChunkCursor currently doesn't handle tracking the chunk index around multi-node chunks correctly. This problem shows up in chunkedForest, which extends this cursor. 

### Files changed
| File | Changes |
| ---- | ---- |
| `basicChunk.ts` | Change location of when `chunkIndex` is pushed onto the stack and `getField` now uses `chunkIndex` to find the parent in `siblingStack`|
| `basicChunk.spec.ts` | Added two unit tests that manually construct a field with a `UniformChunk` followed by a `BasicChunk` with a subfield | 

### What surfaces the bug
<pre>                                                                                                  
  Root field                                                                     
  ├─ chunks[0]  UniformChunk  (nodes 0, 1)
  │    ├─ 10                                                                                             
  │    └─ 20
  └─ chunks[1]  BasicChunk    (node 2)                                                                   
       └─ subField                                                               
            └─ 42     
   
siblingStack when getField is called after navigating to subField: [ UniformChunk(10,20) , BasicChunk "Trailing" ]              
 </pre>
When a field contains multi-node chunks followed by a `BasicChunk` containing a subfield, entering that subfield with `enterField` will call `getField` which searches for the parent of this subfield in the `siblingStack`. Currently this uses the flat node index, which equals the count of all nodes in the field. The problem is that `siblingStack` contains the chunks and not the flat nodes. So when `getField` is called using an index based off the flat nodes it will incorrectly index into the siblings array on that stack.  In the case above we would attempt to get the parent BasicChunk at index 2, but that would be `oob`. 

### Changes

#### chunkIndex
The proposed changes are to swap the use of a flat node index for `getField` and use `chunkIndex`. This was being tracked before, but was a stale reference for what this fix requires. The flow for the current chunk index is: 
`start at 0 -> increment as we change chunks -> enterField(subField) -> getField -> enterNode/firstNode -> push chunkIndex onto the stack`
This causes `chunkIndex` to not be on the stack when we need it. We would be looking at a stale reference for 1 level up. The change needed was pushing `chunkIndex` onto the stack during enterField/firstField so we have the needed `chunkIndex` on the stack when `getField` needs it. 
#### halfHeight
halfHeight balances `indexOfChunkStack.length` against `siblingStack.length`. The current code pushed once per node level. The new code pushes once per Field level, so the rounding isn't needed like before. The assertion has been moved to its own private method `assertChunkStacksMatchNodeDepth()` since this is what the assertion was originally doing. Checking that the chunk stack indices were half the height of sibling stack, which would also correctly match the node depth. 


### New Test Coverage
Two unit tests in `basicChunk.spec.ts` that manually create a multi-node uniform chunk(not currently possible by the chunker) and then navigating into the subfield of a trailing basic chunk throws under the old indexing logic.