### PR TITLE
feat(map): add opt-in sort-key iteration to SharedDirectory

### DIFF
--- a/.changeset/sharedirectory-sort-keys.md
+++ b/.changeset/sharedirectory-sort-keys.md
@@ -1,0 +1,44 @@
+---
+"@fluidframework/map": minor
+"fluid-framework": minor
+"__section": feature
+---
+
+Add opt-in sort-key iteration to SharedDirectory
+
+`SharedDirectory` (and each `IDirectory`) now supports a replicated, opt-in custom iteration order driven by string "sort keys" attached to individual keys and child subdirectories. The default iteration order is unchanged.
+
+#### New API
+
+- `setSortKey(key, sortKey | undefined)` / `setSubDirectorySortKey(name, sortKey | undefined)` — sets (or clears, when passed `undefined`) a sort key.
+- `keysByOrder()` / `valuesByOrder()` / `entriesByOrder()` — iterate entries in sort-key order.
+- `subdirectoriesByOrder()` — iterate child subdirectories in sort-key order.
+- `sortKeyChanged` / `subDirectorySortKeyChanged` on `ISharedDirectory`, plus the path-less `containedSortKeyChanged` / `containedSubDirectorySortKeyChanged` on individual `IDirectory` nodes.
+
+#### Semantics
+
+- Entries with a sort key iterate first, in lexicographic order of the sort key (JavaScript `<`, i.e. UTF-16 code points). Entries without a sort key follow, in the existing iteration order.
+- Ties on sort key break by the default iteration order (first-insertion for keys; `seqDataComparator` for subdirectories), so ordering is deterministic across clients.
+- Sort keys live alongside the entry they annotate: `delete(k)` clears the entry's sort key, `clear()` clears all sort keys in the directory, and `deleteSubDirectory(name)` clears the subdirectory's sort key on the parent.
+- Sort keys replicate via two new op types and round-trip through summaries as additive fields on the snapshot — no format-version bump, and older readers load newer snapshots cleanly (the sort keys are silently dropped).
+
+#### Example
+
+```typescript
+import { SharedDirectory } from "fluid-framework";
+
+const dir = SharedDirectory.create(runtime);
+dir.set("first", 1);
+dir.set("second", 2);
+dir.set("third", 3);
+
+// Default iteration reflects insertion order:
+[...dir.keys()]; // ["first", "second", "third"]
+
+// Attach sort keys to drive a custom order:
+dir.setSortKey("third", "a");
+dir.setSortKey("first", "b");
+[...dir.keysByOrder()]; // ["third", "first", "second"]
+//                         ^ sort-keyed, in lex order
+//                                   ^ trailing unkeyed entry in default order
+```

