### PR TITLE
build(ci): use sparse git checkout for independent package pipelines

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -41,6 +41,7 @@
 		"mocha": "^11.7.5"
 	},
 	"devDependencies": {
+		"@fluidframework/build-common": "^2.0.3",
 		"@fluid-internal/mocha-test-setup": "~2.83.0",
 		"@microsoft/api-extractor": "^7.58.2",
 		"@types/mocha": "^10.0.10",

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@fluid-internal/mocha-test-setup':
         specifier: ~2.83.0
         version: 2.83.0
+      '@fluidframework/build-common':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@microsoft/api-extractor':
         specifier: ^7.58.2
         version: 7.58.2(@types/node@22.19.17)
@@ -149,6 +152,10 @@ packages:
 
   '@fluid-internal/test-driver-definitions@2.83.0':
     resolution: {integrity: sha512-e25u/eR5jifNKwxEjWiLYkK8WJXvoCFAbODvUjiuLZf0k5nII/hUNSRz6id48ycFwJ+FP2eYqnbh43sO50vH9g==}
+
+  '@fluidframework/build-common@2.0.3':
+    resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
+    hasBin: true
 
   '@fluidframework/core-interfaces@2.83.0':
     resolution: {integrity: sha512-urkyfgSYUTKoGMuw5R1rIrFq7QH11tRw+GjGWBzGDd8Ovb0iXZtjV3dEtzC/KJnWEefgNt4NdbsS0f+5hMoJqA==}
@@ -1617,6 +1624,8 @@ snapshots:
     dependencies:
       '@fluidframework/core-interfaces': 2.83.0
       '@fluidframework/driver-definitions': 2.83.0
+
+  '@fluidframework/build-common@2.0.3': {}
 
   '@fluidframework/core-interfaces@2.83.0': {}
 

--- a/tools/benchmark/prettier.config.cjs
+++ b/tools/benchmark/prettier.config.cjs
@@ -4,5 +4,5 @@
  */
 
 module.exports = {
-	...require("../../common/build/build-common/prettier.config.cjs"),
+	...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -102,4 +102,5 @@ extends:
     - test
     sparseCheckoutDirectories: |
       tools/benchmark
+      build-tools
       scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -103,5 +103,6 @@ extends:
     sparseCheckoutDirectories: |
       tools/benchmark
       build-tools
+      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -103,4 +103,5 @@ extends:
     sparseCheckoutDirectories: |
       tools/benchmark
       build-tools
+      patches
       scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -100,7 +100,7 @@ extends:
     taskLint: true
     taskTest:
     - test
+    taskSetVersion: false
     sparseCheckoutDirectories: |
       tools/benchmark
-      build-tools
       scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -100,3 +100,6 @@ extends:
     taskLint: true
     taskTest:
     - test
+    sparseCheckoutDirectories: |
+      tools/benchmark
+      scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -103,4 +103,5 @@ extends:
     taskSetVersion: false
     sparseCheckoutDirectories: |
       tools/benchmark
+      common/build/build-common
       scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -23,9 +23,9 @@ parameters:
     - skip
     - force
 - name: buildToolsVersionToInstall
-  displayName: Fluid build tools version (default = installs version in repo)
+  displayName: Fluid build tools version (default = installs from npm per workspace catalog)
   type: string
-  default: repo
+  default: ^0.65.0
 
 trigger:
   branches:
@@ -100,11 +100,6 @@ extends:
     taskLint: true
     taskTest:
     - test
-    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       tools/benchmark
-      tools/api-markdown-documenter
-      build-tools
-      common/build/eslint-config-fluid
-      patches
       scripts

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -100,8 +100,10 @@ extends:
     taskLint: true
     taskTest:
     - test
+    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       tools/benchmark
+      tools/api-markdown-documenter
       build-tools
       common/build/eslint-config-fluid
       patches

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -103,4 +103,5 @@ extends:
     - prettier
     sparseCheckoutDirectories: |
       common/build/build-common
+      build-tools
       scripts

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -101,3 +101,6 @@ extends:
     taskTest: [] # no tests
     checks:
     - prettier
+    sparseCheckoutDirectories: |
+      common/build/build-common
+      scripts

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -101,7 +101,7 @@ extends:
     taskTest: [] # no tests
     checks:
     - prettier
+    taskSetVersion: false
     sparseCheckoutDirectories: |
       common/build/build-common
-      build-tools
       scripts

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -104,4 +104,5 @@ extends:
     sparseCheckoutDirectories: |
       common/build/build-common
       build-tools
+      patches
       scripts

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -104,5 +104,6 @@ extends:
     sparseCheckoutDirectories: |
       common/build/build-common
       build-tools
+      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -101,8 +101,10 @@ extends:
     taskTest: [] # no tests
     checks:
     - prettier
+    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       common/build/build-common
+      tools/api-markdown-documenter
       build-tools
       common/build/eslint-config-fluid
       patches

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -23,9 +23,9 @@ parameters:
     - skip
     - force
 - name: buildToolsVersionToInstall
-  displayName: Fluid build tools version (default = installs version in repo)
+  displayName: Fluid build tools version (default = installs from npm per workspace catalog)
   type: string
-  default: repo
+  default: ^0.65.0
 
 trigger:
   branches:
@@ -101,11 +101,6 @@ extends:
     taskTest: [] # no tests
     checks:
     - prettier
-    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       common/build/build-common
-      tools/api-markdown-documenter
-      build-tools
-      common/build/eslint-config-fluid
-      patches
       scripts

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -124,4 +124,5 @@ extends:
     - checks
     sparseCheckoutDirectories: |
       build-tools
+      patches
       scripts

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -122,3 +122,6 @@ extends:
     taskBundleAnalysis: false
     checks:
     - checks
+    sparseCheckoutDirectories: |
+      build-tools
+      scripts

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -122,10 +122,3 @@ extends:
     taskBundleAnalysis: false
     checks:
     - checks
-    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
-    sparseCheckoutDirectories: |
-      build-tools
-      tools/api-markdown-documenter
-      common/build/eslint-config-fluid
-      patches
-      scripts

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -122,8 +122,10 @@ extends:
     taskBundleAnalysis: false
     checks:
     - checks
+    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       build-tools
+      tools/api-markdown-documenter
       common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -124,5 +124,6 @@ extends:
     - checks
     sparseCheckoutDirectories: |
       build-tools
+      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -23,9 +23,9 @@ parameters:
     - skip
     - force
 - name: buildToolsVersionToInstall
-  displayName: Fluid build tools version (default = installs version in repo)
+  displayName: Fluid build tools version (default = installs from npm per workspace catalog)
   type: string
-  default: repo
+  default: ^0.65.0
 
 trigger:
   branches:
@@ -103,11 +103,7 @@ extends:
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
-    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       common/lib/common-utils
-      tools/api-markdown-documenter
-      build-tools
-      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -103,3 +103,7 @@ extends:
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
+    sparseCheckoutDirectories: |
+      common/lib/common-utils
+      patches
+      scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -106,5 +106,6 @@ extends:
     taskSetVersion: false
     sparseCheckoutDirectories: |
       common/lib/common-utils
+      common/build/build-common
       patches
       scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -106,5 +106,6 @@ extends:
     sparseCheckoutDirectories: |
       common/lib/common-utils
       build-tools
+      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -103,8 +103,8 @@ extends:
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
+    taskSetVersion: false
     sparseCheckoutDirectories: |
       common/lib/common-utils
-      build-tools
       patches
       scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -105,5 +105,6 @@ extends:
     testCoverage: ${{ variables.testCoverage }}
     sparseCheckoutDirectories: |
       common/lib/common-utils
+      build-tools
       patches
       scripts

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -103,8 +103,10 @@ extends:
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
+    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       common/lib/common-utils
+      tools/api-markdown-documenter
       build-tools
       common/build/eslint-config-fluid
       patches

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -108,5 +108,6 @@ extends:
     taskSetVersion: false
     sparseCheckoutDirectories: |
       common/lib/protocol-definitions
+      common/build/build-common
       patches
       scripts

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -105,8 +105,8 @@ extends:
     tagName: protocol-definitions
     testCoverage: false
     taskTest: [] # no tests
+    taskSetVersion: false
     sparseCheckoutDirectories: |
       common/lib/protocol-definitions
-      build-tools
       patches
       scripts

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -105,8 +105,10 @@ extends:
     tagName: protocol-definitions
     testCoverage: false
     taskTest: [] # no tests
+    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       common/lib/protocol-definitions
+      tools/api-markdown-documenter
       build-tools
       common/build/eslint-config-fluid
       patches

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -105,3 +105,7 @@ extends:
     tagName: protocol-definitions
     testCoverage: false
     taskTest: [] # no tests
+    sparseCheckoutDirectories: |
+      common/lib/protocol-definitions
+      patches
+      scripts

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -108,5 +108,6 @@ extends:
     sparseCheckoutDirectories: |
       common/lib/protocol-definitions
       build-tools
+      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -107,5 +107,6 @@ extends:
     taskTest: [] # no tests
     sparseCheckoutDirectories: |
       common/lib/protocol-definitions
+      build-tools
       patches
       scripts

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -23,9 +23,9 @@ parameters:
     - skip
     - force
 - name: buildToolsVersionToInstall
-  displayName: Fluid build tools version (default = installs version in repo)
+  displayName: Fluid build tools version (default = installs from npm per workspace catalog)
   type: string
-  default: repo
+  default: ^0.65.0
 
 trigger:
   branches:
@@ -105,11 +105,7 @@ extends:
     tagName: protocol-definitions
     testCoverage: false
     taskTest: [] # no tests
-    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       common/lib/protocol-definitions
-      tools/api-markdown-documenter
-      build-tools
-      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -99,5 +99,6 @@ extends:
     sparseCheckoutDirectories: |
       tools/test-tools
       build-tools
+      common/build/eslint-config-fluid
       patches
       scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -96,3 +96,6 @@ extends:
     taskLint: false
     taskTest:
     - test
+    sparseCheckoutDirectories: |
+      tools/test-tools
+      scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -98,4 +98,5 @@ extends:
     - test
     sparseCheckoutDirectories: |
       tools/test-tools
+      build-tools
       scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -99,4 +99,5 @@ extends:
     sparseCheckoutDirectories: |
       tools/test-tools
       build-tools
+      patches
       scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -99,4 +99,5 @@ extends:
     taskSetVersion: false
     sparseCheckoutDirectories: |
       tools/test-tools
+      common/build/build-common
       scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -96,7 +96,7 @@ extends:
     taskLint: false
     taskTest:
     - test
+    taskSetVersion: false
     sparseCheckoutDirectories: |
       tools/test-tools
-      build-tools
       scripts

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -96,8 +96,10 @@ extends:
     taskLint: false
     taskTest:
     - test
+    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       tools/test-tools
+      tools/api-markdown-documenter
       build-tools
       common/build/eslint-config-fluid
       patches

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -22,9 +22,9 @@ parameters:
     - skip
     - force
 - name: buildToolsVersionToInstall
-  displayName: Fluid build tools version (default = installs version in repo)
+  displayName: Fluid build tools version (default = installs from npm per workspace catalog)
   type: string
-  default: repo
+  default: ^0.65.0
 
 trigger:
   branches:
@@ -96,11 +96,6 @@ extends:
     taskLint: false
     taskTest:
     - test
-    # tools/api-markdown-documenter is required by the build-tools build (exact dependency unclear).
     sparseCheckoutDirectories: |
       tools/test-tools
-      tools/api-markdown-documenter
-      build-tools
-      common/build/eslint-config-fluid
-      patches
       scripts

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -343,9 +343,8 @@ extends:
                   packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
 
               # The bundle-size-artifacts pipeline runs a client build but doesn't publish packages,
-              # so we skip version setting for it. taskSetVersion can also be set to false to skip
-              # this step for other pipelines (e.g. independent packages with sparse checkouts).
-              - ${{ if and(eq(parameters.isBundleSizeArtifactsPipeline, false), eq(parameters.taskSetVersion, true)) }}:
+              # so we skip version setting for it.
+              - ${{ if eq(parameters.isBundleSizeArtifactsPipeline, false) }}:
                   - template: /tools/pipelines/templates/include-set-package-version.yml@self
                     parameters:
                       buildDirectory: '${{ parameters.buildDirectory }}'
@@ -354,6 +353,7 @@ extends:
                       tagName: '${{ parameters.tagName }}'
                       interdependencyRange: '${{ parameters.interdependencyRange }}'
                       packageTypesOverride: '${{ parameters.packageTypesOverride }}'
+                      taskSetVersion: ${{ parameters.taskSetVersion }}
 
               # Build and Lint
               - template: /tools/pipelines/templates/include-build-lint.yml@self

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -59,6 +59,13 @@ parameters:
   type: boolean
   default: false
 
+# Newline-separated list of directories to include in a sparse checkout. When empty (the default), a full checkout is
+# performed. When set, only the listed directories (plus all root-level files, which git cone mode always includes) are
+# checked out. Use this to avoid checking out large parts of the repo that aren't needed for this pipeline.
+- name: sparseCheckoutDirectories
+  type: string
+  default: ''
+
 - name: buildNumberInPatch
   type: boolean
   default: false
@@ -189,6 +196,7 @@ extends:
               checks: '${{ parameters.checks }}'
               # Install all dependencies, not just the root ones
               dependencyInstallCommand: pnpm install --frozen-lockfile
+              sparseCheckoutDirectories: '${{ parameters.sparseCheckoutDirectories }}'
 
       # Install / Build / Test Stage
       - stage: build
@@ -225,6 +233,8 @@ extends:
                 clean: true
                 lfs: '${{ parameters.checkoutSubmodules }}'
                 submodules: '${{ parameters.checkoutSubmodules }}'
+                ${{ if ne(parameters.sparseCheckoutDirectories, '') }}:
+                  sparseCheckoutDirectories: ${{ parameters.sparseCheckoutDirectories }}
 
               - task: Bash@3
                 displayName: Parameters

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -47,6 +47,12 @@ parameters:
   type: boolean
   default: false
 
+# Set to false to skip the version-setting step entirely (flub generate buildVersion + package.json bump).
+# Useful for pipelines that use sparse checkouts and don't need a CI-stamped version (e.g. independent packages).
+- name: taskSetVersion
+  type: boolean
+  default: true
+
 - name: taskPack
   type: boolean
   default: true
@@ -337,8 +343,9 @@ extends:
                   packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
 
               # The bundle-size-artifacts pipeline runs a client build but doesn't publish packages,
-              # so we skip version setting for it.
-              - ${{ if eq(parameters.isBundleSizeArtifactsPipeline, false) }}:
+              # so we skip version setting for it. taskSetVersion can also be set to false to skip
+              # this step for other pipelines (e.g. independent packages with sparse checkouts).
+              - ${{ if and(eq(parameters.isBundleSizeArtifactsPipeline, false), eq(parameters.taskSetVersion, true)) }}:
                   - template: /tools/pipelines/templates/include-set-package-version.yml@self
                     parameters:
                       buildDirectory: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -24,6 +24,12 @@ parameters:
   - policy-check
   - layer-check
 
+# Newline-separated list of directories to pass to git sparse checkout (cone mode). When empty (the default), a full
+# checkout is performed. Should match the sparseCheckoutDirectories used in the build stage.
+- name: sparseCheckoutDirectories
+  type: string
+  default: ''
+
 stages:
 - stage: run_checks
   dependsOn: [] # Has no prereqs
@@ -35,6 +41,8 @@ stages:
     steps:
     - checkout: self
       path: $(FluidFrameworkDirectory)
+      ${{ if ne(parameters.sparseCheckoutDirectories, '') }}:
+        sparseCheckoutDirectories: ${{ parameters.sparseCheckoutDirectories }}
     - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
     - template: /tools/pipelines/templates/include-install-pnpm.yml@self

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -46,6 +46,12 @@ parameters:
   type: boolean
   default: true
 
+# Set to false to skip version computation and package.json bumping while still installing build tools.
+# Useful for pipelines using sparse checkouts that need flub available but don't need CI-stamped versions.
+- name: taskSetVersion
+  type: boolean
+  default: true
+
 # Set version
 steps:
 
@@ -55,88 +61,89 @@ steps:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     pnpmStorePath: ${{ parameters.pnpmStorePath }}
 
-- task: Bash@3
-  name: SetVersion
-  displayName: Set Package Version
-  env:
-    VERSION_RELEASE: $(release)
-    VERSION_BUILDNUMBER: $(Build.BuildNumber)
-    TEST_BUILD: $(testBuild)
-    VERSION_PATCH: ${{ parameters.buildNumberInPatch }}
-    VERSION_TAGNAME: ${{ parameters.tagName }}
-    VERSION_INCLUDE_INTERNAL_VERSIONS: ${{ parameters.includeInternalVersions }}
-    PACKAGE_TYPES_FIELD: ${{ parameters.packageTypesOverride }}
-  inputs:
-    targetType: 'inline'
-    workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-    script: |
-      set -eu -o pipefail
-      # expect release group root package.json be in the current working directory
-
-      echo VERSION_BUILDNUMBER=$VERSION_BUILDNUMBER
-      echo TEST_BUILD=$TEST_BUILD
-      echo VERSION_RELEASE=$VERSION_RELEASE
-      echo VERSION_PATCH=$VERSION_PATCH
-      echo VERSION_INCLUDE_INTERNAL_VERSIONS=$VERSION_INCLUDE_INTERNAL_VERSIONS
-      echo PACKAGE_TYPES_FIELD=$PACKAGE_TYPES_FIELD
-
-      # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
-      # These are referenced in following steps prefixed by this task name. E.g. SetVersion.version
-      flub generate buildVersion
-
-# This check runs only when the value of `Change package types` is selected as `alpha` or `beta`
-- ${{ if ne(parameters.packageTypesOverride, 'none') }}:
+- ${{ if eq(parameters.taskSetVersion, true) }}:
   - task: Bash@3
-    displayName: Set Package Types - ${{ parameters.packageTypesOverride }}
-    continueOnError: false
+    name: SetVersion
+    displayName: Set Package Version
+    env:
+      VERSION_RELEASE: $(release)
+      VERSION_BUILDNUMBER: $(Build.BuildNumber)
+      TEST_BUILD: $(testBuild)
+      VERSION_PATCH: ${{ parameters.buildNumberInPatch }}
+      VERSION_TAGNAME: ${{ parameters.tagName }}
+      VERSION_INCLUDE_INTERNAL_VERSIONS: ${{ parameters.includeInternalVersions }}
+      PACKAGE_TYPES_FIELD: ${{ parameters.packageTypesOverride }}
     inputs:
       targetType: 'inline'
       workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
       script: |
         set -eu -o pipefail
-        # At this point in the pipeline the build hasn't been done, so we skip checking if the types files and other build outputs exist.
-        flub release setPackageTypesField -g ${{ parameters.tagName }} --types ${{ parameters.packageTypesOverride }} --no-checkFileExists
+        # expect release group root package.json be in the current working directory
 
-- ${{ if eq(parameters.performBump, true) }}:
+        echo VERSION_BUILDNUMBER=$VERSION_BUILDNUMBER
+        echo TEST_BUILD=$TEST_BUILD
+        echo VERSION_RELEASE=$VERSION_RELEASE
+        echo VERSION_PATCH=$VERSION_PATCH
+        echo VERSION_INCLUDE_INTERNAL_VERSIONS=$VERSION_INCLUDE_INTERNAL_VERSIONS
+        echo PACKAGE_TYPES_FIELD=$PACKAGE_TYPES_FIELD
+
+        # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
+        # These are referenced in following steps prefixed by this task name. E.g. SetVersion.version
+        flub generate buildVersion
+
+  # This check runs only when the value of `Change package types` is selected as `alpha` or `beta`
+  - ${{ if ne(parameters.packageTypesOverride, 'none') }}:
+    - task: Bash@3
+      displayName: Set Package Types - ${{ parameters.packageTypesOverride }}
+      continueOnError: false
+      inputs:
+        targetType: 'inline'
+        workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+        script: |
+          set -eu -o pipefail
+          # At this point in the pipeline the build hasn't been done, so we skip checking if the types files and other build outputs exist.
+          flub release setPackageTypesField -g ${{ parameters.tagName }} --types ${{ parameters.packageTypesOverride }} --no-checkFileExists
+
+  - ${{ if eq(parameters.performBump, true) }}:
+    - task: Bash@3
+      displayName: Update Package Version (flub)
+      env:
+        VERSION_RELEASE: $(release)
+        RELEASE_GROUP: ${{ parameters.tagName }}
+        INTERDEPENDENCY_RANGE: ${{ parameters.interdependencyRange }}
+      inputs:
+        targetType: 'filePath'
+        workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+        filePath: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/scripts/update-package-version.sh
+
+  # This task is a last-minute verification that no Fluid internal versions show up with caret dependencies. This is to
+  # help find and prevent bugs in the version bumping tools.
   - task: Bash@3
-    displayName: Update Package Version (flub)
-    env:
-      VERSION_RELEASE: $(release)
-      RELEASE_GROUP: ${{ parameters.tagName }}
-      INTERDEPENDENCY_RANGE: ${{ parameters.interdependencyRange }}
+    displayName: Check for caret dependencies on internal versions
     inputs:
-      targetType: 'filePath'
+      targetType: 'inline'
       workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-      filePath: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/scripts/update-package-version.sh
+      script: |
+        # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
+        # even in an error case
+        grep -r -e "\^2.0.0-internal.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
+        if [[ $? == 0 ]]; then
+          echo "##vso[task.logissue type=error]Fluid internal versions shouldn't use caret dependencies"
+          exit -1;
+        fi
 
-# This task is a last-minute verification that no Fluid internal versions show up with caret dependencies. This is to
-# help find and prevent bugs in the version bumping tools.
-- task: Bash@3
-  displayName: Check for caret dependencies on internal versions
-  inputs:
-    targetType: 'inline'
-    workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-    script: |
-      # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
-      # even in an error case
-      grep -r -e "\^2.0.0-internal.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
-      if [[ $? == 0 ]]; then
-        echo "##vso[task.logissue type=error]Fluid internal versions shouldn't use caret dependencies"
-        exit -1;
-      fi
-
-# This task is a last-minute verification that no Fluid internal dev versions show up with caret dependencies. This is
-# to help find and prevent bugs in the version bumping tools.
-- task: Bash@3
-  displayName: Check for caret dependencies on dev versions
-  inputs:
-    targetType: 'inline'
-    workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-    script: |
-      # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
-      # even in an error case
-      grep -r -e "\^2.0.0-dev.\d*.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
-      if [[ $? == 0 ]]; then
-        echo "##vso[task.logissue type=error]Fluid internal dev versions shouldn't use caret dependencies"
-        exit -1;
-      fi
+  # This task is a last-minute verification that no Fluid internal dev versions show up with caret dependencies. This is
+  # to help find and prevent bugs in the version bumping tools.
+  - task: Bash@3
+    displayName: Check for caret dependencies on dev versions
+    inputs:
+      targetType: 'inline'
+      workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+      script: |
+        # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
+        # even in an error case
+        grep -r -e "\^2.0.0-dev.\d*.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
+        if [[ $? == 0 ]]; then
+          echo "##vso[task.logissue type=error]Fluid internal dev versions shouldn't use caret dependencies"
+          exit -1;
+        fi


### PR DESCRIPTION
## Description

Enables git sparse checkout (cone mode) for the six independent-package CI pipelines that currently check out the entire monorepo but only need a small subset of it:

- `build-benchmark-tool`
- `build-build-common`
- `build-build-tools`
- `build-common-utils`
- `build-protocol-definitions`
- `build-test-tools`

Each pipeline now declares the directories it actually needs. Git cone mode always includes all root-level files (e.g. `biome.jsonc`, `package.json`, `pnpm-workspace.yaml`, `.npmrc`, `fluidBuild.config.cjs`), so those are always available without being listed explicitly. Subdirectories like `packages/`, `examples/`, `experimental/`, and `azure/` are no longer checked out for these pipelines.

This reduces the scope of auto-injected SDL scanning steps (CredScan, etc.) to only the sources that are relevant to each pipeline. But note: the fact that the root `pnpm-lock.yaml` file is included means that Component Governance will still flag the pipelines for these independent packages (and build-tools) for things that might not be relevant in them. Moving the client release group to its own subfolder would be the necessary fix here.

The `sparseCheckoutDirectories` parameter is threaded through both `build-npm-package.yml` and `include-policy-check.yml` (which runs its own checkout in a separate stage) and defaults to empty, preserving the existing full-checkout behavior for all other pipelines.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The key thing to validate is whether each pipeline's cone includes everything it needs at runtime. The cone for each pipeline was derived from:
1. The `file:` dependencies in each package's `package.json` (which pnpm must resolve from disk)
2. Relative-path `extends` in `tsconfig.json` files
3. The pipeline's trigger paths, which document known runtime dependencies

A follow-up PR will add sparse checkout for the three remaining independent-package pipelines (`build-api-markdown-documenter`, `build-eslint-config-fluid`, `build-eslint-plugin-fluid`), which have slightly more complex dependency graphs.