### PR TITLE
fix(bundle-analysis): publish analyzer.json as a separate bundleAnalyzerJson artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ legacy.d.ts
 
 # Bundle analysis artifacts
 bundleAnalysis
+bundleAnalyzerJson
 
 # Misc pipeline artifacts
 artifacts

--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -128,8 +128,8 @@ USAGE
   $ flub generate bundleSizeDiff [--json] [-v | --quiet] [--localReportPath <value>] [--outputDir <value>]
 
 FLAGS
-  --localReportPath=<value>  [default: ./artifacts/bundleAnalysis] Path to the locally-collected bundle reports for the
-                             PR (as produced by `flub generate bundleStats`).
+  --localReportPath=<value>  [default: ./artifacts/bundleAnalyzerJson] Path to the locally-collected bundle reports for
+                             the PR (as produced by `flub generate bundleStats`).
   --outputDir=<value>        [default: ./artifacts/bundleSizeDiff] Directory to write result.json or error.json into.
 
 LOGGING FLAGS

--- a/build-tools/packages/build-cli/src/commands/generate/bundleSizeDiff.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleSizeDiff.ts
@@ -22,7 +22,7 @@ const adoConstants = {
 	orgUrl: "https://dev.azure.com/fluidframework",
 	projectName: "public",
 	ciBuildDefinitionId: 48,
-	bundleAnalysisArtifactName: "bundleAnalyzerJson",
+	artifactName: "bundleAnalyzerJson",
 } as const;
 
 // Default path to the PR's locally-collected analyzer.json files.

--- a/build-tools/packages/build-cli/src/commands/generate/bundleSizeDiff.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleSizeDiff.ts
@@ -22,12 +22,12 @@ const adoConstants = {
 	orgUrl: "https://dev.azure.com/fluidframework",
 	projectName: "public",
 	ciBuildDefinitionId: 48,
-	bundleAnalysisArtifactName: "bundleAnalysis",
+	bundleAnalysisArtifactName: "bundleAnalyzerJson",
 } as const;
 
-// Default path to the PR's locally-collected bundle reports.
+// Default path to the PR's locally-collected analyzer.json files.
 // Matches where `flub generate bundleStats` (invoked via `npm run bundle-analysis:collect`) writes.
-const defaultLocalReportPath = "./artifacts/bundleAnalysis";
+const defaultLocalReportPath = "./artifacts/bundleAnalyzerJson";
 
 // Default output directory. The pipeline publishes this directory as the `bundleSizeDiff`
 // artifact.

--- a/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/bundleStats.ts
@@ -40,10 +40,15 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 			this.error("failed to get package information");
 		}
 
-		// Check each package location for a bundleAnalysis folder
-		// and copy it to a central location
+		// Check each package location for a bundleAnalysis folder (telemetry-feeding
+		// artifact: report.html, report.json, bundleStats.msp.gz) and a sibling
+		// bundleAnalyzerJson folder (PR-comparison-feeding artifact: analyzer.json),
+		// and copy each to its own central staging location. The two artifacts are
+		// kept separate because the FF-internal telemetry handler walks every .json
+		// under the bundleAnalysis artifact and would mis-parse analyzer.json.
 		let hasSmallAssetError = false;
 		const analysesDestPath = path.join(process.cwd(), "artifacts/bundleAnalysis");
+		const analyzerJsonDestPath = path.join(process.cwd(), "artifacts/bundleAnalyzerJson");
 
 		for (const pkg of pkgList) {
 			if (pkg.path === undefined) {
@@ -81,6 +86,12 @@ export default class GenerateBundlestats extends BaseCommand<typeof GenerateBund
 				/* eslint-enable @typescript-eslint/no-unsafe-member-access */
 
 				copySync(packageAnalysisPath, path.join(analysesDestPath, pkg.name));
+			}
+
+			const packageAnalyzerJsonPath = path.join(pkg.path, "bundleAnalyzerJson");
+			if (existsSync(packageAnalyzerJsonPath)) {
+				this.log(`found bundleAnalyzerJson for ${pkg.name}`);
+				copySync(packageAnalyzerJsonPath, path.join(analyzerJsonDestPath, pkg.name));
 			}
 		}
 

