### PR TITLE
fix(ci): switch review fleet to JSON output and remove fix truncation

### DIFF
--- a/.github/prompts/reviewers/api-compatibility.md
+++ b/.github/prompts/reviewers/api-compatibility.md
@@ -67,17 +67,30 @@ API Quality findings are **promoted +1 level**:
 
 ## Output Format
 
-Write your findings to `review-api-compatibility.md`. Use this exact format for each finding:
+Write your findings to `review-api-compatibility.json` as raw JSON. Do not wrap output in a markdown code block or include any other text — the file must be valid JSON and nothing else.
 
-```
-[SEVERITY] path/to/file.ts:LINE — Description of the API issue and consumer impact — Recommended action
+```json
+{
+  "findings": [
+    {
+      "severity": "CRITICAL",
+      "location": "src/index.ts:12",
+      "description": "`TreeNode` was removed from the public barrel export with no deprecation — any consumer importing it by name will get a compile error after upgrading",
+      "fix": "Restore the export and add `@deprecated` with a migration path to the replacement type before removing in a future release"
+    }
+  ]
+}
 ```
 
-If you find NO high-confidence issues, write exactly this:
+- `severity`: `"CRITICAL"`, `"HIGH"`, or `"MEDIUM"` (API findings are promoted +1 level)
+- `location`: `path/to/file.ts:LINE`
+- `description`: the API issue and its concrete consumer impact
+- `fix`: specific recommended action
 
-```
-<!-- NO_ISSUES_FOUND -->
-No high-confidence API quality concerns found in the current diff.
+If you find NO high-confidence issues:
+
+```json
+{ "findings": [] }
 ```
 
 ## Instructions
@@ -86,4 +99,4 @@ No high-confidence API quality concerns found in the current diff.
 2. Check if any `*.api.md` files changed: `git diff --name-only origin/$BASE_REF...HEAD -- '*.api.md'` — if so, give those packages extra scrutiny
 3. For files that export public APIs, read the full file and any related `index.ts` barrel exports
 4. Apply the high-confidence gate to every finding before including it
-5. Write your review to `review-api-compatibility.md`
+5. Write your review to `review-api-compatibility.json`

--- a/.github/prompts/reviewers/correctness.md
+++ b/.github/prompts/reviewers/correctness.md
@@ -72,23 +72,30 @@ Correctness findings are **promoted +1 level**:
 
 ## Output Format
 
-Write your findings to `review-correctness.md`. Use this exact format for each finding:
+Write your findings to `review-correctness.json` as raw JSON. Do not wrap output in a markdown code block or include any other text — the file must be valid JSON and nothing else.
 
-```
-[SEVERITY] path/to/file.ts:LINE — Description of the bug and concrete failure scenario — Suggested fix
+```json
+{
+  "findings": [
+    {
+      "severity": "HIGH",
+      "location": "src/core/tree.ts:142",
+      "description": "`getNode()` returns undefined when parent is detached but caller assumes non-null, causing TypeError on line 145 when accessing `.children`",
+      "fix": "Add undefined check before accessing children, or throw with a descriptive error if the node must always be present at this call site"
+    }
+  ]
+}
 ```
 
-Example:
+- `severity`: `"CRITICAL"`, `"HIGH"`, or `"MEDIUM"`
+- `location`: `path/to/file.ts:LINE`
+- `description`: the bug and its concrete failure scenario
+- `fix`: specific suggested fix
 
-```
-[HIGH] src/core/tree.ts:142 — `getNode()` returns undefined when parent is detached but caller assumes non-null, causing TypeError on line 145 when accessing `.children` — Add undefined check before accessing children, or throw with descriptive error
-```
+If you find NO high-confidence issues:
 
-If you find NO high-confidence issues, write exactly this:
-
-```
-<!-- NO_ISSUES_FOUND -->
-No high-confidence correctness issues found in the current diff.
+```json
+{ "findings": [] }
 ```
 
 ## Instructions
@@ -97,4 +104,4 @@ No high-confidence correctness issues found in the current diff.
 2. For files with complex changes, read the full file to understand context — especially shared state, callers, and adjacent logic
 3. Focus only on changed lines and their immediate context
 4. Apply the high-confidence gate to every finding before including it
-5. Write your review to `review-correctness.md`
+5. Write your review to `review-correctness.json`

