### PR TITLE
fix(ci): make PR review confirm robust to PR updates

### DIFF
--- a/.github/scripts/pr_review_propose.py
+++ b/.github/scripts/pr_review_propose.py
@@ -5,11 +5,15 @@ Subcommands:
   build-comment    Build the markdown proposal comment body.
   parse-checkboxes Read a comment body file and emit the checked reviewer IDs as JSON.
   format-names     Convert a JSON reviewer-ID array to a display-name string.
+  is-start-checked Print 'true'/'false' depending on Start review box state.
+  reset-start      Print the body with the Start review box reset to [ ].
 
 Usage:
   python pr_review_propose.py build-comment --reviewer-count 3 --lines 247 --files 8
   python pr_review_propose.py parse-checkboxes comment.txt
   python pr_review_propose.py format-names '["correctness","security"]'
+  python pr_review_propose.py is-start-checked comment.txt
+  python pr_review_propose.py reset-start comment.txt
 """
 
 from __future__ import annotations
@@ -60,12 +64,46 @@ def get_selected(reviewer_count: int) -> set[str]:
     return set(priority_ids[:reviewer_count])
 
 
+def parse_checked_ids(body: str) -> list[str]:
+    """Extract checked reviewer IDs (in declaration order) from a comment body."""
+    found: list[str] = []
+    for m in re.finditer(r"- \[x\] \*\*(.+?)\*\*", body, re.IGNORECASE):
+        key = m.group(1).lower()
+        rid = _LABEL_TO_ID.get(key)
+        if rid and rid not in found:
+            found.append(rid)
+    return found
+
+
+def is_start_checked(body: str) -> bool:
+    """Return True if the body has the Start review box ticked."""
+    pattern = rf"- \[x\] \*\*{re.escape(START_LABEL)}\*\*"
+    return re.search(pattern, body, re.IGNORECASE) is not None
+
+
 # ── Subcommand implementations ────────────────────────────────────────────────
 
 
 def cmd_build_comment(args: argparse.Namespace) -> None:
-    """Print the proposal comment markdown to stdout."""
-    selected = get_selected(args.reviewer_count)
+    """Print the proposal comment markdown to stdout.
+
+    If --from-existing-body is provided and the file is non-empty, the prior
+    comment's checked reviewers are carried over instead of using the default
+    priority-based selection. The "Start review" box is always rendered
+    unchecked — checking it is what triggers the fleet, so a re-post must
+    reset it.
+    """
+    selected: set[str] | None = None
+    if args.from_existing_body:
+        try:
+            with open(args.from_existing_body) as f:
+                prior = f.read()
+            if prior.strip():
+                selected = set(parse_checked_ids(prior))
+        except FileNotFoundError:
+            pass
+    if selected is None:
+        selected = get_selected(args.reviewer_count)
 
     lines = [
         "<!-- pr-review-confirm -->",
@@ -95,14 +133,35 @@ def cmd_parse_checkboxes(args: argparse.Namespace) -> None:
     else:
         with open(path) as f:
             body = f.read()
+    print(json.dumps(parse_checked_ids(body)))
 
-    checked: list[str] = []
-    for m in re.finditer(r"- \[x\] \*\*(.+?)\*\*", body, re.IGNORECASE):
-        key = m.group(1).lower()
-        rid = _LABEL_TO_ID.get(key)
-        if rid and rid not in checked:
-            checked.append(rid)
-    print(json.dumps(checked))
+
+def cmd_is_start_checked(args: argparse.Namespace) -> None:
+    """Print 'true' if the body file has Start review ticked, else 'false'."""
+    path = args.body_file
+    if path == "-":
+        body = sys.stdin.read()
+    else:
+        try:
+            with open(path) as f:
+                body = f.read()
+        except FileNotFoundError:
+            print("false")
+            return
+    print("true" if is_start_checked(body) else "false")
+
+
+def cmd_reset_start(args: argparse.Namespace) -> None:
+    """Print the body with the Start review box flipped from [x] to [ ]."""
+    path = args.body_file
+    if path == "-":
+        body = sys.stdin.read()
+    else:
+        with open(path) as f:
+            body = f.read()
+    pattern = rf"- \[x\] \*\*{re.escape(START_LABEL)}\*\*"
+    replacement = f"- [ ] **{START_LABEL}**"
+    sys.stdout.write(re.sub(pattern, replacement, body, flags=re.IGNORECASE))
 
 
 def cmd_format_names(args: argparse.Namespace) -> None:
@@ -130,6 +189,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--lines", type=int, required=True, help="Lines changed in diff")
     p.add_argument("--files", type=int, required=True, help="Files changed in diff")
+    p.add_argument(
+        "--from-existing-body",
+        default=None,
+        help=(
+            "Optional path to a prior comment body. If present and non-empty, "
+            "checked reviewers from the prior body are carried forward instead of "
+            "using the default priority selection."
+        ),
+    )
     p.set_defaults(func=cmd_build_comment)
 
     p = sub.add_parser(
@@ -137,6 +205,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("body_file", help="Path to comment body file, or - for stdin")
     p.set_defaults(func=cmd_parse_checkboxes)
+
+    p = sub.add_parser(
+        "is-start-checked",
+        help="Print 'true' if Start review is ticked in body, else 'false'",
+    )
+    p.add_argument("body_file", help="Path to comment body file, or - for stdin")
+    p.set_defaults(func=cmd_is_start_checked)
+
+    p = sub.add_parser(
+        "reset-start",
+        help="Print body with Start review checkbox flipped to unchecked",
+    )
+    p.add_argument("body_file", help="Path to comment body file, or - for stdin")
+    p.set_defaults(func=cmd_reset_start)
 
     p = sub.add_parser("format-names", help="Format reviewer IDs as display names")
     p.add_argument("reviewers_json", help="JSON array of reviewer IDs")

--- a/.github/scripts/pr_review_propose.py
+++ b/.github/scripts/pr_review_propose.py
@@ -118,7 +118,12 @@ def cmd_build_comment(args: argparse.Namespace) -> None:
         lines.append(f"- [{check}] **{r.label}** — {r.description}")
     lines += [
         "",
-        "Toggle the reviewer checkboxes above to adjust, then tick the box below to start:",
+        "**How this works**",
+        "",
+        "- Adjust the reviewer set by ticking/unticking boxes above. Reviewer toggles alone don't trigger anything.",
+        f"- Tick **{START_LABEL}** below to dispatch the review fleet.",
+        f"- After review finishes, tick **{START_LABEL}** again to request another run — it auto-resets after each dispatch.",
+        "- This comment updates as new commits land; your reviewer selections are preserved.",
         "",
         f"- [ ] **{START_LABEL}**",
     ]

--- a/.github/workflows/pr-review-auto-route.yml
+++ b/.github/workflows/pr-review-auto-route.yml
@@ -1,11 +1,18 @@
 name: "PR Review Auto Router"
 
-# Automatically determines fleet size when a PR is opened, based on diff
-# size and complexity. Posts a confirmation comment with pre-checked reviewer
-# checkboxes so the author can review and confirm before the fleet runs.
-# Routing metadata (pr_number, head_sha, base_ref) is saved as an artifact
-# for the confirm workflow to retrieve; nothing machine-readable is embedded
-# in the comment body.
+# Automatically determines fleet size when a PR is opened or updated, based
+# on diff size and complexity. Posts a confirmation comment with pre-checked
+# reviewer checkboxes so the author can review and confirm before the fleet
+# runs. The confirm workflow (pr-review-confirm.yml) fetches PR head_sha and
+# base_ref directly from the GitHub API at trigger time — no metadata
+# artifact or commit-pinned state is required.
+#
+# Re-runs on `synchronize` so diff-based size estimates and the recommended
+# fleet stay current as commits land. Existing checkbox toggles are carried
+# forward into the re-rendered comment, and re-posting is skipped entirely
+# once the author has ticked "Start review". The sticky comment is
+# overwritten in place; the concurrency group cancels in-progress runs so
+# rapid pushes coalesce.
 #
 # Sizing thresholds:
 #   small  (1 reviewer) — ≤ 100 lines AND ≤ 5 files AND ≤ 1 package
@@ -33,6 +40,7 @@ on:
     types:
       - opened
       - reopened
+      - synchronize
     branches:
       - main
       - next
@@ -110,7 +118,38 @@ jobs:
           echo "reviewer_count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Routing to ${TIER} fleet (${COUNT} reviewer(s))"
 
+      # Fetch the existing sticky proposal comment (if any) so we can:
+      #   1. Short-circuit if the user has already started the review.
+      #   2. Carry forward checkbox toggles the user made so we don't reset them
+      #      every time `synchronize` re-runs us.
+      - name: Fetch prior proposal comment
+        id: prior
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # The sticky comment is identified by the same HTML marker used in
+          # pr_review_propose.py (build-comment) and pr-review-confirm.yml.
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq 'map(select(.user.login == "github-actions[bot]" and (.body | contains("<!-- pr-review-confirm -->")))) | last // {} | .body // ""' \
+            > /tmp/prior-body.md || true
+          if [ -s /tmp/prior-body.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            START_CHECKED=$(python3 .github/scripts/pr_review_propose.py is-start-checked /tmp/prior-body.md)
+            echo "start_checked=${START_CHECKED}" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "start_checked=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if review already started
+        if: steps.prior.outputs.start_checked == 'true'
+        run: |
+          echo "Existing proposal comment has 'Start review' checked — review already triggered. Skipping re-post."
+
       - name: Build confirmation comment
+        if: steps.prior.outputs.start_checked != 'true'
         env:
           REVIEWER_COUNT: ${{ steps.size.outputs.reviewer_count }}
           LINES: ${{ steps.metrics.outputs.lines }}
@@ -120,33 +159,16 @@ jobs:
             --reviewer-count "$REVIEWER_COUNT" \
             --lines "$LINES" \
             --files "$FILES" \
+            --from-existing-body /tmp/prior-body.md \
             > /tmp/confirm-body.md
           echo "Comment body:"
           cat /tmp/confirm-body.md
 
       - name: Post confirmation comment
+        if: steps.prior.outputs.start_checked != 'true'
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-review-confirm
           path: /tmp/confirm-body.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save pending metadata
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          mkdir -p pending
-          printf '{\n  "pr_number": %s,\n  "head_sha": "%s",\n  "base_ref": "%s"\n}\n' \
-            "$PR_NUMBER" "$HEAD_SHA" "$BASE_REF" \
-            > pending/pending.json
-          cat pending/pending.json
-
-      - name: Upload pending metadata
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
-        with:
-          name: pr-review-pending
-          path: pending/pending.json
-          retention-days: 14

--- a/.github/workflows/pr-review-confirm.yml
+++ b/.github/workflows/pr-review-confirm.yml
@@ -3,11 +3,18 @@ name: "PR Review Confirm"
 # Listens for edits to the bot's auto-route proposal comment. When a user with
 # write access ticks the "Start review" checkbox (transitioning it from
 # unchecked to checked), triggers the review fleet with the currently-selected
-# reviewer set.
+# reviewer set, then resets the Start review checkbox so a single tick
+# requests the next review (no uncheck-then-recheck dance required).
 #
-# Activation guard: looks for a pr-review-pending artifact from the most
-# recent successful auto-route run for this PR. If none exists, this workflow
-# exits immediately without taking any action.
+# Activation guard: the `if:` filter below requires the edited comment to be
+# the bot-authored proposal comment (identified by the
+# `<!-- pr-review-confirm -->` HTML marker that pr-review-auto-route.yml
+# embeds). PR head_sha and base_ref are fetched fresh from the GitHub API
+# rather than read from a metadata artifact, so the confirm flow always
+# operates on the PR's current state.
+#
+# The Start-review reset is itself a comment edit but is authored by the bot,
+# so the `sender.type == 'User'` guard on this workflow prevents a self-loop.
 
 on:
   issue_comment:
@@ -66,27 +73,22 @@ jobs:
             .github/scripts
           persist-credentials: false
 
-      # ── Find & download the pending metadata artifact from the most recent ──
-      # ── successful auto-route run for this PR.                              ──
-      - name: Download pending metadata
-        id: download
+      # Fetch the PR's current head_sha and base_ref directly from the API
+      # rather than relying on a metadata artifact uploaded at PR-open time.
+      # This means a force-push or new commit between the auto-route comment
+      # and the user's checkbox toggle is handled correctly — the fleet runs
+      # against the PR's actual current state.
+      - name: Fetch PR state
+        id: pr
         if: steps.authz.outputs.require-result == 'true'
-        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # ratchet:dawidd6/action-download-artifact@v20
-        with:
-          workflow: pr-review-auto-route.yml
-          workflow_conclusion: success
-          pr: ${{ github.event.issue.number }}
-          name: pr-review-pending
-          path: pending
-          if_no_artifact_found: warn
-
-      - name: Parse pending metadata
-        id: pending
-        if: steps.download.outputs.found_artifact == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          PR_NUMBER=$(jq -r '.pr_number' pending/pending.json)
-          HEAD_SHA=$(jq  -r '.head_sha'  pending/pending.json)
-          BASE_REF=$(jq  -r '.base_ref'  pending/pending.json)
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+          BASE_REF=$(echo "$PR_JSON" | jq -r '.base.ref')
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD_SHA"   >> "$GITHUB_OUTPUT"
@@ -96,7 +98,7 @@ jobs:
 
       - name: Parse selected reviewers
         id: checkboxes
-        if: steps.download.outputs.found_artifact == 'true'
+        if: steps.authz.outputs.require-result == 'true'
         env:
           CONFIRM_BODY: ${{ github.event.comment.body }}
         run: |
@@ -107,11 +109,11 @@ jobs:
 
       - name: Handle empty selection
         id: empty-check
-        if: steps.download.outputs.found_artifact == 'true'
+        if: steps.authz.outputs.require-result == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pending.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           SELECTED: ${{ steps.checkboxes.outputs.selected }}
         run: |
           COUNT=$(echo "$SELECTED" | jq 'length')
@@ -125,14 +127,14 @@ jobs:
 
       - name: Trigger review fleet
         if: |
-          steps.download.outputs.found_artifact == 'true' &&
+          steps.authz.outputs.require-result == 'true' &&
           steps.empty-check.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pending.outputs.pr_number }}
-          HEAD_SHA: ${{ steps.pending.outputs.head_sha }}
-          BASE_REF: ${{ steps.pending.outputs.base_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
           SELECTED: ${{ steps.checkboxes.outputs.selected }}
         run: |
           gh workflow run pr-review-fleet.yml \
@@ -146,14 +148,34 @@ jobs:
 
       - name: Post acknowledgement
         if: |
-          steps.download.outputs.found_artifact == 'true' &&
+          steps.authz.outputs.require-result == 'true' &&
           steps.empty-check.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pending.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           SELECTED: ${{ steps.checkboxes.outputs.selected }}
         run: |
           NAMES=$(python3 .github/scripts/pr_review_propose.py format-names "$SELECTED")
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
             --body "On it! Starting review with: ${NAMES}"
+
+      # Reset the Start review checkbox so the next tick triggers a re-review.
+      # Runs whether or not we dispatched (empty-selection paths reset too —
+      # otherwise the user would be stuck with a checked Start box and would
+      # need to uncheck-recheck after fixing their reviewer selection).
+      # Bot-authored edits don't re-fire this workflow because the `if:` filter
+      # requires `sender.type == 'User'`.
+      - name: Reset Start checkbox
+        if: steps.authz.outputs.require-result == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          printf '%s' "$COMMENT_BODY" > /tmp/orig-body.md
+          python3 .github/scripts/pr_review_propose.py reset-start /tmp/orig-body.md > /tmp/reset-body.md
+          gh api --method PATCH \
+            "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+            -F "body=@/tmp/reset-body.md"


### PR DESCRIPTION
## Description

The PR review confirm flow (`pr-review-confirm.yml`) silently no-op'd whenever a PR received a new commit after opening. The auto-router uploaded a `pr-review-pending` metadata artifact tied to the PR's opening commit, and the confirm workflow's artifact lookup was filtered by current HEAD — so any subsequent push left the checkbox-toggle UI inert with a `no matching workflow run found with any artifacts?` warning.

This PR drops the artifact mechanism entirely. The confirm workflow now fetches `head_sha` and `base_ref` directly from the GitHub API at trigger time, so it always operates on the PR's current state.

While in here, the auto-router (`pr-review-auto-route.yml`) gained a few robustness/UX improvements that the artifact removal made simpler to reason about:

- Triggers on `synchronize` so the recommended fleet size and diff stats stay current as commits land.
- Fetches the prior sticky comment and carries forward the user's reviewer checkbox toggles across re-renders, instead of resetting them on every push.
- Short-circuits re-posting once the user has ticked "Start review" — avoids racing a re-render against an in-flight dispatch.

The confirm workflow also auto-resets the Start review checkbox after dispatching the fleet (or after rejecting an empty selection). This means requesting a follow-up review is a single tick, not the previous uncheck-then-recheck dance. Bot-authored edits don't re-fire the workflow because the existing `sender.type == 'User'` guard blocks self-loops.

Net result: ~30 LOC and a `dawidd6/action-download-artifact` dependency removed from the confirm flow; one structural class of bug eliminated; cleaner re-review UX.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).