### PR TITLE
test(app-insights-logger): Share ApplicationInsights across all test suites

### DIFF
--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -667,9 +667,9 @@ describe("FluidAppInsightsLogger", () => {
 				);
 				const actualSentEvent5 = trackEventSpy.getCalls().filter((call) =>
 					call.calledWithExactly({
-						name: event4.eventName,
+						name: event5.eventName,
 						properties: {
-							...event4,
+							...event5,
 						},
 					}),
 				);

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -15,115 +15,12 @@ import {
 	createLogger,
 } from "../fluidAppInsightsLogger.js";
 
-describe("FluidAppInsightsLogger", () => {
+// Create the ApplicationInsights instance once for the whole file and eagerly initialize it.
+// Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
+// initialization path (~250ms locally, potentially much worse in CI). Calling
+// loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
+describe("fluidAppInsightsLogger tests", () => {
 	let appInsightsClient: ApplicationInsights;
-	let trackEventSpy: Sinon.SinonSpy;
-
-	// Create the ApplicationInsights instance once for the suite and eagerly initialize it.
-	// Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
-	// initialization path (~250ms locally, potentially much worse in CI). Calling
-	// loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
-	before(function initializeAppInsights() {
-		appInsightsClient = new ApplicationInsights({
-			config: {
-				connectionString:
-					// (this is an example string)
-					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
-			},
-		});
-		appInsightsClient.loadAppInsights();
-	});
-
-	beforeEach(function createTrackEventSpy() {
-		trackEventSpy = spy(appInsightsClient, "trackEvent");
-	});
-
-	afterEach(function restoreSpy() {
-		trackEventSpy.restore();
-	});
-
-	it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
-		const logger = createLogger(appInsightsClient);
-
-		const mockTelemetryEvent = {
-			category: "mockEvent",
-			eventName: "mockEventName",
-		};
-		logger.send(mockTelemetryEvent);
-		sinonAssert.calledOnce(trackEventSpy);
-
-		const expectedAppInsightsEvent = {
-			name: mockTelemetryEvent.eventName,
-			properties: mockTelemetryEvent,
-		};
-
-		sinonAssert.calledWith(trackEventSpy, expectedAppInsightsEvent);
-	});
-
-	it("constructor() throws error when filter config with duplicate namespaces is provided", () => {
-		const invalidConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "inclusive",
-				filters: [
-					{
-						namespacePattern: "A:B:C",
-					},
-					{
-						namespacePattern: "A:B:C",
-					},
-				],
-			},
-		};
-		assert.throws(
-			() => createLogger(appInsightsClient, invalidConfig),
-			new Error("Cannot have duplicate namespace pattern filters"),
-		);
-	});
-
-	it("constructor() throws error when filter config with namespace pattern exception that is not part of the parent pattern is provided", () => {
-		const invalidConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "inclusive",
-				filters: [
-					{
-						namespacePattern: "A:B:C",
-						namespacePatternExceptions: new Set(["D:C:A"]),
-					},
-				],
-			},
-		};
-		assert.throws(
-			() => createLogger(appInsightsClient, invalidConfig),
-			new Error(
-				"Cannot have a namespace pattern exception that is not a child of the parent namespace",
-			),
-		);
-	});
-
-	it("constructor() throws error when multiple filters that only define categories are provided", () => {
-		const invalidConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "inclusive",
-				filters: [
-					{
-						categories: ["error"],
-					},
-					{
-						categories: ["generic", "performance"],
-					},
-				],
-			},
-		};
-		assert.throws(
-			() => createLogger(appInsightsClient, invalidConfig),
-			new Error("Cannot have multiple filters that only define categories"),
-		);
-	});
-});
-
-describe("Telemetry Filter - filter mode", () => {
-	let appInsightsClient: ApplicationInsights;
-	let trackEventSpy: Sinon.SinonSpy;
 
 	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
@@ -136,631 +33,689 @@ describe("Telemetry Filter - filter mode", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
-	beforeEach(function createTrackEventSpy() {
-		trackEventSpy = spy(appInsightsClient, "trackEvent");
-	});
+	describe("FluidAppInsightsLogger", () => {
+		let trackEventSpy: Sinon.SinonSpy;
 
-	afterEach(function restoreSpy() {
-		trackEventSpy.restore();
-	});
-
-	it("exclusive filter mode sends all events when no filters are defined", () => {
-		const logger = createLogger(appInsightsClient, {
-			filtering: {
-				mode: "exclusive",
-			},
+		beforeEach(function createTrackEventSpy() {
+			trackEventSpy = spy(appInsightsClient, "trackEvent");
 		});
 
-		const perfCategoryEvent = {
-			category: "performance",
-			eventName: "perfCategoryEventName",
-		};
-
-		logger.send(perfCategoryEvent);
-
-		// Expect all events to be sent in exclusive mode
-		sinonAssert.callCount(trackEventSpy, 1);
-	});
-
-	it("inclusive filter mode sends no events when no filters are defined", () => {
-		const logger = createLogger(appInsightsClient, {
-			filtering: {
-				mode: "inclusive",
-			},
+		afterEach(function restoreSpy() {
+			trackEventSpy.restore();
 		});
 
-		const perfCategoryEvent = {
-			category: "performance",
-			eventName: "perfCategoryEventName",
-		};
+		it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
+			const logger = createLogger(appInsightsClient);
 
-		logger.send(perfCategoryEvent);
+			const mockTelemetryEvent = {
+				category: "mockEvent",
+				eventName: "mockEventName",
+			};
+			logger.send(mockTelemetryEvent);
+			sinonAssert.calledOnce(trackEventSpy);
 
-		// Expect no events to be sent
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-});
+			const expectedAppInsightsEvent = {
+				name: mockTelemetryEvent.eventName,
+				properties: mockTelemetryEvent,
+			};
 
-describe("Telemetry Filter - Category Filtering", () => {
-	let appInsightsClient: ApplicationInsights;
-	let trackEventSpy: Sinon.SinonSpy;
-	const configFilters: TelemetryFilter[] = [
-		{
-			categories: ["performance", "generic"],
-		},
-	];
-	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-		filtering: {
-			mode: "exclusive",
-			filters: configFilters,
-		},
-	};
-	const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-		filtering: {
-			mode: "inclusive",
-			filters: configFilters,
-		},
-	};
-
-	before(function initializeAppInsights() {
-		appInsightsClient = new ApplicationInsights({
-			config: {
-				connectionString:
-					// (this is an example string)
-					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
-			},
-		});
-		appInsightsClient.loadAppInsights();
-	});
-
-	beforeEach(function createTrackEventSpy() {
-		trackEventSpy = spy(appInsightsClient, "trackEvent");
-	});
-
-	afterEach(function restoreSpy() {
-		trackEventSpy.restore();
-	});
-
-	it("exclusive filtering mode DOES NOT SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
-		const logger = createLogger(appInsightsClient, {
-			filtering: {
-				mode: "exclusive",
-				filters: [
-					{
-						categories: ["performance", "generic"],
-					},
-				],
-			},
+			sinonAssert.calledWith(trackEventSpy, expectedAppInsightsEvent);
 		});
 
-		// should be excluded - matches category filter
-		const event = {
-			category: "performance",
-			eventName: "perf:runtime:container",
-		};
-		// should be excluded - matches category filter
-		const event2 = {
-			category: "generic",
-			eventName: "perf:runtime:container",
-		};
-		logger.send(event);
-		logger.send(event2);
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-
-	it("exclusive filter mode DOES NOT SEND events that DO MATCH with one of multiple category filters", () => {
-		const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-		// should be excluded - match with category in filter
-		const event1 = {
-			category: "performance",
-			eventName: "perf:latency:ops",
-		};
-		// should be excluded - match with category in filter
-		const event2 = {
-			category: "generic",
-			eventName: "perf:memory:container",
-		};
-		logger.send(event1);
-		logger.send(event2);
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-
-	it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple category filters", () => {
-		const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-		// should be included - does not match any category filter
-		const event = {
-			category: "error",
-			eventName: "perf:runtime:container",
-		};
-
-		logger.send(event);
-
-		const expectedAppInsightsSentEvent: IEventTelemetry = {
-			name: event.eventName,
-			properties: {
-				...event,
-			},
-		};
-		sinonAssert.callCount(trackEventSpy, 1);
-		for (const call of trackEventSpy.getCalls()) {
-			sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
-		}
-	});
-
-	// ------------------------------------------------------------------------------------
-
-	it("inclusive filtering mode DOES SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
-		const logger = createLogger(appInsightsClient, {
-			filtering: {
-				mode: "inclusive",
-				filters: [
-					{
-						categories: ["performance", "generic"],
-					},
-				],
-			},
+		it("constructor() throws error when filter config with duplicate namespaces is provided", () => {
+			const invalidConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "inclusive",
+					filters: [
+						{
+							namespacePattern: "A:B:C",
+						},
+						{
+							namespacePattern: "A:B:C",
+						},
+					],
+				},
+			};
+			assert.throws(
+				() => createLogger(appInsightsClient, invalidConfig),
+				new Error("Cannot have duplicate namespace pattern filters"),
+			);
 		});
 
-		// should be included - matches category filter
-		const event = {
-			category: "performance",
-			eventName: "perf:runtime:container",
-		};
-		// should be included - matches category filter
-		const event2 = {
-			category: "generic",
-			eventName: "perf:runtime:container",
-		};
-		logger.send(event);
-		logger.send(event2);
-		sinonAssert.callCount(trackEventSpy, 2);
-	});
-
-	it("inclusive filter mode DOES SEND events that DO MATCH with one of multiple category filters", () => {
-		const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-		// should be included - match with category filter
-		const event1 = {
-			category: "performance",
-			eventName: "perf:latency:ops",
-		};
-		// should be included - match with category filter
-		const event2 = {
-			category: "generic",
-			eventName: "perf:memory:container",
-		};
-		logger.send(event1);
-		logger.send(event2);
-		sinonAssert.callCount(trackEventSpy, 2);
-	});
-
-	it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple category filters", () => {
-		const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-		// should be excluded - does not match any category filter
-		const event = {
-			category: "error",
-			eventName: "perf:runtime:container",
-		};
-
-		logger.send(event);
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-});
-
-describe("Telemetry Filter - Namespace Filtering", () => {
-	let appInsightsClient: ApplicationInsights;
-	let trackEventSpy: Sinon.SinonSpy;
-	const namespaceFilterPattern1 = "perf:latency";
-	const namespaceFilterPattern2 = "perf:memory";
-	const namespaceFilterPattern1Exception = `${namespaceFilterPattern1}:ops`;
-	const namespaceFilterPattern2Exception = `${namespaceFilterPattern2}:container`;
-	const configFilters: TelemetryFilter[] = [
-		{
-			namespacePattern: namespaceFilterPattern1,
-			namespacePatternExceptions: new Set([namespaceFilterPattern1Exception]),
-		},
-		{
-			namespacePattern: namespaceFilterPattern2,
-			namespacePatternExceptions: new Set([namespaceFilterPattern2Exception]),
-		},
-	];
-	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-		filtering: {
-			mode: "exclusive",
-			filters: configFilters,
-		},
-	};
-	const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-		filtering: {
-			mode: "inclusive",
-			filters: configFilters,
-		},
-	};
-
-	before(function initializeAppInsights() {
-		appInsightsClient = new ApplicationInsights({
-			config: {
-				connectionString:
-					// (this is an example string)
-					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
-			},
-		});
-		appInsightsClient.loadAppInsights();
-	});
-
-	beforeEach(function createTrackEventSpy() {
-		trackEventSpy = spy(appInsightsClient, "trackEvent");
-	});
-
-	afterEach(function restoreSpy() {
-		trackEventSpy.restore();
-	});
-
-	it("exclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters", () => {
-		const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-		// should be excluded - partial match with namespace filter
-		const event1 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern1}:signals`,
-		};
-		// should be excluded - partial match with second namespace filter
-		const event2 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern2}:ops:summary`,
-		};
-		// should be excluded - perfect match with namespace filter
-		const event3 = {
-			category: "performance",
-			eventName: namespaceFilterPattern1,
-		};
-		// should be excluded - perfect match with second namespace filter
-		const event4 = {
-			category: "performance",
-			eventName: namespaceFilterPattern2,
-		};
-		logger.send(event1);
-		logger.send(event2);
-		logger.send(event3);
-		logger.send(event4);
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-
-	it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
-		const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-		// should be included - does not match any namespace filter
-		const event = {
-			category: "performance",
-			eventName: "perf:runtime:container",
-		};
-
-		logger.send(event);
-
-		const expectedAppInsightsSentEvent: IEventTelemetry = {
-			name: event.eventName,
-			properties: {
-				...event,
-			},
-		};
-		sinonAssert.callCount(trackEventSpy, 1);
-		for (const call of trackEventSpy.getCalls()) {
-			sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
-		}
-	});
-
-	it("exclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
-		const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-		// should be included - partial match with namespace filter but also partially matches namespace pattern exception
-		const event1 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern1Exception}:roundTripTime`,
-		};
-		// should be included - partial match with second namespace filter but also partially matches namespace pattern exception
-		const event2 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern2Exception}:summary`,
-		};
-		// should be included - partial match with namespace filter but also perfectly matches namespace pattern exception
-		const event3 = {
-			category: "performance",
-			eventName: namespaceFilterPattern1Exception,
-		};
-		// should be included - partial match with second namespace filter but also perfectly matches namespace pattern exception
-		const event4 = {
-			category: "performance",
-			eventName: namespaceFilterPattern2Exception,
-		};
-		logger.send(event1);
-		logger.send(event2);
-		logger.send(event3);
-		logger.send(event4);
-		sinonAssert.callCount(trackEventSpy, 4);
-	});
-
-	// ------------------------------------------------------------------------------------
-
-	it("inclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters", () => {
-		const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-		// should be included - partial match with namespace filter
-		const event1 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern1}:signals`,
-		};
-		// should be included - partial match with second namespace filter
-		const event2 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern2}:ops:summary`,
-		};
-		// should be included - perfect match with namespace filter
-		const event3 = {
-			category: "performance",
-			eventName: namespaceFilterPattern1,
-		};
-		// should be included - perfect match with second namespace filter
-		const event4 = {
-			category: "performance",
-			eventName: namespaceFilterPattern2,
-		};
-		logger.send(event1);
-		logger.send(event2);
-		logger.send(event3);
-		logger.send(event4);
-		sinonAssert.callCount(trackEventSpy, 4);
-	});
-
-	it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
-		const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-		// should be excluded - does not match any namespace filter
-		const event = {
-			category: "performance",
-			eventName: "perf:runtime:container",
-		};
-
-		logger.send(event);
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-
-	it("inclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
-		const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-		// should be excluded - partial match with namespace filter but also partially matches namespace pattern exception
-		const event1 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern1}:ops:roundTripTime`,
-		};
-		// should be excluded - partial match with second namespace filter but also partially matches namespace pattern exception
-		const event2 = {
-			category: "performance",
-			eventName: `${namespaceFilterPattern2}:container:summary`,
-		};
-		// should be excluded - partial match with namespace filter but also perfectly matches namespace pattern exception
-		const event3 = {
-			category: "performance",
-			eventName: namespaceFilterPattern1Exception,
-		};
-		// should be excluded - partial match with second namespace filter but also perfectly matches namespace pattern exception
-		const event4 = {
-			category: "performance",
-			eventName: namespaceFilterPattern2Exception,
-		};
-		logger.send(event1);
-		logger.send(event2);
-		logger.send(event3);
-		logger.send(event4);
-		sinonAssert.callCount(trackEventSpy, 0);
-	});
-
-	it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH the most specific filter despite matching more generic ones. ", () => {
-		const logger = createLogger(appInsightsClient, {
-			filtering: {
-				mode: "inclusive",
-				filters: [
-					{
-						namespacePattern: "A:B",
-						categories: ["generic", "error"],
-					},
-					{
-						namespacePattern: "A:B:C",
-						categories: ["error"],
-					},
-				],
-			},
+		it("constructor() throws error when filter config with namespace pattern exception that is not part of the parent pattern is provided", () => {
+			const invalidConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "inclusive",
+					filters: [
+						{
+							namespacePattern: "A:B:C",
+							namespacePatternExceptions: new Set(["D:C:A"]),
+						},
+					],
+				},
+			};
+			assert.throws(
+				() => createLogger(appInsightsClient, invalidConfig),
+				new Error(
+					"Cannot have a namespace pattern exception that is not a child of the parent namespace",
+				),
+			);
 		});
 
-		// should be excluded because the event matches the "A:B" filter but the "A:B:C" filter is more specific
-		// so it should be evaluated first and it only allows "errors".
-		const event1 = {
-			category: "generic",
-			eventName: "A:B:C",
-		};
+		it("constructor() throws error when multiple filters that only define categories are provided", () => {
+			const invalidConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "inclusive",
+					filters: [
+						{
+							categories: ["error"],
+						},
+						{
+							categories: ["generic", "performance"],
+						},
+					],
+				},
+			};
+			assert.throws(
+				() => createLogger(appInsightsClient, invalidConfig),
+				new Error("Cannot have multiple filters that only define categories"),
+			);
+		});
+	});
 
-		// should be included because it matches the "A:B:C" filter that should be getting applied to it
-		const event2 = {
-			category: "error",
-			eventName: "A:B:C",
-		};
+	describe("Telemetry Filter - filter mode", () => {
+		let trackEventSpy: Sinon.SinonSpy;
 
-		logger.send(event1);
-		logger.send(event2);
-		sinonAssert.callCount(trackEventSpy, 1);
-		for (const call of trackEventSpy.getCalls()) {
-			sinonAssert.calledWithExactly(call, {
-				name: event2.eventName,
-				properties: {
-					...event2,
+		beforeEach(function createTrackEventSpy() {
+			trackEventSpy = spy(appInsightsClient, "trackEvent");
+		});
+
+		afterEach(function restoreSpy() {
+			trackEventSpy.restore();
+		});
+
+		it("exclusive filter mode sends all events when no filters are defined", () => {
+			const logger = createLogger(appInsightsClient, {
+				filtering: {
+					mode: "exclusive",
 				},
 			});
-		}
-	});
-});
 
-describe("Telemetry Filter - Category & Namespace Combination Filtering", () => {
-	let appInsightsClient: ApplicationInsights;
-	let trackEventSpy: Sinon.SinonSpy;
-	const configFilters: TelemetryFilter[] = [
-		{
-			categories: ["performance"],
-			namespacePattern: "perf:latency",
-			namespacePatternExceptions: new Set(["perf:latency:ops"]),
-		},
-	];
-	const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-		filtering: {
-			mode: "exclusive",
-			filters: configFilters,
-		},
-	};
-	const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-		filtering: {
-			mode: "inclusive",
-			filters: configFilters,
-		},
-	};
+			const perfCategoryEvent = {
+				category: "performance",
+				eventName: "perfCategoryEventName",
+			};
 
-	before(function initializeAppInsights() {
-		appInsightsClient = new ApplicationInsights({
-			config: {
-				connectionString:
-					// (this is an example string)
-					"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
-			},
+			logger.send(perfCategoryEvent);
+
+			// Expect all events to be sent in exclusive mode
+			sinonAssert.callCount(trackEventSpy, 1);
 		});
-		appInsightsClient.loadAppInsights();
+
+		it("inclusive filter mode sends no events when no filters are defined", () => {
+			const logger = createLogger(appInsightsClient, {
+				filtering: {
+					mode: "inclusive",
+				},
+			});
+
+			const perfCategoryEvent = {
+				category: "performance",
+				eventName: "perfCategoryEventName",
+			};
+
+			logger.send(perfCategoryEvent);
+
+			// Expect no events to be sent
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
 	});
 
-	beforeEach(function createTrackEventSpy() {
-		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	describe("Telemetry Filter - Category Filtering", () => {
+		let trackEventSpy: Sinon.SinonSpy;
+		const configFilters: TelemetryFilter[] = [
+			{
+				categories: ["performance", "generic"],
+			},
+		];
+		const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "exclusive",
+				filters: configFilters,
+			},
+		};
+		const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "inclusive",
+				filters: configFilters,
+			},
+		};
+
+		beforeEach(function createTrackEventSpy() {
+			trackEventSpy = spy(appInsightsClient, "trackEvent");
+		});
+
+		afterEach(function restoreSpy() {
+			trackEventSpy.restore();
+		});
+
+		it("exclusive filtering mode DOES NOT SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
+			const logger = createLogger(appInsightsClient, {
+				filtering: {
+					mode: "exclusive",
+					filters: [
+						{
+							categories: ["performance", "generic"],
+						},
+					],
+				},
+			});
+
+			// should be excluded - matches category filter
+			const event = {
+				category: "performance",
+				eventName: "perf:runtime:container",
+			};
+			// should be excluded - matches category filter
+			const event2 = {
+				category: "generic",
+				eventName: "perf:runtime:container",
+			};
+			logger.send(event);
+			logger.send(event2);
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
+
+		it("exclusive filter mode DOES NOT SEND events that DO MATCH with one of multiple category filters", () => {
+			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+			// should be excluded - match with category in filter
+			const event1 = {
+				category: "performance",
+				eventName: "perf:latency:ops",
+			};
+			// should be excluded - match with category in filter
+			const event2 = {
+				category: "generic",
+				eventName: "perf:memory:container",
+			};
+			logger.send(event1);
+			logger.send(event2);
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
+
+		it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple category filters", () => {
+			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+			// should be included - does not match any category filter
+			const event = {
+				category: "error",
+				eventName: "perf:runtime:container",
+			};
+
+			logger.send(event);
+
+			const expectedAppInsightsSentEvent: IEventTelemetry = {
+				name: event.eventName,
+				properties: {
+					...event,
+				},
+			};
+			sinonAssert.callCount(trackEventSpy, 1);
+			for (const call of trackEventSpy.getCalls()) {
+				sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
+			}
+		});
+
+		// ------------------------------------------------------------------------------------
+
+		it("inclusive filtering mode DOES SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
+			const logger = createLogger(appInsightsClient, {
+				filtering: {
+					mode: "inclusive",
+					filters: [
+						{
+							categories: ["performance", "generic"],
+						},
+					],
+				},
+			});
+
+			// should be included - matches category filter
+			const event = {
+				category: "performance",
+				eventName: "perf:runtime:container",
+			};
+			// should be included - matches category filter
+			const event2 = {
+				category: "generic",
+				eventName: "perf:runtime:container",
+			};
+			logger.send(event);
+			logger.send(event2);
+			sinonAssert.callCount(trackEventSpy, 2);
+		});
+
+		it("inclusive filter mode DOES SEND events that DO MATCH with one of multiple category filters", () => {
+			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+			// should be included - match with category filter
+			const event1 = {
+				category: "performance",
+				eventName: "perf:latency:ops",
+			};
+			// should be included - match with category filter
+			const event2 = {
+				category: "generic",
+				eventName: "perf:memory:container",
+			};
+			logger.send(event1);
+			logger.send(event2);
+			sinonAssert.callCount(trackEventSpy, 2);
+		});
+
+		it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple category filters", () => {
+			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+			// should be excluded - does not match any category filter
+			const event = {
+				category: "error",
+				eventName: "perf:runtime:container",
+			};
+
+			logger.send(event);
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
 	});
 
-	afterEach(function restoreSpy() {
-		trackEventSpy.restore();
+	describe("Telemetry Filter - Namespace Filtering", () => {
+		let trackEventSpy: Sinon.SinonSpy;
+		const namespaceFilterPattern1 = "perf:latency";
+		const namespaceFilterPattern2 = "perf:memory";
+		const namespaceFilterPattern1Exception = `${namespaceFilterPattern1}:ops`;
+		const namespaceFilterPattern2Exception = `${namespaceFilterPattern2}:container`;
+		const configFilters: TelemetryFilter[] = [
+			{
+				namespacePattern: namespaceFilterPattern1,
+				namespacePatternExceptions: new Set([namespaceFilterPattern1Exception]),
+			},
+			{
+				namespacePattern: namespaceFilterPattern2,
+				namespacePatternExceptions: new Set([namespaceFilterPattern2Exception]),
+			},
+		];
+		const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "exclusive",
+				filters: configFilters,
+			},
+		};
+		const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "inclusive",
+				filters: configFilters,
+			},
+		};
+
+		beforeEach(function createTrackEventSpy() {
+			trackEventSpy = spy(appInsightsClient, "trackEvent");
+		});
+
+		afterEach(function restoreSpy() {
+			trackEventSpy.restore();
+		});
+
+		it("exclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters", () => {
+			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+			// should be excluded - partial match with namespace filter
+			const event1 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern1}:signals`,
+			};
+			// should be excluded - partial match with second namespace filter
+			const event2 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern2}:ops:summary`,
+			};
+			// should be excluded - perfect match with namespace filter
+			const event3 = {
+				category: "performance",
+				eventName: namespaceFilterPattern1,
+			};
+			// should be excluded - perfect match with second namespace filter
+			const event4 = {
+				category: "performance",
+				eventName: namespaceFilterPattern2,
+			};
+			logger.send(event1);
+			logger.send(event2);
+			logger.send(event3);
+			logger.send(event4);
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
+
+		it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
+			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+			// should be included - does not match any namespace filter
+			const event = {
+				category: "performance",
+				eventName: "perf:runtime:container",
+			};
+
+			logger.send(event);
+
+			const expectedAppInsightsSentEvent: IEventTelemetry = {
+				name: event.eventName,
+				properties: {
+					...event,
+				},
+			};
+			sinonAssert.callCount(trackEventSpy, 1);
+			for (const call of trackEventSpy.getCalls()) {
+				sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
+			}
+		});
+
+		it("exclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
+			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+			// should be included - partial match with namespace filter but also partially matches namespace pattern exception
+			const event1 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern1Exception}:roundTripTime`,
+			};
+			// should be included - partial match with second namespace filter but also partially matches namespace pattern exception
+			const event2 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern2Exception}:summary`,
+			};
+			// should be included - partial match with namespace filter but also perfectly matches namespace pattern exception
+			const event3 = {
+				category: "performance",
+				eventName: namespaceFilterPattern1Exception,
+			};
+			// should be included - partial match with second namespace filter but also perfectly matches namespace pattern exception
+			const event4 = {
+				category: "performance",
+				eventName: namespaceFilterPattern2Exception,
+			};
+			logger.send(event1);
+			logger.send(event2);
+			logger.send(event3);
+			logger.send(event4);
+			sinonAssert.callCount(trackEventSpy, 4);
+		});
+
+		// ------------------------------------------------------------------------------------
+
+		it("inclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters", () => {
+			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+			// should be included - partial match with namespace filter
+			const event1 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern1}:signals`,
+			};
+			// should be included - partial match with second namespace filter
+			const event2 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern2}:ops:summary`,
+			};
+			// should be included - perfect match with namespace filter
+			const event3 = {
+				category: "performance",
+				eventName: namespaceFilterPattern1,
+			};
+			// should be included - perfect match with second namespace filter
+			const event4 = {
+				category: "performance",
+				eventName: namespaceFilterPattern2,
+			};
+			logger.send(event1);
+			logger.send(event2);
+			logger.send(event3);
+			logger.send(event4);
+			sinonAssert.callCount(trackEventSpy, 4);
+		});
+
+		it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
+			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+			// should be excluded - does not match any namespace filter
+			const event = {
+				category: "performance",
+				eventName: "perf:runtime:container",
+			};
+
+			logger.send(event);
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
+
+		it("inclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
+			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+			// should be excluded - partial match with namespace filter but also partially matches namespace pattern exception
+			const event1 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern1}:ops:roundTripTime`,
+			};
+			// should be excluded - partial match with second namespace filter but also partially matches namespace pattern exception
+			const event2 = {
+				category: "performance",
+				eventName: `${namespaceFilterPattern2}:container:summary`,
+			};
+			// should be excluded - partial match with namespace filter but also perfectly matches namespace pattern exception
+			const event3 = {
+				category: "performance",
+				eventName: namespaceFilterPattern1Exception,
+			};
+			// should be excluded - partial match with second namespace filter but also perfectly matches namespace pattern exception
+			const event4 = {
+				category: "performance",
+				eventName: namespaceFilterPattern2Exception,
+			};
+			logger.send(event1);
+			logger.send(event2);
+			logger.send(event3);
+			logger.send(event4);
+			sinonAssert.callCount(trackEventSpy, 0);
+		});
+
+		it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH the most specific filter despite matching more generic ones. ", () => {
+			const logger = createLogger(appInsightsClient, {
+				filtering: {
+					mode: "inclusive",
+					filters: [
+						{
+							namespacePattern: "A:B",
+							categories: ["generic", "error"],
+						},
+						{
+							namespacePattern: "A:B:C",
+							categories: ["error"],
+						},
+					],
+				},
+			});
+
+			// should be excluded because the event matches the "A:B" filter but the "A:B:C" filter is more specific
+			// so it should be evaluated first and it only allows "errors".
+			const event1 = {
+				category: "generic",
+				eventName: "A:B:C",
+			};
+
+			// should be included because it matches the "A:B:C" filter that should be getting applied to it
+			const event2 = {
+				category: "error",
+				eventName: "A:B:C",
+			};
+
+			logger.send(event1);
+			logger.send(event2);
+			sinonAssert.callCount(trackEventSpy, 1);
+			for (const call of trackEventSpy.getCalls()) {
+				sinonAssert.calledWithExactly(call, {
+					name: event2.eventName,
+					properties: {
+						...event2,
+					},
+				});
+			}
+		});
 	});
 
