### PR TITLE
Double-quote AzP cache keys where appropriate

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -43,10 +43,10 @@ steps:
     inputs:
       # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
       # in the cache key
-      key: 'pnpm-store | "$(Agent.OS)" | $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+      key: '"pnpm-store" | "$(Agent.OS)" | $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/pnpm-lock.yaml'
       path: ${{ parameters.pnpmStorePath }}
       restoreKeys: |
-        pnpm-store | "$(Agent.OS)"
+        "pnpm-store" | "$(Agent.OS)"
 
 - task: Bash@3
   displayName: Install and configure pnpm

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -405,7 +405,7 @@ stages:
             continueOnError: true
             inputs:
               # Increment the number on the cache-bust key (no special semantics) to force a new cache key.
-              key: '"compat-version-installs" | cache-bust-1 | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}" | "$(compatVersionCacheKey)"'
+              key: '"compat-version-installs" | "cache-bust-1" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}" | "$(compatVersionCacheKey)"'
               path: $(compatVersionInstallsPath)
 
         # Only check out tenants from the tenant pool if we are running tests against ODSP


### PR DESCRIPTION
## Description

Non-quoted cache keys are at least in some cases (I think always, perhaps modulo ones that have invalid path characters) treated as filepaths. Recommended guidance (see docs [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops&tabs=bundler#configure-the-cache-task)) is to double-quote any key that you intend to be interpreted literally. I've audited places we use the `Cache` task and updated keys accordingly.

If a key is interpreted as a file rather than literally, this can cause issues with undereager cache invalidation since the file contents are likely empty (as will be the file contents of the new key if that key changes).

Test pipeline runs:

- [build-client-packages](https://dev.azure.com/fluidframework/internal/_build/results?buildId=394356&view=results)
- [e2e tests](https://dev.azure.com/fluidframework/internal/_build/results?buildId=394386&view=results)