### PR TITLE
feat(devcontainer): add Azure CLI and mise to AI-enabled (Insiders)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -56,8 +56,9 @@ Insiders is a superset of the base AI-enabled profile. The only differences in t
 - **`name`** — `"AI-enabled (Insiders)"`
 - **`onCreateCommand`** — chains `install-flub.sh` after `on-create.sh` to build and link the `flub` CLI
 - **`codespaces.openFiles`** — points to the insiders copy of `GETTING_STARTED.md`
+- **`features`** *(temporary)* — insiders includes `azure-cli` and `mise` as a preview. Promote to the base profile (or remove) once we decide whether they belong by default.
 
-Everything else (Dockerfile, runArgs, extensions, features, setup scripts, host requirements) is identical.
+Everything else (Dockerfile, runArgs, extensions, setup scripts, host requirements) is identical.
 
 ### Shared vs. duplicated files
 

--- a/.devcontainer/ai-agent-insiders/devcontainer.json
+++ b/.devcontainer/ai-agent-insiders/devcontainer.json
@@ -63,7 +63,11 @@
 		// Enables SSH connections into the container using `gh codespace ssh`
 		"ghcr.io/devcontainers/features/sshd:1": {
 			"version": "latest"
-		}
+		},
+		// Install the Azure CLI
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		// Install mise (polyglot tool/version manager)
+		"ghcr.io/devcontainers-extra/features/mise:1": {}
 	},
 	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
 	// can be lengthy enough that it's convenient.


### PR DESCRIPTION
## Description

Adds two devcontainer features to the AI-enabled (Insiders) codespace profile so they are available by default:

- `ghcr.io/devcontainers/features/azure-cli:1` — Azure CLI
- `ghcr.io/devcontainers-extra/features/mise:1` — mise polyglot tool/version manager (plan to use this to pin versions of repoverlay and similar that are not pnpm-managed)

Scoped to the insiders profile only as a preview, and called out in `.devcontainer/README.md` as a temporary feature difference. Per the README's maintenance rules, these can later be promoted to the base `ai-agent` profile by copying into `ai-agent/devcontainer.json` and removing the insiders override — or removed if we decide they don't belong by default.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).