### PR TITLE
Pin version of ff_pipeline_host to particular commit

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,6 +129,12 @@ parameters:
   type: boolean
   default: false
 
+# The commit SHA to use for the ff_pipeline_host repository resource.
+# Individual pipelines can override this to pin to a different commit.
+- name: ff_pipeline_host_ref
+  type: string
+  default: '11f135dcc8dfa42519157bb460fdcb345c19a477'
+
 # The `resources` specify the location and version of the 1ES Pipeline Template.
 resources:
   repositories:
@@ -140,7 +146,7 @@ resources:
       type: git
       # Specify internal project, since this pipeline runs in both the public and internal projects
       name: internal/ff_pipeline_host
-      ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
+      ref: ${{ parameters.ff_pipeline_host_ref }}
 
   # Listing a pipeline as a resource makes its artifacts available for download in any job
   pipelines:

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -140,6 +140,8 @@ resources:
       type: git
       # Specify internal project, since this pipeline runs in both the public and internal projects
       name: internal/ff_pipeline_host
+      ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
+
   # Listing a pipeline as a resource makes its artifacts available for download in any job
   pipelines:
     # Access to this pipelines artifacts allows 1ES deployment jobs to install build tools without checking out out a repo.

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -134,6 +134,8 @@ resources:
       type: git
       # Specify internal project, since this pipeline runs in both the public and internal projects
       name: internal/ff_pipeline_host
+      ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
+
   # Listing a pipeline as a resource makes its artifacts available for download in any job
   pipelines:
     # Access to this pipelines artifacts allows 1ES deployment jobs to install build tools without checking out out a repo.

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -123,6 +123,12 @@ parameters:
   type: boolean
   default: false
 
+# The commit SHA to use for the ff_pipeline_host repository resource.
+# Individual pipelines can override this to pin to a different commit.
+- name: ff_pipeline_host_ref
+  type: string
+  default: '11f135dcc8dfa42519157bb460fdcb345c19a477'
+
 # The `resources` specify the location and version of the 1ES Pipeline Template.
 resources:
   repositories:
@@ -134,7 +140,7 @@ resources:
       type: git
       # Specify internal project, since this pipeline runs in both the public and internal projects
       name: internal/ff_pipeline_host
-      ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
+      ref: ${{ parameters.ff_pipeline_host_ref }}
 
   # Listing a pipeline as a resource makes its artifacts available for download in any job
   pipelines:

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -22,6 +22,7 @@ resources:
   - repository: ff_pipeline_host
     type: git
     name: ff_pipeline_host
+    # Keep this ref in sync with ff_pipeline_host_ref default in tools/pipelines/templates/build-npm-package.yml
     ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -22,6 +22,7 @@ resources:
   - repository: ff_pipeline_host
     type: git
     name: ff_pipeline_host
+    ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 
 variables:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -80,7 +80,7 @@ resources:
   - repository: ff_pipeline_host
     type: git
     name: ff_pipeline_host
-    ref: main
+    ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:
   - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -80,6 +80,7 @@ resources:
   - repository: ff_pipeline_host
     type: git
     name: ff_pipeline_host
+    # Keep this ref in sync with ff_pipeline_host_ref default in tools/pipelines/templates/build-npm-package.yml
     ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -22,6 +22,7 @@ resources:
   - repository: ff_pipeline_host
     type: git
     name: ff_pipeline_host
+    ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -22,6 +22,7 @@ resources:
   - repository: ff_pipeline_host
     type: git
     name: ff_pipeline_host
+    # Keep this ref in sync with ff_pipeline_host_ref default in tools/pipelines/templates/build-npm-package.yml
     ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -34,6 +34,7 @@ resources:
     - repository: ff_pipeline_host
       type: git
       name: ff_pipeline_host
+      # Keep this ref in sync with ff_pipeline_host_ref default in tools/pipelines/templates/build-npm-package.yml
       ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -34,6 +34,7 @@ resources:
     - repository: ff_pipeline_host
       type: git
       name: ff_pipeline_host
+      ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -24,6 +24,7 @@ resources:
     - repository: ff_pipeline_host
       type: git
       name: ff_pipeline_host
+      ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -24,6 +24,7 @@ resources:
     - repository: ff_pipeline_host
       type: git
       name: ff_pipeline_host
+      # Keep this ref in sync with ff_pipeline_host_ref default in tools/pipelines/templates/build-npm-package.yml
       ref: '11f135dcc8dfa42519157bb460fdcb345c19a477'
 
 variables:


### PR DESCRIPTION
## Description

After some recent discussions, we'd like to make the process of bumping ff_pipeline_host versions a bit more explicit by pinning the active version in `main`. This should make it easier to root cause problematic changes in the e2e tests, as OCEs don't need to leaf through multiple repository's git histories.

The commit chosen here is latest main.