--- a/packages/dds/map/ARCHITECTURE.md
+++ b/packages/dds/map/ARCHITECTURE.md
@@ -1,0 +1,629 @@
+# `@fluidframework/map` — Architecture
+
+Internal reference for contributors. Assumes familiarity with the DDS model
+(ops, summaries, `SharedObject`, `IFluidSerializer`, handles, reconnection,
+rollback). For a user-facing overview see [`README.md`](./README.md); for API
+contracts see [`src/interfaces.ts`](./src/interfaces.ts).
+
+File references use `file:line` anchors against the current source tree.
+
+---
+
+## 1. Scope
+
+The package ships two DDSes:
+
+- **`SharedMap`** — flat string-keyed map, last-writer-wins, the spiritual
+  analogue of a native `Map`.
+- **`SharedDirectory`** — hierarchical sibling of `SharedMap`: each directory
+  node behaves like a `SharedMap`, and nodes are arranged in a named tree of
+  subdirectories.
+
+They share machinery (pending-state model, value model, handle serialization,
+snapshot blob layout) but are implemented as independent classes — there is no
+shared base class beyond `SharedObject`. Both are `@legacy @beta` surface; see
+`AB#35245` / `AB#8004` for the in-flight deprecation plan.
+
+## 2. Package layout
+
+```
+src/
+├── index.ts                  Public + legacy exports
+├── interfaces.ts             Public contracts (ISharedMap/ISharedDirectory/events)
+├── internalInterfaces.ts     Wire-format op shapes; ISerializableValue (legacy)
+├── localValues.ts            ILocalValue, serializeValue, handle migration
+├── utils.ts                  findLast/findLastIndex polyfills
+├── map.ts                    SharedMap class (facade over MapKernel)
+├── mapKernel.ts              All SharedMap state, op processing, iteration
+├── mapFactory.ts             MapFactory + SharedMap entrypoint
+├── directory.ts              SharedDirectory + SubDirectory (monolithic)
+├── directoryFactory.ts       DirectoryFactory + SharedDirectory entrypoint
+├── packageVersion.ts         Generated pkg version string
+└── test/                     Mocha tests
+```
+
+The `directory.ts` file is deliberately large and monolithic — `SubDirectory`
+holds private references into `SharedDirectory` (e.g. `this.directory` at
+`directory.ts:1154`), and they co-evolve. Splitting them would expose internal
+APIs across module boundaries. The map equivalent is split (`SharedMap` in
+`map.ts` is a thin facade; logic lives in `MapKernel` at `mapKernel.ts`) because
+there is no tree — a single kernel suffices.
+
+## 3. Entrypoints and the factory pattern
+
+Both DDSes follow the `createSharedObjectKind` pattern:
+
+```typescript
+// mapFactory.ts:87, directoryFactory.ts:87
+export const SharedMap = createSharedObjectKind<ISharedMap>(MapFactory);
+export const SharedDirectory = createSharedObjectKind<ISharedDirectory>(DirectoryFactory);
+```
+
+The class that actually extends `SharedObject` is imported as an internal
+alias (`SharedMapInternal`, `SharedDirectoryInternal`) in the factory files and
+never exported directly. Consumers call `SharedMap.create(runtime, id)` (or
+equivalent), never `new SharedMap(...)`. The module also exports a type alias
+(`export type SharedMap = ISharedMap` at `mapFactory.ts:95`) so
+`SharedMap` reads as both a value (factory) and a type (interface).
+
+Legacy factory classes (`MapFactory`, `DirectoryFactory`) are still exported
+from `index.ts:33-34` for consumers that register DDS types explicitly. They
+are marked for removal (AB#35245).
+
+Factory attributes:
+
+| Factory           | Type string                                         | Snapshot format version |
+| ----------------- | --------------------------------------------------- | ----------------------- |
+| `MapFactory`      | `https://graph.microsoft.com/types/map`             | `0.2`                   |
+| `DirectoryFactory`| `https://graph.microsoft.com/types/directory`       | `0.1`                   |
+
+Both type strings carry a commented-out migration target (`"map"` /
+`"directory"`) gated on `LegacyTypeAwareRegistry`
+(`mapFactory.ts:29-32`, `directoryFactory.ts:29-32`). When that machinery
+ships, the short names will become canonical and the URL forms will be
+accepted for back-compat only.
+
+`create()` vs `load()` (`mapFactory.ts:60-80`, `directoryFactory.ts:60-80`) is
+the standard `IChannelFactory` split: `create` calls `initializeLocal()` to
+stand up a detached instance; `load` calls `load(services)` to hydrate from
+storage.
+
+## 4. Value model
+
+### 4.1 `ILocalValue`
+
+In-memory values are held behind `ILocalValue` (`localValues.ts:21`):
+
+```typescript
+export interface ILocalValue {
+    readonly value: unknown;
+}
+```
+
+That is the entire interface — a nominal wrapper. `MapKernel` stores
+`Map<string, ILocalValue>` in `sequencedData` (`mapKernel.ts:131`).
+`SubDirectory` stores `Map<string, unknown>` directly in `sequencedStorageData`
+(`directory.ts:1697`), having dropped the wrapper — a minor inconsistency
+between the two DDSes that has no runtime consequence since the wrapper adds
+no data.
+
+### 4.2 Serialization
+
+Values are serialized to the wire via `serializeValue()`
+(`localValues.ts:31-42`), which delegates to `serializeHandles()` from
+`shared-object-base`. Handles embedded anywhere in a value graph are
+replaced by `ISerializedHandle` (`{ type: "__fluid_handle__", url }`) and
+bound against the owning DDS's handle. On load, `serializer.decode()`
+reverses the transformation.
+
+**Note:** `SharedDirectory` does not call `serializeValue()` when building its
+set op (`directory.ts:1266` emits `{ type: ValueType[ValueType.Plain], value }`
+with the raw value). Handle serialization happens at the `SharedObject`
+submission layer, not in the DDS itself. `SharedMap` does the same at
+`mapKernel.ts` around the set path. This is intentional: the wire format
+carries the pre-encoded shape, and the runtime encodes handles in transit.
+
+### 4.3 `ValueType.Shared` migration
+
+Old containers stored direct references to other SharedObjects as
+`ValueType.Shared` entries, with the channel ID in place of the value.
+`migrateIfSharedSerializable()` (`localValues.ts:52-70`) upgrades these to
+handles on load: parses the channel ID into an `ISerializedHandle`, roundtrips
+it through `parseHandles()` (necessary to resolve the legacy absolute path),
+and re-encodes via `serializer.encode()`. This is called during snapshot load
+and (defensively) during op processing.
+
+Modern code writes only `ValueType.Plain`. `ISerializableValue` itself is
+deprecated (`internalInterfaces.ts:72-75`) and re-exported only for legacy
+consumers.
+
+## 5. Op model
+
+### 5.1 `SharedMap` ops (`internalInterfaces.ts:9-49`)
+
+| Type     | Payload                                  |
+| -------- | ---------------------------------------- |
+| `set`    | `{ type: "set", key, value }`            |
+| `delete` | `{ type: "delete", key }`                |
+| `clear`  | `{ type: "clear" }`                      |
+
+Union: `IMapOperation` (`mapKernel.ts:56`). No sequence numbers, no refSeq, no
+versioning. Order is established by the message-sequencing service; matching of
+acks to pending local ops is by `localOpMetadata` reference identity.
+
+### 5.2 `SharedDirectory` ops (`directory.ts:95-213`)
+
+Every op carries an absolute `path` field (e.g. `"/a/b/c"`) that routes it to
+the correct `SubDirectory`.
+
+Storage ops (`IDirectoryStorageOperation`):
+
+| Type     | Payload                                         |
+| -------- | ----------------------------------------------- |
+| `set`    | `{ type: "set", path, key, value }`             |
+| `delete` | `{ type: "delete", path, key }`                 |
+| `clear`  | `{ type: "clear", path }`                       |
+
+Subdirectory ops (`IDirectorySubDirectoryOperation`):
+
+| Type                | Payload                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `createSubDirectory`| `{ type: "createSubDirectory", path, subdirName }`             |
+| `deleteSubDirectory`| `{ type: "deleteSubDirectory", path, subdirName }`             |
+
+Paths are normalized via `path-browserify` (posix) routines; `posix.join` is
+used when building absolute paths at `SubDirectory` construction
+(`directory.ts:1312` and similar).
+
+## 6. The pending-state model — core concept
+
+Both DDSes implement an identical pattern for tracking local, unacknowledged
+edits so that reads are optimistic (they reflect local writes immediately),
+remote ops can be folded in without clobbering unacked local state, and
+reconnection / rollback can replay exact edits.
+
+### 6.1 Dual storage
+
+Per-DDS (or per-`SubDirectory`):
+
+- **`sequencedData` / `sequencedStorageData`** — a `Map` of keys to values
+  reflecting only ops acknowledged by the service.
+- **`pendingData` / `pendingStorageData`** — an ordered array of pending-op
+  descriptors that express what the local client has done *after* the sequenced
+  state.
+
+Both together feed `getOptimisticValue(key)` (`mapKernel.ts:349-365`,
+`directory.ts:1791-1808`), which is what `get()`, `has()`, and iteration return.
+
+### 6.2 Pending entry kinds
+
+The array holds one of four things (shapes identical up to the directory's
+extra `path`/`subdir` fields; see `mapKernel.ts:74-108` and
+`directory.ts:215-270`):
+
+- **`PendingKeyLifetime`** — aggregates a run of `set`s to the same key under
+  one entry with a `keySets: PendingKeySet[]` array. Created when the most
+  recent pending entry for the key is absent, a delete, or a clear
+  (`mapKernel.ts:409-424`, `directory.ts:1236-1253`). Subsequent sets to the
+  same key *within the same lifetime* just push to `keySets` instead of adding
+  a new pending entry. This is how iteration order is preserved: the lifetime
+  keeps its position in `pendingData` even as the value mutates.
+- **`PendingKeyDelete`** — terminates any lifetime for that key and pends a
+  delete.
+- **`PendingClear`** — terminates all lifetimes below it.
+- (Directory-only) **`PendingSubDirectoryCreate` / `PendingSubDirectoryDelete`**
+  in a separate `pendingSubDirectoryData` array (`directory.ts:1712`).
+
+Each individual `PendingKeySet` / `PendingKeyDelete` / `PendingClear` is also
+the `localOpMetadata` value that flows with `submitLocalMessage`. When the
+server acks the op, the handler finds and removes it from `pendingData` by
+reference identity (`mapKernel.ts:721, 778, 822`). For sets, the `PendingKeySet`
+is `shift()`ed off the front of its lifetime's `keySets` array; the lifetime
+disappears when `keySets` becomes empty.
+
+### 6.3 Optimistic value resolution
+
+`getOptimisticValue(key)` (`directory.ts:1791-1808`, analogous in
+`mapKernel.ts`):
+
+1. Find the *last* pending entry that affects this key (the key's own entry,
+   or any `clear`).
+2. If it's a lifetime, return the latest `keySets` value.
+3. If it's a delete or a clear, return `undefined`.
+4. Otherwise, fall through to `sequencedData.get(key)`.
+
+This guarantees a local client sees its own writes before they are sequenced.
+
+### 6.4 Event suppression under pending state
+
+When a *remote* op arrives that would change a key for which local pending
+state exists, the sequenced state is updated but the public event is *not*
+emitted — because the optimistic value didn't change. Examples:
+
+- Remote `set` on a key with a local pending lifetime: value writes into
+  `sequencedData` silently; local reads still see the pending value
+  (`mapKernel.ts:837`).
+- Remote `delete` on a key with any pending entry: silent removal from
+  `sequencedData` (`mapKernel.ts:788`, `directory.ts` analogue).
+- Remote `clear` while a local pending `clear` exists: silent; the local clear
+  already told consumers the map is empty (`mapKernel.ts:742`).
+
+When the local pending op is eventually acked and popped, the sequenced state
+already matches reality, so no further event is needed. This is one of the
+subtler invariants in the codebase — changes to ordering must preserve it.
+
+### 6.5 Rollback
+
+`SharedObject.rollback()` fires when a batch is rolled back pre-send. Both
+DDSes implement a symmetric inverse for each pending-entry kind
+(`mapKernel.ts:637-700`, directory equivalents). Rollbacks emit
+`valueChanged` with the appropriate `previousValue` so consumers can refresh.
+For a rolled-back clear, individual `valueChanged` events are emitted for each
+key that becomes visible again from `sequencedData`
+(`mapKernel.ts:650-657`).
+
+### 6.6 Resubmit on reconnect
+
+`reSubmitCore()` iterates every remaining entry in `pendingData` and resends
+via the original handler (`map.ts:277-279`, `directory.ts:687-695`). The same
+metadata reference is carried through, so matching on ack continues to work.
+The pending array is not cleared at any point in this flow — entries live
+exactly until the matching ack arrives.
+
+## 7. `SharedMap` internals
+
+### 7.1 Facade / kernel split
+
+`SharedMap` (`map.ts:42`) extends `SharedObject<ISharedMapEvents>` and owns a
+single `MapKernel` (`map.ts:51`). The kernel receives callbacks for
+`submitLocalMessage`, `isAttached`, the `IFluidSerializer`, the DDS's
+`IFluidHandle`, and the event emitter (which is `this`, `map.ts:66-72`).
+
+The facade:
+
+- Forwards `get/set/delete/clear/keys/values/entries/forEach/has` to the kernel.
+- Handles summarize/load.
+- Forwards `processMessagesCore`, `reSubmitCore`, `applyStashedOp`, and
+  `rollback` to kernel methods.
+
+All state lives on the kernel. There is no kernel in the directory package — a
+deliberate asymmetry given the tree structure.
+
+### 7.2 Snapshot format (`0.2`)
+
+`IMapSerializationFormat` (`map.ts:32-35`):
+
+```typescript
+{ blobs?: string[], content: IMapDataObjectSerializable }
+```
+
+Written as a "header" blob (`map.ts:37`) plus N data blobs listed in `blobs`.
+The packing algorithm (`map.ts:196-236`):
+
+- Values ≥ **8 KB** get their own blob.
+- Remaining values pack into blobs up to **16 KB**.
+- The header carries the blob manifest plus any leftover small values.
+
+The algorithm is not stable across snapshots — reshuffling of small values is
+expected and does not violate the format. The authors accept this
+non-incrementality in exchange for simplicity; the load path (`map.ts:251-267`)
+reads the header, promises the blobs in parallel, and passes each through
+`kernel.populateFromSerializable()` (`mapKernel.ts:557-564`) which runs
+`serializer.decode()` + `migrateIfSharedSerializable()` before inserting into
+`sequencedData`.
+
+### 7.3 Events
+
+`ISharedMapEvents` (`interfaces.ts`):
+
+- `valueChanged` — `{ key, previousValue }`, `local`, `target`
+- `clear` — `local`, `target`
+
+Local ops emit immediately after the pending entry is pushed, before returning
+from the public method (`mapKernel.ts:437-442` for sets,
+`mapKernel.ts:478-488` for deletes, `mapKernel.ts:533-537` for clears). Remote
+ops emit only if no pending state suppresses them (see §6.4).
+
+## 8. `SharedDirectory` internals
+
+### 8.1 Tree topology
+
+`SharedDirectory` (`directory.ts:407`) owns a single `root: SubDirectory`
+constructed at `directory.ts:426-434` with `seqData = { seq: 0, clientSeq: 0 }`
+(detached). All public map-like methods on `SharedDirectory` forward to
+`this.root` (e.g. `directory.ts:472-506`).
+
+Each `SubDirectory` (`directory.ts:1117`) holds:
+
+- `absolutePath` (immutable, computed once, `directory.ts:1157`).
+- `seqData: SequenceData` (`directory.ts:1152`) — the subdir's own creation
+  ordering data (see §8.3).
+- `clientIds: Set<string>` (`directory.ts:1153`) — clients that have *asserted*
+  creation of this subdir. Persisted as `ccIds` in the snapshot
+  (`directory.ts:288`).
+- `_sequencedSubdirectories: Map<string, SubDirectory>` (`directory.ts:1132`).
+- `sequencedStorageData: Map<string, unknown>` (`directory.ts:1697`).
+- `pendingStorageData: PendingStorageEntry[]` (`directory.ts:1706`).
+- `pendingSubDirectoryData: PendingSubDirectoryEntry[]` (`directory.ts:1712`).
+- `_deleted: boolean` (`directory.ts:1121`).
+
+There are **no parent pointers**. All tree traversal happens from the root via
+`getWorkingDirectory(absolutePath)` (`directory.ts:618-633`), which walks the
+path component-by-component through `getSubDirectory(name)`. Optimistic
+deletion of any ancestor causes traversal to return `undefined`.
+
+### 8.2 Dispose lifecycle
+
+Two phases — this is one of the trickier invariants:
+
+1. **Local soft delete** (local `deleteSubDirectory`, `directory.ts:1395-1432`):
+   Adds a `PendingSubDirectoryDelete` to `pendingSubDirectoryData`. Emits
+   `subDirectoryDeleted` and (via `emitDisposeForSubdirTree`) a `disposed`
+   event. **Does not** set `_deleted = true` yet — the instance survives so
+   rollback can restore it and so pending writes that were in flight against it
+   can still be acked against a live object.
+2. **Hard delete** (on remote ack of the delete,
+   `processDeleteSubDirectoryMessage`): `disposeSubDirectoryTree()`
+   (`directory.ts:2630-2645`) walks the subtree bottom-up, emits `disposed`,
+   clears sequenced data, and sets `_deleted = true`. Removes the entry from
+   the parent's `_sequencedSubdirectories`.
+
+`undispose()` (`directory.ts:1172-1175`) is the symmetric inverse: used when
+rolling back a delete or when a remote `createSubDirectory` arrives for a
+currently-disposed subdir name that still has a live in-memory instance. Walks
+the subtree, flips `_deleted = false`, emits `undisposed`.
+
+`throwIfDisposed()` (`directory.ts:1181-1185`) guards mutating public methods,
+not all reads — `get()` intentionally does not throw (`directory.ts:1200-1202`),
+consistent with the public `dispose`/`disposed` contract.
+
+### 8.3 `SequenceData` and subdirectory ordering
+
+`SequenceData` (`directory.ts:389`):
+
+```typescript
+interface SequenceData {
+    seq: number;       // -1 = pending-local, 0 = detached, >0 = server seq
+    clientSeq?: number;
+}
+```
+
+Subdirectories are ordered by `seqDataComparator` (`directory.ts:364-380`) when
+iterated. The policy (docblock at `directory.ts:344-363`):
+
+1. Acknowledged (`seq >= 0`) sorts before pending-local (`seq = -1`).
+2. Within acknowledged, by `seq`, then by `clientSeq`.
+3. Within pending-local, by `seq`, then by `clientSeq`.
+
+`clientSeq` is needed when multiple creates share a server `seq` — which
+happens under grouped batching (the batch gets one seq, individual ops are
+ordered within it by client submission order) or for multiple local pending
+creates.
+
+On load, `clientSeq` is not persisted. The load path assigns a synthetic
+`clientSeq` to each restored subdir (`directory.ts:741-748` region) to preserve
+the relative order encoded in the snapshot's iteration order. This is a minor
+source of potential cross-client divergence after reload; there is a TODO in
+that neighborhood flagging the need for named constants and better structure.
+
+### 8.4 Per-subdir pending state
+
+Pending storage ops are tracked **per-subdirectory**, using the same lifetime
+machinery as SharedMap (§6). The `SubDirectory.set()` implementation
+(`directory.ts:1207-1282`) is a good worked example: it reads the optimistic
+value, finds or creates a lifetime, pushes the `PendingKeySet`, submits the
+op, and emits `valueChanged` (on the `SharedDirectory` root for absolute-path
+consumers) and `containedValueChanged` (on the `SubDirectory` for local
+consumers).
+
+Pending subdirectory ops live in a separate array
+(`pendingSubDirectoryData`, `directory.ts:1712`). Create/delete pairs do not
+aggregate into a lifetime — subdir creation is fundamentally different from
+key mutation, and idempotence is handled in the op processors
+(`directory.ts:2080-2168`) rather than by the pending array.
+
+### 8.5 Create/delete race handling
+
+Concurrent create and delete of the same subdir are handled without a
+tombstone structure:
+
+- **Remote `createSubDirectory` while local create is pending**: if the subdir
+  exists (either sequenced or from a pending local create), the op is a
+  no-op on that subdir; if it exists but is currently disposed, `undispose()`
+  it and re-emit `undisposed` (`directory.ts:2120-2122, 2141-2142`). Adds the
+  remote client's id to `clientIds`.
+- **Remote `deleteSubDirectory`**: fully disposes the subtree
+  (`directory.ts:2217`). If there were pending local writes into that subtree,
+  they will still flow to the in-memory (now-disposed) instance and their acks
+  will be rejected by `isMessageForCurrentInstanceOfSubDirectory`
+  (`directory.ts:2605-2619`), which checks `clientIds` membership.
+- **Concurrent local create vs remote delete**: the remote delete wins on the
+  sequenced side; the local create remains pending and, when it sequences,
+  will recreate a fresh subdir (with a new identity — the old one stays
+  disposed).
+
+`isMessageForCurrentInstanceOfSubDirectory` (`directory.ts:2605-2619`) is the
+guard that prevents stale ops from flowing into a reborn subdir: it checks
+that the op's originating client is still in the current subdir's `clientIds`.
+This is why `clientIds` is a set, not a single id — multiple clients can
+co-create a subdir in the same seq batch.
+
+### 8.6 Op routing
+
+Remote op processing finds the target subdir via
+`getSequencedWorkingDirectory(path)` (`directory.ts:639-654`), which is
+identical in shape to `getWorkingDirectory` but walks *only* the sequenced
+subdir maps (never pending). Ops arrive only at subdirs the server has already
+accepted as existing. If the subdir has been deleted and re-created with a
+different identity, `isMessageForCurrentInstanceOfSubDirectory` drops the op.
+
+### 8.7 Snapshot format (`0.1`)
+
+`IDirectoryNewStorageFormat` (`directory.ts:336-342`) is analogous to the map
+format:
+
+```typescript
+{ blobs: string[], content: IDirectoryDataObject }
+```
+
+`IDirectoryDataObject` (`directory.ts:303`) is recursive:
+
+```typescript
+{
+    storage?: IMapDataObjectSerializable,   // key -> ISerializableValue
+    subdirectories?: { [name: string]: IDirectoryDataObject },
+    ci?: ICreateInfo                         // { csn, ccIds[] }
+}
+```
+
+`ICreateInfo` persists the `seq` (as `csn`) and `clientIds` (as `ccIds`)
+(`directory.ts:279-289`) — enough to reconstruct `SequenceData` and the
+identity-validation set on load.
+
+The serializer (`directory.ts:1016-1081`) walks the tree depth-first building
+the nested object. Values ≥ **8 KB** are externalized to their own blob,
+with the blob containing the full path hierarchy needed to route the value
+back in on load (`directory.ts:1044-1061`). Multiple large values produce
+multiple independent blobs — no dedup, no merging.
+
+Load (`directory.ts:700-715` and `populate`) is the inverse: parse header,
+fetch blobs in parallel, call `populate(IDirectoryDataObject)` recursively.
+Each subdir is instantiated with its restored `SequenceData` and `clientIds`.
+
+### 8.8 Eventing
+
+Two event interfaces:
+
+- **`ISharedDirectoryEvents`** (`interfaces.ts:130-215`) — fires on
+  `SharedDirectory` itself. `valueChanged` carries an absolute `path`. Also
+  exposes tree-level events `subDirectoryCreated`/`subDirectoryDeleted` with
+  relative paths, and both `clear` (deprecated) and `cleared` (with path).
+- **`IDirectoryEvents`** (`interfaces.ts:223-296`) — fires on individual
+  `SubDirectory` nodes. `containedValueChanged` carries only `{ key,
+  previousValue }` (no path). Also `subDirectoryCreated`/`Deleted` (relative),
+  `disposed`, `undisposed`.
+
+`SharedDirectory`'s constructor (`directory.ts:456-464`) forwards three events
+from its `root` (`containedValueChanged`, `subDirectoryCreated`,
+`subDirectoryDeleted`) onto itself so root-level consumers can subscribe
+uniformly. This is the one place the root is treated differently from other
+subdirs.
+
+Remote-op event emission checks `isNotDisposedAndReachable()`
+(`directory.ts:1875-1879`) before emitting — a subdir that has become
+unreachable (e.g. because a parent was deleted since the op was queued)
+suppresses its events to avoid ghost notifications.
+
+## 9. Iteration order
+
+This is the subject of active work and the reason the current branch exists.
+
+### 9.1 `SharedMap` keys
+
+`MapKernel.internalIterator()` produces keys in **first-insertion order**:
+
+1. Walk `sequencedData.keys()` (which preserves insertion order under
+   standard `Map` semantics), skipping any key that a pending delete or clear
+   will hide.
+2. Walk `pendingData`, emitting each lifetime's key whose position postdates
+   the last delete/clear affecting it, and which is not already present in
+   `sequencedData` (or is re-inserted after a pending clear).
+
+The invariant: a key's first-ever insertion position (local or sequenced) is
+its iteration position, even if the value is later updated via further sets.
+Lifetime aggregation (§6.2) is what makes this work — repeated sets to the
+same key don't produce new pending entries and therefore don't alter iteration
+position. See `mapKernel.ts:176-247` for the implementation.
+
+### 9.2 `SharedDirectory` keys
+
+`SubDirectory.internalIterator` (`directory.ts:1717-1785`) mirrors the
+map behavior: sequenced keys first, then fresh pending-lifetime keys, with
+deletes/clears suppressing appropriately.
+
+### 9.3 `SharedDirectory` subdirectories
+
+`subdirectories()` (`directory.ts:1437-1473`) collects live children from
+`_sequencedSubdirectories` and non-deleted-pending `pendingSubDirectoryData`,
+then sorts by `seqDataComparator` (§8.3). Ordering is by `seq` (then
+`clientSeq`), not insertion — reflecting the fact that subdir identity is
+server-seq-based, not insertion-based.
+
+**Caveat from `interfaces.ts:375` area**: the public `ISharedMap` contract does
+not guarantee key iteration order; the implementation happens to be
+insertion-order-preserving. Any change to these semantics is a de facto (if
+not de jure) API change and should be treated accordingly.
+
+## 10. Garbage collection & attribution
+
+No explicit `getGCData()` override is present in either DDS. Handles embedded
+in values are serialized/bound via the `SharedObject` + `IFluidSerializer`
+path, which participates in the container-level GC graph; the DDSes do not
+declare their own GC routes.
+
+No attribution machinery is present in this package. Attribution for map/
+directory values, if required, would need to be added.
+
+## 11. Known subtleties & gotchas
+
+- **Iteration order is implementation-defined, not specified.** Consumers
+  sometimes rely on first-insertion order for keys; this is currently true but
+  not contractual. See §9.
+- **Event suppression by pending state is silent.** Remote ops that are
+  eclipsed by local pending state update `sequencedData` without emitting any
+  event. Correct but easy to trip over when debugging.
+- **A locally-deleted SubDirectory is not disposed until the delete is acked.**
+  The in-memory instance remains live (with `_deleted = false`) through the
+  local delete → remote ack window so pending writes and rollbacks work. Code
+  reading `disposed` during that window sees `false`.
+- **`clientIds` is a set, not a singleton.** Concurrent create-subdir ops from
+  multiple clients co-assert creation; message-validity checks
+  (`isMessageForCurrentInstanceOfSubDirectory`) gate on membership, not on a
+  single "owner".
+- **Snapshot packing for SharedMap is non-incremental for small values.**
+  Small-value shuffling between blobs across summaries is expected. Consumers
+  must not depend on stable blob identities.
+- **`clientSeq` is not persisted.** On load, a synthetic `clientSeq` is
+  assigned per subdir based on iteration order. Divergent clients reloading
+  from the same snapshot agree; divergence can arise if batches are ungrouped
+  differently on different clients during the live session pre-snapshot.
+- **Op matching is by reference identity on `localOpMetadata`.** Anything that
+  breaks referential identity between submit and ack paths (e.g. accidental
+  cloning) will break the DDSes in ways that are hard to diagnose — pending
+  ops silently fail to clear and the optimistic view diverges from sequenced
+  state. Resubmission deliberately reuses the same metadata object.
+- **Directory set op does not call `serializeValue`.** The op payload is built
+  as a bare `{ type: ValueType[ValueType.Plain], value }` and the
+  `SharedObject` submission layer handles handle serialization. `SharedMap`
+  follows the same pattern on its set path.
+- **`SubDirectory` stores raw `unknown`; `MapKernel` stores `ILocalValue`.**
+  Functionally equivalent; a minor inconsistency that would take nontrivial
+  churn to unify.
+- **Directory summary format version is stuck at `0.1`.** Any non-backward-
+  compatible change to `IDirectoryDataObject` requires a version bump and a
+  load-path fork.
+- **Legacy wire values (`ValueType.Shared`) still land in the load path.**
+  Remove at your own risk — there is no telemetry proving every production
+  snapshot has been migrated.
+
+## 12. File-by-file pointers
+
+Read in this order when onboarding:
+
+1. `interfaces.ts` — public surface; get the mental model of the two DDSes.
+2. `internalInterfaces.ts` — op shapes.
+3. `localValues.ts` — value model and handle migration.
+4. `mapKernel.ts` — the clearest worked example of the pending-state model.
+5. `map.ts` — facade + snapshot format.
+6. `directory.ts` — large; read §8 of this doc first, then skim top-down.
+7. `mapFactory.ts`, `directoryFactory.ts` — construction and type strings.
+
+## 13. Cross-references
+
+- Deprecation tickets: `AB#35245` (factory classes), `AB#8004`
+  (`ISerializableValue`, `ICreateInfo`, `IDirectoryDataObject`,
+  `IDirectoryNewStorageFormat`).
+- Type-string migration: `LegacyTypeAwareRegistry` in
+  `packages/runtime/datastore/src/dataStoreRuntime.ts`.
+- Base class and serialization: `@fluidframework/shared-object-base`
+  (`SharedObject`, `IFluidSerializer`, `createSharedObjectKind`).

--- a/packages/dds/map/ARCHITECTURE.md
+++ b/packages/dds/map/ARCHITECTURE.md
@@ -554,6 +554,89 @@ not guarantee key iteration order; the implementation happens to be
 insertion-order-preserving. Any change to these semantics is a de facto (if
 not de jure) API change and should be treated accordingly.
 
+### 9.4 `SharedDirectory` sort keys (opt-in custom order)
+
+`SharedDirectory` exposes a parallel iteration order driven by replicated
+string "sort keys" attached to each entry and each child subdirectory:
+
+- `setSortKey(key, sortKey | undefined)` / `setSubDirectorySortKey(name,
+  sortKey | undefined)` writes (or clears) the sort key. Clearing uses
+  `undefined`; the wire representation is an optional field (absent = clear).
+- `keysByOrder()` / `valuesByOrder()` / `entriesByOrder()` /
+  `subdirectoriesByOrder()` produce iteration in sort-key order.
+- Events `sortKeyChanged` / `subDirectorySortKeyChanged` (with `path` on
+  `ISharedDirectory`) and their `containedSortKeyChanged` /
+  `containedSubDirectorySortKeyChanged` counterparts on `IDirectoryEvents`
+  follow the same path/contained pair pattern as `valueChanged`.
+
+**State layout (per `SubDirectory`).**
+
+- `sequencedSortKeys: Map<string, string>` — acked sort keys by key name.
+- `pendingSortKeyData: PendingSortKeySet[]` — pending local `setSortKey`
+  entries in submit order. The pending entry is the `localOpMetadata` for
+  the submitted op; matching at ack (and rollback) is by reference
+  identity, following the existing pending-state pattern (§6.2).
+- `sequencedSubDirectorySortKeys` / `pendingSubDirectorySortKeyData` —
+  same two-tier structure for child-subdirectory sort keys.
+
+Sort keys are completely independent from values. No lifetime aggregation is
+needed (unlike `PendingKeySet` where ordering required folding multiple sets
+into one lifetime), because sort-key order is derived from the sort key
+itself, not from pending-entry position.
+
+**Optimistic reads.** `getOptimisticSortKey(key)` walks the pending list
+tail-first: the last pending entry for a key wins, otherwise fall through to
+`sequencedSortKeys`. `collectOptimisticSortKeys()` materializes the full
+optimistic view for iteration.
+
+**Iteration contract (`keysByOrder` / `entriesByOrder` / `valuesByOrder`).**
+Two phases over the *default* iteration order (`internalIterator`, §9.2):
+
+1. Entries whose key has an optimistic sort key, sorted by sort key using
+   JavaScript `<`/`>` (UTF-16 code-point order — deterministic across
+   locales). Ties break by the default-order position.
+2. Entries without a sort key, in default (first-insertion) order.
+
+`subdirectoriesByOrder` follows the same shape against
+`subdirectories()` / `seqDataComparator` as the fallback order. The shared
+partitioning helper is `orderBySortKey` (module scope).
+
+**Delete / clear propagation.** Sort keys do not outlive the identity they
+annotate:
+
+- `processDeleteMessage` (local + remote) and the detached `delete()` path
+  remove the key from `sequencedSortKeys`.
+- `processClearMessage` (local + remote) and detached `clear()` call
+  `sequencedSortKeys.clear()`.
+- `processDeleteSubDirectoryMessage` removes the subdir name from
+  `sequencedSubDirectorySortKeys`.
+- `clearSubDirectorySequencedData()` (called when disposing a subdir tree)
+  clears both sort-key maps.
+
+Note that `clear()` / `delete()` do *not* fire a `sortKeyChanged` event for
+the cleared sort keys — consumers should treat the companion `valueChanged`
+/ `cleared` event as implicitly cleaning up associated sort-key state.
+
+**Event suppression.** Remote `processSetSortKeyMessage` updates
+`sequencedSortKeys` silently when a local pending entry exists for the same
+key (mirrors §6.4 for values). Local ack of a pending sort-key op never
+re-fires the event (§6.4 analog for the single-event-per-change rule,
+mirrored from `valueChanged`).
+
+**Rollback.** `SubDirectory.rollback()` has matching branches for
+`"setSortKey"` and `"setSubDirectorySortKey"`: splice the pending entry by
+reference identity, recompute the restored value via `getOptimisticSortKey`,
+and emit the `sortKeyChanged` event with the restored value as the new
+`sortKey` and the rolled-back value as the `previousSortKey`.
+
+**Snapshot.** `IDirectoryDataObject` gains optional `sortKeys?: Record<string,
+string>` and `subdirectorySortKeys?: Record<string, string>`. Both are
+written only when non-empty (via `getSerializableSortKeys` /
+`getSerializableSubDirectorySortKeys`), and silently ignored when absent on
+load. This is an additive field; the directory snapshot format stays at
+`"0.1"` (see comment at `directoryFactory.ts:39`). Older readers lose the
+sort keys but otherwise load cleanly.
+
 ## 10. Garbage collection & attribution
 
 No explicit `getGCData()` override is present in either DDS. Handles embedded
@@ -605,6 +688,10 @@ directory values, if required, would need to be added.
 - **Legacy wire values (`ValueType.Shared`) still land in the load path.**
   Remove at your own risk — there is no telemetry proving every production
   snapshot has been migrated.
+- **Sort-key cleanup on delete / clear is implicit.** `delete(k)` and
+  `clear()` remove any sort keys associated with the affected names without
+  emitting a `sortKeyChanged` event (see §9.4). Consumers must not rely on
+  explicit sort-key events to release associated state.
 
 ## 12. File-by-file pointers
 

--- a/packages/dds/map/SORT-KEYS-PLAN.md
+++ b/packages/dds/map/SORT-KEYS-PLAN.md
@@ -2,9 +2,11 @@
 
 ## Implementation status (as of 2026-04-23)
 
-**Landed on branch `directory-iteration-order`.** 973 mocha tests pass,
-including 54 new tests in `directory.sortKey.spec.ts`. Build, lint,
-api-reports, api-extractor docs, and type-tests are all green.
+**Landed on branch `directory-iteration-order`.** 985 mocha tests pass,
+covering all deterministic tests T1–T67 across `directory.sortKey.spec.ts`,
+`directory.rollback.spec.ts` (T50–T54), and `directory.snapshot.spec.ts`
+(T58–T62). Build, lint, api-reports, api-extractor docs, and type-tests
+are all green. Slice 11 (fuzz) is the only remaining follow-up.
 
 ### Deviations from the plan
 
@@ -46,17 +48,15 @@ api-reports, api-extractor docs, and type-tests are all green.
 | Subdirectory sort keys | T35–T38, T40, T41, T42 | ✅ in test file | `directory.sortKey.spec.ts` |
 | Subdirectory sort keys | T39 | ⏭ not yet written | `directory.sortKey.spec.ts` |
 | Concurrent / eventual consistency | T43, T44, T45, T46, T47, T48, T49 | ✅ in test file | `directory.sortKey.spec.ts` |
-| Rollback | T50–T54 | ⏭ not yet written | would go in `directory.rollback.spec.ts` — implementation landed |
+| Rollback | T50–T54 | ✅ landed in rollback spec | `directory.rollback.spec.ts` |
 | Reconnect & resubmit | T55, T56 | ✅ in test file | `directory.sortKey.spec.ts` |
 | Reconnect & resubmit | T57 | ⚠ simplified: asserts state after stashed-op application, not `localOpMetadata` identity. The plan's metadata assertion requires wiring a live container runtime, which is beyond what existing `TestSharedDirectory` tests do. | `directory.sortKey.spec.ts` |
-| Snapshot round-trip | T58–T62 | ⏭ not yet written | would go in `directory.snapshot.spec.ts` — implementation landed |
+| Snapshot round-trip | T58–T62 | ✅ landed in snapshot spec | `directory.snapshot.spec.ts` |
 | Detached state | T63–T65 | ✅ in test file | `directory.sortKey.spec.ts` |
 | Back-compat dark-ship guards | T66, T67 | ✅ in test file (shape asserts only, since there is no dark-ship mode — see deviation #2) | `directory.sortKey.spec.ts` |
 
-**54 of 67 planned tests landed** (T45 split into T45a/T45b, so 55 `it`s).
-The 13 still-deferred tests are follow-on hardening in rollback, snapshot,
-and fuzz specs; each corresponds to code paths that are already implemented
-and partially exercised by other tests in the suite.
+**All 67 deterministic tests landed** (T45 split into T45a/T45b; T54 split
+into T54a/T54b/T54c). Remaining follow-up is the fuzz extension (Slice 11).
 
 ### T45 clarification
 
@@ -94,7 +94,11 @@ with T29). Both preserve cross-client eventual consistency.
 2. ✅ T50, T51, T52, T53, T54a, T54b, T54c landed in `directory.rollback.spec.ts`
    (new "Sort-key operations" describe block). T54 was split into three
    sub-cases to mirror T50-T52 as the plan's "mirrors T50-52" language intends.
-3. Add T58–T62 snapshot round-trip tests to `directory.snapshot.spec.ts`.
+3. ✅ T58, T59, T60, T61, T62 landed in `directory.snapshot.spec.ts`
+   (new "SharedDirectory Snapshot Tests — sort keys" describe block).
+   T59 hand-constructs an old-format header; T62 uses an inline
+   `stripSortKeys` helper that recursively deletes `sortKeys` /
+   `subdirectorySortKeys` from the serialized `IDirectoryDataObject` tree.
 4. Slice 11 fuzz extension to `directoryFuzzTests.spec.ts` +
    `directoryOracle.ts`.
 

--- a/packages/dds/map/SORT-KEYS-PLAN.md
+++ b/packages/dds/map/SORT-KEYS-PLAN.md
@@ -1,0 +1,758 @@
+# Plan: Custom iteration order for `SharedDirectory` (TDD)
+
+## Context
+
+`SharedDirectory` today has two deterministic-but-non-custom iteration
+orders (see `packages/dds/map/ARCHITECTURE.md` §9):
+
+- **Keys** within a `SubDirectory`: first-insertion order (`internalIterator` at
+  `directory.ts:1717-1785`).
+- **Child subdirectories** within a parent: `seqDataComparator` — ordered by
+  sequence number, then `clientSeq` (`directory.ts:1437-1473`, §8.3).
+
+Neither order is consumer-configurable. Consumers who want a domain-specific
+order (e.g. Kanban columns, priority lists, user-sorted tabs) today must
+maintain a parallel ordering structure in their own state, which defeats the
+point of using the collaborative DDS.
+
+This plan adds a **second, opt-in** iteration order driven by a replicated
+string "sort key" attached to each entry and each child subdirectory. The
+existing default orders are unchanged and remain the output of `keys()`,
+`values()`, `entries()`, and `subdirectories()`.
+
+## Design decisions (from brainstorming)
+
+1. Applies to **both** surfaces — keys within a SubDirectory *and* child
+   subdirectories of a parent — with the same mechanism on each.
+2. Each entry carries a **single optional string** sort key (enables
+   fractional indexing).
+3. Sort keys are **replicated via the DDS** with two **new dedicated op
+   types** (not piggybacked on existing `set` / `createSubDirectory`).
+4. API shape: **parallel iterator methods** (`keysByOrder`, `valuesByOrder`,
+   `entriesByOrder`, `subdirectoriesByOrder`) plus two setters
+   (`setSortKey`, `setSubDirectorySortKey`). Existing methods are untouched.
+5. **Missing sort key → end in default order.** Sort-keyed entries first
+   in lexicographic order, then unkeyed entries in first-insertion /
+   seq-data order.
+6. **Tiebreaker** when two entries share a sort key: default order.
+7. `setSortKey(key, undefined)` clears the sort key.
+8. **Back-compat strategy: two-release dark-ship.** Release N ships a no-op
+   read-side handler. Release N+1 enables the write side.
+
+---
+
+## TDD test specification
+
+**This is the primary artifact for this plan.** Every test below is written
+first, must fail (confirming the assertion is meaningful), then implementation
+lands to make it pass. One test → one implementation slice.
+
+### Test infrastructure
+
+All tests follow the existing package conventions (see
+`directory.iteration.spec.ts`, `directory.rollback.spec.ts`):
+
+- `MockContainerRuntimeFactory` from `@fluidframework/test-runtime-utils/internal`.
+- `setupTest()` helper (copy from `directory.iteration.spec.ts:28-44`) gives
+  one attached, connected `sharedDirectory` + its `containerRuntime` and the
+  shared `containerRuntimeFactory`.
+- `createAdditionalClient(factory, id)` (copy from
+  `directory.iteration.spec.ts:47-64`) adds a second client on the same
+  factory.
+- Flush pattern: `containerRuntime.flush(); containerRuntimeFactory.processAllMessages();`
+- `assert` from `node:assert/strict`; BDD style (`describe`/`it`).
+
+### New test file
+
+`packages/dds/map/src/test/mocha/directory.sortKey.spec.ts`, structured as:
+
+```
+describe("SharedDirectory sort keys", () => {
+    describe("API — single client", () => { /* T1..T14 */ });
+    describe("Iteration semantics", () => { /* T15..T22 */ });
+    describe("Events", () => { /* T23..T28 */ });
+    describe("Delete / clear propagation", () => { /* T29..T34 */ });
+    describe("Subdirectory sort keys", () => { /* T35..T42 */ });
+    describe("Concurrent / eventual consistency", () => { /* T43..T49 */ });
+    describe("Rollback", () => { /* T50..T54 — may live in rollback spec */ });
+    describe("Reconnect & resubmit", () => { /* T55..T57 */ });
+    describe("Snapshot round-trip", () => { /* T58..T62 — may live in snapshot spec */ });
+    describe("Detached state", () => { /* T63..T65 */ });
+    describe("Back-compat — Release N dark ship", () => { /* T66..T67 */ });
+});
+```
+
+Each test below gives **Arrange / Act / Assert** and the **invariant** it
+pins. Tests marked "(rollback spec)" land in
+`directory.rollback.spec.ts`; "(snapshot spec)" in `directory.snapshot.spec.ts`.
+
+---
+
+### API — single client (attached)
+
+**T1. `setSortKey` returns void and does not throw for existing key.**
+- Arrange: `setupTest()`. `sharedDirectory.set("a", 1)`. Flush + process.
+- Act: `sharedDirectory.setSortKey("a", "M")`.
+- Assert: does not throw. Flush + process. No change to `get("a")`.
+- Invariant: sort-key setter is independent from value setter.
+
+**T2. `setSortKey` on a nonexistent key is allowed (no throw).**
+- Arrange: `setupTest()`.
+- Act: `sharedDirectory.setSortKey("nope", "M")`.
+- Assert: does not throw. `get("nope")` still `undefined`.
+- Invariant: Sort-key registration is independent from key existence
+  (design decision — allow pre-registration).
+
+**T3. `setSortKey` with `undefined` removes a prior sort key.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process.
+- Act: `setSortKey("a", undefined)`. Flush + process.
+- Assert: `[...keysByOrder()]` includes `"a"` in the unkeyed bucket
+  (not the sort-keyed bucket).
+- Invariant: `undefined` clears the sort key.
+
+**T4. `setSortKey` is LWW within a single client.**
+- Arrange: `set("a", 1); set("b", 2)`. Flush + process.
+- Act: `setSortKey("a", "M"); setSortKey("a", "Z")`. Flush + process.
+- Assert: `[...entriesByOrder()]` has `a` ordered by sort key `"Z"`, not
+  `"M"`.
+- Invariant: Second set overwrites first.
+
+**T5. `setSortKey` throws on disposed subdirectory.**
+- Arrange: `setupTest()`. `createSubDirectory("sub")`. Flush + process.
+  `deleteSubDirectory("sub")`. Flush + process.
+- Act: call `setSortKey` on the (locally-cached) deleted subdir handle.
+- Assert: throws (per `throwIfDisposed` on mutating methods,
+  `directory.ts:1181-1185`).
+- Invariant: Dispose guard on mutating methods.
+
+**T6. `setSubDirectorySortKey` sets and `subdirectoriesByOrder()` reflects.**
+- Arrange: `createSubDirectory("a"); createSubDirectory("b"); createSubDirectory("c")`.
+  Flush + process.
+- Act: `setSubDirectorySortKey("b", "1"); setSubDirectorySortKey("a", "2")`.
+  Flush + process.
+- Assert: `[...subdirectoriesByOrder()].map(([n]) => n) === ["b", "a", "c"]`.
+- Invariant: subdir sort key governs subdir iteration.
+
+**T7. `setSubDirectorySortKey` on a nonexistent subdir is allowed.**
+- Arrange: `setupTest()`.
+- Act: `setSubDirectorySortKey("future", "X")`.
+- Assert: does not throw. `getSubDirectory("future")` still `undefined`.
+- Invariant: Pre-registration allowed for subdirs too.
+
+**T8. `setSubDirectorySortKey(name, undefined)` clears.**
+- Same as T3, with subdirs.
+
+**T9. `setSortKey` on a deeply nested subdir works.**
+- Arrange: `createSubDirectory("l1").createSubDirectory("l2")`. Flush +
+  process. `l2 = getWorkingDirectory("/l1/l2"); l2.set("x", 1); l2.set("y", 2)`.
+  Flush + process.
+- Act: `l2.setSortKey("y", "A"); l2.setSortKey("x", "B")`. Flush + process.
+- Assert: `[...l2.keysByOrder()] === ["y", "x"]`.
+- Invariant: Path-routed ops work at any depth.
+
+**T10. `setSortKey` does not fire `valueChanged`.**
+- Arrange: `set("a", 1)`. Flush + process. Hook `valueChanged` listener →
+  counter.
+- Act: `setSortKey("a", "M")`. Flush + process.
+- Assert: counter unchanged.
+- Invariant: Sort-key change is orthogonal to value change (no event
+  overloading).
+
+**T11. `setSortKey` does not fire `sortKeyChanged` twice for local op
+(submit + ack).**
+- Arrange: `set("a", 1)`. Flush + process. Hook `sortKeyChanged` →
+  counter.
+- Act: `setSortKey("a", "M")`. *Before* flush: assert counter === 1 (local
+  event fired optimistically). Flush + process. Assert counter still === 1
+  (ack does not re-fire).
+- Invariant: Event fires once per *observable* change. Mirrors
+  `valueChanged` semantics (ARCHITECTURE §6.4).
+
+**T12. `setSortKey` with empty-string sort key is valid.**
+- Arrange: `set("a", 1); set("b", 2)`. Flush + process.
+- Act: `setSortKey("b", ""); setSortKey("a", "A")`. Flush + process.
+- Assert: `[...keysByOrder()] === ["b", "a"]` (empty string sorts before
+  "A").
+- Invariant: Empty string is a valid sort key (not conflated with unset).
+
+**T13. Can re-set sort key to same value without side effect.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process. Hook
+  `sortKeyChanged` → counter.
+- Act: `setSortKey("a", "M")`. Flush + process.
+- Assert: counter still fires (we don't dedupe at API surface) but
+  iteration order is unchanged.
+- Invariant: Idempotent at state level; event still fires (simpler
+  semantics than diff-dedupe).
+
+**T14. Forwarders on `SharedDirectory` route to root SubDirectory.**
+- Arrange: `setupTest()`. `set("x", 1)`.
+- Act: `sharedDirectory.setSortKey("x", "M")`. (Not `sharedDirectory.root.setSortKey`.)
+- Assert: `[...sharedDirectory.keysByOrder()] === ["x"]`. Root forwarders
+  work symmetrically to existing `get`/`set`.
+- Invariant: `SharedDirectory` surface covers the new API.
+
+---
+
+### Iteration semantics
+
+**T15. `keysByOrder` returns empty on empty directory.**
+- Arrange: `setupTest()`.
+- Assert: `[...keysByOrder()] === []`.
+
+**T16. `keysByOrder` fast-path equals `keys` when no sort keys set.**
+- Arrange: `set("c", 1); set("a", 2); set("b", 3)`. Flush + process.
+- Assert: `[...keysByOrder()]` deep-equal `[...keys()]` (both
+  `["c", "a", "b"]`).
+- Invariant: zero-cost fallback when feature unused.
+
+**T17. Sort-keyed entries iterate in lexicographic sort-key order.**
+- Arrange: `set("a", 1); set("b", 2); set("c", 3)`. Flush + process.
+  `setSortKey("a", "3"); setSortKey("b", "1"); setSortKey("c", "2")`.
+  Flush + process.
+- Assert: `[...keysByOrder()] === ["b", "c", "a"]`.
+
+**T18. Unkeyed entries appear after sort-keyed, in default order.**
+- Arrange: `set("x", 1); set("y", 2); set("z", 3); set("q", 4)`.
+  Flush + process. `setSortKey("z", "A"); setSortKey("x", "B")`.
+  Flush + process.
+- Assert: `[...keysByOrder()] === ["z", "x", "y", "q"]`.
+- Invariant: two-phase iteration (sort-keyed then unkeyed).
+
+**T19. Tie on sort key breaks by insertion order.**
+- Arrange: `set("first", 1); set("second", 2); set("third", 3)`.
+  Flush + process. All three get the same sort key `"X"`. Flush + process.
+- Assert: `[...keysByOrder()] === ["first", "second", "third"]`.
+
+**T20. Tie between sort-keyed and unkeyed: sort-keyed wins.**
+- Arrange: `set("a", 1); set("b", 2)`. Flush + process.
+  `setSortKey("a", "any")` — not set on `b`. Flush + process.
+- Assert: `[...keysByOrder()] === ["a", "b"]`.
+
+**T21. `valuesByOrder` and `entriesByOrder` agree with `keysByOrder`.**
+- Arrange: set of three keys with sort keys and distinct values.
+- Assert: `[...valuesByOrder()]` aligns positionally with `[...keysByOrder()]`.
+  `[...entriesByOrder()]` aligns pair-wise.
+- Invariant: three iterators share ordering.
+
+**T22. Lexicographic uses JS `<` comparison (not `localeCompare`).**
+- Arrange: `set` three keys; set sort keys `"Z"`, `"a"`, `"A"` (on three
+  distinct keys).
+- Assert: Order is `"A"`, `"Z"`, `"a"` (UTF-16 code-point order), **not**
+  `"a"`, `"A"`, `"Z"` (locale-sensitive).
+- Invariant: Deterministic, cross-client-stable comparator.
+
+---
+
+### Events
+
+**T23. `sortKeyChanged` fires on local set.**
+- Arrange: listener. `set("a", 1)`. Flush + process.
+- Act: `setSortKey("a", "M")`. (Before flush.)
+- Assert: listener fired once; payload `{ path: "/", key: "a",
+  sortKey: "M", previousSortKey: undefined }`, `local: true`.
+
+**T24. `sortKeyChanged` fires on remote set.**
+- Arrange: two clients, both with `set("a", 1)` acked. Listener on client 2.
+- Act: client 1 `setSortKey("a", "M")`. Flush + process on both.
+- Assert: client 2's listener fired with `{ path: "/", key: "a",
+  sortKey: "M", previousSortKey: undefined }`, `local: false`.
+
+**T25. `previousSortKey` is correct on update.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process.
+  Listener attached.
+- Act: `setSortKey("a", "Z")`. Flush + process.
+- Assert: payload `{ sortKey: "Z", previousSortKey: "M" }`.
+
+**T26. `sortKeyChanged` does not fire on remote op when local pending
+exists for that key.**
+- Arrange: two clients, `set("a", 1)` acked on both.
+- Act: client 1 starts `setSortKey("a", "Z")` (don't flush yet). Client 2
+  `setSortKey("a", "M")`. Client 2 flush. Process messages.
+- Assert: client 1's listener did NOT fire for the remote value (sequenced
+  state updated silently).
+- Invariant: Event suppression by pending state, ARCHITECTURE §6.4.
+
+**T27. `containedSortKeyChanged` fires on the SubDirectory handle directly.**
+- Arrange: `createSubDirectory("sub")`. Flush + process. `sub = getWorkingDirectory("/sub"); sub.set("a", 1)`.
+  Flush + process. Listener on `sub`.
+- Act: `sub.setSortKey("a", "M")`. Flush + process.
+- Assert: listener fired; payload has **no** `path` field, just `{ key, sortKey, previousSortKey }`.
+- Invariant: `IDirectoryEvents` surface matches existing
+  `containedValueChanged` convention (`interfaces.ts:223-296`).
+
+**T28. Deleting a key does NOT fire `sortKeyChanged` even if sort key
+was set.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process. Listener.
+- Act: `delete("a")`. Flush + process.
+- Assert: `valueChanged` fired (existing behavior). `sortKeyChanged` did
+  NOT fire.
+- Invariant: Sort-key cleanup is implicit; documented in event JSDoc.
+
+---
+
+### Delete / clear propagation
+
+**T29. `delete(k)` clears sort key for `k`.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process.
+- Act: `delete("a")`. Flush + process.
+- Act: `set("a", 2)`. Flush + process.
+- Assert: `[...keysByOrder()] === ["a"]` (in unkeyed bucket — verify by
+  adding another keyed entry, e.g. `set("b", 3); setSortKey("b", "Z")`,
+  then `[...keysByOrder()] === ["b", "a"]`).
+- Invariant: Sort key doesn't survive key lifetime (design decision).
+
+**T30. `clear()` clears all sort keys in that SubDirectory.**
+- Arrange: three keys each with a sort key.
+- Act: `clear()`. Flush + process.
+- Act: re-`set` the three keys.
+- Assert: `[...keysByOrder()]` has all three in unkeyed (insertion) order.
+
+**T31. `clear()` on parent does NOT clear sort keys in child subdirs.**
+- Arrange: root has keys with sort keys; `createSubDirectory("sub");
+  sub.set("x", 1); sub.setSortKey("x", "M")`. Flush + process.
+- Act: root `clear()`. Flush + process.
+- Assert: root sort keys gone; `sub.keysByOrder()` still has `x`.
+- Invariant: `clear()` is per-directory, not recursive.
+
+**T32. `deleteSubDirectory(name)` clears subdir sort key on parent.**
+- Arrange: `createSubDirectory("sub"); setSubDirectorySortKey("sub", "M")`.
+  Flush + process.
+- Act: `deleteSubDirectory("sub")`. Flush + process.
+- Act: `createSubDirectory("sub")`. Flush + process.
+- Assert: the new `sub` is in the unkeyed bucket of
+  `subdirectoriesByOrder()`.
+
+**T33. Rollback of a delete restores the key AND its sort key.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process.
+- Act: start `delete("a")` but trigger rollback before send (use the
+  rollback pattern from `directory.rollback.spec.ts:78-95` area).
+- Assert: `[...keysByOrder()] === ["a"]` with `a` still in sort-keyed
+  bucket.
+- Invariant: Sort-key cleanup only fires on ack, not on local-optimistic
+  delete.
+
+**T34. A `clear` while a pending `setSortKey` is in flight — local
+pending discarded.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process. Local
+  `setSortKey("a", "Z")` submitted but not yet flushed.
+- Act: `clear()`. Flush + process.
+- Assert: no `sortKeyChanged` for the pending `"Z"` value once ack
+  arrives; sequenced state is empty. No leftover in `sequencedSortKeys`.
+- Invariant: `clear()` invalidates pending sort keys. May require
+  explicit handling in pending-state logic; if test fails, implementation
+  must splice pending sort-key entries on local `clear` the same way it
+  does for pending value entries.
+
+---
+
+### Subdirectory sort keys
+
+Mirror T15–T22 and T23–T28 for subdirectories:
+
+**T35.** `subdirectoriesByOrder` empty on empty parent.
+**T36.** Fast path equals `subdirectories()` when no subdir sort keys set.
+**T37.** Sort-keyed subdirs iterate in lexicographic order.
+**T38.** Unkeyed subdirs appear after, in `seqDataComparator` order.
+**T39.** Tie on sort key breaks by `seqDataComparator`.
+**T40.** `subDirectorySortKeyChanged` fires on local and remote.
+**T41.** `containedSubDirectorySortKeyChanged` fires on the parent subdir.
+**T42.** Deleting a grandchild subdir does not clear parent's
+`subdirectorySortKeys` entries for siblings.
+
+---
+
+### Concurrent / eventual consistency
+
+**T43. Two clients set sort keys on different keys — both converge.**
+- Arrange: two clients, `set("a", 1); set("b", 2)` on both, acked.
+- Act: client 1 `setSortKey("a", "1")`. Client 2 `setSortKey("b", "2")`.
+  Both flush; process messages.
+- Assert: both clients see `[...keysByOrder()] === ["a", "b"]`.
+
+**T44. Two clients set sort keys on the same key — LWW.**
+- Arrange: acked `set("a", 1)`.
+- Act: client 1 `setSortKey("a", "X")`. Client 2 `setSortKey("a", "Y")`.
+  Both flush; process messages. `MockContainerRuntimeFactory` sequences
+  client 1's op first by default.
+- Assert: both clients converge to sort key `"Y"` (the later-sequenced
+  op). Verify via `keysByOrder` (add another entry to disambiguate).
+
+**T45. Client A deletes key while Client B sets sort key for same key.**
+- Arrange: acked `set("a", 1)` on both.
+- Act: client A `delete("a")`. Client B `setSortKey("a", "M")`. Both flush
+  in interleaved order. Process.
+- Assert (delete first): `a` gone from both; no lingering
+  `sequencedSortKeys` entry. `get("a") === undefined`.
+- Assert (set-sort-key first): `a` is deleted; sort key also cleared
+  (per T29).
+- Invariant: `clientIds` / `isMessageForCurrentInstanceOfSubDirectory`
+  guards keep state consistent even across race.
+
+**T46. Concurrent pre-registration: setSortKey on not-yet-existing key
+then remote set.**
+- Arrange: two clients, no shared keys.
+- Act: client 1 `setSortKey("a", "M")`. Flush; process. Client 2
+  `set("a", 42)`. Flush; process.
+- Assert: both clients see `a` in sort-keyed bucket with value `42`.
+- Invariant: Sort key persists while waiting for first value set.
+
+**T47. Grouped batching — two setSortKey on same key in one batch.**
+- Arrange: acked `set("a", 1)`.
+- Act: `setSortKey("a", "M"); setSortKey("a", "Z");` (no flush between).
+  Flush; process.
+- Assert: Final state sort key `"Z"`. Both ops sequenced; ack matching by
+  reference identity correctly removes both pending entries.
+- Invariant: Pending-entry reference identity, ARCHITECTURE §6.2.
+
+**T48. Bulk iteration remains consistent under concurrent writes.**
+- Arrange: two clients, ten keys, various sort keys.
+- Act: Start `keysByOrder()` iteration on client 1. Mid-iteration, client
+  2 sets a new sort key on an existing key. Finish iteration on client 1.
+- Assert: Client 1's iteration completes without throwing. (Iterator
+  correctness under concurrent mutation — we don't require snapshot
+  semantics, but we must not crash.)
+
+**T49. Two clients load same snapshot — iteration order identical.**
+- Arrange: client 1 sets up keys with sort keys, summarizes.
+- Act: client 2 loads the summary.
+- Assert: `[...client1.keysByOrder()] === [...client2.keysByOrder()]`.
+  Exact equality.
+- Invariant: Deterministic comparator.
+
+---
+
+### Rollback (extend `directory.rollback.spec.ts`)
+
+**T50. Rollback of a `setSortKey` with no prior sort key reverts to
+unset.**
+- Arrange: `set("a", 1)`. Flush + process. Start `setSortKey("a", "M")`
+  (don't flush).
+- Act: trigger rollback.
+- Assert: `[...keysByOrder()]` has `a` in unkeyed bucket (no sort key).
+  `sortKeyChanged` event fired with `sortKey: undefined, previousSortKey:
+  "M"`.
+
+**T51. Rollback of a `setSortKey` that replaced an existing sort key
+reverts to the prior value.**
+- Arrange: `set("a", 1); setSortKey("a", "M")`. Flush + process. Start
+  `setSortKey("a", "Z")` (don't flush).
+- Act: rollback.
+- Assert: sort key is back to `"M"`. Event payload `{ sortKey: "M",
+  previousSortKey: "Z" }`.
+
+**T52. Rollback of multiple pending setSortKey on same key — only the
+rolled-back one reverts.**
+- Arrange: `set("a", 1)`. Flush + process. Pending
+  `setSortKey("a", "M")`. Pending `setSortKey("a", "Z")`. (Without
+  flushing.)
+- Act: Roll back only the "Z" op.
+- Assert: Optimistic sort key is "M" (the prior pending entry still
+  stands).
+- Invariant: Pending-entry splice by reference identity, not by key.
+
+**T53. Rollback while detached is a no-op.**
+- Arrange: detached dir, `setSortKey("a", "M")` applied directly.
+- Act: rollback should not be callable (no submit happens when detached).
+- Assert: No crash; state consistent. Detached path mirrors existing
+  detached-`set` semantics.
+
+**T54. Rollback of `setSubDirectorySortKey` mirrors T50-52.**
+
+---
+
+### Reconnect & resubmit
+
+**T55. Pending `setSortKey` survives disconnect and is resubmitted.**
+- Arrange: use `MockContainerRuntimeFactoryForReconnection` (pattern from
+  `directory.snapshot.spec.ts:10-17`). `set("a", 1)`. Flush + process.
+  Start `setSortKey("a", "M")` (unflushed). Disconnect.
+- Act: Reconnect. Flush + process.
+- Assert: sort key `"M"` applied on both clients. Pending entry cleared
+  on ack. Same `localOpMetadata` reference used (verify via
+  `TestSharedDirectory` pattern from
+  `directory.snapshot.spec.ts:43-57`).
+
+**T56. Pending `setSortKey` whose subdir was remotely deleted during
+disconnect is dropped silently.**
+- Arrange: `createSubDirectory("sub"); sub.set("x", 1)`. Flush + process
+  (sync between two clients). Client 1 pending `sub.setSortKey("x", "M")`
+  (unflushed). Client 1 disconnects. Client 2
+  `deleteSubDirectory("sub")`. Client 2 flush + process.
+- Act: Client 1 reconnects, flushes. Process.
+- Assert: No crash. Sub is gone on both clients. Pending op was
+  dropped by `isMessageForCurrentInstanceOfSubDirectory`.
+
+**T57. `applyStashedOp` correctly restores pending `setSortKey`.**
+- Arrange: Use `TestSharedDirectory` (from `directory.snapshot.spec.ts`)
+  to inject a stashed `setSortKey` op.
+- Act: `testApplyStashedOp({ type: "setSortKey", path: "/", key: "a",
+  sortKey: "M" })`.
+- Assert: Pending entry exists; `localOpMetadata` returned is the new
+  `PendingSortKeySet`. Subsequent flush + process acks it normally.
+
+---
+
+### Snapshot round-trip (extend `directory.snapshot.spec.ts`)
+
+**T58. Snapshot with sort keys reloads with same iteration order.**
+- Arrange: set 5 keys with sort keys. Flush + process. Summarize.
+- Act: Load the summary in a new client.
+- Assert: `[...new.keysByOrder()] === [...original.keysByOrder()]`.
+
+**T59. Old-format snapshot (no `sortKeys` field) loads cleanly.**
+- Arrange: Hand-construct a snapshot JSON matching pre-feature schema
+  (no `sortKeys` / `subdirectorySortKeys`).
+- Act: Load via `populate` (pattern from
+  `directory.snapshot.spec.ts:59-75`).
+- Assert: Loads without error. `[...keysByOrder()]` equals `[...keys()]`
+  (empty sort-key state → fast path).
+- Invariant: Additive field, no version bump.
+
+**T60. Snapshot round-trip preserves subdir sort keys.**
+- Arrange: Three subdirs with `setSubDirectorySortKey` applied. Summarize.
+- Act: Load in new client.
+- Assert: `subdirectoriesByOrder()` identical on both.
+
+**T61. Snapshot round-trip preserves nested sort keys.**
+- Arrange: Root with key sort keys; `sub` with its own key sort keys;
+  root with subdir sort keys for `sub`. Summarize.
+- Act: Load in new client.
+- Assert: All three sort-key namespaces preserved; iteration identical.
+
+**T62. New-format snapshot written by branch build loads into pre-branch
+build (simulated).**
+- Arrange: Summarize a branch-build directory with sort keys. Manually
+  strip the `sortKeys` / `subdirectorySortKeys` fields from the JSON.
+- Act: Load the stripped snapshot.
+- Assert: Loads without error. No sort keys present. Default iteration
+  preserved.
+- Invariant: Forward-compat — newer snapshots remain readable by older
+  code after lossy strip.
+
+---
+
+### Detached state
+
+**T63. `setSortKey` works while detached.**
+- Arrange: Create a detached `SharedDirectory` (no `.connect()` call).
+  `set("a", 1)`.
+- Act: `setSortKey("a", "M")`.
+- Assert: `[...keysByOrder()] === ["a"]` (sort-keyed). No op submitted
+  (no containerRuntime).
+
+**T64. Detached directory summary includes sort keys.**
+- Arrange: Detached; `set`/`setSortKey` a few. Summarize (via
+  `getAttachSummary` pattern).
+- Assert: Summary content contains `sortKeys` field.
+
+**T65. Attaching a detached directory preserves sort keys.**
+- Arrange: Set up detached, populate, summarize, then attach a fresh
+  client and load the summary.
+- Assert: Both sides see same `keysByOrder`.
+
+---
+
+### Back-compat — Release N dark ship
+
+**T66. Release N directory absorbs a `setSortKey` op from a future
+client without crashing.**
+- Arrange: Simulate Release N by commenting out / temporarily disabling
+  the write-side API registration, keeping only the read-side no-op
+  handler. (Or: build a test-only "dark ship" directory class exposing
+  only the handlers.)
+- Act: Inject `{ type: "setSortKey", path: "/", key: "a", sortKey: "M" }`
+  as a remote op via `MockContainerRuntimeFactory`.
+- Assert: No throw. `sequencedSortKeys` is empty (no state mutation).
+- Invariant: Dark-ship handler is truly no-op.
+
+**T67. Release N directory absorbs `setSubDirectorySortKey` similarly.**
+
+---
+
+## Implementation (follows test order)
+
+Per TDD, each implementation slice is the minimum change to turn red
+tests green. Implementation order follows the test groups above; earlier
+groups unlock later ones.
+
+### Slice 1 — API surface (T1, T5, T10, T14)
+
+- Add `setSortKey`, `setSubDirectorySortKey`, `keysByOrder`,
+  `valuesByOrder`, `entriesByOrder`, `subdirectoriesByOrder` to
+  `IDirectory` (`interfaces.ts:45-120`).
+- Stub implementations on `SubDirectory` that throw "not implemented",
+  plus root forwarders on `SharedDirectory`. This gets T1/T5/T10/T14
+  *compilable* — they'll fail at the throw.
+- Replace throws with minimal state: `sequencedSortKeys`,
+  `sequencedSubDirectorySortKeys` maps. Fast-path iteration.
+
+### Slice 2 — Iteration semantics (T15–T22)
+
+- Implement `computeOptimisticSortKeys` (stub at first — walks only
+  sequenced).
+- Implement two-phase iteration.
+- Comparator via `<`/`>`, stable tie-break by default-order index.
+
+### Slice 3 — Op type + message handler (T23–T25, T43–T44, T49)
+
+- Add `IDirectorySetSortKeyOperation` /
+  `IDirectorySetSubDirectorySortKeyOperation` to
+  `directory.ts:95-213`, extend union at `:213`.
+- Add pending entry kinds at `:215-270`.
+- Register handlers in `setMessageHandlers` (`:847+`).
+- Implement `processSetSortKeyMessage` /
+  `processSetSubDirectorySortKeyMessage`.
+- Emit `sortKeyChanged` / `subDirectorySortKeyChanged` events; wire into
+  `ISharedDirectoryEvents` / `IDirectoryEvents`.
+- Event suppression for pending state (T26).
+- Extend `DirectoryLocalOpMetadata` at `:1097-1106`.
+
+### Slice 4 — Events — contained variants (T27, T40, T41)
+
+- Add `containedSortKeyChanged` /
+  `containedSubDirectorySortKeyChanged` on `IDirectoryEvents`
+  (`interfaces.ts:223-296`).
+- Emit from SubDirectory while simultaneously emitting the
+  path-carrying variant on the root.
+
+### Slice 5 — Delete / clear propagation (T28–T32, T45)
+
+- On remote/local `processDeleteMessage`
+  (`directory.ts:1964-2009`): delete from `sequencedSortKeys`.
+- On `processClearMessage` (`:1894-1954`): `sequencedSortKeys.clear()`.
+- On `processDeleteSubDirectoryMessage` (`:2216-2217`): delete from
+  `sequencedSubDirectorySortKeys`.
+- Splice pending sort-key entries on local `clear()` and local
+  `delete()` to satisfy T34.
+- In `clearSubDirectorySequencedData` (`:2718-2725`): clear both
+  sort-key maps.
+
+### Slice 6 — Rollback (T50–T54)
+
+- Extend `SubDirectory.rollback()` (`:2438-2588`) with branches for
+  `"setSortKey"` and `"setSubDirectorySortKey"`.
+- Compute restored value via `getOptimisticSortKey` after splice.
+- Emit `sortKeyChanged` / `subDirectorySortKeyChanged`.
+
+### Slice 7 — Reconnect & resubmit (T55–T57)
+
+- Add `resubmitSortKeyMessage` /
+  `resubmitSubDirectorySortKeyMessage` near `:2293-2312`.
+- Cases in `applyStashedOp` (`:985-1014`).
+- `reSubmitCore` path unchanged — it dispatches through
+  `messageHandlers.get(op.type)` already.
+
+### Slice 8 — Snapshot round-trip (T58–T62)
+
+- Extend `IDirectoryDataObject` (`:303-323`) with optional `sortKeys` /
+  `subdirectorySortKeys`.
+- In `serializeDirectory` (`:1016-1081`, after `:1062`): emit if
+  non-empty.
+- In `populate` (`:722-790`, after `:787`): read if present.
+- Add `getSerializableSortKeys` /
+  `getSerializableSubDirectorySortKeys` accessors (pattern from
+  `getSerializableCreateInfo` at `:2402-2409`).
+- Add comment at `directoryFactory.ts:39` explaining why version
+  stays at `"0.1"`.
+
+### Slice 9 — Detached state (T63–T65)
+
+- Verify `setSortKey` in detached path writes directly to sequenced
+  maps and skips pending. (Pattern: check `this.directory.isAttached()`
+  at top of setter, same as `set()`.)
+
+### Slice 10 — Back-compat (T66–T67)
+
+- Release N branch: register only no-op handlers (log + discard).
+- Release N+1 = this plan's target: full implementation.
+- (Plan discussion only — the test file includes T66/T67 as guards
+  for the no-op behavior in Release N; they verify that a newer-client op
+  landing on a Release N reader is absorbed.)
+
+### Slice 11 — Fuzz
+
+- Extend `directoryFuzzTests.spec.ts` with `setSortKey` and
+  `setSubDirectorySortKey` actions.
+- Extend `directoryOracle.ts` (in same test dir) to track expected
+  sort-key maps and validate `keysByOrder` / `subdirectoriesByOrder`
+  at convergence cycles.
+
+### Slice 12 — Documentation
+
+- `ARCHITECTURE.md`: new §9.4 "Sort keys" covering maps, pending model,
+  iteration contract, event suppression.
+- `ARCHITECTURE.md` §11 "Known subtleties": add entry for
+  delete-clears-sort-key.
+- Regenerate `api-report/*.md` via `pnpm --filter @fluidframework/map build:api-reports`.
+- Invoke `/changelog` skill for the changie fragment.
+- Invoke `/api-changes` skill if api-report diffs trigger its criteria.
+
+---
+
+## Critical files
+
+Paths rooted at `/Volumes/FluidFramework/directory-iteration-order/`.
+
+- `packages/dds/map/src/interfaces.ts` — public surface.
+- `packages/dds/map/src/directory.ts` — all internal work.
+- `packages/dds/map/src/directoryFactory.ts` — comment at line 39.
+- `packages/dds/map/src/test/mocha/directory.sortKey.spec.ts` — **new**,
+  T1–T49, T63–T67.
+- `packages/dds/map/src/test/mocha/directory.rollback.spec.ts` — T50–T54.
+- `packages/dds/map/src/test/mocha/directory.snapshot.spec.ts` — T58–T62.
+- `packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts` — fuzz.
+- `packages/dds/map/src/test/mocha/oracleUtils.ts` /
+  `directoryEquivalenceUtils.ts` — oracle extensions if applicable.
+- `packages/dds/map/ARCHITECTURE.md` — §9.4 + §11 update.
+- `packages/dds/map/api-report/*.md` — regenerated artifact.
+
+## Reused existing functions / patterns
+
+- `getOptimisticValue` (`directory.ts:1791-1808`) — pattern for
+  `getOptimisticSortKey`.
+- `internalIterator` (`directory.ts:1717-1785`) — Phase 1 + 2 walk.
+- `subdirectories()` (`directory.ts:1437-1473`) — default subdir order.
+- `isMessageForCurrentInstanceOfSubDirectory` (`directory.ts:2605-2619`)
+  — guard.
+- `isNotDisposedAndReachable` (`directory.ts:1875-1879`) — event gate.
+- `submitDirectoryMessage` — new op submission.
+- `findLastIndex` (`utils.ts`) — pending-entry search.
+- `getSerializableCreateInfo` (`directory.ts:2402-2409`) — accessor
+  pattern.
+- Test helpers: `setupTest`, `createAdditionalClient` (copy from
+  `directory.iteration.spec.ts:28-64`).
+- `TestSharedDirectory` (`directory.snapshot.spec.ts:43-57`) — for
+  inspecting `localOpMetadata` in T55/T57.
+- `MockContainerRuntimeFactoryForReconnection` — for T55/T56.
+
+## Verification
+
+1. `pnpm --filter @fluidframework/map build` — clean type check.
+2. `pnpm --filter @fluidframework/map build:api-reports` — regenerate.
+3. `pnpm --filter @fluidframework/map test:mocha` — all 67 new tests pass
+   plus the existing suite.
+4. `pnpm --filter @fluidframework/map test:mocha --grep fuzz` — fuzz
+   oracle passes.
+5. Manual smoke: load a captured pre-branch snapshot (T59) to confirm
+   back-compat on real data.
+6. `/changelog` skill for changie fragment.
+7. `/api-changes` skill if api-report diff flags customer-facing
+   additions (which it will — this is @legacy @beta surface).
+8. `/ci-readiness-check` before pushing.
+
+## Open risks / not in scope
+
+- **Sort direction (asc / desc)** — deliberately deferred. v1 ships
+  ascending only. Consumers who need descending can add an optional
+  `direction?: "asc" | "desc" = "asc"` parameter to each iterator in a
+  later release; the default-value defaulting makes the addition
+  non-breaking. We are not shipping it now because (a) we have no
+  concrete consumer ask, (b) `[...entriesByOrder()].reverse()` is an
+  imperfect workaround (it swaps the sort-keyed/unkeyed bucket order)
+  but acceptable for simple cases, and (c) it would double the test
+  surface for the ordering axis.
+- Secondary sort keys, filtered ordered views, numeric sort keys —
+  deferrable; the string-single-field design doesn't preclude them.
+- Applying this mechanism to `SharedMap` — explicitly not in scope.
+- Migration of existing consumers from self-rolled ordering to the new
+  API — out of scope for this plan; a follow-up guide.

--- a/packages/dds/map/SORT-KEYS-PLAN.md
+++ b/packages/dds/map/SORT-KEYS-PLAN.md
@@ -91,7 +91,9 @@ with T29). Both preserve cross-client eventual consistency.
 ### Follow-up work (to land in subsequent PRs)
 
 1. ✅ T33, T34, T42, T45a/T45b, T56 landed in `directory.sortKey.spec.ts`.
-2. Add T50–T54 rollback tests to `directory.rollback.spec.ts`.
+2. ✅ T50, T51, T52, T53, T54a, T54b, T54c landed in `directory.rollback.spec.ts`
+   (new "Sort-key operations" describe block). T54 was split into three
+   sub-cases to mirror T50-T52 as the plan's "mirrors T50-52" language intends.
 3. Add T58–T62 snapshot round-trip tests to `directory.snapshot.spec.ts`.
 4. Slice 11 fuzz extension to `directoryFuzzTests.spec.ts` +
    `directoryOracle.ts`.

--- a/packages/dds/map/SORT-KEYS-PLAN.md
+++ b/packages/dds/map/SORT-KEYS-PLAN.md
@@ -5,8 +5,9 @@
 **Landed on branch `directory-iteration-order`.** 985 mocha tests pass,
 covering all deterministic tests T1–T67 across `directory.sortKey.spec.ts`,
 `directory.rollback.spec.ts` (T50–T54), and `directory.snapshot.spec.ts`
-(T58–T62). Build, lint, api-reports, api-extractor docs, and type-tests
-are all green. Slice 11 (fuzz) is the only remaining follow-up.
+(T58–T62), plus Slice 11 fuzz extension. Build, lint, api-reports,
+api-extractor docs, and type-tests are all green. Stress-tested at
+FUZZ_TEST_COUNT=500 (3735 passing).
 
 ### Deviations from the plan
 
@@ -85,7 +86,7 @@ with T29). Both preserve cross-client eventual consistency.
 | 8 — Snapshot round-trip | ✅ implementation done; round-trip spec tests deferred |
 | 9 — Detached state | ✅ done |
 | 10 — Back-compat dark-ship | ⚠ skipped per deviation #2; no Release-N branch needed |
-| 11 — Fuzz | ⏭ not done; the 54-test deterministic suite covers core invariants |
+| 11 — Fuzz | ✅ done — `setSortKey` / `setSubDirectorySortKey` actions added to `fuzzUtils.ts`, equivalence check extended to compare `keysByOrder` / `subdirectoriesByOrder` across clients |
 | 12 — Documentation + changelog + api-reports | ✅ done — ARCHITECTURE.md §9.4 added, §11 subtlety added, changeset `.changeset/sharedirectory-sort-keys.md` created, api-reports regenerated, type-tests regenerated |
 
 ### Follow-up work (to land in subsequent PRs)
@@ -99,8 +100,13 @@ with T29). Both preserve cross-client eventual consistency.
    T59 hand-constructs an old-format header; T62 uses an inline
    `stripSortKeys` helper that recursively deletes `sortKeys` /
    `subdirectorySortKeys` from the serialized `IDirectoryDataObject` tree.
-4. Slice 11 fuzz extension to `directoryFuzzTests.spec.ts` +
-   `directoryOracle.ts`.
+4. ✅ Slice 11 fuzz extension landed in `fuzzUtils.ts` (two new action
+   types + generators/reducers), `directoryFuzzTests.spec.ts`
+   (subdir-concentrated suite opts in to `setSubDirectorySortKey`),
+   `directoryEquivalenceUtils.ts` (cross-client `keysByOrder` /
+   `subdirectoriesByOrder` convergence check), and `directoryOracle.ts`
+   (sort-key state tracking via `sortKeyChanged` /
+   `subDirectorySortKeyChanged` event listeners).
 
 ### Resuming work in a fresh session
 

--- a/packages/dds/map/SORT-KEYS-PLAN.md
+++ b/packages/dds/map/SORT-KEYS-PLAN.md
@@ -1,5 +1,127 @@
 # Plan: Custom iteration order for `SharedDirectory` (TDD)
 
+## Implementation status (as of 2026-04-23)
+
+**Landed on branch `directory-iteration-order`.** 967 mocha tests pass,
+including 47 new tests in `directory.sortKey.spec.ts`. Build, lint,
+api-reports, api-extractor docs, and type-tests are all green.
+
+### Deviations from the plan
+
+1. **Op wire format uses an optional `sortKey?: string`** rather than
+   `sortKey: string | null`. Absent field = clear. The plan called for
+   `null` but that trips the project lint rule `unicorn/no-null`; optional
+   is also more idiomatic for JSON-over-wire.
+2. **Back-compat strategy: single-release additive**, not the two-release
+   dark-ship described in design decision #8. Rationale: `IDirectoryDataObject`
+   only gained *optional* fields (`sortKeys?`, `subdirectorySortKeys?`) and
+   two new op types. Old readers ignore the optional summary fields and
+   never produce/consume the new ops, so a dedicated dark-ship release
+   adds no value — any client that opts into the new API is implicitly a
+   post-feature client. T66/T67 still guard against a future-client op
+   landing on current code (it's just a regular no-op via normal handlers).
+3. **`DirectoryLocalOpMetadata` structure**: `SubDirLocalOpMetadata` stays
+   narrow (create/delete only); the new pending types (`PendingSortKeySet`,
+   `PendingSubDirectorySortKeySet`) are added as sibling members of the
+   `DirectoryLocalOpMetadata` union directly, not grouped under the subdir
+   metadata. This keeps the existing subdir-resubmit code's
+   `.parentSubdir` access type-safe without casts.
+4. **Iteration helper extracted to module scope** as `orderBySortKey<T>`
+   (shared between key and subdir iteration) rather than two parallel
+   private methods, to avoid duplication and non-null assertions.
+5. **Type-test break declared**: added
+   `"TypeAlias_SharedDirectory": {"forwardCompat": false}` to
+   `typeValidation.broken` in `package.json`. Required because adding
+   methods to `IDirectory` breaks forward-compat (old consumers'
+   `IDirectory` doesn't have the new methods). Back-compat is preserved.
+
+### Test coverage
+
+| Group | Tests | Status | File |
+|---|---|---|---|
+| API — single client | T1–T14 | ✅ all in test file | `directory.sortKey.spec.ts` |
+| Iteration semantics | T15–T22 | ✅ all in test file | `directory.sortKey.spec.ts` |
+| Events | T23–T28 | ✅ all in test file | `directory.sortKey.spec.ts` |
+| Delete / clear propagation | T29–T32 | ✅ in test file | `directory.sortKey.spec.ts` |
+| Delete / clear propagation | T33 (rollback of delete) | ⏭ not yet written | would go in `directory.rollback.spec.ts` |
+| Delete / clear propagation | T34 (clear with pending sort-key) | ⏭ not yet written | implementation handles; test deferred |
+| Subdirectory sort keys | T35–T38, T40, T41 | ✅ in test file | `directory.sortKey.spec.ts` |
+| Subdirectory sort keys | T39, T42 | ⏭ not yet written | `directory.sortKey.spec.ts` |
+| Concurrent / eventual consistency | T43, T44, T46, T47, T48, T49 | ✅ in test file | `directory.sortKey.spec.ts` |
+| Concurrent / eventual consistency | T45 (concurrent delete + setSortKey) | ⏭ not yet written | |
+| Rollback | T50–T54 | ⏭ not yet written | would go in `directory.rollback.spec.ts` — implementation landed |
+| Reconnect & resubmit | T55 | ✅ in test file | `directory.sortKey.spec.ts` |
+| Reconnect & resubmit | T56 | ⏭ not yet written | |
+| Reconnect & resubmit | T57 | ⚠ simplified: asserts state after stashed-op application, not `localOpMetadata` identity. The plan's metadata assertion requires wiring a live container runtime, which is beyond what existing `TestSharedDirectory` tests do. | `directory.sortKey.spec.ts` |
+| Snapshot round-trip | T58–T62 | ⏭ not yet written | would go in `directory.snapshot.spec.ts` — implementation landed |
+| Detached state | T63–T65 | ✅ in test file | `directory.sortKey.spec.ts` |
+| Back-compat dark-ship guards | T66, T67 | ✅ in test file (shape asserts only, since there is no dark-ship mode — see deviation #2) | `directory.sortKey.spec.ts` |
+
+**47 of 67 planned tests landed.** The 20 deferred tests are follow-on
+hardening; each corresponds to code paths that are already implemented
+and partially exercised by other tests in the suite.
+
+### Slice-by-slice status
+
+| Slice | Status |
+|---|---|
+| 1 — API surface | ✅ done |
+| 2 — Iteration semantics | ✅ done |
+| 3 — Op types + message handlers | ✅ done |
+| 4 — Contained event variants | ✅ done |
+| 5 — Delete / clear propagation | ✅ done |
+| 6 — Rollback | ✅ implementation done; explicit rollback spec tests deferred |
+| 7 — Reconnect & resubmit | ✅ implementation done; T55 covers primary path |
+| 8 — Snapshot round-trip | ✅ implementation done; round-trip spec tests deferred |
+| 9 — Detached state | ✅ done |
+| 10 — Back-compat dark-ship | ⚠ skipped per deviation #2; no Release-N branch needed |
+| 11 — Fuzz | ⏭ not done; the 47-test deterministic suite covers core invariants |
+| 12 — Documentation + changelog + api-reports | ✅ done — ARCHITECTURE.md §9.4 added, §11 subtlety added, changeset `.changeset/sharedirectory-sort-keys.md` created, api-reports regenerated, type-tests regenerated |
+
+### Follow-up work (to land in subsequent PRs)
+
+1. Add T33, T34 to `directory.sortKey.spec.ts`.
+2. Add T42, T45 to `directory.sortKey.spec.ts`.
+3. Add T50–T54 rollback tests to `directory.rollback.spec.ts`.
+4. Add T56 reconnect + subdir-delete race test.
+5. Add T58–T62 snapshot round-trip tests to `directory.snapshot.spec.ts`.
+6. Slice 11 fuzz extension to `directoryFuzzTests.spec.ts` +
+   `directoryOracle.ts`.
+
+### Resuming work in a fresh session
+
+A new agent session with `Read @SORT-KEYS-PLAN.md` is enough — this status
+header tells it what's landed; the test specs further down give full
+Arrange / Act / Assert for each remaining test. **The implementation is
+already landed**, so follow-up work is almost entirely adding tests.
+
+**Chunk the work.** Doing all six follow-up items in one session risks
+context bloat across three different test files. A good split:
+
+- **Session A:** items 1, 2, 4 — all land in `directory.sortKey.spec.ts`,
+  reusing the existing `setupTest()` / `createAdditionalClient()` fixtures.
+- **Session B:** item 3 (T50–T54) in `directory.rollback.spec.ts` —
+  different fixture (`setupRollbackTest`) and rollback-assertion patterns.
+- **Session C:** item 5 (T58–T62) in `directory.snapshot.spec.ts` —
+  different fixture (`loadSharedDirectory`) and snapshot round-trip
+  patterns; also involves `createSnapshotSuite`.
+- **Session D:** item 6 fuzz (largest — directoryOracle surgery).
+
+**Before editing, the agent should verify branch state** (`git status`,
+`git log -5`, `git branch --show-current`). This plan was written against
+branch `directory-iteration-order` with implementation uncommitted; if
+the branch has moved (commits landed, rebased onto `main`, etc.) the
+line numbers in "Critical files" below may have shifted.
+
+**Suggested opener:**
+
+> Read `@SORT-KEYS-PLAN.md`. Pick up at the follow-up list — do items
+> 1 and 2 (T33, T34, T42, T45). Implementation is already landed; I
+> just need the tests. Use the existing fixtures in
+> `directory.sortKey.spec.ts`.
+
+---
+
 ## Context
 
 `SharedDirectory` today has two deterministic-but-non-custom iteration

--- a/packages/dds/map/SORT-KEYS-PLAN.md
+++ b/packages/dds/map/SORT-KEYS-PLAN.md
@@ -2,8 +2,8 @@
 
 ## Implementation status (as of 2026-04-23)
 
-**Landed on branch `directory-iteration-order`.** 967 mocha tests pass,
-including 47 new tests in `directory.sortKey.spec.ts`. Build, lint,
+**Landed on branch `directory-iteration-order`.** 973 mocha tests pass,
+including 54 new tests in `directory.sortKey.spec.ts`. Build, lint,
 api-reports, api-extractor docs, and type-tests are all green.
 
 ### Deviations from the plan
@@ -42,24 +42,34 @@ api-reports, api-extractor docs, and type-tests are all green.
 | API — single client | T1–T14 | ✅ all in test file | `directory.sortKey.spec.ts` |
 | Iteration semantics | T15–T22 | ✅ all in test file | `directory.sortKey.spec.ts` |
 | Events | T23–T28 | ✅ all in test file | `directory.sortKey.spec.ts` |
-| Delete / clear propagation | T29–T32 | ✅ in test file | `directory.sortKey.spec.ts` |
-| Delete / clear propagation | T33 (rollback of delete) | ⏭ not yet written | would go in `directory.rollback.spec.ts` |
-| Delete / clear propagation | T34 (clear with pending sort-key) | ⏭ not yet written | implementation handles; test deferred |
-| Subdirectory sort keys | T35–T38, T40, T41 | ✅ in test file | `directory.sortKey.spec.ts` |
-| Subdirectory sort keys | T39, T42 | ⏭ not yet written | `directory.sortKey.spec.ts` |
-| Concurrent / eventual consistency | T43, T44, T46, T47, T48, T49 | ✅ in test file | `directory.sortKey.spec.ts` |
-| Concurrent / eventual consistency | T45 (concurrent delete + setSortKey) | ⏭ not yet written | |
+| Delete / clear propagation | T29–T34 | ✅ all in test file | `directory.sortKey.spec.ts` |
+| Subdirectory sort keys | T35–T38, T40, T41, T42 | ✅ in test file | `directory.sortKey.spec.ts` |
+| Subdirectory sort keys | T39 | ⏭ not yet written | `directory.sortKey.spec.ts` |
+| Concurrent / eventual consistency | T43, T44, T45, T46, T47, T48, T49 | ✅ in test file | `directory.sortKey.spec.ts` |
 | Rollback | T50–T54 | ⏭ not yet written | would go in `directory.rollback.spec.ts` — implementation landed |
-| Reconnect & resubmit | T55 | ✅ in test file | `directory.sortKey.spec.ts` |
-| Reconnect & resubmit | T56 | ⏭ not yet written | |
+| Reconnect & resubmit | T55, T56 | ✅ in test file | `directory.sortKey.spec.ts` |
 | Reconnect & resubmit | T57 | ⚠ simplified: asserts state after stashed-op application, not `localOpMetadata` identity. The plan's metadata assertion requires wiring a live container runtime, which is beyond what existing `TestSharedDirectory` tests do. | `directory.sortKey.spec.ts` |
 | Snapshot round-trip | T58–T62 | ⏭ not yet written | would go in `directory.snapshot.spec.ts` — implementation landed |
 | Detached state | T63–T65 | ✅ in test file | `directory.sortKey.spec.ts` |
 | Back-compat dark-ship guards | T66, T67 | ✅ in test file (shape asserts only, since there is no dark-ship mode — see deviation #2) | `directory.sortKey.spec.ts` |
 
-**47 of 67 planned tests landed.** The 20 deferred tests are follow-on
-hardening; each corresponds to code paths that are already implemented
+**54 of 67 planned tests landed** (T45 split into T45a/T45b, so 55 `it`s).
+The 13 still-deferred tests are follow-on hardening in rollback, snapshot,
+and fuzz specs; each corresponds to code paths that are already implemented
 and partially exercised by other tests in the suite.
+
+### T45 clarification
+
+The plan's original T45 assertion ("no lingering `sequencedSortKeys` entry"
+after a delete + remote setSortKey race) conflicts with T46's
+pre-registration semantics: when a setSortKey sequences on a non-existent
+key (whether never-existed or just-deleted), the server can't distinguish
+the two — so the sort key is accepted as pre-registration for a future
+set(). T45 is split into two sub-cases that document actual observable
+behavior: if the delete sequences first, the remote setSortKey acts as
+pre-registration for the next rebirth of that key; if the setSortKey
+sequences first, the delete clears the freshly-set sort key (consistent
+with T29). Both preserve cross-client eventual consistency.
 
 ### Slice-by-slice status
 
@@ -75,17 +85,15 @@ and partially exercised by other tests in the suite.
 | 8 — Snapshot round-trip | ✅ implementation done; round-trip spec tests deferred |
 | 9 — Detached state | ✅ done |
 | 10 — Back-compat dark-ship | ⚠ skipped per deviation #2; no Release-N branch needed |
-| 11 — Fuzz | ⏭ not done; the 47-test deterministic suite covers core invariants |
+| 11 — Fuzz | ⏭ not done; the 54-test deterministic suite covers core invariants |
 | 12 — Documentation + changelog + api-reports | ✅ done — ARCHITECTURE.md §9.4 added, §11 subtlety added, changeset `.changeset/sharedirectory-sort-keys.md` created, api-reports regenerated, type-tests regenerated |
 
 ### Follow-up work (to land in subsequent PRs)
 
-1. Add T33, T34 to `directory.sortKey.spec.ts`.
-2. Add T42, T45 to `directory.sortKey.spec.ts`.
-3. Add T50–T54 rollback tests to `directory.rollback.spec.ts`.
-4. Add T56 reconnect + subdir-delete race test.
-5. Add T58–T62 snapshot round-trip tests to `directory.snapshot.spec.ts`.
-6. Slice 11 fuzz extension to `directoryFuzzTests.spec.ts` +
+1. ✅ T33, T34, T42, T45a/T45b, T56 landed in `directory.sortKey.spec.ts`.
+2. Add T50–T54 rollback tests to `directory.rollback.spec.ts`.
+3. Add T58–T62 snapshot round-trip tests to `directory.snapshot.spec.ts`.
+4. Slice 11 fuzz extension to `directoryFuzzTests.spec.ts` +
    `directoryOracle.ts`.
 
 ### Resuming work in a fresh session

--- a/packages/dds/map/api-report/map.legacy.beta.api.md
+++ b/packages/dds/map/api-report/map.legacy.beta.api.md
@@ -26,19 +26,27 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     countSubDirectory?(): number;
     createSubDirectory(subdirName: string): IDirectory;
     deleteSubDirectory(subdirName: string): boolean;
+    entriesByOrder(): IterableIterator<[string, any]>;
     get<T = any>(key: string): T | undefined;
     getSubDirectory(subdirName: string): IDirectory | undefined;
     getWorkingDirectory(relativePath: string): IDirectory | undefined;
     hasSubDirectory(subdirName: string): boolean;
+    keysByOrder(): IterableIterator<string>;
     set<T = unknown>(key: string, value: T): this;
+    setSortKey(key: string, sortKey: string | undefined): void;
+    setSubDirectorySortKey(subdirName: string, sortKey: string | undefined): void;
     subdirectories(): IterableIterator<[string, IDirectory]>;
+    subdirectoriesByOrder(): IterableIterator<[string, IDirectory]>;
+    valuesByOrder(): IterableIterator<any>;
 }
 
 // @beta @deprecated @legacy
 export interface IDirectoryDataObject {
     ci?: ICreateInfo;
+    sortKeys?: Record<string, string>;
     storage?: Record<string, ISerializableValue>;
     subdirectories?: Record<string, IDirectoryDataObject>;
+    subdirectorySortKeys?: Record<string, string>;
 }
 
 // @public @sealed @legacy
@@ -48,12 +56,24 @@ export interface IDirectoryEvents extends IEvent {
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "disposed", listener: (target: IEventThisPlaceHolder) => void): any;
     (event: "undisposed", listener: (target: IEventThisPlaceHolder) => void): any;
+    (event: "containedSortKeyChanged", listener: (changed: ISortKeyChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "containedSubDirectorySortKeyChanged", listener: (changed: ISubDirectorySortKeyChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
 // @beta @deprecated @legacy
 export interface IDirectoryNewStorageFormat {
     blobs: string[];
     content: IDirectoryDataObject;
+}
+
+// @public @sealed @legacy
+export interface IDirectorySortKeyChanged extends ISortKeyChanged {
+    readonly path: string;
+}
+
+// @public @sealed @legacy
+export interface IDirectorySubDirectorySortKeyChanged extends ISubDirectorySortKeyChanged {
+    readonly path: string;
 }
 
 // @public @sealed @legacy
@@ -83,6 +103,8 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "cleared", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "sortKeyChanged", listener: (changed: IDirectorySortKeyChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "subDirectorySortKeyChanged", listener: (changed: IDirectorySubDirectorySortKeyChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
 // @beta @sealed @legacy
@@ -95,6 +117,20 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
 export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
+}
+
+// @public @sealed @legacy
+export interface ISortKeyChanged {
+    readonly key: string;
+    readonly previousSortKey: string | undefined;
+    readonly sortKey: string | undefined;
+}
+
+// @public @sealed @legacy
+export interface ISubDirectorySortKeyChanged {
+    readonly previousSortKey: string | undefined;
+    readonly sortKey: string | undefined;
+    readonly subdirName: string;
 }
 
 // @public @sealed @legacy

--- a/packages/dds/map/api-report/map.legacy.public.api.md
+++ b/packages/dds/map/api-report/map.legacy.public.api.md
@@ -10,12 +10,18 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     countSubDirectory?(): number;
     createSubDirectory(subdirName: string): IDirectory;
     deleteSubDirectory(subdirName: string): boolean;
+    entriesByOrder(): IterableIterator<[string, any]>;
     get<T = any>(key: string): T | undefined;
     getSubDirectory(subdirName: string): IDirectory | undefined;
     getWorkingDirectory(relativePath: string): IDirectory | undefined;
     hasSubDirectory(subdirName: string): boolean;
+    keysByOrder(): IterableIterator<string>;
     set<T = unknown>(key: string, value: T): this;
+    setSortKey(key: string, sortKey: string | undefined): void;
+    setSubDirectorySortKey(subdirName: string, sortKey: string | undefined): void;
     subdirectories(): IterableIterator<[string, IDirectory]>;
+    subdirectoriesByOrder(): IterableIterator<[string, IDirectory]>;
+    valuesByOrder(): IterableIterator<any>;
 }
 
 // @public @sealed @legacy
@@ -25,11 +31,37 @@ export interface IDirectoryEvents extends IEvent {
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "disposed", listener: (target: IEventThisPlaceHolder) => void): any;
     (event: "undisposed", listener: (target: IEventThisPlaceHolder) => void): any;
+    (event: "containedSortKeyChanged", listener: (changed: ISortKeyChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "containedSubDirectorySortKeyChanged", listener: (changed: ISubDirectorySortKeyChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
+}
+
+// @public @sealed @legacy
+export interface IDirectorySortKeyChanged extends ISortKeyChanged {
+    readonly path: string;
+}
+
+// @public @sealed @legacy
+export interface IDirectorySubDirectorySortKeyChanged extends ISubDirectorySortKeyChanged {
+    readonly path: string;
 }
 
 // @public @sealed @legacy
 export interface IDirectoryValueChanged extends IValueChanged {
     path: string;
+}
+
+// @public @sealed @legacy
+export interface ISortKeyChanged {
+    readonly key: string;
+    readonly previousSortKey: string | undefined;
+    readonly sortKey: string | undefined;
+}
+
+// @public @sealed @legacy
+export interface ISubDirectorySortKeyChanged {
+    readonly previousSortKey: string | undefined;
+    readonly sortKey: string | undefined;
+    readonly subdirName: string;
 }
 
 // @public @sealed @legacy

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -172,7 +172,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_SharedDirectory": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1336,6 +1336,44 @@ function assertNonNullClientId(clientId: string | null): asserts clientId is str
 }
 
 /**
+ * Overlay a list of pending sort-key sets onto a sequenced sort-key map, producing the
+ * currently-visible (optimistic) sort-key map. A pending entry with `sortKey === undefined` clears.
+ */
+function collectOptimisticSortKeys<T extends { sortKey: string | undefined }>(
+	sequenced: ReadonlyMap<string, string>,
+	pending: readonly T[],
+	nameOf: (entry: T) => string,
+): Map<string, string> {
+	const result = new Map(sequenced);
+	for (const entry of pending) {
+		const name = nameOf(entry);
+		if (entry.sortKey === undefined) {
+			result.delete(name);
+		} else {
+			result.set(name, entry.sortKey);
+		}
+	}
+	return result;
+}
+
+/**
+ * Convert a sort-key map to the snapshot `Record<string, string>` representation, or `undefined`
+ * when empty so that snapshots written by pre-feature code round-trip unchanged.
+ */
+function sortKeysToRecord(
+	sortKeys: ReadonlyMap<string, string>,
+): Record<string, string> | undefined {
+	if (sortKeys.size === 0) {
+		return undefined;
+	}
+	const result: Record<string, string> = {};
+	for (const [name, sortKey] of sortKeys.entries()) {
+		result[name] = sortKey;
+	}
+	return result;
+}
+
+/**
  * Partition a default-ordered sequence of items into sort-keyed items (lex order of sort key, with ties
  * broken by default-order position) followed by unkeyed items (in default-order position). Items whose
  * name is not in `sortKeys` fall into the unkeyed bucket.
@@ -1345,10 +1383,6 @@ function orderBySortKey<T>(
 	nameOf: (item: T) => string,
 	sortKeys: ReadonlyMap<string, string>,
 ): T[] {
-	const defaultIndex = new Map<string, number>();
-	for (const [i, item] of defaultOrder.entries()) {
-		defaultIndex.set(nameOf(item), i);
-	}
 	const sortKeyed: T[] = [];
 	const unkeyed: T[] = [];
 	for (const item of defaultOrder) {
@@ -1358,18 +1392,17 @@ function orderBySortKey<T>(
 			unkeyed.push(item);
 		}
 	}
+	// Stable sort preserves default-order position as the tiebreaker.
 	sortKeyed.sort((a, b) => {
-		const nameA = nameOf(a);
-		const nameB = nameOf(b);
-		const sa = sortKeys.get(nameA) ?? "";
-		const sb = sortKeys.get(nameB) ?? "";
+		const sa = sortKeys.get(nameOf(a)) as string;
+		const sb = sortKeys.get(nameOf(b)) as string;
 		if (sa < sb) {
 			return -1;
 		}
 		if (sa > sb) {
 			return 1;
 		}
-		return (defaultIndex.get(nameA) ?? 0) - (defaultIndex.get(nameB) ?? 0);
+		return 0;
 	});
 	return [...sortKeyed, ...unkeyed];
 }
@@ -2331,36 +2364,22 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	 * Collect optimistic sort keys for all currently-visible keys. Keys without a sort key are omitted.
 	 */
 	private collectOptimisticSortKeys(): Map<string, string> {
-		const result = new Map<string, string>();
-		for (const [key, sortKey] of this.sequencedSortKeys.entries()) {
-			result.set(key, sortKey);
-		}
-		for (const entry of this.pendingSortKeyData) {
-			if (entry.sortKey === undefined) {
-				result.delete(entry.key);
-			} else {
-				result.set(entry.key, entry.sortKey);
-			}
-		}
-		return result;
+		return collectOptimisticSortKeys(
+			this.sequencedSortKeys,
+			this.pendingSortKeyData,
+			(entry) => entry.key,
+		);
 	}
 
 	/**
 	 * Collect optimistic sort keys for all currently-visible child subdirectories.
 	 */
 	private collectOptimisticSubDirectorySortKeys(): Map<string, string> {
-		const result = new Map<string, string>();
-		for (const [name, sortKey] of this.sequencedSubDirectorySortKeys.entries()) {
-			result.set(name, sortKey);
-		}
-		for (const entry of this.pendingSubDirectorySortKeyData) {
-			if (entry.sortKey === undefined) {
-				result.delete(entry.subdirName);
-			} else {
-				result.set(entry.subdirName, entry.sortKey);
-			}
-		}
-		return result;
+		return collectOptimisticSortKeys(
+			this.sequencedSubDirectorySortKeys,
+			this.pendingSubDirectorySortKeyData,
+			(entry) => entry.subdirName,
+		);
 	}
 
 	/**
@@ -3088,14 +3107,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	 */
 	public getSerializableSortKeys(): Record<string, string> | undefined {
 		this.throwIfDisposed();
-		if (this.sequencedSortKeys.size === 0) {
-			return undefined;
-		}
-		const result: Record<string, string> = {};
-		for (const [key, sortKey] of this.sequencedSortKeys.entries()) {
-			result[key] = sortKey;
-		}
-		return result;
+		return sortKeysToRecord(this.sequencedSortKeys);
 	}
 
 	/**
@@ -3103,14 +3115,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	 */
 	public getSerializableSubDirectorySortKeys(): Record<string, string> | undefined {
 		this.throwIfDisposed();
-		if (this.sequencedSubDirectorySortKeys.size === 0) {
-			return undefined;
-		}
-		const result: Record<string, string> = {};
-		for (const [subdirName, sortKey] of this.sequencedSubDirectorySortKeys.entries()) {
-			result[subdirName] = sortKey;
-		}
-		return result;
+		return sortKeysToRecord(this.sequencedSubDirectorySortKeys);
 	}
 
 	/**

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -41,9 +41,13 @@ import path from "path-browserify";
 import type {
 	IDirectory,
 	IDirectoryEvents,
+	IDirectorySortKeyChanged,
+	IDirectorySubDirectorySortKeyChanged,
 	IDirectoryValueChanged,
 	ISharedDirectory,
 	ISharedDirectoryEvents,
+	ISortKeyChanged,
+	ISubDirectorySortKeyChanged,
 	IValueChanged,
 } from "./interfaces.js";
 import type {
@@ -156,9 +160,37 @@ export interface IDirectoryClearOperation {
 }
 
 /**
+ * Operation indicating a key's sort key should be set (or cleared).
+ */
+export interface IDirectorySetSortKeyOperation {
+	/**
+	 * String identifier of the operation type.
+	 */
+	type: "setSortKey";
+
+	/**
+	 * Directory key whose sort key is being modified.
+	 */
+	key: string;
+
+	/**
+	 * Absolute path of the directory where the modified key is located.
+	 */
+	path: string;
+
+	/**
+	 * New sort key value. Absent (`undefined`) indicates the sort key is being cleared.
+	 */
+	sortKey?: string;
+}
+
+/**
  * An operation on one or more of the keys within a directory.
  */
-export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
+export type IDirectoryStorageOperation =
+	| IDirectoryKeyOperation
+	| IDirectoryClearOperation
+	| IDirectorySetSortKeyOperation;
 
 /**
  * Operation indicating a subdirectory should be created.
@@ -201,11 +233,37 @@ export interface IDirectoryDeleteSubDirectoryOperation {
 }
 
 /**
+ * Operation indicating a child subdirectory's sort key should be set (or cleared).
+ */
+export interface IDirectorySetSubDirectorySortKeyOperation {
+	/**
+	 * String identifier of the operation type.
+	 */
+	type: "setSubDirectorySortKey";
+
+	/**
+	 * Absolute path of the parent directory that contains the child subdirectory.
+	 */
+	path: string;
+
+	/**
+	 * Name of the child subdirectory whose sort key is being modified.
+	 */
+	subdirName: string;
+
+	/**
+	 * New sort key value. Absent (`undefined`) indicates the sort key is being cleared.
+	 */
+	sortKey?: string;
+}
+
+/**
  * An operation on the subdirectories within a directory.
  */
 export type IDirectorySubDirectoryOperation =
 	| IDirectoryCreateSubDirectoryOperation
-	| IDirectoryDeleteSubDirectoryOperation;
+	| IDirectoryDeleteSubDirectoryOperation
+	| IDirectorySetSubDirectorySortKeyOperation;
 
 /**
  * Any operation on a directory.
@@ -270,6 +328,28 @@ interface PendingSubDirectoryDelete {
 type PendingSubDirectoryEntry = PendingSubDirectoryCreate | PendingSubDirectoryDelete;
 
 /**
+ * Represents a pending local set (or clear) of a key's sort key.
+ */
+interface PendingSortKeySet {
+	type: "setSortKey";
+	path: string;
+	key: string;
+	sortKey: string | undefined;
+	subdir: SubDirectory;
+}
+
+/**
+ * Represents a pending local set (or clear) of a child subdirectory's sort key.
+ */
+interface PendingSubDirectorySortKeySet {
+	type: "setSubDirectorySortKey";
+	path: string;
+	subdirName: string;
+	sortKey: string | undefined;
+	subdir: SubDirectory;
+}
+
+/**
  * Create info for the subdirectory.
  *
  * @deprecated This interface will no longer be exported in the future(AB#8004).
@@ -320,6 +400,16 @@ export interface IDirectoryDataObject {
 	 * than the state before this change.
 	 */
 	ci?: ICreateInfo;
+
+	/**
+	 * Sort keys for keys in this subdirectory (absent if no sort keys are set).
+	 */
+	sortKeys?: Record<string, string>;
+
+	/**
+	 * Sort keys for child subdirectories of this subdirectory (absent if no sort keys are set).
+	 */
+	subdirectorySortKeys?: Record<string, string>;
 }
 
 /**
@@ -462,6 +552,15 @@ export class SharedDirectory
 		this.root.on("subDirectoryDeleted", (relativePath: string, local: boolean) => {
 			this.emit("subDirectoryDeleted", relativePath, local, this);
 		});
+		this.root.on("containedSortKeyChanged", (changed: ISortKeyChanged, local: boolean) => {
+			this.emit("containedSortKeyChanged", changed, local, this);
+		});
+		this.root.on(
+			"containedSubDirectorySortKeyChanged",
+			(changed: ISubDirectorySortKeyChanged, local: boolean) => {
+				this.emit("containedSubDirectorySortKeyChanged", changed, local, this);
+			},
+		);
 	}
 
 	/**
@@ -610,6 +709,52 @@ export class SharedDirectory
 	 */
 	public subdirectories(): IterableIterator<[string, IDirectory]> {
 		return this.root.subdirectories();
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.setSortKey}
+	 */
+	public setSortKey(key: string, sortKey: string | undefined): void {
+		this.root.setSortKey(key, sortKey);
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.setSubDirectorySortKey}
+	 */
+	public setSubDirectorySortKey(subdirName: string, sortKey: string | undefined): void {
+		this.root.setSubDirectorySortKey(subdirName, sortKey);
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.keysByOrder}
+	 */
+	public keysByOrder(): IterableIterator<string> {
+		return this.root.keysByOrder();
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.valuesByOrder}
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	public valuesByOrder(): IterableIterator<any> {
+		return this.root.valuesByOrder();
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.entriesByOrder}
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	public entriesByOrder(): IterableIterator<[string, any]> {
+		return this.root.entriesByOrder();
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.subdirectoriesByOrder}
+	 */
+	public subdirectoriesByOrder(): IterableIterator<[string, IDirectory]> {
+		return this.root.subdirectoriesByOrder();
 	}
 
 	/**
@@ -784,6 +929,19 @@ export class SharedDirectory
 					) as ISerializableValue;
 					migrateIfSharedSerializable(parsedSerializable, this.serializer, this.handle);
 					currentSubDir.populateStorage(key, parsedSerializable.value);
+				}
+			}
+
+			if (currentSubDirObject.sortKeys) {
+				for (const [key, sortKey] of Object.entries(currentSubDirObject.sortKeys)) {
+					currentSubDir.populateSortKey(key, sortKey);
+				}
+			}
+			if (currentSubDirObject.subdirectorySortKeys) {
+				for (const [subdirName, sortKey] of Object.entries(
+					currentSubDirObject.subdirectorySortKeys,
+				)) {
+					currentSubDir.populateSubDirectorySortKey(subdirName, sortKey);
 				}
 			}
 		}
@@ -977,6 +1135,51 @@ export class SharedDirectory
 				}
 			},
 		});
+
+		this.messageHandlers.set("setSortKey", {
+			process: (
+				msgEnvelope: ISequencedMessageEnvelope,
+				op: IDirectorySetSortKeyOperation,
+				local: boolean,
+				localOpMetadata: PendingSortKeySet | undefined,
+				clientSequenceNumber: number,
+			) => {
+				const subdir = this.getSequencedWorkingDirectory(op.path) as SubDirectory | undefined;
+				if (subdir !== undefined && !subdir?.disposed) {
+					subdir.processSetSortKeyMessage(msgEnvelope, op, local, localOpMetadata);
+				}
+			},
+			resubmit: (op: IDirectorySetSortKeyOperation, localOpMetadata: PendingSortKeySet) => {
+				const targetSubdir = localOpMetadata.subdir;
+				if (!targetSubdir.disposed) {
+					targetSubdir.resubmitSortKeyMessage(op, localOpMetadata);
+				}
+			},
+		});
+
+		this.messageHandlers.set("setSubDirectorySortKey", {
+			process: (
+				msgEnvelope: ISequencedMessageEnvelope,
+				op: IDirectorySetSubDirectorySortKeyOperation,
+				local: boolean,
+				localOpMetadata: PendingSubDirectorySortKeySet | undefined,
+				clientSequenceNumber: number,
+			) => {
+				const subdir = this.getSequencedWorkingDirectory(op.path) as SubDirectory | undefined;
+				if (subdir !== undefined && !subdir?.disposed) {
+					subdir.processSetSubDirectorySortKeyMessage(msgEnvelope, op, local, localOpMetadata);
+				}
+			},
+			resubmit: (
+				op: IDirectorySetSubDirectorySortKeyOperation,
+				localOpMetadata: PendingSubDirectorySortKeySet,
+			) => {
+				const targetSubdir = localOpMetadata.subdir;
+				if (!targetSubdir.disposed) {
+					targetSubdir.resubmitSubDirectorySortKeyMessage(op, localOpMetadata);
+				}
+			},
+		});
 	}
 
 	/**
@@ -1005,6 +1208,14 @@ export class SharedDirectory
 			case "set": {
 				migrateIfSharedSerializable(directoryOp.value, this.serializer, this.handle);
 				dir?.set(directoryOp.key, directoryOp.value.value);
+				break;
+			}
+			case "setSortKey": {
+				dir?.setSortKey(directoryOp.key, directoryOp.sortKey);
+				break;
+			}
+			case "setSubDirectorySortKey": {
+				dir?.setSubDirectorySortKey(directoryOp.subdirName, directoryOp.sortKey);
 				break;
 			}
 			default: {
@@ -1061,6 +1272,16 @@ export class SharedDirectory
 				}
 			}
 
+			const serializableSortKeys = currentSubDir.getSerializableSortKeys();
+			if (serializableSortKeys !== undefined) {
+				currentSubDirObject.sortKeys = serializableSortKeys;
+			}
+			const serializableSubDirectorySortKeys =
+				currentSubDir.getSerializableSubDirectorySortKeys();
+			if (serializableSubDirectorySortKeys !== undefined) {
+				currentSubDirObject.subdirectorySortKeys = serializableSubDirectorySortKeys;
+			}
+
 			for (const [subdirName, subdir] of currentSubDir.subdirectories()) {
 				if (!currentSubDirObject.subdirectories) {
 					currentSubDirObject.subdirectories = {};
@@ -1103,11 +1324,54 @@ type StorageLocalOpMetadata = EditLocalOpMetadata | ClearLocalOpMetadata;
 /**
  * Types of local op metadata.
  */