-	it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
-		const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-
-		// should be included - does not match any filter
-		const event1 = {
-			category: "error",
-			eventName: "perf:runtime:container",
+	describe("Telemetry Filter - Category & Namespace Combination Filtering", () => {
+		let trackEventSpy: Sinon.SinonSpy;
+		const configFilters: TelemetryFilter[] = [
+			{
+				categories: ["performance"],
+				namespacePattern: "perf:latency",
+				namespacePatternExceptions: new Set(["perf:latency:ops"]),
+			},
+		];
+		const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "exclusive",
+				filters: configFilters,
+			},
+		};
+		const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "inclusive",
+				filters: configFilters,
+			},
 		};
 
-		// should be included - only partial matches namespace filter but not category
-		const event2 = {
-			category: "error",
-			eventName: "perf:latency:ops:delta",
-		};
+		beforeEach(function createTrackEventSpy() {
+			trackEventSpy = spy(appInsightsClient, "trackEvent");
+		});
 
-		// should be included - partial namespace match and category match but also matches exception.
-		const event3 = {
-			category: "performance",
-			eventName: "perf:latency:ops:delta",
-		};
+		afterEach(function restoreSpy() {
+			trackEventSpy.restore();
+		});
 
-		// should be excluded - perfect namespace and category match.
-		const event4 = {
-			category: "performance",
-			eventName: "perf:latency",
-		};
+		it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
+			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
 
