### PR TITLE
fix(build-cli): avoid full repo package scan in generate buildVersion

### DIFF
--- a/build-tools/packages/build-cli/docs/vnext.md
+++ b/build-tools/packages/build-cli/docs/vnext.md
@@ -4,6 +4,7 @@
 Vnext commands are new implementations of standard flub commands using new infrastructure.
 
 * [`flub vnext check latestVersions`](#flub-vnext-check-latestversions)
+* [`flub vnext generate buildVersion`](#flub-vnext-generate-buildversion)
 * [`flub vnext generate changelog`](#flub-vnext-generate-changelog)
 
 ## `flub vnext check latestVersions`
@@ -32,6 +33,45 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/vnext/check/latestVersions.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/vnext/check/latestVersions.ts)_
+
+## `flub vnext generate buildVersion`
+
+This command is used to compute the version number of Fluid packages. The release version number is based on what's in the release group root package.json. The CI pipeline will supply the build number and branch to determine the prerelease suffix if it is not a tagged build.
+
+```
+USAGE
+  $ flub vnext generate buildVersion --build <value> [-v | --quiet] [--testBuild <value>] [--release release|prerelease|none]
+    [--patch <value>] [--base <value>] [--tag <value>] [-i <value>] [--packageTypes none|alpha|beta|public|untrimmed]
+
+FLAGS
+  -i, --includeInternalVersions=<value>  [env: VERSION_INCLUDE_INTERNAL_VERSIONS] Include Fluid internal versions.
+      --base=<value>                     The base version. This will be read from package.json if not provided.
+      --build=<value>                    (required) [env: VERSION_BUILDNUMBER] The CI build number.
+      --packageTypes=<option>            [default: none, env: PACKAGE_TYPES_FIELD] If provided, the version generated
+                                         will include extra strings based on the TypeScript types that are expected to
+                                         be used. This flag should only be used in the Fluid Framework CI pipeline.
+                                         <options: none|alpha|beta|public|untrimmed>
+      --patch=<value>                    [env: VERSION_PATCH] Indicates the build should use "simple patch versioning"
+                                         where the value of the --build flag is used as the patch version.
+      --release=<option>                 [env: VERSION_RELEASE] Indicates the build is a release build.
+                                         <options: release|prerelease|none>
+      --tag=<value>                      [env: VERSION_TAGNAME] The tag name to use.
+      --testBuild=<value>                [env: TEST_BUILD] Indicates the build is a test build.
+
+LOGGING FLAGS
+  -v, --verbose  Enable verbose logging.
+      --quiet    Disable all logging.
+
+DESCRIPTION
+  This command is used to compute the version number of Fluid packages. The release version number is based on what's in
+  the release group root package.json. The CI pipeline will supply the build number and branch to determine the
+  prerelease suffix if it is not a tagged build.
+
+EXAMPLES
+  $ flub vnext generate buildVersion
+```
+
+_See code: [src/commands/vnext/generate/buildVersion.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/vnext/generate/buildVersion.ts)_
 
 ## `flub vnext generate changelog`
 

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -5,12 +5,10 @@
 
 import * as fs from "node:fs";
 import { getIsLatest, getSimpleVersion } from "@fluid-tools/version-tools";
-import { getResolvedFluidRoot } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 
 import { semverFlag } from "../../flags.js";
 import { BaseCommand } from "../../library/commands/base.js";
-import { Repository } from "../../library/git.js";
 
 /**
  * This command class is used to compute the version number of Fluid packages. The release version number is based on
@@ -101,8 +99,8 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 			this.error("Test build shouldn't be released");
 		}
 
-		const gitRoot = await getResolvedFluidRoot();
-		const repo = new Repository({ baseDir: gitRoot }, "microsoft/FluidFramework");
+		const context = await this.getContext();
+		const repo = await context.getGitRepository();
 		// eslint-disable-next-line unicorn/no-await-expression-member
 		const tags = flags.tags ?? (await repo.gitClient.tags()).all;
 

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -5,10 +5,12 @@
 
 import * as fs from "node:fs";
 import { getIsLatest, getSimpleVersion } from "@fluid-tools/version-tools";
+import { getResolvedFluidRoot } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 
 import { semverFlag } from "../../flags.js";
 import { BaseCommand } from "../../library/commands/base.js";
+import { Repository } from "../../library/git.js";
 
 /**
  * This command class is used to compute the version number of Fluid packages. The release version number is based on
@@ -99,8 +101,8 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 			this.error("Test build shouldn't be released");
 		}
 
-		const context = await this.getContext();
-		const repo = await context.getGitRepository();
+		const gitRoot = await getResolvedFluidRoot();
+		const repo = new Repository({ baseDir: gitRoot }, "microsoft/FluidFramework");
 		// eslint-disable-next-line unicorn/no-await-expression-member
 		const tags = flags.tags ?? (await repo.gitClient.tags()).all;
 

--- a/build-tools/packages/build-cli/src/commands/vnext/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/vnext/generate/buildVersion.ts
@@ -1,0 +1,180 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as fs from "node:fs";
+import { getIsLatest, getSimpleVersion } from "@fluid-tools/version-tools";
+import { getResolvedFluidRoot } from "@fluidframework/build-tools";
+import { Flags } from "@oclif/core";
+
+import { semverFlag } from "../../../flags.js";
+import { BaseCommandWithBuildProject } from "../../../library/commands/base.js";
+import { Repository } from "../../../library/git.js";
+
+/**
+ * This command class is used to compute the version number of Fluid packages. The release version number is based on
+ * what's in the release group root package.json. The CI pipeline will supply the build number and branch to determine
+ * the prerelease suffix if it is not a tagged build.
+ */
+export default class GenerateBuildVersionCommand extends BaseCommandWithBuildProject<
+	typeof GenerateBuildVersionCommand
+> {
+	static readonly description =
+		`This command is used to compute the version number of Fluid packages. The release version number is based on what's in the release group root package.json. The CI pipeline will supply the build number and branch to determine the prerelease suffix if it is not a tagged build.`;
+
+	static readonly examples = ["<%= config.bin %> <%= command.id %>"];
+
+	static readonly flags = {
+		build: Flags.string({
+			description: "The CI build number.",
+			env: "VERSION_BUILDNUMBER",
+			required: true,
+		}),
+		testBuild: Flags.string({
+			description: "Indicates the build is a test build.",
+			env: "TEST_BUILD",
+		}),
+		release: Flags.string({
+			description: "Indicates the build is a release build.",
+			options: ["release", "prerelease", "none"],
+			env: "VERSION_RELEASE",
+		}),
+		patch: Flags.string({
+			description: `Indicates the build should use "simple patch versioning" where the value of the --build flag is used as the patch version.`,
+			env: "VERSION_PATCH",
+		}),
+		base: Flags.string({
+			description: "The base version. This will be read from package.json if not provided.",
+		}),
+		tag: Flags.string({
+			description: "The tag name to use.",
+			env: "VERSION_TAGNAME",
+		}),
+		includeInternalVersions: Flags.string({
+			char: "i",
+			description: "Include Fluid internal versions.",
+			env: "VERSION_INCLUDE_INTERNAL_VERSIONS",
+		}),
+		packageTypes: Flags.string({
+			description:
+				"If provided, the version generated will include extra strings based on the TypeScript types that are expected to be used. This flag should only be used in the Fluid Framework CI pipeline.",
+			options: ["none", "alpha", "beta", "public", "untrimmed"],
+			default: "none",
+			env: "PACKAGE_TYPES_FIELD",
+		}),
+		fileVersion: semverFlag({
+			description:
+				"Will be used as the version instead of reading from package.json. Used for testing.",
+			hidden: true,
+		}),
+		tags: Flags.string({
+			description:
+				"The git tags to consider when determining whether a version is latest. Used for testing.",
+			hidden: true,
+			multiple: true,
+		}),
+		...BaseCommandWithBuildProject.flags,
+	} as const;
+
+	public async run(): Promise<void> {
+		const { flags } = this;
+		const isRelease = flags.release === "release";
+		const useSimplePatchVersion = flags.patch?.toLowerCase() === "true";
+		const useTestVersion = flags.testBuild?.toLowerCase() === "true";
+		const shouldIncludeInternalVersions =
+			flags.includeInternalVersions?.toLowerCase() === "true";
+		const isAlphaOrBetaTypes = ["alpha", "beta"].includes(flags.packageTypes);
+		// `alphabetaTypePrefix` will be either `alpha-types` or `beta-types`
+		const alphabetaTypePrefix = `${flags.packageTypes}-types`;
+
+		let fileVersion = "";
+
+		if (flags.base === undefined) {
+			fileVersion = flags.fileVersion?.version ?? this.getFileVersion();
+			if (!fileVersion) {
+				this.error("Missing version in package.json");
+			}
+		}
+
+		if (flags.testBuild?.toLowerCase() === "true" && isRelease) {
+			this.error("Test build shouldn't be released");
+		}
+
+		const gitRoot = await getResolvedFluidRoot();
+		const repo = new Repository({ baseDir: gitRoot }, "microsoft/FluidFramework");
+		// eslint-disable-next-line unicorn/no-await-expression-member
+		const tags = flags.tags ?? (await repo.gitClient.tags()).all;
+
+		if (!useSimplePatchVersion && flags.tag !== undefined) {
+			const tagName = `${flags.tag}_v${fileVersion}`;
+			if (tags.includes(tagName)) {
+				if (isRelease) {
+					this.error(`Tag ${tagName} already exists.`);
+				}
+
+				this.warning(`Tag ${tagName} already exists.`);
+			}
+		}
+
+		// Generate and print the version to console
+		const simpleVersion = getSimpleVersion(
+			fileVersion,
+			flags.build,
+			isRelease,
+			useSimplePatchVersion,
+		);
+
+		let version = simpleVersion;
+
+		if (useTestVersion) {
+			// Determine the version string for test builds.
+			// If it's an alpha or beta type, append `alphabetaTypePrefix`.
+			version = isAlphaOrBetaTypes
+				? `0.0.0-${flags.build}-test-${alphabetaTypePrefix}`
+				: `0.0.0-${flags.build}-test`;
+
+			// Output the code version for test builds. This is used in the CI system.
+			// See common/build/build-common/gen_version.js
+			const codeVersion = isAlphaOrBetaTypes
+				? `${simpleVersion}-test-${alphabetaTypePrefix}`
+				: `${simpleVersion}-test`;
+			this.log(`codeVersion=${codeVersion}`);
+			this.log(`##vso[task.setvariable variable=codeVersion;isOutput=true]${codeVersion}`);
+		}
+
+		if (isAlphaOrBetaTypes) {
+			if (isRelease || flags.release === "none") {
+				this.errorLog(
+					"This release type is not supported. Alpha/beta ***prereleases*** are allowed.",
+				);
+				this.exit(1);
+			} else if (!useTestVersion) {
+				// For prereleases, update the version string with `alphabetaTypePrefix` prefix.
+				version = `${simpleVersion}-${alphabetaTypePrefix}`;
+			}
+		}
+
+		this.log(`version=${version}`);
+		this.log(`##vso[task.setvariable variable=version;isOutput=true]${version}`);
+
+		if (flags.tag !== undefined) {
+			const isLatest = getIsLatest(flags.tag, version, tags, shouldIncludeInternalVersions);
+			this.log(`isLatest=${isLatest}`);
+			if (isRelease && isLatest === true) {
+				this.log(`##vso[task.setvariable variable=isLatest;isOutput=true]${isLatest}`);
+			}
+		}
+	}
+
+	private getFileVersion(): string {
+		if (fs.existsSync("./package.json")) {
+			return (
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				JSON.parse(fs.readFileSync("./package.json", { encoding: "utf8" })).version as string
+			);
+		}
+
+		this.error(`package.json not found`);
+	}
+}

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -114,7 +114,7 @@ stages:
             workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
             script: |
               # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
-              flub generate buildVersion
+              flub vnext generate buildVersion
         - task: Bash@3
           name: SetShouldDeploy
           displayName: 'Check Version Deployment Condition'

--- a/tools/pipelines/publish-api-model-artifact.yml
+++ b/tools/pipelines/publish-api-model-artifact.yml
@@ -127,7 +127,7 @@ stages:
             workingDirectory: $(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
             script: |
               # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
-              flub generate buildVersion
+              flub vnext generate buildVersion
         - task: Bash@3
           name: SetShouldDeploy
           displayName: 'Check Version Deployment Condition'

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -82,7 +82,7 @@ steps:
 
       # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
       # These are referenced in following steps prefixed by this task name. E.g. SetVersion.version
-      flub generate buildVersion
+      flub vnext generate buildVersion
 
 # This check runs only when the value of `Change package types` is selected as `alpha` or `beta`
 - ${{ if ne(parameters.packageTypesOverride, 'none') }}:


### PR DESCRIPTION
## Description

`flub generate buildVersion` was calling `getContext()` to get access to a git client for reading tags. `getContext()` constructs a full `FluidRepo` object, which eagerly calls `readdirSync` on every release group directory defined in `fluidBuild.config.cjs` (including `build-tools/`, `server/routerlicious/`, etc.). This makes it impossible to run that flub command in sparse git checkouts, where any missing release group directory causes an immediate `ENOENT` crash, even though the command has no need for any of those packages.

The fix replaces the `getContext()` + `context.getGitRepository()` chain with a direct `Repository` instantiation using `getResolvedFluidRoot()`. This resolves the repo root by walking up the directory tree (no package scanning), and `Repository` wraps `simple-git` directly. The command's behavior is unchanged for full checkouts. This pattern is already used in `commands/check/policy.ts`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The change is small (4 lines added, 2 removed) and the logic is identical — only the path to a `SimpleGit` client changes. The existing `--tags` test flag continues to let the git call be bypassed entirely in unit tests.