### PR TITLE
DO NOT MERGE: test bundle-size comparison step

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1638,6 +1638,9 @@ export class ContainerRuntime
 	) {
 		super();
 
+		// DO NOT MERGE: Dummy log to perturb bundle size for CI testing.
+		console.log("ContainerRuntime: bundle size test");
+
 		const {
 			options,
 			clientDetails,

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -421,12 +421,10 @@ extends:
                   # At this point we want to publish the artifact with the bundle size analysis,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-                  # TODO(AB#56981): Re-enable once githubPublicRepoSecret is rotated in prague-key-vault.
-                  # Disabled because the token is expired/rejected.
-                  # Original condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+                  # DO NOT MERGE: Temporary test for bundle-size comparison (AB#56981).
                   - task: Npm@1
-                    displayName: (PR only) Compare bundle sizes against baseline (DISABLED)
-                    condition: false
+                    displayName: (PR only) Compare bundle sizes against baseline
+                    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
                     continueOnError: true
                     env:
                       ADO_API_TOKEN: $(System.AccessToken)


### PR DESCRIPTION
Throwaway PR to test the bundle-size comparison CI step.

This PR will not be merged — it exists only to trigger PR CI.