### PR TITLE
Make many of the "EditManager - Bench" tests omitted in correctness mode

### DIFF
--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -5,7 +5,12 @@
 
 import { strict as assert } from "node:assert";
 
-import { BenchmarkType, benchmarkDuration, benchmarkIt } from "@fluid-tools/benchmark";
+import {
+	BenchmarkType,
+	benchmarkDuration,
+	benchmarkIt,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 
 import {
 	type ChangeFamily,
@@ -41,13 +46,20 @@ describe("EditManager - Bench", () => {
 
 	const scenarios: Scenario[] = [
 		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 100, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1000, trunkEditCount: 1 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 10 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 100 },
-		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1000 },
-		{ type: BenchmarkType.Measurement, rebasedEditCount: 100, trunkEditCount: 100 },
+		// These tests, even in correctness mode, are a bit slow, and occasionally timeout,
+		// so run a smaller set  with smaller sizes in correctness mode.
+		...(isInPerformanceTestingMode
+			? [
+					{ type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },
+					{ type: BenchmarkType.Perspective, rebasedEditCount: 100, trunkEditCount: 1 },
+					{ type: BenchmarkType.Perspective, rebasedEditCount: 1000, trunkEditCount: 1 },
+					{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 10 },
+					{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 100 },
+					{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1000 },
+					{ type: BenchmarkType.Measurement, rebasedEditCount: 100, trunkEditCount: 100 },
+				]
+			: // Ensure in correctness mode we have a case where both counts are greater than 1
+				[{ type: BenchmarkType.Perspective, rebasedEditCount: 2, trunkEditCount: 2 }]),
 	];
 
 	interface Family<TChange> {

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -46,8 +46,8 @@ describe("EditManager - Bench", () => {
 
 	const scenarios: Scenario[] = [
 		{ type: BenchmarkType.Perspective, rebasedEditCount: 1, trunkEditCount: 1 },
-		// These tests, even in correctness mode, are a bit slow, and occasionally timeout,
-		// so run a smaller set  with smaller sizes in correctness mode.
+		// These tests, even in correctness mode, are a bit slow, and occasionally time out,
+		// so run a smaller set with smaller sizes in correctness mode.
 		...(isInPerformanceTestingMode
 			? [
 					{ type: BenchmarkType.Perspective, rebasedEditCount: 10, trunkEditCount: 1 },


### PR DESCRIPTION
## Description

I saw two of these tests nondeterminstically timeout on CI.

This change not only mitigates that, but also generally speeds out testing by skipping tests which are not useful in correctness mode.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