--- a/.github/prompts/reviewers/performance.md
+++ b/.github/prompts/reviewers/performance.md
@@ -60,17 +60,30 @@ Performance findings are **capped at HIGH**:
 
 ## Output Format
 
-Write your findings to `review-performance.md`. Use this exact format for each finding:
+Write your findings to `review-performance.json` as raw JSON. Do not wrap output in a markdown code block or include any other text — the file must be valid JSON and nothing else.
 
-```
-[SEVERITY] path/to/file.ts:LINE — Description of the performance concern and expected impact — Suggested optimization
+```json
+{
+  "findings": [
+    {
+      "severity": "HIGH",
+      "location": "src/merge/resolver.ts:204",
+      "description": "`Array.find()` called inside a loop over all nodes — O(n²) on the hot merge path, will degrade visibly at >1000 nodes",
+      "fix": "Build a `Map<id, node>` before the loop and use `.get()` for O(1) lookups"
+    }
+  ]
+}
 ```
 
-If you find NO high-confidence issues, write exactly this:
+- `severity`: `"HIGH"` or `"MEDIUM"` (performance findings are capped at HIGH)
+- `location`: `path/to/file.ts:LINE`
+- `description`: the regression and its expected impact at scale
+- `fix`: specific suggested optimization
 
-```
-<!-- NO_ISSUES_FOUND -->
-No high-confidence performance concerns found in the current diff.
+If you find NO high-confidence issues:
+
+```json
+{ "findings": [] }
 ```
 
 ## Instructions
@@ -79,4 +92,4 @@ No high-confidence performance concerns found in the current diff.
 2. For performance-critical changes, read the full file to understand the hot path context — callers, loop structures, frequency of invocation
 3. Focus on code that runs per-operation, per-event, or in loops — not one-time setup
 4. Apply the high-confidence gate to every finding before including it
-5. Write your review to `review-performance.md`
+5. Write your review to `review-performance.json`

--- a/.github/prompts/reviewers/security.md
+++ b/.github/prompts/reviewers/security.md
@@ -66,17 +66,30 @@ Severity levels:
 
 ## Output Format
 
-Write your findings to `review-security.md`. Use this exact format for each finding:
+Write your findings to `review-security.json` as raw JSON. Do not wrap output in a markdown code block or include any other text — the file must be valid JSON and nothing else.
 
-```
-[SEVERITY] path/to/file.ts:LINE — Description of the vulnerability and attack scenario — Remediation
+```json
+{
+  "findings": [
+    {
+      "severity": "HIGH",
+      "location": "src/server/handler.ts:88",
+      "description": "User-supplied `path` is passed to `fs.readFile` without sanitization, allowing directory traversal to read arbitrary files",
+      "fix": "Resolve the path against a trusted base directory and verify it stays within bounds before reading"
+    }
+  ]
+}
 ```
 
-If you find NO high-confidence issues, write exactly this:
+- `severity`: `"CRITICAL"`, `"HIGH"`, or `"MEDIUM"`
+- `location`: `path/to/file.ts:LINE`
+- `description`: the vulnerability and its concrete attack scenario
+- `fix`: specific remediation
 
-```
-<!-- NO_ISSUES_FOUND -->
-No high-confidence security vulnerabilities found in the current diff.
+If you find NO high-confidence issues:
+
+```json
+{ "findings": [] }
 ```
 
 ## Instructions
@@ -85,4 +98,4 @@ No high-confidence security vulnerabilities found in the current diff.
 2. For files with security-sensitive changes, read the full file to understand the complete security context
 3. Focus on changes that handle user input, file system access, or token handling
 4. Apply the high-confidence gate to every finding before including it
-5. Write your review to `review-security.md`
+5. Write your review to `review-security.json`

--- a/.github/prompts/reviewers/testing.md
+++ b/.github/prompts/reviewers/testing.md
@@ -56,17 +56,30 @@ Testing findings are **capped at HIGH**:
 
 ## Output Format
 
-Write your findings to `review-testing.md`. Use this exact format for each finding:
+Write your findings to `review-testing.json` as raw JSON. Do not wrap output in a markdown code block or include any other text — the file must be valid JSON and nothing else.
 
