### PR TITLE
ci: Do test pass-rate threshold check in real-service test pipelines

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -471,6 +471,41 @@ stages:
             workingDir: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)/node_modules/${{ parameters.testPackage }}
             customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
 
+        - ${{ if eq(parameters.skipTestResultPublishing, false) }}:
+          # filter report
+          - task: Bash@3
+            displayName: Filter skipped test from report
+            condition: succeededOrFailed()
+            inputs:
+              targetType: 'inline'
+              workingDirectory: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)
+              script: |
+                set -eu -o pipefail
+
+                if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
+                  echo "directory '${{ variables.testPackageDir }}/nyc' exists."
+                  cd ${{ variables.testPackageDir }}/nyc
+                  if ! [[ -z "$(ls -A .)" ]]; then
+                    curdirfiles=`ls`
+                    echo "report file(s) ${curdirfiles} found. Filtering skipped tests..."
+                    for i in `ls`; do sed -i '/<skipped/d' $i; done
+                  else
+                    echo "No report files found in '${{ variables.testPackageDir }}/nyc'"
+                  fi
+                else
+                  echo "Directory '${{ variables.testPackageDir }}/nyc' not found"
+                fi
+
+          # Upload results
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: '**/*junit-report.xml'
+              searchFolder: ${{ variables.testPackageDir }}/nyc
+              mergeTestResults: false
+            condition: succeededOrFailed()
+
         - task: Bash@3
           displayName: 'Check test pass rate (threshold: ${{ parameters.passRateThreshold }}%)'
           condition: succeededOrFailed()
@@ -517,41 +552,6 @@ stages:
               elif total_failures > 0:
                   print(f"##vso[task.complete result=SucceededWithIssues;]Pass rate {pass_rate:.1%} meets the {threshold_pct:.0f}% threshold ({total_passed}/{total_tests} passed)")
               PYEOF
-
-        - ${{ if eq(parameters.skipTestResultPublishing, false) }}:
-          # filter report
-          - task: Bash@3
-            displayName: Filter skipped test from report
-            condition: succeededOrFailed()
-            inputs:
-              targetType: 'inline'
-              workingDirectory: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)
-              script: |
-                set -eu -o pipefail
-
-                if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
-                  echo "directory '${{ variables.testPackageDir }}/nyc' exists."
-                  cd ${{ variables.testPackageDir }}/nyc
-                  if ! [[ -z "$(ls -A .)" ]]; then
-                    curdirfiles=`ls`
-                    echo "report file(s) ${curdirfiles} found. Filtering skipped tests..."
-                    for i in `ls`; do sed -i '/<skipped/d' $i; done
-                  else
-                    echo "No report files found in '${{ variables.testPackageDir }}/nyc'"
-                  fi
-                else
-                  echo "Directory '${{ variables.testPackageDir }}/nyc' not found"
-                fi
-
-          # Upload results
-          - task: PublishTestResults@2
-            displayName: Publish Test Results
-            inputs:
-              testResultsFormat: 'JUnit'
-              testResultsFiles: '**/*junit-report.xml'
-              searchFolder: ${{ variables.testPackageDir }}/nyc
-              mergeTestResults: false
-            condition: succeededOrFailed()
 
         # Publish tinylicious log for troubleshooting
         - ${{ if or(contains(convertToJson(parameters.testCommand), 'tinylicious'), contains(convertToJson(parameters.testCommand), 't9s')) }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -110,6 +110,15 @@ parameters:
     - none
     - sequential
 
+# Minimum pass rate (0–100) required for the stage to not hard-fail.
+# When all tests pass the stage succeeds normally.
+# When some tests fail but the pass rate meets or exceeds this threshold, the stage succeeds with issues (soft failure).
+# When the pass rate falls below this threshold, the stage hard-fails.
+# At 100 (the default), any test failure is a hard failure
+- name: passRateThreshold
+  type: number
+  default: 100
+
 # if true, the FluidFramework repo will be checked out and a docker-compose env will be spun up for testing
 - name: runAgainstDocker
   type: boolean
@@ -439,7 +448,7 @@ stages:
         # run the test
         - task: Npm@1
           displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
-          continueOnError: ${{ parameters.continueOnError }}
+          continueOnError: ${{ or(parameters.continueOnError, lt(parameters.passRateThreshold, 100)) }}
           env:
             ${{ each pair in parameters.env }}:
               ${{ pair.key }}: ${{ pair.value }}
@@ -461,6 +470,54 @@ stages:
             command: 'custom'
             workingDir: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)/node_modules/${{ parameters.testPackage }}
             customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
