### PR TITLE
fix(pipelines): install build-tools on bundle-size-artifacts pipeline so flub is on PATH

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -471,6 +471,18 @@ extends:
 
               # Bundle analysis
               - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
+                  # The bundle-size-artifacts pipeline skips set-package-version (and
+                  # therefore the include-install-build-tools step that globally links
+                  # `flub`); install build-tools standalone here so `flub` is on PATH for
+                  # the bundle-analysis steps below. Other pipelines already have flub
+                  # linked via set-package-version, so this is a no-op for them.
+                  - ${{ if eq(parameters.isBundleSizeArtifactsPipeline, true) }}:
+                      - template: /tools/pipelines/templates/include-install-build-tools.yml@self
+                        parameters:
+                          buildDirectory: ${{ parameters.buildDirectory }}
+                          buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
+                          pnpmStorePath: $(Pipeline.Workspace)/.pnpm-store
+
                   # Bash@3 (not Npm@1) so `flub` resolves via PATH to the globally-linked
                   # workspace build; `npm run` would shadow it with the catalog-pinned
                   # flub, which currently lacks the bundleAnalyzerJson aggregation.


### PR DESCRIPTION
[AB#73003](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73003)

## Description

Follow-up fix for #27246. That PR switched the "Calculate bundle sizes" step in `build-npm-package.yml` from `Npm@1` to `Bash@3` so `flub` would resolve through PATH to the globally-linked workspace build (which has the new `bundleAnalyzerJson` aggregation logic) instead of `node_modules/.bin/flub` (the catalog-pinned version, which does not).

That fix worked on PR builds and main-branch client CI builds because both run `include-set-package-version`, which transitively invokes `include-install-build-tools` and globally `npm link`s the workspace flub.

It broke the dedicated baseline-CI pipeline (`build-bundle-size-artifacts.yml`, definition 48 — the pipeline that publishes the `bundleAnalyzerJson` artifact that PR builds compare against). That pipeline sets `isBundleSizeArtifactsPipeline: true`, which gates `set-package-version` off, so `flub` is never linked. Build [398408](https://dev.azure.com/fluidframework/public/_build/results?buildId=398408) failed at the "Calculate bundle sizes" step with `flub: command not found`.

The `set-package-version` skip is itself a deliberate workaround — see #15110, which originally added the gate. Briefly: `update-package-version.sh` calls `flub bump $RELEASE_GROUP …` where `$RELEASE_GROUP` is the `tagName` parameter. The bundle-size-artifacts pipeline passes `tagName: bundle-and-code-coverage-artifacts`, which isn't a real release group in the fluidBuild config. Running `flub bump` against it would fail at release-group lookup. Properly fixing `flub bump` to support "set versions for a non-release-group set of packages" is a much larger change than this PR wants to take on.

### Fix

Decouple flub installation from version-setting: invoke `include-install-build-tools` standalone right before the bundle-analysis section in `build-npm-package.yml`, gated on `isBundleSizeArtifactsPipeline=true`. That makes `flub` available in exactly the case `set-package-version` doesn't cover, without invoking the fragile release-group-name machinery. PR/main-client paths are untouched — they still get `flub` via `set-package-version`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).