### PR TITLE
Clean up test-version-utils method semantics

### DIFF
--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -126,8 +126,7 @@ We also accept some of the flags via environment variables.
 
 This bypasses any configuration of version used by the describe\* functions and provides direct access to the versioned APIs.
 
-First make sure to call `ensurePackageInstalled` before running the tests to make sure the necessary legacy version are
-installed.
+First make sure to call `ensureVersionLoaded` before running the tests to make sure the necessary legacy versions are available.
 
 The main entry point is `getVersionedTestObjectProvider` to get a `TestObjectProvider` for a specific version combinations
 and driver config. Additionally, you can get versioned API for specific layers using these API.

--- a/packages/test/test-version-utils/scripts/updateCompatVersions.ts
+++ b/packages/test/test-version-utils/scripts/updateCompatVersions.ts
@@ -42,7 +42,11 @@ import * as semver from "semver";
 
 // Re-use version arithmetic and package list from the main source to keep them in sync.
 // jiti (used to run this script) resolves .js imports to .ts files automatically.
-import { calculateRequestedRange, versionHasMovedSparsedMatrix } from "../src/versionUtils.js";
+import {
+	calculateRequestedRange,
+	versionHasMovedSparsedMatrix,
+	resolveRangeViaRegistry,
+} from "../src/versionUtils.js";
 import { packageListToInstall } from "../src/compatPackageList.js";
 import {
 	numOfInternalMajorsBeforePublic2dot0,
@@ -64,30 +68,6 @@ const generatedVersionsCjsPath = path.join(compatWorkspacesDir, "generated-versi
 // ---------------------------------------------------------------------------
 // Version resolution
 // ---------------------------------------------------------------------------
-
-/**
- * Resolves a semver dependency spec to the single highest version matching that spec which is published in the npm registry.
- * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
- */
-function resolveRangeViaRegistry(rangeSpec: string): string {
-	if (semver.valid(rangeSpec)) return rangeSpec;
-	let result: string;
-	try {
-		result = execSync(
-			`pnpm view "@fluidframework/container-loader@${rangeSpec}" version --json`,
-			{
-				encoding: "utf8",
-			},
-		).trim();
-	} catch (e) {
-		throw new Error(`pnpm view failed for range "${rangeSpec}": ${e}`);
-	}
-	if (!result) throw new Error(`No published version for range: ${rangeSpec}`);
-	const versions: string | string[] = JSON.parse(result);
-	const version = Array.isArray(versions) ? versions.sort(semver.rcompare)[0] : versions;
-	if (!version) throw new Error(`Could not resolve range: ${rangeSpec}`);
-	return version;
-}
 
 /** Like {@link resolveRangeViaRegistry} but returns `undefined` and warns instead of throwing. */
 function tryResolveRangeViaRegistry(rangeSpec: string): string | undefined {

--- a/packages/test/test-version-utils/src/baseVersion.ts
+++ b/packages/test/test-version-utils/src/baseVersion.ts
@@ -7,7 +7,7 @@ import { isInternalVersionScheme } from "@fluid-tools/version-tools";
 import nconf from "nconf";
 
 import { pkgVersion } from "./packageVersion.js";
-import { resolveVersion } from "./versionUtils.js";
+import { resolveRangeViaRegistry } from "./versionUtils.js";
 // This import ensures nconf has been configured to load from correct sources before we compute the right baseVersion.
 // eslint-disable-next-line import-x/no-unassigned-import
 import "./compatOptions.js";
@@ -29,16 +29,15 @@ function getCodeVersion(): string {
 /**
  * @internal
  */
-export const codeVersion = resolveVersion(getCodeVersion(), false);
+export const codeVersion = resolveRangeViaRegistry(getCodeVersion());
 
 /**
  * Usually this is enough, but it can be bad on test branches which would have a value of 0.0.0-xyz-test.
  *
  * @internal
  */
-export const baseVersion = resolveVersion(
+export const baseVersion = resolveRangeViaRegistry(
 	(nconf.get("fluid:test:baseVersion") as string) ?? pkgVersion,
-	false,
 );
 
 /**

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -22,8 +22,8 @@ import {
 	odspEndpointName,
 } from "./compatOptions.js";
 import { pkgVersion } from "./packageVersion.js";
-import { ensurePackageInstalled } from "./testApi.js";
-import { getRequestedVersion, resolveVersion } from "./versionUtils.js";
+import { ensureVersionLoaded } from "./testApi.js";
+import { getRequestedVersion, resolveRangeViaRegistry } from "./versionUtils.js";
 
 /**
  * Represents a previous major release of a package based on the provided delta. For example, if the base version is 2.X and
@@ -62,7 +62,7 @@ export interface CompatConfig {
 	loadVersion?: string;
 }
 
-export const oldestCompatibleVersion = resolveVersion("2.0.0-internal.5.4.2", false);
+export const oldestCompatibleVersion = resolveRangeViaRegistry("2.0.0-internal.5.4.2");
 
 /**
  * The default versions to be used for generating configurations for layer compat testing.
@@ -514,16 +514,15 @@ export async function mochaGlobalSetup(): Promise<void> {
 		return;
 	}
 
-	// Load all versioned packages concurrently. The compat workspace is pre-installed via
-	// pnpm install (postinstall hook), so no install step is needed here.
+	// Load all versioned packages concurrently.
 	const versions = new Set(configs.map((value) => value.compatVersion));
-	const ensureInstalledP = Array.from(versions.values()).map(async (value) => {
+	const loadPromises = Array.from(versions.values()).map(async (value) => {
 		const version = testBaseVersion(value);
-		return ensurePackageInstalled(version, value);
+		return ensureVersionLoaded(version, value);
 	});
 
 	let error: unknown;
-	for (const p of ensureInstalledP) {
+	for (const p of loadPromises) {
 		try {
 			await p;
 		} catch (e) {

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -34,7 +34,7 @@ export interface IRequestedFluidVersions {
 	requestAbsoluteVersions?: string[];
 }
 
-const installRequiredVersions = async (config: IRequestedFluidVersions): Promise<void> => {
+const loadVersions = async (config: IRequestedFluidVersions): Promise<void> => {
 	const loadPromises: Promise<void>[] = [];
 	if (config.requestAbsoluteVersions !== undefined) {
 		loadPromises.push(
@@ -77,7 +77,7 @@ function createTestSuiteWithInstalledVersion(
 		before("Create TestObjectProvider", async function () {
 			this.timeout(Math.max(defaultTimeoutMs, timeoutMs));
 
-			await installRequiredVersions(requiredVersions);
+			await loadVersions(requiredVersions);
 			provider = await getVersionedTestObjectProvider(
 				pkgVersion, // baseVersion
 				pkgVersion, // loaderVersion

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -13,7 +13,7 @@ import { driver, odspEndpointName, r11sEndpointName, tenantIndex } from "./compa
 import { getVersionedTestObjectProvider } from "./compatUtils.js";
 import { ITestObjectProviderOptions } from "./describeCompat.js";
 import { pkgVersion } from "./packageVersion.js";
-import { ensurePackageInstalled, InstalledPackage } from "./testApi.js";
+import { ensureVersionLoaded } from "./testApi.js";
 
 /**
  * Interface to hold the requested versions which should be installed
@@ -35,21 +35,21 @@ export interface IRequestedFluidVersions {
 }
 
 const installRequiredVersions = async (config: IRequestedFluidVersions): Promise<void> => {
-	const installPromises: Promise<InstalledPackage | undefined>[] = [];
+	const loadPromises: Promise<void>[] = [];
 	if (config.requestAbsoluteVersions !== undefined) {
-		installPromises.push(
+		loadPromises.push(
 			...config.requestAbsoluteVersions.map(async (version) =>
-				ensurePackageInstalled(version, 0),
+				ensureVersionLoaded(version, 0),
 			),
 		);
 	}
 
 	if (config.requestRelativeVersions !== undefined) {
-		installPromises.push(ensurePackageInstalled(pkgVersion, config.requestRelativeVersions));
+		loadPromises.push(ensureVersionLoaded(pkgVersion, config.requestRelativeVersions));
 	}
 
 	let hadErrors = false;
-	for (const promise of installPromises) {
+	for (const promise of loadPromises) {
 		try {
 			await promise;
 		} catch (e) {

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -44,7 +44,7 @@ export {
 export { ExpectedEvents, ExpectsTest, itExpects } from "./itExpects.js";
 export {
 	CompatApis,
-	ensurePackageInstalled,
+	ensureVersionLoaded,
 	getContainerRuntimeApi,
 	getDataRuntimeApi,
 	getDriverApi,

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -75,17 +75,19 @@ export interface InstalledPackage {
  * Loads all layer APIs for the requested version. The compat workspace is expected to be
  * pre-installed via `pnpm install` (through the package `postinstall` hook).
  *
- * @remarks
- * This function no longer supports dynamically installing packages. If you need to reference a specific FF version, see explicit-versions.mjs in test-version-utils/compat-workspaces.
+ * @returns
+ * A promise that resolves when the requested version is loaded and can be accessed synchronously
+ * using the getters for each layer's API (e.g. `getLoaderApi`)
+ *
  * @internal
  */
-export const ensurePackageInstalled = async (
+export const ensureVersionLoaded = async (
 	baseVersion: string,
 	version: number | string,
-): Promise<InstalledPackage | undefined> => {
+): Promise<void> => {
 	const requestedStr = getRequestedVersion(baseVersion, version);
 	if (semver.satisfies(pkgVersion, requestedStr)) {
-		return undefined;
+		return;
 	}
 
 	await Promise.all([
@@ -94,9 +96,6 @@ export const ensurePackageInstalled = async (
 		loadLoader(baseVersion, version),
 		loadDriver(baseVersion, version),
 	]);
-
-	const { version: resolvedVersion, modulePath } = checkInstalled(requestedStr);
-	return { version: resolvedVersion, modulePath };
 };
 
 // This module supports synchronous functions to import packages once their install has been

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -70,16 +70,23 @@ const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
  * The typing on this is constructed so that users of the cached function will have their inner function type (including e.g. parameter names) preserved.
  */
 function cached<TFunc extends (...args: any[]) => unknown>(f: TFunc): TFunc {
-	const cache = new Map<string, ReturnType<TFunc>>();
+	const undefinedSentinel = Symbol("undefined");
+	const cache = new Map<string, ReturnType<TFunc> | typeof undefinedSentinel>();
 	return ((...args: Parameters<TFunc>) => {
 		const key = JSON.stringify(args);
-		let cachedOutput: ReturnType<TFunc> | undefined = cache.get(key);
+		let cachedOutput: ReturnType<TFunc> | typeof undefinedSentinel | undefined = cache.get(key);
 		if (cachedOutput === undefined) {
 			cachedOutput = f(...args) as ReturnType<TFunc>;
-			cache.set(key, cachedOutput!);
+			cache.set(key, cachedOutput ?? undefinedSentinel);
 		}
-		return cachedOutput!;
+		return cachedOutput === undefinedSentinel ? undefined : cachedOutput;
 	}) as unknown as TFunc;
+}
+
+function validateRangeSpec(rangeSpec: string): void {
+	if (!semver.validRange(rangeSpec)) {
+		throw new Error(`Invalid semver range: "${rangeSpec}"`);
+	}
 }
 
 /**
@@ -91,9 +98,7 @@ export const resolveRangeViaRegistry = cached((rangeSpec: string): string => {
 		return rangeSpec;
 	}
 
-	if (!semver.validRange(rangeSpec)) {
-		throw new Error(`Invalid semver range: "${rangeSpec}"`);
-	}
+	validateRangeSpec(rangeSpec);
 	let result: string;
 	try {
 		result = execFileSync(
@@ -123,6 +128,7 @@ export const resolveRangeViaRegistry = cached((rangeSpec: string): string => {
  * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
  */
 function resolveRangeViaManifest(rangeSpec: string): string {
+	validateRangeSpec(rangeSpec);
 	const manifest = readVersionsManifest();
 	const matching = manifest.versions
 		.filter((v) => semver.valid(v) && semver.satisfies(v, rangeSpec))

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -3,30 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/**
- * Utilities for loading legacy versions of Fluid Framework packages for compatibility testing.
- *
- * ## Architecture
- *
- * Legacy packages live in a single committed pnpm sub-workspace at `compat-workspaces/full/`.
- * The workspace is installed automatically when `pnpm install` is run from the repo root (via
- * the `postinstall` script in this package's `package.json`), so no runtime installation step
- * is required in tests.
- *
- * The exact resolved versions are recorded in `compat-workspaces/generated-versions.cjs`, which is
- * maintained by the `update-compat-versions` script and committed to the repository. Tests
- * read this manifest at startup to resolve version ranges to exact versions.
- *
- * ## Updating compat versions
- *
- * After a version bump, run:
- * `pnpm run update-compat-versions`
- *
- * This regenerates `generated-versions.cjs` and all per-version `package.json` files, then runs
- * `pnpm install --no-frozen-lockfile` in the workspace to update the committed lockfile.
- * Commit all changes produced by the script.
- */
-
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -75,13 +51,6 @@ export function readVersionsManifest(): CompatVersionsManifest {
 	return cachedManifest;
 }
 
-/**
- * Returns all exact versions recorded in the manifest.
- */
-export function getAllManifestVersions(manifest: CompatVersionsManifest): string[] {
-	return manifest.versions;
-}
-
 // ---------------------------------------------------------------------------
 // Version resolution
 // ---------------------------------------------------------------------------
@@ -94,70 +63,74 @@ const resolutionCache = new Map<string, string>();
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 /**
- * Resolves a version range or alias to an exact version using the committed manifest.
- *
- * @internal
+ * @returns A version of the provided function which caches outputs based on JSON-stringified arguments.
+ * @remarks
+ * Do not use this function if any of the arguments to the function are conceptually not primitives OR if they can be undefined.
+ * @privateRemarks
+ * The typing on this is constructed so that users of the cached function will have their inner function type (including e.g. parameter names) preserved.
  */
-export function resolveVersion(requested: string, installed: boolean): string {
-	const cachedVersion = resolutionCache.get(requested);
-	if (cachedVersion) {
-		return cachedVersion;
-	}
-	if (semver.valid(requested)) {
-		// If it is a valid semver already instead of a range, just use it
-		resolutionCache.set(requested, requested);
-		return requested;
+function cached<TFunc extends (...args: any[]) => unknown>(f: TFunc): TFunc {
+	const cache = new Map<string, ReturnType<TFunc>>();
+	return ((...args: Parameters<TFunc>) => {
+		const key = JSON.stringify(args);
+		let cachedOutput: ReturnType<TFunc> | undefined = cache.get(key);
+		if (cachedOutput === undefined) {
+			cachedOutput = f(...args) as ReturnType<TFunc>;
+			cache.set(key, cachedOutput!);
+		}
+		return cachedOutput!;
+	}) as unknown as TFunc;
+}
+
+/**
+ * Resolves a semver dependency spec to the single highest version matching that spec which is published in the npm registry.
+ * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
+ */
+export const resolveRangeViaRegistry = cached((rangeSpec: string): string => {
+	if (semver.valid(rangeSpec)) {
+		return rangeSpec;
 	}
 
-	if (!semver.validRange(requested)) {
-		throw new Error(`Invalid semver range: "${requested}"`);
+	if (!semver.validRange(rangeSpec)) {
+		throw new Error(`Invalid semver range: "${rangeSpec}"`);
 	}
-
-	if (installed) {
-		const manifest = readVersionsManifest();
-		const matching = manifest.versions
-			.filter((v) => semver.valid(v) && semver.satisfies(v, requested))
-			.sort(semver.rcompare);
-		if (matching.length > 0) {
-			resolutionCache.set(requested, matching[0]);
-			return matching[0];
-		}
-		throw new Error(`No version in manifest satisfies range: "${requested}"`);
-	} else {
-		let result: string | undefined;
-		try {
-			result = execFileSync(
-				pnpmCmd,
-				["view", `"@fluidframework/container-loader@${requested}"`, "version", "--json"],
-				{
-					encoding: "utf8",
-					// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-					shell: true,
-				},
-			);
-		} catch (error: any) {
-			debugger;
-			throw new Error(
-				`Error while running: ${pnpmCmd} view "@fluidframework/container-loader@${requested}" version --json`,
-			);
-		}
-		if (result === "" || result === undefined) {
-			throw new Error(`No version published as ${requested}`);
-		}
-
-		try {
-			const versions: string | string[] = result !== "" ? JSON.parse(result) : "";
-			const version = Array.isArray(versions) ? versions.sort(semver.rcompare)[0] : versions;
-			if (version) {
-				resolutionCache.set(requested, version);
-				return version;
-			}
-		} catch (e) {
-			throw new Error(`Error parsing versions for ${requested}`);
-		}
-
-		throw new Error(`No version found for ${requested}`);
+	let result: string;
+	try {
+		result = execFileSync(
+			pnpmCmd,
+			["view", `"@fluidframework/container-loader@${rangeSpec}"`, "version", "--json"],
+			{
+				encoding: "utf8",
+				// When using pnpm.cmd shell must be true: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+				shell: true,
+			},
+		);
+	} catch (e) {
+		throw new Error(`pnpm view failed for range "${rangeSpec}": ${e}`);
 	}
+	if (!result) throw new Error(`No published version for range: ${rangeSpec}`);
+	const versions: string | string[] = JSON.parse(result);
+	const version = Array.isArray(versions) ? versions.sort(semver.rcompare)[0] : versions;
+	if (!version) throw new Error(`Could not resolve range: ${rangeSpec}`);
+	return version;
+});
+
+/**
+ * Resolves a semver dependency spec to the most recent installed version under compat-workspaces which
+ * satisfies that range.
+ *
+ * Throws if the currently installed compat workspace does not include any version that matches the spec.
+ * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
+ */
+function resolveRangeFromManifest(rangeSpec: string): string {
+	const manifest = readVersionsManifest();
+	const matching = manifest.versions
+		.filter((v) => semver.valid(v) && semver.satisfies(v, rangeSpec))
+		.sort(semver.rcompare);
+	if (matching.length > 0) {
+		return matching[0];
+	}
+	throw new Error(`No version in manifest satisfies range: "${rangeSpec}"`);
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +145,7 @@ export function resolveVersion(requested: string, installed: boolean): string {
  * @internal
  */
 export function checkInstalled(requested: string): { version: string; modulePath: string } {
-	const version = resolveVersion(requested, true);
+	const version = resolveRangeFromManifest(requested);
 	const versionDir = path.join(fullWorkspaceDir, version);
 
 	if (existsSync(versionDir)) {
@@ -403,7 +376,7 @@ export function getRequestedVersion(
 	try {
 		// Returns the exact version that was requested (i.e. 2.0.0-rc.2.0.2).
 		// Will throw if the requested version range is not valid.
-		return resolveVersion(calculatedRange, false);
+		return resolveRangeViaRegistry(calculatedRange);
 	} catch (err: any) {
 		// If we tried fetching N-1 and it failed, try N-2. It is possible that we are trying to bump the current branch
 		// to a new version. If that is the case, then N-1 may not be published yet, and we should try to use N-2 in it's place.

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -74,7 +74,8 @@ function cached<TFunc extends (...args: any[]) => unknown>(f: TFunc): TFunc {
 	const cache = new Map<string, ReturnType<TFunc> | typeof undefinedSentinel>();
 	return ((...args: Parameters<TFunc>) => {
 		const key = JSON.stringify(args);
-		let cachedOutput: ReturnType<TFunc> | typeof undefinedSentinel | undefined = cache.get(key);
+		let cachedOutput: ReturnType<TFunc> | typeof undefinedSentinel | undefined =
+			cache.get(key);
 		if (cachedOutput === undefined) {
 			cachedOutput = f(...args) as ReturnType<TFunc>;
 			cache.set(key, cachedOutput ?? undefinedSentinel);

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -161,7 +161,9 @@ export function checkInstalled(requested: string): { version: string; modulePath
 
 	throw new Error(
 		`Version ${version} is not installed in compat-workspaces/full/.\n` +
-			`Run \`pnpm run update-compat-versions\` to regenerate the workspace, then re-run \`pnpm install\`.`,
+			`To add it, update explicit-versions.mjs, then run \`pnpm run update-compat-versions\` to regenerate the workspace dependencies.\n` +
+			`If it is already listed as a dependency of compat-workspaces/full, this error might indicate that the workspace was not installed correctly.\n` +
+			`Try running \`pnpm install\` from the repo root to ensure the workspace is installed.`,
 	);
 }
 

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -122,7 +122,7 @@ export const resolveRangeViaRegistry = cached((rangeSpec: string): string => {
  * Throws if the currently installed compat workspace does not include any version that matches the spec.
  * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
  */
-function resolveRangeFromManifest(rangeSpec: string): string {
+function resolveRangeViaManifest(rangeSpec: string): string {
 	const manifest = readVersionsManifest();
 	const matching = manifest.versions
 		.filter((v) => semver.valid(v) && semver.satisfies(v, rangeSpec))
@@ -145,7 +145,7 @@ function resolveRangeFromManifest(rangeSpec: string): string {
  * @internal
  */
 export function checkInstalled(requested: string): { version: string; modulePath: string } {
-	const version = resolveRangeFromManifest(requested);
+	const version = resolveRangeViaManifest(requested);
 	const versionDir = path.join(fullWorkspaceDir, version);
 
 	if (existsSync(versionDir)) {


### PR DESCRIPTION
## Description

Followup to #27186 which addresses some minor points of feedback I didn't want to bundle into that (or which were made after it merged):

- Simplify return type of `ensurePackageInstalled` (and rename to `ensureVersionLoaded` to better reflect its purpose)
- Split `resolveVersion` into two functions with more natural signatures: `resolveRangeViaRegistry` and `resolveRangeViaManifest`
- Deduplicate `resolveRangeViaRegistry` in update script by making it reference the one in `versionUtils.ts`
- Minor other bits of feedback on docs clarity