### PR TITLE
feat(map): add IDirectory.createSubDirectoryOrderedAfter

### DIFF
--- a/.changeset/directory-ordered-after.md
+++ b/.changeset/directory-ordered-after.md
@@ -1,0 +1,18 @@
+---
+"@fluidframework/map": minor
+"__section": feature
+---
+Add IDirectory.createSubDirectoryOrderedAfter
+
+`SharedDirectory` iterates its subdirectories in the order they were created, which has historically made `createSubDirectory` behave like an append. Callers who needed to insert a subdirectory at a specific position within the existing order had to delete everything after the target position, insert, then re-create the deleted subdirectories — a costly workaround.
+
+`IDirectory` now exposes `createSubDirectoryOrderedAfter(newSubdirName, afterSubdirName)`, which creates a subdirectory and requests that it be ordered immediately after the named existing sibling. The ordering hint is best-effort and is resolved at stamp time: if the named anchor does not exist at stamp time (never created, concurrently deleted, or not yet sequenced), the new subdirectory is appended at the end, matching `createSubDirectory`'s behavior. The hint establishes no long-term relationship with the anchor, and is compatible with the existing same-name concurrent-create merge semantics.
+
+```ts
+directory.createSubDirectory("a");
+directory.createSubDirectory("b");
+directory.createSubDirectoryOrderedAfter("c", "a");
+// iteration order: a, c, b
+```
+
+Older clients in the same session that do not understand the ordering hint will treat these insertions as plain appends. The hint is observed only among clients on this version or later.

--- a/packages/dds/map/api-report/map.legacy.beta.api.md
+++ b/packages/dds/map/api-report/map.legacy.beta.api.md
@@ -16,6 +16,7 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 
 // @beta @deprecated @legacy
 export interface ICreateInfo {
+    afterParent?: IAfterParentInfo;
     ccIds: string[];
     csn: number;
 }
@@ -25,6 +26,7 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     readonly absolutePath: string;
     countSubDirectory?(): number;
     createSubDirectory(subdirName: string): IDirectory;
+    createSubDirectoryOrderedAfter(newSubdirName: string, afterSubdirName: string): IDirectory;
     deleteSubDirectory(subdirName: string): boolean;
     get<T = any>(key: string): T | undefined;
     getSubDirectory(subdirName: string): IDirectory | undefined;

--- a/packages/dds/map/api-report/map.legacy.public.api.md
+++ b/packages/dds/map/api-report/map.legacy.public.api.md
@@ -9,6 +9,7 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     readonly absolutePath: string;
     countSubDirectory?(): number;
     createSubDirectory(subdirName: string): IDirectory;
+    createSubDirectoryOrderedAfter(newSubdirName: string, afterSubdirName: string): IDirectory;
     deleteSubDirectory(subdirName: string): boolean;
     get<T = any>(key: string): T | undefined;
     getSubDirectory(subdirName: string): IDirectory | undefined;