-```
-[SEVERITY] path/to/source-file.ts:LINE — Description of the coverage gap and what bug could go undetected — Concrete test scenario to add
+```json
+{
+  "findings": [
+    {
+      "severity": "HIGH",
+      "location": "src/merge/resolver.ts:78",
+      "description": "`resolveConflict()` has no test for the case where both sides delete the same node — a silent data loss bug would go undetected",
+      "fix": "Add a test: two clients each delete node X, merge result should reflect a single deletion with no error thrown"
+    }
+  ]
+}
 ```
 
-If you find NO high-confidence issues, write exactly this:
+- `severity`: `"HIGH"` or `"MEDIUM"` (testing findings are capped at HIGH)
+- `location`: `path/to/source-file.ts:LINE` (point to the production code that lacks coverage)
+- `description`: the coverage gap and the concrete bug it would miss
+- `fix`: specific test scenario to add, including inputs and expected behavior
 
-```
-<!-- NO_ISSUES_FOUND -->
-No high-confidence testing gaps found in the current diff.
+If you find NO high-confidence issues:
+
+```json
+{ "findings": [] }
 ```
 
 ## Instructions
@@ -75,4 +88,4 @@ No high-confidence testing gaps found in the current diff.
 2. Identify all production code changes and check if corresponding test changes exist
 3. For new functions or modified behavior, verify tests actually exercise the new code paths
 4. Apply the high-confidence gate to every finding before including it
-5. Write your review to `review-testing.md`
+5. Write your review to `review-testing.json`

--- a/.github/scripts/consolidate_reviews.py
+++ b/.github/scripts/consolidate_reviews.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import re
 import sys
 from dataclasses import dataclass
@@ -69,15 +70,7 @@ SEVERITY_LABEL_SETS: list[SeverityLabelSet] = [
     },
 ]
 
-# Pattern: [SEVERITY] file:line — description — fix
-FINDING_RE = re.compile(
-    r"^\[(CRITICAL|HIGH|MEDIUM)\]\s+"  # severity
-    r"(\S+)"  # file:line (or just file)
-    r"\s+—\s+"  # separator
-    r"(.+?)"  # description (non-greedy)
-    r"\s+—\s+"  # separator
-    r"(.+)$"  # fix
-)
+VALID_SEVERITIES = frozenset({"CRITICAL", "HIGH", "MEDIUM"})
 
 
 @dataclass
@@ -89,27 +82,43 @@ class Finding:
     area: str
 
 
-def parse_review_file(path: Path, area: str) -> list[Finding]:
-    """Parse a single review file and extract findings."""
+def parse_review_file(path: Path, area: str) -> list[Finding] | None:
+    """Parse a single review file and extract findings from its JSON content.
+
+    Returns None when the file is not valid JSON or has an unexpected shape,
+    so callers can distinguish a broken reviewer from a clean empty run.
+    """
     text = path.read_text(encoding="utf-8")
 
-    if "NO_ISSUES_FOUND" in text:
-        return []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"Warning: {path.name}: invalid JSON ({exc}), skipping")
+        return None
+
+    if not isinstance(data, dict):
+        print(f"Warning: {path.name}: expected a JSON object, got {type(data).__name__}, skipping")
+        return None
 
     findings: list[Finding] = []
-    for line in text.splitlines():
-        m = FINDING_RE.match(line.strip())
-        if m:
-            findings.append(
-                Finding(
-                    severity=m.group(1),
-                    location=m.group(2),
-                    description=m.group(3),
-                    fix=m.group(4)[:200],
-                    area=area,
-                )
-            )
+    for item in data.get("findings") or []:
+        if not isinstance(item, dict):
+            continue
+        severity = item.get("severity", "")
+        if severity not in VALID_SEVERITIES:
+            continue
+        location = item.get("location", "")
+        description = item.get("description", "")
+        fix = item.get("fix", "")
+        if not location or not description or not fix:
+            continue
+        findings.append(Finding(severity=severity, location=location, description=description, fix=fix, area=area))
     return findings
+
+
+def _sanitize_cell(text: str) -> str:
+    """Normalize text for a markdown table cell: collapse newlines, escape pipes."""
+    return text.replace("\r\n", " ").replace("\r", " ").replace("\n", " ").replace("|", "\\|")
 
 
 def deduplicate(findings: list[Finding]) -> list[Finding]:
