### PR TITLE
Clean up dead non-FIC env vars in test pipelines

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -443,20 +443,14 @@ stages:
           env:
             ${{ each pair in parameters.env }}:
               ${{ pair.key }}: ${{ pair.value }}
-            # ODSP tenant setup script injects the values here (appClientId, tenantCreds).
-            # The e2e test workload references the keys (login__*).
-            ${{ if eq(parameters.odspTenantType, 'dogfood') }}:
+            # The ODSP tenant setup script (trips-setup --useFic) sets login__odsp__fic__test__users
+            # and token__package__import__location as pipeline variables. The e2e test workload reads
+            # those plus login__microsoft__clientId (sourced from prague-key-vault).
+            ${{ if or(eq(parameters.odspTenantType, 'dogfood'), eq(parameters.odspTenantType, 'prod')) }}:
               token__package__import__location: $(token__package__import__location)
               login__odsp__fic__test__users: $(login__odsp__fic__test__users)
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              login__microsoft__clientId: $(appClientId)
-              login__odspdf__test__tenants: $(tenantCreds)
-            ${{ elseif eq(parameters.odspTenantType, 'prod') }}:
-              token__package__import__location: $(token__package__import__location)
-              login__odsp__fic__test__users: $(login__odsp__fic__test__users)
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              login__microsoft__clientId: $(appClientId)
-              login__odsp__test__tenants: $(tenantCreds)
+              login__microsoft__clientId: $(login-microsoft-clientId)
           inputs:
             command: 'custom'
             workingDir: $(Pipeline.Workspace)/$(FFPipelineHostDirectory)/node_modules/${{ parameters.testPackage }}


### PR DESCRIPTION
## Description

PR #26892 added FIC (federated identity credential) support to `include-test-real-service.yml` but kept the legacy `login__odsp(df)__test__tenants` and `login__microsoft__clientId: $(appClientId)` pass-throughs. With FIC's strict precedence in `OdspTestDriver.getOdspCredentials`, those legacy vars are dead at runtime.

This mirrors the cleanup PR #26897 already applied to `test-perf-benchmarks.yml`:

- Drop `login__odspdf__test__tenants: $(tenantCreds)` and `login__odsp__test__tenants: $(tenantCreds)`.
- Source `login__microsoft__clientId` from `prague-key-vault` directly (`$(login-microsoft-clientId)`) instead of the script-injected `$(appClientId)`.
- Merge the now-identical dogfood/prod env blocks.
- Update the comment to describe the FIC flow.

After this, `$(appClientId)`, `$(tenantCreds)`, and `$(stringBearerToken)` no longer appear in any pipeline YAML.

Out of scope: the password-flow code paths in `getOdspCredentials` and the related dev-only examples (`webpack-fluid-loader`, `example-webpack-integration`) still use legacy vars. Migrating them to FIC is non-trivial (browsers can't use `az` CLI), so they're left as-is.

[AB#65605](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/65605)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Verification path: `test-real-service`, `test-real-service-stress`, and `test-service-clients` pipelines must succeed end-to-end against ODSP — specifically the `Run tenant setup script`, test execution, and `Release tenant credentials` stages.