### PR TITLE
fix(docs): boost api title matches and fix search ranking in Typesense

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -189,8 +189,15 @@ const config: Config = {
 					],
 					apiKey: TYPESENSE_API_KEY,
 				},
-				// Optional
 				contextualSearch: true,
+				additionalSearchParameters: {
+					query_by:
+						"hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content",
+					query_by_weights: "6,5,4,3,2,1",
+					sort_by: "_text_match:desc",
+					prioritize_exact_match: true,
+					num_typos: "1,1,1,1,1,0",
+				},
 			},
 		}),
 	} satisfies Preset.ThemeConfig,

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -18,6 +18,19 @@ const TYPESENSE_API_KEY = process.env.TYPESENSE_API_KEY;
 
 const isTypesenseConfigured = TYPESENSE_HOST !== undefined && TYPESENSE_API_KEY !== undefined;
 
+// Each entry is [field, weight, numTypos]. Order determines priority: first = highest ranked.
+const typesenseSearchFields: [field: string, weight: number, numTypos: number][] = [
+	["hierarchy.lvl1", 6, 1],
+	["hierarchy.lvl2", 5, 1],
+	["hierarchy.lvl3", 4, 1],
+	["hierarchy.lvl4", 3, 1],
+	["hierarchy.lvl5", 2, 1],
+	["content", 1, 0],
+];
+const typesenseQueryBy = typesenseSearchFields.map(([field]) => field).join(",");
+const typesenseQueryByWeights = typesenseSearchFields.map(([, weight]) => weight).join(",");
+const typesenseNumTypos = typesenseSearchFields.map(([, , typos]) => typos).join(",");
+
 const githubUrl = "https://github.com/microsoft/FluidFramework";
 const githubMainBranchUrl = `${githubUrl}/tree/main`;
 const githubDocsUrl = `${githubMainBranchUrl}/docs`;
@@ -191,12 +204,11 @@ const config: Config = {
 				},
 				contextualSearch: true,
 				additionalSearchParameters: {
-					query_by:
-						"hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content",
-					query_by_weights: "6,5,4,3,2,1",
+					query_by: typesenseQueryBy,
+					query_by_weights: typesenseQueryByWeights,
 					sort_by: "_text_match:desc",
 					prioritize_exact_match: true,
-					num_typos: "1,1,1,1,1,0",
+					num_typos: typesenseNumTypos,
 				},
 			},
 		}),


### PR DESCRIPTION
## Description

The Typesense plugin had no additionalSearchParameters configured, so a mention of "tree" buried in body text ranked the same as a page titled "Tree". This caused searches like "Tree" to return 175+ poorly-ordered results, and exact type names like "TreeNodeApi" to return 0 results.

Changes:

Added query_by_weights — page title (lvl1) is weighted 6× higher than body content, descending through hierarchy levels
Added prioritize_exact_match: true — exact type name searches find the right page first
Added sort_by: _text_match:desc — strongest overall match wins
Added num_typos — typo tolerance on hierarchy levels, strict on content to reduce noise
Refactored additionalSearchParameters to derive query_by, query_by_weights, and num_typos from a single ordered array, so adding/removing a search field can't silently misalign the three lists


A separate scraper config change (typesense.config.json) will be applied directly on the VM and the index rebuilt via ./run-scraper after this deploys.

