### PR TITLE
fix(test): increase presence disconnect test timeout for Azure

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -128,7 +128,7 @@ describe(`Presence with AzureClient`, () => {
 			/**
 			 * Timeout for presence attendees to fully join (everyone knows about everyone) {@link AttendeeConnectedEvent}
 			 */
-			const allAttendeesFullyJoinedTimeoutMs = (2000 + 300 * numClients) * timeoutMultiplier;
+			const allAttendeesFullyJoinedTimeoutMs = (3000 + 450 * numClients) * timeoutMultiplier;
 
 			for (const writeClients of [numClients, 1]) {
 				it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients, ${writeClients} writers]`, async function testAnnouncesAttendeeConnected() {


### PR DESCRIPTION
## Description

The `attendeeDisconnected` tests with 40 clients have been transiently failing in the Service
Clients E2E pipeline (`e2e_azure_client_frs` stage) due to the "fully joined" setup phase timing
out. This phase requires all 40 clients to observe all 39 other clients' `attendeeConnected` events
(1,560 events total), and the previous 70-second timeout was marginal under current AFR latency.

Increases `allAttendeesFullyJoinedTimeoutMs` from `(2000 + 300*n)` to `(3000 + 450*n)` per client,
giving 105s instead of 70s for 40-client tests (a 50% increase).

Related: IcM #783841908

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This is a test-only timeout increase — no production code changes. The failure pattern was confirmed
across 50+ pipeline runs with a ~65-70% failure rate on recent builds.