### PR TITLE
Bump benchmark-tool to 0.58.0

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluid-tools/benchmark
 
+## 0.58.0
+
 ## 0.57.0
 
 -   Mocha dependency updated from v10 to v11.

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.57.0",
+	"version": "0.58.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Bump benchmark-tool to version 0.58.0

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
