### PR TITLE
feat(tree): implement isAuditableFromOutcome

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeTypes.ts
@@ -17,7 +17,7 @@ import type { TreeChunk } from "../chunked-forest/index.js";
 
 import type { CrossFieldTarget } from "./crossFieldQueries.js";
 
-export interface ModularChangeset extends HasFieldChanges {
+export interface ModularChangeset extends Readonly<HasFieldChanges> {
 	/**
 	 * The numerically highest `ChangesetLocalId` used in this changeset.
 	 * If undefined then this changeset contains no IDs.

--- a/packages/dds/tree/src/shared-tree/isAuditableFromOutcome.ts
+++ b/packages/dds/tree/src/shared-tree/isAuditableFromOutcome.ts
@@ -17,10 +17,18 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
  * Otherwise returns `true` (including for an empty change, which has nothing
  * a viewer of the post-apply state would be unable to see).
  *
- * @remarks
- * Tracked by ADO 56693. Not yet implemented; the body throws so test cases
- * targeting the eventual contract fail loudly until the implementation lands.
  */
 export function isAuditableFromOutcome(change: SharedTreeChange): boolean {
-	throw new Error("isAuditableFromOutcome is not implemented");
+	if (change.changes.length > 1) {
+		return false;
+	}
+	for (const inner of change.changes) {
+		if (inner.type === "schema") {
+			return false;
+		}
+		if ((inner.innerChange.constraintViolationCount ?? 0) > 0) {
+			return false;
+		}
+	}
+	return true;
 }

--- a/packages/dds/tree/src/shared-tree/isAuditableFromOutcome.ts
+++ b/packages/dds/tree/src/shared-tree/isAuditableFromOutcome.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
+
+/**
+ * Determines whether a {@link SharedTreeChange} is auditable for HitL purposes
+ * by inspecting the resulting state after the change is applied.
+ *
+ * Returns `false` if any of the following is true:
+ * - The change contains more than one inner change.
+ * - The change contains a schema change.
+ * - The change contains a data change with violated constraints.
+ *
+ * Otherwise returns `true` (including for an empty change, which has nothing
+ * a viewer of the post-apply state would be unable to see).
+ *
+ * @remarks
+ * Tracked by ADO 56693. Not yet implemented; the body throws so test cases
+ * targeting the eventual contract fail loudly until the implementation lands.
+ */
+export function isAuditableFromOutcome(change: SharedTreeChange): boolean {
+	throw new Error("isAuditableFromOutcome is not implemented");
+}

--- a/packages/dds/tree/src/test/shared-tree/isAuditableFromOutcome.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/isAuditableFromOutcome.spec.ts
@@ -1,0 +1,122 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { currentVersion, type CodecWriteOptions } from "../../codec/index.js";
+import { type TreeStoredSchema, rootFieldKey } from "../../core/index.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import { forbidden } from "../../feature-libraries/default-schema/defaultFieldKinds.js";
+import {
+	DefaultEditBuilder,
+	ModularChangeFamily,
+	type ModularChangeset,
+	fieldKinds,
+	type SchemaChange,
+	FieldBatchFormatVersion,
+	type FieldBatchCodec,
+} from "../../feature-libraries/index.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import { isAuditableFromOutcome } from "../../shared-tree/isAuditableFromOutcome.js";
+import type {
+	SharedTreeChange,
+	SharedTreeInnerChange,
+	// eslint-disable-next-line import-x/no-internal-modules
+} from "../../shared-tree/sharedTreeChangeTypes.js";
+import { ajvValidator } from "../codec/index.js";
+import { chunkFromJsonTrees, failCodecFamily, mintRevisionTag } from "../utils.js";
+
+const codecOptions = {
+	jsonValidator: ajvValidator,
+	minVersionForCollab: currentVersion,
+} as const satisfies CodecWriteOptions;
+const fieldBatchCodec = {
+	encode: () => assert.fail("Unexpected encode"),
+	decode: () => assert.fail("Unexpected decode"),
+	writeVersion: FieldBatchFormatVersion.v2,
+} as const satisfies FieldBatchCodec;
+
+const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily, codecOptions);
+const dataChanges: ModularChangeset[] = [];
+const editor = new DefaultEditBuilder(
+	modularFamily,
+	mintRevisionTag,
+	(taggedChange) => dataChanges.push(taggedChange.change),
+	codecOptions,
+);
+
+const rootField = { parent: undefined, field: rootFieldKey };
+editor.valueField(rootField).set(chunkFromJsonTrees(["X"]));
+editor.valueField(rootField).set(chunkFromJsonTrees(["Y"]));
+
+const dataChangeA = dataChanges[0];
+const dataChangeB = dataChanges[1];
+
+const emptySchema = {
+	nodeSchema: new Map(),
+	rootFieldSchema: {
+		kind: forbidden.identifier,
+		types: new Set(),
+		persistedMetadata: undefined,
+	},
+} as const satisfies TreeStoredSchema;
+const innerSchemaChange = {
+	schema: { new: emptySchema, old: emptySchema },
+	isInverse: false,
+} as const satisfies SchemaChange;
+
+const dataInner = (change: ModularChangeset): SharedTreeInnerChange => ({
+	type: "data",
+	innerChange: change,
+});
+const schemaInner = {
+	type: "schema",
+	innerChange: innerSchemaChange,
+} as const satisfies SharedTreeInnerChange;
+
+describe("isAuditableFromOutcome", () => {
+	it("returns true for an empty change", () => {
+		const change = { changes: [] } as const satisfies SharedTreeChange;
+		assert.equal(isAuditableFromOutcome(change), true);
+	});
+
+	it("returns true for a single data change with no violated constraints", () => {
+		const change = { changes: [dataInner(dataChangeA)] } as const satisfies SharedTreeChange;
+		assert.equal(isAuditableFromOutcome(change), true);
+	});
+
+	it("returns true when a data change has constraintViolationCount explicitly 0", () => {
+		const change = {
+			changes: [dataInner({ ...dataChangeA, constraintViolationCount: 0 })],
+		} as const satisfies SharedTreeChange;
+		assert.equal(isAuditableFromOutcome(change), true);
+	});
+
+	it("returns false when the change contains more than one inner change", () => {
+		const change = {
+			changes: [dataInner(dataChangeA), dataInner(dataChangeB)],
+		} as const satisfies SharedTreeChange;
+		assert.equal(isAuditableFromOutcome(change), false);
+	});
+
+	it("returns false for a single schema change", () => {
+		const change: SharedTreeChange = { changes: [schemaInner] };
+		assert.equal(isAuditableFromOutcome(change), false);
+	});
+
+	it("returns false when the change contains a schema change interleaved with a data change", () => {
+		const change: SharedTreeChange = {
+			changes: [dataInner(dataChangeA), schemaInner],
+		};
+		assert.equal(isAuditableFromOutcome(change), false);
+	});
+
+	it("returns false when a single data change has violated constraints", () => {
+		const change: SharedTreeChange = {
+			changes: [dataInner({ ...dataChangeA, constraintViolationCount: 1 })],
+		};
+		assert.equal(isAuditableFromOutcome(change), false);
+	});
+});

--- a/packages/dds/tree/src/test/shared-tree/isAuditableFromOutcome.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/isAuditableFromOutcome.spec.ts
@@ -15,8 +15,6 @@ import {
 	type ModularChangeset,
 	fieldKinds,
 	type SchemaChange,
-	FieldBatchFormatVersion,
-	type FieldBatchCodec,
 } from "../../feature-libraries/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { isAuditableFromOutcome } from "../../shared-tree/isAuditableFromOutcome.js";
@@ -32,12 +30,6 @@ const codecOptions = {
 	jsonValidator: ajvValidator,
 	minVersionForCollab: currentVersion,
 } as const satisfies CodecWriteOptions;
-const fieldBatchCodec = {
-	encode: () => assert.fail("Unexpected encode"),
-	decode: () => assert.fail("Unexpected decode"),
-	writeVersion: FieldBatchFormatVersion.v2,
-} as const satisfies FieldBatchCodec;
-
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily, codecOptions);
 const dataChanges: ModularChangeset[] = [];
 const editor = new DefaultEditBuilder(

--- a/packages/dds/tree/src/test/shared-tree/isAuditableFromOutcome.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/isAuditableFromOutcome.spec.ts
@@ -5,17 +5,23 @@
 
 import { strict as assert } from "node:assert";
 
-import { currentVersion, type CodecWriteOptions } from "../../codec/index.js";
-import { type TreeStoredSchema, rootFieldKey } from "../../core/index.js";
+import { SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
+import { createIndependentTreeAlpha } from "@fluidframework/tree/alpha";
+
+// #region Internal production imports
+import type { CodecWriteOptions } from "../../codec/index.js";
+import { currentVersion } from "../../codec/index.js";
+import type { TreeStoredSchema } from "../../core/index.js";
+import { rootFieldKey } from "../../core/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { forbidden } from "../../feature-libraries/default-schema/defaultFieldKinds.js";
+import type { ModularChangeset, SchemaChange } from "../../feature-libraries/index.js";
 import {
 	DefaultEditBuilder,
 	ModularChangeFamily,
-	type ModularChangeset,
 	fieldKinds,
-	type SchemaChange,
 } from "../../feature-libraries/index.js";
+import type { SchematizingSimpleTreeView } from "../../shared-tree/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { isAuditableFromOutcome } from "../../shared-tree/isAuditableFromOutcome.js";
 import type {
@@ -23,92 +29,255 @@ import type {
 	SharedTreeInnerChange,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../shared-tree/sharedTreeChangeTypes.js";
+// #endregion
+// #region Test imports
 import { ajvValidator } from "../codec/index.js";
-import { chunkFromJsonTrees, failCodecFamily, mintRevisionTag } from "../utils.js";
-
-const codecOptions = {
-	jsonValidator: ajvValidator,
-	minVersionForCollab: currentVersion,
-} as const satisfies CodecWriteOptions;
-const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily, codecOptions);
-const dataChanges: ModularChangeset[] = [];
-const editor = new DefaultEditBuilder(
-	modularFamily,
+import {
+	TestTreeProviderLite,
+	chunkFromJsonTrees,
+	failCodecFamily,
+	getView,
 	mintRevisionTag,
-	(taggedChange) => dataChanges.push(taggedChange.change),
-	codecOptions,
-);
-
-const rootField = { parent: undefined, field: rootFieldKey };
-editor.valueField(rootField).set(chunkFromJsonTrees(["X"]));
-editor.valueField(rootField).set(chunkFromJsonTrees(["Y"]));
-
-const dataChangeA = dataChanges[0];
-const dataChangeB = dataChanges[1];
-
-const emptySchema = {
-	nodeSchema: new Map(),
-	rootFieldSchema: {
-		kind: forbidden.identifier,
-		types: new Set(),
-		persistedMetadata: undefined,
-	},
-} as const satisfies TreeStoredSchema;
-const innerSchemaChange = {
-	schema: { new: emptySchema, old: emptySchema },
-	isInverse: false,
-} as const satisfies SchemaChange;
-
-const dataInner = (change: ModularChangeset): SharedTreeInnerChange => ({
-	type: "data",
-	innerChange: change,
-});
-const schemaInner = {
-	type: "schema",
-	innerChange: innerSchemaChange,
-} as const satisfies SharedTreeInnerChange;
+} from "../utils.js";
+// #endregion
 
 describe("isAuditableFromOutcome", () => {
-	it("returns true for an empty change", () => {
-		const change = { changes: [] } as const satisfies SharedTreeChange;
-		assert.equal(isAuditableFromOutcome(change), true);
+	describe("using explicit SharedTreeChange constructs", () => {
+		const codecOptions = {
+			jsonValidator: ajvValidator,
+			minVersionForCollab: currentVersion,
+		} as const satisfies CodecWriteOptions;
+		const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily, codecOptions);
+		const dataChanges: ModularChangeset[] = [];
+		const editor = new DefaultEditBuilder(
+			modularFamily,
+			mintRevisionTag,
+			(taggedChange) => dataChanges.push(taggedChange.change),
+			codecOptions,
+		);
+
+		const rootField = { parent: undefined, field: rootFieldKey };
+		editor.valueField(rootField).set(chunkFromJsonTrees(["X"]));
+		editor.valueField(rootField).set(chunkFromJsonTrees(["Y"]));
+
+		const dataChangeA = dataChanges[0];
+		const dataChangeB = dataChanges[1];
+
+		const emptySchema = {
+			nodeSchema: new Map(),
+			rootFieldSchema: {
+				kind: forbidden.identifier,
+				types: new Set(),
+				persistedMetadata: undefined,
+			},
+		} as const satisfies TreeStoredSchema;
+		const innerSchemaChange = {
+			schema: { new: emptySchema, old: emptySchema },
+			isInverse: false,
+		} as const satisfies SchemaChange;
+
+		const dataInner = (change: ModularChangeset): SharedTreeInnerChange => ({
+			type: "data",
+			innerChange: change,
+		});
+		const schemaInner = {
+			type: "schema",
+			innerChange: innerSchemaChange,
+		} as const satisfies SharedTreeInnerChange;
+
+		it("returns true for an empty change", () => {
+			const change = { changes: [] } as const satisfies SharedTreeChange;
+			assert.equal(isAuditableFromOutcome(change), true);
+		});
+
+		it("returns true for a single data change with no violated constraints", () => {
+			const change = { changes: [dataInner(dataChangeA)] } as const satisfies SharedTreeChange;
+			assert.equal(isAuditableFromOutcome(change), true);
+		});
+
+		it("returns true when a data change has constraintViolationCount explicitly 0", () => {
+			const change = {
+				changes: [dataInner({ ...dataChangeA, constraintViolationCount: 0 })],
+			} as const satisfies SharedTreeChange;
+			assert.equal(isAuditableFromOutcome(change), true);
+		});
+
+		it("returns false when the change contains more than one inner change", () => {
+			const change = {
+				changes: [dataInner(dataChangeA), dataInner(dataChangeB)],
+			} as const satisfies SharedTreeChange;
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
+
+		it("returns false for a single schema change", () => {
+			const change: SharedTreeChange = { changes: [schemaInner] };
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
+
+		// Note: the types of changes are not discriminated in the implementation,
+		// so one being schema change does not matter.
+		it("returns false when the change contains a schema change interleaved with a data change", () => {
+			const change: SharedTreeChange = {
+				changes: [dataInner(dataChangeA), schemaInner],
+			};
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
+
+		it("returns false when a single data change has violated constraints", () => {
+			const change: SharedTreeChange = {
+				changes: [dataInner({ ...dataChangeA, constraintViolationCount: 1 })],
+			};
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
 	});
 
-	it("returns true for a single data change with no violated constraints", () => {
-		const change = { changes: [dataInner(dataChangeA)] } as const satisfies SharedTreeChange;
-		assert.equal(isAuditableFromOutcome(change), true);
-	});
+	describe("using production edits", () => {
+		it("auditable: a simple field insert produces a single data change with no violated constraints", () => {
+			// Setup
+			// Public actions
+			const sf = new SchemaFactory("audit-prod-data");
+			class Item extends sf.object("Item", { id: sf.string }) {}
+			const ItemArray = sf.array(Item);
+			const view = getView(
+				new TreeViewConfiguration({ schema: ItemArray, enableSchemaValidation: true }),
+			);
+			view.initialize([]);
+			view.root.insertAtEnd({ id: "A" });
 
-	it("returns true when a data change has constraintViolationCount explicitly 0", () => {
-		const change = {
-			changes: [dataInner({ ...dataChangeA, constraintViolationCount: 0 })],
-		} as const satisfies SharedTreeChange;
-		assert.equal(isAuditableFromOutcome(change), true);
-	});
+			// Begin internal access
+			const change = view.checkout.mainBranch.getHead().change;
+			// Confirm expected SharedTreeChange shape
+			assert.equal(change.changes.length, 1);
+			const inner = change.changes[0];
+			assert.equal(inner.type, "data");
+			// constraintViolationCount must be 0 or undefined
+			assert.equal(inner.innerChange.constraintViolationCount ?? 0, 0);
 
-	it("returns false when the change contains more than one inner change", () => {
-		const change = {
-			changes: [dataInner(dataChangeA), dataInner(dataChangeB)],
-		} as const satisfies SharedTreeChange;
-		assert.equal(isAuditableFromOutcome(change), false);
-	});
+			// Act and Verify
+			assert.equal(isAuditableFromOutcome(change), true);
+		});
 
-	it("returns false for a single schema change", () => {
-		const change: SharedTreeChange = { changes: [schemaInner] };
-		assert.equal(isAuditableFromOutcome(change), false);
-	});
+		it("not auditable: a single schema upgrade (produces a single schema inner change)", () => {
+			// Setup
+			// Public actions
+			const sf = new SchemaFactory("audit-prod-schema");
+			const InitialField = sf.optional(sf.string);
+			const ExpandedField = sf.optional([sf.string, sf.number]);
 
-	it("returns false when the change contains a schema change interleaved with a data change", () => {
-		const change: SharedTreeChange = {
-			changes: [dataInner(dataChangeA), schemaInner],
-		};
-		assert.equal(isAuditableFromOutcome(change), false);
-	});
+			const tree = createIndependentTreeAlpha();
+			const initialView = tree.viewWith(new TreeViewConfiguration({ schema: InitialField }));
+			initialView.initialize(undefined);
+			initialView.dispose();
 
-	it("returns false when a single data change has violated constraints", () => {
-		const change: SharedTreeChange = {
-			changes: [dataInner({ ...dataChangeA, constraintViolationCount: 1 })],
-		};
-		assert.equal(isAuditableFromOutcome(change), false);
+			const view = tree.viewWith(
+				new TreeViewConfiguration({
+					schema: ExpandedField,
+					enableSchemaValidation: true,
+				}),
+			);
+			view.upgradeSchema();
+
+			// Begin internal access
+			const checkout = (view as SchematizingSimpleTreeView<typeof ExpandedField>).checkout;
+			const change = checkout.mainBranch.getHead().change;
+			// Confirm expected SharedTreeChange shape
+			assert.equal(change.changes.length, 1);
+			assert.equal(change.changes[0].type, "schema");
+
+			// Act and Verify
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
+
+		it("not auditable: a transaction combining a data edit with a schema upgrade (contains more than one data inner change)", () => {
+			// Setup
+			// Public actions
+			const sf = new SchemaFactory("audit-prod-multi");
+			const InitialField = sf.optional(sf.string);
+			const ExpandedField = sf.optional([sf.string, sf.number]);
+
+			const tree = createIndependentTreeAlpha();
+			const initialView = tree.viewWith(new TreeViewConfiguration({ schema: InitialField }));
+			initialView.initialize(undefined);
+			initialView.dispose();
+
+			const view = tree.viewWith(
+				new TreeViewConfiguration({
+					schema: ExpandedField,
+					enableSchemaValidation: true,
+				}),
+			);
+
+			// Begin internal access
+			const checkout = (view as SchematizingSimpleTreeView<typeof ExpandedField>).checkout;
+
+			// Compose a schema upgrade and a data edit into a single commit via a transaction.
+			// The schema must be upgraded first because the view's typed setter requires the
+			// stored schema to match the view's schema.
+			checkout.runTransaction(() => {
+				view.upgradeSchema();
+				view.root = 2;
+			});
+
+			const change = checkout.mainBranch.getHead().change;
+			// Confirm expected SharedTreeChange shape: more than one inner change
+			assert(change.changes.length > 1);
+			// Expectations that are not critical
+			assert(change.changes.some((c) => c.type === "schema"));
+			assert(change.changes.some((c) => c.type === "data"));
+
+			// Act and Verify
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
+
+		it("not auditable: a concurrent edit invalidates a nodeInDocument precondition (violated constraints)", () => {
+			// Setup
+			const sf = new SchemaFactory("audit-prod-constraint");
+			class Child extends sf.object("Child", { value: sf.number }) {}
+			class Parent extends sf.object("Parent", {
+				content: sf.number,
+				child: sf.optional(Child),
+			}) {}
+
+			const config = new TreeViewConfiguration({
+				schema: Parent,
+				enableSchemaValidation: true,
+			});
+
+			const provider = new TestTreeProviderLite(2);
+			const viewA = provider.trees[0].kernel.viewWith(config);
+			const viewB = provider.trees[1].kernel.viewWith(config);
+
+			viewA.initialize({ content: 1, child: { value: 1 } });
+			provider.synchronizeMessages();
+
+			// Tree A removes the child node. Because submission order is sequencing order,
+			// this lands before Tree B's transaction below.
+			viewA.root.child = undefined;
+
+			// Tree B authors a transaction whose precondition depends on the (locally still
+			// present) child node.
+			const childB = viewB.root.child;
+			assert(childB !== undefined);
+			viewB.runTransaction(
+				() => {
+					viewB.root.content = 2;
+				},
+				{ preconditions: [{ type: "nodeInDocument", node: childB }] },
+			);
+
+			// After sequencing, Tree A's removal lands first, which invalidates the
+			// precondition on Tree B's rebased commit.
+			provider.synchronizeMessages();
+
+			// Confirm expected SharedTreeChange shape
+			const change = viewB.checkout.mainBranch.getHead().change;
+			assert.equal(change.changes.length, 1);
+			const inner = change.changes[0];
+			assert.equal(inner.type, "data");
+			assert.equal(inner.innerChange.constraintViolationCount, 1);
+
+			// Act and Verify
+			assert.equal(isAuditableFromOutcome(change), false);
+		});
 	});
 });


### PR DESCRIPTION
[AB#56693](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/56693)

isAuditableFromOutcome - Returns false when the change has more than one inner change, contains a schema change, or contains a data change with violated constraints.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>