-		// should be excluded - partial namespace match and category match.
-		const event5 = {
-			category: "performance",
-			eventName: "perf:latency:container:syncTime",
-		};
+			// should be included - does not match any filter
+			const event1 = {
+				category: "error",
+				eventName: "perf:runtime:container",
+			};
 
-		logger.send(event1);
-		logger.send(event2);
-		logger.send(event3);
-		logger.send(event4);
-		logger.send(event5);
+			// should be included - only partial matches namespace filter but not category
+			const event2 = {
+				category: "error",
+				eventName: "perf:latency:ops:delta",
+			};
 
-		const actualSentEvent1 = trackEventSpy.getCalls().filter((call) =>
-			call.calledWithExactly({
-				name: event1.eventName,
-				properties: {
-					...event1,
-				},
-			}),
-		);
-		const actualSentEvent2 = trackEventSpy.getCalls().filter((call) =>
-			call.calledWithExactly({
-				name: event2.eventName,
-				properties: {
-					...event2,
-				},
-			}),
-		);
-		const actualSentEvent3 = trackEventSpy.getCalls().filter((call) =>
-			call.calledWithExactly({
-				name: event3.eventName,
-				properties: {
-					...event3,
-				},
-			}),
-		);
+			// should be included - partial namespace match and category match but also matches exception.
+			const event3 = {
+				category: "performance",
+				eventName: "perf:latency:ops:delta",
+			};
 
