### PR TITLE
Auto-Enable Duplicate Batch Detection on Pending-State Capture

### DIFF
--- a/.changeset/spicy-moonbeam-batch-id-detection.md
+++ b/.changeset/spicy-moonbeam-batch-id-detection.md
@@ -4,11 +4,12 @@
 ---
 Duplicate batch detection now activates automatically with pending state
 
-Duplicate batch detection in `ContainerRuntime` previously had to be opted in via `Fluid.ContainerRuntime.enableBatchIdTracking` or `Fluid.Container.enableOfflineFull` config. It now activates automatically whenever this runtime is involved in the pending-state lifecycle:
+Duplicate batch detection in `ContainerRuntime` previously had to be opted in via `Fluid.ContainerRuntime.enableBatchIdTracking` or `Fluid.Container.enableOfflineFull` config. It now activates automatically whenever fork detection is in play in this session:
 
 - The runtime is rehydrated from a captured pending state.
 - The loaded snapshot already contains a `recentBatchInfo` blob.
 - `getPendingLocalState()` is called.
+- An inbound batch arrives carrying an explicit `batchId` in its metadata. This covers pure observers — clients that aren't a fork source themselves but need to track inbound batchIds in order to stay consistent with peers that will throw on the duplicate.
 
 Once activated, detection (and `batchId` stamping on resubmits) is sticky for the runtime's lifetime.
 

--- a/.changeset/spicy-moonbeam-batch-id-detection.md
+++ b/.changeset/spicy-moonbeam-batch-id-detection.md
@@ -1,0 +1,19 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": feature
+---
+Duplicate batch detection now activates automatically with pending state
+
+Duplicate batch detection in `ContainerRuntime` previously had to be opted in via `Fluid.ContainerRuntime.enableBatchIdTracking` or `Fluid.Container.enableOfflineFull` config. It now activates automatically whenever this runtime is involved in the pending-state lifecycle:
+
+- The runtime is rehydrated from a captured pending state.
+- The loaded snapshot already contains a `recentBatchInfo` blob.
+- `getPendingLocalState()` is called.
+
+Once activated, detection (and `batchId` stamping on resubmits) is sticky for the runtime's lifetime.
+
+The previous opt-in flags are no longer read by `ContainerRuntime`. The loader-layer reads of `Fluid.Container.enableOfflineFull` (gating `SerializedStateManager` and snapshot refresh) are unchanged.
+
+The constructor-time check that disallowed Offline Load with non-`TurnBased` flush mode has moved to `getPendingLocalState()`, where it now throws `UsageError("getPendingLocalState requires FlushMode.TurnBased")` at the moment of capture. Constructing a runtime in `FlushMode.Immediate` no longer throws even when pending state is provided.
+
+A short-lived kill switch, `Fluid.ContainerRuntime.DisableDuplicateBatchDetection`, is added so the new auto-activation can be disabled via configuration if it causes regressions. The kill switch is intended to be removed in a future release.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1517,17 +1517,34 @@ export class ContainerRuntime
 	 * serialized pending state and submit batches with the same batchId.
 	 *
 	 * @remarks
-	 * Activates automatically (sticky once on) when this runtime is involved in the
-	 * pending-state lifecycle:
+	 * Activates automatically (sticky once on) once we have any signal that fork
+	 * detection is in play in this session:
 	 *
 	 * - rehydrated from a captured pending state at construction (`pendingLocalState`),
 	 * - loaded from a snapshot whose `recentBatchInfo` blob is non-empty,
-	 * - or `getPendingLocalState()` is called (the moment we capture pending state).
+	 * - `getPendingLocalState()` is called (the moment we capture pending state),
+	 * - or an inbound batch arrives carrying an explicit `batchId` in its metadata,
+	 * which means some peer has activated stamping, so this runtime — even as a
+	 * pure observer — needs to be tracking too in order to stay consistent.
 	 *
 	 * Can be force-disabled via the `Fluid.ContainerRuntime.DisableDuplicateBatchDetection`
 	 * config (see {@link ContainerRuntime.duplicateBatchDetectionDisabled}).
 	 */
 	private duplicateBatchDetector: DuplicateBatchDetector | undefined;
