### PR TITLE
docs(ci-readiness-check): require explicit mode prompt before running

### DIFF
--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -6,12 +6,14 @@ description: Use when the user explicitly asks for a CI check or to push their b
 <required>
 **You MUST ask the user the Step 1 mode-choice question before doing anything else.** Do not pick a mode for them. Do not default to a mode. Auto/autonomous mode does NOT authorize you to skip this question - being in auto mode is never a valid reason to bypass the prompt.
 
-There are exactly two narrow exceptions where you MAY proceed without asking. Both must be applied conservatively; if you are not certain an exception applies, you MUST ask.
+There are exactly two narrow exceptions where you MAY skip the Step 1 mode-choice question. Both must be applied conservatively; if you are not certain an exception applies, you MUST ask.
 
-1. **No-op since the last check in this conversation.** The most recent CI readiness check in the *current* conversation already ran, and every change since then is obviously/provably outside the scope of any check the skill performs (e.g. edits only to comments, unrelated markdown, or files the skill does not touch).
+1. **No-op since the last check in this conversation.** The most recent CI readiness check in the *current* conversation already ran, and every change since then is obviously/provably outside the scope of any check the skill performs. Examples that qualify: edits only to comments; edits only to files outside any workspace package (e.g. files under `.claude/`, repo-root `README.md` / `CHANGELOG.md`, top-level docs not in a `docs/*` package). **Watch out:** `docs/api/` and similar are themselves workspace packages — markdown inside a workspace package does NOT automatically qualify. If you cannot quickly verify the changed files are outside every workspace package, ask.
 2. **Explicit standing instruction.** The user has explicitly told you — in this conversation or in a saved memory entry — to auto-skip the CI readiness check without asking. Inferred preference, prior approvals of past runs, or general "be less interruptive" guidance does NOT qualify.
 
-When you apply an exception, you MUST report — every single time, with no abbreviation across repeated runs — that you skipped and which exception applied. Silent skipping is forbidden.
+If either exception applies, treat it as equivalent to the user picking **Skip** in Step 1: do NOT ask the mode-choice question, do NOT create CI-readiness tasks/todos, and do NOT run the CI script or any other build/test/API-report steps. Stop the skill after reporting the skip.
+
+When you apply an exception, you MUST explicitly report — every single time, with no abbreviation across repeated runs — that (a) you skipped asking the mode-choice question, (b) the CI readiness check itself was skipped, and (c) which exception applied. Silent skipping is forbidden.
 
 When neither exception applies, ask the user and wait for their response. Immediately after they respond, create one task/todo item per applicable step using your available task tooling (TaskCreate for Claude, TodoWrite for Copilot) — before doing any other work. Mark each task in_progress when you start it and completed when you finish. This prevents steps from being silently skipped as context grows.
 

--- a/.claude/skills/ci-readiness-check/SKILL.md
+++ b/.claude/skills/ci-readiness-check/SKILL.md
@@ -4,7 +4,16 @@ description: Use when the user explicitly asks for a CI check or to push their b
 ---
 
 <required>
-Step 1 asks the user to pick a mode. Immediately after they respond, create one task/todo item per applicable step using your available task tooling (TaskCreate for Claude, TodoWrite for Copilot) — before doing any other work. Mark each task in_progress when you start it and completed when you finish. This prevents steps from being silently skipped as context grows.
+**You MUST ask the user the Step 1 mode-choice question before doing anything else.** Do not pick a mode for them. Do not default to a mode. Auto/autonomous mode does NOT authorize you to skip this question - being in auto mode is never a valid reason to bypass the prompt.
+
+There are exactly two narrow exceptions where you MAY proceed without asking. Both must be applied conservatively; if you are not certain an exception applies, you MUST ask.
+
+1. **No-op since the last check in this conversation.** The most recent CI readiness check in the *current* conversation already ran, and every change since then is obviously/provably outside the scope of any check the skill performs (e.g. edits only to comments, unrelated markdown, or files the skill does not touch).
+2. **Explicit standing instruction.** The user has explicitly told you — in this conversation or in a saved memory entry — to auto-skip the CI readiness check without asking. Inferred preference, prior approvals of past runs, or general "be less interruptive" guidance does NOT qualify.
+
+When you apply an exception, you MUST report — every single time, with no abbreviation across repeated runs — that you skipped and which exception applied. Silent skipping is forbidden.
+
+When neither exception applies, ask the user and wait for their response. Immediately after they respond, create one task/todo item per applicable step using your available task tooling (TaskCreate for Claude, TodoWrite for Copilot) — before doing any other work. Mark each task in_progress when you start it and completed when you finish. This prevents steps from being silently skipped as context grows.
 
 Tasks to create by mode:
 


### PR DESCRIPTION
## Description

A user reported that the `ci-readiness-check` skill would silently run in
Build mode (the expensive one) every time they pushed, instead of asking
which mode to run. Step 1 of the skill already said to ask the user, but
the directive was buried below the `<required>` block, soft-worded
("Step 1 asks the user..."), and not enforced against auto/autonomous mode.

This change rewrites the lead of the `<required>` block to make the prompt
unmissable:

- States as a MUST that the agent ask the Step 1 mode-choice question first.
- Explicitly disqualifies "we're in auto mode" as a justification to skip.
- Defines exactly two narrow exceptions where the agent may proceed without
  asking (no-op since the previous check in this conversation; explicit
  standing user instruction), with conservative wording so subjective "I
  think nothing important changed" does not qualify.
- Requires that, in both exceptions, the agent still report the skip and
  which exception applied — every time, with no abbreviation across
  repeated runs.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).