### PR TITLE
fix(api-markdown-documenter): Fix some misc. bugs

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -58,7 +58,7 @@ export function transformApiModel(options: ApiItemTransformationOptions): ApiDoc
 	const filteredPackages = apiModel.packages.filter((apiPackage) => !excludeItem(apiPackage));
 
 	if (filteredPackages.length === 0) {
-		logger.warning("No packages found after filtering per `skipPackages` configuration.");
+		logger.warning("No packages found after filtering per `exclude` configuration.");
 		return [...documentsMap.values()];
 	}
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -51,7 +51,7 @@ export function transformApiModel(options: ApiItemTransformationOptions): ApiDoc
 
 	if (packages.length === 0) {
 		logger.warning("No packages found.");
-		return [];
+		return [...documentsMap.values()];
 	}
 
 	// Filter out packages not wanted per user config
@@ -59,7 +59,7 @@ export function transformApiModel(options: ApiItemTransformationOptions): ApiDoc
 
 	if (filteredPackages.length === 0) {
 		logger.warning("No packages found after filtering per `skipPackages` configuration.");
-		return [];
+		return [...documentsMap.values()];
 	}
 
 	// For each package, walk the child graph to find API items which should be rendered to their own document

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModel.ts
@@ -16,8 +16,11 @@ export function transformApiModel(
 	apiModel: ApiModel,
 	config: ApiItemTransformationConfiguration,
 ): Section[] {
-	if (apiModel.packages.length === 0) {
-		// If no packages under model, print simple note.
+	const filteredPackages = apiModel.packages.filter(
+		(apiPackage) => !config.exclude(apiPackage),
+	);
+
+	if (filteredPackages.length === 0) {
 		return [
 			{
 				type: "section",
@@ -40,11 +43,6 @@ export function transformApiModel(
 			},
 		];
 	}
-
-	// Filter out packages not wanted per user config
-	const filteredPackages = apiModel.packages.filter(
-		(apiPackage) => !config.exclude(apiPackage),
-	);
 
 	// Render packages table
 	const packagesTable = createPackagesTable(filteredPackages, config);

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -789,6 +789,31 @@ describe("ApiItem to Documentation transformation tests", () => {
 		expect(result).deep.equals(expected);
 	});
 
+	it("transformApiModel returns model document when the model has no packages", () => {
+		const apiModel = new ApiModel();
+		const config = createConfig({}, apiModel);
+
+		const result = transformApiModel(config);
+
+		expect(result).to.have.length(1);
+		expect(result[0].apiItem).to.equal(apiModel);
+	});
+
+	it("transformApiModel returns model document when all packages are filtered out via exclude", () => {
+		const model = generateModel("test-variable.json");
+		const config = createConfig(
+			{
+				exclude: (apiItem) => apiItem.kind === ApiItemKind.Package,
+			},
+			model,
+		);
+
+		const result = transformApiModel(config);
+
+		expect(result).to.have.length(1);
+		expect(result[0].apiItem).to.equal(model);
+	});
+
 	it("Transform a Model with multiple entry-points", () => {
 		const model = generateModel("multiple-entry-points.json");
 		const config = createConfig({}, model);

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
@@ -97,7 +97,7 @@ export function getLinkUrlForApiItem(
 	}
 
 	const headingId = getHeadingIdForApiItem(apiItem, config);
-	const headingPostfix = headingId !== undefined ? `#${headingId}` : "";
+	const headingPostfix = headingId === undefined ? "" : `#${headingId}`;
 
 	return `${uriBase}/${documentPath}${headingPostfix}`;
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/utilities/ApiItemTransformUtilities.ts
@@ -96,12 +96,8 @@ export function getLinkUrlForApiItem(
 		documentPath = documentPath.slice(0, documentPath.length - "index".length);
 	}
 
-	// Don't bother with heading ID if we are linking to the root item of a document
-	let headingPostfix = "";
-	if (!doesItemRequireOwnDocument(apiItem, config.hierarchy)) {
-		const headingId = getHeadingIdForApiItem(apiItem, config);
-		headingPostfix = `#${headingId}`;
-	}
+	const headingId = getHeadingIdForApiItem(apiItem, config);
+	const headingPostfix = headingId !== undefined ? `#${headingId}` : "";
 
 	return `${uriBase}/${documentPath}${headingPostfix}`;
 }
@@ -271,10 +267,7 @@ export function getHeadingForApiItem(
 	apiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
 ): SectionHeading {
-	// Don't generate an ID for the root heading
-	const id = doesItemRequireOwnDocument(apiItem, config.hierarchy)
-		? undefined
-		: getHeadingIdForApiItem(apiItem, config);
+	const id = getHeadingIdForApiItem(apiItem, config);
 	const title = config.getHeadingTextForItem(apiItem);
 
 	return {
@@ -284,29 +277,28 @@ export function getHeadingForApiItem(
 	};
 }
 
-// TODO: this doesn't actually return `undefined` for own document. Verify and fix.
 /**
  * Generates a heading ID for the provided API item.
  * Guaranteed to be unique within the document to which the API item is being rendered.
  *
  * @remarks
- * Notes:
- *
- * - If the item is one that will be rendered to its own document, this will return `undefined`.
- * Any links pointing to this item may simply link to the document; no heading ID is needed.
- *
- * - The resulting ID is context-dependent. In order to guarantee uniqueness, it will need to express
+ * The resulting ID is context-dependent. In order to guarantee uniqueness, it will need to express
  * hierarchical information up to the ancestor item whose document the specified item will ultimately be rendered to.
  *
  * @param apiItem - The API item for which the heading ID is being generated.
  * @param config - See {@link ApiItemTransformationConfiguration}.
  *
- * @returns A unique heading ID for the API item if one is needed. Otherwise, `undefined`.
+ * @returns A unique heading ID for the API item, or `undefined` if the item is rendered to its own document
+ * (in which case no heading ID is needed — callers may link directly to the document).
  */
 function getHeadingIdForApiItem(
 	apiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
-): string {
+): string | undefined {
+	if (doesItemRequireOwnDocument(apiItem, config.hierarchy)) {
+		return undefined;
+	}
+
 	let baseName: string | undefined;
 	const apiItemKind = getApiItemKind(apiItem);
 
@@ -328,6 +320,7 @@ function getHeadingIdForApiItem(
 		hierarchyItem = parent;
 	}
 
+	assert(baseName !== undefined, "baseName should always be set for non-own-document items.");
 	return `${baseName}-${apiItemKind.toLowerCase()}`;
 }
 

--- a/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
@@ -7,8 +7,8 @@ import Path from "node:path";
 
 import {
 	ApiItemKind,
+	ApiModel,
 	ReleaseTag,
-	type ApiModel,
 	type ApiPackage,
 } from "@microsoft/api-extractor-model";
 
@@ -119,4 +119,24 @@ describe("Markdown end-to-end tests", () => {
 			}
 		});
 	}
+
+	describe("empty model", () => {
+		const modelName = "empty-model";
+		const configName = "default-config";
+		const temporaryOutputPath = Path.join(testTemporaryDirectoryPath, modelName, configName);
+		const snapshotPath = Path.join(snapshotsDirectoryPath, modelName, configName);
+
+		it("Renders model document when API model has no packages", async () => {
+			// loadModel throws when no .api.json files are present, so construct the model directly.
+			const apiModel = new ApiModel();
+
+			await MarkdownRenderer.renderApiModel({
+				apiModel,
+				uriRoot: "",
+				outputDirectoryPath: temporaryOutputPath,
+			});
+
+			await compareDocumentationSuiteSnapshot(snapshotPath, temporaryOutputPath);
+		});
+	});
 });

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/empty-model/default-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/empty-model/default-config/index.md
@@ -1,0 +1,3 @@
+# API Overview
+
+_No packages discovered while parsing model._


### PR DESCRIPTION
- Fixes an issue where a model with no packages (or an empty set of packages after applying configured filtering) would fail to generate a document for the model itself.
- Fixed an issue where incorrect heading IDs would be generated for items configured to generate their own documents.