### PR TITLE
fix(routerlicious): enforce scope checks on PATCH /root endpoint (#27…

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -136,6 +136,7 @@ export function create(
 				enableJwtTokenCache,
 				jwtTokenCache,
 				revokedTokenChecker,
+				[ScopeType.DocRead, ScopeType.DocWrite],
 			);
 			handleResponse(
 				validP.then(() => undefined),
@@ -309,6 +310,7 @@ const verifyRequest = async (
 	tokenCacheEnabled: boolean,
 	tokenCache?: core.ICache,
 	revokedTokenChecker?: core.IRevokedTokenChecker,
+	requiredScopes?: ScopeType[],
 ) =>
 	Promise.all([
 		verifyTokenWrapper(
@@ -319,6 +321,7 @@ const verifyRequest = async (
 			tokenCacheEnabled,
 			tokenCache,
 			revokedTokenChecker,
+			requiredScopes,
 		),
 		checkDocumentExistence(request, storage),
 	]);
@@ -331,6 +334,7 @@ async function verifyTokenWrapper(
 	tokenCacheEnabled: boolean,
 	tokenCache?: core.ICache,
 	revokedTokenChecker?: core.IRevokedTokenChecker,
+	requiredScopes?: ScopeType[],
 ): Promise<void> {
 	const token = request.headers["access-token"] as string;
 	if (!token) {
@@ -355,7 +359,7 @@ async function verifyTokenWrapper(
 		tokenCache,
 		revokedTokenChecker,
 	};
-	return verifyToken(tenantId, documentId, token, tenantManager, options);
+	return verifyToken(tenantId, documentId, token, tenantManager, options, requiredScopes);
 }
 
 async function checkDocumentExistence(

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -1313,6 +1313,125 @@ describe("Routerlicious", () => {
 					});
 				});
 			});
+
+			describe("patchRoot feature flag", () => {
+				let spyProducerSend;
+
+				beforeEach(() => {
+					spyProducerSend = Sinon.spy(defaultProducer, "send");
+				});
+
+				afterEach(() => {
+					Sinon.restore();
+				});
+
+				const createAppWithPatchRootConfig = (patchRootEnabled: boolean | undefined) => {
+					const provider = new nconf.Provider({}).defaults({
+						alfred: {
+							restJsonSize: 1000000,
+							api: {
+								patchRoot: patchRootEnabled,
+							},
+						},
+						auth: {
+							maxTokenLifetimeSec: 1000000,
+							enableTokenExpiration: false,
+						},
+						logger: {
+							morganFormat: "json",
+						},
+						mongo: {
+							collectionNames: {
+								deltas: deltasCollectionName,
+								rawDeltas: rawDeltasCollectionName,
+							},
+						},
+						worker: {
+							blobStorageUrl: "http://localhost:3001",
+							deltaStreamUrl: "http://localhost:3005",
+							serverUrl: "http://localhost:3003",
+						},
+					});
+
+					Sinon.stub(defaultStorage, "getDocument").resolves({} as IDocument);
+
+					const restTenantThrottlers = new Map<string, TestThrottler>();
+
+					const restClusterThrottlers = new Map<string, TestThrottler>();
+
+					const startupCheck = new StartupCheck();
+					testFluidAccessTokenGenerator = new TestFluidAccessTokenGenerator();
+					return alfredApp.create(
+						provider,
+						defaultTenantManager,
+						restTenantThrottlers,
+						restClusterThrottlers,
+						defaultSingleUseTokenCache,
+						defaultStorage,
+						defaultAppTenants,
+						defaultDeltaService,
+						defaultProducer,
+						defaultDocumentRepository,
+						defaultDocumentDeleteService,
+						startupCheck,
+						undefined,
+						undefined,
+						defaultCollaborationSessionEventEmitter,
+						undefined,
+						undefined,
+						undefined,
+						testFluidAccessTokenGenerator,
+					);
+				};
+
+				it("should reject doc:read-only token with 403", async () => {
+					const readOnlyToken = `Basic ${generateToken(
+						appTenant1.id,
+						document1._id,
+						appTenant1.key,
+						[ScopeType.DocRead],
+					)}`;
+					const testApp = createAppWithPatchRootConfig(true);
+					const testSupertest = request(testApp);
+
+					await testSupertest
+						.patch(`/api/v1/${appTenant1.id}/${document1._id}/root`)
+						.set("Authorization", readOnlyToken)
+						.set("access-token", readOnlyToken.split(" ")[1])
+						.send([{ op: "testOp", path: "/testPath", value: "testValue" }])
+						.expect(403)
+						.expect(() => {
+							assert(
+								spyProducerSend.notCalled,
+								"Producer should not be called for read-only token",
+							);
+						});
+				});
+
+				it("should reject doc:write-only token (missing doc:read) with 403", async () => {
+					const writeOnlyToken = `Basic ${generateToken(
+						appTenant1.id,
+						document1._id,
+						appTenant1.key,
+						[ScopeType.DocWrite],
+					)}`;
+					const testApp = createAppWithPatchRootConfig(true);
+					const testSupertest = request(testApp);
+
+					await testSupertest
+						.patch(`/api/v1/${appTenant1.id}/${document1._id}/root`)
+						.set("Authorization", writeOnlyToken)
+						.set("access-token", writeOnlyToken.split(" ")[1])
+						.send([{ op: "testOp", path: "/testPath", value: "testValue" }])
+						.expect(403)
+						.expect(() => {
+							assert(
+								spyProducerSend.notCalled,
+								"Producer should not be called for write-only token",
+							);
+						});
+				});
+			});
 		});
 	});
 });

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -235,6 +235,7 @@ export async function verifyToken(
 	token: string,
 	tenantManager: ITenantManager,
 	options: IVerifyTokenOptions,
+	requiredScopes?: string[],
 ): Promise<void> {
 	if (options.requireDocumentId && !documentId) {
 		throw new NetworkError(403, "Missing documentId.");
@@ -265,6 +266,18 @@ export async function verifyToken(
 			);
 			if (isTokenRevoked) {
 				throw new NetworkError(403, "Permission denied. Access token has been revoked.");
+			}
+		}
+
+		if (requiredScopes) {
+			const hasAllRequiredScopes = requiredScopes.every((scope) =>
+				claims.scopes.includes(scope),
+			);
+			if (!hasAllRequiredScopes) {
+				throw new NetworkError(
+					403,
+					`Permission denied. Insufficient scopes. Required scopes: ${requiredScopes}`,
+				);
 			}
 		}
 


### PR DESCRIPTION
…073)

The `PATCH /:tenantId/:id/root` endpoint in Alfred's REST API called `verifyToken()` without passing the `requiredScopes` parameter. This meant any valid JWT — including tokens with only `doc:read` scope — could write arbitrary key-value data into a document's root map. The injected operations were permanently sequenced into the document's op log and replayed by all connected clients.

The fix threads a `requiredScopes` parameter through the `verifyRequest` → `verifyTokenWrapper` → `verifyToken` call chain and passes `[ScopeType.DocRead, ScopeType.DocWrite]` from the PATCH handler. This matches the scope enforcement already used by the adjacent `POST /broadcast-signal` endpoint via `verifyStorageToken`.

Two new tests confirm that:
- A `doc:read`-only token is rejected with 403
- A `doc:write`-only token (missing `doc:read`) is also rejected with 403

The existing "process normally" test with a full-scope token continues to pass, confirming no regression for legitimate callers.

The review process is outlined on [this wiki
page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- This is a security fix (MSRC 113235). The changes are intentionally minimal and surgical — 4 hunks in the production file, all adding a single `requiredScopes` parameter through the existing function chain.
- `verifyRequest` and `verifyTokenWrapper` are module-private (not exported). The `create()` export signature is unchanged. Zero consumer impact.