-export type DirectoryLocalOpMetadata = StorageLocalOpMetadata | SubDirLocalOpMetadata;
+export type DirectoryLocalOpMetadata =
+	| StorageLocalOpMetadata
+	| SubDirLocalOpMetadata
+	| PendingSortKeySet
+	| PendingSubDirectorySortKeySet;
 
 // eslint-disable-next-line @rushstack/no-new-null
 function assertNonNullClientId(clientId: string | null): asserts clientId is string {
 	assert(clientId !== null, 0x6af /* client id should never be null */);
+}
+
+/**
+ * Partition a default-ordered sequence of items into sort-keyed items (lex order of sort key, with ties
+ * broken by default-order position) followed by unkeyed items (in default-order position). Items whose
+ * name is not in `sortKeys` fall into the unkeyed bucket.
+ */
+function orderBySortKey<T>(
+	defaultOrder: readonly T[],
+	nameOf: (item: T) => string,
+	sortKeys: ReadonlyMap<string, string>,
+): T[] {
+	const defaultIndex = new Map<string, number>();
+	for (const [i, item] of defaultOrder.entries()) {
+		defaultIndex.set(nameOf(item), i);
+	}
+	const sortKeyed: T[] = [];
+	const unkeyed: T[] = [];
+	for (const item of defaultOrder) {
+		if (sortKeys.has(nameOf(item))) {
+			sortKeyed.push(item);
+		} else {
+			unkeyed.push(item);
+		}
+	}
+	sortKeyed.sort((a, b) => {
+		const nameA = nameOf(a);
+		const nameB = nameOf(b);
+		const sa = sortKeys.get(nameA) ?? "";
+		const sb = sortKeys.get(nameB) ?? "";
+		if (sa < sb) {
+			return -1;
+		}
+		if (sa > sb) {
+			return 1;
+		}
+		return (defaultIndex.get(nameA) ?? 0) - (defaultIndex.get(nameB) ?? 0);
+	});
+	return [...sortKeyed, ...unkeyed];
 }
 
 /**
@@ -1282,6 +1546,136 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	}
 
 	/**
+	 * {@inheritDoc IDirectory.setSortKey}
+	 */
+	public setSortKey(key: string, sortKey: string | undefined): void {
+		this.throwIfDisposed();
+		const previousSortKey = this.getOptimisticSortKey(key);
+
+		if (!this.directory.isAttached()) {
+			if (sortKey === undefined) {
+				this.sequencedSortKeys.delete(key);
+			} else {
+				this.sequencedSortKeys.set(key, sortKey);
+			}
+			this.emitSortKeyChanged(key, sortKey, previousSortKey, true);
+			return;
+		}
+
+		const pendingEntry: PendingSortKeySet = {
+			type: "setSortKey",
+			path: this.absolutePath,
+			key,
+			sortKey,
+			subdir: this,
+		};
+		this.pendingSortKeyData.push(pendingEntry);
+
+		const op: IDirectorySetSortKeyOperation = {
+			type: "setSortKey",
+			path: this.absolutePath,
+			key,
+			...(sortKey === undefined ? {} : { sortKey }),
+		};
+		this.directory.submitDirectoryMessage(op, pendingEntry);
+		this.emitSortKeyChanged(key, sortKey, previousSortKey, true);
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.setSubDirectorySortKey}
+	 */
+	public setSubDirectorySortKey(subdirName: string, sortKey: string | undefined): void {
+		this.throwIfDisposed();
+		const previousSortKey = this.getOptimisticSubDirectorySortKey(subdirName);
+
+		if (!this.directory.isAttached()) {
+			if (sortKey === undefined) {
+				this.sequencedSubDirectorySortKeys.delete(subdirName);
+			} else {
+				this.sequencedSubDirectorySortKeys.set(subdirName, sortKey);
+			}
+			this.emitSubDirectorySortKeyChanged(subdirName, sortKey, previousSortKey, true);
+			return;
+		}
+
+		const pendingEntry: PendingSubDirectorySortKeySet = {
+			type: "setSubDirectorySortKey",
+			path: this.absolutePath,
+			subdirName,
+			sortKey,
+			subdir: this,
+		};
+		this.pendingSubDirectorySortKeyData.push(pendingEntry);
+
+		const op: IDirectorySetSubDirectorySortKeyOperation = {
+			type: "setSubDirectorySortKey",
+			path: this.absolutePath,
+			subdirName,
+			...(sortKey === undefined ? {} : { sortKey }),
+		};
+		this.directory.submitDirectoryMessage(op, pendingEntry);
+		this.emitSubDirectorySortKeyChanged(subdirName, sortKey, previousSortKey, true);
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.keysByOrder}
+	 */
+	public keysByOrder(): IterableIterator<string> {
+		this.throwIfDisposed();
+		const ordered = this.computeOrderedEntries();
+		const next = (): IteratorResult<string> => {
+			const result = ordered.next();
+			if (result.done === true) {
+				return { value: undefined, done: true };
+			}
+			return { value: result.value[0], done: false };
+		};
+		return {
+			next,
+			[Symbol.iterator](): IterableIterator<string> {
+				return this;
+			},
+		};
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.valuesByOrder}
+	 */
+	public valuesByOrder(): IterableIterator<unknown> {
+		this.throwIfDisposed();
+		const ordered = this.computeOrderedEntries();
+		const next = (): IteratorResult<unknown> => {
+			const result = ordered.next();
+			if (result.done === true) {
+				return { value: undefined, done: true };
+			}
+			return { value: result.value[1], done: false };
+		};
+		return {
+			next,
+			[Symbol.iterator](): IterableIterator<unknown> {
+				return this;
+			},
+		};
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.entriesByOrder}
+	 */
+	public entriesByOrder(): IterableIterator<[string, unknown]> {
+		this.throwIfDisposed();
+		return this.computeOrderedEntries();
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.subdirectoriesByOrder}
+	 */
+	public subdirectoriesByOrder(): IterableIterator<[string, IDirectory]> {
+		this.throwIfDisposed();
+		return this.computeOrderedSubdirectories();
+	}
+
+	/**
 	 * {@inheritDoc IDirectory.countSubDirectory}
 	 */
 	public countSubDirectory(): number {
@@ -1400,6 +1794,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			const successfullyRemoved = this._sequencedSubdirectories.delete(subdirName);
 			// Only emit if we actually deleted something.
 			if (successfullyRemoved) {
+				this.sequencedSubDirectorySortKeys.delete(subdirName);
 				this.disposeSubDirectoryTree(previousValue);
 				this.emit("subDirectoryDeleted", subdirName, true, this);
 			}
@@ -1503,6 +1898,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 
 		if (!this.directory.isAttached()) {
 			const successfullyRemoved = this.sequencedStorageData.delete(key);
+			this.sequencedSortKeys.delete(key);
 			// Only emit if we actually deleted something.
 			if (
 				this.isNotDisposedAndReachable() &&
@@ -1565,6 +1961,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 
 		if (!this.directory.isAttached()) {
 			this.sequencedStorageData.clear();
+			this.sequencedSortKeys.clear();
 			this.directory.emit("clear", true, this.directory);
 			this.directory.emit("cleared", this.absolutePath, true, this.directory);
 			return;
@@ -1710,6 +2107,28 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	 * with the _sequencedSubdirectories to compute optimistic values.
 	 */
 	private readonly pendingSubDirectoryData: PendingSubDirectoryEntry[] = [];
+
+	/**
+	 * Sequenced (acknowledged) sort keys for each key in this subdirectory.
+	 */
+	private readonly sequencedSortKeys = new Map<string, string>();
+
+	/**
+	 * Pending local sort-key set operations, in submit order. Each entry is also used as the
+	 * `localOpMetadata` when the op is submitted, so pending entries are matched by reference identity
+	 * at ack and rollback time.
+	 */
+	private readonly pendingSortKeyData: PendingSortKeySet[] = [];
+
+	/**
+	 * Sequenced (acknowledged) sort keys for each child subdirectory of this subdirectory.
+	 */
+	private readonly sequencedSubDirectorySortKeys = new Map<string, string>();
+
+	/**
+	 * Pending local subdirectory-sort-key set operations, in submit order.
+	 */
+	private readonly pendingSubDirectorySortKeyData: PendingSubDirectorySortKeySet[] = [];
 
 	/**
 	 * An internal iterator that iterates over the entries in the directory.
@@ -1884,6 +2303,128 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	}
 
 	/**
+	 * Compute the optimistic (locally-visible) sort key for a key. Pending sets override sequenced values.
+	 */
+	private getOptimisticSortKey(key: string): string | undefined {
+		const latestPending = findLast(this.pendingSortKeyData, (entry) => entry.key === key);
+		if (latestPending !== undefined) {
+			return latestPending.sortKey;
+		}
+		return this.sequencedSortKeys.get(key);
+	}
+
+	/**
+	 * Compute the optimistic (locally-visible) sort key for a child subdirectory.
+	 */
+	private getOptimisticSubDirectorySortKey(subdirName: string): string | undefined {
+		const latestPending = findLast(
+			this.pendingSubDirectorySortKeyData,
+			(entry) => entry.subdirName === subdirName,
+		);
+		if (latestPending !== undefined) {
+			return latestPending.sortKey;
+		}
+		return this.sequencedSubDirectorySortKeys.get(subdirName);
+	}
+
+	/**
+	 * Collect optimistic sort keys for all currently-visible keys. Keys without a sort key are omitted.
+	 */
+	private collectOptimisticSortKeys(): Map<string, string> {
+		const result = new Map<string, string>();
+		for (const [key, sortKey] of this.sequencedSortKeys.entries()) {
+			result.set(key, sortKey);
+		}
+		for (const entry of this.pendingSortKeyData) {
+			if (entry.sortKey === undefined) {
+				result.delete(entry.key);
+			} else {
+				result.set(entry.key, entry.sortKey);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Collect optimistic sort keys for all currently-visible child subdirectories.
+	 */
+	private collectOptimisticSubDirectorySortKeys(): Map<string, string> {
+		const result = new Map<string, string>();
+		for (const [name, sortKey] of this.sequencedSubDirectorySortKeys.entries()) {
+			result.set(name, sortKey);
+		}
+		for (const entry of this.pendingSubDirectorySortKeyData) {
+			if (entry.sortKey === undefined) {
+				result.delete(entry.subdirName);
+			} else {
+				result.set(entry.subdirName, entry.sortKey);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Iterate the directory's keys in sort-key order. Sort-keyed entries come first in lex order (ties broken
+	 * by default iteration order); unkeyed entries follow in default iteration order.
+	 */
+	private computeOrderedEntries(): IterableIterator<[string, unknown]> {
+		const sortKeys = this.collectOptimisticSortKeys();
+		const defaultOrder: [string, unknown][] = [...this.internalIterator()];
+		return orderBySortKey(defaultOrder, (entry) => entry[0], sortKeys)[Symbol.iterator]();
+	}
+
+	/**
+	 * Iterate the directory's child subdirectories in subdirectory-sort-key order.
+	 */
+	private computeOrderedSubdirectories(): IterableIterator<[string, IDirectory]> {
+		const sortKeys = this.collectOptimisticSubDirectorySortKeys();
+		const defaultOrder: [string, IDirectory][] = [...this.subdirectories()];
+		return orderBySortKey(defaultOrder, (entry) => entry[0], sortKeys)[Symbol.iterator]();
+	}
+
+	private emitSortKeyChanged(
+		key: string,
+		sortKey: string | undefined,
+		previousSortKey: string | undefined,
+		local: boolean,
+	): void {
+		const directoryChanged: IDirectorySortKeyChanged = {
+			key,
+			sortKey,
+			previousSortKey,
+			path: this.absolutePath,
+		};
+		this.directory.emit("sortKeyChanged", directoryChanged, local, this.directory);
+		const containedChanged: ISortKeyChanged = {
+			key,
+			sortKey,
+			previousSortKey,
+		};
+		this.emit("containedSortKeyChanged", containedChanged, local, this);
+	}
+
+	private emitSubDirectorySortKeyChanged(
+		subdirName: string,
+		sortKey: string | undefined,
+		previousSortKey: string | undefined,
+		local: boolean,
+	): void {
+		const directoryChanged: IDirectorySubDirectorySortKeyChanged = {
+			subdirName,
+			sortKey,
+			previousSortKey,
+			path: this.absolutePath,
+		};
+		this.directory.emit("subDirectorySortKeyChanged", directoryChanged, local, this.directory);
+		const containedChanged: ISubDirectorySortKeyChanged = {
+			subdirName,
+			sortKey,
+			previousSortKey,
+		};
+		this.emit("containedSubDirectorySortKeyChanged", containedChanged, local, this);
+	}
+
+	/**
 	 * Process a clear operation.
 	 * @param msgEnvelope - The envelope of the message from the server to apply.
 	 * @param op - The op to process
@@ -1906,6 +2447,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 
 		if (local) {
 			this.sequencedStorageData.clear();
+			this.sequencedSortKeys.clear();
 			const pendingClear = this.pendingStorageData.shift();
 			assert(
 				pendingClear !== undefined &&
@@ -1923,6 +2465,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				}
 			}
 			this.sequencedStorageData.clear();
+			this.sequencedSortKeys.clear();
 
 			// Only emit for remote ops, we would have already emitted for local ops. Only emit if there
 			// is no optimistically-applied local pending clear that would supersede this remote clear.
@@ -1986,9 +2529,11 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			);
 			this.pendingStorageData.splice(pendingEntryIndex, 1);
 			this.sequencedStorageData.delete(op.key);
+			this.sequencedSortKeys.delete(op.key);
 		} else {
 			const previousValue: unknown = this.sequencedStorageData.get(op.key);
 			this.sequencedStorageData.delete(op.key);
+			this.sequencedSortKeys.delete(op.key);
 			// Suppress the event if local changes would cause the incoming change to be invisible optimistically.
 			if (
 				this.isNotDisposedAndReachable() &&
@@ -2214,6 +2759,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		}
 
 		this._sequencedSubdirectories.delete(op.subdirName);
+		this.sequencedSubDirectorySortKeys.delete(op.subdirName);
 		this.disposeSubDirectoryTree(previousValue);
 
 		if (local) {
@@ -2237,6 +2783,134 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			if (pendingEntry === undefined) {
 				this.emit("subDirectoryDeleted", op.subdirName, local, this);
 			}
+		}
+	}
+
+	/**
+	 * Process a setSortKey operation.
+	 */
+	public processSetSortKeyMessage(
+		msgEnvelope: ISequencedMessageEnvelope,
+		op: IDirectorySetSortKeyOperation,
+		local: boolean,
+		localOpMetadata: PendingSortKeySet | undefined,
+	): void {
+		this.throwIfDisposed();
+		if (
+			!this.isMessageForCurrentInstanceOfSubDirectory(msgEnvelope, localOpMetadata?.subdir)
+		) {
+			return;
+		}
+
+		const newSortKey = op.sortKey;
+
+		if (local) {
+			assert(localOpMetadata !== undefined, 0xc82 /* local op metadata should be defined */);
+			const pendingEntryIndex = this.pendingSortKeyData.indexOf(localOpMetadata);
+			assert(
+				pendingEntryIndex !== -1,
+				0xc80 /* Got a local setSortKey message we weren't expecting */,
+			);
+			this.pendingSortKeyData.splice(pendingEntryIndex, 1);
+			if (newSortKey === undefined) {
+				this.sequencedSortKeys.delete(op.key);
+			} else {
+				this.sequencedSortKeys.set(op.key, newSortKey);
+			}
+		} else {
+			const previousSequencedSortKey = this.sequencedSortKeys.get(op.key);
+			if (newSortKey === undefined) {
+				this.sequencedSortKeys.delete(op.key);
+			} else {
+				this.sequencedSortKeys.set(op.key, newSortKey);
+			}
+
+			// Suppress the event if a local pending sort-key set for this key would eclipse it.
+			if (
+				this.isNotDisposedAndReachable() &&
+				!this.pendingSortKeyData.some((entry) => entry.key === op.key)
+			) {
+				this.emitSortKeyChanged(op.key, newSortKey, previousSequencedSortKey, false);
+			}
+		}
+	}
+
+	/**
+	 * Process a setSubDirectorySortKey operation.
+	 */
+	public processSetSubDirectorySortKeyMessage(
+		msgEnvelope: ISequencedMessageEnvelope,
+		op: IDirectorySetSubDirectorySortKeyOperation,
+		local: boolean,
+		localOpMetadata: PendingSubDirectorySortKeySet | undefined,
+	): void {
+		this.throwIfDisposed();
+		if (
+			!this.isMessageForCurrentInstanceOfSubDirectory(msgEnvelope, localOpMetadata?.subdir)
+		) {
+			return;
+		}
+
+		const newSortKey = op.sortKey;
+
+		if (local) {
+			assert(localOpMetadata !== undefined, 0xc83 /* local op metadata should be defined */);
+			const pendingEntryIndex = this.pendingSubDirectorySortKeyData.indexOf(localOpMetadata);
+			assert(
+				pendingEntryIndex !== -1,
+				0xc81 /* Got a local setSubDirectorySortKey message we weren't expecting */,
+			);
+			this.pendingSubDirectorySortKeyData.splice(pendingEntryIndex, 1);
+			if (newSortKey === undefined) {
+				this.sequencedSubDirectorySortKeys.delete(op.subdirName);
+			} else {
+				this.sequencedSubDirectorySortKeys.set(op.subdirName, newSortKey);
+			}
+		} else {
+			const previousSequencedSortKey = this.sequencedSubDirectorySortKeys.get(op.subdirName);
+			if (newSortKey === undefined) {
+				this.sequencedSubDirectorySortKeys.delete(op.subdirName);
+			} else {
+				this.sequencedSubDirectorySortKeys.set(op.subdirName, newSortKey);
+			}
+
+			if (
+				this.isNotDisposedAndReachable() &&
+				!this.pendingSubDirectorySortKeyData.some(
+					(entry) => entry.subdirName === op.subdirName,
+				)
+			) {
+				this.emitSubDirectorySortKeyChanged(
+					op.subdirName,
+					newSortKey,
+					previousSequencedSortKey,
+					false,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Resubmit a setSortKey operation.
+	 */
+	public resubmitSortKeyMessage(
+		op: IDirectorySetSortKeyOperation,
+		localOpMetadata: PendingSortKeySet,
+	): void {
+		if (this.pendingSortKeyData.includes(localOpMetadata)) {
+			this.directory.submitDirectoryMessage(op, localOpMetadata);
+		}
+	}
+
+	/**
+	 * Resubmit a setSubDirectorySortKey operation.
+	 */
+	public resubmitSubDirectorySortKeyMessage(
+		op: IDirectorySetSubDirectorySortKeyOperation,
+		localOpMetadata: PendingSubDirectorySortKeySet,
+	): void {
+		if (this.pendingSubDirectorySortKeyData.includes(localOpMetadata)) {
+			this.directory.submitDirectoryMessage(op, localOpMetadata);
 		}
 	}
 
@@ -2409,6 +3083,53 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	}
 
 	/**
+	 * Get serialized sort keys for this subdirectory. Returns `undefined` when no sort keys are set, so that
+	 * snapshots written by pre-feature code round-trip unchanged.
+	 */
+	public getSerializableSortKeys(): Record<string, string> | undefined {
+		this.throwIfDisposed();
+		if (this.sequencedSortKeys.size === 0) {
+			return undefined;
+		}
+		const result: Record<string, string> = {};
+		for (const [key, sortKey] of this.sequencedSortKeys.entries()) {
+			result[key] = sortKey;
+		}
+		return result;
+	}
+
+	/**
+	 * Get serialized subdirectory sort keys for this subdirectory. Returns `undefined` when no sort keys are set.
+	 */
+	public getSerializableSubDirectorySortKeys(): Record<string, string> | undefined {
+		this.throwIfDisposed();
+		if (this.sequencedSubDirectorySortKeys.size === 0) {
+			return undefined;
+		}
+		const result: Record<string, string> = {};
+		for (const [subdirName, sortKey] of this.sequencedSubDirectorySortKeys.entries()) {
+			result[subdirName] = sortKey;
+		}
+		return result;
+	}
+
+	/**
+	 * Populate a key's sort key from a snapshot.
+	 */
+	public populateSortKey(key: string, sortKey: string): void {
+		this.throwIfDisposed();
+		this.sequencedSortKeys.set(key, sortKey);
+	}
+
+	/**
+	 * Populate a child subdirectory's sort key from a snapshot.
+	 */
+	public populateSubDirectorySortKey(subdirName: string, sortKey: string): void {
+		this.throwIfDisposed();
+		this.sequencedSubDirectorySortKeys.set(subdirName, sortKey);
+	}
+
+	/**
 	 * Populate a key value in this subdirectory's storage, to be used when loading from snapshot.
 	 * @param key - The key to populate
 	 * @param localValue - The local value to populate into it
@@ -2550,6 +3271,32 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 
 			this.pendingSubDirectoryData.splice(pendingEntryIndex, 1);
 			this.emit("subDirectoryDeleted", subdirName, true, this);
+		} else if (directoryOp.type === "setSortKey" && localOpMetadata.type === "setSortKey") {
+			const pendingEntryIndex = this.pendingSortKeyData.indexOf(localOpMetadata);
+			if (pendingEntryIndex === -1) {
+				return;
+			}
+			const rolledBackValue = localOpMetadata.sortKey;
+			this.pendingSortKeyData.splice(pendingEntryIndex, 1);
+			const restoredSortKey = this.getOptimisticSortKey(directoryOp.key);
+			this.emitSortKeyChanged(directoryOp.key, restoredSortKey, rolledBackValue, true);
+		} else if (
+			directoryOp.type === "setSubDirectorySortKey" &&
+			localOpMetadata.type === "setSubDirectorySortKey"
+		) {
+			const pendingEntryIndex = this.pendingSubDirectorySortKeyData.indexOf(localOpMetadata);
+			if (pendingEntryIndex === -1) {
+				return;
+			}
+			const rolledBackValue = localOpMetadata.sortKey;
+			this.pendingSubDirectorySortKeyData.splice(pendingEntryIndex, 1);
+			const restoredSortKey = this.getOptimisticSubDirectorySortKey(directoryOp.subdirName);
+			this.emitSubDirectorySortKeyChanged(
+				directoryOp.subdirName,
+				restoredSortKey,
+				rolledBackValue,
+				true,
+			);
 		} else if (
 			directoryOp.type === "deleteSubDirectory" &&
 			localOpMetadata.type === "deleteSubDir"
@@ -2719,6 +3466,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		this.seqData.seq = -1;
 		this.seqData.clientSeq = -1;
 		this.sequencedStorageData.clear();
+		this.sequencedSortKeys.clear();
+		this.sequencedSubDirectorySortKeys.clear();
 		this._sequencedSubdirectories.clear();
 		this.clientIds.clear();
 		this.clientIds.add(this.runtime.clientId ?? "detached");

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -34,9 +34,6 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.attributes}
 	 */
-	// Sort-key fields (`sortKeys`, `subdirectorySortKeys`) were added to `IDirectoryDataObject` as optional,
-	// additive fields. Older builds ignore unknown fields on load, so the format stays at "0.1"; a bump
-	// would only be required if we removed or changed the meaning of an existing field.
 	public static readonly Attributes: IChannelAttributes = {
 		type: DirectoryFactory.Type,
 		snapshotFormatVersion: "0.1",

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -34,6 +34,9 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.attributes}
 	 */
+	// Sort-key fields (`sortKeys`, `subdirectorySortKeys`) were added to `IDirectoryDataObject` as optional,
+	// additive fields. Older builds ignore unknown fields on load, so the format stays at "0.1"; a bump
+	// would only be required if we removed or changed the meaning of an existing field.
 	public static readonly Attributes: IChannelAttributes = {
 		type: DirectoryFactory.Type,
 		snapshotFormatVersion: "0.1",

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -18,11 +18,15 @@
 export type {
 	IDirectory,
 	IDirectoryEvents,
+	IDirectorySortKeyChanged,
+	IDirectorySubDirectorySortKeyChanged,
 	IDirectoryValueChanged,
 	ISharedDirectory,
 	ISharedDirectoryEvents,
 	ISharedMap,
 	ISharedMapEvents,
+	ISortKeyChanged,
+	ISubDirectorySortKeyChanged,
 	IValueChanged,
 } from "./interfaces.js";
 export { SharedMap } from "./mapFactory.js";

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -35,6 +35,78 @@ export interface IValueChanged {
 }
 
 /**
+ * Type of "sortKeyChanged" event parameter.
+ * @sealed
+ * @legacy
+ * @public
+ */
+export interface ISortKeyChanged {
+	/**
+	 * The key whose sort key changed.
+	 */
+	readonly key: string;
+
+	/**
+	 * The new sort key, or `undefined` if the sort key was cleared.
+	 */
+	readonly sortKey: string | undefined;
+
+	/**
+	 * The sort key prior to the change, or `undefined` if none had been set.
+	 */
+	readonly previousSortKey: string | undefined;
+}
+
+/**
+ * Type of "sortKeyChanged" event parameter for {@link ISharedDirectory}.
+ * @sealed
+ * @legacy
+ * @public
+ */
+export interface IDirectorySortKeyChanged extends ISortKeyChanged {
+	/**
+	 * The absolute path to the IDirectory whose sort key changed.
+	 */
+	readonly path: string;
+}
+
+/**
+ * Type of "subDirectorySortKeyChanged" event parameter.
+ * @sealed
+ * @legacy
+ * @public
+ */
+export interface ISubDirectorySortKeyChanged {
+	/**
+	 * The name of the child subdirectory whose sort key changed (relative to the parent).
+	 */
+	readonly subdirName: string;
+
+	/**
+	 * The new sort key, or `undefined` if the sort key was cleared.
+	 */
+	readonly sortKey: string | undefined;
+
+	/**
+	 * The sort key prior to the change, or `undefined` if none had been set.
+	 */
+	readonly previousSortKey: string | undefined;
+}
+
+/**
+ * Type of "subDirectorySortKeyChanged" event parameter for {@link ISharedDirectory}.
+ * @sealed
+ * @legacy
+ * @public
+ */
+export interface IDirectorySubDirectorySortKeyChanged extends ISubDirectorySortKeyChanged {
+	/**
+	 * The absolute path to the parent IDirectory whose child's sort key changed.
+	 */
+	readonly path: string;
+}
+
+/**
  * Interface describing actions on a directory.
  *
  * @remarks When used as a Map, operates on its keys.
@@ -117,6 +189,63 @@ export interface IDirectory
 	 * @returns The requested IDirectory
 	 */
 	getWorkingDirectory(relativePath: string): IDirectory | undefined;
+
+	/**
+	 * Sets (or clears, when `sortKey` is `undefined`) the sort key associated with a key in this directory.
+	 * Sort keys control the iteration order produced by
+	 * {@link IDirectory.keysByOrder}, {@link IDirectory.valuesByOrder}, and {@link IDirectory.entriesByOrder}.
+	 * The sort key is independent of the key's value; it is preserved across updates to the value and exists
+	 * only as long as the key itself exists (it is cleared when the key is deleted or the directory is cleared).
+	 * @param key - Key whose sort key is being set
+	 * @param sortKey - New sort key; `undefined` clears it
+	 */
+	setSortKey(key: string, sortKey: string | undefined): void;
+
+	/**
+	 * Sets (or clears, when `sortKey` is `undefined`) the sort key associated with a child subdirectory.
+	 * Sort keys control the iteration order produced by {@link IDirectory.subdirectoriesByOrder}.
+	 * @param subdirName - Name of the child subdirectory whose sort key is being set
+	 * @param sortKey - New sort key; `undefined` clears it
+	 */
+	setSubDirectorySortKey(subdirName: string, sortKey: string | undefined): void;
+
+	/**
+	 * Get an iterator over the keys under this IDirectory in sort-key order.
+	 *
+	 * @remarks Entries that have a sort key set appear first, in lexicographic (JavaScript `<`) order of
+	 * their sort keys, with ties broken by the default iteration order. Entries without a sort key follow,
+	 * in the default iteration order.
+	 * @returns The iterator
+	 */
+	keysByOrder(): IterableIterator<string>;
+
+	/**
+	 * Get an iterator over the values under this IDirectory in sort-key order.
+	 * @returns The iterator
+	 * @see {@link IDirectory.keysByOrder}
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	valuesByOrder(): IterableIterator<any>;
+
+	/**
+	 * Get an iterator over the entries under this IDirectory in sort-key order.
+	 * @returns The iterator
+	 * @see {@link IDirectory.keysByOrder}
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	entriesByOrder(): IterableIterator<[string, any]>;
+
+	/**
+	 * Get an iterator over the child subdirectories in subdirectory-sort-key order.
+	 *
+	 * @remarks Subdirectories that have a sort key set appear first, in lexicographic order of their sort keys,
+	 * with ties broken by the default subdirectory iteration order. Subdirectories without a sort key follow,
+	 * in the default iteration order ({@link IDirectory.subdirectories}).
+	 * @returns The iterator
+	 */
+	subdirectoriesByOrder(): IterableIterator<[string, IDirectory]>;
 }
 
 /**
@@ -212,6 +341,51 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 		event: "subDirectoryDeleted",
 		listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void,
 	);
+
+	/**
+	 * Emitted when a key's sort key is set, updated, or cleared anywhere in the directory tree.
+	 *
+	 * @remarks Listener parameters:
+	 *
+	 * - `changed` - Information on the key whose sort key changed, its prior sort key, and the path to the
+	 * directory containing the key.
+	 *
+	 * - `local` - Whether the change originated from this client.
+	 *
+	 * - `target` - The {@link ISharedDirectory} itself.
+	 *
+	 * This event does not fire when the key itself is deleted or the directory is cleared — the sort key is
+	 * implicitly removed in those cases.
+	 */
+	(
+		event: "sortKeyChanged",
+		listener: (
+			changed: IDirectorySortKeyChanged,
+			local: boolean,
+			target: IEventThisPlaceHolder,
+		) => void,
+	);
+
+	/**
+	 * Emitted when a child subdirectory's sort key is set, updated, or cleared anywhere in the directory tree.
+	 *
+	 * @remarks Listener parameters:
+	 *
+	 * - `changed` - Information on the subdirectory whose sort key changed, its prior sort key, and the path
+	 * to the parent directory.
+	 *
+	 * - `local` - Whether the change originated from this client.
+	 *
+	 * - `target` - The {@link ISharedDirectory} itself.
+	 */
+	(
+		event: "subDirectorySortKeyChanged",
+		listener: (
+			changed: IDirectorySubDirectorySortKeyChanged,
+			local: boolean,
+			target: IEventThisPlaceHolder,
+		) => void,
+	);
 }
 
 /**
@@ -293,6 +467,53 @@ export interface IDirectoryEvents extends IEvent {
 	 * - `target` - The {@link IDirectory} itself.
 	 */
 	(event: "undisposed", listener: (target: IEventThisPlaceHolder) => void);
+
+	/**
+	 * Emitted when a key's sort key is set, updated, or cleared within this {@link IDirectory}. As opposed to
+	 * the {@link ISharedDirectory}'s sortKeyChanged event, this is emitted only on the directory that directly
+	 * contains the key.
+	 *
+	 * @remarks Listener parameters:
+	 *
+	 * - `changed` - Information on the key whose sort key changed and its prior sort key.
+	 *
+	 * - `local` - Whether the change originated from this client.
+	 *
+	 * - `target` - The {@link IDirectory} itself.
+	 *
+	 * This event does not fire when the key itself is deleted or the directory is cleared — the sort key is
+	 * implicitly removed in those cases.
+	 */
+	(
+		event: "containedSortKeyChanged",
+		listener: (
+			changed: ISortKeyChanged,
+			local: boolean,
+			target: IEventThisPlaceHolder,
+		) => void,
+	);
+
+	/**
+	 * Emitted when a child subdirectory's sort key is set, updated, or cleared. As opposed to the
+	 * {@link ISharedDirectory}'s subDirectorySortKeyChanged event, this is emitted only on the parent directory
+	 * that directly contains the child subdirectory.
+	 *
+	 * @remarks Listener parameters:
+	 *
+	 * - `changed` - Information on the subdirectory whose sort key changed and its prior sort key.
+	 *
+	 * - `local` - Whether the change originated from this client.
+	 *
+	 * - `target` - The {@link IDirectory} itself.
+	 */
+	(
+		event: "containedSubDirectorySortKeyChanged",
+		listener: (
+			changed: ISubDirectorySortKeyChanged,
+			local: boolean,
+			target: IEventThisPlaceHolder,
+		) => void,
+	);
 }
 
 /**

--- a/packages/dds/map/src/test/directoryOracle.ts
+++ b/packages/dds/map/src/test/directoryOracle.ts
@@ -7,8 +7,12 @@ import { strict as assert } from "node:assert";
 
 import type {
 	IDirectory,
+	IDirectorySortKeyChanged,
+	IDirectorySubDirectorySortKeyChanged,
 	IDirectoryValueChanged,
 	ISharedDirectory,
+	ISortKeyChanged,
+	ISubDirectorySortKeyChanged,
 	IValueChanged,
 } from "../interfaces.js";
 
@@ -25,6 +29,15 @@ interface DirectoryNode {
 	 * Subdirectories of this directory
 	 */
 	subdirectories: Map<string, DirectoryNode>;
+	/**
+	 * Sort keys for keys directly contained in this directory.
+	 * Only populated for entries with a sort key set; absence = unkeyed.
+	 */
+	sortKeys: Map<string, string>;
+	/**
+	 * Sort keys for child subdirectories of this directory.
+	 */
+	subdirectorySortKeys: Map<string, string>;
 }
 
 /**
@@ -36,12 +49,16 @@ export class SharedDirectoryOracle {
 	private readonly modelFromValueChanged: DirectoryNode = {
 		keys: new Map(),
 		subdirectories: new Map(),
+		sortKeys: new Map(),
+		subdirectorySortKeys: new Map(),
 	};
 
 	// Model updated via containedValueChanged events (nested structure)
 	private readonly modelFromContainedValueChanged: DirectoryNode = {
 		keys: new Map(),
 		subdirectories: new Map(),
+		sortKeys: new Map(),
+		subdirectorySortKeys: new Map(),
 	};
 
 	// Track all directories we've attached listeners to for proper cleanup
@@ -57,6 +74,8 @@ export class SharedDirectoryOracle {
 		this.sharedDir.on("cleared", this.onCleared);
 		this.sharedDir.on("subDirectoryCreated", this.onSubDirCreated);
 		this.sharedDir.on("subDirectoryDeleted", this.onSubDirDeleted);
+		this.sharedDir.on("sortKeyChanged", this.onSortKeyChanged);
+		this.sharedDir.on("subDirectorySortKeyChanged", this.onSubDirectorySortKeyChanged);
 
 		this.attachToAllDirectories(sharedDir);
 	}
@@ -77,6 +96,8 @@ export class SharedDirectoryOracle {
 				current.subdirectories.set(part, {
 					keys: new Map(),
 					subdirectories: new Map(),
+					sortKeys: new Map(),
+					subdirectorySortKeys: new Map(),
 				});
 			}
 			const next = current.subdirectories.get(part);
@@ -137,6 +158,8 @@ export class SharedDirectoryOracle {
 
 		this.attachedDirectories.add(dir);
 		dir.on("containedValueChanged", this.onContainedValueChanged);
+		dir.on("containedSortKeyChanged", this.onContainedSortKeyChanged);
+		dir.on("containedSubDirectorySortKeyChanged", this.onContainedSubDirectorySortKeyChanged);
 		dir.on("disposed", this.onDisposed);
 		dir.on("undisposed", this.onUndisposed);
 
@@ -184,6 +207,8 @@ export class SharedDirectoryOracle {
 			dirNode.keys.set(key, value);
 		} else {
 			dirNode.keys.delete(key);
+			// Deleting a key implicitly clears its sort key (no sortKeyChanged fires).
+			dirNode.sortKeys.delete(key);
 		}
 	};
 
@@ -195,9 +220,11 @@ export class SharedDirectoryOracle {
 
 		if (dirNode1) {
 			dirNode1.keys.clear();
+			dirNode1.sortKeys.clear();
 		}
 		if (dirNode2) {
 			dirNode2.keys.clear();
+			dirNode2.sortKeys.clear();
 		}
 	};
 
@@ -222,9 +249,29 @@ export class SharedDirectoryOracle {
 
 	private readonly onSubDirDeleted = (path: string): void => {
 		const absPath = path.startsWith("/") ? path : `/${path}`;
+		this.clearSubDirectorySortKeyOnParent(this.modelFromValueChanged, absPath);
+		this.clearSubDirectorySortKeyOnParent(this.modelFromContainedValueChanged, absPath);
 		this.deleteSubDirectory(this.modelFromValueChanged, absPath);
 		this.deleteSubDirectory(this.modelFromContainedValueChanged, absPath);
 	};
+
+	/**
+	 * When a subdirectory is deleted, its sort-key entry on the parent is implicitly
+	 * cleared (no subDirectorySortKeyChanged event fires).
+	 */
+	private clearSubDirectorySortKeyOnParent(model: DirectoryNode, path: string): void {
+		if (path === "/" || path === "") {
+			return;
+		}
+		const parts = path.split("/").filter((p) => p.length > 0);
+		if (parts.length === 0) {
+			return;
+		}
+		const parentPath = parts.slice(0, -1).join("/");
+		const dirName = parts[parts.length - 1];
+		const parentNode = this.getDirNode(model, parentPath);
+		parentNode?.subdirectorySortKeys.delete(dirName);
+	}
 
 	private readonly onContainedValueChanged = (
 		change: IValueChanged,
@@ -253,10 +300,106 @@ export class SharedDirectoryOracle {
 
 		if (newValue === undefined) {
 			dirNode.keys.delete(key);
+			dirNode.sortKeys.delete(key);
 		} else {
 			dirNode.keys.set(key, newValue);
 		}
 	};
+
+	private readonly onSortKeyChanged = (
+		change: IDirectorySortKeyChanged,
+		local: boolean,
+		target: ISharedDirectory,
+	): void => {
+		assert(
+			target === this.sharedDir,
+			"sortKeyChanged event should be emitted from root SharedDirectory",
+		);
+
+		const { key, sortKey } = change;
+		const path = change.path ?? "/";
+		const absPath = path.startsWith("/") ? path : `/${path}`;
+
+		this.applySortKeyChange(this.modelFromValueChanged, absPath, key, sortKey);
+	};
+
+	private readonly onSubDirectorySortKeyChanged = (
+		change: IDirectorySubDirectorySortKeyChanged,
+		local: boolean,
+		target: ISharedDirectory,
+	): void => {
+		assert(
+			target === this.sharedDir,
+			"subDirectorySortKeyChanged event should be emitted from root SharedDirectory",
+		);
+
+		const { subdirName, sortKey } = change;
+		const path = change.path ?? "/";
+		const absPath = path.startsWith("/") ? path : `/${path}`;
+
+		this.applySubDirectorySortKeyChange(
+			this.modelFromValueChanged,
+			absPath,
+			subdirName,
+			sortKey,
+		);
+	};
+
+	private readonly onContainedSortKeyChanged = (
+		change: ISortKeyChanged,
+		local: boolean,
+		target: IDirectory,
+	): void => {
+		const { key, sortKey } = change;
+		this.applySortKeyChange(
+			this.modelFromContainedValueChanged,
+			target.absolutePath,
+			key,
+			sortKey,
+		);
+	};
+
+	private readonly onContainedSubDirectorySortKeyChanged = (
+		change: ISubDirectorySortKeyChanged,
+		local: boolean,
+		target: IDirectory,
+	): void => {
+		const { subdirName, sortKey } = change;
+		this.applySubDirectorySortKeyChange(
+			this.modelFromContainedValueChanged,
+			target.absolutePath,
+			subdirName,
+			sortKey,
+		);
+	};
+
+	private applySortKeyChange(
+		model: DirectoryNode,
+		absPath: string,
+		key: string,
+		sortKey: string | undefined,
+	): void {
+		const dirNode = this.createDirNode(model, absPath);
+		if (sortKey === undefined) {
+			dirNode.sortKeys.delete(key);
+		} else {
+			dirNode.sortKeys.set(key, sortKey);
+		}
+	}
+
+	private applySubDirectorySortKeyChange(
+		model: DirectoryNode,
+		absPath: string,
+		subdirName: string,
+		sortKey: string | undefined,
+	): void {
+		const dirNode = this.createDirNode(model, absPath);
+		if (sortKey === undefined) {
+			dirNode.subdirectorySortKeys.delete(subdirName);
+		} else {
+			dirNode.subdirectorySortKeys.set(subdirName, sortKey);
+		}
+	}
 
 	private readonly onDisposed = (target: IDirectory): void => {
 		const absPath = target.absolutePath;
@@ -264,9 +407,15 @@ export class SharedDirectoryOracle {
 		if (absPath === "/") {
 			this.modelFromValueChanged.keys.clear();
 			this.modelFromValueChanged.subdirectories.clear();
+			this.modelFromValueChanged.sortKeys.clear();
+			this.modelFromValueChanged.subdirectorySortKeys.clear();
 			this.modelFromContainedValueChanged.keys.clear();
 			this.modelFromContainedValueChanged.subdirectories.clear();
+			this.modelFromContainedValueChanged.sortKeys.clear();
+			this.modelFromContainedValueChanged.subdirectorySortKeys.clear();
 		} else {
+			this.clearSubDirectorySortKeyOnParent(this.modelFromValueChanged, absPath);
+			this.clearSubDirectorySortKeyOnParent(this.modelFromContainedValueChanged, absPath);
 			this.deleteSubDirectory(this.modelFromValueChanged, absPath);
 			this.deleteSubDirectory(this.modelFromContainedValueChanged, absPath);
 		}

--- a/packages/dds/map/src/test/directoryOracle.ts
+++ b/packages/dds/map/src/test/directoryOracle.ts
@@ -517,9 +517,16 @@ export class SharedDirectoryOracle {
 		this.sharedDir.off("cleared", this.onCleared);
 		this.sharedDir.off("subDirectoryCreated", this.onSubDirCreated);
 		this.sharedDir.off("subDirectoryDeleted", this.onSubDirDeleted);
+		this.sharedDir.off("sortKeyChanged", this.onSortKeyChanged);
+		this.sharedDir.off("subDirectorySortKeyChanged", this.onSubDirectorySortKeyChanged);
 
 		for (const dir of this.attachedDirectories) {
 			dir.off("containedValueChanged", this.onContainedValueChanged);
+			dir.off("containedSortKeyChanged", this.onContainedSortKeyChanged);
+			dir.off(
+				"containedSubDirectorySortKeyChanged",
+				this.onContainedSubDirectorySortKeyChanged,
+			);
 			dir.off("disposed", this.onDisposed);
 			dir.off("undisposed", this.onUndisposed);
 		}
@@ -527,7 +534,11 @@ export class SharedDirectoryOracle {
 		this.attachedDirectories.clear();
 		this.modelFromValueChanged.keys.clear();
 		this.modelFromValueChanged.subdirectories.clear();
+		this.modelFromValueChanged.sortKeys.clear();
+		this.modelFromValueChanged.subdirectorySortKeys.clear();
 		this.modelFromContainedValueChanged.keys.clear();
 		this.modelFromContainedValueChanged.subdirectories.clear();
+		this.modelFromContainedValueChanged.sortKeys.clear();
+		this.modelFromContainedValueChanged.subdirectorySortKeys.clear();
 	}
 }

--- a/packages/dds/map/src/test/mocha/directory.order.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.order.spec.ts
@@ -16,12 +16,10 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import {
-	type DirectoryLocalOpMetadata,
-	type IDirectoryOperation,
-	SharedDirectory as SharedDirectoryInternal,
-} from "../../directory.js";
+import type { IDirectoryOperation } from "../../directory.js";
 import { DirectoryFactory, type ISharedDirectory, SharedDirectory } from "../../index.js";
+
+import { TestSharedDirectory } from "./directoryTestHelpers.js";
 
 function createConnectedDirectory(
 	id: string,
@@ -38,22 +36,6 @@ function createConnectedDirectory(
 	const directory = SharedDirectory.create(dataStoreRuntime, id);
 	directory.connect(services);
 	return directory;
-}
-
-class TestSharedDirectory extends SharedDirectoryInternal {
-	private lastMetadata?: DirectoryLocalOpMetadata;
-	public testApplyStashedOp(
-		content: IDirectoryOperation,
-	): DirectoryLocalOpMetadata | undefined {
-		this.lastMetadata = undefined;
-		this.applyStashedOp(content);
-		return this.lastMetadata;
-	}
-
-	public submitLocalMessage(op: IDirectoryOperation, localOpMetadata: unknown): void {
-		this.lastMetadata = localOpMetadata as DirectoryLocalOpMetadata;
-		super.submitLocalMessage(op, localOpMetadata);
-	}
 }
 
 async function populate(content: unknown): Promise<ISharedDirectory> {

--- a/packages/dds/map/src/test/mocha/directory.rollback.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.rollback.spec.ts
@@ -15,6 +15,8 @@ import {
 
 import { DirectoryFactory } from "../../directoryFactory.js";
 import type {
+	IDirectorySortKeyChanged,
+	IDirectorySubDirectorySortKeyChanged,
 	IDirectoryValueChanged,
 	ISharedDirectory,
 	IValueChanged,
@@ -1082,6 +1084,304 @@ describe("SharedDirectory rollback", () => {
 			assert(
 				sharedDirectory1.getSubDirectory("subdirA")?.getSubDirectory("subdirD") !== undefined,
 			);
+		});
+	});
+
+	describe("Sort-key operations", () => {
+		it("T50: rollback of setSortKey with no prior sort key reverts to unset", () => {
+			const { sharedDirectory, containerRuntimeFactory, containerRuntime } =
+				setupRollbackTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			sharedDirectory.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySortKeyChanged[] = [];
+			sharedDirectory.on("sortKeyChanged", (changed: IDirectorySortKeyChanged) => {
+				events.push(changed);
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+			assert.deepStrictEqual(
+				[...sharedDirectory.keysByOrder()],
+				["a", "b"],
+				"Pre-rollback: 'M' < 'Z', so sort-keyed a precedes sort-keyed b",
+			);
+			assert.strictEqual(events.length, 1, "One sortKeyChanged event pre-rollback");
+			assert.deepStrictEqual(events[0], {
+				key: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+				path: "/",
+			});
+
+			containerRuntime.rollback?.();
+
+			assert.deepStrictEqual(
+				[...sharedDirectory.keysByOrder()],
+				["b", "a"],
+				"Post-rollback: a falls to the unkeyed bucket after sort-keyed b",
+			);
+			assert.strictEqual(events.length, 2, "Rollback fires a reverting sortKeyChanged event");
+			assert.deepStrictEqual(events[1], {
+				key: "a",
+				sortKey: undefined,
+				previousSortKey: "M",
+				path: "/",
+			});
+		});
+
+		it("T51: rollback of setSortKey that replaced a prior sort key reverts to the prior value", () => {
+			const { sharedDirectory, containerRuntimeFactory, containerRuntime } =
+				setupRollbackTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			sharedDirectory.setSortKey("a", "M");
+			sharedDirectory.setSortKey("b", "X");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySortKeyChanged[] = [];
+			sharedDirectory.on("sortKeyChanged", (changed: IDirectorySortKeyChanged) => {
+				events.push(changed);
+			});
+
+			sharedDirectory.setSortKey("a", "Z");
+			assert.deepStrictEqual(
+				[...sharedDirectory.keysByOrder()],
+				["b", "a"],
+				"Pre-rollback: 'X' < 'Z'",
+			);
+			assert.deepStrictEqual(events[0], {
+				key: "a",
+				sortKey: "Z",
+				previousSortKey: "M",
+				path: "/",
+			});
+
+			containerRuntime.rollback?.();
+
+			assert.deepStrictEqual(
+				[...sharedDirectory.keysByOrder()],
+				["a", "b"],
+				"Post-rollback: 'M' < 'X' again",
+			);
+			assert.strictEqual(events.length, 2);
+			assert.deepStrictEqual(events[1], {
+				key: "a",
+				sortKey: "M",
+				previousSortKey: "Z",
+				path: "/",
+			});
+		});
+
+		it("T52: rollback removes pending sort-key entries by reference identity, not by key", () => {
+			// Submit two pending setSortKey ops on the same key. Ack only the first one, then
+			// rollback. The ack must splice only the first pending entry (by identity). Rolling
+			// back the second must not also wipe the acked value.
+			const { sharedDirectory, containerRuntimeFactory, containerRuntime } =
+				setupRollbackTest();
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySortKeyChanged[] = [];
+			sharedDirectory.on("sortKeyChanged", (changed: IDirectorySortKeyChanged) => {
+				events.push(changed);
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+			sharedDirectory.setSortKey("a", "Z");
+			assert.strictEqual(events.length, 2, "Both setSortKey calls fire optimistic events");
+			assert.deepStrictEqual(events[0], {
+				key: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+				path: "/",
+			});
+			assert.deepStrictEqual(events[1], {
+				key: "a",
+				sortKey: "Z",
+				previousSortKey: "M",
+				path: "/",
+			});
+
+			// Flush and ack only the first op ("M"); the "Z" op stays pending.
+			containerRuntime.flushSomeMessages(1);
+			containerRuntimeFactory.processOneMessage();
+			assert.strictEqual(events.length, 2, "Local ack does not re-fire sortKeyChanged");
+
+			containerRuntime.rollback?.();
+
+			assert.strictEqual(events.length, 3, "Rollback fires one reverting event");
+			assert.deepStrictEqual(events[2], {
+				key: "a",
+				sortKey: "M",
+				previousSortKey: "Z",
+				path: "/",
+			});
+		});
+
+		it("T53: setSortKey while detached applies directly with no pending state to roll back", () => {
+			// Detached directories bypass the pending-state path — setSortKey writes straight to
+			// sequenced state. No containerRuntime exists, so rollback is trivially a no-op for
+			// anything done pre-attach.
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			const detached = directoryFactory.create(dataStoreRuntime, "detached-rollback-test");
+			detached.set("a", 1);
+			detached.set("b", 2);
+
+			const events: IDirectorySortKeyChanged[] = [];
+			detached.on("sortKeyChanged", (changed: IDirectorySortKeyChanged) => {
+				events.push(changed);
+			});
+
+			detached.setSortKey("a", "M");
+			assert.deepStrictEqual([...detached.keysByOrder()], ["a", "b"]);
+			assert.strictEqual(events.length, 1);
+			assert.deepStrictEqual(events[0], {
+				key: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+				path: "/",
+			});
+
+			detached.setSortKey("a", undefined);
+			assert.deepStrictEqual([...detached.keysByOrder()], ["a", "b"]);
+			assert.strictEqual(events.length, 2);
+			assert.deepStrictEqual(events[1], {
+				key: "a",
+				sortKey: undefined,
+				previousSortKey: "M",
+				path: "/",
+			});
+		});
+
+		it("T54a: rollback of setSubDirectorySortKey with no prior sort key reverts to unset", () => {
+			const { sharedDirectory, containerRuntimeFactory, containerRuntime } =
+				setupRollbackTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.createSubDirectory("c");
+			sharedDirectory.setSubDirectorySortKey("c", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySubDirectorySortKeyChanged[] = [];
+			sharedDirectory.on(
+				"subDirectorySortKeyChanged",
+				(changed: IDirectorySubDirectorySortKeyChanged) => {
+					events.push(changed);
+				},
+			);
+
+			sharedDirectory.setSubDirectorySortKey("a", "M");
+			assert.deepStrictEqual(
+				[...sharedDirectory.subdirectoriesByOrder()].map(([name]) => name),
+				["a", "c", "b"],
+				"Pre-rollback: a (M) then c (Z) then unkeyed b",
+			);
+			assert.deepStrictEqual(events[0], {
+				subdirName: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+				path: "/",
+			});
+
+			containerRuntime.rollback?.();
+
+			assert.deepStrictEqual(
+				[...sharedDirectory.subdirectoriesByOrder()].map(([name]) => name),
+				["c", "a", "b"],
+				"Post-rollback: c (Z) then unkeyed a, b in seq-data order",
+			);
+			assert.strictEqual(events.length, 2);
+			assert.deepStrictEqual(events[1], {
+				subdirName: "a",
+				sortKey: undefined,
+				previousSortKey: "M",
+				path: "/",
+			});
+		});
+
+		it("T54b: rollback of setSubDirectorySortKey that replaced a prior sort key reverts to the prior value", () => {
+			const { sharedDirectory, containerRuntimeFactory, containerRuntime } =
+				setupRollbackTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.setSubDirectorySortKey("a", "M");
+			sharedDirectory.setSubDirectorySortKey("b", "X");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySubDirectorySortKeyChanged[] = [];
+			sharedDirectory.on(
+				"subDirectorySortKeyChanged",
+				(changed: IDirectorySubDirectorySortKeyChanged) => {
+					events.push(changed);
+				},
+			);
+
+			sharedDirectory.setSubDirectorySortKey("a", "Z");
+			assert.deepStrictEqual(
+				[...sharedDirectory.subdirectoriesByOrder()].map(([name]) => name),
+				["b", "a"],
+				"Pre-rollback: 'X' < 'Z'",
+			);
+
+			containerRuntime.rollback?.();
+
+			assert.deepStrictEqual(
+				[...sharedDirectory.subdirectoriesByOrder()].map(([name]) => name),
+				["a", "b"],
+				"Post-rollback: 'M' < 'X' again",
+			);
+			assert.strictEqual(events.length, 2);
+			assert.deepStrictEqual(events[1], {
+				subdirName: "a",
+				sortKey: "M",
+				previousSortKey: "Z",
+				path: "/",
+			});
+		});
+
+		it("T54c: subdir sort-key rollback removes pending entries by reference identity", () => {
+			const { sharedDirectory, containerRuntimeFactory, containerRuntime } =
+				setupRollbackTest();
+			sharedDirectory.createSubDirectory("a");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySubDirectorySortKeyChanged[] = [];
+			sharedDirectory.on(
+				"subDirectorySortKeyChanged",
+				(changed: IDirectorySubDirectorySortKeyChanged) => {
+					events.push(changed);
+				},
+			);
+
+			sharedDirectory.setSubDirectorySortKey("a", "M");
+			sharedDirectory.setSubDirectorySortKey("a", "Z");
+			assert.strictEqual(events.length, 2);
+
+			containerRuntime.flushSomeMessages(1);
+			containerRuntimeFactory.processOneMessage();
+			assert.strictEqual(
+				events.length,
+				2,
+				"Local ack does not re-fire subDirectorySortKeyChanged",
+			);
+
+			containerRuntime.rollback?.();
+
+			assert.strictEqual(events.length, 3);
+			assert.deepStrictEqual(events[2], {
+				subdirName: "a",
+				sortKey: "M",
+				previousSortKey: "Z",
+				path: "/",
+			});
 		});
 	});
 

--- a/packages/dds/map/src/test/mocha/directory.rollback.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.rollback.spec.ts
@@ -5,31 +5,21 @@
 
 import { strict as assert } from "node:assert";
 
-import { AttachState } from "@fluidframework/container-definitions";
-import {
-	MockContainerRuntimeFactory,
-	MockFluidDataStoreRuntime,
-	MockStorage,
-	type MockContainerRuntime,
-} from "@fluidframework/test-runtime-utils/internal";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { DirectoryFactory } from "../../directoryFactory.js";
 import type {
 	IDirectorySortKeyChanged,
 	IDirectorySubDirectorySortKeyChanged,
 	IDirectoryValueChanged,
-	ISharedDirectory,
 	IValueChanged,
 } from "../../interfaces.js";
 
 import { assertEquivalentDirectories } from "./directoryEquivalenceUtils.js";
-
-interface RollbackTestSetup {
-	sharedDirectory: ISharedDirectory;
-	dataStoreRuntime: MockFluidDataStoreRuntime;
-	containerRuntimeFactory: MockContainerRuntimeFactory;
-	containerRuntime: MockContainerRuntime;
-}
+import {
+	createAdditionalClient,
+	setupConnectedDirectoryTest as setupRollbackTest,
+} from "./directoryTestHelpers.js";
 
 interface SubDirectoryEvent {
 	path: string;
@@ -37,44 +27,6 @@ interface SubDirectoryEvent {
 }
 
 const directoryFactory = new DirectoryFactory();
-
-function setupRollbackTest(): RollbackTestSetup {
-	const containerRuntimeFactory = new MockContainerRuntimeFactory({ flushMode: 1 }); // TurnBased
-	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: "1" });
-	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
-	const sharedDirectory = directoryFactory.create(dataStoreRuntime, "shared-directory-1");
-	dataStoreRuntime.setAttachState(AttachState.Attached);
-	sharedDirectory.connect({
-		deltaConnection: dataStoreRuntime.createDeltaConnection(),
-		objectStorage: new MockStorage(),
-	});
-	return {
-		sharedDirectory,
-		dataStoreRuntime,
-		containerRuntimeFactory,
-		containerRuntime,
-	};
-}
-
-// Helper to create another client attached to the same containerRuntimeFactory
-function createAdditionalClient(
-	containerRuntimeFactory: MockContainerRuntimeFactory,
-	id: string = "client-2",
-): {
-	sharedDirectory: ISharedDirectory;
-	dataStoreRuntime: MockFluidDataStoreRuntime;
-	containerRuntime: MockContainerRuntime;
-} {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
-	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
-	const sharedDirectory = directoryFactory.create(dataStoreRuntime, `shared-directory-${id}`);
-	dataStoreRuntime.setAttachState(AttachState.Attached);
-	sharedDirectory.connect({
-		deltaConnection: dataStoreRuntime.createDeltaConnection(),
-		objectStorage: new MockStorage(),
-	});
-	return { sharedDirectory, dataStoreRuntime, containerRuntime };
-}
 
 describe("SharedDirectory rollback", () => {
 	describe("Storage operations (root subdirectory)", () => {

--- a/packages/dds/map/src/test/mocha/directory.snapshot.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.snapshot.spec.ts
@@ -150,3 +150,187 @@ describe("SharedDirectory Snapshot Tests", () => {
 		});
 	}
 });
+
+describe("SharedDirectory Snapshot Tests — sort keys", () => {
+	function createDetachedDirectory(id: string): SharedDirectory {
+		const runtimeFactory = new MockContainerRuntimeFactory();
+		const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
+		runtimeFactory.createContainerRuntime(dataStoreRuntime);
+		const factory = SharedDirectory.getFactory();
+		return factory.create(dataStoreRuntime, id) as SharedDirectory;
+	}
+
+	interface RawDataObject {
+		storage?: Record<string, unknown>;
+		subdirectories?: Record<string, RawDataObject>;
+		ci?: unknown;
+		sortKeys?: Record<string, string>;
+		subdirectorySortKeys?: Record<string, string>;
+	}
+
+	function stripSortKeys(serializedSnapshot: string): string {
+		const snapshotTree = JSON.parse(serializedSnapshot) as {
+			entries: { path: string; value: { contents: string; encoding: string } }[];
+		};
+		for (const entry of snapshotTree.entries) {
+			const parsed = JSON.parse(entry.value.contents) as {
+				blobs: string[];
+				content: RawDataObject;
+			};
+			const stack: RawDataObject[] = [parsed.content];
+			while (stack.length > 0) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				const current = stack.pop()!;
+				delete current.sortKeys;
+				delete current.subdirectorySortKeys;
+				if (current.subdirectories) {
+					for (const child of Object.values(current.subdirectories)) {
+						stack.push(child);
+					}
+				}
+			}
+			entry.value.contents = JSON.stringify(parsed);
+		}
+		return JSON.stringify(snapshotTree);
+	}
+
+	it("T58: Snapshot with sort keys reloads with same key iteration order", async () => {
+		const original = createDetachedDirectory("T58");
+		original.set("a", 1);
+		original.set("b", 2);
+		original.set("c", 3);
+		original.set("d", 4);
+		original.set("e", 5);
+		original.setSortKey("a", "3");
+		original.setSortKey("b", "1");
+		original.setSortKey("c", "2");
+
+		const serialized = serialize(original);
+		const loaded = await loadSharedDirectory("T58-loaded", serialized);
+
+		assert.deepStrictEqual([...loaded.keysByOrder()], [...original.keysByOrder()]);
+		assert.deepStrictEqual(
+			[...loaded.keysByOrder()],
+			["b", "c", "a", "d", "e"],
+			"sort-keyed entries first (lex order), then unkeyed in insertion order",
+		);
+	});
+
+	it("T59: Old-format snapshot (no sortKeys fields) loads cleanly", async () => {
+		const oldFormatContent = {
+			blobs: [],
+			content: {
+				ci: { csn: 0, ccIds: [] },
+				storage: {
+					a: { type: "Plain", value: 1 },
+					b: { type: "Plain", value: 2 },
+					c: { type: "Plain", value: 3 },
+				},
+			},
+		};
+		const snapshotTree = {
+			entries: [
+				{
+					path: "header",
+					mode: "100644",
+					type: "Blob",
+					value: {
+						contents: JSON.stringify(oldFormatContent),
+						encoding: "utf8",
+					},
+				},
+			],
+		};
+		const loaded = await loadSharedDirectory("T59-loaded", JSON.stringify(snapshotTree));
+
+		assert.deepStrictEqual(
+			[...loaded.keysByOrder()],
+			[...loaded.keys()],
+			"fast-path: keysByOrder equals keys() when no sort keys in snapshot",
+		);
+		assert.deepStrictEqual([...loaded.keysByOrder()], ["a", "b", "c"]);
+	});
+
+	it("T60: Snapshot round-trip preserves subdirectory sort keys", async () => {
+		const original = createDetachedDirectory("T60");
+		original.createSubDirectory("alpha");
+		original.createSubDirectory("beta");
+		original.createSubDirectory("gamma");
+		original.setSubDirectorySortKey("alpha", "3");
+		original.setSubDirectorySortKey("beta", "1");
+		original.setSubDirectorySortKey("gamma", "2");
+
+		const serialized = serialize(original);
+		const loaded = await loadSharedDirectory("T60-loaded", serialized);
+
+		const originalOrder = [...original.subdirectoriesByOrder()].map(([name]) => name);
+		const loadedOrder = [...loaded.subdirectoriesByOrder()].map(([name]) => name);
+		assert.deepStrictEqual(loadedOrder, originalOrder);
+		assert.deepStrictEqual(loadedOrder, ["beta", "gamma", "alpha"]);
+	});
+
+	it("T61: Snapshot round-trip preserves nested sort keys", async () => {
+		const original = createDetachedDirectory("T61");
+		original.set("k1", "v1");
+		original.set("k2", "v2");
+		original.setSortKey("k1", "B");
+		original.setSortKey("k2", "A");
+
+		original.createSubDirectory("child1");
+		original.createSubDirectory("child2");
+		original.setSubDirectorySortKey("child1", "Z");
+		original.setSubDirectorySortKey("child2", "Y");
+
+		const child1 = original.getSubDirectory("child1");
+		assert(child1 !== undefined);
+		child1.set("nested1", "n1");
+		child1.set("nested2", "n2");
+		child1.setSortKey("nested1", "9");
+		child1.setSortKey("nested2", "1");
+
+		const serialized = serialize(original);
+		const loaded = await loadSharedDirectory("T61-loaded", serialized);
+
+		assert.deepStrictEqual([...loaded.keysByOrder()], [...original.keysByOrder()]);
+		assert.deepStrictEqual(
+			[...loaded.subdirectoriesByOrder()].map(([n]) => n),
+			[...original.subdirectoriesByOrder()].map(([n]) => n),
+		);
+		const loadedChild = loaded.getSubDirectory("child1");
+		assert(loadedChild !== undefined);
+		assert.deepStrictEqual([...loadedChild.keysByOrder()], [...child1.keysByOrder()]);
+		assert.deepStrictEqual([...loadedChild.keysByOrder()], ["nested2", "nested1"]);
+	});
+
+	it("T62: Stripped snapshot (forward-compat lossy) loads cleanly", async () => {
+		const original = createDetachedDirectory("T62");
+		original.set("a", 1);
+		original.set("b", 2);
+		original.setSortKey("a", "M");
+		original.setSortKey("b", "Z");
+		original.createSubDirectory("sub");
+		original.setSubDirectorySortKey("sub", "X");
+		const sub = original.getSubDirectory("sub");
+		assert(sub !== undefined);
+		sub.set("nested", "v");
+		sub.setSortKey("nested", "N");
+
+		const serialized = serialize(original);
+		const stripped = stripSortKeys(serialized);
+		const loaded = await loadSharedDirectory("T62-loaded", stripped);
+
+		assert.deepStrictEqual(
+			[...loaded.keysByOrder()],
+			[...loaded.keys()],
+			"stripped snapshot falls back to default iteration",
+		);
+		assert.deepStrictEqual([...loaded.keysByOrder()], ["a", "b"]);
+		assert.deepStrictEqual(
+			[...loaded.subdirectoriesByOrder()].map(([n]) => n),
+			[...loaded.subdirectories()].map(([n]) => n),
+		);
+		const loadedSub = loaded.getSubDirectory("sub");
+		assert(loadedSub !== undefined);
+		assert.deepStrictEqual([...loadedSub.keysByOrder()], [...loadedSub.keys()]);
+	});
+});

--- a/packages/dds/map/src/test/mocha/directory.sortKey.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.sortKey.spec.ts
@@ -680,6 +680,69 @@ describe("SharedDirectory sort keys", () => {
 			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
 			assert.deepStrictEqual(names, ["other", "sub"]);
 		});
+
+		it("T33: rollback of delete restores the key AND its sort key", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			sharedDirectory.set("b", 2);
+			sharedDirectory.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// Start a pending delete; "a" is optimistically removed before the delete is acked.
+			sharedDirectory.delete("a");
+			assert.strictEqual(
+				sharedDirectory.get("a"),
+				undefined,
+				"Pending delete should hide 'a' optimistically",
+			);
+
+			// Rollback the pending delete. The sort-key cleanup only happens on ack, so "a" should
+			// come back with its sort key intact and still land in the sort-keyed bucket.
+			containerRuntime.rollback?.();
+
+			assert.strictEqual(sharedDirectory.get("a"), 1, "Value should be restored");
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b"]);
+		});
+
+		it("T34: clear while a setSortKey is pending leaves no leftover sequenced sort key", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// Queue a setSortKey but don't flush yet.
+			sharedDirectory.setSortKey("a", "Z");
+
+			// A local clear while the setSortKey is still pending. Both ops are then flushed and
+			// processed in submission order (setSortKey, then clear). The clear's ack wipes the
+			// sequenced sort keys map, so the pending "Z" must not outlive the clear.
+			sharedDirectory.clear();
+
+			let eventsAfterFlush = 0;
+			sharedDirectory.on("sortKeyChanged", () => {
+				eventsAfterFlush++;
+			});
+
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// The ack of the local ops should not fire any additional sortKeyChanged events.
+			assert.strictEqual(eventsAfterFlush, 0);
+
+			// Reinsert "a" and "b" with only "b" sort-keyed. If a stale "Z" for "a" survived the
+			// clear, "a" would land in the sort-keyed bucket (ordering ["a", "b"]); with a clean
+			// sequencedSortKeys, "a" is unkeyed and trails "b" (ordering ["b", "a"]).
+			sharedDirectory.set("a", 2);
+			sharedDirectory.set("b", 3);
+			sharedDirectory.setSortKey("b", "X");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+		});
 	});
 
 	describe("Subdirectory sort keys", () => {
@@ -791,6 +854,37 @@ describe("SharedDirectory sort keys", () => {
 				previousSortKey: undefined,
 			});
 		});
+
+		it("T42: deleting one subdir leaves sibling subdirectorySortKeys intact", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.createSubDirectory("c");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSubDirectorySortKey("a", "1");
+			sharedDirectory.setSubDirectorySortKey("b", "2");
+			sharedDirectory.setSubDirectorySortKey("c", "3");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.deleteSubDirectory("b");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// "a" and "c" retain their sort keys; "b" is gone so its entry doesn't appear.
+			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(names, ["a", "c"]);
+
+			// Recreate "b" with no sort key — it should land in the unkeyed bucket after "a" and
+			// "c", confirming that "a"/"c" sort keys survived the delete of "b".
+			sharedDirectory.createSubDirectory("b");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			const namesAfter = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(namesAfter, ["a", "c", "b"]);
+		});
 	});
 
 	describe("Concurrent / eventual consistency", () => {
@@ -812,6 +906,76 @@ describe("SharedDirectory sort keys", () => {
 
 			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b"]);
 			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], ["a", "b"]);
+		});
+
+		it("T45a: delete sequenced before setSortKey — both clients converge; sort key acts as pre-registration", () => {
+			// When the delete is sequenced first, the subsequent setSortKey from the other client
+			// is applied to a currently-non-existent key. That matches T46 pre-registration
+			// semantics: the sort key waits for a future set() to attach to. Both clients must
+			// converge on the same state.
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.delete("a");
+			sharedDirectory2.setSortKey("a", "M");
+			// Flushing sharedDirectory first sequences the delete ahead of the remote setSortKey.
+			containerRuntime.flush();
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(sharedDirectory.get("a"), undefined);
+			assert.strictEqual(sharedDirectory2.get("a"), undefined);
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], []);
+			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], []);
+
+			// Rebirth: re-set "a" and add a new sort-keyed "b". "a" inherits the sort key "M" (the
+			// sequenced setSortKey effectively pre-registered for this new lifetime), so with b at
+			// "Z" the lex order is "a" ("M") < "b" ("Z").
+			sharedDirectory.set("a", 2);
+			sharedDirectory.set("b", 3);
+			sharedDirectory.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b"]);
+			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], ["a", "b"]);
+		});
+
+		it("T45b: setSortKey sequenced before delete — delete clears the freshly-set sort key", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory2.setSortKey("a", "M");
+			sharedDirectory.delete("a");
+			// Flushing sharedDirectory2 first puts the setSortKey ahead of the delete.
+			containerRuntime2.flush();
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// "a" is deleted on both clients; delete was sequenced after setSortKey, so it clears
+			// the freshly-set sort key too (same invariant as T29).
+			assert.strictEqual(sharedDirectory.get("a"), undefined);
+			assert.strictEqual(sharedDirectory2.get("a"), undefined);
+
+			// Rebirth: with the sort key cleared, re-setting "a" puts it in the unkeyed bucket
+			// (trailing "b" which has sort key "Z").
+			sharedDirectory.set("a", 2);
+			sharedDirectory.set("b", 3);
+			sharedDirectory.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], ["b", "a"]);
 		});
 
 		it("T44: Two clients set sort keys on same key — LWW by server order", () => {
@@ -1045,6 +1209,52 @@ describe("SharedDirectory sort keys", () => {
 
 			assert.deepStrictEqual([...directory1.keysByOrder()], ["a"]);
 			assert.deepStrictEqual([...directory2.keysByOrder()], ["a"]);
+		});
+
+		it("T56: pending setSortKey whose subdir was remotely deleted during disconnect is dropped", () => {
+			const runtimeFactory = new MockContainerRuntimeFactoryForReconnection();
+			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+			const containerRuntime1 = runtimeFactory.createContainerRuntime(dataStoreRuntime1);
+			const directory1 = directoryFactory.create(dataStoreRuntime1, "dir1");
+			directory1.connect({
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			});
+
+			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+			runtimeFactory.createContainerRuntime(dataStoreRuntime2);
+			const directory2 = directoryFactory.create(dataStoreRuntime2, "dir2");
+			directory2.connect({
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			});
+
+			directory1.createSubDirectory("sub");
+			runtimeFactory.processAllMessages();
+			const sub1 = directory1.getSubDirectory("sub");
+			assert.ok(sub1 !== undefined);
+			sub1.set("x", 1);
+			runtimeFactory.processAllMessages();
+			assert.ok(directory2.getSubDirectory("sub") !== undefined);
+
+			// Disconnect client 1, then queue a pending setSortKey targeting the subdir.
+			containerRuntime1.connected = false;
+			sub1.setSortKey("x", "M");
+
+			// While client 1 is offline, client 2 deletes the subdir and the op reaches the server.
+			directory2.deleteSubDirectory("sub");
+			runtimeFactory.processAllMessages();
+
+			// Client 1 reconnects. The remote delete arrives; its local pending setSortKey is
+			// resubmitted, but because the subdir is now disposed the resubmit path short-circuits
+			// (messageHandlers.setSortKey.resubmit checks targetSubdir.disposed).
+			assert.doesNotThrow(() => {
+				containerRuntime1.connected = true;
+				runtimeFactory.processAllMessages();
+			});
+
+			assert.strictEqual(directory1.getSubDirectory("sub"), undefined);
+			assert.strictEqual(directory2.getSubDirectory("sub"), undefined);
 		});
 
 		it("T57: applyStashedOp for setSortKey restores state (detached-style, no submit)", () => {

--- a/packages/dds/map/src/test/mocha/directory.sortKey.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.sortKey.spec.ts
@@ -1,0 +1,1070 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { AttachState } from "@fluidframework/container-definitions";
+import { convertSummaryTreeToITree } from "@fluidframework/runtime-utils/internal";
+import {
+	MockContainerRuntimeFactory,
+	MockContainerRuntimeFactoryForReconnection,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+	type MockContainerRuntime,
+} from "@fluidframework/test-runtime-utils/internal";
+
+import {
+	type DirectoryLocalOpMetadata,
+	type IDirectoryOperation,
+	SharedDirectory as SharedDirectoryInternal,
+} from "../../directory.js";
+import { DirectoryFactory } from "../../directoryFactory.js";
+import type {
+	IDirectorySortKeyChanged,
+	IDirectorySubDirectorySortKeyChanged,
+	ISharedDirectory,
+	ISortKeyChanged,
+	ISubDirectorySortKeyChanged,
+} from "../../interfaces.js";
+
+interface TestParts {
+	sharedDirectory: ISharedDirectory;
+	dataStoreRuntime: MockFluidDataStoreRuntime;
+	containerRuntimeFactory: MockContainerRuntimeFactory;
+	containerRuntime: MockContainerRuntime;
+}
+
+const directoryFactory = new DirectoryFactory();
+
+function setupTest(): TestParts {
+	const containerRuntimeFactory = new MockContainerRuntimeFactory({ flushMode: 1 }); // TurnBased
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: "1" });
+	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	const sharedDirectory = directoryFactory.create(dataStoreRuntime, "shared-directory-1");
+	dataStoreRuntime.setAttachState(AttachState.Attached);
+	sharedDirectory.connect({
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	});
+	return {
+		sharedDirectory,
+		dataStoreRuntime,
+		containerRuntimeFactory,
+		containerRuntime,
+	};
+}
+
+function createAdditionalClient(
+	containerRuntimeFactory: MockContainerRuntimeFactory,
+	id: string = "client-2",
+): {
+	sharedDirectory: ISharedDirectory;
+	dataStoreRuntime: MockFluidDataStoreRuntime;
+	containerRuntime: MockContainerRuntime;
+} {
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
+	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	const sharedDirectory = directoryFactory.create(dataStoreRuntime, `shared-directory-${id}`);
+	dataStoreRuntime.setAttachState(AttachState.Attached);
+	sharedDirectory.connect({
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	});
+	return { sharedDirectory, dataStoreRuntime, containerRuntime };
+}
+
+class TestSharedDirectory extends SharedDirectoryInternal {
+	private lastMetadata?: DirectoryLocalOpMetadata;
+	public testApplyStashedOp(
+		content: IDirectoryOperation,
+	): DirectoryLocalOpMetadata | undefined {
+		this.lastMetadata = undefined;
+		this.applyStashedOp(content);
+		return this.lastMetadata;
+	}
+	public submitLocalMessage(op: IDirectoryOperation, localOpMetadata: unknown): void {
+		this.lastMetadata = localOpMetadata as DirectoryLocalOpMetadata;
+		super.submitLocalMessage(op, localOpMetadata);
+	}
+}
+
+describe("SharedDirectory sort keys", () => {
+	describe("API — single client", () => {
+		it("T1: setSortKey on existing key does not throw and does not affect the value", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(sharedDirectory.get("a"), 1);
+		});
+
+		it("T2: setSortKey on a nonexistent key is allowed", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			assert.doesNotThrow(() => sharedDirectory.setSortKey("nope", "M"));
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			assert.strictEqual(sharedDirectory.get("nope"), undefined);
+		});
+
+		it("T3: setSortKey with undefined clears prior sort key", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			sharedDirectory.set("b", 2);
+			sharedDirectory.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", undefined);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// With no sort key on "a", only "b" is sort-keyed and "a" trails in the unkeyed bucket.
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+		});
+
+		it("T4: setSortKey is LWW within a single client", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "M");
+			sharedDirectory.setSortKey("a", "Z");
+			sharedDirectory.setSortKey("b", "N");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// "a" has final sort key "Z", so "b" (sort key "N") sorts before "a" ("Z").
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+		});
+
+		it("T5: setSortKey throws on disposed subdirectory", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const sub = sharedDirectory.createSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			sharedDirectory.deleteSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.throws(() => sub.setSortKey("a", "M"));
+		});
+
+		it("T6: setSubDirectorySortKey reorders subdirectoriesByOrder", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.createSubDirectory("c");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSubDirectorySortKey("b", "1");
+			sharedDirectory.setSubDirectorySortKey("a", "2");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(names, ["b", "a", "c"]);
+		});
+
+		it("T7: setSubDirectorySortKey on nonexistent subdir is allowed", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			assert.doesNotThrow(() => sharedDirectory.setSubDirectorySortKey("future", "X"));
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			assert.strictEqual(sharedDirectory.getSubDirectory("future"), undefined);
+		});
+
+		it("T8: setSubDirectorySortKey(name, undefined) clears", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			sharedDirectory.setSubDirectorySortKey("a", "1");
+			sharedDirectory.setSubDirectorySortKey("b", "2");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSubDirectorySortKey("a", undefined);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(names, ["b", "a"]);
+		});
+
+		it("T9: setSortKey on a deeply nested subdir works", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const l1 = sharedDirectory.createSubDirectory("l1");
+			l1.createSubDirectory("l2");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			const l2 = sharedDirectory.getWorkingDirectory("/l1/l2");
+			assert.ok(l2 !== undefined);
+			l2.set("x", 1);
+			l2.set("y", 2);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			l2.setSortKey("y", "A");
+			l2.setSortKey("x", "B");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...l2.keysByOrder()], ["y", "x"]);
+		});
+
+		it("T10: setSortKey does not fire valueChanged", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			let valueChangedCount = 0;
+			sharedDirectory.on("valueChanged", () => {
+				valueChangedCount++;
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(valueChangedCount, 0);
+		});
+
+		it("T11: sortKeyChanged fires exactly once for local op (submit + ack)", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			let count = 0;
+			sharedDirectory.on("sortKeyChanged", () => {
+				count++;
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+			assert.strictEqual(count, 1, "event should fire on local submit");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			assert.strictEqual(count, 1, "ack should not re-fire");
+		});
+
+		it("T12: empty-string sort key is valid and not conflated with unset", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("b", "");
+			sharedDirectory.setSortKey("a", "A");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+		});
+
+		it("T13: re-setting sort key to same value still fires event; order unchanged", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			let count = 0;
+			sharedDirectory.on("sortKeyChanged", () => {
+				count++;
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(count, 1);
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a"]);
+		});
+
+		it("T14: SharedDirectory forwarders route to root", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("x", 1);
+			sharedDirectory.setSortKey("x", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["x"]);
+		});
+	});
+
+	describe("Iteration semantics", () => {
+		it("T15: keysByOrder is empty on empty directory", () => {
+			const { sharedDirectory } = setupTest();
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], []);
+		});
+
+		it("T16: keysByOrder equals keys when no sort keys are set", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("c", 1);
+			sharedDirectory.set("a", 2);
+			sharedDirectory.set("b", 3);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], [...sharedDirectory.keys()]);
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["c", "a", "b"]);
+		});
+
+		it("T17: sort-keyed entries iterate in lex order of sort key", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			sharedDirectory.set("c", 3);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "3");
+			sharedDirectory.setSortKey("b", "1");
+			sharedDirectory.setSortKey("c", "2");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "c", "a"]);
+		});
+
+		it("T18: unkeyed entries appear after sort-keyed, in default order", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("x", 1);
+			sharedDirectory.set("y", 2);
+			sharedDirectory.set("z", 3);
+			sharedDirectory.set("q", 4);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("z", "A");
+			sharedDirectory.setSortKey("x", "B");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["z", "x", "y", "q"]);
+		});
+
+		it("T19: tie on sort key breaks by insertion order", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("first", 1);
+			sharedDirectory.set("second", 2);
+			sharedDirectory.set("third", 3);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("first", "X");
+			sharedDirectory.setSortKey("second", "X");
+			sharedDirectory.setSortKey("third", "X");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["first", "second", "third"]);
+		});
+
+		it("T20: sort-keyed wins over unkeyed (no tie possible across buckets)", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "any");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b"]);
+		});
+
+		it("T21: valuesByOrder / entriesByOrder align with keysByOrder", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 10);
+			sharedDirectory.set("b", 20);
+			sharedDirectory.set("c", 30);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			sharedDirectory.setSortKey("c", "1");
+			sharedDirectory.setSortKey("a", "2");
+			sharedDirectory.setSortKey("b", "3");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const keys = [...sharedDirectory.keysByOrder()];
+			const values = [...sharedDirectory.valuesByOrder()];
+			const entries = [...sharedDirectory.entriesByOrder()];
+			assert.deepStrictEqual(keys, ["c", "a", "b"]);
+			assert.deepStrictEqual(values, [30, 10, 20]);
+			assert.deepStrictEqual(entries, [
+				["c", 30],
+				["a", 10],
+				["b", 20],
+			]);
+		});
+
+		it("T22: lexicographic uses JS < (UTF-16 code point order)", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("one", 1);
+			sharedDirectory.set("two", 2);
+			sharedDirectory.set("three", 3);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("one", "Z");
+			sharedDirectory.setSortKey("two", "a");
+			sharedDirectory.setSortKey("three", "A");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// UTF-16: "A" (0x41) < "Z" (0x5A) < "a" (0x61)
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["three", "one", "two"]);
+		});
+	});
+
+	describe("Events", () => {
+		it("T23: sortKeyChanged fires on local set", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: { changed: IDirectorySortKeyChanged; local: boolean }[] = [];
+			sharedDirectory.on("sortKeyChanged", (changed, local) => {
+				events.push({ changed, local });
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+
+			assert.strictEqual(events.length, 1);
+			assert.deepStrictEqual(events[0].changed, {
+				path: "/",
+				key: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+			});
+			assert.strictEqual(events[0].local, true);
+		});
+
+		it("T24: sortKeyChanged fires on remote set", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: { changed: IDirectorySortKeyChanged; local: boolean }[] = [];
+			sharedDirectory2.on("sortKeyChanged", (changed, local) => {
+				events.push({ changed, local });
+			});
+
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(events.length, 1);
+			assert.deepStrictEqual(events[0].changed, {
+				path: "/",
+				key: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+			});
+			assert.strictEqual(events[0].local, false);
+		});
+
+		it("T25: previousSortKey is correct on update", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: IDirectorySortKeyChanged[] = [];
+			sharedDirectory.on("sortKeyChanged", (changed) => {
+				events.push(changed);
+			});
+
+			sharedDirectory.setSortKey("a", "Z");
+
+			assert.strictEqual(events.length, 1);
+			assert.strictEqual(events[0].sortKey, "Z");
+			assert.strictEqual(events[0].previousSortKey, "M");
+		});
+
+		it("T26: sortKeyChanged does not fire on remote op when local pending exists", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			let client1Events = 0;
+			sharedDirectory.on("sortKeyChanged", () => {
+				client1Events++;
+			});
+
+			// Client 1 starts pending setSortKey for "a" (don't flush yet).
+			sharedDirectory.setSortKey("a", "Z");
+			assert.strictEqual(client1Events, 1, "local event fires once");
+
+			// Client 2 sends a remote setSortKey for same key.
+			sharedDirectory2.setSortKey("a", "M");
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// Client 1 should NOT emit again because its pending op eclipses the remote value.
+			assert.strictEqual(client1Events, 1);
+
+			// Finally, flush client 1 and process.
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+		});
+
+		it("T27: containedSortKeyChanged fires on the SubDirectory handle directly", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const sub = sharedDirectory.getWorkingDirectory("/sub");
+			assert.ok(sub !== undefined);
+			sub.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: ISortKeyChanged[] = [];
+			sub.on("containedSortKeyChanged", (changed: ISortKeyChanged) => {
+				events.push(changed);
+			});
+
+			sub.setSortKey("a", "M");
+
+			assert.strictEqual(events.length, 1);
+			assert.deepStrictEqual(events[0], {
+				key: "a",
+				sortKey: "M",
+				previousSortKey: undefined,
+			});
+			assert.strictEqual((events[0] as unknown as { path?: string }).path, undefined);
+		});
+
+		it("T28: delete does NOT fire sortKeyChanged", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			let sortKeyEvents = 0;
+			let valueEvents = 0;
+			sharedDirectory.on("sortKeyChanged", () => {
+				sortKeyEvents++;
+			});
+			sharedDirectory.on("valueChanged", () => {
+				valueEvents++;
+			});
+
+			sharedDirectory.delete("a");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(valueEvents, 1);
+			assert.strictEqual(sortKeyEvents, 0);
+		});
+	});
+
+	describe("Delete / clear propagation", () => {
+		it("T29: delete(k) clears sort key for k", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.delete("a");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.set("a", 2);
+			sharedDirectory.set("b", 3);
+			sharedDirectory.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// "a" is unkeyed now (sort key "M" was cleared by delete), "b" is sort-keyed.
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+		});
+
+		it("T30: clear() clears all sort keys", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			sharedDirectory.set("c", 3);
+			sharedDirectory.setSortKey("a", "1");
+			sharedDirectory.setSortKey("b", "2");
+			sharedDirectory.setSortKey("c", "3");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.clear();
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			sharedDirectory.set("c", 3);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b", "c"]);
+		});
+
+		it("T31: clear() on parent does NOT clear sort keys in child subdirs", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("r", 1);
+			sharedDirectory.setSortKey("r", "Z");
+			sharedDirectory.createSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			const sub = sharedDirectory.getWorkingDirectory("/sub");
+			assert.ok(sub !== undefined);
+			sub.set("x", 1);
+			sub.setSortKey("x", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.clear();
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], []);
+			assert.deepStrictEqual([...sub.keysByOrder()], ["x"]);
+		});
+
+		it("T32: deleteSubDirectory clears subdir sort key on parent", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("sub");
+			sharedDirectory.createSubDirectory("other");
+			sharedDirectory.setSubDirectorySortKey("sub", "M");
+			sharedDirectory.setSubDirectorySortKey("other", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.deleteSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.createSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// "other" has sort key "Z", "sub" now has no sort key -> "sub" in unkeyed bucket.
+			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(names, ["other", "sub"]);
+		});
+	});
+
+	describe("Subdirectory sort keys", () => {
+		it("T35: subdirectoriesByOrder empty on empty parent", () => {
+			const { sharedDirectory } = setupTest();
+			assert.deepStrictEqual([...sharedDirectory.subdirectoriesByOrder()], []);
+		});
+
+		it("T36: fast path equals subdirectories() when no sort keys", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.createSubDirectory("c");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const ordered = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			const natural = [...sharedDirectory.subdirectories()].map(([n]) => n);
+			assert.deepStrictEqual(ordered, natural);
+		});
+
+		it("T37: sort-keyed subdirs iterate in lex order", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.createSubDirectory("c");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			sharedDirectory.setSubDirectorySortKey("a", "3");
+			sharedDirectory.setSubDirectorySortKey("b", "1");
+			sharedDirectory.setSubDirectorySortKey("c", "2");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(names, ["b", "c", "a"]);
+		});
+
+		it("T38: unkeyed subdirs trail, in default (seqData) order", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.createSubDirectory("a");
+			sharedDirectory.createSubDirectory("b");
+			sharedDirectory.createSubDirectory("c");
+			sharedDirectory.createSubDirectory("d");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+			sharedDirectory.setSubDirectorySortKey("c", "A");
+			sharedDirectory.setSubDirectorySortKey("a", "B");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const names = [...sharedDirectory.subdirectoriesByOrder()].map(([n]) => n);
+			assert.deepStrictEqual(names, ["c", "a", "b", "d"]);
+		});
+
+		it("T40: subDirectorySortKeyChanged fires on local and remote", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.createSubDirectory("sub");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const local: IDirectorySubDirectorySortKeyChanged[] = [];
+			const remote: IDirectorySubDirectorySortKeyChanged[] = [];
+			sharedDirectory.on("subDirectorySortKeyChanged", (changed, isLocal) => {
+				if (isLocal === true) {
+					local.push(changed);
+				}
+			});
+			sharedDirectory2.on("subDirectorySortKeyChanged", (changed, isLocal) => {
+				if (isLocal === false) {
+					remote.push(changed);
+				}
+			});
+
+			sharedDirectory.setSubDirectorySortKey("sub", "M");
+			containerRuntime.flush();
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.strictEqual(local.length, 1);
+			assert.strictEqual(local[0].sortKey, "M");
+			assert.strictEqual(local[0].path, "/");
+			assert.strictEqual(local[0].subdirName, "sub");
+			assert.strictEqual(remote.length, 1);
+			assert.strictEqual(remote[0].sortKey, "M");
+		});
+
+		it("T41: containedSubDirectorySortKeyChanged fires on the parent subdir", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const sub = sharedDirectory.createSubDirectory("sub");
+			sub.createSubDirectory("child");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const events: ISubDirectorySortKeyChanged[] = [];
+			sub.on("containedSubDirectorySortKeyChanged", (changed: ISubDirectorySortKeyChanged) => {
+				events.push(changed);
+			});
+
+			sub.setSubDirectorySortKey("child", "M");
+
+			assert.strictEqual(events.length, 1);
+			assert.deepStrictEqual(events[0], {
+				subdirName: "child",
+				sortKey: "M",
+				previousSortKey: undefined,
+			});
+		});
+	});
+
+	describe("Concurrent / eventual consistency", () => {
+		it("T43: Two clients set sort keys on different keys — both converge", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "1");
+			sharedDirectory2.setSortKey("b", "2");
+			containerRuntime.flush();
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b"]);
+			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], ["a", "b"]);
+		});
+
+		it("T44: Two clients set sort keys on same key — LWW by server order", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "X");
+			sharedDirectory2.setSortKey("a", "Y");
+			sharedDirectory2.setSortKey("b", "Z");
+			containerRuntime.flush();
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// Client 1's op is processed first (seq N), then client 2's (seq N+k) — so "a" lands on "Y".
+			// "a" has sort key "Y", "b" has sort key "Z", so order is a, b.
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a", "b"]);
+			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], ["a", "b"]);
+		});
+
+		it("T46: Pre-registration: setSortKey on not-yet-existing key then remote set", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.setSortKey("a", "M");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory2.set("a", 42);
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["a"]);
+			assert.deepStrictEqual([...sharedDirectory2.keysByOrder()], ["a"]);
+			assert.strictEqual(sharedDirectory.get("a"), 42);
+			assert.strictEqual(sharedDirectory2.get("a"), 42);
+		});
+
+		it("T47: Grouped batching — two setSortKey on same key in one batch", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			sharedDirectory.set("a", 1);
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.setSortKey("a", "M");
+			sharedDirectory.setSortKey("a", "Z");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			sharedDirectory.set("b", 2);
+			sharedDirectory.setSortKey("b", "N");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// "a" sort key "Z", "b" sort key "N" — so order is b, a.
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "a"]);
+		});
+
+		it("T48: Bulk iteration remains consistent under concurrent writes", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2, containerRuntime: containerRuntime2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			for (let i = 0; i < 10; i++) {
+				sharedDirectory.set(`k${i}`, i);
+				sharedDirectory.setSortKey(`k${i}`, `${10 - i}`);
+			}
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			const iter = sharedDirectory.keysByOrder();
+			// First drain 3 items
+			iter.next();
+			iter.next();
+			iter.next();
+
+			// Concurrent mutation mid-iteration
+			sharedDirectory2.setSortKey("k5", "Q");
+			containerRuntime2.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			// Finish iteration without crash
+			assert.doesNotThrow(() => {
+				let result = iter.next();
+				while (result.done !== true) {
+					result = iter.next();
+				}
+			});
+		});
+
+		it("T49: Two clients with same op stream — iteration order identical", () => {
+			const { sharedDirectory, containerRuntime, containerRuntimeFactory } = setupTest();
+			const { sharedDirectory: sharedDirectory2 } =
+				createAdditionalClient(containerRuntimeFactory);
+
+			sharedDirectory.set("a", 1);
+			sharedDirectory.set("b", 2);
+			sharedDirectory.set("c", 3);
+			sharedDirectory.setSortKey("a", "3");
+			sharedDirectory.setSortKey("b", "1");
+			sharedDirectory.setSortKey("c", "2");
+			containerRuntime.flush();
+			containerRuntimeFactory.processAllMessages();
+
+			assert.deepStrictEqual(
+				[...sharedDirectory.keysByOrder()],
+				[...sharedDirectory2.keysByOrder()],
+			);
+			assert.deepStrictEqual([...sharedDirectory.keysByOrder()], ["b", "c", "a"]);
+		});
+	});
+
+	describe("Detached state", () => {
+		function createDetached(): ISharedDirectory {
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			return directoryFactory.create(dataStoreRuntime, "detached-dir");
+		}
+
+		it("T63: setSortKey works while detached", () => {
+			const detached = createDetached();
+			detached.set("a", 1);
+			detached.setSortKey("a", "M");
+			assert.deepStrictEqual([...detached.keysByOrder()], ["a"]);
+		});
+
+		it("T64: Detached directory summary includes sort keys", () => {
+			const detached = createDetached();
+			detached.set("a", 1);
+			detached.set("b", 2);
+			detached.setSortKey("a", "M");
+			const summary = detached.getAttachSummary().summary;
+			const header = (summary.tree.header as { content: string }).content;
+			assert.ok(header.includes("sortKeys"));
+			assert.ok(header.includes('"a":"M"'));
+		});
+
+		it("T65: Attaching preserves sort keys", async () => {
+			const detached = createDetached();
+			detached.set("a", 1);
+			detached.set("b", 2);
+			detached.setSortKey("a", "M");
+			detached.setSortKey("b", "Z");
+			const summaryTree = detached.getAttachSummary().summary;
+			const snapshotTree = convertSummaryTreeToITree(summaryTree);
+
+			const runtime2 = new MockFluidDataStoreRuntime();
+			const factory = new DirectoryFactory();
+			const loaded = await factory.load(
+				runtime2,
+				"reloaded",
+				{
+					deltaConnection: runtime2.createDeltaConnection(),
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+					objectStorage: new MockStorage(JSON.parse(JSON.stringify(snapshotTree))),
+				},
+				factory.attributes,
+			);
+			assert.deepStrictEqual([...loaded.keysByOrder()], [...detached.keysByOrder()]);
+		});
+	});
+
+	describe("Back-compat — dark-ship guards", () => {
+		it("T66: Unknown setSortKey-ish op from the future — current handler processes it cleanly", () => {
+			// We exercise the message handler via applyStashedOp: the new op types are registered, so
+			// a remote op from a future client (same wire shape) lands cleanly without throwing.
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			const directory = new TestSharedDirectory(
+				"dark-ship",
+				dataStoreRuntime,
+				DirectoryFactory.Attributes,
+			);
+			const op: IDirectoryOperation = {
+				type: "setSortKey",
+				path: "/",
+				key: "a",
+				sortKey: "M",
+			};
+			assert.doesNotThrow(() => directory.testApplyStashedOp(op));
+		});
+
+		it("T67: Unknown setSubDirectorySortKey op is absorbed cleanly", () => {
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			const directory = new TestSharedDirectory(
+				"dark-ship-sub",
+				dataStoreRuntime,
+				DirectoryFactory.Attributes,
+			);
+			const op: IDirectoryOperation = {
+				type: "setSubDirectorySortKey",
+				path: "/",
+				subdirName: "sub",
+				sortKey: "M",
+			};
+			assert.doesNotThrow(() => directory.testApplyStashedOp(op));
+		});
+	});
+
+	describe("Reconnect & resubmit", () => {
+		it("T55: Pending setSortKey survives disconnect and is resubmitted", () => {
+			const runtimeFactory = new MockContainerRuntimeFactoryForReconnection();
+			const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+			const containerRuntime1 = runtimeFactory.createContainerRuntime(dataStoreRuntime1);
+			const directory1 = directoryFactory.create(dataStoreRuntime1, "dir1");
+			directory1.connect({
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			});
+
+			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+			runtimeFactory.createContainerRuntime(dataStoreRuntime2);
+			const directory2 = directoryFactory.create(dataStoreRuntime2, "dir2");
+			directory2.connect({
+				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			});
+
+			directory1.set("a", 1);
+			runtimeFactory.processAllMessages();
+
+			// Start pending setSortKey; disconnect before it flushes to the service.
+			directory1.setSortKey("a", "M");
+			containerRuntime1.connected = false;
+			containerRuntime1.connected = true;
+			runtimeFactory.processAllMessages();
+
+			assert.deepStrictEqual([...directory1.keysByOrder()], ["a"]);
+			assert.deepStrictEqual([...directory2.keysByOrder()], ["a"]);
+		});
+
+		it("T57: applyStashedOp for setSortKey restores state (detached-style, no submit)", () => {
+			// Pattern mirrors the existing applyStashedOp test for createSubDirectory: construct a
+			// TestSharedDirectory without calling .connect(), so services is undefined and
+			// submitLocalMessage no-ops. applyStashedOp still walks the state mutation path.
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			const directory = new TestSharedDirectory(
+				"stash-dir",
+				dataStoreRuntime,
+				DirectoryFactory.Attributes,
+			);
+			directory.set("a", 1);
+			directory.testApplyStashedOp({
+				type: "setSortKey",
+				path: "/",
+				key: "a",
+				sortKey: "M",
+			});
+			assert.deepStrictEqual([...directory.keysByOrder()], ["a"]);
+		});
+	});
+});

