### PR TITLE
test(tree): add staged optional schema snapshots

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -7,7 +7,12 @@ import { strict as assert } from "node:assert";
 
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-import { EmptyKey } from "../../core/index.js";
+import {
+	EmptyKey,
+	ObjectNodeStoredSchema,
+	type TreeNodeSchemaIdentifier,
+	type TreeStoredSchema,
+} from "../../core/index.js";
 import {
 	cursorForJsonableTreeField,
 	defaultSchemaPolicy,
@@ -46,6 +51,23 @@ import {
 	HasStagedOptionalFieldAfterUpdate,
 	testDocuments,
 } from "../testTrees.js";
+
+function getTestDocumentSchemaData(name: string): TreeStoredSchema {
+	return testDocuments.find((test) => test.name === name)?.schemaData ?? assert.fail();
+}
+
+function getObjectNodeSchema(
+	schema: TreeStoredSchema,
+	identifier: string,
+): ObjectNodeStoredSchema {
+	const node = schema.nodeSchema.get(brand(identifier)) ?? assert.fail();
+	assert(node instanceof ObjectNodeStoredSchema);
+	return node;
+}
+
+function typeSet(...identifiers: string[]): Set<TreeNodeSchemaIdentifier> {
+	return new Set(identifiers.map((identifier) => brand<TreeNodeSchemaIdentifier>(identifier)));
+}
 
 describe("toStoredSchema", () => {
 	describe("toStoredSchema", () => {
@@ -204,6 +226,43 @@ describe("toStoredSchema", () => {
 					});
 				});
 			}
+
+			it("partially includes staged allowed types by upgrade identity", () => {
+				const node = getObjectNodeSchema(
+					getTestDocumentSchemaData("NestedMultiStage with one upgrade"),
+					"test.NestedMultiStage",
+				);
+
+				const fieldA = node.getFieldSchema(brand("a"));
+				assert.equal(fieldA.kind, FieldKinds.optional.identifier);
+				assert.deepEqual(fieldA.types, typeSet());
+
+				const fieldB = node.getFieldSchema(brand("b"));
+				assert.equal(fieldB.kind, FieldKinds.required.identifier);
+				assert.deepEqual(fieldB.types, typeSet("com.fluidframework.leaf.null"));
+
+				const fieldC = node.getFieldSchema(brand("c"));
+				assert.equal(fieldC.kind, FieldKinds.required.identifier);
+				assert.deepEqual(
+					fieldC.types,
+					typeSet("com.fluidframework.leaf.null", "test.ArrayWithStaged"),
+				);
+			});
+
+			it("partially includes staged optional fields by upgrade identity", () => {
+				const node = getObjectNodeSchema(
+					getTestDocumentSchemaData("NestedStagedOptional with one upgrade"),
+					"test.NestedStagedOptional",
+				);
+
+				const fieldA = node.getFieldSchema(brand("a"));
+				assert.equal(fieldA.kind, FieldKinds.optional.identifier);
+				assert.deepEqual(fieldA.types, typeSet("com.fluidframework.leaf.number"));
+
+				const fieldB = node.getFieldSchema(brand("b"));
+				assert.equal(fieldB.kind, FieldKinds.required.identifier);
+				assert.deepEqual(fieldB.types, typeSet("com.fluidframework.leaf.string"));
+			});
 		});
 	});
 

--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -227,41 +227,56 @@ describe("toStoredSchema", () => {
 				});
 			}
 
