### PR TITLE
ci: remove fleet review acknowledgement comment

### DIFF
--- a/.github/workflows/pr-review-confirm.yml
+++ b/.github/workflows/pr-review-confirm.yml
@@ -146,20 +146,6 @@ jobs:
 
           echo "Triggered fleet for PR #${PR_NUMBER} with reviewers: ${SELECTED}"
 
-      - name: Post acknowledgement
-        if: |
-          steps.authz.outputs.require-result == 'true' &&
-          steps.empty-check.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          SELECTED: ${{ steps.checkboxes.outputs.selected }}
-        run: |
-          NAMES=$(python3 .github/scripts/pr_review_propose.py format-names "$SELECTED")
-          gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-            --body "On it! Starting review with: ${NAMES}"
-
       # Reset the Start review checkbox so the next tick triggers a re-review.
       # Runs whether or not we dispatched (empty-selection paths reset too —
       # otherwise the user would be stuck with a checked Start box and would


### PR DESCRIPTION
## Description

Removes the automatic acknowledgement comment from the PR review confirmation workflow after dispatching the fleet review. The workflow still triggers the selected reviewers and resets the Start review checkbox, but no longer adds the extra "On it! Starting review with..." PR comment.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
