### PR TITLE
Misc. improvements to collaborative text controls and `text-editor` example application

### DIFF
--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -331,7 +331,7 @@ const UserPanel: FC<{
 						</button>
 						{/*
 						  * Note: we are intentionally forcing the editor components to be unmounted when their respective cards are collapsed.
-						  * We are doing this to make it possible to do use this app to do performance analysis on individual editor components in isolation.
+						  * We are doing this to make it possible to use this app to do performance analysis on individual editor components in isolation.
 						  */}
 						{isExpanded && (
 							<div id={`${viewType}-panel`} style={{ padding: "12px" }}>

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -330,9 +330,9 @@ const UserPanel: FC<{
 							</span>
 						</button>
 						{/*
-						  * Note: we are intentionally forcing the editor components to be unmounted when their respective cards are collapsed.
-						  * We are doing this to make it possible to use this app to do performance analysis on individual editor components in isolation.
-						  */}
+						 * Note: we are intentionally forcing the editor components to be unmounted when their respective cards are collapsed.
+						 * We are doing this to make it possible to use this app to do performance analysis on individual editor components in isolation.
+						 */}
 						{isExpanded && (
 							<div id={`${viewType}-panel`} style={{ padding: "12px" }}>
 								{viewLabels[viewType].component(root, treeView, undoRedo)}

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -329,6 +329,10 @@ const UserPanel: FC<{
 								{isExpanded ? "▲" : "▼"}
 							</span>
 						</button>
+						{/*
+						  * Note: we are intentionally forcing the editor components to be unmounted when their respective cards are collapsed.
+						  * We are doing this to make it possible to do use this app to do performance analysis on individual editor components in isolation.
+						  */}
 						{isExpanded && (
 							<div id={`${viewType}-panel`} style={{ padding: "12px" }}>
 								{viewLabels[viewType].component(root, treeView, undoRedo)}

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -248,24 +248,32 @@ const viewLabels = {
 } as const;
 
 const UserPanel: FC<{
-	label: string;
 	color: string;
-	viewType: ViewType;
 	treeView: TreeView<typeof TextEditorRoot>;
-}> = ({ label, color, viewType, treeView }) => {
+}> = ({ color, treeView }) => {
 	// Create undo/redo stack for this user's tree view
-	const undoRedo = useMemo(() => new UndoRedoStacks(treeView.events), [treeView.events]);
+	const undoRedo: UndoRedo = useMemo(
+		() => new UndoRedoStacks(treeView.events),
+		[treeView.events],
+	);
 
 	// Cleanup on unmount
 	useEffect(() => {
 		return () => undoRedo.dispose();
 	}, [undoRedo]);
 
-	// TODO: handle root invalidation, schema upgrades and out of schema documents.
-	const renderView = (): JSX.Element => {
-		const root = treeView.root;
-		return viewLabels[viewType].component(root, treeView, undoRedo);
+	const [collapsed, setCollapsed] = useState<Record<ViewType, boolean>>({
+		plainTextarea: false,
+		plainQuill: false,
+		formatted: false,
+	});
+
+	const toggleCollapsed = (viewType: ViewType): void => {
+		setCollapsed((prev) => ({ ...prev, [viewType]: !prev[viewType] }));
 	};
+
+	// TODO: handle root invalidation, schema upgrades and out of schema documents.
+	const root = treeView.root;
 
 	return (
 		<div
@@ -277,25 +285,59 @@ const UserPanel: FC<{
 				padding: "10px",
 				display: "flex",
 				flexDirection: "column",
+				overflowY: "auto",
 			}}
 		>
-			<div
-				style={{
-					marginBottom: "10px",
-					fontWeight: "bold",
-					color,
-				}}
-			>
-				{label}
-			</div>
-			<div style={{ flex: 1 }}>{renderView()}</div>
+			{(Object.keys(viewLabels) as ViewType[]).map((viewType) => {
+				const isExpanded = !collapsed[viewType];
+				return (
+					<div
+						key={viewType}
+						style={{
+							border: "1px solid #ddd",
+							borderRadius: "6px",
+							marginBottom: "12px",
+							boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+							overflow: "hidden",
+						}}
+					>
+						<button
+							type="button"
+							onClick={() => toggleCollapsed(viewType)}
+							style={{
+								display: "flex",
+								justifyContent: "space-between",
+								alignItems: "center",
+								width: "100%",
+								padding: "10px 14px",
+								background: "#f5f5f5",
+								border: "none",
+								borderBottom: isExpanded ? "1px solid #ddd" : "none",
+								cursor: "pointer",
+								fontWeight: "600",
+								fontSize: "16px",
+								textAlign: "left",
+								color: "#333",
+							}}
+						>
+							<span>{viewLabels[viewType].description}</span>
+							<span style={{ fontSize: "11px", color: "#666" }}>
+								{isExpanded ? "▲" : "▼"}
+							</span>
+						</button>
+						{isExpanded && (
+							<div style={{ padding: "12px" }}>
+								{viewLabels[viewType].component(root, treeView, undoRedo)}
+							</div>
+						)}
+					</div>
+				);
+			})}
 		</div>
 	);
 };
 
 export const App: FC<{ views: DualUserViews }> = ({ views }) => {
-	const [viewType, setViewType] = useState<ViewType>("formatted");
-
 	return (
 		<div
 			style={{
@@ -306,28 +348,6 @@ export const App: FC<{ views: DualUserViews }> = ({ views }) => {
 				flexDirection: "column",
 			}}
 		>
-			<div style={{ marginBottom: "15px" }}>
-				<label htmlFor="view-select" style={{ marginRight: "10px", fontWeight: "bold" }}>
-					View:
-				</label>
-				<select
-					id="view-select"
-					value={viewType}
-					onChange={(e) => setViewType(e.target.value as ViewType)}
-					style={{
-						padding: "8px 12px",
-						fontSize: "14px",
-						borderRadius: "4px",
-						border: "1px solid #ccc",
-					}}
-				>
-					{(Object.keys(viewLabels) as ViewType[]).map((type) => (
-						<option key={type} value={type}>
-							{viewLabels[type].description}
-						</option>
-					))}
-				</select>
-			</div>
 			<div
 				style={{
 					flex: 1,
@@ -336,8 +356,8 @@ export const App: FC<{ views: DualUserViews }> = ({ views }) => {
 					alignItems: "stretch",
 				}}
 			>
-				<UserPanel label="User 1" color="#4a90d9" viewType={viewType} treeView={views.user1} />
-				<UserPanel label="User 2" color="#28a745" viewType={viewType} treeView={views.user2} />
+				<UserPanel color="#4a90d9" treeView={views.user1} />
+				<UserPanel color="#28a745" treeView={views.user2} />
 			</div>
 		</div>
 	);

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -305,6 +305,8 @@ const UserPanel: FC<{
 					>
 						<button
 							type="button"
+							aria-expanded={isExpanded}
+							aria-controls={`${viewType}-panel`}
 							onClick={() => toggleCollapsed(viewType)}
 							style={{
 								display: "flex",
@@ -323,12 +325,12 @@ const UserPanel: FC<{
 							}}
 						>
 							<span>{viewLabels[viewType].description}</span>
-							<span style={{ fontSize: "11px", color: "#666" }}>
+							<span aria-hidden="true" style={{ fontSize: "11px", color: "#666" }}>
 								{isExpanded ? "▲" : "▼"}
 							</span>
 						</button>
 						{isExpanded && (
-							<div style={{ padding: "12px" }}>
+							<div id={`${viewType}-panel`} style={{ padding: "12px" }}>
 								{viewLabels[viewType].component(root, treeView, undoRedo)}
 							</div>
 						)}

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -248,9 +248,10 @@ const viewLabels = {
 } as const;
 
 const UserPanel: FC<{
+	label: string;
 	color: string;
 	treeView: TreeView<typeof TextEditorRoot>;
-}> = ({ color, treeView }) => {
+}> = ({ label, color, treeView }) => {
 	// Create undo/redo stack for this user's tree view
 	const undoRedo: UndoRedo = useMemo(
 		() => new UndoRedoStacks(treeView.events),
@@ -288,6 +289,7 @@ const UserPanel: FC<{
 				overflowY: "auto",
 			}}
 		>
+			<div style={{ marginBottom: "10px", fontWeight: "bold", color }}>{label}</div>
 			{(Object.keys(viewLabels) as ViewType[]).map((viewType) => {
 				const isExpanded = !collapsed[viewType];
 				return (
@@ -356,8 +358,8 @@ export const App: FC<{ views: DualUserViews }> = ({ views }) => {
 					alignItems: "stretch",
 				}}
 			>
-				<UserPanel color="#4a90d9" treeView={views.user1} />
-				<UserPanel color="#28a745" treeView={views.user2} />
+				<UserPanel label="User 1" color="#4a90d9" treeView={views.user1} />
+				<UserPanel label="User 2" color="#28a745" treeView={views.user2} />
 			</div>
 		</div>
 	);

--- a/packages/framework/quill-react/.mocharc.cjs
+++ b/packages/framework/quill-react/.mocharc.cjs
@@ -12,4 +12,9 @@ const config = getFluidTestMochaConfig(__dirname);
 // AB#7856
 config.exit = true;
 
+// Quill accesses `document` at module-import time, so JSDOM must be initialized before any test
+// files are loaded. Requiring mochaHooks explicitly here guarantees it runs before spec discovery,
+// regardless of alphabetical file-load order within lib/test/.
+config.require = [...config.require, "./lib/test/mochaHooks.js"];
+
 module.exports = config;

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -636,7 +636,10 @@ const FormattedTextEditorView = forwardRef<
 		: undefined;
 
 	return (
-		<div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+		<div
+			style={{ height: "100%", display: "flex", flexDirection: "column" }}
+			onClick={() => quillRef.current?.focus()}
+		>
 			<style>{`
 				.ql-container { height: 100%; font-size: 14px; }
 				.ql-editor { height: 100%; outline: none; }
@@ -659,6 +662,7 @@ const FormattedTextEditorView = forwardRef<
 					minHeight: "300px",
 					border: "1px solid #ccc",
 					borderRadius: "4px",
+					cursor: "text",
 				}}
 			/>
 			{undoRedoButtons}

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -389,7 +389,7 @@ const FormattedTextEditorView = forwardRef<
 	// DOM element where Quill will mount its editor
 	const editorRef = useRef<HTMLDivElement>(null);
 	// Quill instance, persisted across renders to avoid re-initialization
-	const quillRef = useRef<Quill | null>(null);
+	const quillRef = useRef<Quill | undefined>(undefined);
 	// Guards against update loops between Quill and the tree
 	const isUpdating = useRef(false);
 	// Container element for undo/redo button portal
@@ -407,7 +407,10 @@ const FormattedTextEditorView = forwardRef<
 
 	// Initialize Quill editor with formatting toolbar using Quill provided CSS
 	useEffect(() => {
-		if (!editorRef.current || quillRef.current) return;
+		if (!editorRef.current || quillRef.current){
+			return;
+		}
+
 		const quill = new Quill(editorRef.current, {
 			theme: "snow",
 			placeholder: "Start typing with formatting...",
@@ -438,7 +441,7 @@ const FormattedTextEditorView = forwardRef<
 		// the inference for this event is strongly typed, but the types are wrong (The wrong "Delta" type is provided).
 		// This is likely related to the node16 module resolution issues with quill-delta.
 		// If we break that inference by adding types, `any` is inferred for all of them, so incorrect types here would still compile.
-		quill.on("text-change", (delta: Delta, _oldDelta: Delta, source: EmitterSource) => {
+		const handleTextChange = (delta: Delta, _oldDelta: Delta, source: EmitterSource): void => {
 			if (source !== "user" || isUpdating.current) return;
 			isUpdating.current = true;
 
@@ -559,18 +562,28 @@ const FormattedTextEditorView = forwardRef<
 			}
 
 			isUpdating.current = false;
-		});
+		};
 
+		quill.on("text-change", handleTextChange);
 		quillRef.current = quill;
 
 		// Create container for React-controlled undo/redo buttons and prepend to toolbar
-		const toolbar = editorRef.current.previousElementSibling as HTMLElement;
+		const editor = editorRef.current;
+		const toolbar = editor.previousElementSibling as HTMLElement;
 		const container = document.createElement("span");
 		container.className = "ql-formats";
 		toolbar.prepend(container);
 		setUndoRedoContainer(container);
-		// In React strict mode, effects run twice. The `!quillRef.current` check above
-		// makes the second call a no-op, preventing double-initialization of Quill.
+
+		return () => {
+			quill.off("text-change", handleTextChange);
+			quillRef.current = undefined;
+			setUndoRedoContainer(undefined);
+			// Clear Quill's DOM modifications so the container is clean for any remount.
+			toolbar.remove();
+			editor.innerHTML = "";
+			editor.className = "";
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -652,7 +652,6 @@ const FormattedTextEditorView = forwardRef<
 				li[data-list="bullet"] { display: flex; align-items: center; }
 				li[data-list="bullet"] .ql-ui { align-self: center; }
 			`}</style>
-			<h2 style={{ margin: "10px 0" }}>Collaborative Formatted Text Editor</h2>
 			<div
 				ref={editorRef}
 				style={{

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -407,7 +407,7 @@ const FormattedTextEditorView = forwardRef<
 
 	// Initialize Quill editor with formatting toolbar using Quill provided CSS
 	useEffect(() => {
-		if (!editorRef.current || quillRef.current){
+		if (!editorRef.current || quillRef.current) {
 			return;
 		}
 

--- a/packages/framework/quill-react/src/plain/quillView.tsx
+++ b/packages/framework/quill-react/src/plain/quillView.tsx
@@ -133,7 +133,6 @@ const TextEditorView = withMemoizedTreeObservations(({ root }: { root: TextAsTre
 					}
 				`}
 			</style>
-			<h2 style={{ margin: "10px 0" }}>Collaborative Text Editor</h2>
 			<div
 				ref={editorRef}
 				style={{

--- a/packages/framework/quill-react/src/plain/quillView.tsx
+++ b/packages/framework/quill-react/src/plain/quillView.tsx
@@ -116,6 +116,7 @@ const TextEditorView = withMemoizedTreeObservations(({ root }: { root: TextAsTre
 		<div
 			className="text-editor-container"
 			style={{ height: "100%", display: "flex", flexDirection: "column" }}
+			onClick={() => quillRef.current?.focus()}
 		>
 			<style>
 				{`
@@ -141,6 +142,7 @@ const TextEditorView = withMemoizedTreeObservations(({ root }: { root: TextAsTre
 					border: "1px solid #ccc",
 					borderRadius: "4px",
 					padding: "8px",
+					cursor: "text",
 				}}
 			/>
 		</div>

--- a/packages/framework/quill-react/src/plain/quillView.tsx
+++ b/packages/framework/quill-react/src/plain/quillView.tsx
@@ -42,7 +42,7 @@ const TextEditorView = withMemoizedTreeObservations(({ root }: { root: TextAsTre
 	// DOM element where Quill will mount its editor
 	const editorRef = useRef<HTMLDivElement>(null);
 	// Quill instance, persisted across renders to avoid re-initialization
-	const quillRef = useRef<Quill | null>(null);
+	const quillRef = useRef<Quill | undefined>(undefined);
 	// Guards against update loops between Quill and the tree
 	const isUpdatingRef = useRef<boolean>(false);
 
@@ -52,37 +52,48 @@ const TextEditorView = withMemoizedTreeObservations(({ root }: { root: TextAsTre
 
 	// Initialize Quill editor
 	useEffect(() => {
-		if (editorRef.current && !quillRef.current) {
-			const quill = new Quill(editorRef.current, {
-				placeholder: "Start typing...",
-			});
-
-			// Set initial content from tree (add trailing newline to match Quill's convention)
-			const initialText = root.fullString();
-			if (initialText.length > 0) {
-				const textWithNewline = initialText.endsWith("\n") ? initialText : `${initialText}\n`;
-				quill.setText(textWithNewline);
-			}
-
-			// Listen to local Quill changes
-			quill.on("text-change", (_delta, _oldDelta, source) => {
-				if (source === "user" && !isUpdatingRef.current) {
-					isUpdatingRef.current = true;
-
-					// Get plain text from Quill and preserve trailing newline
-					const newText = quill.getText();
-					// TODO: Consider using delta from Quill to compute a more minimal update,
-					// and maybe add a debugAssert that the delta actually gets the strings synchronized.
-					syncTextToTree(root, newText);
-
-					isUpdatingRef.current = false;
-				}
-			});
-
-			quillRef.current = quill;
+		if (!editorRef.current || quillRef.current) {
+			return;
 		}
-		// In React strict mode, effects run twice. The `!quillRef.current` check above
-		// makes the second call a no-op, preventing double-initialization of Quill.
+
+		const quill = new Quill(editorRef.current, {
+			placeholder: "Start typing...",
+		});
+
+		// Set initial content from tree (add trailing newline to match Quill's convention)
+		const initialText = root.fullString();
+		if (initialText.length > 0) {
+			const textWithNewline = initialText.endsWith("\n") ? initialText : `${initialText}\n`;
+			quill.setText(textWithNewline);
+		}
+
+		// Listen to local Quill changes
+		const handleTextChange = (_delta: unknown, _oldDelta: unknown, source: string): void => {
+			if (source === "user" && !isUpdatingRef.current) {
+				isUpdatingRef.current = true;
+
+				// Get plain text from Quill and preserve trailing newline
+				const newText = quill.getText();
+				// TODO: Consider using delta from Quill to compute a more minimal update,
+				// and maybe add a debugAssert that the delta actually gets the strings synchronized.
+				syncTextToTree(root, newText);
+
+				isUpdatingRef.current = false;
+			}
+		};
+
+		quill.on("text-change", handleTextChange);
+		quillRef.current = quill;
+
+		// Capture for cleanup — editorRef.current may have changed by then.
+		const editor = editorRef.current;
+		return () => {
+			quill.off("text-change", handleTextChange);
+			quillRef.current = undefined;
+			// Clear Quill's DOM modifications so the container is clean for any remount.
+			editor.innerHTML = "";
+			editor.className = "";
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/packages/framework/quill-react/src/test/cleanup.test.tsx
+++ b/packages/framework/quill-react/src/test/cleanup.test.tsx
@@ -1,0 +1,164 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { toPropTreeNode } from "@fluidframework/react/internal";
+import { TreeViewConfiguration } from "@fluidframework/tree";
+import { independentView } from "@fluidframework/tree/alpha";
+import { FormattedTextAsTree, TextAsTree } from "@fluidframework/tree/internal";
+import { cleanup as rtlCleanup, render } from "@testing-library/react";
+import globalJsdom from "global-jsdom";
+import Quill from "quill";
+import { StrictMode } from "react";
+
+import { FormattedMainView } from "../formatted/index.js";
+import { QuillMainView } from "../plain/index.js";
+
+function createPlainRoot(text = ""): ReturnType<typeof toPropTreeNode<TextAsTree.Tree>> {
+	const view = independentView(new TreeViewConfiguration({ schema: TextAsTree.Tree }));
+	view.initialize(TextAsTree.Tree.fromString(text));
+	return toPropTreeNode(view.root);
+}
+
+function createFormattedRoot(
+	text = "",
+): ReturnType<typeof toPropTreeNode<FormattedTextAsTree.Tree>> {
+	const view = independentView(
+		new TreeViewConfiguration({ schema: FormattedTextAsTree.Tree }),
+	);
+	view.initialize(FormattedTextAsTree.Tree.fromString(text));
+	return toPropTreeNode(view.root);
+}
+
+describe("Quill editor unmount cleanup", () => {
+	let cleanupJsdom: () => void;
+
+	beforeEach(() => {
+		cleanupJsdom = globalJsdom();
+	});
+
+	afterEach(() => {
+		rtlCleanup();
+		cleanupJsdom();
+	});
+
+	describe("plain text editor (MainView)", () => {
+		it("initializes Quill on mount", () => {
+			const { container } = render(<QuillMainView root={createPlainRoot("hello")} />);
+			assert.ok(
+				container.querySelector(".ql-container"),
+				"Quill container should be present after mount",
+			);
+			assert.ok(
+				container.querySelector(".ql-editor"),
+				"Quill editor should be present after mount",
+			);
+		});
+
+		it("unregisters the text-change listener when unmounted", () => {
+			// Spy on Quill.prototype.off to track event listener removals during cleanup.
+			const offCalls: unknown[] = [];
+			const originalOff = Quill.prototype.off;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+			(Quill.prototype as any).off = function (event: unknown, ...rest: unknown[]): unknown {
+				offCalls.push(event);
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+				return (originalOff as any).call(this, event, ...rest);
+			};
+
+			try {
+				const { unmount } = render(<QuillMainView root={createPlainRoot("hello")} />);
+				const callsBefore = offCalls.length;
+				unmount();
+
+				assert.ok(
+					offCalls.slice(callsBefore).includes("text-change"),
+					"quill.off('text-change') should be called on unmount to remove the listener",
+				);
+			} finally {
+				Quill.prototype.off = originalOff;
+			}
+		});
+
+		it("resets Quill DOM so the component can remount cleanly in React StrictMode", () => {
+			// React 18 StrictMode double-invokes effects in development: mount → cleanup → remount,
+			// using the same DOM node for both invocations. Without cleanup resetting quillRef and
+			// clearing the container's DOM, the second mount would be skipped (quillRef still set)
+			// or Quill would initialize on an already-modified div.
+			const { container } = render(
+				<StrictMode>
+					<QuillMainView root={createPlainRoot("hello")} />
+				</StrictMode>,
+			);
+
+			assert.equal(
+				container.querySelectorAll(".ql-editor").length,
+				1,
+				"StrictMode double-invoke should produce exactly one Quill editor",
+			);
+		});
+	});
+
+	describe("formatted text editor (FormattedMainView)", () => {
+		it("initializes Quill with Snow toolbar on mount", () => {
+			const { container } = render(<FormattedMainView root={createFormattedRoot("hello")} />);
+			assert.ok(
+				container.querySelector(".ql-toolbar"),
+				"Snow toolbar should be present after mount",
+			);
+			assert.ok(
+				container.querySelector(".ql-editor"),
+				"Quill editor should be present after mount",
+			);
+		});
+
+		it("unregisters the text-change listener when unmounted", () => {
+			const offCalls: unknown[] = [];
+			const originalOff = Quill.prototype.off;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+			(Quill.prototype as any).off = function (event: unknown, ...rest: unknown[]): unknown {
+				offCalls.push(event);
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+				return (originalOff as any).call(this, event, ...rest);
+			};
+
+			try {
+				const { unmount } = render(<FormattedMainView root={createFormattedRoot("hello")} />);
+				const callsBefore = offCalls.length;
+				unmount();
+
+				assert.ok(
+					offCalls.slice(callsBefore).includes("text-change"),
+					"quill.off('text-change') should be called on unmount to remove the listener",
+				);
+			} finally {
+				Quill.prototype.off = originalOff;
+			}
+		});
+
+		it("removes Snow toolbar and resets Quill DOM for clean remount in React StrictMode", () => {
+			// The Snow theme toolbar is injected into the DOM by Quill as a sibling to the editor
+			// container (outside React's control). The cleanup must explicitly remove it so that
+			// StrictMode's remount doesn't produce a duplicate toolbar.
+			const { container } = render(
+				<StrictMode>
+					<FormattedMainView root={createFormattedRoot("hello")} />
+				</StrictMode>,
+			);
+
+			assert.equal(
+				container.querySelectorAll(".ql-toolbar").length,
+				1,
+				"StrictMode double-invoke should produce exactly one Snow toolbar",
+			);
+			assert.equal(
+				container.querySelectorAll(".ql-editor").length,
+				1,
+				"StrictMode double-invoke should produce exactly one Quill editor",
+			);
+		});
+	});
+});

--- a/packages/framework/quill-react/src/test/mochaHooks.ts
+++ b/packages/framework/quill-react/src/test/mochaHooks.ts
@@ -4,12 +4,18 @@
  */
 
 import globalJsdom from "global-jsdom";
+import type { RootHookObject } from "mocha";
 
-// Set up JSDOM before any modules are loaded (Quill needs document at import time)
+// Set up JSDOM at module load time so Quill can access `document` when test files import it.
+// This file is loaded via --require (before spec file discovery) to guarantee correct ordering.
 const cleanup = globalJsdom();
 
-// Remove JSDOM after imports are done, but before we run any tests.
-// Tests which require JSDOM can call globalJsdom() to setup their own clean dom.
-before(() => {
-	cleanup();
-});
+/**
+ * Mocha Root Hook Plugin. The `beforeAll` hook removes the initial JSDOM before any
+ * tests run; individual tests set up their own clean JSDOM via globalJsdom() in beforeEach.
+ */
+export const mochaHooks: RootHookObject = {
+	beforeAll() {
+		cleanup();
+	},
+};

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -92,7 +92,10 @@ describe("textEditor", () => {
 						const content = <ViewComponent root={toPropTreeNode(text)} />;
 						const rendered = render(content, { reactStrictMode });
 
-						assert.match(rendered.baseElement.textContent ?? "", /Collaborative Text Editor/);
+						assert.ok(
+							rendered.container.querySelector(".ql-editor"),
+							"Quill editor should be present after mount",
+						);
 					});
 
 					it("renders MainView with initial text content", () => {
@@ -214,9 +217,13 @@ describe("textEditor", () => {
 						const content = <FormattedMainView root={toPropTreeNode(tree)} />;
 						const rendered = render(content, { reactStrictMode });
 
-						assert.match(
-							rendered.baseElement.textContent ?? "",
-							/Collaborative Formatted Text Editor/,
+						assert.ok(
+							rendered.container.querySelector(".ql-editor"),
+							"Quill editor should be present after mount",
+						);
+						assert.ok(
+							rendered.container.querySelector(".ql-toolbar"),
+							"Snow toolbar should be present after mount",
 						);
 					});
 

--- a/packages/framework/react/src/test/text/textEditor.test.tsx
+++ b/packages/framework/react/src/test/text/textEditor.test.tsx
@@ -33,7 +33,10 @@ describe("Plain TextArea view", () => {
 					const content = <ViewComponent root={toPropTreeNode(text)} />;
 					const rendered = render(content, { reactStrictMode });
 
-					assert.match(rendered.baseElement.textContent ?? "", /Collaborative Text Editor/);
+					assert.ok(
+						rendered.container.querySelector("textarea"),
+						"Textarea should be present after mount",
+					);
 				});
 
 				it("renders MainView with initial text content", () => {

--- a/packages/framework/react/src/text/plain/plainTextView.tsx
+++ b/packages/framework/react/src/text/plain/plainTextView.tsx
@@ -86,6 +86,7 @@ const PlainTextEditorView = withMemoizedTreeObservations(
 			<div
 				className="text-editor-container"
 				style={{ height: "100%", display: "flex", flexDirection: "column" }}
+				onClick={() => textareaRef.current?.focus()}
 			>
 				<textarea
 					ref={textareaRef}

--- a/packages/framework/react/src/text/plain/plainTextView.tsx
+++ b/packages/framework/react/src/text/plain/plainTextView.tsx
@@ -87,7 +87,6 @@ const PlainTextEditorView = withMemoizedTreeObservations(
 				className="text-editor-container"
 				style={{ height: "100%", display: "flex", flexDirection: "column" }}
 			>
-				<h2 style={{ margin: "10px 0" }}>Collaborative Text Editor</h2>
 				<textarea
 					ref={textareaRef}
 					defaultValue={currentText}


### PR DESCRIPTION
- Removes the hardcoded headers from above exported text controls in `react` and `quill-react` - this isn't something we should be exporting as a part of our library. Users can add their own headings as needed.
- Updates exported text controls to ensure their entire editor space is clickable and causes the editor to be selected (previously, you could only accomplish this by clicking on a line that contained text, or the first line only if empty).
- Updates `quill`-based editor components to perform necessary cleanup on unmount.

Also updates the `text-editor` app to display all 3 editors at once, rather than only one at a time. Each is displayed as a collapsable card.

<img width="1870" height="1222" alt="image" src="https://github.com/user-attachments/assets/a8eac0f8-81d5-4f1c-ac20-40e432fad59e" />