-			it("partially includes staged allowed types by upgrade identity", () => {
-				const node = getObjectNodeSchema(
+			it("partially includes staged schema by upgrade identity", () => {
+				// Test that the filtering logic in `toStoredSchema` works correctly.
+				// These test trees compare the upgrade identity of the staged schema to implement the filter.
+				// Schema that are included by the filter should be present in the resulting stored schema, and any other staged schema should not.
+				// See testTrees.ts for the test cases: "NestedMultiStage with one upgrade" and "NestedStagedOptional with one upgrade".
+				const allowedTypesNode = getObjectNodeSchema(
 					getTestDocumentSchemaData("NestedMultiStage with one upgrade"),
 					"test.NestedMultiStage",
 				);
 
-				const fieldA = node.getFieldSchema(brand("a"));
+				// See NestedMultiStage in testTrees.ts for the definition.
+				// Field a: optional([staged(number)]) -> optional, empty types.
+				// Field b: required([staged(MapWithStaged), null]) -> required, null only.
+				// Field c: required([staged(ArrayWithStaged), null]) -> required, null and ArrayWithStaged.
+				const fieldA = allowedTypesNode.getFieldSchema(brand("a"));
 				assert.equal(fieldA.kind, FieldKinds.optional.identifier);
 				assert.deepEqual(fieldA.types, typeSet());
 
-				const fieldB = node.getFieldSchema(brand("b"));
+				const fieldB = allowedTypesNode.getFieldSchema(brand("b"));
 				assert.equal(fieldB.kind, FieldKinds.required.identifier);
 				assert.deepEqual(fieldB.types, typeSet("com.fluidframework.leaf.null"));
 
-				const fieldC = node.getFieldSchema(brand("c"));
+				const fieldC = allowedTypesNode.getFieldSchema(brand("c"));
 				assert.equal(fieldC.kind, FieldKinds.required.identifier);
 				assert.deepEqual(
 					fieldC.types,
 					typeSet("com.fluidframework.leaf.null", "test.ArrayWithStaged"),
 				);
-			});
 
-			it("partially includes staged optional fields by upgrade identity", () => {
-				const node = getObjectNodeSchema(
+				const stagedOptionalNode = getObjectNodeSchema(
 					getTestDocumentSchemaData("NestedStagedOptional with one upgrade"),
 					"test.NestedStagedOptional",
 				);
 
-				const fieldA = node.getFieldSchema(brand("a"));
-				assert.equal(fieldA.kind, FieldKinds.optional.identifier);
-				assert.deepEqual(fieldA.types, typeSet("com.fluidframework.leaf.number"));
+				// See NestedStagedOptional in testTrees.ts for the definition.
+				// Field a: stagedOptional(number) -> optional number.
+				// Field b: stagedOptional(string) -> required string.
+				const stagedOptionalFieldA = stagedOptionalNode.getFieldSchema(brand("a"));
+				assert.equal(stagedOptionalFieldA.kind, FieldKinds.optional.identifier);
+				assert.deepEqual(
+					stagedOptionalFieldA.types,
+					typeSet("com.fluidframework.leaf.number"),
+				);
 
-				const fieldB = node.getFieldSchema(brand("b"));
-				assert.equal(fieldB.kind, FieldKinds.required.identifier);
-				assert.deepEqual(fieldB.types, typeSet("com.fluidframework.leaf.string"));
+				const stagedOptionalFieldB = stagedOptionalNode.getFieldSchema(brand("b"));
+				assert.equal(stagedOptionalFieldB.kind, FieldKinds.required.identifier);
+				assert.deepEqual(
+					stagedOptionalFieldB.types,
+					typeSet("com.fluidframework.leaf.string"),
+				);
 			});
 		});
 	});

--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -42,6 +42,8 @@ import { brand } from "../../util/index.js";
 import {
 	HasStagedAllowedTypes,
 	HasStagedAllowedTypesAfterUpdate,
+	HasStagedOptionalField,
+	HasStagedOptionalFieldAfterUpdate,
 	testDocuments,
 } from "../testTrees.js";
 
