### PR TITLE
Remove workaround for TypeScript before 4.7

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindFormat.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindFormat.ts
@@ -3,33 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { type Static, type TAnySchema, type TSchema, Type } from "@sinclair/typebox";
-
 // Many of the return types in this module are intentionally derived, rather than explicitly specified.
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-/**
- * Note: TS doesn't easily support extracting a generic function's return type until 4.7:
- * https://github.com/microsoft/TypeScript/pull/47607
- * This type is a workaround and can be removed once we're on a version of typescript which
- * supports expressions more like:
- * `Static<ReturnType<typeof EncodedGenericChange<Schema>>>`
- */
-class Wrapper<T extends TSchema> {
-	public encodedGenericChange(e: T) {
-		return EncodedGenericChange<T>(e);
-	}
-	public encodedGenericChangeset(e: T) {
-		return EncodedGenericChangeset<T>(e);
-	}
-}
+import { type Static, type TAnySchema, type TSchema, Type } from "@sinclair/typebox";
 
 export const EncodedGenericChange = <NodeChangesetSchema extends TSchema>(
 	tNodeChangeset: NodeChangesetSchema,
 ) => Type.Tuple([Type.Number({ minimum: 0, multipleOf: 1 }), tNodeChangeset]);
 
 export type EncodedGenericChange<Schema extends TSchema = TAnySchema> = Static<
-	ReturnType<Wrapper<Schema>["encodedGenericChange"]>
+	ReturnType<typeof EncodedGenericChange<Schema>>
 >;
 
 export const EncodedGenericChangeset = <NodeChangesetSchema extends TSchema>(
@@ -37,7 +21,5 @@ export const EncodedGenericChangeset = <NodeChangesetSchema extends TSchema>(
 ) => Type.Array(EncodedGenericChange(tNodeChangeset));
 
 export type EncodedGenericChangeset<Schema extends TSchema = TAnySchema> = Static<
-	ReturnType<Wrapper<Schema>["encodedGenericChangeset"]>
+	ReturnType<typeof EncodedGenericChangeset<Schema>>
 >;
-
-/* eslint-enable @typescript-eslint/explicit-function-return-type */


### PR DESCRIPTION
## Description

Remove a workaround for TypeScript before 4.7

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
