### PR TITLE
build: add missing packages to Node 22 changeset for 2.100.0

### DIFF
--- a/.changeset/brave-lions-march.md
+++ b/.changeset/brave-lions-march.md
@@ -18,8 +18,10 @@
 "@fluid-experimental/sharejs-json1": minor
 "@fluid-experimental/tree": minor
 "@fluid-internal/client-utils": minor
+"@fluid-internal/platform-dependent": minor
 "@fluid-internal/presence-definitions": minor
 "@fluid-internal/presence-runtime": minor
+"@fluid-internal/replay-tool": minor
 "@fluid-private/test-dds-utils": minor
 "@fluid-private/test-loader-utils": minor
 "@fluid-tools/fetch-tool": minor
@@ -78,6 +80,7 @@
 "@fluidframework/task-manager": minor
 "@fluidframework/telemetry-utils": minor
 "@fluidframework/test-runtime-utils": minor
+"@fluidframework/test-utils": minor
 "@fluidframework/tinylicious-client": minor
 "@fluidframework/tinylicious-driver": minor
 "@fluidframework/tool-utils": minor


### PR DESCRIPTION
## Description

Adds three packages to the Node 22 minimum-version changeset (`brave-lions-march.md`) that were missed in the original changeset:

- `@fluid-internal/platform-dependent`
- `@fluid-internal/replay-tool`
- `@fluidframework/test-utils`

This was caught during review of #27175 (release notes / changelogs PR for 2.100.0). Per the release process, changeset edits go in a separate PR that merges first; the release-prep branch will then be regenerated to pick up the corrected affected-packages list in the release notes and the Node 22 entries in those three CHANGELOG files.

**This must merge before #27175 can be regenerated.**

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Trivial changeset edit — three lines added in alphabetical position. No code changes.