### PR TITLE
feat(tree): extract supportsIncrementalEncoding helper for codec version checks

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -49,8 +49,8 @@ import {
 	type EncodedNestedArrayShape,
 	type EncodedNodeShape,
 	type EncodedValueShape,
-	FieldBatchFormatVersion,
 	SpecialField,
+	supportsIncrementalEncoding,
 } from "./format/index.js";
 
 export interface IdDecodingContext {
@@ -256,7 +256,7 @@ export class IncrementalChunkDecoder implements ChunkDecoder {
 
 		const chunkDecoder = (batch: EncodedFieldBatchV2): TreeChunk => {
 			assert(
-				batch.version >= FieldBatchFormatVersion.v2,
+				supportsIncrementalEncoding(batch.version),
 				0xc9f /* Unsupported FieldBatchFormatVersion for incremental chunks; must be v2 or higher */,
 			);
 			const context = new DecoderContext(

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -30,6 +30,7 @@ import {
 	EncodedFieldBatchV1,
 	EncodedFieldBatchV2,
 	FieldBatchFormatVersion,
+	supportsIncrementalEncoding,
 	type EncodedFieldBatchV1OrV2,
 } from "./format/index.js";
 import type { IncrementalEncodingPolicy } from "./incrementalEncodingPolicy.js";
@@ -147,7 +148,7 @@ function makeFieldBatchCodecForVersion(
 				}
 				case TreeCompressionStrategy.CompressedIncremental: {
 					assert(
-						version >= FieldBatchFormatVersion.v2,
+						supportsIncrementalEncoding(version),
 						0xca0 /* Unsupported FieldBatchFormatVersion for incremental encoding; must be v2 or higher */,
 					);
 					// Incremental encoding is only supported for CompressedIncremental.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -36,8 +36,9 @@ import {
 	type EncodedFieldBatchV1OrV2,
 	type EncodedNestedArrayShape,
 	type EncodedValueShape,
-	FieldBatchFormatVersion,
+	type FieldBatchFormatVersion,
 	SpecialField,
+	supportsIncrementalEncoding,
 } from "./format/index.js";
 
 /**
@@ -461,7 +462,7 @@ export const incrementalFieldEncoder: FieldEncoder = {
 			0xc88 /* incremental encoder must be defined to use incrementalFieldEncoder */,
 		);
 		assert(
-			context.version >= FieldBatchFormatVersion.v2,
+			supportsIncrementalEncoding(context.version),
 			0xca1 /* Unsupported FieldBatchFormatVersion for incremental encoding; must be v2 or higher */,
 		);
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/formatGeneric.ts
@@ -28,7 +28,6 @@ export const Count = Type.Number({ multipleOf: 1, minimum: 0 });
 
 const EncodedFieldBatchBase = Type.Object(
 	{
-		version: Type.Number(),
 		identifiers: Type.Array(Type.String()),
 		/**
 		 * Top level array is list of field from batch.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/index.ts
@@ -20,6 +20,7 @@ export {
 	FieldBatchFormatVersion,
 	EncodedFieldBatchV1,
 	EncodedFieldBatchV2,
+	supportsIncrementalEncoding,
 	type EncodedFieldBatchV1OrV2,
 	type EncodedFieldBatchV1AndV2,
 	type EncodedChunkShapeV1OrV2,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
@@ -32,6 +32,21 @@ export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
 });
 
 /**
+ * Whether the given format version supports incremental chunk encoding.
+ *
+ * @remarks
+ * This helper should be used instead of an equality check since experimental versions
+ * can be a string.
+ */
+export function supportsIncrementalEncoding(version: FieldBatchFormatVersion): boolean {
+	if (version === FieldBatchFormatVersion.v1) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Encoded {@link FieldBatch} using V1 format.
  * @remarks
  * Does not support {@link EncodedIncrementalChunkShape}.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/format/versions.ts
@@ -35,7 +35,7 @@ export const FieldBatchFormatVersion = strictEnum("FieldBatchFormatVersion", {
  * Whether the given format version supports incremental chunk encoding.
  *
  * @remarks
- * This helper should be used instead of an equality check since experimental versions
+ * This helper should be used for comparison since experimental versions
  * can be a string.
  */
 export function supportsIncrementalEncoding(version: FieldBatchFormatVersion): boolean {

--- a/packages/dds/tree/src/test/snapshots/output/codecFormats/snapshot of supported codec formats_FieldBatch_codec.json
+++ b/packages/dds/tree/src/test/snapshots/output/codecFormats/snapshot of supported codec formats_FieldBatch_codec.json
@@ -6,17 +6,6 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "version": {
-          "allOf": [
-            {
-              "type": "number"
-            },
-            {
-              "const": 1,
-              "type": "number"
-            }
-          ]
-        },
         "identifiers": {
           "type": "array",
           "items": {
@@ -29,6 +18,10 @@
             "type": "array",
             "items": {}
           }
+        },
+        "version": {
+          "const": 1,
+          "type": "number"
         },
         "shapes": {
           "type": "array",
@@ -143,9 +136,9 @@
         }
       },
       "required": [
-        "version",
         "identifiers",
         "data",
+        "version",
         "shapes"
       ]
     }
@@ -157,17 +150,6 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "version": {
-          "allOf": [
-            {
-              "type": "number"
-            },
-            {
-              "const": 2,
-              "type": "number"
-            }
-          ]
-        },
         "identifiers": {
           "type": "array",
           "items": {
@@ -180,6 +162,10 @@
             "type": "array",
             "items": {}
           }
+        },
+        "version": {
+          "const": 2,
+          "type": "number"
         },
         "shapes": {
           "type": "array",
@@ -295,9 +281,9 @@
         }
       },
       "required": [
-        "version",
         "identifiers",
         "data",
+        "version",
         "shapes"
       ]
     }


### PR DESCRIPTION
## Description
When prototyping adding a new, string-typed experimental codec this helper and `version` field in `EncodedFieldBatchBase` don't allow for its introduction.

This change replaces direct numeric comparisons (`version >= FieldBatchFormatVersion.v2`) with a
`supportsIncrementalEncoding(version)` helper. Since `>=` is invalid across `string | number`
unions, a string-valued experimental version would cause a compile error at every callsite;
the helper centralizes the check to one place.

Also removes the redundant `version: Type.Number()` from `EncodedFieldBatchBase` — the
composite already adds `Type.Literal(version)`, and the broad `Number` type would produce an
impossible intersection with any future string-valued version.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
