### PR TITLE
test(tree): Disable text op size benchmarks

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/textDomain.integration.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/textDomain.integration.bench.ts
@@ -42,7 +42,8 @@ function makeTestString(length: number): string {
 	return "ab".repeat(Math.ceil(length / 2)).slice(0, length);
 }
 
-describe("TextDomain benchmarks", () => {
+// TODO: AB#72660: Investigate why these appear to be breaking the benchmarks pipeline and re-enable once the issue is resolved.
+describe.skip("TextDomain benchmarks", () => {
 	configureBenchmarkHooks();
 
 	describe("TextDomain op size benchmarks", () => {


### PR DESCRIPTION
These tests appear to be causing problems in our benchmarks pipeline. Disabling for now.

[AB#72660](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/72660)