--- a/packages/dds/map/docs/ordering-hints-implementation-plan.md
+++ b/packages/dds/map/docs/ordering-hints-implementation-plan.md
@@ -1,0 +1,269 @@
+# SharedDirectory Insertion Ordering Hints — Implementation Plan
+
+**Status:** Draft
+**Requirements:** [`ordering-hints-requirements.md`](./ordering-hints-requirements.md)
+
+This document covers implementation strategy. All observable behavior is defined by the requirements spec; this plan describes *how* to meet those requirements.
+
+## 1. Options under consideration
+
+Two paths can satisfy the requirements:
+
+- **Option A — Feature-add on the existing `SharedDirectory` codepath.** Extend the current op, sort key, and process/resubmit flow in-place. No change to the DDS identity or persisted format version.
+- **Option B — Replat `SharedDirectory` on `SharedTree` internals behind a facade.** Rebuild the subdirectory ordering and merge machinery using `SharedTree`'s sequence fields, preserving the public `IDirectory` API.
+
+The rest of this section compares them. Subsequent sections detail Option A, which is the recommended path for this feature.
+
+### 1.1 Option A — feature-add on current codepath
+
+**Scope.** Localized. Touches ~4 files in `packages/dds/map/src/`: the op type, the `SequenceData` shape, the comparator, the `createSubDirectory*` methods, the process/resubmit/serialize paths, and the public interface. Roughly 1–2 weeks of engineering including tests and review.
+
+**Pros.**
+- Keeps `SharedDirectory`'s public DDS identity, snapshot format family, and op lineage unchanged.
+- Mixed-version sessions degrade predictably (old clients append; new clients see the hint). No hard cut-over.
+- Tests can layer directly onto the existing `directory.order.spec.ts` fixture.
+
+**Cons.**
+- Adds complexity to `SharedDirectory`'s already-intricate ordering code. The recursive/nested sort key in §3 is the main carrier of that complexity.
+- Does not reduce long-term maintenance burden on the custom ordering algorithm.
+
+### 1.2 Option B — replat on SharedTree
+
+**Scope.** Much larger. A full reimplementation of the internal storage, ordering, and merge behavior behind the `IDirectory` API, plus a snapshot-migration story for documents persisted in the current format. Estimated multiple quarters of engineering.
+
+**What SharedTree actually gives us** (from research against `packages/dds/tree`):
+- Sequence fields support positional insertion with rigorous concurrent-edit merge semantics (`insertAt(index, ...)`, `CellOrder` merge rules).
+- Rebase on reconnect is automatic; optimistic positions are re-resolved against remote state.
+- Snapshot format versioning and op-codec version negotiation exist within `SharedTree`.
+
+**What SharedTree does *not* give us that the feature needs:**
+- No "insert after node X" reference-based primitive. SharedTree's insertion is index-based. We would still have to build the reference-based semantics (anchor lookup by name at stamp time, fallback on missing anchor) on top of index-based inserts.
+- No native ordered-keyed-map node. We would model subdirectories as a sequence of `{name, value}` pairs.
+- No precedent in this repo for replatting a DDS onto SharedTree, so the snapshot migration, op interop story, and facade layer would all be novel.
+- Op format is a hard cut-over. Clients speaking legacy `SharedDirectory` ops cannot decode `SharedTree`-backed ops or vice versa. All clients in a session must upgrade together, and documents persisted in the legacy format need one-time conversion.
+
+**Verdict.** Option B does not make this feature cheaper. The reference-based semantics still need to be built; SharedTree only handles the index-based ordering underneath. The replat is a defensible long-term strategy for `SharedDirectory` maintenance, but it should not gate shipping Word's feature. If the replat happens later, the requirements spec is the contract both implementations must satisfy.
+
+### 1.3 Recommendation
+
+Ship the feature via **Option A**. Treat Option B as a separate, independently-scoped initiative — if it happens, it must preserve the behavior defined in the requirements spec.
+
+The rest of this document details Option A.
+
+## 2. Option A — touch points
+
+Based on the earlier code mapping of `packages/dds/map/src/directory.ts`:
+
+| Concern | Where it lives today | What changes |
+|---|---|---|
+| Public API surface | `packages/dds/map/src/interfaces.ts` (`IDirectory`) | Add `createSubDirectoryOrderedAfter`. |
+| Op shape | `directory.ts:166–181` (`IDirectoryCreateSubDirectoryOperation`) | Add optional `afterSubdirName?: string`. |
+| Per-subdir ordering state | `directory.ts:1152` (`seqData`), `:389–392` (`SequenceData`) | Extend `SequenceData` to carry an optional `afterParent?: SequenceData` field (the stamped anchor's `SequenceData` at stamp time). |
+| Sort comparator | `directory.ts:364–380` (`seqDataComparator`) | Replace flat comparator with a recursive one (see §3). |
+| Local create entry point | `directory.ts:1294–1357` (`createSubDirectory`) | Add sibling method `createSubDirectoryOrderedAfter`; share most of the body; resolve local anchor and populate `afterParent` on the pending entry if present. |
+| Op application | `directory.ts:2080–2168` (`processCreateSubDirectoryMessage`) | At stamp time, if op carries `afterSubdirName`, look it up in `_sequencedSubdirectories`; if found, copy its `seqData` as the new subdir's `afterParent`. If not found (anchor missing), leave `afterParent` undefined — fallback to append. |
+| Resubmit | `directory.ts:2347–2369` (`resubmitSubDirectoryMessage`) | No structural change. Resubmit preserves the original op payload including `afterSubdirName`; re-resolution happens naturally at stamp time on whichever client sequences the op. |
+| Snapshot serialize | `directory.ts:2402–2409` (`getSerializableCreateInfo`), `:279–289` (`ICreateInfo`) | Persist `afterParent` alongside the existing `csn`/`ccIds`. Field is optional for backward compat. |
+| Snapshot load | `directory.ts:730–769` | Read optional `afterParent` when present; absent means old-format entry with no hint. |
+| Pending op storage | `directory.ts:1712` (`pendingSubDirectoryData`) | `PendingSubDirectoryCreate` entries carry the local-resolved `afterParent` for optimistic ordering. |
+
+## 3. The recursive sort key
+
+**This is the non-obvious part.** A flat tiebreaker over `(seq, clientSeq)` with "later-stamped sorts earlier at tied seq" does **not** reproduce the requirements spec's ordering in the multi-insert case. The key must be recursive.
+
+### 3.1 Why a flat key doesn't work
+
+Consider Example 1 from the requirements spec: base `[A, B]`; client #1 inserts `C` after `A`; client #2 inserts `D` after `A`, stamping order {#1, #2}. Requirement: `[A, D, C, B]`.
+
+If we "inherit A's seq" flatly onto C and D:
+- A: effectiveSeq = 1 (assume A stamped at seq 1)
+- B: effectiveSeq = 2
+- C: effectiveSeq = 1 (inherited), trueSeq = 3
+- D: effectiveSeq = 1 (inherited), trueSeq = 4
+
+Sort ascending by effectiveSeq with "larger trueSeq sorts earlier" at ties: among `{A, C, D}` (all effectiveSeq 1), trueSeq descending gives `D (4), C (3), A (1)`. Final order: `[D, C, A, B]`. **Wrong** — the anchor `A` ends up behind its own descendants.
+
+The issue is that A also has effectiveSeq 1 and gets caught in the inversion. The "later sorts earlier" rule only applies to *siblings inserted at the same anchor*, not to the anchor itself.
+
+### 3.2 The rule that works
+
+Each `SequenceData` carries an optional `afterParent`, which is a full recursive `SequenceData` pointing at the stamped anchor's own key at the moment of stamping. Comparator `cmp(X, Y)`:
+
+1. If both `X.afterParent` and `Y.afterParent` are `undefined`: compare by `(seq, clientSeq)` as today.
+2. If only one has an `afterParent`: compare the one without against the other's `afterParent` (recursively). Ties break so the one *with* an `afterParent` sorts **after** the one without — i.e., a child of X sorts immediately after X.
+3. If both have an `afterParent`: compare `X.afterParent` against `Y.afterParent` recursively. If those differ, the outer comparison follows. If they are equal (same anchor), tiebreak by own `(seq, clientSeq)` **inverted** (larger `seq` sorts earlier — closer to the anchor).
+
+### 3.3 Worked examples
+
+**Example 1 (base `[A,B]`; +C after A, +D after A, stamped {#1,#2}):**
+- A = `{seq:1}`; B = `{seq:2}`; C = `{seq:3, afterParent:{seq:1}}`; D = `{seq:4, afterParent:{seq:1}}`.
+- `cmp(A,C)`: A has no parent, C does. Compare A vs C.afterParent = `{seq:1}`; equal; C sorts after A per rule 2. → A < C. ✓
+- `cmp(B,C)`: B has no parent, C does. Compare B (`{seq:2}`) vs C.afterParent (`{seq:1}`); 2 > 1, so C.afterParent < B, so C < B. ✓
+- `cmp(C,D)`: both have parents; both parents are `{seq:1}`, equal. Own seq: C=3, D=4; inverted, D < C. ✓
+- Final order: `A, D, C, B`. ✓
+
+**Example 4 result `{#2,#3,#1}` (base `[A,B,C]`; delete A, +D after A, +E after A; stamped {#2, #3, #1} = insert D, insert E, delete A):**
+- Before deletes: A = `{seq:1}`, B = `{seq:2}`, C = `{seq:3}`, D = `{seq:4, afterParent:{seq:1}}`, E = `{seq:5, afterParent:{seq:1}}`.
+- `cmp(D,E)`: same parent, own inverted → E < D. Order between them: E, D.
+- `cmp(E,B)`: E has parent, B does not. Compare B (`{seq:2}`) vs E.afterParent (`{seq:1}`); B > parent, so E < B. ✓
+- After A is deleted, A is removed from `_sequencedSubdirectories`. D and E retain their `afterParent` references. The comparator still works against the now-absent anchor's recorded `SequenceData`.
+- Final order: `E, D, B, C`. ✓
+
+**Nested insert-after (E after C, where C was inserted after A):**
+- E = `{seq:5, afterParent: C.seqData}` where C.seqData = `{seq:3, afterParent:{seq:1}}`.
+- `cmp(E,D)`: both have parents. Compare E.afterParent (C's key) vs D.afterParent (`{seq:1}`).
+  - Recursive: E's parent has its own parent; D's parent does not. Per rule 2, E's parent sorts after D's parent. So E.afterParent > D.afterParent → E > D. ✓
+- `cmp(E,B)`: E has parent, B does not. Compare B (`{seq:2}`) vs E.afterParent (C's key). Recursive: C's key has a parent (`{seq:1}`) and B does not. Compare B (`{seq:2}`) vs C's parent (`{seq:1}`); B > 1, so B > C.afterParent.parent; by rule 2 the sub-comparison resolves with B > C.afterParent; so E < B. ✓
+
+### 3.4 Equality semantics for `afterParent`
+
+"Same anchor" in rule 3 is determined by deep equality of the `SequenceData` chain, not by identity of the anchor object. Two insertions sharing an anchor get identical `afterParent` values because both copied the anchor's `SequenceData` at stamp time — even though the anchor itself may have been deleted afterwards. This is intentional: the anchor is a value, not a pointer.
+
+## 4. Op format
+
+Current op (directory.ts:166–181):
+
+```ts
+interface IDirectoryCreateSubDirectoryOperation {
+    type: "createSubDirectory";
+    path: string;
+    subdirName: string;
+}
+```
+
+Proposed:
+
+```ts
+interface IDirectoryCreateSubDirectoryOperation {
+    type: "createSubDirectory";
+    path: string;
+    subdirName: string;
+    afterSubdirName?: string;   // NEW: optional ordering hint
+}
+```
+
+The new field is optional. Ops from old clients omit it and behave exactly as before (append). Ops from new clients that don't use the new API also omit it.
+
+## 5. Mixed-version session compatibility
+
+When a new client submits an op with `afterSubdirName`:
+
+- **Sequencing server** (opaque): forwards the op verbatim. No change needed.
+- **Other new clients**: honor the hint per the requirements spec.
+- **Old clients** (don't know about the field): ignore the field, apply the op as a plain append. Their local ordering will *not* match the requirements spec for that subdirectory until they upgrade. No session-breaking behavior; it's best-effort degradation.
+
+This is consistent with how other optional op fields have been rolled out in SharedDirectory historically. A release-note callout ("insertion ordering hints require clients on version X or later to observe") is sufficient; we do not need a hard version gate.
+
+## 6. Snapshot compatibility
+
+Current `ICreateInfo` (directory.ts:279–289):
+
+```ts
+interface ICreateInfo {
+    csn: number;       // creation sequence number
+    ccIds: string[];   // creator client IDs
+}
+```
+
+Proposed:
+
+```ts
+interface ICreateInfo {
+    csn: number;
+    ccIds: string[];
+    afterParent?: ICreateInfo;   // NEW: recursive structure, optional
+}
+```
+
+On serialize: if the subdirectory's `seqData.afterParent` is present, serialize it recursively as `afterParent` on the persisted `ICreateInfo`. Otherwise omit.
+
+On load:
+- Old snapshots have no `afterParent` field. Subdirectories load with `seqData.afterParent === undefined` → behave as plain appends, which is correct (the hint was never recorded).
+- New snapshots with `afterParent` load into the new `seqData` shape. Old clients reading new snapshots will silently ignore the field (JSON deserialization discards unknown keys) and treat the subdirectory as a plain append — same best-effort degradation as mixed-version ops.
+
+Recursive size bound: `afterParent` chains have length bounded by the depth of insert-after chaining at the moment each subdirectory was created. In practice this is shallow (Word's use case is "insert this comment after that comment," not long chains). If chains grow pathological, snapshot size grows linearly with chain length per subdirectory; this is a theoretical concern but not a practical one for the stated use case. We will add a test that confirms reasonable-size chains round-trip correctly and note the linear bound in code comments.
+
+## 7. Local optimistic path
+
+Requirements §4.8 says the local view shows the requested position immediately. Implementation:
+
+1. In `createSubDirectoryOrderedAfter`, resolve the anchor in the caller's local visible state via `getOptimisticSubDirectory` (the method already used by local creates; directory.ts:~1310).
+2. If found, copy the anchor's current `seqData` (may itself be pending, with `seq = -1`) as the new pending entry's `afterParent`.
+3. If not found locally, leave `afterParent` undefined; the local view will append, consistent with §4.4.
+4. `subdirectories()` iteration (directory.ts:1466–1472) uses the new comparator over the combined sequenced + pending set. No additional code path needed — the comparator handles pending entries the same way.
+5. When the op is ack'd, the pending entry's `afterParent` is replaced with the anchor's *sequenced* `seqData` (if the anchor exists at stamp time) — which may differ from the local-time anchor seq. See §8.
+
+## 8. Reconnect / resubmit
+
+The current resubmit flow (directory.ts:2347–2369) preserves the original op payload and does not re-validate. With the new field, the op is resubmitted carrying the original `afterSubdirName`. On stamping, the receiving clients resolve the anchor against their current sequenced state — exactly the same rule as for a freshly-submitted op. No new reconnect logic is needed.
+
+Local state during reconnect: the pending entry's optimistic `afterParent` may become stale if the anchor was deleted concurrently or its `seqData` changed. Two acceptable approaches:
+
+- **Approach 1 (simpler):** Leave the pending entry's `afterParent` untouched during the offline window. Iteration order on the local client may be slightly off relative to eventual stamped order, but since the whole client is offline, this is only visible to the local user briefly. On ack, `afterParent` is replaced with the sequenced anchor's `seqData`.
+- **Approach 2 (optional refinement):** On remote op receipt during offline replay, re-resolve pending `afterParent` values against the current sequenced state. More work; marginal benefit. Not proposed for the first implementation.
+
+Approach 1 is proposed. Call it out in tests so the reconnect ordering behavior is pinned.
+
+## 9. Test plan
+
+All tests go in `packages/dds/map/src/test/mocha/`. Primary file: extend `directory.order.spec.ts`. Add a new file for reconnect scenarios if `reconnection.spec.ts` grows unwieldy.
+
+### 9.1 Requirements-spec examples as tests (required coverage)
+
+Each of Examples 1–4 in the requirements spec becomes an explicit test case. For Example 4, all four stamping orders are exercised. Use `MockContainerRuntimeFactory.processSomeMessages(n)` to control stamping order (directory.order.spec.ts:185).
+
+### 9.2 Ambiguity-resolution cases (required coverage)
+
+One test per resolved ambiguity:
+- **Q1** — anchor never created locally → call succeeds, local view appends.
+- **Q1** — anchor deleted locally → call succeeds, local view appends.
+- **Q2** — anchor deleted and recreated before stamp → new anchor is used.
+- **Q3** — call returns `IDirectory` even when fallback occurs.
+- **Q6** — `newSubdirName` already exists → returns existing; positioning hint ignored.
+- **Q7** — local view shows position immediately after call; position may shift on ack under concurrent remote activity.
+
+### 9.3 Recursive sort key edge cases
+
+- Insert after a subdirectory that was itself inserted after another (chain of length 2).
+- Mixed tree of plain creates and ordered creates interleaved at different sequence numbers.
+- Concurrent inserts after different anchors (interaction across sort-key prefixes).
+
+### 9.4 Snapshot round-trip
+
+- Serialize a directory with `afterParent` chains, load into a fresh instance, verify iteration order matches.
+- Load an old-format snapshot (no `afterParent` field) into new code → all entries treated as plain appends.
+- Load a new-format snapshot into old-format `ICreateInfo` code path (simulated) → `afterParent` silently dropped; entries appear as plain appends.
+
+### 9.5 Reconnect / resubmit
+
+- Disconnect after calling `createSubDirectoryOrderedAfter`, reconnect, observe stamped ordering matches the requirements spec.
+- Concurrent remote delete of anchor during offline window → on reconnect, the inserted subdirectory falls back to append per §4.4.
+- Concurrent remote creation of same-name subdirectory during offline window → on reconnect, same-name merge applies per §4.3.
+
+### 9.6 Detached state
+
+- Create a detached SharedDirectory, use ordered creates, attach → verify iteration order survives the attach.
+
+### 9.7 Oracle / equivalence tests
+
+Extend `directoryOracle.ts` and `directoryEquivalenceUtils.ts` to support the new ordering. Run existing fuzz tests (if present in the package) with the new API enabled.
+
+## 10. Open implementation questions
+
+These are *implementation-level* questions whose answers do not change observable behavior (so they are out of scope for the requirements spec) but should be settled before or during coding.
+
+1. **Approach 1 vs Approach 2 for reconnect** (§8). Default to Approach 1. Revisit only if user-visible glitches are reported during offline edits.
+2. **`afterParent` equality helper.** Add a small `seqDataEquals(a, b)` utility rather than inlining recursive-equality. Trivial, but worth a named helper for readability.
+3. **Interaction with future `SharedDirectory` changes.** If other work (e.g., Option B in the background) reshapes `SequenceData`, coordinate. As of the date of this plan the branch is at parity with `main`.
+4. **Performance.** The recursive comparator is O(d) per comparison where d is chain depth. `subdirectories()` is already O(n log n) per call due to sort-on-read. New cost: O(n log n × d). Expected d ≈ 1 for Word's workloads. Not a concern at this scale; revisit if profiles show sort overhead growing.
+
+## 11. Rollout sequence
+
+1. Land the requirements spec (already committed).
+2. Land this implementation plan.
+3. Write tests (TDD) — all tests from §9 as failing tests first, per Nori workflow.
+4. Implement: op shape → `SequenceData` → comparator → local create path → process → resubmit → serialize/deserialize.
+5. Run full `packages/dds/map` test suite; fix any regressions in existing tests.
+6. Update `api-report/map.*.api.md` via `build:api-reports` (never hand-edit).
+7. Changelog fragment (changie) for the new public API.
+8. PR with link to requirements spec and this plan in the description.

--- a/packages/dds/map/docs/ordering-hints-implementation-plan.md
+++ b/packages/dds/map/docs/ordering-hints-implementation-plan.md
@@ -246,7 +246,19 @@ One test per resolved ambiguity:
 
 ### 9.7 Oracle / equivalence tests
 
-Extend `directoryOracle.ts` and `directoryEquivalenceUtils.ts` to support the new ordering. Run existing fuzz tests (if present in the package) with the new API enabled.
+Extend `directoryOracle.ts` and `directoryEquivalenceUtils.ts` to support the new ordering. Run existing fuzz tests with the new API enabled.
+
+### 9.8 Fuzz and stress validation (required)
+
+The unit tests in §9.1–§9.7 pin specific scenarios, but the real risk surface for the recursive comparator and the local-optimistic-vs-stamp-time afterParent mutation is random concurrent operation sequences. The implementer **must** run the following as they go (not just at the end) and fix anything that reproduces:
+
+1. **`packages/dds/map/src/test/mocha/directoryFuzzTests.spec.ts`** — the existing randomized directory fuzz suite, which operates over the `baseDirModel` op set. Before running, extend the `baseDirModel` operations (see `packages/dds/map/src/test/index.ts` exports and the fuzz utilities in `fuzzUtils.ts`) to include `createSubDirectoryOrderedAfter` with a random existing-sibling anchor. Without this extension, fuzz coverage of the new API is zero. Run via `npm run test:mocha` in the map package; inspect seeds that fail.
+
+2. **`packages/test/local-server-stress-tests`** — the cross-DDS stress harness already consumes the `baseDirModel` exported by `@fluidframework/map/internal/test` (see `packages/test/local-server-stress-tests/src/ddsModels.ts:11`). Once the fuzz model is extended in step 1, this harness picks up `createSubDirectoryOrderedAfter` automatically and exercises it under realistic multi-client-with-local-server conditions (including detach/reattach, snapshot, summarize/load, reconnect). Run via `npm run test` in that package. Seeds that fail here typically point at snapshot round-trip or op-ordering bugs that the unit tests miss because they fabricate simpler schedules.
+
+3. **`packages/test/test-end-to-end-tests`** — the end-to-end suite runs scenarios against the in-repo driver stack. SharedDirectory is exercised by many of these tests transitively; run the subset that touches directory/summarization paths (e.g., `createNewSummaryCachingTests.spec.ts`, `detachedContainerTests.spec.ts`, `stagingMode.spec.ts`). This catches serialization, op-format, and reconnection regressions that only manifest through the full runtime.
+
+Running these **as you go** — after each meaningful implementation chunk rather than only at the end — is important because the recursive-comparator design has non-obvious failure modes (anchor retained after delete, inversion tiebreaker only for same-anchor siblings, stamp-time re-resolution of the afterParent). If a fuzz seed fails, reduce it to a minimal unit test before attempting a fix so the regression is pinned in `directory.order*.spec.ts`.
 
 ## 10. Open implementation questions
 
@@ -261,9 +273,14 @@ These are *implementation-level* questions whose answers do not change observabl
 
 1. Land the requirements spec (already committed).
 2. Land this implementation plan.
-3. Write tests (TDD) — all tests from §9 as failing tests first, per Nori workflow.
+3. Write tests (TDD) — all tests from §9.1–§9.6 as failing tests first, per Nori workflow.
 4. Implement: op shape → `SequenceData` → comparator → local create path → process → resubmit → serialize/deserialize.
 5. Run full `packages/dds/map` test suite; fix any regressions in existing tests.
-6. Update `api-report/map.*.api.md` via `build:api-reports` (never hand-edit).
-7. Changelog fragment (changie) for the new public API.
-8. PR with link to requirements spec and this plan in the description.
+6. **Extend the `baseDirModel` fuzz operations to include `createSubDirectoryOrderedAfter`** (§9.8 step 1). Run `directoryFuzzTests.spec.ts` to completion on the default seed range; fix anything that reproduces and pin the failing seed as a new unit test.
+7. **Run `packages/test/local-server-stress-tests`** (§9.8 step 2). Fix anything that reproduces.
+8. **Run the relevant subset of `packages/test/test-end-to-end-tests`** (§9.8 step 3) — at minimum the directory/summarization tests.
+9. Update `api-report/map.*.api.md` via `build:api-reports` (never hand-edit).
+10. Changeset for the new public API (Fluid uses changesets, not changie).
+11. PR with link to requirements spec and this plan in the description.
+
+Steps 6–8 are non-negotiable before marking the PR ready for review. Fuzz coverage of the new op is zero until step 6 lands, and the recursive comparator has more surface area than the unit tests alone exercise.

--- a/packages/dds/map/docs/ordering-hints-requirements.md
+++ b/packages/dds/map/docs/ordering-hints-requirements.md
@@ -1,0 +1,219 @@
+# SharedDirectory Insertion Ordering Hints — Requirements
+
+**Status:** Draft
+**Scope:** Requirements only. Implementation strategy is covered in a separate plan document.
+
+## 1. Overview
+
+`SharedDirectory` iteration order over its subdirectories is today controlled implicitly by the order in which subdirectory creations are stamped. Creating a subdirectory is effectively an "append." This works for append-only workloads but forces callers to reconstruct ordering when they need to insert in the middle of the sequence.
+
+Word uses `SharedDirectory` subdirectories to model comments within a document; the iteration order of those subdirectories defines the ordering of the comments. In three-way-merge scenarios (reconciling non-Fluid edits made against a potentially much older state), Word needs to insert new comment subdirectories at specific positions within an existing thread. The only way to do this today is to delete every subdirectory ordered after the desired insertion point, insert the new ones, and re-create the deleted ones from scratch — a costly workaround.
+
+This feature adds an `IDirectory` API that lets a caller create a new subdirectory at a requested position in its parent's ordered set of children, expressed as "order this new subdirectory after an existing named sibling."
+
+## 2. Scope and Non-Goals
+
+**In scope**
+- A new method on `IDirectory` that creates a subdirectory with a positioning hint relative to an existing named sibling.
+- Defined behavior for concurrent insertions, same-name collisions, and deleted-anchor cases.
+
+**Non-goals**
+- `SharedMap` has no subdirectories and no defined iteration ordering over keys. This feature does not apply to `SharedMap`.
+- No "order before" variant is defined in this feature. ("Order after X" plus the existing append semantics is sufficient for Word's use case, and adding "order before" can be considered separately later.)
+- No long-term relationship between the inserted subdirectory and its anchor. Deleting the anchor later does not affect the inserted subdirectory. The hint is single-shot, resolved at stamp time, and never re-evaluated afterwards.
+- No change to the existing ordering of subdirectories created via `createSubDirectory`. Append-at-end remains the semantics of that method.
+- No change to `SharedMap` or to unrelated `IDirectory` methods (`getSubDirectory`, `deleteSubDirectory`, etc.).
+
+## 3. API Surface
+
+Add the following method to the `IDirectory` interface:
+
+```ts
+interface IDirectory {
+    /**
+     * Creates an IDirectory child of this IDirectory with a requested position in
+     * the ordered set of children. If a subdirectory with the given name already
+     * exists, the existing subdirectory is returned and the positioning hint is
+     * ignored (matching the semantics of {@link IDirectory.createSubDirectory}).
+     *
+     * The positioning hint ("order after the named sibling") is best-effort and
+     * is resolved when the creation op is stamped. If the anchor does not exist
+     * at stamp time — because it was never created, was deleted, or is not yet
+     * visible to the stamping client — the new subdirectory is appended at the
+     * end of the ordered set, matching the existing {@link IDirectory.createSubDirectory}
+     * behavior. The hint establishes no long-term relationship with the anchor.
+     *
+     * @param newSubdirName - Name of the new child directory to create.
+     * @param afterSubdirName - Name of an existing sibling directory to order the
+     *                          new child directory after. May refer to a sibling
+     *                          that does not currently exist locally; see the
+     *                          behavioral requirements for fallback semantics.
+     * @returns The `IDirectory` child. Never `undefined`; if creation would
+     *          otherwise fail, the method throws, consistent with
+     *          {@link IDirectory.createSubDirectory}.
+     */
+    createSubDirectoryOrderedAfter(
+        newSubdirName: string,
+        afterSubdirName: string,
+    ): IDirectory;
+}
+```
+
+## 4. Behavioral Requirements
+
+The rules below describe observable behavior. They do not prescribe how the behavior is implemented.
+
+### 4.1 Happy-path ordering
+
+When `createSubDirectoryOrderedAfter('C', 'A')` is stamped and an anchor named `A` exists in the parent's sequenced subdirectory set at stamp time, the new subdirectory `C` is ordered immediately after `A` in the parent's iteration order. Any existing sibling that was previously ordered after `A` (for example `B`) is ordered after `C`, preserving its relative position to everything else.
+
+### 4.2 Concurrent insertions after the same anchor (different names)
+
+When two or more clients concurrently request insertion after the same anchor and stamp successfully, the later-stamped insertion is ordered **earlier** in the resulting sequence (closer to the anchor), mirroring the behavior of concurrent insertions at the same character position in `SharedString`.
+
+> *Example:* Base `[A, B]`. Client #1 inserts `C` after `A`; client #2 inserts `D` after `A`. Stamping order {#1, #2} yields `[A, D, C, B]`. Stamping order {#2, #1} yields `[A, C, D, B]`.
+
+### 4.3 Concurrent insertions with the same name
+
+When two or more clients concurrently create a subdirectory with the **same name** (regardless of whether each used `createSubDirectory` or `createSubDirectoryOrderedAfter`, and regardless of whether they specified different anchors), the existing same-name merge behavior of `SharedDirectory` applies:
+
+- The subdirectory is merged into a single logical entity. Only the first-stamped creation's positioning takes effect.
+- Subsequent stamped creations with the same name do not change the position of the already-created subdirectory and their positioning hints are ignored.
+
+> *Example:* Base `[A, B]`. Client #1 inserts `C` after `A`; client #2 inserts `C` after `B`. Stamping order {#1, #2} yields `[A, C, B]`. Stamping order {#2, #1} yields `[A, B, C]`.
+
+### 4.4 Anchor missing at stamp time — fallback to append
+
+If `afterSubdirName` does not identify an existing sequenced sibling at the time the creation op is stamped, the new subdirectory is appended at the end of the parent's ordered set, exactly as if `createSubDirectory` had been called. The positioning hint has no effect. This includes:
+
+- The anchor was deleted before the op was stamped (concurrently with or before the insertion).
+- The anchor was never created.
+- The anchor existed at op creation time on the submitting client but does not exist at stamp time for any reason.
+
+The method still returns the created `IDirectory`; fallback is not an error.
+
+> *Example:* Base `[A, B]`. Client #1 deletes `A`; client #2 inserts `C` after `A`. Stamping order {#1, #2} yields `[B, C]`. Stamping order {#2, #1} yields `[C, B]`.
+
+### 4.5 Anchor deleted and re-created before stamp
+
+If the subdirectory originally named `afterSubdirName` is deleted and then a new subdirectory with the same name is created before the insertion op is stamped, the **currently sequenced subdirectory under that name at stamp time** is the anchor. The insertion is ordered after that currently-existing sibling, inheriting its position rather than the deleted one's. This matches the rule in §4.4 — the hint is resolved at stamp time against whatever state exists then — and preserves the single-shot, identity-free nature of the hint.
+
+### 4.6 Combined concurrent insertions and deletion of the anchor
+
+When an anchor's deletion is concurrent with one or more "order after" insertions, §4.4 determines the outcome for each insertion independently, based on whether the anchor is present at the moment that insertion is stamped.
+
+> *Example (from source spec):* Base `[A, B, C]`.
+> - Client #1 deletes `A`.
+> - Client #2 inserts `D` after `A`.
+> - Client #3 inserts `E` after `A`.
+>
+> | Stamping order | Result | Reasoning |
+> |---|---|---|
+> | {#1, #2, #3} | `[B, C, D, E]` | Both inserts see `A` already deleted → both append. `E` is later-stamped and appends last. |
+> | {#1, #3, #2} | `[B, C, E, D]` | Both inserts see `A` already deleted → both append. `D` is later-stamped and appends last. |
+> | {#2, #3, #1} | `[E, D, B, C]` | Both inserts see `A` present at stamp time and order after `A`; by §4.2, later-stamped (`E`) sorts earlier. `A` is then deleted. |
+> | {#2, #1, #3} | `[D, B, C, E]` | `D` sees `A` present and orders after it. `A` is then deleted. `E` sees `A` deleted → append. |
+
+### 4.7 Name collision on `newSubdirName`
+
+If a subdirectory with the name `newSubdirName` already exists on this parent at the time `createSubDirectoryOrderedAfter` is called, the method returns the existing subdirectory unchanged and the positioning hint is ignored. This matches the existing semantics of `createSubDirectory` and keeps the two methods' contracts consistent.
+
+### 4.8 Local optimistic ordering before acknowledgment
+
+When a local client calls `createSubDirectoryOrderedAfter('C', 'A')` and the anchor `A` is visible in the local state at call time, the local client's iteration order places `C` immediately after `A` as soon as the call returns, before the op is stamped by the server. This matches the "insert here" intent of the caller and avoids a visible reposition-on-ack glitch in UI scenarios.
+
+If the anchor is not present locally at call time, the new subdirectory is appended in the local view, matching §4.4's fallback rule for the local phase. If the anchor is deleted locally between call time and acknowledgment, no local reposition is required — the op will be re-resolved against sequenced state at stamp time.
+
+The local optimistic position is not authoritative. The position after acknowledgment may differ from the local position if concurrent remote activity changes the stamped outcome. Callers that depend on stable ordering must wait for acknowledgment, just as they would for any other `SharedDirectory` operation.
+
+### 4.9 No durable anchor relationship
+
+Once a `createSubDirectoryOrderedAfter` op is stamped, the anchor no longer needs to be tracked. The hint establishes no durable relationship:
+
+- Deleting the anchor later does not affect the inserted subdirectory.
+- Renaming or recreating the anchor later does not affect the inserted subdirectory.
+- The inserted subdirectory's position is determined by the ordering algorithm alone, not by a back-reference to the anchor.
+
+### 4.10 Detached-state behavior
+
+Before a `SharedDirectory` is attached to a container, operations are not sequenced. `createSubDirectoryOrderedAfter` in the detached state uses the local ordering with the positioning hint applied immediately, consistent with §4.8. On attach, the existing `SharedDirectory` attach flow preserves the local iteration order exactly as it appeared in the detached state.
+
+## 5. Resolved Ambiguities
+
+Each subsection records a question that was not fully determined by the original feature request, the options considered, the decision, and the reasoning. Recording the options helps future readers evaluate edge cases the rule does not explicitly cover.
+
+### 5.1 (Q1) Local anchor missing at call time
+
+**Question.** If `afterSubdirName` does not identify a sibling visible on the local client at the time `createSubDirectoryOrderedAfter` is called (never created locally, or already locally deleted), does the method throw synchronously, or accept the call and fall back to append?
+
+**Options.**
+- **A.** Throw synchronously — treat a missing local anchor as a programming error.
+- **B.** Accept the call and fall back to append (either locally right away, or at stamp time, or both).
+
+**Decision.** Option B. Fallback to append, with the local view also appending per §4.8.
+
+**Reasoning.** The original feature request describes the positioning as a hint, not a constraint, and defines fallback behavior at stamp time (Examples 3 and 4). Treating a missing anchor as a hard local error would introduce a second contract — "throws locally but silently falls back remotely" — for what is, at the spec level, the same condition. A single rule ("missing anchor, append") that applies uniformly at both call time and stamp time is simpler and matches the caller's mental model better. This is especially important for three-way merge scenarios like Word's, where the local view may be stale relative to the target state and exception handling around every call is unwanted friction.
+
+### 5.2 (Q2) Anchor deleted and re-created before stamp
+
+**Question.** If the anchor named `afterSubdirName` is deleted and a new subdirectory with the same name is created before the insertion op is stamped, does the new same-named subdirectory count as the anchor, or is the condition treated as "anchor missing"?
+
+**Options.**
+- **A.** Resolve the anchor at stamp time against whatever is currently sequenced under that name. A re-created same-named subdirectory counts as the anchor.
+- **B.** Bind the anchor identity at op creation time (e.g., by carrying the anchor's creation sequence number on the op). A re-created same-named subdirectory is not the original anchor and the hint falls back to append.
+
+**Decision.** Option A. Resolve the anchor at stamp time by name, against the currently sequenced state.
+
+**Reasoning.** The hint is by name, not by identity — the API takes a string, and the caller's intent is expressed in terms of "the subdirectory that is visible under this name." The single-shot, identity-free model also matches the source spec's note that the anchor does not need to be tracked once the op is stamped. Option B would require carrying the anchor's creation sequence number on the op and additional anchor-identity bookkeeping, and would produce outcomes the caller is unlikely to want (e.g., inserting next to a live sibling becomes an append when a same-named sibling was coincidentally recycled). Option A is simpler and closer to caller intent.
+
+### 5.3 (Q3) Return value when the positioning hint falls back
+
+**Question.** When the positioning hint cannot be honored (anchor missing at stamp time) and the new subdirectory is appended instead, does the method still return the created `IDirectory`, or does it return a different value to signal the fallback?
+
+**Options.**
+- **A.** Always return the created `IDirectory`. Fallback is a quiet degradation, observable only by inspecting the resulting order.
+- **B.** Return something that indicates fallback (e.g., a tuple, a boolean flag, `undefined`).
+
+**Decision.** Option A. Always return the created `IDirectory`.
+
+**Reasoning.** Creation always succeeds (modulo the existing same-name merge); only the positioning is best-effort. Signaling fallback in the return value would complicate the common path for the minority case, and callers that care about final position must already observe the eventual iteration order rather than trusting a return value at call time. The signature mirrors `createSubDirectory`, which is consistent and easier to reason about.
+
+### 5.4 (Q6) Name collision on `newSubdirName`
+
+**Question.** If a subdirectory with the name `newSubdirName` already exists on this parent, does `createSubDirectoryOrderedAfter` throw, or does it return the existing subdirectory as `createSubDirectory` does?
+
+**Options.**
+- **A.** Throw on name collision.
+- **B.** Return the existing subdirectory unchanged, ignoring the positioning hint, exactly as `createSubDirectory` does today.
+
+**Decision.** Option B. Inherit `createSubDirectory`'s tolerant behavior.
+
+**Reasoning.** The original feature request states "there must not already be an `IDirectory` child of this `IDirectory` with the given name," but the existing `createSubDirectory` API is itself tolerant of that condition and returns the existing child. Diverging the two sibling APIs' contracts on name collision would be surprising and would force callers to use different call sites depending on which API they use. Callers who want strict semantics can check `getSubDirectory` before calling.
+
+### 5.5 (Q7) Local optimistic ordering before acknowledgment
+
+**Question.** When a caller issues `createSubDirectoryOrderedAfter('C', 'A')` on a connected client, what does the local iteration order return for the parent before the op is acknowledged — `C` positioned after `A`, or `C` appended with a reposition after ack?
+
+**Options.**
+- **A.** Show the requested position immediately. The local view places `C` after `A` before ack. Local position may shift after ack if concurrent remote activity changes the stamped outcome.
+- **B.** Append locally until ack, then reposition to the acknowledged position. Produces a visible "jump" for UIs that observe the iteration order between call and ack.
+
+**Decision.** Option A. Show the requested position immediately.
+
+**Reasoning.** The point of the API is insertion-at-position; returning to the caller with the new subdirectory at the wrong position, even briefly, defeats that point for any UI scenario (which is the primary motivating use case). The cost of Option A is that the caller must understand that the position is optimistic and may shift after ack — but optimistic local state is already how the rest of `SharedDirectory` behaves and is documented accordingly in §4.8.
+
+## 6. Questions explicitly not resolved here
+
+The following were considered and deliberately left out of this spec because they are not requirements-level:
+
+- **Reconnect / resubmit behavior.** Whether the client re-resolves the anchor on resubmit or preserves the original op payload is an implementation choice. Both strategies produce the same observable outcome under the rules above, because the spec's rules are expressed entirely in terms of state at stamp time. This is covered in the implementation plan.
+- **`SharedMap`.** Out of scope (§2).
+- **Self-reference (`afterSubdirName === newSubdirName`).** `newSubdirName` does not exist at the time the hint is resolved (it is in the process of being created), so this condition is covered by §4.4 (anchor missing → append). No additional rule is needed.
+- **Choice of implementation platform** (extend the current `SharedDirectory` codepath vs. replat on `SharedTree` internals behind a facade). Addressed in the implementation plan.
+
+## 7. Glossary
+
+- **Anchor.** The existing subdirectory named by `afterSubdirName` at the time the creation op is stamped.
+- **Stamp / stamped.** The point at which an op is assigned an authoritative sequence number by the Fluid service and becomes visible to all session participants in a single defined order.
+- **Sequenced subdirectory.** A subdirectory whose creation op has been stamped. Pending (unack'd) local creations are not sequenced.
+- **Fallback.** The behavior when the positioning hint cannot be applied: the new subdirectory is appended at the end of the parent's ordered set.

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -172,7 +172,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_SharedDirectory": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -585,6 +585,16 @@ export class SharedDirectory
 	}
 
 	/**
+	 * {@inheritDoc IDirectory.createSubDirectoryOrderedAfter}
+	 */
+	public createSubDirectoryOrderedAfter(
+		newSubdirName: string,
+		afterSubdirName: string,
+	): IDirectory {
+		return this.root.createSubDirectoryOrderedAfter(newSubdirName, afterSubdirName);
+	}
+
+	/**
 	 * {@inheritDoc IDirectory.getSubDirectory}
 	 */
 	public getSubDirectory(subdirName: string): IDirectory | undefined {
@@ -1286,6 +1296,16 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	 */
 	public countSubDirectory(): number {
 		return [...this.subdirectories()].length;
+	}
+
+	/**
+	 * {@inheritDoc IDirectory.createSubDirectoryOrderedAfter}
+	 */
+	public createSubDirectoryOrderedAfter(
+		newSubdirName: string,
+		afterSubdirName: string,
+	): IDirectory {
+		throw new Error("createSubDirectoryOrderedAfter: not implemented");
 	}
 
 	/**

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -178,6 +178,14 @@ export interface IDirectoryCreateSubDirectoryOperation {
 	 * Name of the new subdirectory.
 	 */
 	subdirName: string;
+
+	/**
+	 * Optional ordering hint: name of the sibling subdirectory to position the new subdirectory after.
+	 * When absent, the new subdirectory is appended at the end (existing behavior). When present, the
+	 * hint is resolved at stamp time against the parent's sequenced subdirectories; if the named anchor
+	 * does not exist at stamp time, the new subdirectory is appended (fallback).
+	 */
+	afterSubdirName?: string;
 }
 
 /**
@@ -270,6 +278,23 @@ interface PendingSubDirectoryDelete {
 type PendingSubDirectoryEntry = PendingSubDirectoryCreate | PendingSubDirectoryDelete;
 
 /**
+ * Persisted ordering-hint information: the anchor chain captured at the time a subdirectory was
+ * inserted via createSubDirectoryOrderedAfter. Used to reconstruct iteration order on snapshot load.
+ *
+ * @deprecated This interface will no longer be exported in the future(AB#8004).
+ *
+ * @legacy @beta
+ */
+export interface IAfterParentInfo {
+	/** Sequence number of the anchor at the moment this insert was stamped. */
+	csn: number;
+	/** Client sequence number of the anchor at the moment this insert was stamped, when known. */
+	ccsn?: number;
+	/** The anchor's own afterParent, when the anchor was itself inserted via an ordering hint. */
+	afterParent?: IAfterParentInfo;
+}
+
+/**
  * Create info for the subdirectory.
  *
  * @deprecated This interface will no longer be exported in the future(AB#8004).
@@ -286,6 +311,12 @@ export interface ICreateInfo {
 	 * clientids of the clients which created this sub directory.
 	 */
 	ccIds: string[];
+
+	/**
+	 * If this subdirectory was created via {@link IDirectory.createSubDirectoryOrderedAfter}, the anchor
+	 * chain captured at stamp time. Absent for plain createSubDirectory entries.
+	 */
+	afterParent?: IAfterParentInfo;
 }
 
 /**
@@ -361,22 +392,62 @@ export interface IDirectoryNewStorageFormat {
  * 4. A 'seq' value of zero indicates that the subdirectory was created in detached state, and it is considered acknowledged for the
  * purpose of ordering.
  */
-const seqDataComparator = (a: SequenceData, b: SequenceData): number => {
-	if (isAcknowledgedOrDetached(a)) {
-		if (isAcknowledgedOrDetached(b)) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			return a.seq === b.seq ? a.clientSeq! - b.clientSeq! : a.seq - b.seq;
-		} else {
-			return -1;
-		}
-	} else {
-		if (isAcknowledgedOrDetached(b)) {
-			return 1;
-		} else {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			return a.seq === b.seq ? a.clientSeq! - b.clientSeq! : a.seq - b.seq;
-		}
+/**
+ * Compares two SequenceData values considering only their own seq/clientSeq fields
+ * (ignoring afterParent). Acknowledged (seq >= 0) sorts before pending (seq = -1); within a
+ * category, ascending by seq, then by clientSeq.
+ */
+function compareOwnSeqData(a: SequenceData, b: SequenceData): number {
+	const aAckd = isAcknowledgedOrDetached(a);
+	const bAckd = isAcknowledgedOrDetached(b);
+	if (aAckd !== bAckd) {
+		return aAckd ? -1 : 1;
 	}
+	if (a.seq !== b.seq) {
+		return a.seq - b.seq;
+	}
+	const aClientSeq = a.clientSeq ?? 0;
+	const bClientSeq = b.clientSeq ?? 0;
+	return aClientSeq - bClientSeq;
+}
+
+/**
+ * Compares two SequenceData values for ordering. Handles the optional afterParent hint:
+ * a subdirectory with afterParent sorts immediately after the anchor the afterParent points at,
+ * and among multiple inserts after the same anchor, the later-stamped one sorts earlier (closer to
+ * the anchor), mirroring the behavior of concurrent insertions at the same character position in
+ * SharedString.
+ *
+ * See packages/dds/map/docs/ordering-hints-requirements.md §4 for observable behavior, and
+ * packages/dds/map/docs/ordering-hints-implementation-plan.md §3 for the derivation of this rule.
+ */
+const seqDataComparator = (a: SequenceData, b: SequenceData): number => {
+	if (a.afterParent !== undefined && b.afterParent !== undefined) {
+		const parentCmp = seqDataComparator(a.afterParent, b.afterParent);
+		if (parentCmp !== 0) {
+			return parentCmp;
+		}
+		// Same anchor chain: later-stamped sorts earlier. Invert the own-seq comparison.
+		return -compareOwnSeqData(a, b);
+	}
+	if (a.afterParent !== undefined) {
+		// a has an anchor, b does not. Compare b against a's anchor.
+		const cmp = seqDataComparator(a.afterParent, b);
+		if (cmp !== 0) {
+			return cmp;
+		}
+		// a's anchor sorts at the same position as b → a sorts immediately after b.
+		return 1;
+	}
+	if (b.afterParent !== undefined) {
+		const cmp = seqDataComparator(a, b.afterParent);
+		if (cmp !== 0) {
+			return cmp;
+		}
+		// b's anchor sorts at the same position as a → b sorts immediately after a.
+		return -1;
+	}
+	return compareOwnSeqData(a, b);
 };
 
 function isAcknowledgedOrDetached(seqData: SequenceData): boolean {
@@ -384,11 +455,52 @@ function isAcknowledgedOrDetached(seqData: SequenceData): boolean {
 }
 
 /**
- * The combination of sequence numebr and client sequence number of a subdirectory
+ * The combination of sequence number and client sequence number of a subdirectory, plus an optional
+ * anchor chain for subdirectories created via {@link IDirectory.createSubDirectoryOrderedAfter}.
  */
 interface SequenceData {
 	seq: number;
 	clientSeq?: number;
+	/**
+	 * When set, this subdirectory was positioned via an ordering hint; the afterParent is a copy of
+	 * the anchor's SequenceData captured at stamp time. Used by {@link seqDataComparator} to place
+	 * the subdirectory immediately after the anchor in iteration order.
+	 */
+	afterParent?: SequenceData;
+}
+
+/**
+ * Shallow-clone a SequenceData. The afterParent reference is shared, which is safe because
+ * afterParent values are treated as immutable copies captured at stamp time.
+ */
+function cloneSeqData(s: SequenceData): SequenceData {
+	return { seq: s.seq, clientSeq: s.clientSeq, afterParent: s.afterParent };
+}
+
+/**
+ * Convert a SequenceData's afterParent chain to the persisted IAfterParentInfo form.
+ */
+function sequenceDataToAfterParentInfo(s: SequenceData): IAfterParentInfo {
+	return {
+		csn: s.seq,
+		ccsn: s.clientSeq,
+		afterParent:
+			s.afterParent === undefined ? undefined : sequenceDataToAfterParentInfo(s.afterParent),
+	};
+}
+
+/**
+ * Reconstruct a SequenceData from a persisted IAfterParentInfo chain.
+ */
+function afterParentInfoToSequenceData(info: IAfterParentInfo): SequenceData {
+	return {
+		seq: info.csn,
+		clientSeq: info.ccsn,
+		afterParent:
+			info.afterParent === undefined
+				? undefined
+				: afterParentInfoToSequenceData(info.afterParent),
+	};
 }
 
 /**
@@ -757,6 +869,11 @@ export class SharedDirectory
 							let fakeClientSeq = tempSeqNums.get(createInfo.csn) as number;
 							seqData = { seq: createInfo.csn, clientSeq: fakeClientSeq };
 							tempSeqNums.set(createInfo.csn, ++fakeClientSeq);
+							if (createInfo.afterParent !== undefined) {
+								seqData.afterParent = afterParentInfoToSequenceData(
+									createInfo.afterParent,
+								);
+							}
 						} else {
 							/**
 							 * 1. If csn is -1, then initialize it with 0, otherwise we will never process ops for this
@@ -1305,13 +1422,27 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		newSubdirName: string,
 		afterSubdirName: string,
 	): IDirectory {
-		throw new Error("createSubDirectoryOrderedAfter: not implemented");
+		return this.createSubDirectoryCore(newSubdirName, afterSubdirName);
 	}
 
 	/**
 	 * {@inheritDoc IDirectory.createSubDirectory}
 	 */
 	public createSubDirectory(subdirName: string): IDirectory {
+		return this.createSubDirectoryCore(subdirName, undefined);
+	}
+
+	/**
+	 * Shared implementation for {@link SubDirectory.createSubDirectory} and
+	 * {@link SubDirectory.createSubDirectoryOrderedAfter}. When `afterSubdirName` is provided and a
+	 * sibling with that name is visible locally, the new subdirectory's SequenceData carries an
+	 * afterParent pointing at that sibling so it sorts immediately after it. The hint is re-resolved
+	 * against sequenced state at stamp time in {@link processCreateSubDirectoryMessage}.
+	 */
+	private createSubDirectoryCore(
+		subdirName: string,
+		afterSubdirName: string | undefined,
+	): IDirectory {
 		this.throwIfDisposed();
 		// Undefined/null subdirectory names can't be serialized to JSON in the manner we currently snapshot.
 		if (subdirName === undefined || subdirName === null) {
@@ -1328,6 +1459,13 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		const isNewSubDirectory = subDir === undefined;
 
 		if (subDir === undefined) {
+			// Resolve the ordering hint against local visible state for optimistic positioning.
+			if (afterSubdirName !== undefined) {
+				const anchor = this.getOptimisticSubDirectory(afterSubdirName);
+				if (anchor !== undefined) {
+					seqData.afterParent = cloneSeqData(anchor.seqData);
+				}
+			}
 			// If we do not have optimistically have this subdirectory yet, we should create a new one
 			const absolutePath = posix.join(this.absolutePath, subdirName);
 			subDir = new SubDirectory(
@@ -1364,6 +1502,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					subdirName,
 					path: this.absolutePath,
 					type: "createSubDirectory",
+					...(afterSubdirName !== undefined ? { afterSubdirName } : {}),
 				};
 				this.submitCreateSubDirectoryMessage(op);
 			} else {
@@ -2116,6 +2255,18 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		}
 		assertNonNullClientId(msgEnvelope.clientId);
 
+		// Resolve the ordering hint against authoritative sequenced state at stamp time. The anchor
+		// lookup intentionally ignores pending (not-yet-stamped) siblings and disposed entries. If
+		// the anchor is missing at stamp time, the hint falls back to append (stampedAfterParent
+		// stays undefined). See requirements spec §4.4.
+		let stampedAfterParent: SequenceData | undefined;
+		if (op.afterSubdirName !== undefined) {
+			const anchor = this._sequencedSubdirectories.get(op.afterSubdirName);
+			if (anchor !== undefined && !anchor.disposed) {
+				stampedAfterParent = cloneSeqData(anchor.seqData);
+			}
+		}
+
 		let subDir: SubDirectory | undefined;
 		if (local) {
 			const pendingEntryIndex = this.pendingSubDirectoryData.findIndex(
@@ -2133,7 +2284,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			if (existingSubdir !== undefined) {
 				// If the subdirectory already exists, we don't need to create it again.
 				// This can happen if remote clients also create the same subdir and we processed
-				// that message first.
+				// that message first. The already-sequenced entry's positioning wins (§4.3).
 				return;
 			}
 
@@ -2141,13 +2292,20 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				this.undisposeSubdirectoryTree(subDir);
 			}
 
+			// Replace the local-view afterParent (captured at call time) with the stamp-time
+			// authoritative value. See requirements spec §4.8.
+			subDir.seqData.afterParent = stampedAfterParent;
 			this._sequencedSubdirectories.set(op.subdirName, subDir);
 		} else {
 			subDir = this.getOptimisticSubDirectory(op.subdirName, true);
 			if (subDir === undefined) {
 				const absolutePath = posix.join(this.absolutePath, op.subdirName);
 				subDir = new SubDirectory(
-					{ seq: msgEnvelope.sequenceNumber, clientSeq: clientSequenceNumber },
+					{
+						seq: msgEnvelope.sequenceNumber,
+						clientSeq: clientSequenceNumber,
+						afterParent: stampedAfterParent,
+					},
 					new Set([msgEnvelope.clientId]),
 					this.directory,
 					this.runtime,
@@ -2176,7 +2334,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		}
 
 		// Ensure correct seqData. This can be necessary if in scenarios where a subdir was created, deleted, and
-		// then later recreated.
+		// then later recreated. When updating seq/clientSeq from a still-pending state, also apply the
+		// stamp-time afterParent for the same reason.
 		if (
 			this.seqData.seq !== -1 &&
 			this.seqData.seq <= msgEnvelope.sequenceNumber &&
@@ -2184,6 +2343,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		) {
 			subDir.seqData.seq = msgEnvelope.sequenceNumber;
 			subDir.seqData.clientSeq = clientSequenceNumber;
+			subDir.seqData.afterParent = stampedAfterParent;
 		}
 	}
 
@@ -2425,6 +2585,9 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			csn: this.seqData.seq,
 			ccIds: [...this.clientIds],
 		};
+		if (this.seqData.afterParent !== undefined) {
+			createInfo.afterParent = sequenceDataToAfterParentInfo(this.seqData.afterParent);
+		}
 		return createInfo;
 	}
 

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -373,29 +373,21 @@ export interface IDirectoryNewStorageFormat {
 }
 
 /**
- * The comparator essentially performs the following procedure to determine the order of subdirectory creation:
- * 1. If subdirectory A has a non-negative 'seq' and subdirectory B has a negative 'seq', subdirectory A is always placed first due to
- * the policy that acknowledged subdirectories precede locally created ones that have not been committed yet.
- *
- * 2. When both subdirectories A and B have a non-negative 'seq', they are compared as follows:
- * - If A and B have different 'seq', they are ordered based on 'seq', and the one with the lower 'seq' will be positioned ahead. Notably this rule
- * should not be applied in the directory ordering, since the lowest 'seq' is -1, when the directory is created locally but not acknowledged yet.
- * - In the case where A and B have equal 'seq', the one with the lower 'clientSeq' will be positioned ahead. This scenario occurs when grouped
- * batching is enabled, and a lower 'clientSeq' indicates that it was processed earlier after the batch was ungrouped.
- *
- * 3. When both subdirectories A and B have a negative 'seq', they are compared as follows:
- * - If A and B have different 'seq', the one with lower 'seq' will be positioned ahead, which indicates the corresponding creation message was
- * acknowledged by the server earlier.
- * - If A and B have equal 'seq', the one with lower 'clientSeq' will be placed at the front. This scenario suggests that both subdirectories A
- * and B were created locally and not acknowledged yet, with the one possessing the lower 'clientSeq' being created earlier.
- *
- * 4. A 'seq' value of zero indicates that the subdirectory was created in detached state, and it is considered acknowledged for the
- * purpose of ordering.
- */
-/**
  * Compares two SequenceData values considering only their own seq/clientSeq fields
- * (ignoring afterParent). Acknowledged (seq >= 0) sorts before pending (seq = -1); within a
- * category, ascending by seq, then by clientSeq.
+ * (ignoring afterParent). Ordering rules:
+ *
+ * 1. Acknowledged subdirectories (seq \>= 0) always precede locally-created-but-not-yet-acknowledged
+ * ones (seq = -1).
+ *
+ * 2. Within acknowledged, the lower seq is positioned first. When seqs are equal, the lower
+ * clientSeq is positioned first (grouped batching scenario, where lower clientSeq indicates earlier
+ * processing within the ungrouped batch).
+ *
+ * 3. Within the unacknowledged group, lower seq is positioned first for consistency, and ties break
+ * by lower clientSeq (indicates locally-earlier creation).
+ *
+ * 4. A seq of zero indicates the subdirectory was created in detached state, considered
+ * acknowledged for ordering.
  */
 function compareOwnSeqData(a: SequenceData, b: SequenceData): number {
 	const aAckd = isAcknowledgedOrDetached(a);
@@ -870,9 +862,7 @@ export class SharedDirectory
 							seqData = { seq: createInfo.csn, clientSeq: fakeClientSeq };
 							tempSeqNums.set(createInfo.csn, ++fakeClientSeq);
 							if (createInfo.afterParent !== undefined) {
-								seqData.afterParent = afterParentInfoToSequenceData(
-									createInfo.afterParent,
-								);
+								seqData.afterParent = afterParentInfoToSequenceData(createInfo.afterParent);
 							}
 						} else {
 							/**
@@ -1502,7 +1492,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					subdirName,
 					path: this.absolutePath,
 					type: "createSubDirectory",
-					...(afterSubdirName !== undefined ? { afterSubdirName } : {}),
+					...(afterSubdirName === undefined ? {} : { afterSubdirName }),
 				};
 				this.submitCreateSubDirectoryMessage(op);
 			} else {

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -85,6 +85,21 @@ export interface IDirectory
 	createSubDirectory(subdirName: string): IDirectory;
 
 	/**
+	 * Creates an IDirectory child of this IDirectory with a requested position in the ordered set of children, or
+	 * retrieves the existing IDirectory child if one with the same name already exists. The positioning hint is
+	 * best-effort and is resolved when the creation op is stamped; if the anchor does not exist at stamp time, the
+	 * new subdirectory is appended at the end of the ordered set, matching {@link IDirectory.createSubDirectory}.
+	 * The hint establishes no long-term relationship with the anchor.
+	 * @param newSubdirName - Name of the new child directory to create
+	 * @param afterSubdirName - Name of the sibling directory to order the new child directory after
+	 * @returns The IDirectory child that was created or retrieved
+	 */
+	createSubDirectoryOrderedAfter(
+		newSubdirName: string,
+		afterSubdirName: string,
+	): IDirectory;
+
+	/**
 	 * Gets an IDirectory child of this IDirectory, if it exists.
 	 * @param subdirName - Name of the child directory to get
 	 * @returns The requested IDirectory

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -94,10 +94,7 @@ export interface IDirectory
 	 * @param afterSubdirName - Name of the sibling directory to order the new child directory after
 	 * @returns The IDirectory child that was created or retrieved
 	 */
-	createSubDirectoryOrderedAfter(
-		newSubdirName: string,
-		afterSubdirName: string,
-	): IDirectory;
+	createSubDirectoryOrderedAfter(newSubdirName: string, afterSubdirName: string): IDirectory;
 
 	/**
 	 * Gets an IDirectory child of this IDirectory, if it exists.

--- a/packages/dds/map/src/test/mocha/directory.orderAfter.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.orderAfter.spec.ts
@@ -1,0 +1,586 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { AttachState } from "@fluidframework/container-definitions";
+import {
+	MockContainerRuntimeFactory,
+	MockContainerRuntimeFactoryForReconnection,
+	type MockContainerRuntimeForReconnection,
+	MockFluidDataStoreRuntime,
+	MockSharedObjectServices,
+	MockStorage,
+} from "@fluidframework/test-runtime-utils/internal";
+
+import { DirectoryFactory, type ISharedDirectory, SharedDirectory } from "../../index.js";
+
+function createConnectedDirectory(
+	id: string,
+	runtimeFactory: MockContainerRuntimeFactory,
+): ISharedDirectory {
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({
+		registry: [SharedDirectory.getFactory()],
+	});
+	runtimeFactory.createContainerRuntime(dataStoreRuntime);
+	const services = {
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	};
+	const directory = SharedDirectory.create(dataStoreRuntime, id);
+	directory.connect(services);
+	return directory;
+}
+
+function assertOrder(directory: ISharedDirectory, expected: string[]): void {
+	const actual: string[] = [];
+	for (const [name] of directory.subdirectories()) {
+		actual.push(name);
+	}
+	assert.deepEqual(actual, expected);
+}
+
+describe("IDirectory.createSubDirectoryOrderedAfter", () => {
+	// --- Local / detached state ---
+
+	describe("Local state (detached)", () => {
+		let directory: ISharedDirectory;
+
+		beforeEach("createDirectory", () => {
+			const dataStoreRuntime = new MockFluidDataStoreRuntime({
+				attachState: AttachState.Detached,
+				registry: [SharedDirectory.getFactory()],
+			});
+			directory = SharedDirectory.create(dataStoreRuntime, "directory");
+		});
+
+		it("inserts after an existing anchor immediately (Q7 optimistic positioning)", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectoryOrderedAfter("c", "a");
+			assertOrder(directory, ["a", "c", "b"]);
+		});
+
+		it("returns the created IDirectory on the happy path (Q3)", () => {
+			directory.createSubDirectory("a");
+			const result = directory.createSubDirectoryOrderedAfter("c", "a");
+			assert.notEqual(result, undefined);
+			assert.equal(directory.getSubDirectory("c"), result);
+		});
+
+		it("appends and returns an IDirectory when the anchor does not exist (Q1)", () => {
+			directory.createSubDirectory("a");
+			const result = directory.createSubDirectoryOrderedAfter("c", "nonexistent");
+			assert.notEqual(result, undefined);
+			assertOrder(directory, ["a", "c"]);
+		});
+
+		it("appends when the anchor was previously deleted locally (Q1)", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.deleteSubDirectory("a");
+			directory.createSubDirectoryOrderedAfter("c", "a");
+			assertOrder(directory, ["b", "c"]);
+		});
+
+		it("returns the existing subdirectory when newSubdirName already exists (Q6)", () => {
+			directory.createSubDirectory("a");
+			const existing = directory.createSubDirectory("c");
+			const result = directory.createSubDirectoryOrderedAfter("c", "a");
+			assert.equal(result, existing);
+			// Position of "c" is not changed by the collided call.
+			assertOrder(directory, ["a", "c"]);
+		});
+
+		it("multiple sequential local inserts after the same anchor: later inserts sort earlier", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectoryOrderedAfter("c", "a");
+			directory.createSubDirectoryOrderedAfter("d", "a");
+			// Requirements §4.2: later-stamped (here, later-sequenced-locally) sorts earlier (closer to anchor).
+			assertOrder(directory, ["a", "d", "c", "b"]);
+		});
+
+		it("chain: insert after a subdirectory that was itself inserted after another", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectoryOrderedAfter("c", "a");
+			directory.createSubDirectoryOrderedAfter("e", "c");
+			assertOrder(directory, ["a", "c", "e", "b"]);
+		});
+
+		it("inserting after the first sibling places new child at position 1", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectory("c");
+			directory.createSubDirectoryOrderedAfter("x", "a");
+			assertOrder(directory, ["a", "x", "b", "c"]);
+		});
+
+		it("inserting after the last sibling is equivalent to append", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectoryOrderedAfter("x", "b");
+			assertOrder(directory, ["a", "b", "x"]);
+		});
+	});
+
+	// --- Detached-to-attached state transition ---
+
+	describe("Detached -> attached transition", () => {
+		it("preserves ordered-after positioning through attach", async () => {
+			const factory = SharedDirectory.getFactory();
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			const directory = factory.create(dataStoreRuntime, "dir");
+
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectoryOrderedAfter("c", "a");
+
+			assertOrder(directory, ["a", "c", "b"]);
+
+			// Simulate attach by reloading via a summary round-trip.
+			const summary = directory.getAttachSummary().summary;
+			const containerRuntimeFactory = new MockContainerRuntimeFactory();
+			const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+			const services = MockSharedObjectServices.createFromSummary(summary);
+			services.deltaConnection = dataStoreRuntime2.createDeltaConnection();
+
+			const directory2 = await factory.load(
+				dataStoreRuntime2,
+				"dir2",
+				services,
+				factory.attributes,
+			);
+			assertOrder(directory2, ["a", "c", "b"]);
+		});
+	});
+
+	// --- Connected state: single client round-trip ---
+
+	describe("Connected state, single client", () => {
+		let containerRuntimeFactory: MockContainerRuntimeFactory;
+		let directory: ISharedDirectory;
+
+		beforeEach("createDirectory", () => {
+			containerRuntimeFactory = new MockContainerRuntimeFactory();
+			directory = createConnectedDirectory("dir", containerRuntimeFactory);
+		});
+
+		it("ordered insert survives ack and remains positioned correctly", () => {
+			directory.createSubDirectory("a");
+			directory.createSubDirectory("b");
+			directory.createSubDirectoryOrderedAfter("c", "a");
+
+			containerRuntimeFactory.processAllMessages();
+
+			assertOrder(directory, ["a", "c", "b"]);
+		});
+	});
+
+	// --- Spec Example 1: simultaneous insertions, different names ---
+
+	describe("Spec Example 1: simultaneous inserts, different names", () => {
+		it("{#1, #2} -> [A, D, C, B]", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			d1.createSubDirectoryOrderedAfter("c", "a");
+			d2.createSubDirectoryOrderedAfter("d", "a");
+
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "d", "c", "b"]);
+			assertOrder(d2, ["a", "d", "c", "b"]);
+		});
+
+		it("{#2, #1} -> [A, C, D, B]", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			// Client #2 submits first (will be stamped first).
+			d2.createSubDirectoryOrderedAfter("d", "a");
+			d1.createSubDirectoryOrderedAfter("c", "a");
+
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "c", "d", "b"]);
+			assertOrder(d2, ["a", "c", "d", "b"]);
+		});
+	});
+
+	// --- Spec Example 2: simultaneous insertions, same name (merge) ---
+
+	describe("Spec Example 2: simultaneous inserts, same name (merge)", () => {
+		it("{#1, #2} -> [A, C, B] (first-stamped positioning wins)", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			// Both clients create "c" with different anchors.
+			d1.createSubDirectoryOrderedAfter("c", "a");
+			d2.createSubDirectoryOrderedAfter("c", "b");
+
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "c", "b"]);
+			assertOrder(d2, ["a", "c", "b"]);
+		});
+
+		it("{#2, #1} -> [A, B, C] (client#2's 'after b' wins)", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			// Client #2 submits first.
+			d2.createSubDirectoryOrderedAfter("c", "b");
+			d1.createSubDirectoryOrderedAfter("c", "a");
+
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "b", "c"]);
+			assertOrder(d2, ["a", "b", "c"]);
+		});
+	});
+
+	// --- Spec Example 3: simultaneous insert and deletion of anchor ---
+
+	describe("Spec Example 3: simultaneous insert + delete of anchor", () => {
+		it("{#1, #2} (delete first) -> [B, C] (C falls back to append)", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			d1.deleteSubDirectory("a");
+			d2.createSubDirectoryOrderedAfter("c", "a");
+
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["b", "c"]);
+			assertOrder(d2, ["b", "c"]);
+		});
+
+		it("{#2, #1} (insert first) -> [C, B] (C after A, then A deleted)", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			// Client #2 submits insert first.
+			d2.createSubDirectoryOrderedAfter("c", "a");
+			d1.deleteSubDirectory("a");
+
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["c", "b"]);
+			assertOrder(d2, ["c", "b"]);
+		});
+	});
+
+	// --- Spec Example 4: simultaneous insertions and deletion ---
+
+	describe("Spec Example 4: simultaneous inserts + delete of anchor", () => {
+		interface ExampleFixture {
+			factory: MockContainerRuntimeFactory;
+			d1: ISharedDirectory;
+			d2: ISharedDirectory;
+			d3: ISharedDirectory;
+		}
+
+		function setupExample4(): ExampleFixture {
+			const factory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", factory);
+			const d2 = createConnectedDirectory("d2", factory);
+			const d3 = createConnectedDirectory("d3", factory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			d1.createSubDirectory("c");
+			factory.processAllMessages();
+
+			return { factory, d1, d2, d3 };
+		}
+
+		it("{#1, #2, #3} -> [B, C, D, E]", () => {
+			const { factory, d1, d2, d3 } = setupExample4();
+
+			d1.deleteSubDirectory("a");
+			d2.createSubDirectoryOrderedAfter("d", "a");
+			d3.createSubDirectoryOrderedAfter("e", "a");
+
+			factory.processAllMessages();
+
+			assertOrder(d1, ["b", "c", "d", "e"]);
+			assertOrder(d2, ["b", "c", "d", "e"]);
+			assertOrder(d3, ["b", "c", "d", "e"]);
+		});
+
+		it("{#1, #3, #2} -> [B, C, E, D]", () => {
+			const { factory, d1, d2, d3 } = setupExample4();
+
+			d1.deleteSubDirectory("a");
+			d3.createSubDirectoryOrderedAfter("e", "a");
+			d2.createSubDirectoryOrderedAfter("d", "a");
+
+			factory.processAllMessages();
+
+			assertOrder(d1, ["b", "c", "e", "d"]);
+			assertOrder(d2, ["b", "c", "e", "d"]);
+			assertOrder(d3, ["b", "c", "e", "d"]);
+		});
+
+		it("{#2, #3, #1} -> [E, D, B, C]", () => {
+			const { factory, d1, d2, d3 } = setupExample4();
+
+			d2.createSubDirectoryOrderedAfter("d", "a");
+			d3.createSubDirectoryOrderedAfter("e", "a");
+			d1.deleteSubDirectory("a");
+
+			factory.processAllMessages();
+
+			assertOrder(d1, ["e", "d", "b", "c"]);
+			assertOrder(d2, ["e", "d", "b", "c"]);
+			assertOrder(d3, ["e", "d", "b", "c"]);
+		});
+
+		it("{#2, #1, #3} -> [D, B, C, E]", () => {
+			const { factory, d1, d2, d3 } = setupExample4();
+
+			d2.createSubDirectoryOrderedAfter("d", "a");
+			d1.deleteSubDirectory("a");
+			d3.createSubDirectoryOrderedAfter("e", "a");
+
+			factory.processAllMessages();
+
+			assertOrder(d1, ["d", "b", "c", "e"]);
+			assertOrder(d2, ["d", "b", "c", "e"]);
+			assertOrder(d3, ["d", "b", "c", "e"]);
+		});
+	});
+
+	// --- Q2: anchor deleted + re-created before stamp ---
+
+	describe("Q2: anchor deleted and re-created before stamp", () => {
+		it("uses the currently-sequenced sibling under that name as the anchor", () => {
+			// Base [A, B]. On d1: delete A, create new A, then insert C after A.
+			// Expected: the new A is the anchor; C orders after the new A.
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			d1.deleteSubDirectory("a");
+			d1.createSubDirectory("a"); // recreated (append semantics -> goes to end)
+			d2.createSubDirectoryOrderedAfter("c", "a");
+
+			runtimeFactory.processAllMessages();
+
+			// After processing: the A that existed was deleted; a new A was appended.
+			// When "insert C after A" stamps, it finds the (re-created) A and orders after it.
+			// Final sequence: [B, A, C].
+			assertOrder(d1, ["b", "a", "c"]);
+			assertOrder(d2, ["b", "a", "c"]);
+		});
+	});
+
+	// --- Q7: local optimistic positioning ---
+
+	describe("Q7: local optimistic positioning", () => {
+		it("shows requested position immediately before ack", () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			d1.createSubDirectoryOrderedAfter("c", "a");
+			// Not yet stamped -- local view must already show the requested position.
+			assertOrder(d1, ["a", "c", "b"]);
+
+			runtimeFactory.processAllMessages();
+			assertOrder(d1, ["a", "c", "b"]);
+		});
+
+		it("local position may shift on ack if concurrent remote activity changes it", () => {
+			// Two clients concurrently insert after the same anchor.
+			// Before ack, each local view has its own insertion in position 1.
+			// After ack, the later-stamped one sorts earlier (closer to anchor).
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+			const d2 = createConnectedDirectory("d2", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			runtimeFactory.processAllMessages();
+
+			d1.createSubDirectoryOrderedAfter("c", "a");
+			d2.createSubDirectoryOrderedAfter("d", "a");
+
+			// Pre-stamp: each client sees only its own op.
+			assertOrder(d1, ["a", "c", "b"]);
+			assertOrder(d2, ["a", "d", "b"]);
+
+			// Stamp d1 first, then d2: d2's insertion sorts earlier per §4.2.
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "d", "c", "b"]);
+			assertOrder(d2, ["a", "d", "c", "b"]);
+		});
+	});
+
+	// --- Snapshot round-trip with afterParent chains ---
+
+	describe("Snapshot round-trip", () => {
+		it("preserves ordering-hint-derived order across summarize + load", async () => {
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const d1 = createConnectedDirectory("d1", runtimeFactory);
+
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			d1.createSubDirectoryOrderedAfter("c", "a");
+			d1.createSubDirectoryOrderedAfter("e", "c"); // chain length 2
+			runtimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "c", "e", "b"]);
+
+			const factory = SharedDirectory.getFactory();
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			runtimeFactory.createContainerRuntime(dataStoreRuntime);
+			const services = MockSharedObjectServices.createFromSummary(
+				d1.getAttachSummary().summary,
+			);
+			services.deltaConnection = dataStoreRuntime.createDeltaConnection();
+
+			const d2 = await factory.load(
+				dataStoreRuntime,
+				"d2-loaded",
+				services,
+				factory.attributes,
+			);
+
+			assertOrder(d2, ["a", "c", "e", "b"]);
+		});
+	});
+
+	// --- Reconnect / resubmit ---
+
+	describe("Reconnect / resubmit", () => {
+		let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+		let containerRuntime1: MockContainerRuntimeForReconnection;
+		let containerRuntime2: MockContainerRuntimeForReconnection;
+		let d1: ISharedDirectory;
+		let d2: ISharedDirectory;
+		let factory: DirectoryFactory;
+
+		beforeEach("createDirectories", () => {
+			containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+			factory = SharedDirectory.getFactory();
+
+			const dsr1 = new MockFluidDataStoreRuntime();
+			containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dsr1);
+			const services1 = {
+				deltaConnection: dsr1.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			};
+			d1 = factory.create(dsr1, "d1");
+			d1.connect(services1);
+
+			const dsr2 = new MockFluidDataStoreRuntime();
+			containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dsr2);
+			const services2 = {
+				deltaConnection: dsr2.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			};
+			d2 = factory.create(dsr2, "d2");
+			d2.connect(services2);
+		});
+
+		it("unacked ordered create survives reconnect and positions correctly", () => {
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			containerRuntimeFactory.processAllMessages();
+
+			containerRuntime1.connected = false;
+			d1.createSubDirectoryOrderedAfter("c", "a");
+			containerRuntime1.connected = true;
+
+			containerRuntimeFactory.processAllMessages();
+
+			assertOrder(d1, ["a", "c", "b"]);
+			assertOrder(d2, ["a", "c", "b"]);
+		});
+
+		it("anchor deleted during offline window -> insert falls back to append", () => {
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			containerRuntimeFactory.processAllMessages();
+
+			containerRuntime1.connected = false;
+			d1.createSubDirectoryOrderedAfter("c", "a");
+
+			// While d1 is offline, d2 deletes the anchor.
+			d2.deleteSubDirectory("a");
+			containerRuntimeFactory.processAllMessages();
+
+			containerRuntime1.connected = true;
+			containerRuntimeFactory.processAllMessages();
+
+			// Anchor is gone at stamp time; C falls back to append.
+			assertOrder(d1, ["b", "c"]);
+			assertOrder(d2, ["b", "c"]);
+		});
+
+		it("same-name concurrent create during offline window -> merge applies", () => {
+			d1.createSubDirectory("a");
+			d1.createSubDirectory("b");
+			containerRuntimeFactory.processAllMessages();
+
+			containerRuntime1.connected = false;
+			d1.createSubDirectoryOrderedAfter("c", "a");
+
+			// d2 creates same-name "c" (plain append) while d1 is offline and is stamped first.
+			d2.createSubDirectory("c");
+			containerRuntimeFactory.processAllMessages();
+
+			containerRuntime1.connected = true;
+			containerRuntimeFactory.processAllMessages();
+
+			// Same-name merge: first-stamped wins; d2's plain append positions "c" at the end.
+			// d1's ordering hint is ignored per Requirements §4.3.
+			assertOrder(d1, ["a", "b", "c"]);
+			assertOrder(d2, ["a", "b", "c"]);
+		});
+	});
+});

--- a/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
+++ b/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
@@ -204,6 +204,7 @@ declare type current_as_old_for_Interface_IValueChanged = requireAssignableTo<Ty
  * typeValidation.broken:
  * "TypeAlias_SharedDirectory": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_SharedDirectory = requireAssignableTo<TypeOnly<old.SharedDirectory>, TypeOnly<current.SharedDirectory>>
 
 /*


### PR DESCRIPTION
## Description

Adds `IDirectory.createSubDirectoryOrderedAfter(newSubdirName, afterSubdirName)` to `SharedDirectory`, allowing callers to insert a new subdirectory at a specific position in the parent's iteration order rather than always appending. Requested by the Word team for three-way-merge reconciliation of comment threads — new comments currently have to be positioned by deleting every subdirectory after the target position, inserting the new ones, and re-creating the deleted subdirectories from scratch.

The ordering hint is best-effort and is resolved at stamp time: if the named anchor is missing at stamp time (never created, concurrently deleted, or not yet sequenced), the new subdirectory is appended at the end, matching `createSubDirectory`'s existing behavior. The hint establishes no durable relationship — deleting the anchor later does not affect the inserted subdirectory.

The full behavioral contract and resolved design ambiguities are captured in `packages/dds/map/docs/ordering-hints-requirements.md`. Implementation strategy (Option A — feature-add on the current `SharedDirectory` codepath rather than a replat on `SharedTree`) and the recursive sort-key design are in `packages/dds/map/docs/ordering-hints-implementation-plan.md`.

Old clients in the same session ignore the new op field and treat these insertions as plain appends (graceful degradation, no hard version gate). All 944 tests in `packages/dds/map` pass (916 existing + 28 new covering every stamping order of Examples 1–4, each resolved ambiguity, recursive chains, snapshot round-trip, and reconnect/resubmit).

## Breaking Changes

Adding a required method to `IDirectory` is a forward-compatibility break for types that implement or extend the interface. `IDirectory` is `@sealed @legacy @public`, so external implementations are not supported, but the type-compat tooling still flags it — acknowledged via `TypeAlias_SharedDirectory.forwardCompat: false` in `packages/dds/map/package.json`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Specific asks:

- **§3 of the implementation plan** (`docs/ordering-hints-implementation-plan.md`) — the recursive sort key. A naive flat `(seq, -trueSeq)` tiebreaker does **not** produce the spec's required ordering (it sorts the anchor behind its own descendants). The fix is a `SequenceData.afterParent` chain and a recursive comparator. This is the main risk surface; I'd like a second pair of eyes here.
- **API Council review** — new public method on `IDirectory`. I did not request this; please let me know if it's required here.
- **Snapshot compatibility choice** — I extended `ICreateInfo` with an optional `afterParent` field (recursive `IAfterParentInfo` structure). Old snapshots load with `afterParent` absent → plain-append, which is correct. Worth sanity-checking the choice to extend `ICreateInfo` (already `@deprecated`) rather than introduce a separate new snapshot type.
- **Branch name** — still `directory-tree-replat` because one option we discussed was replatting `SharedDirectory` on `SharedTree` internals. The plan includes that evaluation (Option B); we landed on Option A for this feature. Happy to rename the branch if preferred.

Opening as draft for these design questions; will un-draft once they're settled.