### PR TITLE
fix(ci): unbreak pr-review-confirm workflow YAML parsing

### DIFF
--- a/.github/prompts/pr-review-qa.md
+++ b/.github/prompts/pr-review-qa.md
@@ -1,0 +1,14 @@
+You are a helpful PR review assistant. A developer opened a pull request and you proposed
+to run an automated code review. The review plan is:
+
+__REVIEWER_CONTEXT__
+
+(✓ = queued, ○ = not queued)
+
+The developer asked:
+
+__REPLY__
+
+Answer in 1-3 sentences. End with a brief reminder that they can reply "yes" to start
+or toggle the checkboxes in the proposal comment to adjust which reviewers run.
+Write plain text only — no code blocks, no headers. Output the answer to answer.txt.

--- a/.github/scripts/pr_review_propose.py
+++ b/.github/scripts/pr_review_propose.py
@@ -6,18 +6,21 @@ Subcommands:
   parse-checkboxes Read a comment body file and emit the checked reviewer IDs as JSON.
   format-names     Convert a JSON reviewer-ID array to a display-name string.
   build-qa-context Build the reviewer-plan context string for Copilot Q&A.
+  render-qa-prompt Render the Q&A prompt template with REVIEWER_CONTEXT/REPLY from env.
 
 Usage:
   python pr_review_propose.py build-comment --reviewer-count 3 --lines 247 --files 8
   python pr_review_propose.py parse-checkboxes comment.txt
   python pr_review_propose.py format-names '["correctness","security"]'
   python pr_review_propose.py build-qa-context '["correctness","security"]'
+  REVIEWER_CONTEXT=... REPLY=... python pr_review_propose.py render-qa-prompt path/to/qa.md
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from typing import NamedTuple
@@ -117,6 +120,19 @@ def cmd_build_qa_context(args: argparse.Namespace) -> None:
     print("\n".join(lines))
 
 
+def cmd_render_qa_prompt(args: argparse.Namespace) -> None:
+    """Substitute __REVIEWER_CONTEXT__ and __REPLY__ in a template and write to stdout.
+
+    Values are read from the REVIEWER_CONTEXT and REPLY environment variables,
+    which safely carry multi-line content and arbitrary special characters.
+    """
+    with open(args.template, encoding="utf-8") as f:
+        rendered = f.read()
+    rendered = rendered.replace("__REVIEWER_CONTEXT__", os.environ.get("REVIEWER_CONTEXT", ""))
+    rendered = rendered.replace("__REPLY__", os.environ.get("REPLY", ""))
+    sys.stdout.write(rendered)
+
+
 # ── CLI wiring ────────────────────────────────────────────────────────────────
 
 
@@ -152,6 +168,13 @@ def _build_parser() -> argparse.ArgumentParser:
         "selected_json", help="JSON array of currently selected reviewer IDs"
     )
     p.set_defaults(func=cmd_build_qa_context)
+
+    p = sub.add_parser(
+        "render-qa-prompt",
+        help="Render Q&A prompt template (REVIEWER_CONTEXT and REPLY read from env)",
+    )
+    p.add_argument("template", help="Path to the Q&A prompt template file")
+    p.set_defaults(func=cmd_render_qa_prompt)
 
     return parser
 

--- a/.github/scripts/test_pr_review_propose.py
+++ b/.github/scripts/test_pr_review_propose.py
@@ -18,6 +18,7 @@ from pr_review_propose import (
     cmd_build_qa_context,
     cmd_format_names,
     cmd_parse_checkboxes,
+    cmd_render_qa_prompt,
     get_selected,
 )
 
@@ -298,6 +299,76 @@ class TestBuildQAContext:
             assert r.description in out
 
 
