### PR TITLE
Remove Node 22 engines block from externally-installed packages

### DIFF
--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -120,9 +120,6 @@
 		"typescript-eslint": "~8.55.0"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-	"engines": {
-		"node": ">=22.22.2"
-	},
 	"fluidBuild": {
 		"branchReleaseTypes": {
 			"main": "minor",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -104,9 +104,6 @@
 		"typescript-eslint": "~8.55.0"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-	"engines": {
-		"node": ">=22.22.2"
-	},
 	"fluidBuild": {
 		"tasks": {
 			"tsc": [

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -61,9 +61,6 @@
 		"typescript-eslint": "~8.54.0"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-	"engines": {
-		"node": ">=22.22.2"
-	},
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"unrs-resolver"

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -45,9 +45,6 @@
 		"typescript": "~5.4.5"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-	"engines": {
-		"node": ">=22.22.2"
-	},
 	"pnpm": {
 		"commentsOverrides": [
 			"js-yaml: overridden to fix CVE-2025-64718 (prototype pollution via merge keys).",


### PR DESCRIPTION
## Summary

Fixes [AB#71790](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71790).

PR #27116 added `"engines": { "node": ">=22.22.2" }` to a number of packages. For packages that external customers install, that floor can disrupt workflows for customers on slightly older Node 22 patch versions. This PR limits the enforcement to packages that are internal-only or never published, reverting the engines block on:

- `@fluidframework/common-utils`
- `@fluidframework/protocol-definitions`
- `@fluid-tools/benchmark`
- `@fluidframework/test-tools`

The remaining packages that were updated in #27116 keep the engines block, since they are internal-only or unpublished release-group roots:

- `@fluidframework/eslint-config-fluid`
- `@fluid-tools/api-markdown-documenter`
- `gitrest-release-group-root`
- `historian-release-group-root`

## Test plan

- [ ] CI green