### PR TITLE
fix(test): add driverTenantName telemetry to stress tests and benchmarks

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -69,6 +69,7 @@ export function createDocument(props: IDocumentCreatorProps): IDocumentLoaderAnd
 				namespace: "FFEngineering",
 				driverType: props.provider.driver.type,
 				driverEndpointName: props.provider.driver.endpointName,
+				driverTenantName: props.provider.driver.tenantName,
 				testDocument: props.testName,
 				testDocumentType: props.documentType,
 				details: JSON.stringify(props.documentTypeInfo),

--- a/packages/test/test-service-load/src/FileLogger.ts
+++ b/packages/test/test-service-load/src/FileLogger.ts
@@ -41,6 +41,7 @@ export const createLogger = async (
 	dimensions: {
 		driverType: string;
 		driverEndpointName: string | undefined;
+		driverTenantName: string | undefined;
 		profile: string;
 		runId: number | undefined;
 	},

--- a/packages/test/test-service-load/src/main.ts
+++ b/packages/test/test-service-load/src/main.ts
@@ -98,6 +98,7 @@ const main = async (): Promise<void> => {
 	const { logger, flush } = await createLogger(outputDir, "orchestrator", {
 		driverType: testDriver.type,
 		driverEndpointName: testDriver.endpointName,
+		driverTenantName: testDriver.tenantName,
 		profile: profileName,
 		runId: undefined,
 	});

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -70,6 +70,7 @@ async function main(): Promise<void> {
 		.requiredOption("-s, --seed <number>", "Seed for this runners random number generator")
 		.requiredOption("-o, --outputDir <path>", "Path for log output files")
 		.option("-e, --driverEndpoint <endpoint>", "Which endpoint should the driver target?")
+		.option("--driverTenantName <name>", "The tenant name for the driver")
 		.option(
 			"-l, --log <filter>",
 			"Filter debug logging. If not provided, uses DEBUG env variable.",
@@ -80,6 +81,7 @@ async function main(): Promise<void> {
 
 	const driver: TestDriverTypes = commander.driver;
 	const endpoint: DriverEndpoint | undefined = commander.driverEndpoint;
+	const tenantName: string | undefined = commander.driverTenantName;
 	const profileName: string = commander.profile;
 	const url: string = commander.url;
 	const runId: number = commander.runId;
@@ -97,6 +99,7 @@ async function main(): Promise<void> {
 		runId,
 		driverType: driver,
 		driverEndpointName: endpoint,
+		driverTenantName: tenantName,
 		profile: profileName,
 	});
 

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -105,6 +105,10 @@ export async function stressTest(
 			childArgs.push(`--driverEndpoint`, testDriver.endpointName);
 		}
 
+		if (testDriver.tenantName !== undefined) {
+			childArgs.push(`--driverTenantName`, testDriver.tenantName);
+		}
+
 		runnerArgs.push(childArgs);
 	}
 	console.log(runnerArgs.map((a) => a.join(" ")).join("\n"));


### PR DESCRIPTION
## Description

* Adding the driverTenantName in OSDP.
* Only OdspTestDriver implements ITestDriver.tenantName (derived from the ODSP test user's email domain). According to claude: RouterliciousTestDriver has an internal tenantId but does not expose it as tenantName. TinyliciousTestDriver and LocalServerTestDriver have no tenant concept. For non-ODSP drivers, driverTenantName will log as undefined.
* Change is pure plumbing so no real of testing until the PR is merged and we can rerun the kusto query to confirm `Data_driverTenantName` is populated.

fixes [AB#58597](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/58597)