### PR TITLE
ci: verify non-opt-in baseline for changed-package test scoping

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -50,6 +50,15 @@ parameters:
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
+# Rollout switch for scoping PR test execution to packages changed by the PR
+# (plus their transitive dependents). When false, scoping still activates
+# automatically for PR builds whose source branch contains 'test/filtered-ci/'
+# — a magic substring used to verify the feature end-to-end before general
+# rollout. See build-npm-client-package.yml for the full rules.
+- name: enableChangedPackageTestScoping
+  displayName: Scope tests to changed packages (PR builds only)
+  type: boolean
+  default: false
 
 trigger:
   branches:
@@ -199,6 +208,7 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     packageTypesOverride: ${{ parameters.packageTypesOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+    enableChangedPackageTestScoping: ${{ parameters.enableChangedPackageTestScoping }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -50,12 +50,6 @@ parameters:
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
-# Rollout switch for scoping PR test execution to changed packages.
-# See build-npm-client-package.yml for the full activation rules.
-- name: enableChangedPackageTestScoping
-  displayName: Scope tests to changed packages (PR builds only)
-  type: boolean
-  default: false
 
 trigger:
   branches:
@@ -205,7 +199,6 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     packageTypesOverride: ${{ parameters.packageTypesOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
-    enableChangedPackageTestScoping: ${{ parameters.enableChangedPackageTestScoping }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -50,11 +50,8 @@ parameters:
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
-# Rollout switch for scoping PR test execution to packages changed by the PR
-# (plus their transitive dependents). When false, scoping still activates
-# automatically for PR builds whose source branch contains 'test/filtered-ci/'
-# — a magic substring used to verify the feature end-to-end before general
-# rollout. See build-npm-client-package.yml for the full rules.
+# Rollout switch for scoping PR test execution to changed packages.
+# See build-npm-client-package.yml for the full activation rules.
 - name: enableChangedPackageTestScoping
   displayName: Scope tests to changed packages (PR builds only)
   type: boolean

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,17 +129,6 @@ parameters:
   type: boolean
   default: false
 
-# Feature flag: when true, PR builds scope test execution to packages
-# affected by the PR diff (plus transitive dependents) via pnpm's native
-# `--filter "...[<merge-base>]"`. Also activates when the PR source branch
-# name contains 'test/filtered-ci/' — a rollout opt-in for exercising the
-# behavior from an auto-triggered PR build without flipping a parameter at
-# queue time. Non-opt-in runs remain effectively byte-identical to today.
-# See include-detect-changed-packages.yml for the full filter semantics.
-- name: enableChangedPackageTestScoping
-  type: boolean
-  default: false
-
 # The `resources` specify the location and version of the 1ES Pipeline Template.
 resources:
   repositories:
@@ -218,17 +207,16 @@ extends:
         dependsOn: [] # this stage doesn't depend on preceding stage
         jobs:
           # Detect packages changed by this PR; publishes output variables that
-          # scope downstream test jobs. Skipped for non-PR builds and non-opt-in
-          # PRs; see include-detect-changed-packages.yml for the full semantics.
+          # scope downstream test jobs. Activated only for PR builds whose
+          # source branch name contains 'test/filtered-ci/' — a rollout opt-in
+          # to be broadened once the feature has soaked. See
+          # include-detect-changed-packages.yml for the full semantics.
           - job: detect_changes
             displayName: Detect changed packages
             condition: >-
               and(
                 eq(variables['Build.Reason'], 'PullRequest'),
-                or(
-                  eq('${{ parameters.enableChangedPackageTestScoping }}', 'True'),
-                  contains(variables['System.PullRequest.SourceBranch'], 'test/filtered-ci/')
-                )
+                contains(variables['System.PullRequest.SourceBranch'], 'test/filtered-ci/')
               )
             variables:
               - name: targetBranchName

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,24 +129,13 @@ parameters:
   type: boolean
   default: false
 
-# Feature flag: when true, PR builds run a `detect_changes` job up front
-# and scope subsequent test execution to packages affected by the PR diff
-# (plus their transitive dependents). Scoping is applied natively by pnpm
-# via `npm_config_filter="...[<merge-base>]"`, so no wrapper scripts or
-# package.json changes are needed.
-#
-# The detect_changes job is always compiled into the pipeline but runs
-# conditionally at build time. It executes when all of these are true:
-#   (1) Build.Reason == 'PullRequest' (scoping only makes sense for PRs)
-#   (2) this parameter is true,
-#       OR the PR source branch name contains 'test/filtered-ci/' — a magic
-#       branch-name prefix that lets contributors exercise the scoped
-#       behavior from an auto-triggered PR build without flipping a
-#       parameter at queue time.
-# When the condition is false the job is skipped; its output variables
-# resolve to empty strings, and downstream test jobs interpret that as
-# "no filter — run every package" (the historical behavior). So the
-# pipeline remains effectively byte-identical for non-opt-in runs.
+# Feature flag: when true, PR builds scope test execution to packages
+# affected by the PR diff (plus transitive dependents) via pnpm's native
+# `--filter "...[<merge-base>]"`. Also activates when the PR source branch
+# name contains 'test/filtered-ci/' — a rollout opt-in for exercising the
+# behavior from an auto-triggered PR build without flipping a parameter at
+# queue time. Non-opt-in runs remain effectively byte-identical to today.
+# See include-detect-changed-packages.yml for the full filter semantics.
 - name: enableChangedPackageTestScoping
   type: boolean
   default: false
@@ -228,14 +217,9 @@ extends:
         displayName: Build Stage
         dependsOn: [] # this stage doesn't depend on preceding stage
         jobs:
-          # Detect packages changed by this PR so downstream test jobs can
-          # scope via pnpm's `--filter "...[<sha>]"` selector (set as
-          # `npm_config_filter`). Always compiled in, but skipped at runtime
-          # for non-PR builds and for PR builds that haven't opted into
-          # scoping (neither the parameter set nor the magic branch name).
-          # When skipped, the output variables resolve to empty strings,
-          # which downstream jobs interpret as "run every package" — the
-          # historical behavior.
+          # Detect packages changed by this PR; publishes output variables that
+          # scope downstream test jobs. Skipped for non-PR builds and non-opt-in
+          # PRs; see include-detect-changed-packages.yml for the full semantics.
           - job: detect_changes
             displayName: Detect changed packages
             condition: >-
@@ -613,6 +597,11 @@ extends:
             dependsOn:
               - build
               - detect_changes
+            # Skip the job entirely when detect_changes explicitly concluded no
+            # packages were affected — saves agent allocation, checkout, and
+            # install on scoped PRs. Empty (detect_changes was skipped) still
+            # runs. See include-detect-changed-packages.yml for the invariants.
+            condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -628,12 +617,10 @@ extends:
                 value: 'false'
               - name: COMMIT_SHA
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-              # Outputs from the detect_changes job. Empty when the job was
-              # skipped (non-PR builds, or PR builds that didn't opt into
-              # scoping) — downstream steps interpret that as "run every
-              # package", matching the historical behavior.
-              - name: shouldRunTests
-                value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+              # Output from detect_changes; empty when that job was skipped
+              # (interpreted downstream as "full run" — the historical behavior).
+              # `shouldRunTests` is consumed via the job-level condition above,
+              # so only `scopedPnpmFilter` needs a job-scoped variable here.
               - name: scopedPnpmFilter
                 value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
 
@@ -678,14 +665,9 @@ extends:
 
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
-              # The extra `ne(shouldRunTests, 'false')` guard skips test execution
-              # when the detect job explicitly concluded no packages were affected.
-              # An empty `shouldRunTests` (the job was skipped entirely) still lets
-              # tests run — matching the historical "no scoping" behavior.
               - script: |
                   echo "##vso[task.setvariable variable=startTest]true"
                 displayName: Start Test
-                condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
               - ${{ each test in parameters.coverageTests }}:
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -790,6 +772,11 @@ extends:
               dependsOn:
                 - build
                 - detect_changes
+              # Skip the job entirely when detect_changes explicitly concluded no
+              # packages were affected — saves agent allocation, checkout, and
+              # install on scoped PRs. Empty (detect_changes was skipped) still
+              # runs. See include-detect-changed-packages.yml for the invariants.
+              condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName
@@ -805,12 +792,10 @@ extends:
                   value: 'false'
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-                # Outputs from the detect_changes job. Empty when the job was
-                # skipped (non-PR builds, or PR builds that didn't opt into
-                # scoping) — downstream steps interpret that as "run every
-                # package", matching the historical behavior.
-                - name: shouldRunTests
-                  value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+                # Output from detect_changes; empty when that job was skipped
+                # (interpreted downstream as "full run" — the historical behavior).
+                # `shouldRunTests` is consumed via the job-level condition above,
+                # so only `scopedPnpmFilter` needs a job-scoped variable here.
                 - name: scopedPnpmFilter
                   value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
               steps:
@@ -849,14 +834,9 @@ extends:
 
                 # Set variable startTest if everything is good so far and we'll start running tests,
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
-                # The extra `ne(shouldRunTests, 'false')` guard skips test execution
-                # when the detect job explicitly concluded no packages were affected.
-                # An empty `shouldRunTests` (the job was skipped entirely) still lets
-                # tests run — matching the historical "no scoping" behavior.
                 - script: |
                     echo "##vso[task.setvariable variable=startTest]true"
                   displayName: Start Test
-                  condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
                   parameters:

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -601,7 +601,11 @@ extends:
             # packages were affected — saves agent allocation, checkout, and
             # install on scoped PRs. Empty (detect_changes was skipped) still
             # runs. See include-detect-changed-packages.yml for the invariants.
-            condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
+            #
+            # We check `build.result` directly instead of using `succeeded()`
+            # because the latter treats a Skipped `detect_changes` dependency
+            # as non-success and false-skips this job on non-opt-in PR builds.
+            condition: and(in(dependencies.build.result, 'Succeeded', 'SucceededWithIssues'), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -776,7 +780,11 @@ extends:
               # packages were affected — saves agent allocation, checkout, and
               # install on scoped PRs. Empty (detect_changes was skipped) still
               # runs. See include-detect-changed-packages.yml for the invariants.
-              condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
+              #
+              # We check `build.result` directly instead of using `succeeded()`
+              # because the latter treats a Skipped `detect_changes` dependency
+              # as non-success and false-skips this job on non-opt-in PR builds.
+              condition: and(in(dependencies.build.result, 'Succeeded', 'SucceededWithIssues'), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,6 +129,28 @@ parameters:
   type: boolean
   default: false
 
+# Feature flag: when true, PR builds run a `detect_changes` job up front
+# and scope subsequent test execution to packages affected by the PR diff
+# (plus their transitive dependents). Scoping is applied natively by pnpm
+# via `npm_config_filter="...[<merge-base>]"`, so no wrapper scripts or
+# package.json changes are needed.
+#
+# The detect_changes job is always compiled into the pipeline but runs
+# conditionally at build time. It executes when all of these are true:
+#   (1) Build.Reason == 'PullRequest' (scoping only makes sense for PRs)
+#   (2) this parameter is true,
+#       OR the PR source branch name contains 'test/filtered-ci/' — a magic
+#       branch-name prefix that lets contributors exercise the scoped
+#       behavior from an auto-triggered PR build without flipping a
+#       parameter at queue time.
+# When the condition is false the job is skipped; its output variables
+# resolve to empty strings, and downstream test jobs interpret that as
+# "no filter — run every package" (the historical behavior). So the
+# pipeline remains effectively byte-identical for non-opt-in runs.
+- name: enableChangedPackageTestScoping
+  type: boolean
+  default: false
+
 # The `resources` specify the location and version of the 1ES Pipeline Template.
 resources:
   repositories:
@@ -206,6 +228,33 @@ extends:
         displayName: Build Stage
         dependsOn: [] # this stage doesn't depend on preceding stage
         jobs:
+          # Detect packages changed by this PR so downstream test jobs can
+          # scope via pnpm's `--filter "...[<sha>]"` selector (set as
+          # `npm_config_filter`). Always compiled in, but skipped at runtime
+          # for non-PR builds and for PR builds that haven't opted into
+          # scoping (neither the parameter set nor the magic branch name).
+          # When skipped, the output variables resolve to empty strings,
+          # which downstream jobs interpret as "run every package" — the
+          # historical behavior.
+          - job: detect_changes
+            displayName: Detect changed packages
+            condition: >-
+              and(
+                eq(variables['Build.Reason'], 'PullRequest'),
+                or(
+                  eq('${{ parameters.enableChangedPackageTestScoping }}', 'True'),
+                  contains(variables['System.PullRequest.SourceBranch'], 'test/filtered-ci/')
+                )
+              )
+            variables:
+              - name: targetBranchName
+                value: $(System.PullRequest.TargetBranch)
+            steps:
+              - template: /tools/pipelines/templates/include-detect-changed-packages.yml@self
+                parameters:
+                  buildDirectory: ${{ parameters.buildDirectory }}
+                  targetBranchName: $(targetBranchName)
+
           # Job - Build
           - job: build
             displayName: Build
@@ -561,7 +610,9 @@ extends:
 
           - job: Coverage_tests
             displayName: "Coverage tests"
-            dependsOn: build
+            dependsOn:
+              - build
+              - detect_changes
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -577,6 +628,14 @@ extends:
                 value: 'false'
               - name: COMMIT_SHA
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+              # Outputs from the detect_changes job. Empty when the job was
+              # skipped (non-PR builds, or PR builds that didn't opt into
+              # scoping) — downstream steps interpret that as "run every
+              # package", matching the historical behavior.
+              - name: shouldRunTests
+                value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+              - name: scopedPnpmFilter
+                value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
 
             steps:
               # Setup
@@ -619,9 +678,14 @@ extends:
 
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
+              # The extra `ne(shouldRunTests, 'false')` guard skips test execution
+              # when the detect job explicitly concluded no packages were affected.
+              # An empty `shouldRunTests` (the job was skipped entirely) still lets
+              # tests run — matching the historical "no scoping" behavior.
               - script: |
                   echo "##vso[task.setvariable variable=startTest]true"
                 displayName: Start Test
+                condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
               - ${{ each test in parameters.coverageTests }}:
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -629,6 +693,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: '${{ parameters.testCoverage }}'
+                    pnpmFilter: $(scopedPnpmFilter)
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
@@ -722,7 +787,9 @@ extends:
           - ${{ each test in parameters.taskTest }}:
             - job: Test_${{ test.jobName }}
               displayName: "Run Task Test ${{ test.jobName }}"
-              dependsOn: build
+              dependsOn:
+                - build
+                - detect_changes
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName
@@ -738,6 +805,14 @@ extends:
                   value: 'false'
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                # Outputs from the detect_changes job. Empty when the job was
+                # skipped (non-PR builds, or PR builds that didn't opt into
+                # scoping) — downstream steps interpret that as "run every
+                # package", matching the historical behavior.
+                - name: shouldRunTests
+                  value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+                - name: scopedPnpmFilter
+                  value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
               steps:
                 # Setup
                 - checkout: self
@@ -774,15 +849,21 @@ extends:
 
                 # Set variable startTest if everything is good so far and we'll start running tests,
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
+                # The extra `ne(shouldRunTests, 'false')` guard skips test execution
+                # when the detect job explicitly concluded no packages were affected.
+                # An empty `shouldRunTests` (the job was skipped entirely) still lets
+                # tests run — matching the historical "no scoping" behavior.
                 - script: |
                     echo "##vso[task.setvariable variable=startTest]true"
                   displayName: Start Test
+                  condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
                   parameters:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: 'false'
+                    pnpmFilter: $(scopedPnpmFilter)
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'

--- a/tools/pipelines/templates/include-detect-changed-packages.yml
+++ b/tools/pipelines/templates/include-detect-changed-packages.yml
@@ -44,9 +44,10 @@ steps:
   - checkout: self
     path: $(FluidFrameworkDirectory)
     clean: true
-    # Full history is required for `git merge-base HEAD origin/<target>` to
-    # produce a meaningful ancestor on a PR branch.
-    fetchDepth: 0
+    # Shallow clone; the bash step below unshallows on demand if the
+    # merge-base can't be resolved within this depth. Most PRs merge-base
+    # within a few hundred commits, so this is cheap in the common case.
+    fetchDepth: 200
 
   - task: Bash@3
     name: setChangedPackages
@@ -79,7 +80,17 @@ steps:
           emit_and_exit
         fi
 
+        # Try to resolve the merge-base in the shallow clone first. If the
+        # PR diverged further back than the shallow boundary, unshallow and
+        # retry once. The presence of a `shallow` file under `.git` is how
+        # git marks a shallow repo; skip the unshallow on a full clone
+        # (which would error with "--unshallow on a complete repository").
         MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)"
+        if [ -z "${MERGE_BASE}" ] && [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+          echo "Merge-base not found in shallow clone; unshallowing and retrying."
+          git fetch --unshallow origin "${TARGET_BRANCH}" 2>/dev/null || true
+          MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)"
+        fi
         if [ -z "${MERGE_BASE}" ]; then
           echo "##vso[task.logissue type=warning]No merge-base with origin/${TARGET_BRANCH}; falling back to full test run."
           emit_and_exit
@@ -99,6 +110,14 @@ steps:
         # across the whole workspace).
         # Keep this list conservative — it's the safety net for changes that
         # could plausibly invalidate assumptions across the entire workspace.
+        #
+        # This list partially overlaps with `pr: paths: include:` in
+        # tools/pipelines/build-client.yml (which decides whether the pipeline
+        # runs at all). The concepts differ — one gates the pipeline, the
+        # other gates scoping within a pipeline that's already running — but
+        # adding a new cross-cutting root-level file generally warrants
+        # updating both. There's no programmatic link, so keep them in sync
+        # by convention.
         FULL_RUN_PATTERNS=(
           '^package\.json$'
           '^pnpm-lock\.yaml$'

--- a/tools/pipelines/templates/include-detect-changed-packages.yml
+++ b/tools/pipelines/templates/include-detect-changed-packages.yml
@@ -1,0 +1,149 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-detect-changed-packages
+#
+# Detects whether a PR's diff warrants scoping downstream test execution to
+# a subset of workspace packages and publishes output variables that test
+# jobs read to make that decision.
+#
+# The scoping itself is handled natively by pnpm via the
+# `--filter "...[<ref>]"` selector — this template just computes the right
+# git ref (the merge-base between HEAD and the target branch) and emits it
+# as a ready-to-use filter string that downstream jobs set as
+# `npm_config_filter`. pnpm then picks up the env var automatically and
+# applies it to any `pnpm -r run <task>` invocation. That keeps the root
+# package.json scripts unchanged and removes the need for a custom wrapper.
+#
+# Output variables (from the `setChangedPackages` step):
+#   - shouldRunTests    "true" | "false"  — whether any test work is needed at all
+#   - scopedPnpmFilter  The pnpm filter string ("...[<sha>]") when scoping is
+#                       active, or an empty string when a full test run is
+#                       required. Downstream jobs pass this into
+#                       `npm_config_filter` verbatim; pnpm treats an empty
+#                       value as "no filter applied", so recursive `-r` runs
+#                       fall back to the historical every-package behavior.
+#
+# On any error path (missing merge-base, unsupported ref format) this
+# template degrades safely to a full-run outcome, never to a silent skip.
+#
+# Why merge-base (and not just `origin/<branch>` directly): pnpm's
+# `--filter "[ref]"` uses a two-dot diff internally (see pnpm/pnpm#9907), so
+# commits that landed on `origin/<branch>` after this PR diverged would show
+# up as "changed." Computing the merge-base SHA ourselves and feeding that
+# SHA into the selector gives three-dot (merge-base) semantics.
+
+parameters:
+- name: buildDirectory
+  type: string
+
+- name: targetBranchName
+  type: string
+
+steps:
+  - checkout: self
+    path: $(FluidFrameworkDirectory)
+    clean: true
+    # Full history is required for `git merge-base HEAD origin/<target>` to
+    # produce a meaningful ancestor on a PR branch.
+    fetchDepth: 0
+
+  - task: Bash@3
+    name: setChangedPackages
+    displayName: Detect changed packages
+    inputs:
+      targetType: inline
+      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+      script: |
+        set -eu -o pipefail
+
+        # Normalize: ADO returns "refs/heads/main" on Azure Repos, just "main" on GitHub.
+        TARGET_BRANCH="${{ parameters.targetBranchName }}"
+        TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
+        echo "Target branch: ${TARGET_BRANCH}"
+
+        # Safe fallback is always a full run — non-empty filter would be a skip.
+        SHOULD_RUN="true"
+        FILTER=""
+
+        emit_and_exit() {
+          echo "shouldRunTests=${SHOULD_RUN}"
+          echo "scopedPnpmFilter=${FILTER}"
+          echo "##vso[task.setvariable variable=shouldRunTests;isOutput=true]${SHOULD_RUN}"
+          echo "##vso[task.setvariable variable=scopedPnpmFilter;isOutput=true]${FILTER}"
+          exit 0
+        }
+
+        if ! git fetch origin "${TARGET_BRANCH}"; then
+          echo "##vso[task.logissue type=warning]Could not fetch origin/${TARGET_BRANCH}; falling back to full test run."
+          emit_and_exit
+        fi
+
+        MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)"
+        if [ -z "${MERGE_BASE}" ]; then
+          echo "##vso[task.logissue type=warning]No merge-base with origin/${TARGET_BRANCH}; falling back to full test run."
+          emit_and_exit
+        fi
+        echo "Merge base: ${MERGE_BASE}"
+
+        CHANGED_FILES="$(git diff --name-only "${MERGE_BASE}" || true)"
+        FILE_COUNT="$(printf '%s\n' "${CHANGED_FILES}" | grep -c . || true)"
+        echo "Changed files (${FILE_COUNT}):"
+        printf '%s\n' "${CHANGED_FILES}" | head -30
+        if [ "${FILE_COUNT}" -gt 30 ]; then
+          echo "... and $((FILE_COUNT - 30)) more"
+        fi
+
+        # Full-run trigger patterns. A diff touching any of these paths forces
+        # running every package's tests (FILTER stays empty → pnpm -r runs
+        # across the whole workspace).
+        # Keep this list conservative — it's the safety net for changes that
+        # could plausibly invalidate assumptions across the entire workspace.
+        FULL_RUN_PATTERNS=(
+          '^package\.json$'
+          '^pnpm-lock\.yaml$'
+          '^pnpm-workspace\.yaml$'
+          '^fluidBuild\.config\.cjs$'
+          '^tsconfig[^/]*\.json$'
+          '^biome\.'
+          '^tools/'
+          '^common/'
+          '^scripts/'
+          '^\.changeset/config\.json$'
+        )
+        for pattern in "${FULL_RUN_PATTERNS[@]}"; do
+          if printf '%s\n' "${CHANGED_FILES}" | grep -Eq "${pattern}"; then
+            echo "Match for full-run pattern '${pattern}' — forcing full test run."
+            emit_and_exit
+          fi
+        done
+
+        # Quick sanity check: did any changed file land under a package dir
+        # (anything with a package.json below the repo root)? If not, there's
+        # no test work to do at all and we can short-circuit.
+        HAS_PACKAGE_CHANGE="false"
+        while IFS= read -r file; do
+          [ -z "${file}" ] && continue
+          d="$(dirname "${file}")"
+          while [ "${d}" != "." ] && [ "${d}" != "/" ]; do
+            if [ -f "${d}/package.json" ]; then
+              HAS_PACKAGE_CHANGE="true"
+              break 2
+            fi
+            d="$(dirname "${d}")"
+          done
+        done <<< "${CHANGED_FILES}"
+
+        if [ "${HAS_PACKAGE_CHANGE}" = "false" ]; then
+          echo "No changed files mapped to a workspace package — skipping test execution."
+          SHOULD_RUN="false"
+          FILTER=""
+          emit_and_exit
+        fi
+
+        # Hand the merge-base SHA to pnpm's native selector. The leading `...`
+        # pulls in transitive dependents so consumers of a changed package
+        # also get re-tested.
+        FILTER="...[${MERGE_BASE}]"
+        echo "Computed pnpm filter: ${FILTER}"
+        emit_and_exit

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -14,6 +14,14 @@ parameters:
   type: boolean
   default: false
 
+# Optional pnpm filter expression (e.g. "...[<sha>]"). When non-empty, it is
+# set as `npm_config_filter` so pnpm scopes the recursive run to the listed
+# packages plus their dependents. Empty means "no filter" — pnpm falls back
+# to running across every workspace package (the historical behavior).
+- name: pnpmFilter
+  type: string
+  default: ''
+
 steps:
 # Test - With coverage
 - ${{ if and(parameters.testCoverage, startsWith(parameters.taskTestStep, 'ci:test')) }}:
@@ -25,6 +33,7 @@ steps:
       customCommand: 'run ${{ parameters.taskTestStep }}:coverage'
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
+      npm_config_filter: ${{ parameters.pnpmFilter }}
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
         # Disable colorization for tinylicious logs (not useful when printing to a file)
@@ -41,6 +50,7 @@ steps:
       customCommand: 'run ${{ parameters.taskTestStep }}'
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
+      npm_config_filter: ${{ parameters.pnpmFilter }}
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
         # Disable colorization for tinylicious logs (not useful when printing to a file)


### PR DESCRIPTION
## Description

**Verification-only, do not merge.** Throwaway companion PR to #27133.

This branch deliberately omits the `test/filtered-ci/` prefix so that the `detect_changes` job's activation condition evaluates to false at runtime. It's used to confirm that non-opt-in PR builds behave identically to the pre-scoping baseline.

## Scenario under test

Scenario C from the review of #27133: when `detect_changes` is skipped (because neither the `enableChangedPackageTestScoping` parameter nor the `test/filtered-ci/` branch-name trigger fires), its output variables resolve to empty. The job-level condition on `Coverage_tests` and `Test_*`:

```
condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
```

should evaluate to true, and tests should run across the full workspace with no pnpm filter.

## Expected pipeline behavior

- `detect_changes` → **Skipped** (condition false)
- `Coverage_tests` and `Test_*` → **Run normally** with empty `npm_config_filter` (full workspace test run)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

After the pipeline has queued, please look at the ADO build and confirm:

- [ ] `detect_changes` appears as Skipped (not Succeeded, not Failed)
- [ ] `Coverage_tests` and every `Test_*` start and execute tests
- [ ] No `npm_config_filter` is set on the pnpm recursive run
- [ ] Overall build passes

If any test job is itself skipped, the `succeeded()` clause in the job-level condition is rejecting the skipped `detect_changes` dependency — a bug to fix in #27133 before merge.

Close this PR without merging once the build has finished.