### PR TITLE
(Compat) Fix error handling section in Layer compatibility document

### DIFF
--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -84,9 +84,9 @@ Layer incompatibility is detected when a layer interacts with another layer for 
 
 The incompatibilities between the layers are detected as follows:
 
-- **Loader ↔ Driver** and **Loader ↔ Runtime**: Incompatibility is detected during container create / load. If incompatibility is detected, the creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
-- **Runtime ↔ DataStore**: Incompatibility is detected during data store create / load. If incompatibility is detected, the data store creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
-  If the data store is being created / loaded during container create / load, that will also fail with `FluidErrorTypes.layerIncompatibilityError`.
+- **Loader ↔ Driver** and **Loader ↔ Runtime**: Incompatibility is detected during container create / load. If incompatibility is detected, a `FluidErrorTypes.layerIncompatibilityError` error is thrown, failing the container creation / load.
+- **Runtime ↔ DataStore**: Incompatibility is detected during data store create / load. If incompatibility is detected, a `FluidErrorTypes.layerIncompatibilityError` error is thrown, failing the data store creation / load.
+  If the data store is being created / loaded during container create / load, that will also throw a `FluidErrorTypes.layerIncompatibilityError` error, failing the container creation / load.
 
 #### Telemetry
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -80,9 +80,18 @@ flowchart
 
 ### Error Handling
 
-When incompatibility is detected, an error of type `FluidErrorTypes.layerIncompatibilityError` which implements the `ILayerIncompatibilityError` interface is thrown.
-In all layer validations except at the Runtime ↔ DataStore boundary, the error causes the container to close. This prevents any potential data corruption that could occur from incompatible operations.
-In case of the Runtime ↔ DataStore boundary, the data store creation / load will fail to prevent corruption of the data store from incompatible operations. The container may also close, e.g. if the data store is created / loaded during container create / load.
+Layer incompatibility is detected when a layer interacts with another layer for the first time. When that happens, an error of type `FluidErrorTypes.layerIncompatibilityError` is thrown. The error implements `ILayerIncompatibilityError` interface whose properties provide detailed information on the error. This prevents any potential data corruption that could occur from incompatible operations.
+
+The incompatibilities between the layers are detected as follows:
+
+- **Loader ↔ Driver** and **Loader ↔ Runtime**: Incompatibility is detected during Container create / load. If incompatibility is detected, the creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
+- **Runtime ↔ DataStore**: Incompatibility is detected during data store create / load. If incompatibility is detected, the data store creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
+  If the data store is being created / loaded during Container create / load, that will also fail with `FluidErrorTypes.layerIncompatibilityError`.
+
+### Telemetry
+
+An error telemetry with eventName `LayerIncompatibilityError` will be logged whenever a layer incompatibility is detected. The event will include key properties defined in `ILayerIncompatibilityError` interface.
+
 
 ## Layer Compatibility Policy
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -80,17 +80,17 @@ flowchart
 
 ### Error Handling
 
-Layer incompatibility is detected when a layer interacts with another layer for the first time. When that happens, an error of type `FluidErrorTypes.layerIncompatibilityError` is thrown. The error implements `ILayerIncompatibilityError` interface whose properties provide detailed information on the error. This prevents any potential data corruption that could occur from incompatible operations.
+Layer incompatibility is detected when a layer interacts with another layer for the first time. When that happens, an error of type `FluidErrorTypes.layerIncompatibilityError` is thrown. The error implements the `ILayerIncompatibilityError` interface, whose properties provide detailed information about the incompatibility. Throwing this error prevents potentially incompatible operations that could lead to data corruption.
 
 The incompatibilities between the layers are detected as follows:
 
-- **Loader ↔ Driver** and **Loader ↔ Runtime**: Incompatibility is detected during Container create / load. If incompatibility is detected, the creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
+- **Loader ↔ Driver** and **Loader ↔ Runtime**: Incompatibility is detected during container create / load. If incompatibility is detected, the creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
 - **Runtime ↔ DataStore**: Incompatibility is detected during data store create / load. If incompatibility is detected, the data store creation / load will fail with `FluidErrorTypes.layerIncompatibilityError`.
-  If the data store is being created / loaded during Container create / load, that will also fail with `FluidErrorTypes.layerIncompatibilityError`.
+  If the data store is being created / loaded during container create / load, that will also fail with `FluidErrorTypes.layerIncompatibilityError`.
 
-### Telemetry
+#### Telemetry
 
-An error telemetry with eventName `LayerIncompatibilityError` will be logged whenever a layer incompatibility is detected. The event will include key properties defined in `ILayerIncompatibilityError` interface.
+A telemetry event named `LayerIncompatibilityError` will be logged whenever a layer incompatibility is detected. The event will include key properties defined in the `ILayerIncompatibilityError` interface.
 
 
 ## Layer Compatibility Policy


### PR DESCRIPTION
## Description

Rewrites the Error Handling section in `LayerCompatibility.md` to be clearer and more precise.

- Restructures the per-boundary error behavior from a dense paragraph into scannable bullet points, making it easier to understand what fails and when for each layer boundary.
- Fixes the faiilure mode description - The container isn't closed when incompatibility is detected, the container creation / load fails.
- Corrects the description of when detection occurs (at first interaction between layers, not broadly "all validations except...").
- Adds a new **Telemetry** subsection documenting the `LayerIncompatibilityError` event and its properties.
- Fixes minor issues: subject-verb agreement, inconsistent `DataStore` casing, and orphaned sentence indentation.

## Reviewer Guidance

No logic changes — docs only.