--- a/build-tools/packages/bundle-size-tools/api-report/bundle-size-tools.api.md
+++ b/build-tools/packages/bundle-size-tools/api-report/bundle-size-tools.api.md
@@ -142,14 +142,14 @@ export interface GetBundleSummariesFromAnalyzerArgs {
 export function getPriorCommit(baseCommit: string): string;
 
 // @public
-export function getZipObjectFromArtifact(adoConnection: WebApi, projectName: string, buildNumber: number, bundleAnalysisArtifactName: string): Promise<JSZip>;
+export function getZipObjectFromArtifact(adoConnection: WebApi, projectName: string, buildNumber: number, artifactName: string): Promise<JSZip>;
 
 // @public (undocumented)
 export interface IADOConstants {
     // (undocumented)
-    buildsToSearch?: number;
+    artifactName: string;
     // (undocumented)
-    bundleAnalysisArtifactName: string;
+    buildsToSearch?: number;
     // (undocumented)
     ciBuildDefinitionId: number;
     // (undocumented)

--- a/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
@@ -36,7 +36,7 @@ export async function getZipObjectFromArtifact(
 	adoConnection: WebApi,
 	projectName: string,
 	buildNumber: number,
-	bundleAnalysisArtifactName: string,
+	artifactName: string,
 ): Promise<JSZip> {
 	const buildApi = await adoConnection.getBuildApi();
 
@@ -51,16 +51,16 @@ export async function getZipObjectFromArtifact(
 	const artifactStream = await buildApi.getArtifactContentZip(
 		projectName,
 		buildNumber,
-		bundleAnalysisArtifactName,
+		artifactName,
 	);
 	// Undo hack from above
 	buildApi.createAcceptHeader = originalCreateAcceptHeader;
 
 	// We want our relative paths to be clean, so navigating JsZip into the top level folder
-	const result = (await unzipStream(artifactStream)).folder(bundleAnalysisArtifactName);
+	const result = (await unzipStream(artifactStream)).folder(artifactName);
 	assert(
 		result,
-		`getZipObjectFromArtifact could not find the folder ${bundleAnalysisArtifactName}`,
+		`getZipObjectFromArtifact could not find the folder ${artifactName}`,
 	);
 
 	return result;

--- a/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
@@ -58,10 +58,7 @@ export async function getZipObjectFromArtifact(
 
 	// We want our relative paths to be clean, so navigating JsZip into the top level folder
 	const result = (await unzipStream(artifactStream)).folder(artifactName);
-	assert(
-		result,
-		`getZipObjectFromArtifact could not find the folder ${artifactName}`,
-	);
+	assert(result, `getZipObjectFromArtifact could not find the folder ${artifactName}`);
 
 	return result;
 }

--- a/build-tools/packages/bundle-size-tools/src/ADO/AdoSizeComparator.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/AdoSizeComparator.ts
@@ -166,14 +166,14 @@ export class ADOSizeComparator {
 				console.log(`Found baseline build with id: ${baselineBuild.id}`);
 				console.log(`projectName: ${this.adoConstants.projectName}`);
 				console.log(
-					`bundleAnalysisArtifactName: ${this.adoConstants.bundleAnalysisArtifactName}`,
+					`artifactName: ${this.adoConstants.artifactName}`,
 				);
 
 				baselineZip = await getZipObjectFromArtifact(
 					this.adoConnection,
 					this.adoConstants.projectName,
 					baselineBuild.id,
-					this.adoConstants.bundleAnalysisArtifactName,
+					this.adoConstants.artifactName,
 				).catch((error) => {
 					console.log(`Error unzipping object from artifact: ${error.message}`);
 					console.log(`Error stack: ${error.stack}`);

--- a/build-tools/packages/bundle-size-tools/src/ADO/AdoSizeComparator.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/AdoSizeComparator.ts
@@ -165,9 +165,7 @@ export class ADOSizeComparator {
 				// Baseline build succeeded
 				console.log(`Found baseline build with id: ${baselineBuild.id}`);
 				console.log(`projectName: ${this.adoConstants.projectName}`);
-				console.log(
-					`artifactName: ${this.adoConstants.artifactName}`,
-				);
+				console.log(`artifactName: ${this.adoConstants.artifactName}`);
 
 				baselineZip = await getZipObjectFromArtifact(
 					this.adoConnection,

--- a/build-tools/packages/bundle-size-tools/src/ADO/Constants.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/Constants.ts
@@ -18,8 +18,8 @@ export interface IADOConstants {
 	// Note: Assumes CI and PR builds both run in the same org/project
 	prBuildDefinitionId?: number;
 
-	// The name of the build artifact that contains the bundle size artifacts
-	bundleAnalysisArtifactName: string;
+	// The name of the build artifact that contains the bundle size data
+	artifactName: string;
 
 	// The guid of the repo
 	// Used to post/update comments in ADO

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -20,7 +20,7 @@
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
-		"clean": "rimraf --glob build dist lib bundleAnalysis \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
+		"clean": "rimraf --glob build dist lib bundleAnalysis bundleAnalyzerJson \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --quiet --format stylish src",
 		"eslint:fix": "eslint --quiet --format stylish src --fix --fix-type problem,suggestion,layout",
 		"explore:tree": "fluid-build . --task webpack && source-map-explorer ./build/sharedTree.js --html bundleAnalysis/reportTree.html",

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -130,9 +130,13 @@ module.exports = {
 		}),
 		// Generates analyzer.json with per-asset statSize/parsedSize/gzipSize that
 		// `flub generate bundleSizeDiff` consumes to compute the bundle-size diff.
+		// Emitted to a sibling folder so the file ends up in its own artifact
+		// (bundleAnalyzerJson) rather than alongside bundleAnalysis content; the
+		// FF-internal telemetry handler walks every .json under the bundleAnalysis
+		// artifact and would otherwise try to parse this file as webpack stats.
 		new BundleAnalyzerPlugin({
 			analyzerMode: "json",
-			reportFilename: path.resolve(process.cwd(), "bundleAnalysis/analyzer.json"),
+			reportFilename: path.resolve(process.cwd(), "bundleAnalyzerJson/analyzer.json"),
 		}),
 		// Generates bundleStats.msp.gz (compressed webpack stats; consumed by the
 		// FF-internal telemetry handler).

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -418,8 +418,20 @@ extends:
                       sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
                       targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
 
-                  # At this point we want to publish the bundleAnalysis artifact,
-                  # but as part of 1ES migration that's now part of templateContext.outputs below.
+                  # bundleAnalyzerJson is a parallel artifact carrying analyzer.json
+                  # (consumed by `flub generate bundleSizeDiff`). It's separate from the
+                  # bundleAnalysis artifact so the FF-internal telemetry handler — which
+                  # walks every .json under bundleAnalysis — doesn't trip over a file
+                  # whose shape it doesn't recognize.
+                  - task: CopyFiles@2
+                    displayName: Copy bundle analyzer JSON files to artifact staging directory
+                    inputs:
+                      sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/artifacts/bundleAnalyzerJson'
+                      targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalyzerJson
+
+                  # At this point we want to publish the bundleAnalysis and
+                  # bundleAnalyzerJson artifacts, but as part of 1ES migration that's
+                  # now part of templateContext.outputs below.
 
                   # Computes the bundle size diff against the baseline CI build (definitionId 48 in the public
                   # project) and writes either artifacts/bundleSizeDiff/result.json (on success) or
@@ -576,6 +588,20 @@ extends:
                       condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest') )
                       targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
                       artifactName: bundleAnalysis
+                      sbomEnabled: false
+                      publishLocation: pipeline
+
+                    # Parallel artifact for analyzer.json. Kept separate from
+                    # bundleAnalysis so the FF-internal telemetry handler (which walks
+                    # every .json file under that artifact) doesn't pick this up.
+                    # Only published on non-PR (CI) builds so it can serve as the baseline
+                    # that PR builds compare against; PRs read their own analyzer.json
+                    # from artifacts/bundleAnalyzerJson locally and don't need to publish it.
+                    - output: pipelineArtifact
+                      displayName: Publish Artifacts - bundle-analyzer-json
+                      condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest') )
+                      targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalyzerJson
+                      artifactName: bundleAnalyzerJson
                       sbomEnabled: false
                       publishLocation: pipeline
 

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -403,15 +403,21 @@ extends:
 
               # Bundle analysis
               - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                  - task: Npm@1
+                  # Bash@3 (not Npm@1) so `flub` resolves via PATH to the globally-linked
+                  # workspace build; `npm run` would shadow it with the catalog-pinned
+                  # flub, which currently lacks the bundleAnalyzerJson aggregation.
+                  - task: Bash@3
                     displayName: 'Calculate bundle sizes'
                     inputs:
-                      command: custom
-                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:collect'
+                      targetType: inline
+                      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                      script: |
+                        set -eu -o pipefail
+                        pnpm run webpack:profile
+                        flub generate bundleStats
 
                   # Copy files so all artifacts we publish end up under the same parent folder.
-                  # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
+                  # The sourceFolder should be wherever the 'Calculate bundle sizes' task places its output.
                   - task: CopyFiles@2
                     displayName: Copy bundle size files to artifact staging directory
                     inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -486,8 +486,20 @@ extends:
                       sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
                       targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
 
-                  # At this point we want to publish the bundleAnalysis artifact,
-                  # but as part of 1ES migration that's now part of templateContext.outputs below.
+                  # bundleAnalyzerJson is a parallel artifact carrying analyzer.json
+                  # (consumed by `flub generate bundleSizeDiff`). It's separate from the
+                  # bundleAnalysis artifact so the FF-internal telemetry handler — which
+                  # walks every .json under bundleAnalysis — doesn't trip over a file
+                  # whose shape it doesn't recognize.
+                  - task: CopyFiles@2
+                    displayName: Copy bundle analyzer JSON files to artifact staging directory
+                    inputs:
+                      sourceFolder: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}/artifacts/bundleAnalyzerJson'
+                      targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalyzerJson
+
+                  # At this point we want to publish the bundleAnalysis and
+                  # bundleAnalyzerJson artifacts, but as part of 1ES migration that's
+                  # now part of templateContext.outputs below.
 
               # Docs
               - ${{ if ne(parameters.taskBuildDocs, false) }}:
@@ -571,6 +583,20 @@ extends:
                       condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.isBundleSizeArtifactsPipeline }}, true) )
                       targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
                       artifactName: bundleAnalysis
+                      sbomEnabled: false
+                      publishLocation: pipeline
+
+                    # Parallel artifact for analyzer.json. Kept separate from
+                    # bundleAnalysis so the FF-internal telemetry handler (which walks
+                    # every .json file under that artifact) doesn't pick this up.
+                    # Only published on non-PR (CI) builds so it can serve as the baseline
+                    # that PR builds compare against; PRs read their own analyzer.json
+                    # from artifacts/bundleAnalyzerJson locally and don't need to publish it.
+                    - output: pipelineArtifact
+                      displayName: Publish Artifacts - bundle-analyzer-json
+                      condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.isBundleSizeArtifactsPipeline }}, true) )
+                      targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalyzerJson
+                      artifactName: bundleAnalyzerJson
                       sbomEnabled: false
                       publishLocation: pipeline
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -471,15 +471,21 @@ extends:
 
               # Bundle analysis
               - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                  - task: Npm@1
