### PR TITLE
build: tag untagged asserts for 2.100.0 release

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -210,8 +210,8 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 	}
 
 	private getStackedChunkIndex(height: number): number {
-		assert(height % 2 === 1, "must be node height");
-		assert(height >= 0, "must not be above root");
+		assert(height % 2 === 1, 0xcf3 /* must be node height */);
+		assert(height >= 0, 0xcf4 /* must not be above root */);
 		return this.indexOfChunkStack[this.getNodeOnlyHeightFromHeight(height)] ?? oob();
 	}
 
@@ -524,9 +524,10 @@ export class BasicChunkCursor extends SynchronousCursor implements ChunkedCursor
 			this.siblingStack.pop() ?? fail(0xaf0 /* Unexpected siblingStack.length */);
 		this.index = this.indexStack.pop() ?? fail(0xaf1 /* Unexpected indexStack.length */);
 		this.indexOfChunk =
-			this.indexOfChunkStack.pop() ?? fail("Unexpected indexOfChunkStack.length");
+			this.indexOfChunkStack.pop() ?? fail(0xcf5 /* Unexpected indexOfChunkStack.length */);
 		this.indexWithinChunk =
-			this.indexWithinChunkStack.pop() ?? fail("Unexpected indexWithinChunkStack.length");
+			this.indexWithinChunkStack.pop() ??
+			fail(0xcf6 /* Unexpected indexWithinChunkStack.length */);
 		this.assertChunkStacksMatchNodeDepth();
 	}
 

--- a/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/incrementalSummaryBuilder.ts
@@ -398,7 +398,10 @@ export class ForestIncrementalSummaryBuilder implements IncrementalEncoderDecode
 				break;
 			}
 			current = latestSummaryRefIdMap.get(current.parentReferenceId);
-			assert(current !== undefined, "Parent chunk not found in latest summary tracking");
+			assert(
+				current !== undefined,
+				0xcf7 /* Parent chunk not found in latest summary tracking */,
+			);
 		}
 		// Segments are collected leaf-to-root and then reversed. The alternative would be to use unshift
 		// instead of push and reverse. However, using push and reverse is O(n) whereas using unshift would be O(n²).

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1504,8 +1504,6 @@ export const shortCodeMap = {
 	"0xaf1": "Unexpected indexStack.length",
 	"0xaf2": "Unexpected siblingStack.length",
 	"0xaf3": "Unexpected indexStack.length",
-	"0xaf4": "Unexpected indexOfChunkStack.length",
-	"0xaf5": "Unexpected indexWithinChunkStack.length",
 	"0xaf6": "missing edited field",
 	"0xaf7": "missing edited node",
 	"0xaf8": "should not be at root",
@@ -1933,5 +1931,10 @@ export const shortCodeMap = {
 	"0xcef": "only non-leaf can have fields",
 	"0xcf0": "only strings can opt into maybeCompressedIdLeaf",
 	"0xcf1": "chunk required idCompressor but did not provide it",
-	"0xcf2": "Re-submitting a batch with reentrant ops is not supported"
+	"0xcf2": "Re-submitting a batch with reentrant ops is not supported",
+	"0xcf3": "must be node height",
+	"0xcf4": "must not be above root",
+	"0xcf5": "Unexpected indexOfChunkStack.length",
+	"0xcf6": "Unexpected indexWithinChunkStack.length",
+	"0xcf7": "Parent chunk not found in latest summary tracking"
 };


### PR DESCRIPTION
## Description

Tags untagged asserts in preparation for the 2.100.0 release. Ran `pnpm run policy-check:asserts` and committed the resulting tags.

- 5 newly tagged asserts in `@fluidframework/tree`: 0xcf3-0xcf7
- Regenerated `packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts`

This PR is part of the 2.100.0 release prep series. It must merge **before** the version-bump PR.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).