### PR TITLE
Disable code coverage for server Docker builds

### DIFF
--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -137,6 +137,9 @@ extends:
     pack: true
     lint: true
     test: ci:test
+    # Disabled: coverage performance regressed in Node 22, causing test timeouts
+    # that need mitigation before coverage can be reenabled.
+    # testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
     docs: true
     containerBaseDir: /usr/FluidFramework/server/routerlicious
     checks:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -22,6 +22,11 @@ parameters:
     type: string
     default:
 
+  # Indicates if tests should be run with code coverage analysis.
+  - name: testCoverage
+    type: boolean
+    default: false
+
   - name: docs
     type: boolean
     default: false
@@ -441,7 +446,7 @@ extends:
           - ${{ if ne(parameters.test, '') }}:
 
             # Test - With coverage
-            - ${{ if and(eq(parameters.test, 'ci:test'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            - ${{ if eq(parameters.testCoverage, true) }}:
               - task: Docker@1
                 displayName: npm run ci:test:coverage
                 inputs:


### PR DESCRIPTION
[AB#71226](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71226)

## Description

Adds a `testCoverage` parameter to the `build-docker-service` template (defaults to `false`)
to control whether tests run with code coverage analysis. Previously code coverage was
hardcoded to run for non-PR `ci:test` builds. The new parameter aligns with the existing
`testCoverage` parameter in `build-npm-client-package.yml`.

Code coverage is disabled for routerlicious because it regressed in Node 22, causing test
timeouts that have failed several CI runs (e.g. 392547, 3925124). This wasn't caught earlier
because code coverage only runs for CI builds, not PR validation builds.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The `testCoverage` parameter defaults to `false`, so no existing pipeline behavior changes
  unless a consumer explicitly opts in.
- The commented-out `testCoverage` line in `server-routerlicious.yml` preserves the original
  condition for when coverage can be re-enabled.