@@ -115,9 +117,9 @@ describe("toStoredSchema", () => {
 							permissiveStoredSchemaGenerationOptions,
 						);
 
-						// The restrictive case, used for initial schemas and upgrades, does not include any staged allowed types.
-						// The permissive case, used for unhydrated trees, includes all staged allowed types.
-						// They should be equal if an only if there are no staged allowed types.
+						// The restrictive case, used for initial schemas and upgrades, does not include any staged schema features.
+						// The permissive case, used for unhydrated trees, includes all staged schema features.
+						// They should be equal if and only if there are no staged schema features.
 						if (testCase.hasStagedSchema) {
 							assert.notDeepEqual(restrictive, permissive);
 						} else {
@@ -336,6 +338,27 @@ describe("toStoredSchema", () => {
 			);
 			assert.notDeepEqual(v1.encodeV1(), v1Permissive.encodeV1());
 			assert.deepEqual(v1Permissive.encodeV1(), v2.encodeV1());
+
+			const stagedOptionalV1 = getStoredSchema(
+				transformSimpleNodeSchema(
+					HasStagedOptionalField,
+					restrictiveStoredSchemaGenerationOptions,
+				),
+			);
+			const stagedOptionalV2 = getStoredSchema(
+				transformSimpleNodeSchema(
+					HasStagedOptionalFieldAfterUpdate,
+					restrictiveStoredSchemaGenerationOptions,
+				),
+			);
+			const stagedOptionalV1Permissive = getStoredSchema(
+				transformSimpleNodeSchema(
+					HasStagedOptionalField,
+					permissiveStoredSchemaGenerationOptions,
+				),
+			);
+			assert.notDeepEqual(stagedOptionalV1.encodeV1(), stagedOptionalV1Permissive.encodeV1());
+			assert.deepEqual(stagedOptionalV1Permissive.encodeV1(), stagedOptionalV2.encodeV1());
 		});
 	});
 });

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldAfterUpdate - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldAfterUpdate - schema v1 - without staged.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.hasStagedOptionalField": {
+      "object": {
+        "x": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedOptionalField"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldAfterUpdate - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldAfterUpdate - schema v1.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.hasStagedOptionalField": {
+      "object": {
+        "x": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedOptionalField"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldBeforeUpdate - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldBeforeUpdate - schema v1 - without staged.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.hasStagedOptionalField": {
+      "object": {
+        "x": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedOptionalField"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldBeforeUpdate - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/HasStagedOptionalFieldBeforeUpdate - schema v1.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.hasStagedOptionalField": {
+      "object": {
+        "x": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedOptionalField"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with all upgrades - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with all upgrades - schema v1 - without staged.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with all upgrades - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with all upgrades - schema v1.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with no upgrades - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with no upgrades - schema v1 - without staged.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with no upgrades - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with no upgrades - schema v1.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with one upgrade - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with one upgrade - schema v1 - without staged.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with one upgrade - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/NestedStagedOptional with one upgrade - schema v1.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional empty root - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional empty root - schema v1 - without staged.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional empty root - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional empty root - schema v1.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    }
+  },
+  "root": {
+    "kind": "Optional",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional in root - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional in root - schema v1 - without staged.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional in root - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/Staged optional in root - schema v1.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    }
+  },
+  "root": {
+    "kind": "Optional",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -100,14 +100,14 @@ export interface TestDocument extends TestTree, Omit<TestSimpleTree, "root"> {
 	readonly hasUnknownOptionalFieldSchema?: true;
 
 	/**
-	 * True if and only if the document had staged allowed types.
+	 * True if and only if the document had staged schema features.
 	 */
 	readonly hasStagedSchema?: true;
 
 	/**
-	 * True if and only if the document content requires staged allowed types.
+	 * True if and only if the document content requires staged schema features.
 	 *
-	 * For this to be the case, the stored schema must also have had the staged type included.
+	 * For this to be the case, the stored schema must also have had staged schema features included.
 	 */
 	readonly requiresStagedSchema?: true;
 }
@@ -406,6 +406,17 @@ export class HasStagedAllowedTypesAfterUpdate extends factory.objectAlpha(
 	},
 ) {}
 
+export class HasStagedOptionalField extends factory.objectAlpha("hasStagedOptionalField", {
+	x: SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number),
+}) {}
+
+export class HasStagedOptionalFieldAfterUpdate extends factory.objectAlpha(
+	"hasStagedOptionalField",
+	{
+		x: SchemaFactoryAlpha.optional(SchemaFactoryAlpha.number),
+	},
+) {}
+
 class MapWithStaged extends factory.mapAlpha(
 	"MapWithStaged",
 	SchemaFactoryAlpha.types([
@@ -421,6 +432,16 @@ class ArrayWithStaged extends factory.arrayAlpha(
 		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
 	]),
 ) {}
+
+const stagedOptionalRoot = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number);
+const optionalRoot = SchemaFactoryAlpha.optional(SchemaFactoryAlpha.number);
+const stagedOptionalA = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number);
+const stagedOptionalB = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.string);
+
+class NestedStagedOptional extends factory.object("NestedStagedOptional", {
+	a: stagedOptionalA,
+	b: stagedOptionalB,
+}) {}
 
 const multiStageCUpgrade = SchemaFactoryAlpha.staged(ArrayWithStaged);
 
@@ -452,7 +473,7 @@ class NestedMultiStage extends factory.object("NestedMultiStage", {
  * Can be used to test schema evolution related features where view and stored schema can diverge.
  * Includes for example documents with unknown optional fields;
  *
- * TODO: will include documents with staged allowed types (once supported) both before and after the stored schema update.
+ * Includes documents with staged schema features both before and after the stored schema update.
  */
 export const testDocuments: readonly TestDocument[] = [
 	...testSimpleTrees.map(
@@ -564,6 +585,87 @@ export const testDocuments: readonly TestDocument[] = [
 		schemaData: toStoredSchema(MapWithStaged, permissiveStoredSchemaGenerationOptions),
 		treeFactory: () =>
 			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(MapWithStaged, [["key", "text"]])),
+	},
+	{
+		ambiguous: false,
+		name: "HasStagedOptionalFieldBeforeUpdate",
+		schema: HasStagedOptionalField,
+		hasStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toInitialSchema(HasStagedOptionalField),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(HasStagedOptionalField, { x: 5 })),
+	},
+	{
+		ambiguous: false,
+		name: "HasStagedOptionalFieldAfterUpdate",
+		schema: HasStagedOptionalField,
+		hasStagedSchema: true,
+		requiresStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toInitialSchema(HasStagedOptionalFieldAfterUpdate),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(HasStagedOptionalField, {})),
+	},
+	{
+		ambiguous: false,
+		name: "Staged optional in root",
+		schema: stagedOptionalRoot,
+		hasStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toInitialSchema(stagedOptionalRoot),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(stagedOptionalRoot, 5)),
+	},
+	{
+		ambiguous: false,
+		name: "Staged optional empty root",
+		schema: stagedOptionalRoot,
+		hasStagedSchema: true,
+		requiresStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toInitialSchema(optionalRoot),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(stagedOptionalRoot, undefined)),
+	},
+	{
+		ambiguous: false,
+		name: "NestedStagedOptional with no upgrades",
+		schema: NestedStagedOptional,
+		hasStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toStoredSchema(NestedStagedOptional, restrictiveStoredSchemaGenerationOptions),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(
+				fieldCursorFromInsertable(NestedStagedOptional, { a: 5, b: "text" }),
+			),
+	},
+	{
+		ambiguous: false,
+		name: "NestedStagedOptional with one upgrade",
+		schema: NestedStagedOptional,
+		hasStagedSchema: true,
+		requiresStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toStoredSchema(NestedStagedOptional, {
+			includeStaged: () => false,
+			includeStagedOptional: (upgrade) => upgrade === stagedOptionalA.isStagedOptional,
+		}),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(
+				fieldCursorFromInsertable(NestedStagedOptional, { b: "text" }),
+			),
+	},
+	{
+		ambiguous: false,
+		name: "NestedStagedOptional with all upgrades",
+		schema: NestedStagedOptional,
+		hasStagedSchema: true,
+		requiresStagedSchema: true,
+		policy: defaultSchemaPolicy,
+		schemaData: toStoredSchema(NestedStagedOptional, permissiveStoredSchemaGenerationOptions),
+		treeFactory: () =>
+			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(NestedStagedOptional, {})),
 	},
 	{
 		ambiguous: false,


### PR DESCRIPTION
## Description

Adds staged optional field cases to the SharedTree stored schema snapshot coverage. These cases mirror the staged allowed-types coverage and capture before-update, after-update, root-field, and nested staged optional rollout states.

The tests verify that staged optional fields use the existing persisted schema shapes: restrictive schemas keep staged optional fields required, permissive schemas include them as optional, and the permissive staged-optional schema matches the fully optional after-update schema.

Also adds a new test case for staged allowed types that was lacking some coverage.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The main thing to review is whether the new staged optional test documents are the right analogs to the existing staged allowed-types snapshot cases.