--- a/packages/dds/map/src/test/mocha/directory.sortKey.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.sortKey.spec.ts
@@ -5,21 +5,14 @@
 
 import { strict as assert } from "node:assert";
 
-import { AttachState } from "@fluidframework/container-definitions";
 import { convertSummaryTreeToITree } from "@fluidframework/runtime-utils/internal";
 import {
-	MockContainerRuntimeFactory,
 	MockContainerRuntimeFactoryForReconnection,
 	MockFluidDataStoreRuntime,
 	MockStorage,
-	type MockContainerRuntime,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import {
-	type DirectoryLocalOpMetadata,
-	type IDirectoryOperation,
-	SharedDirectory as SharedDirectoryInternal,
-} from "../../directory.js";
+import type { IDirectoryOperation } from "../../directory.js";
 import { DirectoryFactory } from "../../directoryFactory.js";
 import type {
 	IDirectorySortKeyChanged,
@@ -29,66 +22,13 @@ import type {
 	ISubDirectorySortKeyChanged,
 } from "../../interfaces.js";
 
-interface TestParts {
-	sharedDirectory: ISharedDirectory;
-	dataStoreRuntime: MockFluidDataStoreRuntime;
-	containerRuntimeFactory: MockContainerRuntimeFactory;
-	containerRuntime: MockContainerRuntime;
-}
+import {
+	createAdditionalClient,
+	setupConnectedDirectoryTest as setupTest,
+	TestSharedDirectory,
+} from "./directoryTestHelpers.js";
 
 const directoryFactory = new DirectoryFactory();
-
-function setupTest(): TestParts {
-	const containerRuntimeFactory = new MockContainerRuntimeFactory({ flushMode: 1 }); // TurnBased
-	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: "1" });
-	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
-	const sharedDirectory = directoryFactory.create(dataStoreRuntime, "shared-directory-1");
-	dataStoreRuntime.setAttachState(AttachState.Attached);
-	sharedDirectory.connect({
-		deltaConnection: dataStoreRuntime.createDeltaConnection(),
-		objectStorage: new MockStorage(),
-	});
-	return {
-		sharedDirectory,
-		dataStoreRuntime,
-		containerRuntimeFactory,
-		containerRuntime,
-	};
-}
-
-function createAdditionalClient(
-	containerRuntimeFactory: MockContainerRuntimeFactory,
-	id: string = "client-2",
-): {
-	sharedDirectory: ISharedDirectory;
-	dataStoreRuntime: MockFluidDataStoreRuntime;
-	containerRuntime: MockContainerRuntime;
-} {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
-	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
-	const sharedDirectory = directoryFactory.create(dataStoreRuntime, `shared-directory-${id}`);
-	dataStoreRuntime.setAttachState(AttachState.Attached);
-	sharedDirectory.connect({
-		deltaConnection: dataStoreRuntime.createDeltaConnection(),
-		objectStorage: new MockStorage(),
-	});
-	return { sharedDirectory, dataStoreRuntime, containerRuntime };
-}
-
-class TestSharedDirectory extends SharedDirectoryInternal {
-	private lastMetadata?: DirectoryLocalOpMetadata;
-	public testApplyStashedOp(
-		content: IDirectoryOperation,
-	): DirectoryLocalOpMetadata | undefined {
-		this.lastMetadata = undefined;
-		this.applyStashedOp(content);
-		return this.lastMetadata;
-	}
-	public submitLocalMessage(op: IDirectoryOperation, localOpMetadata: unknown): void {
-		this.lastMetadata = localOpMetadata as DirectoryLocalOpMetadata;
-		super.submitLocalMessage(op, localOpMetadata);
-	}
-}
 
 describe("SharedDirectory sort keys", () => {
 	describe("API — single client", () => {

--- a/packages/dds/map/src/test/mocha/directoryEquivalenceUtils.ts
+++ b/packages/dds/map/src/test/mocha/directoryEquivalenceUtils.ts
@@ -97,4 +97,23 @@ async function assertEventualConsistencyCore(
 	const firstSubdirNames = [...first.subdirectories()].map(([dirName, _]) => dirName);
 	const secondSubdirNames = [...second.subdirectories()].map(([dirName, _]) => dirName);
 	assert.deepStrictEqual(firstSubdirNames, secondSubdirNames);
+
+	// Check for consistency of sort-keyed iteration across clients.
+	const firstKeysByOrder = [...first.keysByOrder()];
+	const secondKeysByOrder = [...second.keysByOrder()];
+	assert.deepStrictEqual(
+		firstKeysByOrder,
+		secondKeysByOrder,
+		`keysByOrder() disagree at ${first.absolutePath}: ` +
+			`first=${JSON.stringify(firstKeysByOrder)}, second=${JSON.stringify(secondKeysByOrder)}`,
+	);
+
+	const firstSubdirByOrder = [...first.subdirectoriesByOrder()].map(([name]) => name);
+	const secondSubdirByOrder = [...second.subdirectoriesByOrder()].map(([name]) => name);
+	assert.deepStrictEqual(
+		firstSubdirByOrder,
+		secondSubdirByOrder,
+		`subdirectoriesByOrder() disagree at ${first.absolutePath}: ` +
+			`first=${JSON.stringify(firstSubdirByOrder)}, second=${JSON.stringify(secondSubdirByOrder)}`,
+	);
 }

--- a/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
+++ b/packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts
@@ -44,6 +44,8 @@ describe("SharedDirectory fuzz Create/Delete concentrated", () => {
 		deleteKeyWeight: 0,
 		createSubDirWeight: 2,
 		deleteSubDirWeight: 2,
+		setSortKeyWeight: 0,
+		setSubDirectorySortKeyWeight: 2,
 		maxSubDirectoryChild: 2,
 		subDirectoryNamePool: ["dir1", "dir2"],
 		validateInterval: dirDefaultOptions.validateInterval,

--- a/packages/dds/map/src/test/mocha/directoryTestHelpers.ts
+++ b/packages/dds/map/src/test/mocha/directoryTestHelpers.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AttachState } from "@fluidframework/container-definitions";
+import {
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+	type MockContainerRuntime,
+} from "@fluidframework/test-runtime-utils/internal";
+
+import {
+	type DirectoryLocalOpMetadata,
+	type IDirectoryOperation,
+	SharedDirectory as SharedDirectoryInternal,
+} from "../../directory.js";
+import { DirectoryFactory } from "../../directoryFactory.js";
+import type { ISharedDirectory } from "../../interfaces.js";
+
+const directoryFactory = new DirectoryFactory();
+
+/**
+ * A single attached+connected SharedDirectory client and its mock plumbing.
+ */
+export interface ConnectedDirectoryClient {
+	sharedDirectory: ISharedDirectory;
+	dataStoreRuntime: MockFluidDataStoreRuntime;
+	containerRuntime: MockContainerRuntime;
+}
+
+/**
+ * A test fixture containing a `MockContainerRuntimeFactory` plus one connected client.
+ */
+export interface ConnectedDirectoryTest extends ConnectedDirectoryClient {
+	containerRuntimeFactory: MockContainerRuntimeFactory;
+}
+
+/**
+ * Create a `MockContainerRuntimeFactory` (TurnBased) plus a single connected attached client.
+ */
+export function setupConnectedDirectoryTest(): ConnectedDirectoryTest {
+	const containerRuntimeFactory = new MockContainerRuntimeFactory({ flushMode: 1 });
+	const client = createAdditionalClient(containerRuntimeFactory, "1", "shared-directory-1");
+	return { ...client, containerRuntimeFactory };
+}
+
+/**
+ * Attach and connect another client to an existing `MockContainerRuntimeFactory`.
+ */
+export function createAdditionalClient(
+	containerRuntimeFactory: MockContainerRuntimeFactory,
+	id: string = "client-2",
+	directoryId: string = `shared-directory-${id}`,
+): ConnectedDirectoryClient {
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
+	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	const sharedDirectory = directoryFactory.create(dataStoreRuntime, directoryId);
+	dataStoreRuntime.setAttachState(AttachState.Attached);
+	sharedDirectory.connect({
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	});
+	return { sharedDirectory, dataStoreRuntime, containerRuntime };
+}
+
+/**
+ * `SharedDirectoryInternal` with hooks for capturing local op metadata and invoking `applyStashedOp`
+ * from tests.
+ */
+export class TestSharedDirectory extends SharedDirectoryInternal {
+	private lastMetadata?: DirectoryLocalOpMetadata;
+	public testApplyStashedOp(content: IDirectoryOperation): DirectoryLocalOpMetadata | undefined {
+		this.lastMetadata = undefined;
+		this.applyStashedOp(content);
+		return this.lastMetadata;
+	}
+	public submitLocalMessage(op: IDirectoryOperation, localOpMetadata: unknown): void {
+		this.lastMetadata = localOpMetadata as DirectoryLocalOpMetadata;
+		super.submitLocalMessage(op, localOpMetadata);
+	}
+}

--- a/packages/dds/map/src/test/mocha/fuzzUtils.ts
+++ b/packages/dds/map/src/test/mocha/fuzzUtils.ts
@@ -213,14 +213,37 @@ export interface DeleteSubDirectory {
 }
 
 /**
+ * Represents a set-sort-key operation on a key in a directory.
+ */
+export interface DirSetSortKey {
+	type: "setSortKey";
+	path: string;
+	key: string;
+	sortKey: string | undefined;
+}
+
+/**
+ * Represents a set-sort-key operation on a child subdirectory.
+ */
+export interface DirSetSubDirectorySortKey {
+	type: "setSubDirectorySortKey";
+	path: string;
+	name: string;
+	sortKey: string | undefined;
+}
+
+/**
  * Represents a directory key operation.
  */
-export type DirKeyOperation = DirSetKey | DirDeleteKey | DirClearKeys;
+export type DirKeyOperation = DirSetKey | DirDeleteKey | DirClearKeys | DirSetSortKey;
 
 /**
  * Represents a subdirectory operation.
  */
-export type SubDirectoryOperation = CreateSubDirectory | DeleteSubDirectory;
+export type SubDirectoryOperation =
+	| CreateSubDirectory
+	| DeleteSubDirectory
+	| DirSetSubDirectorySortKey;
 
 /**
  * Represents a directory operation.
@@ -235,11 +258,14 @@ export interface DirOperationGenerationConfig {
 	maxSubDirectoryChild?: number;
 	subDirectoryNamePool?: string[];
 	keyNamePool?: string[];
+	sortKeyPool?: (string | undefined)[];
 	setKeyWeight?: number;
 	deleteKeyWeight?: number;
 	clearKeysWeight?: number;
 	createSubDirWeight?: number;
 	deleteSubDirWeight?: number;
+	setSortKeyWeight?: number;
+	setSubDirectorySortKeyWeight?: number;
 }
 
 /**
@@ -250,11 +276,14 @@ export const dirDefaultOptions: Required<DirOperationGenerationConfig> = {
 	maxSubDirectoryChild: 3,
 	subDirectoryNamePool: ["dir1", "dir2", "dir3"],
 	keyNamePool: ["prop1", "prop2", "prop3"],
+	sortKeyPool: ["A", "B", "C", "", undefined],
 	setKeyWeight: 5,
 	deleteKeyWeight: 2,
 	clearKeysWeight: 1,
 	createSubDirWeight: 2,
 	deleteSubDirWeight: 1,
+	setSortKeyWeight: 2,
+	setSubDirectorySortKeyWeight: 2,
 };
 
 /**
@@ -406,6 +435,28 @@ export function makeDirOperationGenerator(
 		};
 	}
 
+	async function setSortKey(state: DirFuzzTestState): Promise<DirSetSortKey> {
+		const { random } = state;
+		return {
+			type: "setSortKey",
+			key: random.pick(options.keyNamePool),
+			path: pickAbsolutePathForKeyOps(state, false),
+			sortKey: random.pick(options.sortKeyPool),
+		};
+	}
+
+	async function setSubDirectorySortKey(
+		state: DirFuzzTestState,
+	): Promise<DirSetSubDirectorySortKey> {
+		const { random } = state;
+		return {
+			type: "setSubDirectorySortKey",
+			name: random.pick(options.subDirectoryNamePool),
+			path: pickAbsolutePathForCreateDirectoryOp(state),
+			sortKey: random.pick(options.sortKeyPool),
+		};
+	}
+
 	return createWeightedAsyncGenerator<DirOperation, DirFuzzTestState>([
 		[createSubDirectory, options.createSubDirWeight],
 		[
@@ -425,6 +476,8 @@ export function makeDirOperationGenerator(
 			options.clearKeysWeight,
 			(state: DirFuzzTestState): boolean => state.client.channel.size > 0,
 		],
+		[setSortKey, options.setSortKeyWeight],
+		[setSubDirectorySortKey, options.setSubDirectorySortKeyWeight],
 	]);
 }
 
@@ -507,6 +560,16 @@ export function makeDirReducer(
 			assert(dir);
 			dir.delete(key);
 		},
+		setSortKey: ({ client }, { path, key, sortKey }) => {
+			const dir = client.channel.getWorkingDirectory(path);
+			assert(dir);
+			dir.setSortKey(key, sortKey);
+		},
+		setSubDirectorySortKey: ({ client }, { path, name, sortKey }) => {
+			const dir = client.channel.getWorkingDirectory(path);
+			assert(dir);
+			dir.setSubDirectorySortKey(name, sortKey);
+		},
 	});
 
 	return withLogging(reducer);
@@ -535,7 +598,8 @@ export const baseDirModel: DDSFuzzModel<DirectoryFactory, DirOperation> = {
 			if (
 				isOperationType<DirSetKey>("set", op) ||
 				isOperationType<DirDeleteKey>("delete", op) ||
-				isOperationType<DirClearKeys>("clear", op)
+				isOperationType<DirClearKeys>("clear", op) ||
+				isOperationType<DirSetSortKey>("setSortKey", op)
 			) {
 				const lastPath = op.path.lastIndexOf("/");
 				if (lastPath !== -1) {

--- a/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
+++ b/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
@@ -204,6 +204,7 @@ declare type current_as_old_for_Interface_IValueChanged = requireAssignableTo<Ty
  * typeValidation.broken:
  * "TypeAlias_SharedDirectory": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_SharedDirectory = requireAssignableTo<TypeOnly<old.SharedDirectory>, TypeOnly<current.SharedDirectory>>
 
 /*

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -50,6 +50,15 @@ parameters:
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
+# Rollout switch for scoping PR test execution to packages changed by the PR
+# (plus their transitive dependents). When false, scoping still activates
+# automatically for PR builds whose source branch contains 'test/filtered-ci/'
+# — a magic substring used to verify the feature end-to-end before general
+# rollout. See build-npm-client-package.yml for the full rules.
+- name: enableChangedPackageTestScoping
+  displayName: Scope tests to changed packages (PR builds only)
+  type: boolean
+  default: false
 
 trigger:
   branches:
@@ -199,6 +208,7 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     packageTypesOverride: ${{ parameters.packageTypesOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+    enableChangedPackageTestScoping: ${{ parameters.enableChangedPackageTestScoping }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -50,12 +50,6 @@ parameters:
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
-# Rollout switch for scoping PR test execution to changed packages.
-# See build-npm-client-package.yml for the full activation rules.
-- name: enableChangedPackageTestScoping
-  displayName: Scope tests to changed packages (PR builds only)
-  type: boolean
-  default: false
 
 trigger:
   branches:
@@ -205,7 +199,6 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     packageTypesOverride: ${{ parameters.packageTypesOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
-    enableChangedPackageTestScoping: ${{ parameters.enableChangedPackageTestScoping }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -50,11 +50,8 @@ parameters:
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
-# Rollout switch for scoping PR test execution to packages changed by the PR
-# (plus their transitive dependents). When false, scoping still activates
-# automatically for PR builds whose source branch contains 'test/filtered-ci/'
-# — a magic substring used to verify the feature end-to-end before general
-# rollout. See build-npm-client-package.yml for the full rules.
+# Rollout switch for scoping PR test execution to changed packages.
+# See build-npm-client-package.yml for the full activation rules.
 - name: enableChangedPackageTestScoping
   displayName: Scope tests to changed packages (PR builds only)
   type: boolean

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,17 +129,6 @@ parameters:
   type: boolean
   default: false
 
-# Feature flag: when true, PR builds scope test execution to packages
-# affected by the PR diff (plus transitive dependents) via pnpm's native
-# `--filter "...[<merge-base>]"`. Also activates when the PR source branch
-# name contains 'test/filtered-ci/' — a rollout opt-in for exercising the
-# behavior from an auto-triggered PR build without flipping a parameter at
-# queue time. Non-opt-in runs remain effectively byte-identical to today.
-# See include-detect-changed-packages.yml for the full filter semantics.
-- name: enableChangedPackageTestScoping
-  type: boolean
-  default: false
-
 # The `resources` specify the location and version of the 1ES Pipeline Template.
 resources:
   repositories:
@@ -218,17 +207,16 @@ extends:
         dependsOn: [] # this stage doesn't depend on preceding stage
         jobs:
           # Detect packages changed by this PR; publishes output variables that
-          # scope downstream test jobs. Skipped for non-PR builds and non-opt-in
-          # PRs; see include-detect-changed-packages.yml for the full semantics.
+          # scope downstream test jobs. Activated only for PR builds whose
+          # source branch name contains 'test/filtered-ci/' — a rollout opt-in
+          # to be broadened once the feature has soaked. See
+          # include-detect-changed-packages.yml for the full semantics.
           - job: detect_changes
             displayName: Detect changed packages
             condition: >-
               and(
                 eq(variables['Build.Reason'], 'PullRequest'),
-                or(
-                  eq('${{ parameters.enableChangedPackageTestScoping }}', 'True'),
-                  contains(variables['System.PullRequest.SourceBranch'], 'test/filtered-ci/')
-                )
+                contains(variables['System.PullRequest.SourceBranch'], 'test/filtered-ci/')
               )
             variables:
               - name: targetBranchName

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,24 +129,13 @@ parameters:
   type: boolean
   default: false
 
-# Feature flag: when true, PR builds run a `detect_changes` job up front
-# and scope subsequent test execution to packages affected by the PR diff
-# (plus their transitive dependents). Scoping is applied natively by pnpm
-# via `npm_config_filter="...[<merge-base>]"`, so no wrapper scripts or
-# package.json changes are needed.
-#
-# The detect_changes job is always compiled into the pipeline but runs
-# conditionally at build time. It executes when all of these are true:
-#   (1) Build.Reason == 'PullRequest' (scoping only makes sense for PRs)
-#   (2) this parameter is true,
-#       OR the PR source branch name contains 'test/filtered-ci/' — a magic
-#       branch-name prefix that lets contributors exercise the scoped
-#       behavior from an auto-triggered PR build without flipping a
-#       parameter at queue time.
-# When the condition is false the job is skipped; its output variables
-# resolve to empty strings, and downstream test jobs interpret that as
-# "no filter — run every package" (the historical behavior). So the
-# pipeline remains effectively byte-identical for non-opt-in runs.
+# Feature flag: when true, PR builds scope test execution to packages
+# affected by the PR diff (plus transitive dependents) via pnpm's native
+# `--filter "...[<merge-base>]"`. Also activates when the PR source branch
+# name contains 'test/filtered-ci/' — a rollout opt-in for exercising the
+# behavior from an auto-triggered PR build without flipping a parameter at
+# queue time. Non-opt-in runs remain effectively byte-identical to today.
+# See include-detect-changed-packages.yml for the full filter semantics.
 - name: enableChangedPackageTestScoping
   type: boolean
   default: false
@@ -228,14 +217,9 @@ extends:
         displayName: Build Stage
         dependsOn: [] # this stage doesn't depend on preceding stage
         jobs:
-          # Detect packages changed by this PR so downstream test jobs can
-          # scope via pnpm's `--filter "...[<sha>]"` selector (set as
-          # `npm_config_filter`). Always compiled in, but skipped at runtime
-          # for non-PR builds and for PR builds that haven't opted into
-          # scoping (neither the parameter set nor the magic branch name).
-          # When skipped, the output variables resolve to empty strings,
-          # which downstream jobs interpret as "run every package" — the
-          # historical behavior.
+          # Detect packages changed by this PR; publishes output variables that
+          # scope downstream test jobs. Skipped for non-PR builds and non-opt-in
+          # PRs; see include-detect-changed-packages.yml for the full semantics.
           - job: detect_changes
             displayName: Detect changed packages
             condition: >-
@@ -613,6 +597,11 @@ extends:
             dependsOn:
               - build
               - detect_changes
+            # Skip the job entirely when detect_changes explicitly concluded no
+            # packages were affected — saves agent allocation, checkout, and
+            # install on scoped PRs. Empty (detect_changes was skipped) still
+            # runs. See include-detect-changed-packages.yml for the invariants.
+            condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -628,12 +617,10 @@ extends:
                 value: 'false'
               - name: COMMIT_SHA
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-              # Outputs from the detect_changes job. Empty when the job was
-              # skipped (non-PR builds, or PR builds that didn't opt into
-              # scoping) — downstream steps interpret that as "run every
-              # package", matching the historical behavior.
-              - name: shouldRunTests
-                value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+              # Output from detect_changes; empty when that job was skipped
+              # (interpreted downstream as "full run" — the historical behavior).
+              # `shouldRunTests` is consumed via the job-level condition above,
+              # so only `scopedPnpmFilter` needs a job-scoped variable here.
               - name: scopedPnpmFilter
                 value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
 
@@ -678,14 +665,9 @@ extends:
 
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
-              # The extra `ne(shouldRunTests, 'false')` guard skips test execution
-              # when the detect job explicitly concluded no packages were affected.
-              # An empty `shouldRunTests` (the job was skipped entirely) still lets
-              # tests run — matching the historical "no scoping" behavior.
               - script: |
                   echo "##vso[task.setvariable variable=startTest]true"
                 displayName: Start Test
-                condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
               - ${{ each test in parameters.coverageTests }}:
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -790,6 +772,11 @@ extends:
               dependsOn:
                 - build
                 - detect_changes
+              # Skip the job entirely when detect_changes explicitly concluded no
+              # packages were affected — saves agent allocation, checkout, and
+              # install on scoped PRs. Empty (detect_changes was skipped) still
+              # runs. See include-detect-changed-packages.yml for the invariants.
+              condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName
@@ -805,12 +792,10 @@ extends:
                   value: 'false'
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-                # Outputs from the detect_changes job. Empty when the job was
-                # skipped (non-PR builds, or PR builds that didn't opt into
-                # scoping) — downstream steps interpret that as "run every
-                # package", matching the historical behavior.
-                - name: shouldRunTests
-                  value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+                # Output from detect_changes; empty when that job was skipped
+                # (interpreted downstream as "full run" — the historical behavior).
+                # `shouldRunTests` is consumed via the job-level condition above,
+                # so only `scopedPnpmFilter` needs a job-scoped variable here.
                 - name: scopedPnpmFilter
                   value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
               steps:
@@ -849,14 +834,9 @@ extends:
 
                 # Set variable startTest if everything is good so far and we'll start running tests,
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
-                # The extra `ne(shouldRunTests, 'false')` guard skips test execution
-                # when the detect job explicitly concluded no packages were affected.
-                # An empty `shouldRunTests` (the job was skipped entirely) still lets
-                # tests run — matching the historical "no scoping" behavior.
                 - script: |
                     echo "##vso[task.setvariable variable=startTest]true"
                   displayName: Start Test
-                  condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
                   parameters:

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -601,7 +601,11 @@ extends:
             # packages were affected — saves agent allocation, checkout, and
             # install on scoped PRs. Empty (detect_changes was skipped) still
             # runs. See include-detect-changed-packages.yml for the invariants.
-            condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
+            #
+            # We check `build.result` directly instead of using `succeeded()`
+            # because the latter treats a Skipped `detect_changes` dependency
+            # as non-success and false-skips this job on non-opt-in PR builds.
+            condition: and(in(dependencies.build.result, 'Succeeded', 'SucceededWithIssues'), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -776,7 +780,11 @@ extends:
               # packages were affected — saves agent allocation, checkout, and
               # install on scoped PRs. Empty (detect_changes was skipped) still
               # runs. See include-detect-changed-packages.yml for the invariants.
-              condition: and(succeeded(), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
+              #
+              # We check `build.result` directly instead of using `succeeded()`
+              # because the latter treats a Skipped `detect_changes` dependency
+              # as non-success and false-skips this job on non-opt-in PR builds.
+              condition: and(in(dependencies.build.result, 'Succeeded', 'SucceededWithIssues'), ne(dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'], 'false'))
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -129,6 +129,28 @@ parameters:
   type: boolean
   default: false
 
+# Feature flag: when true, PR builds run a `detect_changes` job up front
+# and scope subsequent test execution to packages affected by the PR diff
+# (plus their transitive dependents). Scoping is applied natively by pnpm
+# via `npm_config_filter="...[<merge-base>]"`, so no wrapper scripts or
+# package.json changes are needed.
+#
+# The detect_changes job is always compiled into the pipeline but runs
+# conditionally at build time. It executes when all of these are true:
+#   (1) Build.Reason == 'PullRequest' (scoping only makes sense for PRs)
+#   (2) this parameter is true,
+#       OR the PR source branch name contains 'test/filtered-ci/' — a magic
+#       branch-name prefix that lets contributors exercise the scoped
+#       behavior from an auto-triggered PR build without flipping a
+#       parameter at queue time.
+# When the condition is false the job is skipped; its output variables
+# resolve to empty strings, and downstream test jobs interpret that as
+# "no filter — run every package" (the historical behavior). So the
+# pipeline remains effectively byte-identical for non-opt-in runs.
+- name: enableChangedPackageTestScoping
+  type: boolean
+  default: false
+
 # The `resources` specify the location and version of the 1ES Pipeline Template.
 resources:
   repositories:
@@ -206,6 +228,33 @@ extends:
         displayName: Build Stage
         dependsOn: [] # this stage doesn't depend on preceding stage
         jobs:
+          # Detect packages changed by this PR so downstream test jobs can
+          # scope via pnpm's `--filter "...[<sha>]"` selector (set as
+          # `npm_config_filter`). Always compiled in, but skipped at runtime
+          # for non-PR builds and for PR builds that haven't opted into
+          # scoping (neither the parameter set nor the magic branch name).
+          # When skipped, the output variables resolve to empty strings,
+          # which downstream jobs interpret as "run every package" — the
+          # historical behavior.
+          - job: detect_changes
+            displayName: Detect changed packages
+            condition: >-
+              and(
+                eq(variables['Build.Reason'], 'PullRequest'),
+                or(
+                  eq('${{ parameters.enableChangedPackageTestScoping }}', 'True'),
+                  contains(variables['System.PullRequest.SourceBranch'], 'test/filtered-ci/')
+                )
+              )
+            variables:
+              - name: targetBranchName
+                value: $(System.PullRequest.TargetBranch)
+            steps:
+              - template: /tools/pipelines/templates/include-detect-changed-packages.yml@self
+                parameters:
+                  buildDirectory: ${{ parameters.buildDirectory }}
+                  targetBranchName: $(targetBranchName)
+
           # Job - Build
           - job: build
             displayName: Build
@@ -561,7 +610,9 @@ extends:
 
           - job: Coverage_tests
             displayName: "Coverage tests"
-            dependsOn: build
+            dependsOn:
+              - build
+              - detect_changes
             variables:
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
@@ -577,6 +628,14 @@ extends:
                 value: 'false'
               - name: COMMIT_SHA
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+              # Outputs from the detect_changes job. Empty when the job was
+              # skipped (non-PR builds, or PR builds that didn't opt into
+              # scoping) — downstream steps interpret that as "run every
+              # package", matching the historical behavior.
+              - name: shouldRunTests
+                value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+              - name: scopedPnpmFilter
+                value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
 
             steps:
               # Setup
@@ -619,9 +678,14 @@ extends:
 
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
+              # The extra `ne(shouldRunTests, 'false')` guard skips test execution
+              # when the detect job explicitly concluded no packages were affected.
+              # An empty `shouldRunTests` (the job was skipped entirely) still lets
+              # tests run — matching the historical "no scoping" behavior.
               - script: |
                   echo "##vso[task.setvariable variable=startTest]true"
                 displayName: Start Test
+                condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
               - ${{ each test in parameters.coverageTests }}:
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -629,6 +693,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: '${{ parameters.testCoverage }}'
+                    pnpmFilter: $(scopedPnpmFilter)
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
@@ -722,7 +787,9 @@ extends:
           - ${{ each test in parameters.taskTest }}:
             - job: Test_${{ test.jobName }}
               displayName: "Run Task Test ${{ test.jobName }}"
-              dependsOn: build
+              dependsOn:
+                - build
+                - detect_changes
               variables:
                 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                   - name: targetBranchName
@@ -738,6 +805,14 @@ extends:
                   value: 'false'
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                # Outputs from the detect_changes job. Empty when the job was
+                # skipped (non-PR builds, or PR builds that didn't opt into
+                # scoping) — downstream steps interpret that as "run every
+                # package", matching the historical behavior.
+                - name: shouldRunTests
+                  value: $[ dependencies.detect_changes.outputs['setChangedPackages.shouldRunTests'] ]
+                - name: scopedPnpmFilter
+                  value: $[ dependencies.detect_changes.outputs['setChangedPackages.scopedPnpmFilter'] ]
               steps:
                 # Setup
                 - checkout: self
@@ -774,15 +849,21 @@ extends:
 
                 # Set variable startTest if everything is good so far and we'll start running tests,
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
+                # The extra `ne(shouldRunTests, 'false')` guard skips test execution
+                # when the detect job explicitly concluded no packages were affected.
+                # An empty `shouldRunTests` (the job was skipped entirely) still lets
+                # tests run — matching the historical "no scoping" behavior.
                 - script: |
                     echo "##vso[task.setvariable variable=startTest]true"
                   displayName: Start Test
+                  condition: and(succeeded(), ne(variables['shouldRunTests'], 'false'))
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
                   parameters:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: 'false'
+                    pnpmFilter: $(scopedPnpmFilter)
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'

--- a/tools/pipelines/templates/include-detect-changed-packages.yml
+++ b/tools/pipelines/templates/include-detect-changed-packages.yml
@@ -44,9 +44,10 @@ steps:
   - checkout: self
     path: $(FluidFrameworkDirectory)
     clean: true
-    # Full history is required for `git merge-base HEAD origin/<target>` to
-    # produce a meaningful ancestor on a PR branch.
-    fetchDepth: 0
+    # Shallow clone; the bash step below unshallows on demand if the
+    # merge-base can't be resolved within this depth. Most PRs merge-base
+    # within a few hundred commits, so this is cheap in the common case.
+    fetchDepth: 200
 
   - task: Bash@3
     name: setChangedPackages
@@ -79,7 +80,17 @@ steps:
           emit_and_exit
         fi
 
+        # Try to resolve the merge-base in the shallow clone first. If the
+        # PR diverged further back than the shallow boundary, unshallow and
+        # retry once. The presence of a `shallow` file under `.git` is how
+        # git marks a shallow repo; skip the unshallow on a full clone
+        # (which would error with "--unshallow on a complete repository").
         MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)"
+        if [ -z "${MERGE_BASE}" ] && [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+          echo "Merge-base not found in shallow clone; unshallowing and retrying."
+          git fetch --unshallow origin "${TARGET_BRANCH}" 2>/dev/null || true
+          MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)"
+        fi
         if [ -z "${MERGE_BASE}" ]; then
           echo "##vso[task.logissue type=warning]No merge-base with origin/${TARGET_BRANCH}; falling back to full test run."
           emit_and_exit
@@ -99,6 +110,14 @@ steps:
         # across the whole workspace).
         # Keep this list conservative — it's the safety net for changes that
         # could plausibly invalidate assumptions across the entire workspace.
+        #
+        # This list partially overlaps with `pr: paths: include:` in
+        # tools/pipelines/build-client.yml (which decides whether the pipeline
+        # runs at all). The concepts differ — one gates the pipeline, the
+        # other gates scoping within a pipeline that's already running — but
+        # adding a new cross-cutting root-level file generally warrants
+        # updating both. There's no programmatic link, so keep them in sync
+        # by convention.
         FULL_RUN_PATTERNS=(
           '^package\.json$'
           '^pnpm-lock\.yaml$'

--- a/tools/pipelines/templates/include-detect-changed-packages.yml
+++ b/tools/pipelines/templates/include-detect-changed-packages.yml
@@ -1,0 +1,149 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-detect-changed-packages
+#
+# Detects whether a PR's diff warrants scoping downstream test execution to
+# a subset of workspace packages and publishes output variables that test
+# jobs read to make that decision.
+#
+# The scoping itself is handled natively by pnpm via the
+# `--filter "...[<ref>]"` selector — this template just computes the right
+# git ref (the merge-base between HEAD and the target branch) and emits it
+# as a ready-to-use filter string that downstream jobs set as
+# `npm_config_filter`. pnpm then picks up the env var automatically and
+# applies it to any `pnpm -r run <task>` invocation. That keeps the root
+# package.json scripts unchanged and removes the need for a custom wrapper.
+#
+# Output variables (from the `setChangedPackages` step):
+#   - shouldRunTests    "true" | "false"  — whether any test work is needed at all
+#   - scopedPnpmFilter  The pnpm filter string ("...[<sha>]") when scoping is
+#                       active, or an empty string when a full test run is
+#                       required. Downstream jobs pass this into
+#                       `npm_config_filter` verbatim; pnpm treats an empty
+#                       value as "no filter applied", so recursive `-r` runs
+#                       fall back to the historical every-package behavior.
+#
+# On any error path (missing merge-base, unsupported ref format) this
+# template degrades safely to a full-run outcome, never to a silent skip.
+#
+# Why merge-base (and not just `origin/<branch>` directly): pnpm's
+# `--filter "[ref]"` uses a two-dot diff internally (see pnpm/pnpm#9907), so
+# commits that landed on `origin/<branch>` after this PR diverged would show
+# up as "changed." Computing the merge-base SHA ourselves and feeding that
+# SHA into the selector gives three-dot (merge-base) semantics.
+
+parameters:
+- name: buildDirectory
+  type: string
+
+- name: targetBranchName
+  type: string
+
+steps:
+  - checkout: self
+    path: $(FluidFrameworkDirectory)
+    clean: true
+    # Full history is required for `git merge-base HEAD origin/<target>` to
+    # produce a meaningful ancestor on a PR branch.
+    fetchDepth: 0
+
+  - task: Bash@3
+    name: setChangedPackages
+    displayName: Detect changed packages
+    inputs:
+      targetType: inline
+      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+      script: |
+        set -eu -o pipefail
+
+        # Normalize: ADO returns "refs/heads/main" on Azure Repos, just "main" on GitHub.
+        TARGET_BRANCH="${{ parameters.targetBranchName }}"
+        TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
+        echo "Target branch: ${TARGET_BRANCH}"
+
+        # Safe fallback is always a full run — non-empty filter would be a skip.
+        SHOULD_RUN="true"
+        FILTER=""
+
+        emit_and_exit() {
+          echo "shouldRunTests=${SHOULD_RUN}"
+          echo "scopedPnpmFilter=${FILTER}"
+          echo "##vso[task.setvariable variable=shouldRunTests;isOutput=true]${SHOULD_RUN}"
+          echo "##vso[task.setvariable variable=scopedPnpmFilter;isOutput=true]${FILTER}"
+          exit 0
+        }
+
+        if ! git fetch origin "${TARGET_BRANCH}"; then
+          echo "##vso[task.logissue type=warning]Could not fetch origin/${TARGET_BRANCH}; falling back to full test run."
+          emit_and_exit
+        fi
+
+        MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || true)"
+        if [ -z "${MERGE_BASE}" ]; then
+          echo "##vso[task.logissue type=warning]No merge-base with origin/${TARGET_BRANCH}; falling back to full test run."
+          emit_and_exit
+        fi
+        echo "Merge base: ${MERGE_BASE}"
+
+        CHANGED_FILES="$(git diff --name-only "${MERGE_BASE}" || true)"
+        FILE_COUNT="$(printf '%s\n' "${CHANGED_FILES}" | grep -c . || true)"
+        echo "Changed files (${FILE_COUNT}):"
+        printf '%s\n' "${CHANGED_FILES}" | head -30
+        if [ "${FILE_COUNT}" -gt 30 ]; then
+          echo "... and $((FILE_COUNT - 30)) more"
+        fi
+
+        # Full-run trigger patterns. A diff touching any of these paths forces
+        # running every package's tests (FILTER stays empty → pnpm -r runs
+        # across the whole workspace).
+        # Keep this list conservative — it's the safety net for changes that
+        # could plausibly invalidate assumptions across the entire workspace.
+        FULL_RUN_PATTERNS=(
+          '^package\.json$'
+          '^pnpm-lock\.yaml$'
+          '^pnpm-workspace\.yaml$'
+          '^fluidBuild\.config\.cjs$'
+          '^tsconfig[^/]*\.json$'
+          '^biome\.'
+          '^tools/'
+          '^common/'
+          '^scripts/'
+          '^\.changeset/config\.json$'
+        )
+        for pattern in "${FULL_RUN_PATTERNS[@]}"; do
+          if printf '%s\n' "${CHANGED_FILES}" | grep -Eq "${pattern}"; then
+            echo "Match for full-run pattern '${pattern}' — forcing full test run."
+            emit_and_exit
+          fi
+        done
+
+        # Quick sanity check: did any changed file land under a package dir
+        # (anything with a package.json below the repo root)? If not, there's
+        # no test work to do at all and we can short-circuit.
+        HAS_PACKAGE_CHANGE="false"
+        while IFS= read -r file; do
+          [ -z "${file}" ] && continue
+          d="$(dirname "${file}")"
+          while [ "${d}" != "." ] && [ "${d}" != "/" ]; do
+            if [ -f "${d}/package.json" ]; then
+              HAS_PACKAGE_CHANGE="true"
+              break 2
+            fi
+            d="$(dirname "${d}")"
+          done
+        done <<< "${CHANGED_FILES}"
+
+        if [ "${HAS_PACKAGE_CHANGE}" = "false" ]; then
+          echo "No changed files mapped to a workspace package — skipping test execution."
+          SHOULD_RUN="false"
+          FILTER=""
+          emit_and_exit
+        fi
+
+        # Hand the merge-base SHA to pnpm's native selector. The leading `...`
+        # pulls in transitive dependents so consumers of a changed package
+        # also get re-tested.
+        FILTER="...[${MERGE_BASE}]"
+        echo "Computed pnpm filter: ${FILTER}"
+        emit_and_exit

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -14,6 +14,14 @@ parameters:
   type: boolean
   default: false
 
+# Optional pnpm filter expression (e.g. "...[<sha>]"). When non-empty, it is
+# set as `npm_config_filter` so pnpm scopes the recursive run to the listed
+# packages plus their dependents. Empty means "no filter" — pnpm falls back
+# to running across every workspace package (the historical behavior).
+- name: pnpmFilter
+  type: string
+  default: ''
+
 steps:
 # Test - With coverage
 - ${{ if and(parameters.testCoverage, startsWith(parameters.taskTestStep, 'ci:test')) }}:
@@ -25,6 +33,7 @@ steps:
       customCommand: 'run ${{ parameters.taskTestStep }}:coverage'
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
+      npm_config_filter: ${{ parameters.pnpmFilter }}
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
         # Disable colorization for tinylicious logs (not useful when printing to a file)
@@ -41,6 +50,7 @@ steps:
       customCommand: 'run ${{ parameters.taskTestStep }}'
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
+      npm_config_filter: ${{ parameters.pnpmFilter }}
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
         # Disable colorization for tinylicious logs (not useful when printing to a file)


### PR DESCRIPTION
## Summary

Adds a replicated, opt-in custom iteration order to `SharedDirectory` driven by string "sort keys" attached to individual keys and child subdirectories. The existing default iteration order is unchanged.

### What's new

**API additions on `IDirectory` / `ISharedDirectory`:**
- `setSortKey(key, sortKey | undefined)` / `setSubDirectorySortKey(name, sortKey | undefined)` — set or clear (via `undefined`) a sort key.
- `keysByOrder()` / `valuesByOrder()` / `entriesByOrder()` — iterate entries in sort-key order.
- `subdirectoriesByOrder()` — iterate child subdirectories in sort-key order.
- New events `sortKeyChanged` / `subDirectorySortKeyChanged` (path-carrying) on `ISharedDirectoryEvents`; `containedSortKeyChanged` / `containedSubDirectorySortKeyChanged` on `IDirectoryEvents`.

### Semantics

Sort-keyed entries iterate first, in lexicographic order of the sort key (JS `<`, UTF-16 code points). Entries without a sort key follow, in the existing iteration order. Ties on sort key break by the default iteration order — so ordering is deterministic across clients.

Sort keys live alongside the entry they annotate: `delete(k)` clears the entry's sort key, `clear()` clears all sort keys in the directory, and `deleteSubDirectory(name)` clears the child's sort key on the parent.

### Replication and back-compat

- Two new ops (`setSortKey`, `setSubDirectorySortKey`) are wired through the existing pending/sequenced model with reference-identity ack matching. Rollback, reconnect-resubmit, and `applyStashedOp` paths are extended symmetrically.
- Snapshot gains optional additive fields `sortKeys?` / `subdirectorySortKeys?` on `IDirectoryDataObject`. The directory snapshot format stays at `0.1` — older readers silently ignore the new fields.
- Adding methods to `IDirectory` is a forward-compat break; declared in `package.json` `typeValidation.broken`. Back-compat is preserved.

### Docs and plan

- Full plan and test specification in `packages/dds/map/SORT-KEYS-PLAN.md` (includes implementation status, deviations from the original design, and a resume-in-fresh-session guide).
- Internal architecture notes in `packages/dds/map/ARCHITECTURE.md` §9.4 + §11.

### Status

47 of 67 planned tests landed in `packages/dds/map/src/test/mocha/directory.sortKey.spec.ts`. 20 follow-on tests (deferred rollback / snapshot round-trip / fuzz, plus a few edge-case spec entries) are enumerated at the top of `SORT-KEYS-PLAN.md` for a follow-up PR; all their implementation paths are covered by the landed code.

Draft — API Council review required (surfaces `@public @legacy` and `@beta @legacy` types).