@@ -194,7 +203,7 @@ def build_report(findings: list[Finding], run_url: str, pr_number: int | None = 
         level = severity_labels[f.severity]
         sev_display = f"{level[EMOJI_KEY]} {level[TITLE_KEY]}"
         rows.append(
-            f"| {sev_display} | {label} | {f.area} | `{f.location}` | {f.description} | {f.fix} |"
+            f"| {sev_display} | {label} | {f.area} | `{f.location}` | {_sanitize_cell(f.description)} | {_sanitize_cell(f.fix)} |"
         )
 
     table = "\n".join(rows)
@@ -234,18 +243,22 @@ def main(argv: list[str] | None = None) -> int:
 
     # Collect findings from all reviewer files
     all_findings: list[Finding] = []
+    skipped_count = 0
     for reviewer_key, area_name in REVIEWERS.items():
-        path = args.reviews_dir / f"review-{reviewer_key}.md"
+        path = args.reviews_dir / f"review-{reviewer_key}.json"
         if not path.exists():
             print(f"{reviewer_key}: no output file")
             continue
 
         findings = parse_review_file(path, area_name)
-        if not findings:
+        if findings is None:
+            print(f"{reviewer_key}: skipped (invalid output)")
+            skipped_count += 1
+        elif not findings:
             print(f"{reviewer_key}: no issues found")
         else:
             print(f"{reviewer_key}: {len(findings)} finding(s)")
-        all_findings.extend(findings)
+            all_findings.extend(findings)
 
     # Sort by severity order, then de-duplicate
     severity_rank = {s: i for i, s in enumerate(SEVERITY_ORDER)}
@@ -253,6 +266,9 @@ def main(argv: list[str] | None = None) -> int:
     all_findings = deduplicate(all_findings)
 
     if not all_findings:
+        if skipped_count > 0:
+            print(f"{skipped_count} reviewer(s) produced invalid output — cannot confirm clean run.")
+            return 1
         print("All reviewers passed with no findings.")
         return 2
 

--- a/.github/scripts/test_consolidate_reviews.py
+++ b/.github/scripts/test_consolidate_reviews.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import textwrap
+import json
 from pathlib import Path
 
 import pytest
@@ -11,6 +11,7 @@ import pytest
 from consolidate_reviews import (
     MARKER,
     Finding,
+    _sanitize_cell,
     build_report,
     deduplicate,
     determine_verdict,
@@ -22,11 +23,11 @@ from consolidate_reviews import (
 
 class TestParseReviewFile:
     def test_parses_findings(self, tmp_path: Path) -> None:
-        review = tmp_path / "review-correctness.md"
-        review.write_text(textwrap.dedent("""\
-            [HIGH] src/core/tree.ts:142 — getNode() returns undefined — Add undefined check
-            [MEDIUM] src/core/tree.ts:200 — Off-by-one in loop — Use < instead of <=
-        """))
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "src/core/tree.ts:142", "description": "getNode() returns undefined", "fix": "Add undefined check"},
+            {"severity": "MEDIUM", "location": "src/core/tree.ts:200", "description": "Off-by-one in loop", "fix": "Use < instead of <="},
+        ]}))
         findings = parse_review_file(review, "Correctness")
         assert len(findings) == 2
         assert findings[0].severity == "HIGH"
@@ -35,30 +36,66 @@ class TestParseReviewFile:
         assert "getNode()" in findings[0].description
         assert "undefined check" in findings[0].fix
 
-    def test_no_issues_found_returns_empty(self, tmp_path: Path) -> None:
-        review = tmp_path / "review-security.md"
-        review.write_text("<!-- NO_ISSUES_FOUND -->\nNo issues found.")
+    def test_empty_findings_returns_empty(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-security.json"
+        review.write_text(json.dumps({"findings": []}))
         findings = parse_review_file(review, "Security")
         assert findings == []
 
-    def test_ignores_non_finding_lines(self, tmp_path: Path) -> None:
-        review = tmp_path / "review-correctness.md"
-        review.write_text(textwrap.dedent("""\
-            ## Correctness Review
-            Some preamble text mentioning [HIGH] severity patterns.
-            [HIGH] src/foo.ts:10 — Bug description — Fix suggestion
-            More prose about [MEDIUM] things.
-        """))
+    def test_skips_invalid_severity(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": [
+            {"severity": "LOW", "location": "src/foo.ts:10", "description": "desc", "fix": "fix"},
+            {"severity": "HIGH", "location": "src/foo.ts:20", "description": "real bug", "fix": "real fix"},
+        ]}))
+        findings = parse_review_file(review, "Correctness")
+        assert len(findings) == 1
+        assert findings[0].location == "src/foo.ts:20"
+
+    def test_handles_malformed_json(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-correctness.json"
+        review.write_text("this is not json")
+        assert parse_review_file(review, "Correctness") is None
+
+    def test_handles_non_object_json(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-correctness.json"
+        review.write_text("[]")
+        assert parse_review_file(review, "Correctness") is None
+
+    def test_skips_non_dict_finding_items(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": [
+            "not a dict",
+            {"severity": "HIGH", "location": "src/foo.ts:10", "description": "real", "fix": "fix it"},
+        ]}))
         findings = parse_review_file(review, "Correctness")
         assert len(findings) == 1
         assert findings[0].location == "src/foo.ts:10"
 
