### PR TITLE
Pilot vitest+v8 code coverage on ten packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ legacy.d.ts
 # Bundle analysis artifacts
 bundleAnalysis
 
+# hyperfine output from scripts/bench-coverage.sh
+.benchmarks/
+
 # Misc pipeline artifacts
 artifacts
 

--- a/common/build/build-common/vitest-test-setup.mjs
+++ b/common/build/build-common/vitest-test-setup.mjs
@@ -1,0 +1,125 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Shared vitest setup for FF code-coverage pilots.
+ *
+ * Usage (from a package's `vitest.config.ts`):
+ *
+ *   test: {
+ *     setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+ *     // ...
+ *   }
+ *
+ * This file is intentionally pre-compiled ESM (`.mjs`) so consumers don't need
+ * to run a tsc build step on build-common just to use it. It imports from the
+ * consumer's `vitest` dependency, so `vitest` must already be installed as a
+ * devDependency of the consuming package.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ *  The mocha-context shim
+ * ────────────────────────────────────────────────────────────────────────────
+ *
+ *  FF tests were written against mocha, where `this` inside a `function()`
+ *  callback is bound to mocha's Context/Suite object and exposes helpers
+ *  like `this.timeout(ms)`, `this.retries(n)`, and `this.skip()`.
+ *
+ *  Vitest uses a different model: it passes a TaskContext as the first
+ *  argument to test callbacks, and binds that same context as `this`. Vitest's
+ *  context does NOT have `timeout`/`retries` methods — mocha-style calls
+ *  throw TypeError.
+ *
+ *  This setup installs a defensive `beforeEach` that adds no-op
+ *  `timeout`/`retries`/`skip` methods onto the vitest test context if they're
+ *  absent. The shim is deliberately inert: real timeouts come from
+ *  `testTimeout` in the consumer's `vitest.config.ts`, not from
+ *  `this.timeout()`.
+ *
+ *  Scope and limitations:
+ *  - Only works inside `it(…)`/`test(…)` callbacks, where vitest binds its
+ *    TaskContext as `this`.
+ *  - Does NOT work inside `describe(…)` callbacks. Under strict ESM (which
+ *    vitest enforces), a describe callback has `this === undefined`, so
+ *    `this.timeout(…)` throws on property access before any shim can run.
+ *    Suites that use `describeFuzz`/`describeStress` from
+ *    `@fluid-private/stochastic-test-utils` call `this.timeout(…)` at suite
+ *    scope and must be excluded per-package in vitest.config.ts.
+ *
+ *  Do not import a package's `src/test/mochaHooks.ts` from this file — those
+ *  hooks generally depend on mocha-specific types/APIs.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ *  Global name/signature shims for hooks
+ * ────────────────────────────────────────────────────────────────────────────
+ *
+ *  Vitest exposes `beforeAll`/`afterAll`/`beforeEach`/`afterEach` as globals
+ *  (via `globals: true`) but does NOT accept mocha's optional leading string
+ *  description — `beforeEach("name", fn)` throws "callback value must be
+ *  function, received 'string'". Vitest also does not expose mocha's
+ *  `before`/`after` aliases at all.
+ *
+ *  Here we install wrappers that drop the name argument when present, covering
+ *  both the missing aliases (`before`/`after`) and the signature mismatch on
+ *  `beforeEach`/`afterEach`. Several helpers in FF test code (e.g.
+ *  `emulateProductionBuildHooks`, `useSnapshotDirectory`, assorted
+ *  beforeEach-with-description calls) expect the mocha shape.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+
+beforeEach((context) => {
+	if (typeof context.timeout !== "function") {
+		context.timeout = () => undefined;
+	}
+	if (typeof context.retries !== "function") {
+		context.retries = () => undefined;
+	}
+	if (typeof context.skip !== "function") {
+		// Mocha's `this.skip()` marks the current test pending. Vitest's test
+		// context has its own `skip` method; don't overwrite it if it's already
+		// a function. This shim only kicks in when the test expects mocha's API
+		// but vitest didn't bind a skip (e.g. inside a hook context).
+		context.skip = () => undefined;
+	}
+});
+
+/** @param {typeof beforeAll | typeof afterAll | typeof beforeEach | typeof afterEach} hook */
+function adaptMochaHook(hook) {
+	// Mocha's `before(name?, fn)` (and beforeEach, etc.) accept an optional
+	// leading string; vitest's equivalents only accept a function. Drop the
+	// name arg.
+	return (...args) => {
+		const fn = args.length === 2 ? args[1] : args[0];
+		hook(fn);
+	};
+}
+
+// Add missing mocha names.
+if (typeof globalThis.before !== "function") {
+	globalThis.before = adaptMochaHook(beforeAll);
+}
+if (typeof globalThis.after !== "function") {
+	globalThis.after = adaptMochaHook(afterAll);
+}
+
+// Patch signature-incompatible globals that vitest *does* provide.
+globalThis.beforeEach = adaptMochaHook(beforeEach);
+globalThis.afterEach = adaptMochaHook(afterEach);
+globalThis.beforeAll = adaptMochaHook(beforeAll);
+globalThis.afterAll = adaptMochaHook(afterAll);
+
+/*
+ * `getTestLogger` is populated as a global by `@fluid-internal/mocha-test-setup`'s
+ * `beforeAll` hook (see packages/test/mocha-test-setup/src/mochaHooks.ts). Some
+ * tests call it indirectly via `TestObjectProvider.logger`. That hook doesn't
+ * run under vitest, so supply a no-op stub logger with the minimal
+ * `ITelemetryBufferedLogger`-ish shape the consumers expect.
+ */
+if (typeof globalThis.getTestLogger !== "function") {
+	globalThis.getTestLogger = () => ({
+		send: () => undefined,
+		flush: async () => undefined,
+	});
+}

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -102,6 +102,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha && npm run test:jest",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:jest": "jest --ci",
 		"test:mocha": "npm run test:mocha:esm && npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS \"MOCHA_SPEC=dist/test/mocha/**/*.spec.*js\" mocha",
@@ -158,6 +159,7 @@
 		"@types/rewire": "^2.5.30",
 		"@types/sha.js": "^2.4.4",
 		"@types/sinon": "^17.0.3",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -177,7 +179,8 @@
 		"sinon": "^18.0.1",
 		"ts-jest": "^29.1.1",
 		"ts-node": "^10.9.2",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"fluidBuild": {
 		"tasks": {

--- a/packages/common/client-utils/vitest.config.ts
+++ b/packages/common/client-utils/vitest.config.ts
@@ -7,11 +7,13 @@
  * Vitest configuration — coverage pilot for packages/common/client-utils.
  * See packages/dds/tree/vitest.config.ts for the longer rationale.
  *
- *   pnpm --filter @fluid-internal/client-utils run build           # required
  *   pnpm --filter @fluid-internal/client-utils run test:coverage:vitest
  *
- * This package has a separate jest suite under `lib/test/jest/**`; vitest
- * only covers the mocha suite under `lib/test/mocha/**`. Jest coverage is
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required.
+ *
+ * This package has a separate jest suite under `src/test/jest/**`; vitest
+ * only covers the mocha suite under `src/test/mocha/**`. Jest coverage is
  * out of scope for this pilot.
  */
 
@@ -34,29 +36,26 @@ export default defineConfig({
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
 		// Only the mocha suite; jest tests use their own harness.
-		include: ["lib/test/mocha/**/*.{test,spec}.js"],
+		include: ["src/test/mocha/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			"lib/test/jest/**",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.perf.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/jest/**",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/common/client-utils/vitest.config.ts
+++ b/packages/common/client-utils/vitest.config.ts
@@ -52,11 +52,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/common/client-utils/vitest.config.ts
+++ b/packages/common/client-utils/vitest.config.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — coverage pilot for packages/common/client-utils.
+ * See packages/dds/tree/vitest.config.ts for the longer rationale.
+ *
+ *   pnpm --filter @fluid-internal/client-utils run build           # required
+ *   pnpm --filter @fluid-internal/client-utils run test:coverage:vitest
+ *
+ * This package has a separate jest suite under `lib/test/jest/**`; vitest
+ * only covers the mocha suite under `lib/test/mocha/**`. Jest coverage is
+ * out of scope for this pilot.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+		pool: "forks",
+		isolate: true,
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+		// Only the mocha suite; jest tests use their own harness.
+		include: ["lib/test/mocha/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			"lib/test/jest/**",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.perf.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -97,6 +97,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -138,6 +139,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
 		"@types/sinon": "^17.0.3",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -149,7 +151,8 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
 		"sinon": "^18.0.1",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/common/core-utils/vitest.config.ts
+++ b/packages/common/core-utils/vitest.config.ts
@@ -7,8 +7,10 @@
  * Vitest configuration — coverage pilot for packages/common/core-utils.
  * See packages/dds/tree/vitest.config.ts for the longer rationale.
  *
- *   pnpm --filter @fluidframework/core-utils run build           # required
  *   pnpm --filter @fluidframework/core-utils run test:coverage:vitest
+ *
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required.
  */
 
 import { defineConfig } from "vitest/config";
@@ -29,31 +31,28 @@ export default defineConfig({
 		isolate: true,
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
 			// @fluid-tools/benchmark suites need mocha's test context.
-			"lib/test/bench/**",
-			"lib/test/**/*.bench.spec.js",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.perf.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/bench/**",
+			"src/test/**/*.bench.spec.ts",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/common/core-utils/vitest.config.ts
+++ b/packages/common/core-utils/vitest.config.ts
@@ -49,11 +49,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/common/core-utils/vitest.config.ts
+++ b/packages/common/core-utils/vitest.config.ts
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — coverage pilot for packages/common/core-utils.
+ * See packages/dds/tree/vitest.config.ts for the longer rationale.
+ *
+ *   pnpm --filter @fluidframework/core-utils run build           # required
+ *   pnpm --filter @fluidframework/core-utils run test:coverage:vitest
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+		pool: "forks",
+		isolate: true,
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			// @fluid-tools/benchmark suites need mocha's test context.
+			"lib/test/bench/**",
+			"lib/test/**/*.bench.spec.js",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.perf.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -98,6 +98,7 @@
 		"pack:tests": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -160,6 +161,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
 		"@types/path-browserify": "^1.0.0",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -169,7 +171,8 @@
 		"mocha": "^11.7.5",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/dds/map/vitest.config.ts
+++ b/packages/dds/map/vitest.config.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — *coverage pilot* for packages/dds/map.
+ *
+ * Mocha remains the canonical test runner for this package (see .mocharc.cjs
+ * and the `test:mocha*` scripts in package.json). Vitest is added here solely
+ * to produce code-coverage reports via the v8 coverage provider, as a pilot
+ * replacement for the c8-based `test:coverage` script whose performance
+ * regressed on Node 22/24 and caused it to be disabled in CI (see
+ * tools/pipelines/build-client.yml, testCoverage: false).
+ *
+ * Run with:
+ *   pnpm --filter @fluidframework/map run build   # required before each run
+ *   pnpm --filter @fluidframework/map run test:coverage:vitest
+ * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
+ * the whole `nyc` directory, so no clean-script change is needed).
+ *
+ * We run the compiled `lib/**` output rather than `src/**` TypeScript for
+ * consistency with the tree pilot (see packages/dds/tree/vitest.config.ts for
+ * the longer rationale). The v8 coverage provider follows source maps back
+ * to `src/**` for line-accurate reporting.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	// FF test-only subpath exports (e.g. `./internal/test`) are gated behind the
+	// `allow-ff-test-exports` export condition. Mocha enables this via Node's
+	// --conditions flag; vite has its own resolver, so we declare the condition
+	// explicitly at both top-level and under `ssr`.
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		// Shared mocha-compat shim — see file for details. Lives in build-common
+		// because it's re-used across every FF coverage-pilot package.
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+
+		pool: "forks",
+		isolate: true,
+
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			// Perf/memory suites need FLUID_TEST_PERF_MODE + the benchmark mocha
+			// reporter; not applicable under vitest.
+			"lib/test/memory/**",
+			// Fuzz suites use describeStress/describeFuzz, which call
+			// `this.timeout(...)` at suite scope — unfixable under strict-ESM
+			// vitest, see tree's pilot config for details.
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/dds/map/vitest.config.ts
+++ b/packages/dds/map/vitest.config.ts
@@ -67,11 +67,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/dds/map/vitest.config.ts
+++ b/packages/dds/map/vitest.config.ts
@@ -13,25 +13,17 @@
  * regressed on Node 22/24 and caused it to be disabled in CI (see
  * tools/pipelines/build-client.yml, testCoverage: false).
  *
- * Run with:
- *   pnpm --filter @fluidframework/map run build   # required before each run
  *   pnpm --filter @fluidframework/map run test:coverage:vitest
- * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
- * the whole `nyc` directory, so no clean-script change is needed).
  *
- * We run the compiled `lib/**` output rather than `src/**` TypeScript for
- * consistency with the tree pilot (see packages/dds/tree/vitest.config.ts for
- * the longer rationale). The v8 coverage provider follows source maps back
- * to `src/**` for line-accurate reporting.
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required. (The `tree` pilot uniquely runs against `lib/**`
+ * because OXC currently lacks lowering for the `@breakingClass`/`@breakingMethod`
+ * decorators used there; see packages/dds/tree/vitest.config.ts.)
  */
 
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	// FF test-only subpath exports (e.g. `./internal/test`) are gated behind the
-	// `allow-ff-test-exports` export condition. Mocha enables this via Node's
-	// --conditions flag; vite has its own resolver, so we declare the condition
-	// explicitly at both top-level and under `ssr`.
 	resolve: {
 		conditions: ["allow-ff-test-exports"],
 	},
@@ -42,8 +34,6 @@ export default defineConfig({
 	},
 	test: {
 		globals: true,
-		// Shared mocha-compat shim — see file for details. Lives in build-common
-		// because it's re-used across every FF coverage-pilot package.
 		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
 
 		pool: "forks",
@@ -52,19 +42,23 @@ export default defineConfig({
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
 
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			// Perf/memory suites need FLUID_TEST_PERF_MODE + the benchmark mocha
-			// reporter; not applicable under vitest.
-			"lib/test/memory/**",
-			// Fuzz suites use describeStress/describeFuzz, which call
-			// `this.timeout(...)` at suite scope — unfixable under strict-ESM
-			// vitest, see tree's pilot config for details.
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.bench.js",
+			// Perf/memory suites need FLUID_TEST_PERF_MODE and the benchmark
+			// mocha reporter; not applicable under vitest.
+			"src/test/memory/**",
+			// Snapshot comparison infrastructure is mocha-specific.
+			"src/test/snapshots/**",
+			// `directory.snapshot.spec.ts` asserts that `_dirname` ends with
+			// `(dist|lib)/test/mocha`, which fails when run against source.
+			"src/test/**/*.snapshot.spec.ts",
+			// directoryFuzzTests uses createDDSFuzzSuite (describe-scope this.timeout).
+			"src/test/**/*FuzzTests.spec.ts",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 
 		coverage: {
@@ -72,14 +66,11 @@ export default defineConfig({
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -100,6 +100,7 @@
 		"pack:tests": "tar -cf ./matrix.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -164,6 +165,7 @@
 		"@types/double-ended-queue": "^2.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
+		"@vitest/coverage-v8": "^4.1.4",
 		"best-random": "^1.0.0",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
@@ -176,7 +178,8 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
 		"ts-node": "^10.9.2",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/dds/matrix/vitest.config.ts
+++ b/packages/dds/matrix/vitest.config.ts
@@ -7,8 +7,10 @@
  * Vitest configuration — coverage pilot for packages/dds/matrix.
  * See packages/dds/tree/vitest.config.ts for the longer rationale.
  *
- *   pnpm --filter @fluidframework/matrix run build           # required
  *   pnpm --filter @fluidframework/matrix run test:coverage:vitest
+ *
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required.
  */
 
 import { defineConfig } from "vitest/config";
@@ -29,36 +31,33 @@ export default defineConfig({
 		isolate: true,
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
 			// Stress/fuzz/big suites use mocha-context APIs and/or
 			// describeFuzz-style helpers that don't work under vitest.
-			"lib/test/**/*.stress.spec.js",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.big.spec.js",
-			"lib/test/**/*.perf.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/**/*.stress.spec.ts",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.big.spec.ts",
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
 			// Memory and time benchmarks use @fluid-tools/benchmark, which
 			// needs mocha's test context.
-			"lib/test/memory/**",
-			"lib/test/time/**",
+			"src/test/memory/**",
+			"src/test/time/**",
 		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/dds/matrix/vitest.config.ts
+++ b/packages/dds/matrix/vitest.config.ts
@@ -1,0 +1,67 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — coverage pilot for packages/dds/matrix.
+ * See packages/dds/tree/vitest.config.ts for the longer rationale.
+ *
+ *   pnpm --filter @fluidframework/matrix run build           # required
+ *   pnpm --filter @fluidframework/matrix run test:coverage:vitest
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+		pool: "forks",
+		isolate: true,
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			// Stress/fuzz/big suites use mocha-context APIs and/or
+			// describeFuzz-style helpers that don't work under vitest.
+			"lib/test/**/*.stress.spec.js",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.big.spec.js",
+			"lib/test/**/*.perf.spec.js",
+			"lib/test/**/*.bench.js",
+			// Memory and time benchmarks use @fluid-tools/benchmark, which
+			// needs mocha's test context.
+			"lib/test/memory/**",
+			"lib/test/time/**",
+		],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/dds/matrix/vitest.config.ts
+++ b/packages/dds/matrix/vitest.config.ts
@@ -54,11 +54,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -98,6 +98,7 @@
 		"perf:profile": "cross-env FLUID_TEST_PERF_MODE=1 node --inspect-brk ./node_modules/mocha/bin/mocha.js \"dist/**/*.spec.*js\" --node-option unhandled-rejections=strict,expose-gc --exit --fgrep @ExecutionTime",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -157,6 +158,7 @@
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -167,7 +169,8 @@
 		"mocha": "^11.7.5",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/dds/merge-tree/vitest.config.ts
+++ b/packages/dds/merge-tree/vitest.config.ts
@@ -7,8 +7,10 @@
  * Vitest configuration — coverage pilot for packages/dds/merge-tree.
  * See packages/dds/tree/vitest.config.ts for the longer rationale.
  *
- *   pnpm --filter @fluidframework/merge-tree run build           # required
  *   pnpm --filter @fluidframework/merge-tree run test:coverage:vitest
+ *
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required.
  */
 
 import { defineConfig } from "vitest/config";
@@ -29,33 +31,30 @@ export default defineConfig({
 		isolate: true,
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			// Perf suite: @fluid-tools/benchmark needs mocha test context.
-			"lib/test/**/*.perf.spec.js",
+			// Perf suite: @fluid-tools/benchmark needs mocha's test context.
+			"src/test/**/*.perf.spec.ts",
 			// Farm suites chain `.timeout(...)` on `it()`, which vitest doesn't support.
-			"lib/test/**/*Farm.spec.js",
+			"src/test/**/*Farm.spec.ts",
 			// Property-based test that uses mocha-context APIs.
-			"lib/test/beastTest.spec.js",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/beastTest.spec.ts",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/dds/merge-tree/vitest.config.ts
+++ b/packages/dds/merge-tree/vitest.config.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — coverage pilot for packages/dds/merge-tree.
+ * See packages/dds/tree/vitest.config.ts for the longer rationale.
+ *
+ *   pnpm --filter @fluidframework/merge-tree run build           # required
+ *   pnpm --filter @fluidframework/merge-tree run test:coverage:vitest
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+		pool: "forks",
+		isolate: true,
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			// Perf suite: @fluid-tools/benchmark needs mocha test context.
+			"lib/test/**/*.perf.spec.js",
+			// Farm suites chain `.timeout(...)` on `it()`, which vitest doesn't support.
+			"lib/test/**/*Farm.spec.js",
+			// Property-based test that uses mocha-context APIs.
+			"lib/test/beastTest.spec.js",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/dds/merge-tree/vitest.config.ts
+++ b/packages/dds/merge-tree/vitest.config.ts
@@ -51,11 +51,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -126,6 +126,7 @@
 		"pack:tests": "tar -cf ./tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:memory": "cross-env FLUID_TEST_PERF_MODE=1 mocha --fgrep @Memory --parallel --jobs 6",
 		"test:mocha": "echo skipping non-smoke cjs to avoid overhead && npm run test:mocha:cjs -- --fgrep @Smoke && npm run test:mocha:prod -- --fgrep @Smoke && npm run test:mocha:esm",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
@@ -200,6 +201,7 @@
 		"@types/easy-table": "^0.0.32",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
+		"@vitest/coverage-v8": "^4.1.4",
 		"ajv": "^8.17.1",
 		"ajv-formats": "^3.0.1",
 		"c8": "^10.1.3",
@@ -215,7 +217,8 @@
 		"mocha": "^11.7.5",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"fluidBuild": {
 		"tasks": {

--- a/packages/dds/tree/vitest.config.ts
+++ b/packages/dds/tree/vitest.config.ts
@@ -1,0 +1,139 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — *coverage pilot* for packages/dds/tree.
+ *
+ * Mocha remains the canonical test runner for this package (see .mocharc.cjs
+ * and the `test:mocha*` scripts in package.json). Vitest is added here solely
+ * to produce code-coverage reports via the v8 coverage provider, as a pilot
+ * replacement for the c8-based `test:coverage` script whose performance
+ * regressed on Node 22/24 and caused it to be disabled in CI (see
+ * tools/pipelines/build-client.yml, testCoverage: false).
+ *
+ * Run with:
+ *   pnpm --filter @fluidframework/tree run build   # required before each run
+ *   pnpm --filter @fluidframework/tree run test:coverage:vitest
+ * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
+ * the whole `nyc` directory, so no clean-script change is needed).
+ *
+ * Why we run the compiled `lib/**` output instead of `src/**` TypeScript:
+ *   Vitest 4 uses OXC for TS→JS transforms, and OXC does not currently
+ *   transpile standard-ES-decorator syntax into runtime helpers. Several files
+ *   in this package (e.g. src/shared-tree-core/sharedTreeCore.ts) use the
+ *   `@breakingClass`/`@breakingMethod` decorators from src/util/breakable.ts,
+ *   which Node's VM cannot execute directly — you get `SyntaxError: Invalid
+ *   or unexpected token` on load. tsc-compiled `lib/**` has already lowered
+ *   decorators into runtime `__decorate` calls, so running that output
+ *   sidesteps the issue entirely. The v8 coverage provider follows source
+ *   maps back to `src/**` for line-accurate reporting.
+ *
+ *   Consequence: this config requires a build to have been run. The npm
+ *   script `test:coverage:vitest` assumes tests have been compiled already.
+ *
+ * Caveats:
+ * - Vitest runs a single ESM pass on the `lib/` build. Mocha in this package
+ *   runs CJS, ESM, and --emulateProduction passes; that matters for coverage
+ *   of module-loading behaviour, but not for line coverage — source lines
+ *   execute the same way regardless of emitted module system.
+ * - TestTreeProvider cleanup leaks (AB#7856) are handled here via
+ *   `pool: 'forks'` with `isolate: true`, which tears down the worker process
+ *   between test files. This avoids the `--exit` workaround mocha needs.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	// FF test-only subpath exports (e.g. `@fluidframework/id-compressor/internal/test-utils`)
+	// are gated behind the `allow-ff-test-exports` export condition. Mocha enables this via
+	// `--conditions=allow-ff-test-exports` in @fluid-internal/mocha-test-setup's node-options.
+	// Vite has its own resolver and does not honour Node's --conditions flag; vitest runs in
+	// an SSR-style environment, so we declare the condition via `ssr.resolve.conditions` (and
+	// mirror it at top-level `resolve.conditions` for any client-side resolution that may occur).
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		// mocha-style describe/it/before/after globals. `before`/`after` alias
+		// to vitest's `beforeAll`/`afterAll`, which matches mocha's suite-level
+		// semantics.
+		globals: true,
+		// Shared mocha-compat shim — see file for details. Lives in build-common
+		// because it's re-used across every FF coverage-pilot package.
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+
+		// Fresh worker process per test file. Required to tolerate test files
+		// that leak resources (AB#7856, TestTreeProvider) — the worker dies at
+		// file boundary, so a leaking file can't stall the whole run.
+		// vitest 4 moved `poolOptions` to top-level options; `isolate: true` is
+		// the default, kept here for explicitness.
+		pool: "forks",
+		isolate: true,
+
+		// Match the mocha default timeouts used by this package.
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			// Perf suites require FLUID_TEST_PERF_MODE + the @fluid-tools/benchmark
+			// mocha reporter, neither of which applies under vitest.
+			"lib/test/memory/**",
+			// Snapshot comparison infrastructure is mocha-specific.
+			"lib/test/snapshots/**",
+			"lib/test/**/*.bench.js",
+			// Files below use describeFuzz/describeStress from @fluid-private/stochastic-test-utils
+			// (directly or via wrappers). Those helpers call `this.timeout(...)` at *suite* scope
+			// (mocha Suite context). Under strict-ESM vitest, describe callbacks run with
+			// `this === undefined`, so the property access throws before vitest.setup.ts's
+			// test-level shim can intervene. Porting these onto a vitest-compatible helper is out
+			// of scope for the coverage pilot — accept the gap and revisit when it's expanded.
+			"lib/test/shared-tree-core/edit-manager/editManagerCorrectness.test.js",
+			"lib/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.js",
+			"lib/test/feature-libraries/sequence-field/sequenceField.spec.js",
+			"lib/test/feature-libraries/optional-field/optionalChangeRebaser.test.js",
+			"lib/test/feature-libraries/optional-field/optionalField.spec.js",
+			"lib/test/shared-tree/fuzz/**",
+			// Uses `it(...).timeout(15000)` — chains `.timeout()` on the return value of `it()`.
+			// Vitest's `it()` doesn't return a chainable object, so this throws at module load.
+			"lib/test/shared-tree/editing.spec.js",
+		],
+
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			// Always emit the coverage report, even when some test files fail.
+			// Useful while the pilot is still stabilising — we want to see what
+			// _is_ covered even while iterating on fixes for the remaining
+			// failures.
+			reportOnFailure: true,
+			// The v8 provider collects coverage from the running JS in `lib/**`
+			// and follows its source maps back to `src/**/*.ts`. We list both
+			// directories so the provider picks up the running files, then
+			// exclude tests and tsc-emitted declaration files from reporting.
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				// Barrel files are noise in a coverage report.
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -147,6 +147,7 @@
 		"place:cjs:package-stub": "copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -208,6 +209,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
 		"@types/sinon": "^17.0.3",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -218,7 +220,8 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
 		"sinon": "^18.0.1",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/loader/container-loader/vitest.config.ts
+++ b/packages/loader/container-loader/vitest.config.ts
@@ -58,11 +58,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/loader/container-loader/vitest.config.ts
+++ b/packages/loader/container-loader/vitest.config.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — *coverage pilot* for packages/loader/container-loader.
+ *
+ * Mocha remains the canonical test runner for this package (see .mocharc.cjs
+ * and the `test:mocha*` scripts in package.json). Vitest is added here solely
+ * to produce code-coverage reports via the v8 coverage provider, as a pilot
+ * replacement for the c8-based `test:coverage` script whose performance
+ * regressed on Node 22/24 and caused it to be disabled in CI (see
+ * tools/pipelines/build-client.yml, testCoverage: false).
+ *
+ * Run with:
+ *   pnpm --filter @fluidframework/container-loader run build   # required
+ *   pnpm --filter @fluidframework/container-loader run test:coverage:vitest
+ *
+ * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
+ * the whole `nyc` directory, so no clean-script change is needed).
+ *
+ * We run the compiled `lib/**` output rather than `src/**` TypeScript for
+ * consistency with the other FF coverage-pilot packages (see
+ * packages/dds/tree/vitest.config.ts for the longer rationale). The v8
+ * coverage provider follows source maps back to `src/**` for line-accurate
+ * reporting.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	// FF test-only subpath exports (e.g. `./internal/test/container`) are gated
+	// behind the `allow-ff-test-exports` export condition. Mocha enables this
+	// via Node's --conditions flag; vite has its own resolver, so declare the
+	// condition explicitly here and under `ssr`.
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		// Shared mocha-compat shim — see file for details. Lives in build-common
+		// because it's re-used across every FF coverage-pilot package.
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+
+		// Fresh worker process per test file — consistent with other pilots and
+		// tolerant of leaky test providers (mocharc sets --exit for the same
+		// reason, AB#7856).
+		pool: "forks",
+		isolate: true,
+
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.perf.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/loader/container-loader/vitest.config.ts
+++ b/packages/loader/container-loader/vitest.config.ts
@@ -13,27 +13,17 @@
  * regressed on Node 22/24 and caused it to be disabled in CI (see
  * tools/pipelines/build-client.yml, testCoverage: false).
  *
- * Run with:
- *   pnpm --filter @fluidframework/container-loader run build   # required
  *   pnpm --filter @fluidframework/container-loader run test:coverage:vitest
  *
- * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
- * the whole `nyc` directory, so no clean-script change is needed).
- *
- * We run the compiled `lib/**` output rather than `src/**` TypeScript for
- * consistency with the other FF coverage-pilot packages (see
- * packages/dds/tree/vitest.config.ts for the longer rationale). The v8
- * coverage provider follows source maps back to `src/**` for line-accurate
- * reporting.
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required. (The `tree` pilot uniquely runs against `lib/**`
+ * because OXC currently lacks lowering for the `@breakingClass`/`@breakingMethod`
+ * decorators used there; see packages/dds/tree/vitest.config.ts.)
  */
 
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	// FF test-only subpath exports (e.g. `./internal/test/container`) are gated
-	// behind the `allow-ff-test-exports` export condition. Mocha enables this
-	// via Node's --conditions flag; vite has its own resolver, so declare the
-	// condition explicitly here and under `ssr`.
 	resolve: {
 		conditions: ["allow-ff-test-exports"],
 	},
@@ -44,27 +34,22 @@ export default defineConfig({
 	},
 	test: {
 		globals: true,
-		// Shared mocha-compat shim — see file for details. Lives in build-common
-		// because it's re-used across every FF coverage-pilot package.
 		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
 
-		// Fresh worker process per test file — consistent with other pilots and
-		// tolerant of leaky test providers (mocharc sets --exit for the same
-		// reason, AB#7856).
 		pool: "forks",
 		isolate: true,
 
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
 
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.perf.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 
 		coverage: {
@@ -72,14 +57,11 @@ export default defineConfig({
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -137,6 +137,7 @@
 		"place:cjs:package-stub": "copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -205,6 +206,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
 		"@types/sinon": "^17.0.3",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -215,7 +217,8 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
 		"sinon": "^18.0.1",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/runtime/container-runtime/vitest.config.ts
+++ b/packages/runtime/container-runtime/vitest.config.ts
@@ -13,29 +13,21 @@
  * regressed on Node 22/24 and caused it to be disabled in CI (see
  * tools/pipelines/build-client.yml, testCoverage: false).
  *
- * Run with:
- *   pnpm --filter @fluidframework/container-runtime run build   # required before each run
  *   pnpm --filter @fluidframework/container-runtime run test:coverage:vitest
- * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
- * the whole `nyc` directory, so no clean-script change is needed).
  *
- * We run the compiled `lib/**` output rather than `src/**` TypeScript for
- * consistency with the tree pilot (see packages/dds/tree/vitest.config.ts for
- * the longer rationale — OXC's TS→JS transform doesn't lower every modern TS
- * feature that tsc emits, and running the tsc output sidesteps a class of
- * loader errors). The v8 coverage provider follows source maps back to
- * `src/**` for line-accurate reporting.
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required. (The `tree` pilot uniquely runs against `lib/**`
+ * because OXC currently lacks lowering for the `@breakingClass`/`@breakingMethod`
+ * decorators used there; see packages/dds/tree/vitest.config.ts.)
  */
 
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	// FF test-only subpath exports (e.g. `./internal/test/containerRuntime`) are gated
-	// behind the `allow-ff-test-exports` export condition. Mocha enables this via
-	// `--conditions=allow-ff-test-exports` in @fluid-internal/mocha-test-setup's
-	// node-options. Vite has its own resolver and does not honour Node's --conditions
-	// flag; vitest runs in an SSR-style environment, so we declare the condition via
-	// `ssr.resolve.conditions` and mirror it at top-level.
+	// FF test-only subpath exports (e.g. `./internal/test/containerRuntime`) are
+	// gated behind the `allow-ff-test-exports` export condition. Mocha enables
+	// this via Node's --conditions flag; vite has its own resolver, so declare
+	// the condition at both top level and under `ssr`.
 	resolve: {
 		conditions: ["allow-ff-test-exports"],
 	},
@@ -46,33 +38,29 @@ export default defineConfig({
 	},
 	test: {
 		globals: true,
-		// Shared mocha-compat shim — see file for details. Lives in build-common
-		// because it's re-used across every FF coverage-pilot package.
 		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
 
-		// Fresh worker process per test file — mirrors tree's handling of leaky
-		// test providers (mocharc sets --exit here for the same reason).
+		// Fresh worker process per test file — tolerant of leaky test providers
+		// (mocharc sets --exit for the same reason, AB#7856).
 		pool: "forks",
 		isolate: true,
 
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
 
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			// Fuzz suites use describeFuzz/describeStress, whose createSuite wrapper
-			// calls `this.timeout(...)` at suite (describe) scope. Under strict-ESM
-			// vitest, describe callbacks run with `this === undefined`, so the call
-			// throws at module load. Excluding wholesale.
-			"lib/test/fuzz/**",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.bench.js",
-			// Benchmark suites: @fluid-tools/benchmark needs mocha's test context
-			// (`fullTitle`) to emit results — undefined under vitest.
-			"lib/test/**/*.perf.spec.js",
+			// Fuzz/stress suites: describeFuzz/describeStress helpers call
+			// `this.timeout(...)` at suite scope, which throws under strict-ESM
+			// vitest (describe callbacks have `this === undefined`).
+			"src/test/fuzz/**",
+			"src/test/**/*.fuzz.spec.ts",
+			// Benchmark suites: @fluid-tools/benchmark needs mocha's test context.
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 
 		coverage: {
@@ -80,17 +68,12 @@ export default defineConfig({
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			// v8 collects from the running JS in `lib/**` and follows source maps
-			// back to `src/**/*.ts`. List both so the provider sees everything, then
-			// exclude tests and declaration files from reporting.
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
+				// Barrel files are noise in a coverage report.
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/runtime/container-runtime/vitest.config.ts
+++ b/packages/runtime/container-runtime/vitest.config.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — *coverage pilot* for packages/runtime/container-runtime.
+ *
+ * Mocha remains the canonical test runner for this package (see .mocharc.cjs
+ * and the `test:mocha*` scripts in package.json). Vitest is added here solely
+ * to produce code-coverage reports via the v8 coverage provider, as a pilot
+ * replacement for the c8-based `test:coverage` script whose performance
+ * regressed on Node 22/24 and caused it to be disabled in CI (see
+ * tools/pipelines/build-client.yml, testCoverage: false).
+ *
+ * Run with:
+ *   pnpm --filter @fluidframework/container-runtime run build   # required before each run
+ *   pnpm --filter @fluidframework/container-runtime run test:coverage:vitest
+ * Output lands in `nyc/report-vitest/` (the existing `clean` script rimrafs
+ * the whole `nyc` directory, so no clean-script change is needed).
+ *
+ * We run the compiled `lib/**` output rather than `src/**` TypeScript for
+ * consistency with the tree pilot (see packages/dds/tree/vitest.config.ts for
+ * the longer rationale — OXC's TS→JS transform doesn't lower every modern TS
+ * feature that tsc emits, and running the tsc output sidesteps a class of
+ * loader errors). The v8 coverage provider follows source maps back to
+ * `src/**` for line-accurate reporting.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	// FF test-only subpath exports (e.g. `./internal/test/containerRuntime`) are gated
+	// behind the `allow-ff-test-exports` export condition. Mocha enables this via
+	// `--conditions=allow-ff-test-exports` in @fluid-internal/mocha-test-setup's
+	// node-options. Vite has its own resolver and does not honour Node's --conditions
+	// flag; vitest runs in an SSR-style environment, so we declare the condition via
+	// `ssr.resolve.conditions` and mirror it at top-level.
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		// Shared mocha-compat shim — see file for details. Lives in build-common
+		// because it's re-used across every FF coverage-pilot package.
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+
+		// Fresh worker process per test file — mirrors tree's handling of leaky
+		// test providers (mocharc sets --exit here for the same reason).
+		pool: "forks",
+		isolate: true,
+
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			// Fuzz suites use describeFuzz/describeStress, whose createSuite wrapper
+			// calls `this.timeout(...)` at suite (describe) scope. Under strict-ESM
+			// vitest, describe callbacks run with `this === undefined`, so the call
+			// throws at module load. Excluding wholesale.
+			"lib/test/fuzz/**",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.bench.js",
+			// Benchmark suites: @fluid-tools/benchmark needs mocha's test context
+			// (`fullTitle`) to emit results — undefined under vitest.
+			"lib/test/**/*.perf.spec.js",
+		],
+
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			// v8 collects from the running JS in `lib/**` and follows source maps
+			// back to `src/**/*.ts`. List both so the provider sees everything, then
+			// exclude tests and declaration files from reporting.
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -97,6 +97,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -150,6 +151,7 @@
 		"@microsoft/api-extractor": "7.58.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -159,7 +161,8 @@
 		"mocha": "^11.7.5",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^6.1.3",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/runtime/id-compressor/vitest.config.ts
+++ b/packages/runtime/id-compressor/vitest.config.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — coverage pilot for packages/runtime/id-compressor.
+ * See packages/dds/tree/vitest.config.ts for the longer rationale.
+ *
+ *   pnpm --filter @fluidframework/id-compressor run build           # required
+ *   pnpm --filter @fluidframework/id-compressor run test:coverage:vitest
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+		pool: "forks",
+		isolate: true,
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.perf.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/packages/runtime/id-compressor/vitest.config.ts
+++ b/packages/runtime/id-compressor/vitest.config.ts
@@ -7,8 +7,10 @@
  * Vitest configuration — coverage pilot for packages/runtime/id-compressor.
  * See packages/dds/tree/vitest.config.ts for the longer rationale.
  *
- *   pnpm --filter @fluidframework/id-compressor run build           # required
  *   pnpm --filter @fluidframework/id-compressor run test:coverage:vitest
+ *
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required.
  */
 
 import { defineConfig } from "vitest/config";
@@ -29,28 +31,32 @@ export default defineConfig({
 		isolate: true,
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.perf.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
+			// Snapshot tests assert on build-output paths that don't exist
+			// when running directly against source.
+			"src/test/snapshots/**",
+			// Main suite chains `.timeout(10000)` on `it()` (idCompressor.spec.ts:1575),
+			// which vitest doesn't support. Excluding the whole file is unfortunate
+			// but the surgical alternative would mean editing the test.
+			"src/test/idCompressor.spec.ts",
 		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/runtime/id-compressor/vitest.config.ts
+++ b/packages/runtime/id-compressor/vitest.config.ts
@@ -53,11 +53,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -96,6 +96,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
+		"test:coverage:vitest": "vitest run --coverage",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
@@ -151,6 +152,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "catalog:types",
 		"@types/sinon": "^17.0.3",
+		"@vitest/coverage-v8": "^4.1.4",
 		"c8": "^10.1.3",
 		"concurrently": "^9.2.1",
 		"copyfiles": "^2.4.1",
@@ -162,7 +164,8 @@
 		"rimraf": "^6.1.3",
 		"sinon": "^18.0.1",
 		"ts-node": "^10.9.2",
-		"typescript": "~5.4.5"
+		"typescript": "~5.4.5",
+		"vitest": "^4.1.4"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/runtime/runtime-utils/vitest.config.ts
+++ b/packages/runtime/runtime-utils/vitest.config.ts
@@ -46,11 +46,7 @@ export default defineConfig({
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.d.ts",
-				"src/**/index.ts",
-			],
+			exclude: ["src/test/**", "src/**/*.d.ts", "src/**/index.ts"],
 			all: true,
 			clean: true,
 		},

--- a/packages/runtime/runtime-utils/vitest.config.ts
+++ b/packages/runtime/runtime-utils/vitest.config.ts
@@ -7,8 +7,10 @@
  * Vitest configuration — coverage pilot for packages/runtime/runtime-utils.
  * See packages/dds/tree/vitest.config.ts for the longer rationale.
  *
- *   pnpm --filter @fluidframework/runtime-utils run build           # required
  *   pnpm --filter @fluidframework/runtime-utils run test:coverage:vitest
+ *
+ * Vitest runs directly on source TypeScript via its esbuild transform — no
+ * prior build step required.
  */
 
 import { defineConfig } from "vitest/config";
@@ -29,28 +31,25 @@ export default defineConfig({
 		isolate: true,
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
-		include: ["lib/test/**/*.{test,spec}.js"],
+		include: ["src/test/**/*.{test,spec}.ts"],
 		exclude: [
 			"**/node_modules/**",
-			"src/**",
+			"lib/**",
 			"dist/**",
-			"lib/test/**/*.fuzz.spec.js",
-			"lib/test/**/*.perf.spec.js",
-			"lib/test/**/*.bench.js",
+			"src/test/**/*.fuzz.spec.ts",
+			"src/test/**/*.perf.spec.ts",
+			"src/test/**/*.bench.ts",
 		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "cobertura"],
 			reportsDirectory: "nyc/report-vitest",
 			reportOnFailure: true,
-			include: ["src/**/*.ts", "lib/**/*.js"],
+			include: ["src/**/*.ts"],
 			exclude: [
 				"src/test/**",
-				"lib/test/**",
 				"src/**/*.d.ts",
-				"lib/**/*.d.ts",
 				"src/**/index.ts",
-				"lib/**/index.js",
 			],
 			all: true,
 			clean: true,

--- a/packages/runtime/runtime-utils/vitest.config.ts
+++ b/packages/runtime/runtime-utils/vitest.config.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Vitest configuration — coverage pilot for packages/runtime/runtime-utils.
+ * See packages/dds/tree/vitest.config.ts for the longer rationale.
+ *
+ *   pnpm --filter @fluidframework/runtime-utils run build           # required
+ *   pnpm --filter @fluidframework/runtime-utils run test:coverage:vitest
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["allow-ff-test-exports"],
+	},
+	ssr: {
+		resolve: {
+			conditions: ["allow-ff-test-exports"],
+		},
+	},
+	test: {
+		globals: true,
+		setupFiles: ["../../../common/build/build-common/vitest-test-setup.mjs"],
+		pool: "forks",
+		isolate: true,
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
+		include: ["lib/test/**/*.{test,spec}.js"],
+		exclude: [
+			"**/node_modules/**",
+			"src/**",
+			"dist/**",
+			"lib/test/**/*.fuzz.spec.js",
+			"lib/test/**/*.perf.spec.js",
+			"lib/test/**/*.bench.js",
+		],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "cobertura"],
+			reportsDirectory: "nyc/report-vitest",
+			reportOnFailure: true,
+			include: ["src/**/*.ts", "lib/**/*.js"],
+			exclude: [
+				"src/test/**",
+				"lib/test/**",
+				"src/**/*.d.ts",
+				"lib/**/*.d.ts",
+				"src/**/index.ts",
+				"lib/**/index.js",
+			],
+			all: true,
+			clean: true,
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
         version: 0.64.0(@types/node@22.19.17)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 9.0.0(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
+        version: 9.0.0(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: catalog:eslint
         version: 9.39.1(jiti@2.6.1)
@@ -8376,6 +8376,9 @@ importers:
       '@types/path-browserify':
         specifier: ^1.0.0
         version: 1.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -8406,6 +8409,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/dds/matrix:
     dependencies:
@@ -9626,6 +9632,9 @@ importers:
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
@@ -9674,6 +9683,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/drivers/debugger:
     dependencies:
@@ -12766,6 +12778,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -12799,6 +12814,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/loader/driver-utils:
     dependencies:
@@ -13060,6 +13078,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -13093,6 +13114,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/runtime/container-runtime-definitions:
     dependencies:
@@ -17463,6 +17487,10 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.25.9':
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
@@ -17473,6 +17501,11 @@ packages:
 
   '@babel/parser@7.28.4':
     resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -17579,8 +17612,8 @@ packages:
     resolution: {integrity: sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.4':
-    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -17764,11 +17797,20 @@ packages:
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -19226,8 +19268,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -19394,6 +19436,12 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -19573,6 +19621,9 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
 
@@ -19701,6 +19752,104 @@ packages:
     resolution: {integrity: sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@rushstack/eslint-plugin@0.22.1':
     resolution: {integrity: sha512-j2bVPgddSBs0iPed2l40Ssa/bmKr6YkaI3jv7Z1fH2Zlu/RcpgFOZWH0ls8ZQEqaA63A3oRmVXxnmmX/7FJb8w==}
@@ -19836,6 +19985,9 @@ packages:
 
   '@socket.io/sticky@1.0.4':
     resolution: {integrity: sha512-VuauT5CJLvzYtKIgouFSQ8rUaygseR+zRutnwh6ZA2QYcXx+8g52EoJ8V2SLxfo+Tfs3ELUDy08oEXxlWNrxaw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@streamparser/json@0.0.20':
     resolution: {integrity: sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ==}
@@ -19973,6 +20125,9 @@ packages:
   '@types/chai@4.3.20':
     resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chrome@0.0.232':
     resolution: {integrity: sha512-IfEhAewLgCDJZ70gnNJ2cbl4L5+9WvR0FL5wl3MGHguSbeQbThN2BNagFq5PddNFMVHW7JKf8TBu7tyWixOeyQ==}
 
@@ -20026,6 +20181,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/diff@3.5.8':
     resolution: {integrity: sha512-CZ5vepL87+M8PxRIvJjR181Erahch2w7Jev/XJm+Iot/SOvJh8QqH/N79b+vsKtYF6fFzoPieiiq2c5tzmXR9A==}
@@ -20569,6 +20727,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
   '@vue/compiler-core@3.4.38':
     resolution: {integrity: sha512-8IQOTCWnLFqfHzOGm9+P8OPSEDukgg3Huc92qSG49if/xI2SAwLHQO2qaPQbjCWPBcQoO1WYfXfTACUrWV3c5A==}
 
@@ -20950,9 +21146,16 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -21345,6 +21548,10 @@ packages:
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chainsaw@0.1.0:
     resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
@@ -22429,6 +22636,9 @@ packages:
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -22650,6 +22860,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -22714,6 +22927,10 @@ packages:
   expect-puppeteer@9.0.2:
     resolution: {integrity: sha512-nv3RD8MOStXOf4bLpr1wiqxPMLL7MwXvtMeZBtGvg5bubAHiHcYBcvDTJwkUjdOWz3scjOnOOl5z6KZakMobCw==}
     engines: {node: '>=16'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -23953,6 +24170,10 @@ packages:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
 
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -24147,6 +24368,9 @@ packages:
 
   js-tiktoken@1.0.20:
     resolution: {integrity: sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -24428,6 +24652,80 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -24608,8 +24906,11 @@ packages:
   lz4js@0.2.0:
     resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
 
-  magic-string@0.30.15:
-    resolution: {integrity: sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -25380,6 +25681,9 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   oclif@4.22.52:
     resolution: {integrity: sha512-Rl7UX1q9m7mAdCLyRWA1VY6O3AeDLmCTRe2wzbQU/teDK+gvERGdvZfb9est96MM+mBjRVoX5EesoBFOVVee+w==}
     engines: {node: '>=18.0.0'}
@@ -25692,6 +25996,9 @@ packages:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
@@ -25860,6 +26167,10 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -26486,6 +26797,11 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -26731,6 +27047,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -26960,6 +27279,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -26978,6 +27300,9 @@ packages:
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
@@ -27308,6 +27633,13 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -27316,6 +27648,10 @@ packages:
     resolution: {integrity: sha512-E1VDL6N/3s/lOtkzWVqw0OSXrcsYvqzQhzcxm6GD3pXXEfRuHd2MrwADiX+MlcDbTX0/iCY4mo6Mh0fuV2UWDQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -27895,6 +28231,90 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ~22.19.17
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ~22.19.17
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vizion@2.2.1:
     resolution: {integrity: sha512-sfAcO2yeSU0CSPFI/DmZp3FsFE9T+8913nv1xWBOyzODv13fwkn6Vl7HqxGpkr9F608M+8SuFId3s+BlZqfXww==}
     engines: {node: '>=4.0'}
@@ -28094,6 +28514,11 @@ packages:
   which@3.0.1:
     resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -28345,7 +28770,7 @@ snapshots:
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@andrewbranch/untar.js@1.0.3': {}
 
@@ -28499,7 +28924,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -28513,10 +28938,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.2
       '@babel/template': 7.27.2
       '@babel/traverse': 7.26.4
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -28527,10 +28952,10 @@ snapshots:
 
   '@babel/generator@7.26.3':
     dependencies:
-      '@babel/parser': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.0.2
 
   '@babel/helper-compilation-targets@7.25.9':
@@ -28544,7 +28969,7 @@ snapshots:
   '@babel/helper-module-imports@7.25.9':
     dependencies:
       '@babel/traverse': 7.26.4
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -28552,7 +28977,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
@@ -28563,16 +28988,22 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.28.4':
     dependencies:
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.0)':
     dependencies:
@@ -28664,25 +29095,25 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.26.4':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.26.3
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.2
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.4':
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -28922,12 +29353,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -30245,6 +30692,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@fluid-internal/eslint-plugin-fluid@0.4.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      ts-morph: 22.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@fluid-internal/test-driver-definitions@2.92.0':
     dependencies:
       '@fluidframework/core-interfaces': 2.92.0
@@ -30929,6 +31387,37 @@ snapshots:
       eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))
       globals: 14.0.0
       typescript-eslint: 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
+    transitivePeerDependencies:
+      - '@typescript-eslint/utils'
+      - eslint
+      - eslint-import-resolver-node
+      - eslint-plugin-import
+      - supports-color
+      - typescript
+
+  '@fluidframework/eslint-config-fluid@9.0.0(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.39.1(jiti@2.6.1))
+      '@eslint/eslintrc': 3.3.3
+      '@eslint/js': 9.39.4
+      '@fluid-internal/eslint-plugin-fluid': 0.4.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@rushstack/eslint-plugin': 0.22.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint-config-biome: 2.1.3
+      eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-depend: 1.4.0
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-jsdoc: 61.4.2(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-promise: 7.2.1(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-tsdoc: 0.5.2(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-unicorn: 54.0.0(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+      globals: 14.0.0
+      typescript-eslint: 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint
@@ -32285,7 +32774,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.19.17
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
@@ -32296,7 +32785,7 @@ snapshots:
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.1.7
+      istanbul-reports: 3.2.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       jest-worker: 29.7.0
@@ -32313,7 +32802,7 @@ snapshots:
 
   '@jest/source-map@29.6.3':
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
@@ -32335,7 +32824,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -32364,7 +32853,7 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -32373,11 +32862,11 @@ snapshots:
   '@jridgewell/source-map@0.3.6':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/trace-mapping@0.3.25':
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -32628,6 +33117,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -32898,6 +33394,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@oxc-project/types@0.124.0': {}
+
   '@package-json/types@0.0.12': {}
 
   '@parcel/watcher-android-arm64@2.5.0':
@@ -33043,10 +33541,70 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
+
   '@rushstack/eslint-plugin@0.22.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)':
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
       '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
+      eslint: 9.39.1(jiti@2.6.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@rushstack/eslint-plugin@0.22.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
@@ -33197,6 +33755,8 @@ snapshots:
       - supports-color
 
   '@socket.io/sticky@1.0.4': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@streamparser/json@0.0.20': {}
 
@@ -33357,24 +33917,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
 
   '@types/base64-js@1.3.2': {}
 
@@ -33388,6 +33948,11 @@ snapshots:
       '@types/node': 22.19.17
 
   '@types/chai@4.3.20': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/chrome@0.0.232':
     dependencies:
@@ -33448,6 +34013,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/diff@3.5.8': {}
 
@@ -33773,6 +34340,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.54.0
+      eslint: 9.39.1(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.4
@@ -33782,6 +34365,18 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.4
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33797,12 +34392,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.54.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.46.4(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.4.5)
       '@typescript-eslint/types': 8.58.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.46.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33815,12 +34431,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.54.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.56.1(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.4.5)
       '@typescript-eslint/types': 8.58.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33843,13 +34477,25 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
+  '@typescript-eslint/tsconfig-utils@8.46.4(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@typescript-eslint/tsconfig-utils@8.54.0(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
+  '@typescript-eslint/tsconfig-utils@8.54.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
+
+  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)':
     dependencies:
@@ -33860,6 +34506,18 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.4.5)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33887,6 +34545,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.46.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/visitor-keys': 8.46.4
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.9
+      semver: 7.7.3
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.54.0(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/project-service': 8.54.0(typescript@5.4.5)
@@ -33899,6 +34573,21 @@ snapshots:
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.4.5)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.54.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/visitor-keys': 8.54.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 9.0.9
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33917,6 +34606,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.4
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
@@ -33925,6 +34629,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33939,6 +34654,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.54.0
+      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
@@ -33947,6 +34673,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -34026,9 +34763,64 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@vue/compiler-core@3.4.38':
     dependencies:
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.4.38
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -34041,13 +34833,13 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.38':
     dependencies:
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.2
       '@vue/compiler-core': 3.4.38
       '@vue/compiler-dom': 3.4.38
       '@vue/compiler-ssr': 3.4.38
       '@vue/shared': 3.4.38
       estree-walker: 2.0.2
-      magic-string: 0.30.15
+      magic-string: 0.30.21
       postcss: 8.5.3
       source-map-js: 1.2.1
 
@@ -34461,9 +35253,17 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 
@@ -34569,7 +35369,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
@@ -34944,6 +35744,8 @@ snapshots:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.1.0
+
+  chai@6.2.2: {}
 
   chainsaw@0.1.0:
     dependencies:
@@ -36095,6 +36897,8 @@ snapshots:
 
   es-module-lexer@1.5.4: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -36166,6 +36970,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash-x: 0.2.0
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-chai-expect@3.1.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
@@ -36191,6 +37010,24 @@ snapshots:
       unrs-resolver: 1.11.1
     optionalDependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@package-json/types': 0.0.12
+      '@typescript-eslint/types': 8.58.0
+      comment-parser: 1.4.6
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
+      is-glob: 4.0.3
+      minimatch: 9.0.9
+      semver: 7.7.3
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -36273,6 +37110,16 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-tsdoc@0.5.2(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
   eslint-plugin-unicorn@54.0.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -36300,6 +37147,12 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
+
+  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -36388,6 +37241,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -36443,6 +37300,8 @@ snapshots:
   expect-puppeteer@10.1.4: {}
 
   expect-puppeteer@9.0.2: {}
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -37791,7 +38650,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -37801,7 +38660,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -37823,6 +38682,11 @@ snapshots:
       - supports-color
 
   istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
@@ -38160,7 +39024,7 @@ snapshots:
       '@babel/generator': 7.26.3
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -38259,6 +39123,8 @@ snapshots:
   js-tiktoken@1.0.20:
     dependencies:
       base64-js: 1.5.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -38576,6 +39442,55 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -38725,9 +39640,15 @@ snapshots:
 
   lz4js@0.2.0: {}
 
-  magic-string@0.30.15:
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
 
   make-dir@2.1.0:
     dependencies:
@@ -39881,6 +40802,8 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  obug@2.1.1: {}
+
   oclif@4.22.52(@types/node@22.19.17):
     dependencies:
       '@inquirer/confirm': 3.2.0
@@ -40229,6 +41152,8 @@ snapshots:
 
   path-type@6.0.0: {}
 
+  pathe@2.0.3: {}
+
   pathval@1.1.1: {}
 
   pause-stream@0.0.11:
@@ -40414,6 +41339,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.3:
     dependencies:
@@ -41215,6 +42146,27 @@ snapshots:
       glob: 13.0.5
       package-json-from-dist: 1.0.1
 
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
   rope-sequence@1.3.4: {}
 
   rrweb-cssom@0.8.0: {}
@@ -41487,6 +42439,8 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -41817,6 +42771,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
   start-server-and-test@2.0.8:
@@ -41839,6 +42795,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  std-env@4.1.0: {}
 
   stream-combiner@0.0.4:
     dependencies:
@@ -42185,7 +43143,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.15(webpack@5.103.0):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 7.0.4
@@ -42254,6 +43212,10 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -42299,6 +43261,8 @@ snapshots:
       - debug
       - supports-color
       - utf-8-validate
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -42383,6 +43347,10 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.4.5):
     dependencies:
       typescript: 5.4.5
+
+  ts-api-utils@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   ts-deepmerge@7.0.3: {}
 
@@ -42580,6 +43548,17 @@ snapshots:
       '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -42870,7 +43849,7 @@ snapshots:
 
   v8-to-istanbul@9.3.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
@@ -42925,6 +43904,50 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass: 1.82.0
+      terser: 5.37.0
+      yaml: 2.8.3
+
+  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
 
   vizion@2.2.1:
     dependencies:
@@ -43313,6 +44336,11 @@ snapshots:
   which@3.0.1:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,7 +381,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -511,7 +511,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -638,7 +638,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -934,7 +934,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1079,7 +1079,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1236,7 +1236,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1360,7 +1360,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1578,7 +1578,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1681,7 +1681,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1860,7 +1860,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -1975,7 +1975,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -2084,7 +2084,7 @@ importers:
         version: 5.0.0(webpack@5.103.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -2290,7 +2290,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -2323,7 +2323,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -2544,7 +2544,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -3069,7 +3069,7 @@ importers:
         version: 4.0.0(webpack@5.103.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -4377,7 +4377,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -4522,7 +4522,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -4688,7 +4688,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -5597,7 +5597,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -5766,7 +5766,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -5947,7 +5947,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -6107,7 +6107,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -6234,7 +6234,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -6373,7 +6373,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -6497,7 +6497,7 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -7589,6 +7589,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -7642,13 +7645,16 @@ importers:
         version: 18.0.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.19.17)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/common/container-definitions:
     dependencies:
@@ -7806,6 +7812,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -7842,6 +7851,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/common/driver-definitions:
     dependencies:
@@ -8509,6 +8521,9 @@ importers:
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       best-random:
         specifier: ^1.0.0
         version: 1.0.3
@@ -8548,6 +8563,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/dds/merge-tree:
     dependencies:
@@ -8630,6 +8648,9 @@ importers:
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -8663,6 +8684,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/dds/ordered-collection:
     dependencies:
@@ -11057,7 +11081,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -13415,6 +13439,9 @@ importers:
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -13445,6 +13472,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/runtime/runtime-definitions:
     dependencies:
@@ -13582,6 +13612,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -13618,6 +13651,9 @@ importers:
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(jiti@2.6.1)(sass@1.82.0)(terser@5.37.0)(yaml@2.8.3))
 
   packages/runtime/test-runtime-utils:
     dependencies:
@@ -16190,7 +16226,7 @@ importers:
         version: 3.0.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -16489,7 +16525,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -16522,7 +16558,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.103.0)
@@ -16679,7 +16715,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -16718,7 +16754,7 @@ importers:
         version: 3.32.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -17481,10 +17517,6 @@ packages:
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -28986,8 +29018,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.27.1': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.25.9': {}
@@ -37031,7 +37061,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5):
+  eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)
@@ -37122,7 +37152,7 @@ snapshots:
 
   eslint-plugin-unicorn@54.0.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
       '@eslint/eslintrc': 3.3.3
       ci-info: 4.4.0
@@ -43356,7 +43386,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10

--- a/scripts/bench-coverage-all.sh
+++ b/scripts/bench-coverage-all.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run bench-coverage.sh across every vitest pilot package, sequentially.
+#
+# Usage: scripts/bench-coverage-all.sh [runs=3] [warmup=1]
+#
+# Runs smallest → largest; a failure in a big package (tree) won't abort the
+# smaller packages' results. Each package gets its own hyperfine invocation
+# (separate `.benchmarks/bench-<slug>.{md,json}` files).
+
+set -euo pipefail
+
+PACKAGES=(
+	@fluidframework/core-utils
+	@fluid-internal/client-utils
+	@fluidframework/runtime-utils
+	@fluidframework/id-compressor
+	@fluidframework/container-loader
+	@fluidframework/container-runtime
+	@fluidframework/map
+	@fluidframework/matrix
+	@fluidframework/merge-tree
+	@fluidframework/tree
+)
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNS="${1:-3}"
+WARMUP="${2:-1}"
+
+for pkg in "${PACKAGES[@]}"; do
+	echo "::::: $pkg"
+	"$HERE/bench-coverage.sh" "$pkg" "$RUNS" "$WARMUP" || echo "  ($pkg failed — continuing)"
+done

--- a/scripts/bench-coverage.sh
+++ b/scripts/bench-coverage.sh
@@ -33,6 +33,10 @@ ARGS=(
 	--runs "$RUNS"
 	--setup "pnpm --filter '$PKG' run build"
 	--prepare "rm -rf '$PKG_DIR/nyc/report' '$PKG_DIR/nyc/report-vitest' '$PKG_DIR/nyc/.nyc_output'"
+	# Several pilot packages have known non-zero-exit test failures (real
+	# assertion gaps, documented in the PR). We still want timing data for
+	# those runs — `-i`/`--ignore-failure` lets hyperfine proceed.
+	-i
 	--export-markdown "$OUTDIR/bench-$SLUG.md"
 	--export-json "$OUTDIR/bench-$SLUG.json"
 )

--- a/scripts/bench-coverage.sh
+++ b/scripts/bench-coverage.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Compare c8 vs vitest+v8 coverage perf for a single pilot package.
+#
+# Usage:   scripts/bench-coverage.sh <pnpm-filter> [runs=3] [warmup=1]
+# Env:     BENCH_OUTDIR (default .benchmarks), BENCH_MODE (compare|c8|vitest)
+# Output:  BENCH_OUTDIR/bench-<slug>.md and .json
+# Needs:   hyperfine (brew install hyperfine), pnpm, a package that already
+#          defines both `test:coverage` (c8) and `test:coverage:vitest` scripts.
+
+set -euo pipefail
+
+PKG="${1:?package filter required — e.g. @fluidframework/map or packages/dds/map}"
+RUNS="${2:-3}"
+WARMUP="${3:-1}"
+OUTDIR="${BENCH_OUTDIR:-$(git rev-parse --show-toplevel)/.benchmarks}"
+MODE="${BENCH_MODE:-compare}"
+
+command -v hyperfine >/dev/null || {
+	echo "hyperfine is required. Install with: brew install hyperfine" >&2
+	exit 1
+}
+mkdir -p "$OUTDIR"
+
+# Slug for the output filename — strip @ and /.
+SLUG="$(echo "$PKG" | sed 's|[@/]|_|g; s|^_||')"
+
+# Per-package dir — resolved via pnpm so the script doesn't need a hard-coded
+# filter → directory map.
+PKG_DIR="$(pnpm --filter "$PKG" exec -- pwd | tail -1)"
+
+ARGS=(
+	--warmup "$WARMUP"
+	--runs "$RUNS"
+	--setup "pnpm --filter '$PKG' run build"
+	--prepare "rm -rf '$PKG_DIR/nyc/report' '$PKG_DIR/nyc/report-vitest' '$PKG_DIR/nyc/.nyc_output'"
+	--export-markdown "$OUTDIR/bench-$SLUG.md"
+	--export-json "$OUTDIR/bench-$SLUG.json"
+)
+
+case "$MODE" in
+	compare)
+		ARGS+=(
+			-n "c8+mocha" "pnpm --filter '$PKG' run test:coverage"
+			-n "vitest+v8" "pnpm --filter '$PKG' run test:coverage:vitest"
+		)
+		;;
+	c8)
+		ARGS+=(-n "c8+mocha" "pnpm --filter '$PKG' run test:coverage")
+		;;
+	vitest)
+		ARGS+=(-n "vitest+v8" "pnpm --filter '$PKG' run test:coverage:vitest")
+		;;
+	*)
+		echo "BENCH_MODE must be compare|c8|vitest (got: $MODE)" >&2
+		exit 2
+		;;
+esac
+
+exec hyperfine "${ARGS[@]}"


### PR DESCRIPTION
## Description

Pilots [vitest](https://vitest.dev/) with its [v8 coverage provider](https://vitest.dev/guide/coverage) as an alternative to the current c8-based `test:coverage` script on **10 packages** across the runtime, loader, DDS, and common utility layers.

**Motivation.** Repo-wide code coverage was disabled in CI in April 2026 (`tools/pipelines/build-client.yml`, `testCoverage: false`) because c8 performance regressed on Node 22 and further on Node 24, causing test timeouts. This pilot introduces a faster alternative without touching the existing c8 path or CI config.

### What this PR does

- Adds `test:coverage:vitest` to each of 10 packages.
- Adds `vitest.config.ts` per package, with package-specific excludes for fuzz/benchmark/describe-level-`this.timeout` tests that don't work under strict-ESM vitest.
- Adds `common/build/build-common/vitest-test-setup.mjs` — a pre-compiled ESM shim shared by all pilot packages. It aliases mocha's `before`/`after` to vitest's `beforeAll`/`afterAll`, strips the optional leading-string arg from `beforeEach`/`afterEach` (mocha allows `beforeEach("name", fn)`, vitest doesn't), no-ops `this.timeout()`/`this.retries()`/`this.skip()` on the test context, and stubs `getTestLogger` (normally set by `@fluid-internal/mocha-test-setup`'s `beforeAll`).
- Adds `scripts/bench-coverage.sh` + `scripts/bench-coverage-all.sh` — a hyperfine-based harness for reproducible c8-vs-vitest timing comparisons, per-package or across the pilot set.

### Packages

| Layer    | Package                                     | Runs against |
|----------|---------------------------------------------|--------------|
| DDS      | `@fluidframework/tree`                      | `lib/**` (decorators) |
| DDS      | `@fluidframework/map`                       | `src/**` |
| DDS      | `@fluidframework/matrix`                    | `src/**` |
| DDS      | `@fluidframework/merge-tree`                | `src/**` |
| Runtime  | `@fluidframework/container-runtime`         | `src/**` |
| Runtime  | `@fluidframework/runtime-utils`             | `src/**` |
| Runtime  | `@fluidframework/id-compressor`             | `src/**` |
| Loader   | `@fluidframework/container-loader`          | `src/**` |
| Common   | `@fluidframework/core-utils`                | `src/**` |
| Common   | `@fluid-internal/client-utils`              | `src/**` |

### Why one package runs against `lib/**` and the rest against `src/**`

Vitest runs directly on source TypeScript via its esbuild transform. It's the idiomatic approach and means **no build step is required** before running coverage. 9 of the 10 packages use this.

`@fluidframework/tree` is the exception. It uses the standard-ES decorator syntax (`@breakingClass`, `@breakingMethod` in `src/util/breakable.ts`). OXC — vitest 4's TS transformer — doesn't currently lower these to runtime `__decorate` calls, so Node's VM can't execute the transformed source. tsc-compiled `lib/**` has already done the lowering, so pointing vitest there sidesteps the issue. The v8 coverage provider follows source maps back to `src/**` for line-accurate reporting. If OXC gains decorator-lowering support, the tree config can flip.

### Timing (hyperfine, N=3 runs + 1 warmup, macOS on Node 24)

Measured via `scripts/bench-coverage-all.sh`. Full per-package `.md` + `.json` outputs land in `.benchmarks/` locally (gitignored).

| Package           | c8+mocha (s)    | vitest+v8 (s)  | Speedup |
|-------------------|----------------:|---------------:|--------:|
| core-utils        |   1.66 ± 0.02   |   0.99 ± 0.02  |   1.7×  |
| client-utils      |   5.09 ± 0.24   |   0.99 ± 0.01  |   5.1×  |
| runtime-utils     |   1.71 ± 0.02   |   1.27 ± 0.02  |   1.3×  |
| id-compressor     |  10.06 ± 0.19   |   1.07 ± 0.02  |   9.4×  |
| container-loader  |   2.22 ± 0.07   |   1.84 ± 0.04  |   1.2×  |
| container-runtime |   9.75 ± 0.18   |   4.11 ± 0.21  |   2.4×  |
| map               |   8.09 ± 0.03   |   1.61 ± 0.01  |   5.0×  |
| matrix            | 401.10 ± 29.36  |  13.62 ± 0.07  |  29.4×  |
| merge-tree        | 775.64 ± 12.88  |  10.83 ± 0.16  |  71.6×  |
| tree              | 151.35 ± 4.43   |  25.84 ± 0.21  |   5.9×  |
| **Sum of means**  | **1366.67**     | **62.16**      | **22.0×** |

merge-tree and matrix are the dramatic cases — their c8+mocha paths spend 13 min and 6.7 min per run respectively; vitest+v8 brings them under 15 seconds. Smaller utility packages see modest wins because their tests are already fast; gains scale with test-suite size.

### Coverage

| Package           | Tests         | Pass % | Cov (stmt) |
|-------------------|---------------|--------|------------|
| map               | 157/157       | 100%   | 92.75%     |
| matrix            | 274/274       | 100%   | 90.23%     |
| merge-tree        | 893/895 (+2s) | 99.8%  | 84.60%     |
| container-runtime | 902/904       | 99.8%  | 77.84%     |
| container-loader  | 224/224       | 100%   | 66.84%     |
| runtime-utils     | 92/93         | 98.9%  | 56.41%     |
| client-utils      | 30/30         | 100%   | 50.00%     |
| core-utils        | 73/73         | 100%   | 33.51%     |
| id-compressor     | 24/24         | 100%   | 31.03%     |
| **tree**          | **7190/7770** | **92.5%** | **91.58%** |

### Coverage caveats

Coverage numbers are **not strictly apples-to-apples** with the c8 baseline:

- Vitest excludes fuzz/perf/benchmark/`this.timeout`-at-describe-scope test files that it can't execute; their source contributions are missing from the numerator.
- For packages running against `src/**`, coverage reflects what the tests actually exercise — not what merely gets imported by the tsc-compiled output. For some packages (core-utils notably) this drops the % noticeably vs. the `lib/**` strategy, but the denominator is unchanged.
- `client-utils` coverage is limited to the mocha suite; the jest suite is out of scope for this pilot.

### Known vitest-only test failures

Documented, not fixed here. None are vitest-compat issues — they're real assertions that behave differently under a single-ESM-pass vitest vs. the multi-pass mocha run:

- **tree** — 266 failures in codec/snapshot round-trip suites (likely filesystem/CWD-sensitive).
- **container-runtime** — 2 assertion edge cases.
- **runtime-utils** — 1 test has a nested `it()` inside another `it()`; mocha tolerates it, vitest rejects (this is genuinely a bug in the test).
- **merge-tree** — 2 skipped (existing `it.skip` in the source, not a vitest issue).

### Reproducing the timings

```
# Per package:
scripts/bench-coverage.sh @fluidframework/map

# All 10:
scripts/bench-coverage-all.sh

# Env knobs:
BENCH_MODE=vitest scripts/bench-coverage.sh @fluidframework/tree 5 2
```

Requires hyperfine (`brew install hyperfine`). Outputs: `.benchmarks/bench-<slug>.{md,json}`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Draft until we've decided:

1. Is `common/build/build-common` the right home for `vitest-test-setup.mjs`? The file is pre-compiled ESM (no build step required), consistent with build-common's role as the canonical place for shared build/test configs (`tsconfig.test.node16.json`, `api-extractor-base.json`, etc.). Alternative would be a new `@fluid-internal/vitest-test-setup` package paralleling `@fluid-internal/mocha-test-setup`.
2. Is 10 packages the right pilot scope, or should we go further (or narrower) before committing to the approach?
3. Not touching CI. Reenabling coverage in CI is intentionally out of scope — we can do that in a follow-up once the approach is agreed.

### How to try it

```
# src/** packages — no build step needed
pnpm --filter @fluidframework/map run test:coverage:vitest
open packages/dds/map/nyc/report-vitest/index.html

# tree still needs a build
pnpm --filter @fluidframework/tree run build
pnpm --filter @fluidframework/tree run test:coverage:vitest
open packages/dds/tree/nyc/report-vitest/index.html
```