+# ── render-qa-prompt ─────────────────────────────────────────────────────────
+
+
+class TestRenderQAPrompt:
+    def test_substitutes_both_placeholders(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        tmpl = tmp_path / "qa.md"
+        tmpl.write_text("ctx=__REVIEWER_CONTEXT__\nreply=__REPLY__\n")
+        monkeypatch.setenv("REVIEWER_CONTEXT", "ctx-value")
+        monkeypatch.setenv("REPLY", "reply-value")
+        cmd_render_qa_prompt(_ns(template=str(tmpl)))
+        out = capsys.readouterr().out
+        assert out == "ctx=ctx-value\nreply=reply-value\n"
+
+    def test_preserves_multiline_reviewer_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        tmpl = tmp_path / "qa.md"
+        tmpl.write_text("before\n__REVIEWER_CONTEXT__\nafter\n")
+        monkeypatch.setenv("REVIEWER_CONTEXT", "line1\nline2\nline3")
+        monkeypatch.setenv("REPLY", "")
+        cmd_render_qa_prompt(_ns(template=str(tmpl)))
+        out = capsys.readouterr().out
+        assert out == "before\nline1\nline2\nline3\nafter\n"
+
+    def test_preserves_special_characters_in_reply(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        tmpl = tmp_path / "qa.md"
+        tmpl.write_text("__REPLY__")
+        reply = 'quotes " \' backtick ` backslash \\ pipe | amp & dollar $ ✓'
+        monkeypatch.setenv("REVIEWER_CONTEXT", "")
+        monkeypatch.setenv("REPLY", reply)
+        cmd_render_qa_prompt(_ns(template=str(tmpl)))
+        assert capsys.readouterr().out == reply
+
+    def test_missing_env_vars_substitute_empty_string(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        tmpl = tmp_path / "qa.md"
+        tmpl.write_text("[__REVIEWER_CONTEXT__][__REPLY__]")
+        monkeypatch.delenv("REVIEWER_CONTEXT", raising=False)
+        monkeypatch.delenv("REPLY", raising=False)
+        cmd_render_qa_prompt(_ns(template=str(tmpl)))
+        assert capsys.readouterr().out == "[][]"
+
+    def test_missing_template_raises_file_not_found(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("REVIEWER_CONTEXT", "")
+        monkeypatch.setenv("REPLY", "")
+        with pytest.raises(FileNotFoundError):
+            cmd_render_qa_prompt(_ns(template=str(tmp_path / "does-not-exist.md")))
+
+
 # ── CLI wiring ───────────────────────────────────────────────────────────────
 # These tests round-trip through `main()` so a bug in `_build_parser`'s
 # `set_defaults(func=...)` wiring (e.g., a subcommand pointing at the wrong
@@ -389,3 +460,21 @@ class TestCLI:
         out = capsys.readouterr().out
         assert "✓ Correctness" in out
         assert "○ Security" in out
+
+    def test_render_qa_prompt_via_cli(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        from pr_review_propose import main
+
+        tmpl = tmp_path / "qa.md"
+        tmpl.write_text("ctx=__REVIEWER_CONTEXT__ reply=__REPLY__")
+        monkeypatch.setenv("REVIEWER_CONTEXT", "C")
+        monkeypatch.setenv("REPLY", "R")
+        monkeypatch.setattr(
+            "sys.argv", ["pr_review_propose.py", "render-qa-prompt", str(tmpl)]
+        )
+        main()
+        assert capsys.readouterr().out == "ctx=C reply=R"

--- a/.github/workflows/pr-review-confirm.yml
+++ b/.github/workflows/pr-review-confirm.yml
@@ -211,16 +211,8 @@ jobs:
         run: |
           REVIEWER_CONTEXT=$(python3 .github/scripts/pr_review_propose.py build-qa-context "$SELECTED")
           export REVIEWER_CONTEXT
-
-          # Substitute placeholders via python — safe for multi-line values
-          # and arbitrary special characters in the user's reply.
-          python3 -c '
-          import os, sys
-          tmpl = open(sys.argv[1]).read()
-          tmpl = tmpl.replace("__REVIEWER_CONTEXT__", os.environ["REVIEWER_CONTEXT"])
-          tmpl = tmpl.replace("__REPLY__", os.environ["REPLY"])
-          sys.stdout.write(tmpl)
-          ' .github/prompts/pr-review-qa.md > /tmp/qa-prompt.md
+          python3 .github/scripts/pr_review_propose.py render-qa-prompt \
+            .github/prompts/pr-review-qa.md > /tmp/qa-prompt.md
 
           copilot \
             -p "$(cat /tmp/qa-prompt.md)" \

--- a/.github/workflows/pr-review-confirm.yml
+++ b/.github/workflows/pr-review-confirm.yml
@@ -45,10 +45,12 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout scripts
+      - name: Checkout scripts and prompts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/prompts
           persist-credentials: false
 
       # ── Find & download the pending metadata artifact from the most recent ──
@@ -208,26 +210,17 @@ jobs:
           SELECTED: ${{ steps.checkboxes.outputs.selected }}
         run: |
           REVIEWER_CONTEXT=$(python3 .github/scripts/pr_review_propose.py build-qa-context "$SELECTED")
+          export REVIEWER_CONTEXT
 
-          cat > /tmp/qa-prompt.md <<'PROMPT_EOF'
-You are a helpful PR review assistant. A developer opened a pull request and you proposed
-to run an automated code review. The review plan is:
-
-PROMPT_EOF
-          echo "${REVIEWER_CONTEXT}" >> /tmp/qa-prompt.md
-          cat >> /tmp/qa-prompt.md <<'PROMPT_EOF'
-
-(✓ = queued, ○ = not queued)
-
-The developer asked:
-PROMPT_EOF
-          echo "${REPLY}" >> /tmp/qa-prompt.md
-          cat >> /tmp/qa-prompt.md <<'PROMPT_EOF'
-
-Answer in 1-3 sentences. End with a brief reminder that they can reply "yes" to start
-or toggle the checkboxes in the proposal comment to adjust which reviewers run.
-Write plain text only — no code blocks, no headers. Output the answer to answer.txt.
-PROMPT_EOF
+          # Substitute placeholders via python — safe for multi-line values
+          # and arbitrary special characters in the user's reply.
+          python3 -c '
+          import os, sys
+          tmpl = open(sys.argv[1]).read()
+          tmpl = tmpl.replace("__REVIEWER_CONTEXT__", os.environ["REVIEWER_CONTEXT"])
+          tmpl = tmpl.replace("__REPLY__", os.environ["REPLY"])
+          sys.stdout.write(tmpl)
+          ' .github/prompts/pr-review-qa.md > /tmp/qa-prompt.md
 
           copilot \
             -p "$(cat /tmp/qa-prompt.md)" \


### PR DESCRIPTION
## Description

The \`PR Review Confirm\` workflow (introduced in #27107) fails to parse and produces zero jobs on every PR — GitHub reports *"This run likely failed because of a workflow file issue"* (e.g. run [24861202057](https://github.com/microsoft/FluidFramework/actions/runs/24861202057)). The Q&A step used three bash heredocs whose bodies were flush-left inside a \`run: |\` YAML block scalar; YAML terminated the scalar at the first unindented line, leaving the rest of the file unparseable.

This change:

- Extracts the Q&A prompt into \`.github/prompts/pr-review-qa.md\`, sibling to the existing reviewer prompts, using the repo's \`__VAR__\` placeholder convention.
- Adds a \`render-qa-prompt\` subcommand on \`.github/scripts/pr_review_propose.py\` that substitutes \`__REVIEWER_CONTEXT__\` and \`__REPLY__\` from environment variables (safe for multi-line values and arbitrary special characters) and opens the template as UTF-8.
- Replaces the heredoc block in the workflow with a single call to the new subcommand, and extends the step's sparse-checkout to include \`.github/prompts\`.
- Adds unit and CLI tests for the new subcommand alongside the existing \`pr_review_propose.py\` tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).