-		sinonAssert.callCount(trackEventSpy, 3);
-		assert.strictEqual(actualSentEvent1.length, 1);
-		assert.strictEqual(actualSentEvent2.length, 1);
-		assert.strictEqual(actualSentEvent3.length, 1);
-	});
+			// should be excluded - perfect namespace and category match.
+			const event4 = {
+				category: "performance",
+				eventName: "perf:latency",
+			};
 
-	it("inclusive filter mode DOES SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
-		const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+			// should be excluded - partial namespace match and category match.
+			const event5 = {
+				category: "performance",
+				eventName: "perf:latency:container:syncTime",
+			};
 
-		// should be excluded - does not match any filter
-		const event1 = {
-			category: "error",
-			eventName: "perf:runtime:container",
-		};
+			logger.send(event1);
+			logger.send(event2);
+			logger.send(event3);
+			logger.send(event4);
+			logger.send(event5);
 
-		// should be excluded - only partial matches namespace filter but not category
-		const event2 = {
-			category: "error",
-			eventName: "perf:latency:ops:delta",
-		};
+			const actualSentEvent1 = trackEventSpy.getCalls().filter((call) =>
+				call.calledWithExactly({
+					name: event1.eventName,
+					properties: {
+						...event1,
+					},
+				}),
+			);
+			const actualSentEvent2 = trackEventSpy.getCalls().filter((call) =>
+				call.calledWithExactly({
+					name: event2.eventName,
+					properties: {
+						...event2,
+					},
+				}),
+			);
+			const actualSentEvent3 = trackEventSpy.getCalls().filter((call) =>
+				call.calledWithExactly({
+					name: event3.eventName,
+					properties: {
+						...event3,
+					},
+				}),
+			);
 
-		// should be excluded - partial namespace match and category match but also matches exception.
-		const event3 = {
-			category: "performance",
-			eventName: "perf:latency:ops:delta",
-		};
+			sinonAssert.callCount(trackEventSpy, 3);
+			assert.strictEqual(actualSentEvent1.length, 1);
+			assert.strictEqual(actualSentEvent2.length, 1);
+			assert.strictEqual(actualSentEvent3.length, 1);
+		});
 