+
+	/**
+	 * Whether this runtime should stamp `batchId` on resubmitted batches so peers
+	 * can detect forked-container collisions.
+	 *
+	 * @remarks
+	 * Conceptually orthogonal to {@link ContainerRuntime.duplicateBatchDetector}
+	 * (one is about inbound observation, the other about outbound stamping), but
+	 * we currently use a single all-or-nothing switch: stamping is on iff the
+	 * detector is active.
+	 */
+	private get enableBatchIdTracking(): boolean {
+		return this.duplicateBatchDetector !== undefined;
+	}
 	private readonly outbox: Outbox;
 	private readonly garbageCollector: IGarbageCollector;
 
@@ -3133,6 +3150,12 @@ export class ContainerRuntime
 
 			if ("batchStart" in inboundResult) {
 				const batchStart: BatchStartInfo = inboundResult.batchStart;
+				// An explicit batchId means some peer has activated stamping, so we
+				// must track too — even as a pure observer — to stay consistent with
+				// peers that will throw on the duplicate.
+				if (batchStart.batchId !== undefined) {
+					this.ensureDuplicateBatchDetector();
+				}
 				const result = this.duplicateBatchDetector?.processInboundBatch(batchStart);
 				if (result?.duplicate === true) {
 					const error = new DataCorruptionError(
@@ -4979,11 +5002,11 @@ export class ContainerRuntime
 		);
 
 		const resubmitInfo = {
-			// Stamp the batchId on resubmits whenever the duplicate batch detector is
-			// active (this runtime is part of the pending-state lifecycle and a forked
-			// peer might resubmit the same batches). Otherwise omit it to avoid
-			// inflating message metadata.
-			batchId: this.duplicateBatchDetector === undefined ? undefined : batchId,
+			// Stamp batchId on resubmits whenever fork-detection is in play in this
+			// session. Detector-on and stamping-on are conceptually distinct concerns
+			// (inbound observation vs. outbound cooperation), but currently share a
+			// single all-or-nothing switch (see {@link enableBatchIdTracking}).
+			batchId: this.enableBatchIdTracking ? batchId : undefined,
 			staged,
 		};
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1449,13 +1449,10 @@ export class ContainerRuntime
 	private readonly _flushMode: FlushMode;
 	private readonly stagingModeAutoFlushThreshold: number;
 	/**
-	 * BatchId tracking is needed whenever there's a possibility of a "forked Container",
-	 * where the same local state is pending in two different running Containers, each of
-	 * which is trying to ensure it's persisted.
-	 * "Offline Load" from serialized pending state is one such scenario since two Containers
-	 * could load from the same serialized pending state.
+	 * Kill switch for {@link ContainerRuntime.duplicateBatchDetector} auto-activation.
+	 * When true, the detector is never constructed and resubmits omit batchIds.
 	 */
-	private readonly batchIdTrackingEnabled: boolean;
+	private readonly duplicateBatchDetectionDisabled: boolean;
 	private flushScheduled = false;
 
 	private canSendOps: boolean;
@@ -1515,7 +1512,22 @@ export class ContainerRuntime
 	private readonly inboundBatchAggregator: InboundBatchAggregator;
 	private readonly blobManager: BlobManager;
 	private readonly pendingStateManager: PendingStateManager;
-	private readonly duplicateBatchDetector: DuplicateBatchDetector | undefined;
+	/**
+	 * Detects "forked container" scenarios where two containers load from the same
+	 * serialized pending state and submit batches with the same batchId.
+	 *
+	 * @remarks
+	 * Activates automatically (sticky once on) when this runtime is involved in the
+	 * pending-state lifecycle:
+	 *
+	 * - rehydrated from a captured pending state at construction (`pendingLocalState`),
+	 * - loaded from a snapshot whose `recentBatchInfo` blob is non-empty,
+	 * - or `getPendingLocalState()` is called (the moment we capture pending state).
+	 *
+	 * Can be force-disabled via the `Fluid.ContainerRuntime.DisableDuplicateBatchDetection`
+	 * config (see {@link ContainerRuntime.duplicateBatchDetectionDisabled}).
+	 */
+	private duplicateBatchDetector: DuplicateBatchDetector | undefined;
 	private readonly outbox: Outbox;
 	private readonly garbageCollector: IGarbageCollector;
 
@@ -1884,21 +1896,21 @@ export class ContainerRuntime
 			this.mc.config.getNumber("Fluid.ContainerRuntime.StagingModeAutoFlushThreshold") ??
 			runtimeOptions.stagingModeAutoFlushThreshold ??
 			defaultStagingModeAutoFlushThreshold;
-		this.batchIdTrackingEnabled =
-			this.mc.config.getBoolean("Fluid.Container.enableOfflineFull") ??
-			this.mc.config.getBoolean("Fluid.ContainerRuntime.enableBatchIdTracking") ??
-			false;
+		this.duplicateBatchDetectionDisabled =
+			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableDuplicateBatchDetection") === true;
 
-		if (this.batchIdTrackingEnabled && this._flushMode !== FlushMode.TurnBased) {
-			const error = new UsageError("Offline mode is only supported in turn-based mode");
-			this.closeFn(error);
-			throw error;
-		}
-
-		// DuplicateBatchDetection is only enabled if Offline Load is enabled
-		// It maintains a cache of all batchIds/sequenceNumbers within the collab window.
-		// Don't waste resources doing so if not needed.
-		if (this.batchIdTrackingEnabled) {
+		// Activate the duplicate batch detector when this runtime is involved in the
+		// pending-state lifecycle: rehydrated from a captured pending state, or loading
+		// a snapshot that already tracks recent batches. Otherwise, lazily activate when
+		// getPendingLocalState() is called (see ensureDuplicateBatchDetector). Activation
+		// is sticky once on for the runtime's lifetime.
+		const loadedWithPendingState = pendingLocalState !== undefined;
+		const loadedWithRecentBatchInfo =
+			recentBatchInfo !== undefined && recentBatchInfo.length > 0;
+		if (
+			!this.duplicateBatchDetectionDisabled &&
+			(loadedWithPendingState || loadedWithRecentBatchInfo)
+		) {
 			this.duplicateBatchDetector = new DuplicateBatchDetector(recentBatchInfo);
 		}
 
@@ -4953,8 +4965,8 @@ export class ContainerRuntime
 	 * checks in the ConnectionStateHandler (Loader layer)
 	 *
 	 * The only exception to this would be if the Container "forks" due to misuse of the "Offline Load" feature.
-	 * If the "Offline Load" feature is enabled, the batchId is included in the resubmitted messages,
-	 * for correlation to detect container forking.
+	 * When the duplicate batch detector is active, the batchId is included in the resubmitted messages
+	 * so a forked peer can detect duplicates against its own tracked batch IDs.
 	 */
 	private reSubmitBatch(
 		batch: PendingMessageResubmitData[],
@@ -4966,9 +4978,11 @@ export class ContainerRuntime
 		);
 
 		const resubmitInfo = {
-			// Only include Batch ID if "Offline Load" feature is enabled
-			// It's only needed to identify batches across container forks arising from misuse of offline load.
-			batchId: this.batchIdTrackingEnabled ? batchId : undefined,
+			// Stamp the batchId on resubmits whenever the duplicate batch detector is
+			// active (this runtime is part of the pending-state lifecycle and a forked
+			// peer might resubmit the same batches). Otherwise omit it to avoid
+			// inflating message metadata.
+			batchId: this.duplicateBatchDetector === undefined ? undefined : batchId,
 			staged,
 		};
 
@@ -5260,6 +5274,20 @@ export class ContainerRuntime
 		this.disposeFn();
 	}
 
+	/**
+	 * Lazily activates the duplicate batch detector. Used at the moment we capture
+	 * pending state via {@link ContainerRuntime.getPendingLocalState}, since a forked
+	 * container could resubmit any pending batches we are about to serialize.
+	 */
+	private ensureDuplicateBatchDetector(): void {
+		if (
+			!this.duplicateBatchDetectionDisabled &&
+			this.duplicateBatchDetector === undefined
+		) {
+			this.duplicateBatchDetector = new DuplicateBatchDetector(undefined);
+		}
+	}
+
 	public getPendingLocalState(props?: IGetPendingLocalStateProps): unknown {
 		// AB#46464 - Add support for serializing pending state while in staging mode
 		if (this.inStagingMode) {
@@ -5274,6 +5302,16 @@ export class ContainerRuntime
 		if (this.batchRunner.running) {
 			throw new UsageError("can't get state while manually accumulating a batch");
 		}
+
+		// Capturing pending state requires turn-based flush so each captured batch is
+		// well-formed (a contiguous run of ops with a single batchId on resubmit).
+		if (this._flushMode !== FlushMode.TurnBased) {
+			throw new UsageError("getPendingLocalState requires FlushMode.TurnBased");
+		}
+
+		// The act of capturing pending state means a forked container could resubmit
+		// the same batches, so we must track batch IDs from this point forward.
+		this.ensureDuplicateBatchDetector();
 
 		// Flush pending batch.
 		// getPendingLocalState() is only exposed through Container.getPendingLocalState(), so it's safe

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1897,7 +1897,8 @@ export class ContainerRuntime
 			runtimeOptions.stagingModeAutoFlushThreshold ??
 			defaultStagingModeAutoFlushThreshold;
 		this.duplicateBatchDetectionDisabled =
-			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableDuplicateBatchDetection") === true;
+			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableDuplicateBatchDetection") ===
+			true;
 
 		// Activate the duplicate batch detector when this runtime is involved in the
 		// pending-state lifecycle: rehydrated from a captured pending state, or loading
@@ -5280,10 +5281,7 @@ export class ContainerRuntime
 	 * container could resubmit any pending batches we are about to serialize.
 	 */
 	private ensureDuplicateBatchDetector(): void {
-		if (
-			!this.duplicateBatchDetectionDisabled &&
-			this.duplicateBatchDetector === undefined
-		) {
+		if (!this.duplicateBatchDetectionDisabled && this.duplicateBatchDetector === undefined) {
 			this.duplicateBatchDetector = new DuplicateBatchDetector(undefined);
 		}
 	}

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -269,6 +269,7 @@ describe("Runtime", () => {
 			baseSnapshot?: ISnapshotTree;
 			connected?: boolean;
 			attachState?: AttachState;
+			pendingLocalState?: unknown;
 		} = {},
 		clientId: string = mockClientId,
 	): Partial<IContainerContext> => {
@@ -280,6 +281,7 @@ describe("Runtime", () => {
 			baseSnapshot,
 			connected = true,
 			attachState = AttachState.Attached,
+			pendingLocalState,
 		} = params;
 
 		const mockContext = {
@@ -313,6 +315,7 @@ describe("Runtime", () => {
 			connected,
 			storage: mockStorage as IContainerStorageService,
 			baseSnapshot,
+			pendingLocalState,
 		} satisfies Partial<IContainerContext>;
 
 		// Update the delta manager's last message which is used for validation during summarization.
@@ -436,12 +439,10 @@ describe("Runtime", () => {
 				let batchBegin = 0;
 				let batchEnd = 0;
 				let callsToEnsure = 0;
+				// Empty-batch resubmit requires the duplicate batch detector active so the
+				// batchId is stamped on the resubmit and round-trips through the inbound op.
 				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
-					context: getMockContext({
-						settings: {
-							"Fluid.ContainerRuntime.enableBatchIdTracking": true,
-						},
-					}) as IContainerContext,
+					context: getMockContext({ pendingLocalState: {} }) as IContainerContext,
 					registry: new FluidDataStoreRegistry([]),
 					existing: false,
 					runtimeOptions: {},
@@ -481,13 +482,13 @@ describe("Runtime", () => {
 				assert.strictEqual(containerRuntime.isDirty, false);
 			});
 
-			for (const enableBatchIdTracking of [true, undefined])
-				it("Replaying ops should resend in correct order, with batch ID if applicable", async () => {
+			for (const detectorActive of [true, false])
+				it(`Replaying ops should resend in correct order, with batch ID if applicable (detector ${detectorActive ? "active" : "inactive"})`, async () => {
+					// Activate the duplicate batch detector by loading with pending state
+					// when we want batchIds stamped on resubmits; otherwise default load.
 					const { runtime } = await ContainerRuntime.loadRuntime2({
 						context: getMockContext({
-							settings: {
-								"Fluid.ContainerRuntime.enableBatchIdTracking": enableBatchIdTracking, // batchId only stamped if true
-							},
+							pendingLocalState: detectorActive ? {} : undefined,
 						}) as IContainerContext,
 						registry: new FluidDataStoreRegistry([]),
 						existing: false,
@@ -525,7 +526,7 @@ describe("Runtime", () => {
 						);
 					}
 
-					if (enableBatchIdTracking === true) {
+					if (detectorActive) {
 						assert(
 							batchIdMatchesUnsentFormat(
 								// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -2343,96 +2344,171 @@ describe("Runtime", () => {
 		});
 
 		describe("Duplicate Batch Detection", () => {
-			for (const enableBatchIdTracking of [undefined, true]) {
-				it(`DuplicateBatchDetector is disabled if Batch Id Tracking isn't needed (${enableBatchIdTracking === true ? "ENABLED" : "DISABLED"})`, async () => {
-					const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
-						context: getMockContext({
-							settings: {
-								"Fluid.ContainerRuntime.enableBatchIdTracking": enableBatchIdTracking,
-							},
-						}) as IContainerContext,
-						registry: new FluidDataStoreRegistry([]),
-						existing: false,
-						runtimeOptions: {
-							enableRuntimeIdCompressor: "on",
-						},
-						provideEntryPoint: mockProvideEntryPoint,
-					});
+			const errorPredicate = (e: Error): boolean =>
+				e.message === "Duplicate batch - The same batch was sequenced twice";
 
-					// Process batch "batchId1" with seqNum 123
-					containerRuntime.process(
-						{
-							sequenceNumber: 123,
-							type: MessageType.Operation,
-							contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-							metadata: { batchId: "batchId1" },
-						} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
-						false,
-					);
-					// Process a duplicate batch "batchId1" with different seqNum 234
-					const assertThrowsOnlyIfExpected =
-						enableBatchIdTracking === true ? assert.throws : assert.doesNotThrow;
-					const errorPredicate = (e: Error) =>
-						e.message === "Duplicate batch - The same batch was sequenced twice";
-					assertThrowsOnlyIfExpected(
-						() => {
-							containerRuntime.process(
-								{
-									sequenceNumber: 234,
-									type: MessageType.Operation,
-									contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-									metadata: { batchId: "batchId1" },
-								} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
-								false,
-							);
-						},
-						errorPredicate,
-						"Expected duplicate batch detection to match Offline Load enablement",
-					);
+			const processBatchWithId = (
+				containerRuntime: ContainerRuntime,
+				sequenceNumber: number,
+				batchId: string,
+			): void => {
+				containerRuntime.process(
+					{
+						sequenceNumber,
+						type: MessageType.Operation,
+						contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+						metadata: { batchId },
+					} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+					false,
+				);
+			};
+
+			it("Does NOT activate by default", async () => {
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
+					provideEntryPoint: mockProvideEntryPoint,
 				});
-			}
 
-			it("Can roundrip DuplicateBatchDetector state through summary/snapshot", async () => {
-				// Duplicate Batch Detection requires OfflineLoad enabled
-				const settings_enableOfflineLoad = {
-					"Fluid.ContainerRuntime.enableBatchIdTracking": true,
-				};
+				processBatchWithId(containerRuntime, 123, "batchId1");
+				assert.doesNotThrow(
+					() => processBatchWithId(containerRuntime, 234, "batchId1"),
+					"Detector should not activate by default; duplicate should not throw",
+				);
+			});
+
+			it("Activates when constructor receives pendingLocalState", async () => {
 				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
 					context: getMockContext({
-						settings: settings_enableOfflineLoad,
+						pendingLocalState: {},
 					}) as IContainerContext,
 					registry: new FluidDataStoreRegistry([]),
 					existing: false,
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+
+				processBatchWithId(containerRuntime, 123, "batchId1");
+				assert.throws(
+					() => processBatchWithId(containerRuntime, 234, "batchId1"),
+					errorPredicate,
+					"Detector should activate when loaded with pendingLocalState",
+				);
+			});
+
+			it("Activates after getPendingLocalState() is called", async () => {
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+
+				// Trigger lazy activation by capturing pending state
+				containerRuntime.getPendingLocalState();
+
+				processBatchWithId(containerRuntime, 123, "batchId1");
+				assert.throws(
+					() => processBatchWithId(containerRuntime, 234, "batchId1"),
+					errorPredicate,
+					"Detector should activate after getPendingLocalState() call",
+				);
+			});
+
+			it("getPendingLocalState throws if FlushMode is not TurnBased", async () => {
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
 					runtimeOptions: {
+						flushMode: FlushMode.Immediate,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				// Add batchId1 to DuplicateBatchDetected via ContainerRuntime.process,
-				// and get its serialized representation from summarizing
-				containerRuntime.process(
-					{
-						sequenceNumber: 123,
-						type: MessageType.Operation,
-						contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-						metadata: { batchId: "batchId1" },
-					} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
-					false,
+				assert.throws(
+					() => containerRuntime.getPendingLocalState(),
+					(e: Error) =>
+						e instanceof UsageError &&
+						e.message.startsWith("getPendingLocalState requires FlushMode.TurnBased"),
+					"Expected UsageError when capturing pending state outside TurnBased mode",
 				);
+			});
+
+			it("Constructor with pendingLocalState in non-TurnBased mode no longer throws", async () => {
+				// Regression: this used to be a constructor-time UsageError under the old flag gate.
+				// Detection still activates, but the FlushMode check has moved to capture time.
+				await assert.doesNotReject(
+					ContainerRuntime.loadRuntime2({
+						context: getMockContext({
+							pendingLocalState: {},
+						}) as IContainerContext,
+						registry: new FluidDataStoreRegistry([]),
+						existing: false,
+						runtimeOptions: {
+							flushMode: FlushMode.Immediate,
+							enableRuntimeIdCompressor: "on",
+						},
+						provideEntryPoint: mockProvideEntryPoint,
+					}),
+				);
+			});
+
+			it("Kill switch disables auto-activation", async () => {
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext({
+						settings: {
+							"Fluid.ContainerRuntime.DisableDuplicateBatchDetection": true,
+						},
+						pendingLocalState: {},
+					}) as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+
+				// Even with pendingLocalState and getPendingLocalState(), detector stays off.
+				containerRuntime.getPendingLocalState();
+				processBatchWithId(containerRuntime, 123, "batchId1");
+				assert.doesNotThrow(
+					() => processBatchWithId(containerRuntime, 234, "batchId1"),
+					"Kill switch should suppress activation in all paths",
+				);
+			});
+
+			// Note: batchId stamping on resubmits in both detector states is also verified
+			// by the "Replaying ops should resend in correct order" test in the Batching block.
+
+			it("Activates when snapshot contains recentBatchInfo, and roundtrips through summary", async () => {
+				// Writer: activates via getPendingLocalState(), then we summarize to extract the blob.
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+				containerRuntime.getPendingLocalState();
+
+				// Add batchId1 to DuplicateBatchDetector via ContainerRuntime.process,
+				// and get its serialized representation from summarizing
+				processBatchWithId(containerRuntime, 123, "batchId1");
 				const { summary } = await containerRuntime.summarize({ fullTree: true });
 				const blob: SummaryObject | undefined = summary.tree[recentBatchInfoBlobName];
 				assert(blob?.type === SummaryType.Blob, "Expected blob");
 				assert.equal(blob.content, '[[123,"batchId1"]]', "Expected single batchId mapping");
 
-				// Load a new ContainerRuntime with the serialized DuplicateBatchDetector state.
+				// Reader: loads the snapshot, activates via the recentBatchInfo blob alone.
 				const mockStorage = {
-					// Hardcode readblob fn to return the blob contents put in the summary
 					readBlob: async (_id) => stringToBuffer(blob.content as string, "utf8"),
 				};
 				const { runtime: containerRuntime2 } = await ContainerRuntime.loadRuntime2({
 					context: getMockContext({
-						settings: settings_enableOfflineLoad,
 						baseSnapshot: {
 							trees: {},
 							blobs: { [recentBatchInfoBlobName]: "nonempty_id_ignored_by_mockStorage" },
@@ -2441,26 +2517,14 @@ describe("Runtime", () => {
 					}) as IContainerContext,
 					registry: new FluidDataStoreRegistry([]),
 					existing: false,
-					runtimeOptions: {
-						enableRuntimeIdCompressor: "on",
-					},
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				// Process an op with a duplicate batchId to what was loaded with
+				// Reader sees a duplicate batchId from its loaded recentBatchInfo and throws.
 				assert.throws(
-					() => {
-						containerRuntime2.process(
-							{
-								sequenceNumber: 234,
-								type: MessageType.Operation,
-								contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-								metadata: { batchId: "batchId1" },
-							} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
-							false,
-						);
-					},
-					(e: Error) => e.message === "Duplicate batch - The same batch was sequenced twice",
+					() => processBatchWithId(containerRuntime2, 234, "batchId1"),
+					errorPredicate,
 					"Expected duplicate batch detected after loading with recentBatchInfo",
 				);
 			});

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2347,23 +2347,28 @@ describe("Runtime", () => {
 			const errorPredicate = (e: Error): boolean =>
 				e.message === "Duplicate batch - The same batch was sequenced twice";
 
-			const processBatchWithId = (
+			const processBatch = (
 				containerRuntime: ContainerRuntime,
 				sequenceNumber: number,
-				batchId: string,
+				batchId: string | undefined,
 			): void => {
 				containerRuntime.process(
 					{
 						sequenceNumber,
 						type: MessageType.Operation,
 						contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-						metadata: { batchId },
+						metadata: batchId === undefined ? undefined : { batchId },
 					} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
 					false,
 				);
 			};
+			const processBatchWithId = (
+				containerRuntime: ContainerRuntime,
+				sequenceNumber: number,
+				batchId: string,
+			): void => processBatch(containerRuntime, sequenceNumber, batchId);
 
-			it("Does NOT activate by default", async () => {
+			it("Does NOT activate when inbound batches lack an explicit batchId", async () => {
 				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
 					context: getMockContext() as IContainerContext,
 					registry: new FluidDataStoreRegistry([]),
@@ -2372,10 +2377,31 @@ describe("Runtime", () => {
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				processBatchWithId(containerRuntime, 123, "batchId1");
+				// Inbound batches without explicit batchId must not flip activation on,
+				// otherwise plain (non-forked) sessions would unnecessarily start tracking.
+				processBatch(containerRuntime, 123, undefined);
 				assert.doesNotThrow(
+					() => processBatch(containerRuntime, 234, undefined),
+					"Detector should remain off when no explicit batchId is observed",
+				);
+			});
+
+			it("Activates on inbound batch carrying an explicit batchId", async () => {
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: { enableRuntimeIdCompressor: "on" },
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+
+				// First explicit-batchId observation activates the detector; a duplicate
+				// arriving afterwards should be caught.
+				processBatchWithId(containerRuntime, 123, "batchId1");
+				assert.throws(
 					() => processBatchWithId(containerRuntime, 234, "batchId1"),
-					"Detector should not activate by default; duplicate should not throw",
+					errorPredicate,
+					"Detector should activate after seeing an explicit batchId",
 				);
 			});
 
@@ -2472,7 +2498,8 @@ describe("Runtime", () => {
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				// Even with pendingLocalState and getPendingLocalState(), detector stays off.
+				// Even with pendingLocalState, getPendingLocalState(), and explicit
+				// batchIds on inbound batches, the detector stays off.
 				containerRuntime.getPendingLocalState();
 				processBatchWithId(containerRuntime, 123, "batchId1");
 				assert.doesNotThrow(

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -5,8 +5,9 @@
 
 import { strict as assert } from "assert";
 
-import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
+import { asLegacyAlpha } from "@fluidframework/container-loader/internal";
 import {
 	CompressionAlgorithms,
 	ContainerMessageType,
@@ -104,9 +105,7 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 		fluidDataObjectType: DataObjectFactoryType.Test,
 		registry,
 		loaderProps: {
-			configProvider: configProvider({
-				"Fluid.ContainerRuntime.enableBatchIdTracking": true,
-			}),
+			configProvider: configProvider({}),
 		},
 	};
 
@@ -159,21 +158,14 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 		await provider.ensureSynchronized();
 	}
 
-	itExpects(
-		"Can't set up a container with Immediate Mode and Offline Load",
-		[
-			{
-				eventName: "fluid:telemetry:Container:ContainerClose",
-				error: "Offline mode is only supported in turn-based mode",
-			},
-		],
-		async () => {
-			await assert.rejects(
-				setupContainers({ flushMode: FlushMode.Immediate }),
-				"Offline load is not supported with Immediate mode",
-			);
-		},
-	);
+	it("Can't capture pending state in Immediate Mode", async () => {
+		await setupContainers({ flushMode: FlushMode.Immediate });
+		await assert.rejects(
+			asLegacyAlpha(container1).getPendingLocalState(),
+			(e: Error) => e.message.startsWith("getPendingLocalState requires FlushMode.TurnBased"),
+			"Capturing pending state outside turn-based mode should fail",
+		);
+	});
 
 	describe("Batch metadata verification when ops are flushed in batches", () => {
 		let dataObject1BatchMessages: ISequencedDocumentMessage[] = [];


### PR DESCRIPTION
# Auto-Enable Duplicate Batch Detection on Pending-State Capture

## Context

Duplicate batch detection in the container runtime catches "forked container" scenarios — two containers loaded from the same serialized pending state submitting batches with the same batchId. Today it is gated by two opt-in config flags (`Fluid.Container.enableOfflineFull` and `Fluid.ContainerRuntime.enableBatchIdTracking`) that callers must set explicitly.

This change removes the explicit flag gating and makes detection auto-activate whenever the runtime is involved in pending-state lifecycle: when it loads with pending state, when it loads a snapshot that already carries `recentBatchInfo`, or the moment `getPendingLocalState()` is called. The intent is to make safety the default — any runtime exposed to the offline-load fork risk gets detection automatically.

A short-lived kill-switch flag (`Fluid.ContainerRuntime.DisableDuplicateBatchDetection`) is added so the change can be rolled back via configuration if it regresses, then removed in a follow-up.

## Design Summary

- Activate the `DuplicateBatchDetector` when ANY of:
  1. The runtime is constructed with `context.pendingLocalState !== undefined` (rehydrated peer of a fork).
  2. The runtime is constructed with a non-empty `recentBatchInfo` array (snapshot already has tracked batches).
  3. `getPendingLocalState()` is called (this runtime captures pending state for offline rehydration).
- Once activated, the detector lives for the runtime's lifetime.
- Resubmits stamp `batchId` whenever the detector is active.
- The `FlushMode === TurnBased` precondition moves from the constructor to `getPendingLocalState()`.
- Add kill-switch `Fluid.ContainerRuntime.DisableDuplicateBatchDetection` (default false). Delete reads of the two old flags from `containerRuntime.ts`. Loader-layer reads of `enableOfflineFull` (in `container.ts` and `snapshotRefresher.ts`) are NOT touched — they gate unrelated SerializedStateManager and snapshot-refresh behavior.

## Critical Files

- [packages/runtime/container-runtime/src/containerRuntime.ts](packages/runtime/container-runtime/src/containerRuntime.ts) — primary changes
- [packages/runtime/container-runtime/src/opLifecycle/duplicateBatchDetector.ts](packages/runtime/container-runtime/src/opLifecycle/duplicateBatchDetector.ts) — no code changes; reused as-is
- [packages/runtime/container-runtime/src/test/containerRuntime.spec.ts](packages/runtime/container-runtime/src/test/containerRuntime.spec.ts) — update existing tests, add new ones
- [packages/test/test-end-to-end-tests/src/test/batching.spec.ts](packages/test/test-end-to-end-tests/src/test/batching.spec.ts) — drop now-defunct setting
- [packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts](packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts) — verify still passes (loader still reads `enableOfflineFull`)
- [packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts](packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts) — verify still passes
- New changeset under `.changeset/`
