### PR TITLE
build(benchmark): Use base prettier config from dep, not repo, in tools/benchmark/

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -41,8 +41,8 @@
 		"mocha": "^11.7.5"
 	},
 	"devDependencies": {
-		"@fluidframework/build-common": "^2.0.3",
 		"@fluid-internal/mocha-test-setup": "~2.83.0",
+		"@fluidframework/build-common": "^2.0.3",
 		"@microsoft/api-extractor": "^7.58.2",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "~22.19.17",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -41,6 +41,7 @@
 		"mocha": "^11.7.5"
 	},
 	"devDependencies": {
+		"@fluidframework/build-common": "^2.0.3",
 		"@fluid-internal/mocha-test-setup": "~2.83.0",
 		"@microsoft/api-extractor": "^7.58.2",
 		"@types/mocha": "^10.0.10",

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@fluid-internal/mocha-test-setup':
         specifier: ~2.83.0
         version: 2.83.0
+      '@fluidframework/build-common':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@microsoft/api-extractor':
         specifier: ^7.58.2
         version: 7.58.2(@types/node@22.19.17)
@@ -149,6 +152,10 @@ packages:
 
   '@fluid-internal/test-driver-definitions@2.83.0':
     resolution: {integrity: sha512-e25u/eR5jifNKwxEjWiLYkK8WJXvoCFAbODvUjiuLZf0k5nII/hUNSRz6id48ycFwJ+FP2eYqnbh43sO50vH9g==}
+
+  '@fluidframework/build-common@2.0.3':
+    resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
+    hasBin: true
 
   '@fluidframework/core-interfaces@2.83.0':
     resolution: {integrity: sha512-urkyfgSYUTKoGMuw5R1rIrFq7QH11tRw+GjGWBzGDd8Ovb0iXZtjV3dEtzC/KJnWEefgNt4NdbsS0f+5hMoJqA==}
@@ -1617,6 +1624,8 @@ snapshots:
     dependencies:
       '@fluidframework/core-interfaces': 2.83.0
       '@fluidframework/driver-definitions': 2.83.0
+
+  '@fluidframework/build-common@2.0.3': {}
 
   '@fluidframework/core-interfaces@2.83.0': {}
 

--- a/tools/benchmark/prettier.config.cjs
+++ b/tools/benchmark/prettier.config.cjs
@@ -4,5 +4,5 @@
  */
 
 module.exports = {
-	...require("../../common/build/build-common/prettier.config.cjs"),
+	...require("@fluidframework/build-common/prettier.config.cjs"),
 };


### PR DESCRIPTION
## Description

Make benchmark tool import the base `prettier` config from the installed dev dependency instead of from the repo through a relative path. This aligns it with all other references to that config across the repo, and opens the possibility to build benchmark tool in a sparse git checkout.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).