### PR TITLE
docs: Add Service Tree ID to OCE agent quick reference

### DIFF
--- a/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
+++ b/.repoverlay/library/ff-oce/.claude/agents/ff-oce.md
@@ -57,6 +57,12 @@ If the user opens with a specific question or task, skip the dashboard offer and
 
 ## Quick Reference
 
+### Service Tree
+
+Used for IcM incident routing, EngineeringHub scoped searches, and incident ownership assessment.
+
+**Service Tree ID:** `3841020f-2a95-498a-9b5a-934676b350a9`
+
 ### IcM Teams (OCE Rotation)
 
 The OCE rotation covers **three IcM teams**. Always search all three when looking up active incidents, on-call schedules, or shift activity.


### PR DESCRIPTION
## Description

Adds the Fluid Framework Service Tree ID (`3841020f-2a95-498a-9b5a-934676b350a9`) to the OCE agent's Quick Reference section. This ID is needed for IcM incident routing, EngineeringHub scoped searches, and incident ownership assessment, but wasn't documented anywhere in the agent or skill files — requiring a manual lookup via IcM team metadata each time.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).