### PR TITLE
Reduce data size in tests with perf issues

### DIFF
--- a/packages/dds/tree/src/test/memory/tableTree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tableTree.spec.ts
@@ -80,14 +80,14 @@ describe("SharedTree table APIs memory usage", () => {
 	const tableSizes = isInPerformanceTestingMode
 		? [5, 50]
 		: // When not measuring perf, use a single smaller data size so the tests run faster.
-			[5];
+			[3];
 
 	// The number of operations to perform on the tree.
 	// Operation counts 1000 removed due to high overhead and unreliable results.
 	const operationCounts = isInPerformanceTestingMode
 		? [5, 50]
 		: // When not measuring perf, use a single smaller data size so the tests run faster.
-			[5];
+			[3];
 
 	// IMPORTANT: variables scoped to the test suite are a big problem for memory-profiling tests
 	// because they won't be out of scope when we garbage-collect between runs of the same test,

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -98,14 +98,14 @@ describe("SharedTree table APIs execution time", () => {
 	const tableSizes = isInPerformanceTestingMode
 		? [5, 50]
 		: // When not measuring perf, use a single smaller data size so the tests run faster.
-			[5];
+			[3];
 
 	// The number of operations to perform on the tree.
 	// Operation counts 1000 removed due to high overhead and unreliable results.
 	const operationCounts = isInPerformanceTestingMode
 		? [5, 50]
 		: // When not measuring perf, use a single smaller data size so the tests run faster.
-			[5];
+			[3];
 
 	// The maximum duration for each benchmark, in seconds.
 	let maxBenchmarkDurationSeconds: number;


### PR DESCRIPTION
## Description

Something is causing these tests, at least the execution time ones, to be much slower when run as part of the full test suite instead of by themselves.

This is causing non-determinstic timouts on CI.

THis change reduces the data size to hopefully mitigate the issue while it is properly investigated and fixed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