+                  # Bash@3 (not Npm@1) so `flub` resolves via PATH to the globally-linked
+                  # workspace build; `npm run` would shadow it with the catalog-pinned
+                  # flub, which currently lacks the bundleAnalyzerJson aggregation.
+                  - task: Bash@3
                     displayName: 'Calculate bundle sizes'
                     inputs:
-                      command: custom
-                      workingDir: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:collect'
+                      targetType: inline
+                      workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
+                      script: |
+                        set -eu -o pipefail
+                        pnpm run webpack:profile
+                        flub generate bundleStats
 
                   # Copy files so all artifacts we publish end up under the same parent folder.
-                  # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
+                  # The sourceFolder should be wherever the 'Calculate bundle sizes' task places its output.
                   - task: CopyFiles@2
                     displayName: Copy bundle size files to artifact staging directory
                     inputs:


### PR DESCRIPTION
[AB#73002](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73002)

## Description

#27224 added `analyzer.json` to the existing `bundleAnalysis` pipeline artifact. The FF-internal telemetry handler (`@ff-internal/telemetry-generator/dist/handlers/bundleSizeHandler.js`) walks every `.json` file under that artifact and tries to parse each as a webpack stats file (`{ assets: [...] }`). `analyzer.json` is a top-level array, so the handler crashes with `TypeError: fileData.assets is not iterable` and breaks the build-client telemetry upload step.

Fix on our side instead of in the handler: move `analyzer.json` out of the `bundleAnalysis` artifact entirely. It now travels in its own parallel pipeline artifact, `bundleAnalyzerJson`, with its own staging directory at every stage of the producer/collect/publish pipeline.

The split also reflects a real distinction in audience and lifecycle:

- **`bundleAnalysis`** feeds the FF-internal size-telemetry dashboards. Contents (`report.html`, `report.json`, `bundleStats.msp.gz`) and consumer contract are owned by the internal telemetry handler.
- **`bundleAnalyzerJson`** feeds `flub generate bundleSizeDiff` (and the upcoming GH Actions PR-comparison workflow). Contents and shape are owned in this repo.

Keeping them in separate artifacts means we can iterate freely on the PR-comparison feed without coordinating with the FF-internal handler each time we want to change shape, add a file, etc.

### Changes

- `examples/utils/bundle-size-tests/webpack.config.cjs`: emit `analyzer.json` to `bundleAnalyzerJson/` instead of `bundleAnalysis/`.
- `examples/utils/bundle-size-tests/package.json`: clean script also wipes `bundleAnalyzerJson/`.
- `.gitignore`: ignore `bundleAnalyzerJson/` alongside `bundleAnalysis/`.
- `build-cli/src/commands/generate/bundleStats.ts`: also collect any `bundleAnalyzerJson/` folders from each package into `artifacts/bundleAnalyzerJson/<package>/`.
- `build-cli/src/commands/generate/bundleSizeDiff.ts`: switch the artifact name and local report path from `bundleAnalysis` → `bundleAnalyzerJson`.
- `tools/pipelines/templates/build-npm-{client-,}package.yml`: copy the new staging dir and publish `bundleAnalyzerJson` as a parallel pipeline artifact (only on non-PR builds, matching `bundleAnalysis`).

### Validation

- `pnpm webpack` in `bundle-size-tests` emits to both `bundleAnalysis/` and `bundleAnalyzerJson/` directories correctly.
- `flub generate bundleStats` populates both `artifacts/bundleAnalysis/<scope>/<pkg>/` and `artifacts/bundleAnalyzerJson/<scope>/<pkg>/`.
- 489 build-cli tests pass.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The conceptual flow is straightforward — there's just a lot of mechanical plumbing the move has to thread through. Reviewing in this order may help: producer → collect → pipeline publish → consumer.