-    def test_truncates_fix_at_200_chars(self, tmp_path: Path) -> None:
-        long_fix = "x" * 300
-        review = tmp_path / "review-correctness.md"
-        review.write_text(f"[HIGH] src/foo.ts:1 — desc — {long_fix}\n")
+    def test_null_findings_key_returns_empty(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": None}))
         findings = parse_review_file(review, "Correctness")
-        assert len(findings[0].fix) == 200
+        assert findings == []
+
+    def test_skips_finding_with_empty_required_field(self, tmp_path: Path) -> None:
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "", "description": "desc", "fix": "fix"},
+            {"severity": "HIGH", "location": "src/foo.ts:10", "description": "desc", "fix": "fix"},
+        ]}))
+        findings = parse_review_file(review, "Correctness")
+        assert len(findings) == 1
+        assert findings[0].location == "src/foo.ts:10"
+
+    def test_preserves_full_fix_text(self, tmp_path: Path) -> None:
+        long_fix = "x" * 300
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "src/foo.ts:1", "description": "desc", "fix": long_fix},
+        ]}))
+        findings = parse_review_file(review, "Correctness")
+        assert findings[0].fix == long_fix
 
 
 class TestDeduplicate:
@@ -86,6 +123,23 @@ class TestDeduplicate:
         ]
         result = deduplicate(findings)
         assert len(result) == 2
+
+
+class TestSanitizeCell:
+    def test_escapes_pipes(self) -> None:
+        assert _sanitize_cell("a | b") == "a \\| b"
+
+    def test_collapses_newlines(self) -> None:
+        assert _sanitize_cell("line1\nline2") == "line1 line2"
+
+    def test_collapses_crlf(self) -> None:
+        assert _sanitize_cell("line1\r\nline2") == "line1 line2"
+
+    def test_collapses_bare_cr(self) -> None:
+        assert _sanitize_cell("line1\rline2") == "line1 line2"
+
+    def test_plain_text_unchanged(self) -> None:
+        assert _sanitize_cell("no special chars") == "no special chars"
 
 
 class TestDetermineVerdict:
@@ -189,19 +243,28 @@ class TestBuildReport:
         report = build_report(findings, "https://example.com/run/1", pr_number=27071)
         assert f"1 {critical_title}" in report
 
+    def test_sanitizes_pipes_and_newlines_in_table_cells(self) -> None:
+        findings = [Finding("HIGH", "src/a.ts:10", "desc with | pipe", "fix\nwith newline", "Correctness")]
+        report = build_report(findings, "https://example.com/run/1")
+        assert "desc with \\| pipe" in report
+        assert "fix\nwith newline" not in report
+        assert "fix with newline" in report
+
 
 class TestMain:
     def test_no_findings_exits_2(self, tmp_path: Path) -> None:
-        review = tmp_path / "review-correctness.md"
-        review.write_text("<!-- NO_ISSUES_FOUND -->\nAll good.")
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": []}))
         output = tmp_path / "report.md"
         result = main([str(tmp_path), "https://example.com/run/1", "-o", str(output)])
         assert result == 2
         assert not output.exists()
 
     def test_findings_exits_0(self, tmp_path: Path) -> None:
-        review = tmp_path / "review-correctness.md"
-        review.write_text("[HIGH] src/foo.ts:10 — Bug — Fix it\n")
+        review = tmp_path / "review-correctness.json"
+        review.write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "src/foo.ts:10", "description": "Bug", "fix": "Fix it"},
+        ]}))
         output = tmp_path / "report.md"
         result = main([str(tmp_path), "https://example.com/run/1", "-o", str(output)])
         assert result == 0
@@ -211,12 +274,12 @@ class TestMain:
         assert "Bug" in content
 
     def test_deduplicates_across_reviewers(self, tmp_path: Path) -> None:
