### PR TITLE
Disable pnpm's trustPolicy for the client release group's workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,11 @@ minimumReleaseAgeExclude: [
 ]
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# See: https://github.com/orgs/pnpm/discussions/11084 for some discussion.
+# Enabling this is additionally more complicated than coming up with a reasonable allow-list of packages, given that
+# whether a package is trusted may change due to external factors and pnpm lacks a command or mode that scans the full
+# dependency graph to determine trustworthiness. Note the "off" here is the default as well.
+trustPolicy: off
 trustPolicyExclude:
   # axios@0.30.3 is the last legitimate 0.30.x release (published 2026-02-18). The trust
   # downgrade fires because 0.30.x was published via direct CLI rather than the OIDC/GitHub


### PR DESCRIPTION
This change turns off the trustPolicy for the client group's npm workspace. Motivation:

- The trust of a package changes due to external factors, so a package that is in the lockfile may go from trusted to untrusted.
- However, pnpm's trust scanning occurs when modifying the lockfile, and doesn't necessarily visit all packages. It may flag any traversed package as being untrusted. There is no alternative "scan the trust of all the packages" command or flag.

As a result, trust changes can block adding or upgrading packages inconsistently, and we have no way of detecting these changes eagerly without writing tooling on our end (or finding an existing tool). In the future we may leverage such a tool. For now, we are reverting the trustPolicy to the default setting (off).