### PR TITLE
improvement(tree): Optimize table schema input validation leveraging ID -> node cache

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1223,10 +1223,7 @@ export namespace System_TableSchema {
 			 * - A column with a duplicate ID is being inserted.
 			 */
 			#validateNewColumns(newColumns: readonly ColumnInsertableType[]): void {
-				return Table._validateNewColumns(
-					newColumns,
-					new Set(this.table.columns.map((column) => (column as ColumnValueType).id)),
-				);
+				return Table._validateNewColumns(newColumns, this.#getColumnCache());
 			}
 
 			/**
@@ -1236,11 +1233,7 @@ export namespace System_TableSchema {
 			 * - A row is being inserted that contains cells for columns that do not exist in the table.
 			 */
 			#validateNewRows(newRows: readonly RowInsertableType[]): void {
-				return Table._validateNewRows(
-					newRows,
-					new Set(this.table.rows.map((row) => (row as RowValueType).id)),
-					new Set(this.table.columns.map((column) => (column as ColumnValueType).id)),
-				);
+				return Table._validateNewRows(newRows, this.#getRowCache(), this.#getColumnCache());
 			}
 
 			/**
@@ -1250,7 +1243,7 @@ export namespace System_TableSchema {
 			 */
 			private static _validateNewColumns(
 				newColumns: Iterable<ColumnInsertableType>,
-				existingColumnIds: Set<string>,
+				existingColumnIds: { readonly has: (id: string) => boolean },
 			): void {
 				const newColumnIds = new Set<string>();
 				for (const newColumn of newColumns) {
@@ -1278,8 +1271,8 @@ export namespace System_TableSchema {
 			 */
 			private static _validateNewRows(
 				newRows: Iterable<RowInsertableType>,
-				existingRowIds: Set<string>,
-				columnIds: Set<string>,
+				existingRowIds: { readonly has: (id: string) => boolean },
+				columnIds: { readonly has: (id: string) => boolean },
 			): void {
 				const newRowIds = new Set<string>();
 				for (const newRow of newRows) {

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1097,14 +1097,13 @@ export namespace System_TableSchema {
 					return this.table.columns[columnOrIdOrIndex] as ColumnValueType;
 				}
 
+				const columnCache = this.#getColumnCache();
 				if (typeof columnOrIdOrIndex === "string") {
-					return this.#getColumnCache().get(columnOrIdOrIndex);
+					return columnCache.get(columnOrIdOrIndex);
 				}
 
-				// If the user provided a node, look it up by ID in the cache and confirm
-				// the cached node is the same instance — preserving the identity-based
-				// semantics of the prior `.includes` check while avoiding a linear scan.
-				const cached = this.#getColumnCache().get(columnOrIdOrIndex.id);
+				// If the user provided a node, ensure it actually exists in this table.
+				const cached = columnCache.get(columnOrIdOrIndex.id);
 				return cached === columnOrIdOrIndex ? columnOrIdOrIndex : undefined;
 			}
 
@@ -1191,14 +1190,13 @@ export namespace System_TableSchema {
 					return this.table.rows[rowOrIdOrIndex] as RowValueType;
 				}
 
+				const rowCache = this.#getRowCache();
 				if (typeof rowOrIdOrIndex === "string") {
-					return this.#getRowCache().get(rowOrIdOrIndex);
+					return rowCache.get(rowOrIdOrIndex);
 				}
 
-				// If the user provided a node, look it up by ID in the cache and confirm
-				// the cached node is the same instance — preserving the identity-based
-				// semantics of the prior `.includes` check while avoiding a linear scan.
-				const cached = this.#getRowCache().get(rowOrIdOrIndex.id);
+				// If the user provided a node, ensure it actually exists in this table.
+				const cached = rowCache.get(rowOrIdOrIndex.id);
 				return cached === rowOrIdOrIndex ? rowOrIdOrIndex : undefined;
 			}
 

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1101,12 +1101,11 @@ export namespace System_TableSchema {
 					return this.#getColumnCache().get(columnOrIdOrIndex);
 				}
 
-				// If the user provided a node, ensure it actually exists in this table.
-				if (!this.table.columns.includes(columnOrIdOrIndex)) {
-					return undefined;
-				}
-
-				return columnOrIdOrIndex;
+				// If the user provided a node, look it up by ID in the cache and confirm
+				// the cached node is the same instance — preserving the identity-based
+				// semantics of the prior `.includes` check while avoiding a linear scan.
+				const cached = this.#getColumnCache().get(columnOrIdOrIndex.id);
+				return cached === columnOrIdOrIndex ? columnOrIdOrIndex : undefined;
 			}
 
 			/**
@@ -1196,12 +1195,11 @@ export namespace System_TableSchema {
 					return this.#getRowCache().get(rowOrIdOrIndex);
 				}
 
-				// If the user provided a node, ensure it actually exists in this table.
-				if (!this.table.rows.includes(rowOrIdOrIndex)) {
-					return undefined;
-				}
-
-				return rowOrIdOrIndex;
+				// If the user provided a node, look it up by ID in the cache and confirm
+				// the cached node is the same instance — preserving the identity-based
+				// semantics of the prior `.includes` check while avoiding a linear scan.
+				const cached = this.#getRowCache().get(rowOrIdOrIndex.id);
+				return cached === rowOrIdOrIndex ? rowOrIdOrIndex : undefined;
 			}
 
 			/**


### PR DESCRIPTION
- Makes new row/column insert validation O(1) instead of O(n)
- Makes node-based lookup O(1) instead of O(n) when validating that the node belongs to the table