### PR TITLE
ci: disable GitHub releases for build-tools

### DIFF
--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -149,9 +149,9 @@ jobs:
           --output release-notes.md \
           --template .github/workflows/data/patch-changelog.hbs
 
-      # Only creates GH releases for client, server, and build-tools releases.
+      # Only creates GH releases for client and server releases.
       - name: Create GH release
-        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'build-tools' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'server'
+        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'server'
         # release notes: https://github.com/ncipollo/release-action/releases/tag/v1.20.0
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # ratchet:ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Description

Removes `build-tools` from the condition on the "Create GH release" step in `.github/workflows/push-tag-create-release.yml`. After this change, only `client` and `server` release tags create GitHub releases; `build-tools` tags still trigger the workflow (so release metadata and reports are still generated and uploaded as artifacts) but no GitHub release is created.

The "Generate patch release notes" step still runs for build-tools tags. Its `release-notes.md` output is now unused, but the wasted work is small and leaving the step in place keeps the workflow logic simple.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).