+
+        - ${{ if lt(parameters.passRateThreshold, 100) }}:
+          - task: Bash@3
+            displayName: 'Check test pass rate (threshold: ${{ parameters.passRateThreshold }}%)'
+            condition: succeededOrFailed()
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -eu -o pipefail
+                python3 << 'PYEOF'
+                import xml.etree.ElementTree as ET
+                import glob, sys, os
+
+                search_dir = "${{ variables.testPackageDir }}/nyc"
+                threshold_pct = ${{ parameters.passRateThreshold }}
+                threshold = threshold_pct / 100.0
+
+                xml_files = glob.glob(os.path.join(search_dir, '**', '*junit-report.xml'), recursive=True)
+
+                if not xml_files:
+                    print("##vso[task.complete result=Failed;]No JUnit XML files found — cannot evaluate pass rate")
+                    sys.exit(1)
+
+                total_tests = 0
+                total_failures = 0
+                for f in sorted(xml_files):
+                    try:
+                        root = ET.parse(f).getroot()
+                        for suite in root.iter('testsuite'):
+                            total_tests += int(suite.get('tests', 0))
+                            total_failures += int(suite.get('failures', 0)) + int(suite.get('errors', 0))
+                    except Exception as e:
+                        print(f"Warning: could not parse '{f}': {e}", file=sys.stderr)
+
+                if total_tests == 0:
+                    print("##vso[task.complete result=Failed;]No tests were counted in XML files — cannot evaluate pass rate")
+                    sys.exit(1)
+
+                total_passed = total_tests - total_failures
+                pass_rate = total_passed / total_tests
+                print(f"Test results: {total_passed}/{total_tests} passed ({pass_rate:.1%}), threshold: {threshold_pct:.0f}%")
+
+                if pass_rate < threshold:
+                    print(f"##vso[task.logissue type=error]Pass rate {pass_rate:.1%} is below the {threshold_pct:.0f}% threshold")
+                    sys.exit(1)
+                elif total_failures > 0:
+                    print(f"##vso[task.complete result=SucceededWithIssues;]Pass rate {pass_rate:.1%} meets the {threshold_pct:.0f}% threshold ({total_passed}/{total_tests} passed)")
+                PYEOF
 
         - ${{ if eq(parameters.skipTestResultPublishing, false) }}:
           # filter report

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -471,53 +471,52 @@ stages:
             workingDir: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)/node_modules/${{ parameters.testPackage }}
             customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
 
-        - ${{ if lt(parameters.passRateThreshold, 100) }}:
-          - task: Bash@3
-            displayName: 'Check test pass rate (threshold: ${{ parameters.passRateThreshold }}%)'
-            condition: succeededOrFailed()
-            inputs:
-              targetType: 'inline'
-              script: |
-                set -eu -o pipefail
-                python3 << 'PYEOF'
-                import xml.etree.ElementTree as ET
-                import glob, sys, os
+        - task: Bash@3
+          displayName: 'Check test pass rate (threshold: ${{ parameters.passRateThreshold }}%)'
+          condition: succeededOrFailed()
+          inputs:
+            targetType: 'inline'
+            script: |
+              set -eu -o pipefail
+              python3 << 'PYEOF'
+              import xml.etree.ElementTree as ET
+              import glob, sys, os
 
-                search_dir = "${{ variables.testPackageDir }}/nyc"
-                threshold_pct = ${{ parameters.passRateThreshold }}
-                threshold = threshold_pct / 100.0
+              search_dir = "${{ variables.testPackageDir }}/nyc"
+              threshold_pct = ${{ parameters.passRateThreshold }}
+              threshold = threshold_pct / 100.0
 
-                xml_files = glob.glob(os.path.join(search_dir, '**', '*junit-report.xml'), recursive=True)
+              xml_files = glob.glob(os.path.join(search_dir, '**', '*junit-report.xml'), recursive=True)
 
-                if not xml_files:
-                    print("##vso[task.complete result=Failed;]No JUnit XML files found — cannot evaluate pass rate")
-                    sys.exit(1)
+              if not xml_files:
+                  print("##vso[task.complete result=Failed;]No JUnit XML files found — cannot evaluate pass rate")
+                  sys.exit(1)
 
-                total_tests = 0
-                total_failures = 0
-                for f in sorted(xml_files):
-                    try:
-                        root = ET.parse(f).getroot()
-                        for suite in root.iter('testsuite'):
-                            total_tests += int(suite.get('tests', 0))
-                            total_failures += int(suite.get('failures', 0)) + int(suite.get('errors', 0))
-                    except Exception as e:
-                        print(f"Warning: could not parse '{f}': {e}", file=sys.stderr)
+              total_tests = 0
+              total_failures = 0
+              for f in sorted(xml_files):
+                  try:
+                      root = ET.parse(f).getroot()
+                      for suite in root.iter('testsuite'):
+                          total_tests += int(suite.get('tests', 0))
+                          total_failures += int(suite.get('failures', 0)) + int(suite.get('errors', 0))
+                  except Exception as e:
+                      print(f"Warning: could not parse '{f}': {e}", file=sys.stderr)
 
