### PR TITLE
feat(container-definitions): expose resolvedUrl on IContainerContext

### DIFF
--- a/.changeset/resolved-url-on-context.md
+++ b/.changeset/resolved-url-on-context.md
@@ -1,0 +1,15 @@
+---
+"@fluidframework/container-definitions": minor
+"@fluidframework/container-loader": minor
+"__section": legacy
+---
+Expose `resolvedUrl` on `IContainerContext`
+
+`IContainerContext` now carries an optional
+`resolvedUrl?: IResolvedUrl | undefined` property, mirroring
+`IContainer.resolvedUrl` on the runtime side. Runtime code can read document
+identity (including driver-specific fields carried on the driver's resolved URL
+subtype) directly from the context, instead of routing through
+`IContainerContext.getAbsoluteUrl` and the URL resolver.
+
+`resolvedUrl` is `undefined` only while the container is in the detached state.

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
@@ -204,6 +204,7 @@ export interface IContainerContext {
     pendingLocalState?: unknown;
     // (undocumented)
     readonly quorum: IQuorumClients;
+    readonly resolvedUrl?: IResolvedUrl | undefined;
     readonly scope: FluidObject;
     // @system
     readonly signalAudience?: IAudience;

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -16,6 +16,7 @@ import type {
 import type {
 	ISnapshot,
 	IDocumentMessage,
+	IResolvedUrl,
 	ISnapshotTree,
 	ISummaryContent,
 	IVersion,
@@ -405,6 +406,18 @@ export interface IContainerContext {
 	 * TODO: Optional for backwards compatibility. Make non-optional in version 0.19
 	 */
 	getAbsoluteUrl?(relativeUrl: string): Promise<string | undefined>;
+
+	/**
+	 * Represents the resolved url to the Container.
+	 * Will be undefined only when the container is in the {@link AttachState.Detached | detached} state.
+	 *
+	 * @remarks
+	 * Exposes the same value as `IContainer.resolvedUrl` to the runtime layer so
+	 * that runtime code can read document identity (including driver-specific
+	 * fields carried on the driver's resolved URL subtype) without routing
+	 * through {@link IContainerContext.getAbsoluteUrl} and the URL resolver.
+	 */
+	readonly resolvedUrl?: IResolvedUrl | undefined;
 
 	/**
 	 * Indicates the attachment state of the container to a host service.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2441,6 +2441,7 @@ export class Container
 				getAttachState: () => this.attachState,
 				getConnected: () => this.connected,
 				getConnectionState: () => this.connectionState,
+				getResolvedUrl: () => this.resolvedUrl,
 				clientDetails: this._deltaManager.clientDetails,
 				existing,
 				taggedLogger: this.subLogger,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -26,6 +26,7 @@ import type { IClientDetails, IQuorumClients } from "@fluidframework/driver-defi
 import type {
 	ISnapshot,
 	IDocumentMessage,
+	IResolvedUrl,
 	ISnapshotTree,
 	ISummaryContent,
 	IVersion,
@@ -57,6 +58,7 @@ export interface IContainerContextConfig
 				| "getLoadedFromVersion"
 				| "supportedFeatures"
 				| "id"
+				| "resolvedUrl"
 				| "snapshotWithContents"
 			>
 		>
@@ -68,6 +70,7 @@ export interface IContainerContextConfig
 	readonly getClientId: () => string | undefined;
 	readonly getAttachState: () => AttachState;
 	readonly getConnected: () => boolean;
+	readonly getResolvedUrl: () => IResolvedUrl | undefined;
 	readonly existing: boolean;
 	readonly taggedLogger: ITelemetryLoggerExt;
 	// This "overrides" IContainerContext.snapshotWithContents to be required but allow `undefined`.
@@ -79,8 +82,8 @@ export interface IContainerContextConfig
  */
 export class ContainerContext
 	implements
-		Required<Omit<IContainerContext, "snapshotWithContents">>,
-		Pick<IContainerContext, "snapshotWithContents">,
+		Required<Omit<IContainerContext, "snapshotWithContents" | "resolvedUrl">>,
+		Pick<IContainerContext, "snapshotWithContents" | "resolvedUrl">,
 		IProvideLayerCompatDetails
 {
 	/**
@@ -146,10 +149,15 @@ export class ContainerContext
 	private readonly _getContainerDiagnosticId: () => string | undefined;
 	private readonly _getConnected: () => boolean;
 	private readonly _getAttachState: () => AttachState;
+	private readonly _getResolvedUrl: () => IResolvedUrl | undefined;
 	private readonly version: IVersion | undefined;
 
 	public get clientId(): string | undefined {
 		return this._getClientId();
+	}
+
+	public get resolvedUrl(): IResolvedUrl | undefined {
+		return this._getResolvedUrl();
 	}
 
 	/**
@@ -206,6 +214,7 @@ export class ContainerContext
 		this._getContainerDiagnosticId = config.getContainerDiagnosticId;
 		this._getConnected = config.getConnected;
 		this._getAttachState = config.getAttachState;
+		this._getResolvedUrl = config.getResolvedUrl;
 		this.version = config.version;
 	}
 


### PR DESCRIPTION
## Description

 Partner teams building on top of the container runtime need access to document identity (`siteUrl` / `driveId` / `itemId` on an ODSP resolved URL, or equivalent fields on other drivers' resolved URL subtypes) from inside the runtime layer. Today the only available path is `runtime.getAbsoluteUrl('/')` → `urlResolver.getAbsoluteUrl(...)`, which is indirect and — depending on the driver — can pull in sharing-link generation concerns that are irrelevant when the caller just wants document identity.

  `IContainer.resolvedUrl` already carries this information on the host side, but `IContainerContext` did not surface it to the runtime. Hosts have been working around this by capturing `container.resolvedUrl` host-side and smuggling it down through the dependency synthesizer, which leaks Fluid-specific concerns into the host layer.                                                                                                         
                                                         
  This PR adds an optional `resolvedUrl?: IResolvedUrl | undefined` property to `IContainerContext`, mirroring `IContainer.resolvedUrl`. `ContainerContext` is wired via a `getResolvedUrl` callback so the value tracks the container's detached-to-attached lifecycle. Runtime code can now read document identity directly off the context, no resolver round-trip required.                                                                    
                                                         
  The property is optional for Loader/Runtime layer-compat — runtimes running against older Loaders will see `undefined` and must tolerate its absence.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