-        (tmp_path / "review-correctness.md").write_text(
-            "[HIGH] src/foo.ts:10 — Bug from correctness — Fix A\n"
-        )
-        (tmp_path / "review-security.md").write_text(
-            "[CRITICAL] src/foo.ts:10 — Same spot from security — Fix B\n"
-        )
+        (tmp_path / "review-correctness.json").write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "src/foo.ts:10", "description": "Bug from correctness", "fix": "Fix A"},
+        ]}))
+        (tmp_path / "review-security.json").write_text(json.dumps({"findings": [
+            {"severity": "CRITICAL", "location": "src/foo.ts:10", "description": "Same spot from security", "fix": "Fix B"},
+        ]}))
         output = tmp_path / "report.md"
         result = main([str(tmp_path), "https://example.com/run/1", "-o", str(output)])
         assert result == 0
@@ -226,19 +289,40 @@ class TestMain:
         assert "Bug from correctness" not in content
 
     def test_commit_count_arg_accepted(self, tmp_path: Path) -> None:
-        (tmp_path / "review-correctness.md").write_text(
-            "[HIGH] src/foo.ts:10 — Bug — Fix it\n"
-        )
+        (tmp_path / "review-correctness.json").write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "src/foo.ts:10", "description": "Bug", "fix": "Fix it"},
+        ]}))
         output = tmp_path / "report.md"
         result = main([str(tmp_path), "https://example.com/run/1", "--pr-number", "123", "--commit-count", "5", "-o", str(output)])
         assert result == 0
         assert output.exists()
 
+    def test_invalid_reviewer_output_does_not_count_as_clean(self, tmp_path: Path) -> None:
+        # Invalid JSON from one reviewer should not suppress findings from another
+        (tmp_path / "review-correctness.json").write_text("not json")
+        (tmp_path / "review-security.json").write_text(json.dumps({"findings": [
+            {"severity": "HIGH", "location": "src/foo.ts:10", "description": "Bug", "fix": "Fix it"},
+        ]}))
+        output = tmp_path / "report.md"
+        result = main([str(tmp_path), "https://example.com/run/1", "-o", str(output)])
+        assert result == 0
+        assert output.exists()
+        assert "Bug" in output.read_text()
+
+    def test_all_skipped_exits_1_not_2(self, tmp_path: Path) -> None:
+        # All files present but all invalid — must not look like a clean run
+        for reviewer in ["correctness", "security", "performance", "testing", "api-compatibility"]:
+            (tmp_path / f"review-{reviewer}.json").write_text("not json")
+        output = tmp_path / "report.md"
+        result = main([str(tmp_path), "https://example.com/run/1", "-o", str(output)])
+        assert result == 1
+        assert not output.exists()
+
     def test_missing_review_files_skipped(self, tmp_path: Path) -> None:
         # Only one reviewer has output
-        (tmp_path / "review-performance.md").write_text(
-            "[MEDIUM] src/hot.ts:50 — O(n^2) loop — Use a Map\n"
-        )
+        (tmp_path / "review-performance.json").write_text(json.dumps({"findings": [
+            {"severity": "MEDIUM", "location": "src/hot.ts:50", "description": "O(n^2) loop", "fix": "Use a Map"},
+        ]}))
         output = tmp_path / "report.md"
         result = main([str(tmp_path), "https://example.com/run/1", "-o", str(output)])
         assert result == 0

--- a/.github/workflows/pr-review-fleet.yml
+++ b/.github/workflows/pr-review-fleet.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: review-${{ matrix.reviewer }}
-          path: review-${{ matrix.reviewer }}.md
+          path: review-${{ matrix.reviewer }}.json
           if-no-files-found: ignore
           retention-days: 1
 


### PR DESCRIPTION
## Description

The review fleet's consolidated report was silently truncating the `fix` field of each finding at 200 characters with no indication that content was cut.

This removes that limit and replaces the underlying output format — a plaintext one-liner format parsed by regex — with structured JSON from each reviewer agent:

- Each reviewer prompt now instructs the agent to write `{ "findings": [...] }` to its output file instead of `[SEVERITY] file:line — desc — fix` lines.
- `consolidate_reviews.py` parses JSON instead of regex. Malformed agent output now fails loudly per file (warning printed, reviewer skipped) rather than silently dropping lines that don't match the pattern.
- `{ "findings": [] }` replaces the `<\!-- NO_ISSUES_FOUND -->` sentinel.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).