### PR TITLE
build: install @fluid-tools/build-cli in AI-enabled codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,8 +64,11 @@ RUN if [ "$INSTALL_AGENCY" = "true" ]; then printf '%s\n' \
 
 USER node
 
-# Ensure user-local install paths are on PATH for tools installed below
-ENV PATH="/home/node/.local/bin:/home/node/.cargo/bin:${PATH}"
+# Ensure user-local install paths are on PATH for tools installed below.
+# PNPM_HOME is where `pnpm add -g` places binary shims; adding it to PATH makes
+# globally-installed pnpm packages (e.g. @fluid-tools/build-cli) invokable.
+ENV PNPM_HOME="/home/node/.local/share/pnpm"
+ENV PATH="${PNPM_HOME}:/home/node/.local/bin:/home/node/.cargo/bin:${PATH}"
 
 # Optionally install Playwright CLI
 ARG INSTALL_PLAYWRIGHT_CLI=false

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "AI-enabled",
 	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.3
+	// prebuild-version: 1.0.4
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {
@@ -43,7 +43,7 @@
 		"NODE_VERSION_OVERRIDE": "24",
 		"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
 	},
-	"onCreateCommand": "bash scripts/codespace-setup/on-create.sh",
+	"onCreateCommand": "bash scripts/codespace-setup/on-create.sh && bash scripts/codespace-setup/install-build-cli.sh",
 	"postCreateCommand": "bash scripts/codespace-setup/ai-setup.sh",
 	"postStartCommand": {
 		"bwrap-setup": "sudo mount --make-rshared /",

--- a/scripts/codespace-setup/install-build-cli.sh
+++ b/scripts/codespace-setup/install-build-cli.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Installs @fluid-tools/build-cli (the `flub` CLI) globally from npm using pnpm.
+#
+# Prerequisites: node + corepack must already be set up (on-create.sh), and
+# PNPM_HOME must be on PATH (set in .devcontainer/Dockerfile).
+
+set -euo pipefail
+
+echo "Installing @fluid-tools/build-cli globally..."
+pnpm add -g @fluid-tools/build-cli
+
+echo "flub installed: $(which flub)"
+flub --version


### PR DESCRIPTION
## Description

Installs the `flub` CLI (`@fluid-tools/build-cli`) globally from npm into the stable AI-enabled codespace so agents have it available from first shell without any manual setup.

- New `scripts/codespace-setup/install-build-cli.sh` runs `pnpm add -g @fluid-tools/build-cli` during `onCreateCommand`.
- `Dockerfile` sets `PNPM_HOME=/home/node/.local/share/pnpm` and prepends it to `PATH` so pnpm-global shims are invokable from every shell.
- `.devcontainer/ai-agent/devcontainer.json` chains the new script after `on-create.sh` and bumps `prebuild-version` to `1.0.4` to force a prebuild rebuild.

The unstable `ai-agent-insiders` profile is unchanged and continues to build `flub` from the local `build-tools` workspace via `install-flub.sh`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).