-		// should be included - perfect namespace and category match.
-		const event4 = {
-			category: "performance",
-			eventName: "perf:latency",
-		};
+		it("inclusive filter mode DOES SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
+			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
 
-		// should be included - partial namespace match and category match.
-		const event5 = {
-			category: "performance",
-			eventName: "perf:latency:container:syncTime",
-		};
+			// should be excluded - does not match any filter
+			const event1 = {
+				category: "error",
+				eventName: "perf:runtime:container",
+			};
 
-		logger.send(event1);
-		logger.send(event2);
-		logger.send(event3);
-		logger.send(event4);
-		logger.send(event5);
+			// should be excluded - only partial matches namespace filter but not category
+			const event2 = {
+				category: "error",
+				eventName: "perf:latency:ops:delta",
+			};
 
-		const actualSentEvent4 = trackEventSpy.getCalls().filter((call) =>
-			call.calledWithExactly({
-				name: event4.eventName,
-				properties: {
-					...event4,
-				},
-			}),
-		);
-		const actualSentEvent5 = trackEventSpy.getCalls().filter((call) =>
-			call.calledWithExactly({
-				name: event4.eventName,
-				properties: {
-					...event4,
-				},
-			}),
-		);
+			// should be excluded - partial namespace match and category match but also matches exception.
+			const event3 = {
+				category: "performance",
+				eventName: "perf:latency:ops:delta",
+			};
 
-		sinonAssert.callCount(trackEventSpy, 2);
-		assert.strictEqual(actualSentEvent4.length, 1);
-		assert.strictEqual(actualSentEvent5.length, 1);
+			// should be included - perfect namespace and category match.
+			const event4 = {
+				category: "performance",
+				eventName: "perf:latency",
+			};
+
+			// should be included - partial namespace match and category match.
+			const event5 = {
+				category: "performance",
+				eventName: "perf:latency:container:syncTime",
+			};
+
+			logger.send(event1);
+			logger.send(event2);
+			logger.send(event3);
+			logger.send(event4);
+			logger.send(event5);
+
+			const actualSentEvent4 = trackEventSpy.getCalls().filter((call) =>
+				call.calledWithExactly({
+					name: event4.eventName,
+					properties: {
+						...event4,
+					},
+				}),
+			);
+			const actualSentEvent5 = trackEventSpy.getCalls().filter((call) =>
+				call.calledWithExactly({
+					name: event4.eventName,
+					properties: {
+						...event4,
+					},
+				}),
+			);
+
+			sinonAssert.callCount(trackEventSpy, 2);
+			assert.strictEqual(actualSentEvent4.length, 1);
+			assert.strictEqual(actualSentEvent5.length, 1);
+		});
 	});
 });

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -21,6 +21,7 @@ import {
 // loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
 describe("fluidAppInsightsLogger tests", () => {
 	let appInsightsClient: ApplicationInsights;
+	let trackEventSpy: Sinon.SinonSpy;
 
 	before(function initializeAppInsights() {
 		appInsightsClient = new ApplicationInsights({
@@ -33,17 +34,15 @@ describe("fluidAppInsightsLogger tests", () => {
 		appInsightsClient.loadAppInsights();
 	});
 
+	beforeEach(function createTrackEventSpy() {
+		trackEventSpy = spy(appInsightsClient, "trackEvent");
+	});
+
+	afterEach(function restoreSpy() {
+		trackEventSpy.restore();
+	});
+
 	describe("FluidAppInsightsLogger", () => {
-		let trackEventSpy: Sinon.SinonSpy;
-
-		beforeEach(function createTrackEventSpy() {
-			trackEventSpy = spy(appInsightsClient, "trackEvent");
-		});
-
-		afterEach(function restoreSpy() {
-			trackEventSpy.restore();
-		});
-
 		it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
 			const logger = createLogger(appInsightsClient);
 
@@ -124,16 +123,6 @@ describe("fluidAppInsightsLogger tests", () => {
 	});
 
 	describe("Telemetry Filter - filter mode", () => {
-		let trackEventSpy: Sinon.SinonSpy;
-
-		beforeEach(function createTrackEventSpy() {
-			trackEventSpy = spy(appInsightsClient, "trackEvent");
-		});
-
-		afterEach(function restoreSpy() {
-			trackEventSpy.restore();
-		});
-
 		it("exclusive filter mode sends all events when no filters are defined", () => {
 			const logger = createLogger(appInsightsClient, {
 				filtering: {
@@ -172,7 +161,6 @@ describe("fluidAppInsightsLogger tests", () => {
 	});
 
 	describe("Telemetry Filter - Category Filtering", () => {
-		let trackEventSpy: Sinon.SinonSpy;
 		const configFilters: TelemetryFilter[] = [
 			{
 				categories: ["performance", "generic"],
@@ -190,14 +178,6 @@ describe("fluidAppInsightsLogger tests", () => {
 				filters: configFilters,
 			},
 		};
-
-		beforeEach(function createTrackEventSpy() {
-			trackEventSpy = spy(appInsightsClient, "trackEvent");
-		});
-
-		afterEach(function restoreSpy() {
-			trackEventSpy.restore();
-		});
 
 		it("exclusive filtering mode DOES NOT SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
 			const logger = createLogger(appInsightsClient, {
@@ -325,7 +305,6 @@ describe("fluidAppInsightsLogger tests", () => {
 	});
 
 	describe("Telemetry Filter - Namespace Filtering", () => {
-		let trackEventSpy: Sinon.SinonSpy;
 		const namespaceFilterPattern1 = "perf:latency";
 		const namespaceFilterPattern2 = "perf:memory";
 		const namespaceFilterPattern1Exception = `${namespaceFilterPattern1}:ops`;
@@ -352,14 +331,6 @@ describe("fluidAppInsightsLogger tests", () => {
 				filters: configFilters,
 			},
 		};
-
-		beforeEach(function createTrackEventSpy() {
-			trackEventSpy = spy(appInsightsClient, "trackEvent");
-		});
-
-		afterEach(function restoreSpy() {
-			trackEventSpy.restore();
-		});
 
 		it("exclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters", () => {
 			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
@@ -558,7 +529,6 @@ describe("fluidAppInsightsLogger tests", () => {
 	});
 
 	describe("Telemetry Filter - Category & Namespace Combination Filtering", () => {
-		let trackEventSpy: Sinon.SinonSpy;
 		const configFilters: TelemetryFilter[] = [
 			{
 				categories: ["performance"],
@@ -578,14 +548,6 @@ describe("fluidAppInsightsLogger tests", () => {
 				filters: configFilters,
 			},
 		};
-
-		beforeEach(function createTrackEventSpy() {
-			trackEventSpy = spy(appInsightsClient, "trackEvent");
-		});
-
-		afterEach(function restoreSpy() {
-			trackEventSpy.restore();
-		});
 
 		it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
 			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -19,7 +19,7 @@ import {
 // Without loadAppInsights(), the first trackEvent call triggers an expensive fallback
 // initialization path (~250ms locally, potentially much worse in CI). Calling
 // loadAppInsights() up front avoids that path entirely, reducing first trackEvent to ~1ms.
-describe("fluidAppInsightsLogger tests", () => {
+describe("FluidAppInsightsLogger", () => {
 	let appInsightsClient: ApplicationInsights;
 	let trackEventSpy: Sinon.SinonSpy;
 
@@ -42,642 +42,642 @@ describe("fluidAppInsightsLogger tests", () => {
 		trackEventSpy.restore();
 	});
 
-	describe("FluidAppInsightsLogger", () => {
-		it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
-			const logger = createLogger(appInsightsClient);
+	it("send() routes telemetry events to ApplicationInsights.trackEvent", () => {
+		const logger = createLogger(appInsightsClient);
 
-			const mockTelemetryEvent = {
-				category: "mockEvent",
-				eventName: "mockEventName",
-			};
-			logger.send(mockTelemetryEvent);
-			sinonAssert.calledOnce(trackEventSpy);
-
-			const expectedAppInsightsEvent = {
-				name: mockTelemetryEvent.eventName,
-				properties: mockTelemetryEvent,
-			};
-
-			sinonAssert.calledWith(trackEventSpy, expectedAppInsightsEvent);
-		});
-
-		it("constructor() throws error when filter config with duplicate namespaces is provided", () => {
-			const invalidConfig: FluidAppInsightsLoggerConfig = {
-				filtering: {
-					mode: "inclusive",
-					filters: [
-						{
-							namespacePattern: "A:B:C",
-						},
-						{
-							namespacePattern: "A:B:C",
-						},
-					],
-				},
-			};
-			assert.throws(
-				() => createLogger(appInsightsClient, invalidConfig),
-				new Error("Cannot have duplicate namespace pattern filters"),
-			);
-		});
-
-		it("constructor() throws error when filter config with namespace pattern exception that is not part of the parent pattern is provided", () => {
-			const invalidConfig: FluidAppInsightsLoggerConfig = {
-				filtering: {
-					mode: "inclusive",
-					filters: [
-						{
-							namespacePattern: "A:B:C",
-							namespacePatternExceptions: new Set(["D:C:A"]),
-						},
-					],
-				},
-			};
-			assert.throws(
-				() => createLogger(appInsightsClient, invalidConfig),
-				new Error(
-					"Cannot have a namespace pattern exception that is not a child of the parent namespace",
-				),
-			);
-		});
-
-		it("constructor() throws error when multiple filters that only define categories are provided", () => {
-			const invalidConfig: FluidAppInsightsLoggerConfig = {
-				filtering: {
-					mode: "inclusive",
-					filters: [
-						{
-							categories: ["error"],
-						},
-						{
-							categories: ["generic", "performance"],
-						},
-					],
-				},
-			};
-			assert.throws(
-				() => createLogger(appInsightsClient, invalidConfig),
-				new Error("Cannot have multiple filters that only define categories"),
-			);
-		});
-	});
-
-	describe("Telemetry Filter - filter mode", () => {
-		it("exclusive filter mode sends all events when no filters are defined", () => {
-			const logger = createLogger(appInsightsClient, {
-				filtering: {
-					mode: "exclusive",
-				},
-			});
-
-			const perfCategoryEvent = {
-				category: "performance",
-				eventName: "perfCategoryEventName",
-			};
-
-			logger.send(perfCategoryEvent);
-
-			// Expect all events to be sent in exclusive mode
-			sinonAssert.callCount(trackEventSpy, 1);
-		});
-
-		it("inclusive filter mode sends no events when no filters are defined", () => {
-			const logger = createLogger(appInsightsClient, {
-				filtering: {
-					mode: "inclusive",
-				},
-			});
-
-			const perfCategoryEvent = {
-				category: "performance",
-				eventName: "perfCategoryEventName",
-			};
-
-			logger.send(perfCategoryEvent);
-
-			// Expect no events to be sent
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
-	});
-
-	describe("Telemetry Filter - Category Filtering", () => {
-		const configFilters: TelemetryFilter[] = [
-			{
-				categories: ["performance", "generic"],
-			},
-		];
-		const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "exclusive",
-				filters: configFilters,
-			},
+		const mockTelemetryEvent = {
+			category: "mockEvent",
+			eventName: "mockEventName",
 		};
-		const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+		logger.send(mockTelemetryEvent);
+		sinonAssert.calledOnce(trackEventSpy);
+
+		const expectedAppInsightsEvent = {
+			name: mockTelemetryEvent.eventName,
+			properties: mockTelemetryEvent,
+		};
+
+		sinonAssert.calledWith(trackEventSpy, expectedAppInsightsEvent);
+	});
+
+	it("constructor() throws error when filter config with duplicate namespaces is provided", () => {
+		const invalidConfig: FluidAppInsightsLoggerConfig = {
 			filtering: {
 				mode: "inclusive",
-				filters: configFilters,
+				filters: [
+					{
+						namespacePattern: "A:B:C",
+					},
+					{
+						namespacePattern: "A:B:C",
+					},
+				],
 			},
 		};
-
-		it("exclusive filtering mode DOES NOT SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
-			const logger = createLogger(appInsightsClient, {
-				filtering: {
-					mode: "exclusive",
-					filters: [
-						{
-							categories: ["performance", "generic"],
-						},
-					],
-				},
-			});
-
-			// should be excluded - matches category filter
-			const event = {
-				category: "performance",
-				eventName: "perf:runtime:container",
-			};
-			// should be excluded - matches category filter
-			const event2 = {
-				category: "generic",
-				eventName: "perf:runtime:container",
-			};
-			logger.send(event);
-			logger.send(event2);
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
-
-		it("exclusive filter mode DOES NOT SEND events that DO MATCH with one of multiple category filters", () => {
-			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-			// should be excluded - match with category in filter
-			const event1 = {
-				category: "performance",
-				eventName: "perf:latency:ops",
-			};
-			// should be excluded - match with category in filter
-			const event2 = {
-				category: "generic",
-				eventName: "perf:memory:container",
-			};
-			logger.send(event1);
-			logger.send(event2);
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
-
-		it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple category filters", () => {
-			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-			// should be included - does not match any category filter
-			const event = {
-				category: "error",
-				eventName: "perf:runtime:container",
-			};
-
-			logger.send(event);
-
-			const expectedAppInsightsSentEvent: IEventTelemetry = {
-				name: event.eventName,
-				properties: {
-					...event,
-				},
-			};
-			sinonAssert.callCount(trackEventSpy, 1);
-			for (const call of trackEventSpy.getCalls()) {
-				sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
-			}
-		});
-
-		// ------------------------------------------------------------------------------------
-
-		it("inclusive filtering mode DOES SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
-			const logger = createLogger(appInsightsClient, {
-				filtering: {
-					mode: "inclusive",
-					filters: [
-						{
-							categories: ["performance", "generic"],
-						},
-					],
-				},
-			});
-
-			// should be included - matches category filter
-			const event = {
-				category: "performance",
-				eventName: "perf:runtime:container",
-			};
-			// should be included - matches category filter
-			const event2 = {
-				category: "generic",
-				eventName: "perf:runtime:container",
-			};
-			logger.send(event);
-			logger.send(event2);
-			sinonAssert.callCount(trackEventSpy, 2);
-		});
-
-		it("inclusive filter mode DOES SEND events that DO MATCH with one of multiple category filters", () => {
-			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-			// should be included - match with category filter
-			const event1 = {
-				category: "performance",
-				eventName: "perf:latency:ops",
-			};
-			// should be included - match with category filter
-			const event2 = {
-				category: "generic",
-				eventName: "perf:memory:container",
-			};
-			logger.send(event1);
-			logger.send(event2);
-			sinonAssert.callCount(trackEventSpy, 2);
-		});
-
-		it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple category filters", () => {
-			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-			// should be excluded - does not match any category filter
-			const event = {
-				category: "error",
-				eventName: "perf:runtime:container",
-			};
-
-			logger.send(event);
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
+		assert.throws(
+			() => createLogger(appInsightsClient, invalidConfig),
+			new Error("Cannot have duplicate namespace pattern filters"),
+		);
 	});
 
-	describe("Telemetry Filter - Namespace Filtering", () => {
-		const namespaceFilterPattern1 = "perf:latency";
-		const namespaceFilterPattern2 = "perf:memory";
-		const namespaceFilterPattern1Exception = `${namespaceFilterPattern1}:ops`;
-		const namespaceFilterPattern2Exception = `${namespaceFilterPattern2}:container`;
-		const configFilters: TelemetryFilter[] = [
-			{
-				namespacePattern: namespaceFilterPattern1,
-				namespacePatternExceptions: new Set([namespaceFilterPattern1Exception]),
-			},
-			{
-				namespacePattern: namespaceFilterPattern2,
-				namespacePatternExceptions: new Set([namespaceFilterPattern2Exception]),
-			},
-		];
-		const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "exclusive",
-				filters: configFilters,
-			},
-		};
-		const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+	it("constructor() throws error when filter config with namespace pattern exception that is not part of the parent pattern is provided", () => {
+		const invalidConfig: FluidAppInsightsLoggerConfig = {
 			filtering: {
 				mode: "inclusive",
-				filters: configFilters,
+				filters: [
+					{
+						namespacePattern: "A:B:C",
+						namespacePatternExceptions: new Set(["D:C:A"]),
+					},
+				],
 			},
 		};
+		assert.throws(
+			() => createLogger(appInsightsClient, invalidConfig),
+			new Error(
+				"Cannot have a namespace pattern exception that is not a child of the parent namespace",
+			),
+		);
+	});
 
-		it("exclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters", () => {
-			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-			// should be excluded - partial match with namespace filter
-			const event1 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern1}:signals`,
-			};
-			// should be excluded - partial match with second namespace filter
-			const event2 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern2}:ops:summary`,
-			};
-			// should be excluded - perfect match with namespace filter
-			const event3 = {
-				category: "performance",
-				eventName: namespaceFilterPattern1,
-			};
-			// should be excluded - perfect match with second namespace filter
-			const event4 = {
-				category: "performance",
-				eventName: namespaceFilterPattern2,
-			};
-			logger.send(event1);
-			logger.send(event2);
-			logger.send(event3);
-			logger.send(event4);
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
+	it("constructor() throws error when multiple filters that only define categories are provided", () => {
+		const invalidConfig: FluidAppInsightsLoggerConfig = {
+			filtering: {
+				mode: "inclusive",
+				filters: [
+					{
+						categories: ["error"],
+					},
+					{
+						categories: ["generic", "performance"],
+					},
+				],
+			},
+		};
+		assert.throws(
+			() => createLogger(appInsightsClient, invalidConfig),
+			new Error("Cannot have multiple filters that only define categories"),
+		);
+	});
 
-		it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
-			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-			// should be included - does not match any namespace filter
-			const event = {
-				category: "performance",
-				eventName: "perf:runtime:container",
-			};
-
-			logger.send(event);
-
-			const expectedAppInsightsSentEvent: IEventTelemetry = {
-				name: event.eventName,
-				properties: {
-					...event,
-				},
-			};
-			sinonAssert.callCount(trackEventSpy, 1);
-			for (const call of trackEventSpy.getCalls()) {
-				sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
-			}
-		});
-
-		it("exclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
-			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
-			// should be included - partial match with namespace filter but also partially matches namespace pattern exception
-			const event1 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern1Exception}:roundTripTime`,
-			};
-			// should be included - partial match with second namespace filter but also partially matches namespace pattern exception
-			const event2 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern2Exception}:summary`,
-			};
-			// should be included - partial match with namespace filter but also perfectly matches namespace pattern exception
-			const event3 = {
-				category: "performance",
-				eventName: namespaceFilterPattern1Exception,
-			};
-			// should be included - partial match with second namespace filter but also perfectly matches namespace pattern exception
-			const event4 = {
-				category: "performance",
-				eventName: namespaceFilterPattern2Exception,
-			};
-			logger.send(event1);
-			logger.send(event2);
-			logger.send(event3);
-			logger.send(event4);
-			sinonAssert.callCount(trackEventSpy, 4);
-		});
-
-		// ------------------------------------------------------------------------------------
-
-		it("inclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters", () => {
-			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-			// should be included - partial match with namespace filter
-			const event1 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern1}:signals`,
-			};
-			// should be included - partial match with second namespace filter
-			const event2 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern2}:ops:summary`,
-			};
-			// should be included - perfect match with namespace filter
-			const event3 = {
-				category: "performance",
-				eventName: namespaceFilterPattern1,
-			};
-			// should be included - perfect match with second namespace filter
-			const event4 = {
-				category: "performance",
-				eventName: namespaceFilterPattern2,
-			};
-			logger.send(event1);
-			logger.send(event2);
-			logger.send(event3);
-			logger.send(event4);
-			sinonAssert.callCount(trackEventSpy, 4);
-		});
-
-		it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
-			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-			// should be excluded - does not match any namespace filter
-			const event = {
-				category: "performance",
-				eventName: "perf:runtime:container",
-			};
-
-			logger.send(event);
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
-
-		it("inclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
-			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-			// should be excluded - partial match with namespace filter but also partially matches namespace pattern exception
-			const event1 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern1}:ops:roundTripTime`,
-			};
-			// should be excluded - partial match with second namespace filter but also partially matches namespace pattern exception
-			const event2 = {
-				category: "performance",
-				eventName: `${namespaceFilterPattern2}:container:summary`,
-			};
-			// should be excluded - partial match with namespace filter but also perfectly matches namespace pattern exception
-			const event3 = {
-				category: "performance",
-				eventName: namespaceFilterPattern1Exception,
-			};
-			// should be excluded - partial match with second namespace filter but also perfectly matches namespace pattern exception
-			const event4 = {
-				category: "performance",
-				eventName: namespaceFilterPattern2Exception,
-			};
-			logger.send(event1);
-			logger.send(event2);
-			logger.send(event3);
-			logger.send(event4);
-			sinonAssert.callCount(trackEventSpy, 0);
-		});
-
-		it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH the most specific filter despite matching more generic ones. ", () => {
-			const logger = createLogger(appInsightsClient, {
-				filtering: {
-					mode: "inclusive",
-					filters: [
-						{
-							namespacePattern: "A:B",
-							categories: ["generic", "error"],
-						},
-						{
-							namespacePattern: "A:B:C",
-							categories: ["error"],
-						},
-					],
-				},
-			});
-
-			// should be excluded because the event matches the "A:B" filter but the "A:B:C" filter is more specific
-			// so it should be evaluated first and it only allows "errors".
-			const event1 = {
-				category: "generic",
-				eventName: "A:B:C",
-			};
-
-			// should be included because it matches the "A:B:C" filter that should be getting applied to it
-			const event2 = {
-				category: "error",
-				eventName: "A:B:C",
-			};
-
-			logger.send(event1);
-			logger.send(event2);
-			sinonAssert.callCount(trackEventSpy, 1);
-			for (const call of trackEventSpy.getCalls()) {
-				sinonAssert.calledWithExactly(call, {
-					name: event2.eventName,
-					properties: {
-						...event2,
+	describe("Telemetry Filter", () => {
+		describe("filter mode defaults", () => {
+			it("exclusive filter mode sends all events when no filters are defined", () => {
+				const logger = createLogger(appInsightsClient, {
+					filtering: {
+						mode: "exclusive",
 					},
 				});
-			}
-		});
-	});
 
-	describe("Telemetry Filter - Category & Namespace Combination Filtering", () => {
-		const configFilters: TelemetryFilter[] = [
-			{
-				categories: ["performance"],
-				namespacePattern: "perf:latency",
-				namespacePatternExceptions: new Set(["perf:latency:ops"]),
-			},
-		];
-		const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "exclusive",
-				filters: configFilters,
-			},
-		};
-		const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
-			filtering: {
-				mode: "inclusive",
-				filters: configFilters,
-			},
-		};
+				const perfCategoryEvent = {
+					category: "performance",
+					eventName: "perfCategoryEventName",
+				};
 
-		it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
-			const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+				logger.send(perfCategoryEvent);
 
-			// should be included - does not match any filter
-			const event1 = {
-				category: "error",
-				eventName: "perf:runtime:container",
-			};
+				// Expect all events to be sent in exclusive mode
+				sinonAssert.callCount(trackEventSpy, 1);
+			});
 
-			// should be included - only partial matches namespace filter but not category
-			const event2 = {
-				category: "error",
-				eventName: "perf:latency:ops:delta",
-			};
-
-			// should be included - partial namespace match and category match but also matches exception.
-			const event3 = {
-				category: "performance",
-				eventName: "perf:latency:ops:delta",
-			};
-
-			// should be excluded - perfect namespace and category match.
-			const event4 = {
-				category: "performance",
-				eventName: "perf:latency",
-			};
-
-			// should be excluded - partial namespace match and category match.
-			const event5 = {
-				category: "performance",
-				eventName: "perf:latency:container:syncTime",
-			};
-
-			logger.send(event1);
-			logger.send(event2);
-			logger.send(event3);
-			logger.send(event4);
-			logger.send(event5);
-
-			const actualSentEvent1 = trackEventSpy.getCalls().filter((call) =>
-				call.calledWithExactly({
-					name: event1.eventName,
-					properties: {
-						...event1,
+			it("inclusive filter mode sends no events when no filters are defined", () => {
+				const logger = createLogger(appInsightsClient, {
+					filtering: {
+						mode: "inclusive",
 					},
-				}),
-			);
-			const actualSentEvent2 = trackEventSpy.getCalls().filter((call) =>
-				call.calledWithExactly({
-					name: event2.eventName,
-					properties: {
-						...event2,
-					},
-				}),
-			);
-			const actualSentEvent3 = trackEventSpy.getCalls().filter((call) =>
-				call.calledWithExactly({
-					name: event3.eventName,
-					properties: {
-						...event3,
-					},
-				}),
-			);
+				});
 
-			sinonAssert.callCount(trackEventSpy, 3);
-			assert.strictEqual(actualSentEvent1.length, 1);
-			assert.strictEqual(actualSentEvent2.length, 1);
-			assert.strictEqual(actualSentEvent3.length, 1);
+				const perfCategoryEvent = {
+					category: "performance",
+					eventName: "perfCategoryEventName",
+				};
+
+				logger.send(perfCategoryEvent);
+
+				// Expect no events to be sent
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
 		});
 
-		it("inclusive filter mode DOES SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
-			const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
-
-			// should be excluded - does not match any filter
-			const event1 = {
-				category: "error",
-				eventName: "perf:runtime:container",
+		describe("category filtering", () => {
+			const configFilters: TelemetryFilter[] = [
+				{
+					categories: ["performance", "generic"],
+				},
+			];
+			const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "exclusive",
+					filters: configFilters,
+				},
+			};
+			const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "inclusive",
+					filters: configFilters,
+				},
 			};
 
-			// should be excluded - only partial matches namespace filter but not category
-			const event2 = {
-				category: "error",
-				eventName: "perf:latency:ops:delta",
-			};
-
-			// should be excluded - partial namespace match and category match but also matches exception.
-			const event3 = {
-				category: "performance",
-				eventName: "perf:latency:ops:delta",
-			};
-
-			// should be included - perfect namespace and category match.
-			const event4 = {
-				category: "performance",
-				eventName: "perf:latency",
-			};
-
-			// should be included - partial namespace match and category match.
-			const event5 = {
-				category: "performance",
-				eventName: "perf:latency:container:syncTime",
-			};
-
-			logger.send(event1);
-			logger.send(event2);
-			logger.send(event3);
-			logger.send(event4);
-			logger.send(event5);
-
-			const actualSentEvent4 = trackEventSpy.getCalls().filter((call) =>
-				call.calledWithExactly({
-					name: event4.eventName,
-					properties: {
-						...event4,
+			it("exclusive filtering mode DOES NOT SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
+				const logger = createLogger(appInsightsClient, {
+					filtering: {
+						mode: "exclusive",
+						filters: [
+							{
+								categories: ["performance", "generic"],
+							},
+						],
 					},
-				}),
-			);
-			const actualSentEvent5 = trackEventSpy.getCalls().filter((call) =>
-				call.calledWithExactly({
-					name: event4.eventName,
-					properties: {
-						...event4,
-					},
-				}),
-			);
+				});
 
-			sinonAssert.callCount(trackEventSpy, 2);
-			assert.strictEqual(actualSentEvent4.length, 1);
-			assert.strictEqual(actualSentEvent5.length, 1);
+				// should be excluded - matches category filter
+				const event = {
+					category: "performance",
+					eventName: "perf:runtime:container",
+				};
+				// should be excluded - matches category filter
+				const event2 = {
+					category: "generic",
+					eventName: "perf:runtime:container",
+				};
+				logger.send(event);
+				logger.send(event2);
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
+
+			it("exclusive filter mode DOES NOT SEND events that DO MATCH with one of multiple category filters", () => {
+				const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+				// should be excluded - match with category in filter
+				const event1 = {
+					category: "performance",
+					eventName: "perf:latency:ops",
+				};
+				// should be excluded - match with category in filter
+				const event2 = {
+					category: "generic",
+					eventName: "perf:memory:container",
+				};
+				logger.send(event1);
+				logger.send(event2);
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
+
+			it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple category filters", () => {
+				const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+				// should be included - does not match any category filter
+				const event = {
+					category: "error",
+					eventName: "perf:runtime:container",
+				};
+
+				logger.send(event);
+
+				const expectedAppInsightsSentEvent: IEventTelemetry = {
+					name: event.eventName,
+					properties: {
+						...event,
+					},
+				};
+				sinonAssert.callCount(trackEventSpy, 1);
+				for (const call of trackEventSpy.getCalls()) {
+					sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
+				}
+			});
+
+			// ------------------------------------------------------------------------------------
+
+			it("inclusive filtering mode DOES SEND events that DO MATCH with atleast one category within a single filter containing multiple categories", () => {
+				const logger = createLogger(appInsightsClient, {
+					filtering: {
+						mode: "inclusive",
+						filters: [
+							{
+								categories: ["performance", "generic"],
+							},
+						],
+					},
+				});
+
+				// should be included - matches category filter
+				const event = {
+					category: "performance",
+					eventName: "perf:runtime:container",
+				};
+				// should be included - matches category filter
+				const event2 = {
+					category: "generic",
+					eventName: "perf:runtime:container",
+				};
+				logger.send(event);
+				logger.send(event2);
+				sinonAssert.callCount(trackEventSpy, 2);
+			});
+
+			it("inclusive filter mode DOES SEND events that DO MATCH with one of multiple category filters", () => {
+				const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+				// should be included - match with category filter
+				const event1 = {
+					category: "performance",
+					eventName: "perf:latency:ops",
+				};
+				// should be included - match with category filter
+				const event2 = {
+					category: "generic",
+					eventName: "perf:memory:container",
+				};
+				logger.send(event1);
+				logger.send(event2);
+				sinonAssert.callCount(trackEventSpy, 2);
+			});
+
+			it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple category filters", () => {
+				const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+				// should be excluded - does not match any category filter
+				const event = {
+					category: "error",
+					eventName: "perf:runtime:container",
+				};
+
+				logger.send(event);
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
+		});
+
+		describe("namespace filtering", () => {
+			const namespaceFilterPattern1 = "perf:latency";
+			const namespaceFilterPattern2 = "perf:memory";
+			const namespaceFilterPattern1Exception = `${namespaceFilterPattern1}:ops`;
+			const namespaceFilterPattern2Exception = `${namespaceFilterPattern2}:container`;
+			const configFilters: TelemetryFilter[] = [
+				{
+					namespacePattern: namespaceFilterPattern1,
+					namespacePatternExceptions: new Set([namespaceFilterPattern1Exception]),
+				},
+				{
+					namespacePattern: namespaceFilterPattern2,
+					namespacePatternExceptions: new Set([namespaceFilterPattern2Exception]),
+				},
+			];
+			const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "exclusive",
+					filters: configFilters,
+				},
+			};
+			const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "inclusive",
+					filters: configFilters,
+				},
+			};
+
+			it("exclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters", () => {
+				const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+				// should be excluded - partial match with namespace filter
+				const event1 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern1}:signals`,
+				};
+				// should be excluded - partial match with second namespace filter
+				const event2 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern2}:ops:summary`,
+				};
+				// should be excluded - perfect match with namespace filter
+				const event3 = {
+					category: "performance",
+					eventName: namespaceFilterPattern1,
+				};
+				// should be excluded - perfect match with second namespace filter
+				const event4 = {
+					category: "performance",
+					eventName: namespaceFilterPattern2,
+				};
+				logger.send(event1);
+				logger.send(event2);
+				logger.send(event3);
+				logger.send(event4);
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
+
+			it("exclusive filter mode DOES SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
+				const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+				// should be included - does not match any namespace filter
+				const event = {
+					category: "performance",
+					eventName: "perf:runtime:container",
+				};
+
+				logger.send(event);
+
+				const expectedAppInsightsSentEvent: IEventTelemetry = {
+					name: event.eventName,
+					properties: {
+						...event,
+					},
+				};
+				sinonAssert.callCount(trackEventSpy, 1);
+				for (const call of trackEventSpy.getCalls()) {
+					sinonAssert.calledWithExactly(call, expectedAppInsightsSentEvent);
+				}
+			});
+
+			it("exclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
+				const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+				// should be included - partial match with namespace filter but also partially matches namespace pattern exception
+				const event1 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern1Exception}:roundTripTime`,
+				};
+				// should be included - partial match with second namespace filter but also partially matches namespace pattern exception
+				const event2 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern2Exception}:summary`,
+				};
+				// should be included - partial match with namespace filter but also perfectly matches namespace pattern exception
+				const event3 = {
+					category: "performance",
+					eventName: namespaceFilterPattern1Exception,
+				};
+				// should be included - partial match with second namespace filter but also perfectly matches namespace pattern exception
+				const event4 = {
+					category: "performance",
+					eventName: namespaceFilterPattern2Exception,
+				};
+				logger.send(event1);
+				logger.send(event2);
+				logger.send(event3);
+				logger.send(event4);
+				sinonAssert.callCount(trackEventSpy, 4);
+			});
+
+			// ------------------------------------------------------------------------------------
+
+			it("inclusive filter mode DOES SEND events that MATCH with one of multiple namespace filters", () => {
+				const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+				// should be included - partial match with namespace filter
+				const event1 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern1}:signals`,
+				};
+				// should be included - partial match with second namespace filter
+				const event2 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern2}:ops:summary`,
+				};
+				// should be included - perfect match with namespace filter
+				const event3 = {
+					category: "performance",
+					eventName: namespaceFilterPattern1,
+				};
+				// should be included - perfect match with second namespace filter
+				const event4 = {
+					category: "performance",
+					eventName: namespaceFilterPattern2,
+				};
+				logger.send(event1);
+				logger.send(event2);
+				logger.send(event3);
+				logger.send(event4);
+				sinonAssert.callCount(trackEventSpy, 4);
+			});
+
+			it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH with one of multiple namespace filters", () => {
+				const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+				// should be excluded - does not match any namespace filter
+				const event = {
+					category: "performance",
+					eventName: "perf:runtime:container",
+				};
+
+				logger.send(event);
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
+
+			it("inclusive filter mode DOES NOT SEND events that MATCH with one of multiple namespace filters if they also partially match with a namespace exception", () => {
+				const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+				// should be excluded - partial match with namespace filter but also partially matches namespace pattern exception
+				const event1 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern1}:ops:roundTripTime`,
+				};
+				// should be excluded - partial match with second namespace filter but also partially matches namespace pattern exception
+				const event2 = {
+					category: "performance",
+					eventName: `${namespaceFilterPattern2}:container:summary`,
+				};
+				// should be excluded - partial match with namespace filter but also perfectly matches namespace pattern exception
+				const event3 = {
+					category: "performance",
+					eventName: namespaceFilterPattern1Exception,
+				};
+				// should be excluded - partial match with second namespace filter but also perfectly matches namespace pattern exception
+				const event4 = {
+					category: "performance",
+					eventName: namespaceFilterPattern2Exception,
+				};
+				logger.send(event1);
+				logger.send(event2);
+				logger.send(event3);
+				logger.send(event4);
+				sinonAssert.callCount(trackEventSpy, 0);
+			});
+
+			it("inclusive filter mode DOES NOT SEND events that DO NOT MATCH the most specific filter despite matching more generic ones. ", () => {
+				const logger = createLogger(appInsightsClient, {
+					filtering: {
+						mode: "inclusive",
+						filters: [
+							{
+								namespacePattern: "A:B",
+								categories: ["generic", "error"],
+							},
+							{
+								namespacePattern: "A:B:C",
+								categories: ["error"],
+							},
+						],
+					},
+				});
+
+				// should be excluded because the event matches the "A:B" filter but the "A:B:C" filter is more specific
+				// so it should be evaluated first and it only allows "errors".
+				const event1 = {
+					category: "generic",
+					eventName: "A:B:C",
+				};
+
+				// should be included because it matches the "A:B:C" filter that should be getting applied to it
+				const event2 = {
+					category: "error",
+					eventName: "A:B:C",
+				};
+
+				logger.send(event1);
+				logger.send(event2);
+				sinonAssert.callCount(trackEventSpy, 1);
+				for (const call of trackEventSpy.getCalls()) {
+					sinonAssert.calledWithExactly(call, {
+						name: event2.eventName,
+						properties: {
+							...event2,
+						},
+					});
+				}
+			});
+		});
+
+		describe("category + namespace combination", () => {
+			const configFilters: TelemetryFilter[] = [
+				{
+					categories: ["performance"],
+					namespacePattern: "perf:latency",
+					namespacePatternExceptions: new Set(["perf:latency:ops"]),
+				},
+			];
+			const exclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "exclusive",
+					filters: configFilters,
+				},
+			};
+			const inclusiveLoggerFilterConfig: FluidAppInsightsLoggerConfig = {
+				filtering: {
+					mode: "inclusive",
+					filters: configFilters,
+				},
+			};
+
+			it("exclusive filter mode DOES NOT SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
+				const logger = createLogger(appInsightsClient, exclusiveLoggerFilterConfig);
+
+				// should be included - does not match any filter
+				const event1 = {
+					category: "error",
+					eventName: "perf:runtime:container",
+				};
+
+				// should be included - only partial matches namespace filter but not category
+				const event2 = {
+					category: "error",
+					eventName: "perf:latency:ops:delta",
+				};
+
+				// should be included - partial namespace match and category match but also matches exception.
+				const event3 = {
+					category: "performance",
+					eventName: "perf:latency:ops:delta",
+				};
+
+				// should be excluded - perfect namespace and category match.
+				const event4 = {
+					category: "performance",
+					eventName: "perf:latency",
+				};
+
+				// should be excluded - partial namespace match and category match.
+				const event5 = {
+					category: "performance",
+					eventName: "perf:latency:container:syncTime",
+				};
+
+				logger.send(event1);
+				logger.send(event2);
+				logger.send(event3);
+				logger.send(event4);
+				logger.send(event5);
+
+				const actualSentEvent1 = trackEventSpy.getCalls().filter((call) =>
+					call.calledWithExactly({
+						name: event1.eventName,
+						properties: {
+							...event1,
+						},
+					}),
+				);
+				const actualSentEvent2 = trackEventSpy.getCalls().filter((call) =>
+					call.calledWithExactly({
+						name: event2.eventName,
+						properties: {
+							...event2,
+						},
+					}),
+				);
+				const actualSentEvent3 = trackEventSpy.getCalls().filter((call) =>
+					call.calledWithExactly({
+						name: event3.eventName,
+						properties: {
+							...event3,
+						},
+					}),
+				);
+
+				sinonAssert.callCount(trackEventSpy, 3);
+				assert.strictEqual(actualSentEvent1.length, 1);
+				assert.strictEqual(actualSentEvent2.length, 1);
+				assert.strictEqual(actualSentEvent3.length, 1);
+			});
+
+			it("inclusive filter mode DOES SEND events that match combination category and namespace filters unless they match a namespace exception", () => {
+				const logger = createLogger(appInsightsClient, inclusiveLoggerFilterConfig);
+
+				// should be excluded - does not match any filter
+				const event1 = {
+					category: "error",
+					eventName: "perf:runtime:container",
+				};
+
+				// should be excluded - only partial matches namespace filter but not category
+				const event2 = {
+					category: "error",
+					eventName: "perf:latency:ops:delta",
+				};
+
+				// should be excluded - partial namespace match and category match but also matches exception.
+				const event3 = {
+					category: "performance",
+					eventName: "perf:latency:ops:delta",
+				};
+
+				// should be included - perfect namespace and category match.
+				const event4 = {
+					category: "performance",
+					eventName: "perf:latency",
+				};
+
+				// should be included - partial namespace match and category match.
+				const event5 = {
+					category: "performance",
+					eventName: "perf:latency:container:syncTime",
+				};
+
+				logger.send(event1);
+				logger.send(event2);
+				logger.send(event3);
+				logger.send(event4);
+				logger.send(event5);
+
+				const actualSentEvent4 = trackEventSpy.getCalls().filter((call) =>
+					call.calledWithExactly({
+						name: event4.eventName,
+						properties: {
+							...event4,
+						},
+					}),
+				);
+				const actualSentEvent5 = trackEventSpy.getCalls().filter((call) =>
+					call.calledWithExactly({
+						name: event4.eventName,
+						properties: {
+							...event4,
+						},
+					}),
+				);
+
+				sinonAssert.callCount(trackEventSpy, 2);
+				assert.strictEqual(actualSentEvent4.length, 1);
+				assert.strictEqual(actualSentEvent5.length, 1);
+			});
 		});
 	});
 });

--- a/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/test/fluidAppInsightsLogger.spec.ts
@@ -527,7 +527,7 @@ describe("FluidAppInsightsLogger", () => {
 			});
 		});
 
-		describe("category + namespace combination", () => {
+		describe("category + namespace combination filtering", () => {
 			const configFilters: TelemetryFilter[] = [
 				{
 					categories: ["performance"],


### PR DESCRIPTION
## Description

Follow-up to #27015. That PR moved `ApplicationInsights` construction from `beforeEach` to `before` within each of the 5 `describe` blocks in `fluidAppInsightsLogger.spec.ts`, reducing construction from once-per-test to once-per-suite. This PR goes one step further: the 5 per-suite instances are consolidated into a single instance shared across all suites.

Changes:
- Wrap all 5 inner `describe`s in an outer `describe("FluidAppInsightsLogger", …)` that owns the single `ApplicationInsights` instance and its `before()` initializer.
- Hoist the identical `beforeEach`/`afterEach` hooks (create + restore the `trackEvent` spy) to the outer describe, since they're the same in every inner suite.
- Drop the redundant inner `FluidAppInsightsLogger` describe so its 4 tests live directly at the top level.
- Group the 4 filter-related describes under a new `Telemetry Filter` parent and drop the repeated `"Telemetry Filter - "` prefix from each.

## Performance

Measured with a custom mocha reporter over 10 runs per state, comparing the pre-branch commit vs. the tip of this branch.

| | before | after | delta |
|---|---:|---:|---:|
| Total suite | 19.79 ms | 17.83 ms | -1.97 ms (-10%) |
| `initializeAppInsights` before-all hook (sum per run) | 8.90 ms | 5.70 ms | -3.20 ms (-36%) |

A few things worth calling out:

- The `initializeAppInsights` hook is the only one with a meaningful delta; everything else (per-test durations, `beforeEach`/`afterEach`) is within noise.
- The savings don't scale linearly with invocation count (5× → 1× ≠ 5× savings). Inspecting raw hook durations: the *first* `initializeAppInsights` call costs ~6 ms, but subsequent calls within the same process cost ~0.5–1 ms each. The expensive work inside `loadAppInsights()` bootstraps **global** SDK state; once that's warm, constructing additional `ApplicationInsights` instances is cheap. So the ~3.2 ms saved is the cost of 4 redundant instance constructions, not 4 redundant SDK bootstraps.
- The real value of this change isn't the 2 ms today — it's that adding a new `describe` block tomorrow no longer requires (or tempts anyone to duplicate) its own `ApplicationInsights` setup. Shared setup stays shared.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).