### PR TITLE
ci: re-enable enableExpandArchives in 1ES SDL config

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -184,9 +184,9 @@ extends:
       # Tentative workaround for the occasional Credscan failures
       credscan:
         batchSize: 4
-      # Workaround for "Binary Analysis Scan Optimization (Expand Archives)" timing out.
       binaryAnalysisCaching:
-        enableExpandArchives: false
+        enableExpandArchives: true
+        enableExpandTarArchives: true
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true


### PR DESCRIPTION
## Description

Re-enables the `enableExpandArchives` SDL setting (and enables `enableExpandTarArchives`) in the 1ES pipeline template for the npm client package build, based on guidance by the 1ES team.

[PR #26793](https://github.com/microsoft/FluidFramework/pull/26793) disabled `enableExpandArchives` as a workaround for the "Binary Analysis Scan Optimization (Expand Archives)" step timing out. The 1ES Pipeline Templates team has since shipped incremental binary analysis improvements, and the updated guidance ([1ES docs: Tar Archive Expansion](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/incremental-binary-analysis#tar-archive-expansion)) is to set:

```yaml
sdl:
  binaryAnalysisCaching:
    enableExpandArchives: true
    enableExpandTarArchives: true
```

This PR reverses the PR #26793 workaround and drops the stale workaround comment. [AB#71185](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71185).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Config-only change — the authoritative verification is the 1ES pipeline run on this PR. Please confirm the "Binary Analysis Scan Optimization (Expand Archives)" step completes within its timeout before merging. If it times out again, we revert and reopen [AB#71185](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71185).