-                if total_tests == 0:
-                    print("##vso[task.complete result=Failed;]No tests were counted in XML files — cannot evaluate pass rate")
-                    sys.exit(1)
+              if total_tests == 0:
+                  print("##vso[task.complete result=Failed;]No tests were counted in XML files — cannot evaluate pass rate")
+                  sys.exit(1)
 
-                total_passed = total_tests - total_failures
-                pass_rate = total_passed / total_tests
-                print(f"Test results: {total_passed}/{total_tests} passed ({pass_rate:.1%}), threshold: {threshold_pct:.0f}%")
+              total_passed = total_tests - total_failures
+              pass_rate = total_passed / total_tests
+              print(f"Test results: {total_passed}/{total_tests} passed ({pass_rate:.1%}), threshold: {threshold_pct:.0f}%")
 
-                if pass_rate < threshold:
-                    print(f"##vso[task.logissue type=error]Pass rate {pass_rate:.1%} is below the {threshold_pct:.0f}% threshold")
-                    sys.exit(1)
-                elif total_failures > 0:
-                    print(f"##vso[task.complete result=SucceededWithIssues;]Pass rate {pass_rate:.1%} meets the {threshold_pct:.0f}% threshold ({total_passed}/{total_tests} passed)")
-                PYEOF
+              if pass_rate < threshold:
+                  print(f"##vso[task.logissue type=error]Pass rate {pass_rate:.1%} is below the {threshold_pct:.0f}% threshold")
+                  sys.exit(1)
+              elif total_failures > 0:
+                  print(f"##vso[task.complete result=SucceededWithIssues;]Pass rate {pass_rate:.1%} meets the {threshold_pct:.0f}% threshold ({total_passed}/{total_tests} passed)")
+              PYEOF
 
         - ${{ if eq(parameters.skipTestResultPublishing, false) }}:
           # filter report

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -96,7 +96,7 @@ stages:
       testPackage: ${{ variables.testPackage }}
       artifactBuildId: $(resources.pipeline.client.runID)
       continueOnError: true
-      passRateThreshold: 95
+      passRateThreshold: 100
       timeoutInMinutes: 360
       testCommand: test:realsvc:r11s:docker
       stageVariables:
@@ -137,7 +137,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       timeoutInMinutes: 360
       continueOnError: true
-      passRateThreshold: 95
+      passRateThreshold: 100
       testCommand: test:realsvc:frs:report
       lockBehavior: sequential
       r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
@@ -171,7 +171,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       timeoutInMinutes: 360
       continueOnError: true
-      passRateThreshold: 95
+      passRateThreshold: 100
       testCommand: test:realsvc:odsp:report
       splitTestVariants:
         - name: Non-compat

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -96,6 +96,7 @@ stages:
       testPackage: ${{ variables.testPackage }}
       artifactBuildId: $(resources.pipeline.client.runID)
       continueOnError: true
+      passRateThreshold: 95
       timeoutInMinutes: 360
       testCommand: test:realsvc:r11s:docker
       stageVariables:
@@ -136,6 +137,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       timeoutInMinutes: 360
       continueOnError: true
+      passRateThreshold: 95
       testCommand: test:realsvc:frs:report
       lockBehavior: sequential
       r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
@@ -169,6 +171,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       timeoutInMinutes: 360
       continueOnError: true
+      passRateThreshold: 95
       testCommand: test:realsvc:odsp:report
       splitTestVariants:
         - name: Non-compat

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -51,6 +51,7 @@ stages:
       poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testCommand: test:realsvc:azure
+      passRateThreshold: 95
       artifactBuildId: $(resources.pipeline.client.runID)
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
@@ -87,6 +88,7 @@ stages:
       poolBuild: Small-eastus2
       testPackage: ${{ variables.testOdspPackage }}
       testCommand: test:realsvc:odsp
+      passRateThreshold: 95
       artifactBuildId: $(resources.pipeline.client.runID)
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:


### PR DESCRIPTION
## Description

Implement a test-pass-rate threshold check in the real-service test pipelines. This could accomplish the same thing we're accomplishing with an external monitor which requires us to upload telemetry to Kusto, and maintain the monitor in Geneva, which few people on the team are familiar with.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

We don't like putting logic into the pipeline yml files directly, but since the test pipelines don't download the public repo, we would have to put this file in ff_pipeline_host, or start checking out the repo, which we tried to move away from.