### PR TITLE
fix(odsp-driver): Add telemetry so we can distinguish hangs at different points during the snapshot fetching process

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -4,6 +4,7 @@
  */
 
 import { fromUtf8ToBase64 } from "@fluid-internal/client-utils";
+import { LogLevel } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { getW3CData } from "@fluidframework/driver-base/internal";
 import {
@@ -731,6 +732,7 @@ export const downloadSnapshot = mockify(
 		tokenFetchOptions: TokenFetchOptionsEx,
 		loadingGroupIds: string[] | undefined,
 		snapshotOptions: ISnapshotOptions | undefined,
+		logger?: TelemetryLoggerExt,
 		snapshotFormatFetchType?: SnapshotFormatSupportType,
 		controller?: AbortController,
 		epochTracker?: EpochTracker,
@@ -786,6 +788,7 @@ export const downloadSnapshot = mockify(
 			{ ...tokenFetchOptions, request: { url, method } },
 			"downloadSnapshot",
 		);
+		logger?.send({ category: "generic", eventName: "SnapshotAuthHeaderObtained" }, LogLevel.info);
 		assert(authHeader !== null, 0x1e5 /* "Storage token should not be null" */);
 		const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, authHeader, header);
 		const fetchOptions = {
@@ -813,6 +816,7 @@ export const downloadSnapshot = mockify(
 			true,
 			scenarioName,
 		) ?? fetchHelper(url, fetchOptions));
+		logger?.send({ category: "generic", eventName: "SnapshotFetchResponseReceived" }, LogLevel.info);
 
 		return {
 			odspResponse,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -788,8 +788,8 @@ export const downloadSnapshot = mockify(
 			{ ...tokenFetchOptions, request: { url, method } },
 			"downloadSnapshot",
 		);
-		logger?.send({ category: "generic", eventName: "SnapshotAuthHeaderObtained" }, LogLevel.info);
 		assert(authHeader !== null, 0x1e5 /* "Storage token should not be null" */);
+		logger?.send({ category: "generic", eventName: "SnapshotAuthHeaderObtained" }, LogLevel.info);
 		const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, authHeader, header);
 		const fetchOptions = {
 			body,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -4,7 +4,6 @@
  */
 
 import { fromUtf8ToBase64 } from "@fluid-internal/client-utils";
-import { LogLevel } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { getW3CData } from "@fluidframework/driver-base/internal";
 import {
@@ -714,15 +713,18 @@ function getTreeStatsCore(snapshotTree: ISnapshotTree, stats: ITreeStats): void 
 /**
  * This function fetches the snapshot and parse it according to what is mentioned in response headers.
  * @param odspResolvedUrl - resolved odsp url.
- * @param storageToken - token to do the auth for network request.
- * @param snapshotOptions - Options used to specify how and what to fetch in the snapshot.
+ * @param getAuthHeader - function to fetch the auth header for the network request.
+ * @param tokenFetchOptions - options for fetching the token.
  * @param loadingGroupIds - loadingGroupIds for which snapshot needs to be downloaded. Note:
  * 1.) If undefined, then legacy trees latest call will be used where no groupId query param would be specified.
  * 2.) If [] is passed, then snapshot with all ungrouped data will be fetched.
  * 3.) If any groupId is specified like ["g1"], then snapshot for g1 group will be fetched.
+ * @param snapshotOptions - Options used to specify how and what to fetch in the snapshot.
+ * @param logger - logger for sending telemetry events.
  * @param snapshotFormatFetchType - Snapshot format to fetch.
  * @param controller - abort controller if caller needs to abort the network call.
  * @param epochTracker - epoch tracker used to add/validate epoch in the network call.
+ * @param scenarioName - scenario name for telemetry.
  * @returns fetched snapshot.
  */
 export const downloadSnapshot = mockify(
@@ -789,7 +791,7 @@ export const downloadSnapshot = mockify(
 			"downloadSnapshot",
 		);
 		assert(authHeader !== null, 0x1e5 /* "Storage token should not be null" */);
-		logger?.send({ category: "generic", eventName: "SnapshotAuthHeaderObtained" }, LogLevel.info);
+		logger?.sendTelemetryEvent({ eventName: "SnapshotAuthHeaderObtained" });
 		const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, authHeader, header);
 		const fetchOptions = {
 			body,
@@ -816,7 +818,7 @@ export const downloadSnapshot = mockify(
 			true,
 			scenarioName,
 		) ?? fetchHelper(url, fetchOptions));
-		logger?.send({ category: "generic", eventName: "SnapshotFetchResponseReceived" }, LogLevel.info);
+		logger?.sendTelemetryEvent({ eventName: "SnapshotFetchResponseReceived" });
 
 		return {
 			odspResponse,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -639,6 +639,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 				tokenFetchOptions,
 				loadingGroupId,
 				options,
+				this.logger,
 				this.snapshotFormatFetchType,
 				controller,
 				this.epochTracker,

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -110,6 +110,7 @@ export async function prefetchLatestSnapshot(
 			tokenFetchOptions,
 			loadingGroupId,
 			snapshotOptions,
+			odspLogger,
 			undefined,
 			controller,
 		);

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -744,12 +744,11 @@ describe("Tests1 for snapshot fetch", () => {
 		]);
 
 		assert(
-			mockLogger.matchAnyEvent([{ eventName: "SnapshotAuthHeaderObtained", category: "generic" }], false, false),
-			"SnapshotAuthHeaderObtained event should be emitted after auth header is obtained",
-		);
-		assert(
-			mockLogger.matchAnyEvent([{ eventName: "SnapshotFetchResponseReceived", category: "generic" }]),
-			"SnapshotFetchResponseReceived event should be emitted after ODSP fetch response is received",
+			mockLogger.matchEvents([
+				{ eventName: "SnapshotAuthHeaderObtained", category: "generic" },
+				{ eventName: "SnapshotFetchResponseReceived", category: "generic" },
+			]),
+			"SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events should be emitted at info log level",
 		);
 	});
 
@@ -795,12 +794,11 @@ describe("Tests1 for snapshot fetch", () => {
 		]);
 
 		assert(
-			!essentialMockLogger.matchAnyEvent([{ eventName: "SnapshotAuthHeaderObtained", category: "generic" }], false, false),
-			"SnapshotAuthHeaderObtained event should be filtered out at essential log level",
-		);
-		assert(
-			!essentialMockLogger.matchAnyEvent([{ eventName: "SnapshotFetchResponseReceived", category: "generic" }]),
-			"SnapshotFetchResponseReceived event should be filtered out at essential log level",
+			!essentialMockLogger.matchAnyEvent([
+				{ eventName: "SnapshotAuthHeaderObtained", category: "generic" },
+				{ eventName: "SnapshotFetchResponseReceived", category: "generic" },
+			]),
+			"SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events should be filtered out at essential log level",
 		);
 
 		await essentialEpochTracker.removeEntries().catch(() => {});

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -8,7 +8,6 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import { LogLevel } from "@fluidframework/core-interfaces";
 import {
 	DriverErrorTypes,
 	type ISnapshot,
@@ -724,7 +723,7 @@ describe("Tests1 for snapshot fetch", () => {
 		);
 	});
 
-	it("SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events are emitted at info log level", async () => {
+	it("SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events are logged on snapshot fetch", async () => {
 		const snapshot: ISnapshot = {
 			blobContents,
 			snapshotTree: snapshotTreeWithGroupId,
@@ -739,69 +738,18 @@ describe("Tests1 for snapshot fetch", () => {
 			200,
 		)) as unknown as Response;
 
-		await mockFetchMultiple(async () => service.getSnapshot({}), [
-			async (): Promise<Response> => response,
-		]);
-
-		assert(
-			mockLogger.matchEvents([
-				{ eventName: "SnapshotAuthHeaderObtained", category: "generic" },
-				{ eventName: "SnapshotFetchResponseReceived", category: "generic" },
-			]),
-			"SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events should be emitted at info log level",
-		);
-	});
-
-	it("SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events are filtered at essential log level", async () => {
-		const essentialMockLogger = new MockLogger(LogLevel.essential);
-		const essentialLogger = createChildLogger({ logger: essentialMockLogger });
-		const essentialEpochTracker = new EpochTracker(
-			localCache,
-			{ docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
-			essentialLogger,
-		);
-		essentialEpochTracker.setEpoch("epoch1", true, "test");
-		const essentialService = new OdspDocumentStorageService(
-			resolved,
-			async (_options) => "token",
-			essentialLogger,
-			true,
-			{ ...nonPersistentCache, persistedCache: essentialEpochTracker },
-			hostPolicy,
-			essentialEpochTracker,
-			async () => {
-				return {};
-			},
-			() => "tenantid/id",
+		await mockFetchMultiple(
+			async () => service.getSnapshot({}),
+			[async (): Promise<Response> => response],
 		);
 
-		const snapshot: ISnapshot = {
-			blobContents,
-			snapshotTree: snapshotTreeWithGroupId,
-			ops: [],
-			latestSequenceNumber: 0,
-			sequenceNumber: 0,
-			snapshotFormatV: 1,
-		};
-		const response = (await createResponse(
-			{ "x-fluid-epoch": "epoch1", "content-type": "application/ms-fluid" },
-			convertToCompactSnapshot(snapshot),
-			200,
-		)) as unknown as Response;
-
-		await mockFetchMultiple(async () => essentialService.getSnapshot({}), [
-			async (): Promise<Response> => response,
-		]);
-
-		assert(
-			!essentialMockLogger.matchAnyEvent([
-				{ eventName: "SnapshotAuthHeaderObtained", category: "generic" },
-				{ eventName: "SnapshotFetchResponseReceived", category: "generic" },
-			]),
-			"SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events should be filtered out at essential log level",
+		mockLogger.assertMatch(
+			[
+				{ eventName: "SnapshotAuthHeaderObtained" },
+				{ eventName: "SnapshotFetchResponseReceived" },
+			],
+			"SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events should be logged on snapshot fetch",
 		);
-
-		await essentialEpochTracker.removeEntries().catch(() => {});
 	});
 
 	it("Location redirection error still throws when redeem fails", async () => {

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -8,6 +8,7 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
+import { LogLevel } from "@fluidframework/core-interfaces";
 import {
 	DriverErrorTypes,
 	type ISnapshot,
@@ -721,6 +722,88 @@ describe("Tests1 for snapshot fetch", () => {
 			!mockLogger.matchAnyEvent([{ eventName: "RedirectRedeemFallback" }]),
 			"Should not have logged redirect redeem fallback without a shareLink",
 		);
+	});
+
+	it("SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events are emitted at info log level", async () => {
+		const snapshot: ISnapshot = {
+			blobContents,
+			snapshotTree: snapshotTreeWithGroupId,
+			ops: [],
+			latestSequenceNumber: 0,
+			sequenceNumber: 0,
+			snapshotFormatV: 1,
+		};
+		const response = (await createResponse(
+			{ "x-fluid-epoch": "epoch1", "content-type": "application/ms-fluid" },
+			convertToCompactSnapshot(snapshot),
+			200,
+		)) as unknown as Response;
+
+		await mockFetchMultiple(async () => service.getSnapshot({}), [
+			async (): Promise<Response> => response,
+		]);
+
+		assert(
+			mockLogger.matchAnyEvent([{ eventName: "SnapshotAuthHeaderObtained", category: "generic" }], false, false),
+			"SnapshotAuthHeaderObtained event should be emitted after auth header is obtained",
+		);
+		assert(
+			mockLogger.matchAnyEvent([{ eventName: "SnapshotFetchResponseReceived", category: "generic" }]),
+			"SnapshotFetchResponseReceived event should be emitted after ODSP fetch response is received",
+		);
+	});
+
+	it("SnapshotAuthHeaderObtained and SnapshotFetchResponseReceived events are filtered at essential log level", async () => {
+		const essentialMockLogger = new MockLogger(LogLevel.essential);
+		const essentialLogger = createChildLogger({ logger: essentialMockLogger });
+		const essentialEpochTracker = new EpochTracker(
+			localCache,
+			{ docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+			essentialLogger,
+		);
+		essentialEpochTracker.setEpoch("epoch1", true, "test");
+		const essentialService = new OdspDocumentStorageService(
+			resolved,
+			async (_options) => "token",
+			essentialLogger,
+			true,
+			{ ...nonPersistentCache, persistedCache: essentialEpochTracker },
+			hostPolicy,
+			essentialEpochTracker,
+			async () => {
+				return {};
+			},
+			() => "tenantid/id",
+		);
+
+		const snapshot: ISnapshot = {
+			blobContents,
+			snapshotTree: snapshotTreeWithGroupId,
+			ops: [],
+			latestSequenceNumber: 0,
+			sequenceNumber: 0,
+			snapshotFormatV: 1,
+		};
+		const response = (await createResponse(
+			{ "x-fluid-epoch": "epoch1", "content-type": "application/ms-fluid" },
+			convertToCompactSnapshot(snapshot),
+			200,
+		)) as unknown as Response;
+
+		await mockFetchMultiple(async () => essentialService.getSnapshot({}), [
+			async (): Promise<Response> => response,
+		]);
+
+		assert(
+			!essentialMockLogger.matchAnyEvent([{ eventName: "SnapshotAuthHeaderObtained", category: "generic" }], false, false),
+			"SnapshotAuthHeaderObtained event should be filtered out at essential log level",
+		);
+		assert(
+			!essentialMockLogger.matchAnyEvent([{ eventName: "SnapshotFetchResponseReceived", category: "generic" }]),
+			"SnapshotFetchResponseReceived event should be filtered out at essential log level",
+		);
+
+		await essentialEpochTracker.removeEntries().catch(() => {});
 	});
 
 	it("Location redirection error still throws when redeem fails", async () => {


### PR DESCRIPTION
## Description

This is a repair item for: [Incident-720043682 Details - IcM](https://portal.microsofticm.com/imp/v5/incidents/details/720043682/summary)

Teams thread: [Brent Weatherall: Sev 2 Incident 720043682 : Increase in lower ring timed out load... | Loop > LiveSite ⚠️ | Microsoft Teams](https://teams.microsoft.com/l/message/19:9034865f2a4f49b5ab8df4569dbb0e73@thread.skype/1765240880928?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=422665a0-7ad3-4d0d-9171-e8881d0397d9&parentMessageId=1765240880928&teamName=Loop&channelName=LiveSite%20%E2%9A%A0%EF%B8%8F&createdTime=1765240880928)

The ask here is to improve the telemetry around fetching snapshot ("ObtainSnapshot") to help us identify where things are getting stuck prior to cancellations/failures.

We are just adding two events after the potental methods that are hanging so that in the future we'll know specifically what part hangs if this happens again.

## Testing

 Added a unit test that validates both telemetry events are logged when a snapshot is fetched.

fixes [AB#55435](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/55435)