### PR TITLE
ci: Suppress Guardian warnings

### DIFF
--- a/tools/pipelines/templates/include-vars-docker.yml
+++ b/tools/pipelines/templates/include-vars-docker.yml
@@ -58,3 +58,11 @@ variables:
   value: '${{ variables.consistentSourcesDirectory }}/FluidFramework'
 - name: FFPipelineHostDirectory
   value: '${{ variables.consistentSourcesDirectory }}/ff_pipeline_host'
+
+# Suppress warning from 1ES' Guardian task since we know our PR builds can come from forked repositories
+# Original warning reads:
+#   "Guardian is not supported for builds from forked GitHub repositories.
+#   Current Guardian Task will be skipped.
+#   To disable this warning, set the environment variable 'GDN_SUPPRESS_FORKED_BUILD_WARNING' to 'true'."
+- name: GDN_SUPPRESS_FORKED_BUILD_WARNING
+  value: 'true'

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -131,3 +131,11 @@ variables:
 - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - name: ONEES_ENFORCED_CODEQL_ENABLED
     value: 'false'
+
+# Suppress warning from 1ES' Guardian task since we know our PR builds can come from forked repositories
+# Original warning reads:
+#   "Guardian is not supported for builds from forked GitHub repositories.
+#   Current Guardian Task will be skipped.
+#   To disable this warning, set the environment variable 'GDN_SUPPRESS_FORKED_BUILD_WARNING' to 'true'."
+- name: GDN_SUPPRESS_FORKED_BUILD_WARNING
+  value: 'true'


### PR DESCRIPTION
## Description

Suppress warnings (see screenshot) reported in ADO since we know our repo gets builds from forks.

<img width="1412" height="485" alt="image" src="https://github.com/user-attachments/assets/91d740e4-b219-4030-b5db-1049ced3cb20" />

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
