### PR TITLE
build: policy check handler to ensure pipelines have correct yml template triggers

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/index.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/index.ts
@@ -11,6 +11,7 @@ import { handler as fluidCaseHandler } from "./fluidCase.js";
 import { handlers as lockfileHandlers } from "./lockfiles.js";
 import { handler as noJsFileHandler } from "./noJsFiles.js";
 import { handlers as npmPackageContentsHandlers } from "./npmPackages.js";
+import { handler as pipelineTriggerPathsHandler } from "./pipelineTriggerPaths.js";
 import { handlers as pnpmHandlers } from "./pnpm.js";
 import { handler as yamlTabsHandler } from "./spacesOverTabsInYaml.js";
 
@@ -26,6 +27,7 @@ export const policyHandlers: Handler[] = [
 	...pnpmHandlers,
 	...fluidBuildTasks,
 	noJsFileHandler,
+	pipelineTriggerPathsHandler,
 	yamlTabsHandler,
 ];
 

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/pipelineTriggerPaths.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/pipelineTriggerPaths.ts
@@ -251,6 +251,16 @@ export function findTopLevelBlock(content: string, key: "pr" | "trigger"): Block
 }
 
 /**
+ * Reads the content of a file by absolute path. Throws if the file cannot be read for
+ * any reason — including not existing. Allows callers to inject an in-memory file
+ * system for testing. A missing file in this code path is always a bug (either in the
+ * caller or in a hand-written YAML reference), so we do not treat it as a soft signal.
+ */
+export type FileReader = (absPath: string) => string;
+
+const defaultFsReader: FileReader = (absPath) => fs.readFileSync(absPath, "utf8");
+
+/**
  * BFS over `template:` references reachable from `rootFile`. Follows only same-repo
  * references (`@self` or no resource suffix).
  *
@@ -261,15 +271,25 @@ export function findTopLevelBlock(content: string, key: "pr" | "trigger"): Block
  *
  * Templates whose paths cannot be resolved (e.g. `${{ ... }}` interpolation, missing
  * files) are reported in `unresolved` as human-readable strings.
+ *
+ * @param read - Optional file-reader. Defaults to a real-filesystem reader; tests can
+ * supply a Map-backed reader to exercise resolution without scaffolding files.
  */
 export function findIncludedTemplates(
 	rootFile: string,
 	repoRoot: string,
+	read: FileReader = defaultFsReader,
 ): { parents: Map<string, string | undefined>; unresolved: Set<string> } {
 	const rootAbs = path.resolve(rootFile);
 	const parents = new Map<string, string | undefined>();
 	parents.set(rootAbs, undefined);
 	const unresolved = new Set<string>();
+	// Cache content of files that have been successfully read, so each reachable file
+	// is read at most once.
+	const cachedContent = new Map<string, string>();
+
+	cachedContent.set(rootAbs, read(rootAbs));
+
 	const visited = new Set<string>();
 	const queue: string[] = [rootAbs];
 
@@ -277,16 +297,7 @@ export function findIncludedTemplates(
 		const file = queue.shift() as string;
 		if (visited.has(file)) continue;
 		visited.add(file);
-
-		let content: string;
-		try {
-			content = fs.readFileSync(file, "utf8");
-		} catch (err) {
-			unresolved.add(
-				`Could not read ${path.relative(repoRoot, file)}: ${(err as Error).message}`,
-			);
-			continue;
-		}
+		const content = cachedContent.get(file) as string;
 
 		for (const rawLine of content.split(/\r?\n/)) {
 			if (rawLine.trim().startsWith("#")) continue;
@@ -310,18 +321,25 @@ export function findIncludedTemplates(
 			const absPath = templatePath.startsWith("/")
 				? path.join(repoRoot, templatePath)
 				: path.resolve(path.dirname(file), templatePath);
-
-			if (!fs.existsSync(absPath)) {
-				unresolved.add(
-					`'${value}' → '${path.relative(repoRoot, absPath)}' (referenced from '${path.relative(repoRoot, file)}', file not found)`,
-				);
-				continue;
-			}
-
 			const norm = path.resolve(absPath);
-			// First-seen wins: BFS guarantees this is a shortest chain to `norm`.
-			if (!parents.has(norm)) parents.set(norm, file);
-			if (!visited.has(norm)) queue.push(norm);
+
+			// Already discovered — BFS guarantees its shortest chain is already recorded.
+			if (parents.has(norm) || cachedContent.has(norm)) continue;
+
+			let childContent: string;
+			try {
+				childContent = read(norm);
+			} catch (err) {
+				// Re-throw with the originating reference as context so the error pinpoints
+				// the broken YAML location instead of just a bare absolute path.
+				throw new Error(
+					`Failed to read template '${value}' (referenced from '${path.relative(repoRoot, file)}'): ${(err as Error).message}`,
+					{ cause: err },
+				);
+			}
+			parents.set(norm, file);
+			cachedContent.set(norm, childContent);
+			queue.push(norm);
 		}
 	}
 
@@ -392,12 +410,16 @@ function toRepoRelative(absolute: string, repoRoot: string): string {
 	return path.relative(repoRoot, absolute).replaceAll(path.sep, "/");
 }
 
-export function analyzePipeline(file: string, repoRoot: string): Analysis {
-	const content = readFile(file);
+export function analyzePipeline(
+	file: string,
+	repoRoot: string,
+	read: FileReader = defaultFsReader,
+): Analysis {
+	const content = read(path.resolve(file));
 	const trigger = findTopLevelBlock(content, "trigger");
 	const pr = findTopLevelBlock(content, "pr");
 
-	const { parents, unresolved } = findIncludedTemplates(file, repoRoot);
+	const { parents, unresolved } = findIncludedTemplates(file, repoRoot, read);
 	// `findIncludedTemplates` already records the pipeline file itself as a root, so
 	// `parents.keys()` contains every file that should be covered by the trigger paths.
 

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/pipelineTriggerPaths.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/pipelineTriggerPaths.ts
@@ -1,0 +1,700 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { type Handler, readFile, writeFile } from "./common.js";
+
+/**
+ * Verifies that every YAML template transitively included by a top-level ADO pipeline
+ * is covered by that pipeline's `trigger.paths.include` and `pr.paths.include` filters.
+ *
+ * If a pipeline includes a template (directly or via another template) whose path is not
+ * matched by the trigger path filters, edits to that template will not trigger the pipeline.
+ *
+ * Scope:
+ * - Only matches top-level `*.yml` files directly under `tools/pipelines/`.
+ * - Follows `template:` references targeting the same repo (`@self` or no resource alias).
+ * - Skips templates from other repository resources (e.g. `@m365Pipelines`).
+ * - Treats `trigger: none` / `pr: none` as an explicit opt-out and does not flag those.
+ * - Treats a `trigger:`/`pr:` block that has `branches:` but no `paths:` as already covering
+ * every path (no path filter), so does not flag those.
+ *
+ * The resolver fixes coverage gaps in two ways:
+ * - Inserts missing entries into existing `paths.include` lists at the lexicographically
+ * correct position relative to surrounding entries.
+ * - Adds a missing `trigger:` or `pr:` block (with both `branches:` and `paths:`) when the
+ * file uses templates but lacks the section. Branches are copied from the sibling block
+ * when present, otherwise default to `main, next, lts, release/*`.
+ */
+export const handler: Handler = {
+	name: "pipeline-trigger-paths",
+	match: /^tools\/pipelines\/[^/]+\.yml$/i,
+	handler: async (file: string, root: string): Promise<string | undefined> => {
+		const issues = analyzePipeline(file, root).issues;
+		return issues.length === 0 ? undefined : issues.join("\n");
+	},
+	resolver: (file: string, root: string): { resolved: boolean; message?: string } => {
+		const analysis = analyzePipeline(file, root);
+		if (analysis.issues.length === 0) {
+			return { resolved: true };
+		}
+		try {
+			const newContent = applyFixes(readFile(file), analysis);
+			writeFile(file, newContent);
+			return { resolved: true };
+		} catch (err) {
+			return {
+				resolved: false,
+				message: `Could not auto-fix: ${(err as Error).message}`,
+			};
+		}
+	},
+};
+
+// =====================================================================================
+// Parsing
+// =====================================================================================
+
+const TEMPLATE_REF_REGEX = /^\s*-?\s*template:\s*(.+?)\s*$/;
+
+/** Half-open line range [start, end). */
+interface LineRange {
+	start: number;
+	end: number;
+}
+
+/**
+ * Information about a `paths.include` list: its existing items and the lines they occupy.
+ */
+interface PathsIncludeInfo {
+	/** Existing items in file order. */
+	items: string[];
+	/** Indent (in spaces) used by each `- item` line. */
+	itemIndent: number;
+	/**
+	 * Half-open line range covering the items themselves (does not include the
+	 * `include:` line nor any trailing line outside the list).
+	 */
+	itemRange: LineRange;
+	/**
+	 * Line number of the `include:` line (zero-indexed).
+	 */
+	includeLine: number;
+}
+
+type BlockShape =
+	| { kind: "missing" }
+	| { kind: "none"; keyLine: number }
+	/** `<key>:` block exists but uses no `paths:` filter (all paths trigger). */
+	| { kind: "branchesOnly"; keyLine: number; blockRange: LineRange }
+	/** `<key>:` block has a `paths.include:` we can read and modify. */
+	| {
+			kind: "include";
+			keyLine: number;
+			blockRange: LineRange;
+			paths: PathsIncludeInfo;
+	  };
+
+function getIndent(line: string): number {
+	let i = 0;
+	while (i < line.length && line[i] === " ") i++;
+	return i;
+}
+
+function stripQuotes(s: string): string {
+	if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+		return s.slice(1, -1);
+	}
+	return s;
+}
+
+function findInlineCommentIndex(s: string): number {
+	let inSingle = false;
+	let inDouble = false;
+	for (let i = 0; i < s.length; i++) {
+		const c = s[i];
+		if (c === "'" && !inDouble) inSingle = !inSingle;
+		else if (c === '"' && !inSingle) inDouble = !inDouble;
+		else if (c === "#" && !inSingle && !inDouble) {
+			if (i === 0 || s[i - 1] === " " || s[i - 1] === "\t") return i;
+		}
+	}
+	return -1;
+}
+
+function stripInlineComment(s: string): string {
+	const i = findInlineCommentIndex(s);
+	return (i >= 0 ? s.slice(0, i) : s).trimEnd();
+}
+
+/**
+ * Find a top-level `<key>:` block in a YAML file and extract its shape.
+ * Relies on the consistent 2-space indentation used across this repo's pipeline files.
+ */
+export function findTopLevelBlock(content: string, key: "pr" | "trigger"): BlockShape {
+	const lines = content.split(/\r?\n/);
+	let keyLine = -1;
+	let blockEnd = lines.length;
+	let isNone = false;
+
+	for (let i = 0; i < lines.length; i++) {
+		const ln = lines[i];
+		const trimmed = ln.trim();
+		if (trimmed === "" || trimmed.startsWith("#")) continue;
+		if (getIndent(ln) !== 0) continue;
+		const colonIdx = trimmed.indexOf(":");
+		if (colonIdx < 0) continue;
+		const k = trimmed.slice(0, colonIdx);
+		if (keyLine === -1) {
+			if (k === key) {
+				keyLine = i;
+				const rest = stripInlineComment(trimmed.slice(colonIdx + 1)).trim();
+				if (rest === "none") {
+					isNone = true;
+				}
+			}
+			continue;
+		}
+		// We've already found the key line. The next col-0 key line ends the block.
+		blockEnd = i;
+		break;
+	}
+
+	if (keyLine === -1) return { kind: "missing" };
+	if (isNone) return { kind: "none", keyLine };
+
+	// Find paths.include within the block.
+	const blockRange: LineRange = { start: keyLine, end: blockEnd };
+	let pathsIncludeLine = -1;
+	for (let i = keyLine + 1; i < blockEnd; i++) {
+		const ln = lines[i];
+		const trimmed = ln.trim();
+		if (trimmed === "" || trimmed.startsWith("#")) continue;
+		const indent = getIndent(ln);
+		if (indent === 2) {
+			if (trimmed === "paths:") {
+				// Find `include:` under it.
+				for (let j = i + 1; j < blockEnd; j++) {
+					const ln2 = lines[j];
+					const t2 = ln2.trim();
+					if (t2 === "" || t2.startsWith("#")) continue;
+					const ind = getIndent(ln2);
+					if (ind <= 2) break;
+					if (ind === 4 && t2 === "include:") {
+						pathsIncludeLine = j;
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	if (pathsIncludeLine === -1) {
+		return { kind: "branchesOnly", keyLine, blockRange };
+	}
+
+	// Collect items under include:.
+	const items: string[] = [];
+	let itemStart = -1;
+	let itemEnd = pathsIncludeLine + 1;
+	let itemIndent = 4;
+	for (let j = pathsIncludeLine + 1; j < blockEnd; j++) {
+		const ln = lines[j];
+		const trimmed = ln.trim();
+		if (trimmed === "") {
+			itemEnd = j + 1;
+			continue;
+		}
+		if (trimmed.startsWith("#")) {
+			itemEnd = j + 1;
+			continue;
+		}
+		const indent = getIndent(ln);
+		if (indent < 4) break;
+		if (indent === 4 && trimmed.startsWith("- ")) {
+			if (itemStart === -1) itemStart = j;
+			itemIndent = indent;
+			let v = trimmed.slice(2).trim();
+			v = stripInlineComment(v).trim();
+			v = stripQuotes(v);
+			if (v.length > 0) items.push(v);
+			itemEnd = j + 1;
+		} else if (indent > 4) {
+			// Continuation (e.g. multi-line value) — unusual here. Treat as part of the list.
+			itemEnd = j + 1;
+		} else {
+			break;
+		}
+	}
+
+	if (itemStart === -1) {
+		// Empty include list. Place items right after `include:`.
+		itemStart = pathsIncludeLine + 1;
+		itemEnd = pathsIncludeLine + 1;
+	}
+
+	return {
+		kind: "include",
+		keyLine,
+		blockRange,
+		paths: {
+			items,
+			itemIndent,
+			itemRange: { start: itemStart, end: itemEnd },
+			includeLine: pathsIncludeLine,
+		},
+	};
+}
+
+/**
+ * BFS over `template:` references reachable from `rootFile`. Follows only same-repo
+ * references (`@self` or no resource suffix).
+ *
+ * Returns a map from each reachable file's absolute path to the absolute path of the
+ * file that first introduced it (its parent in the BFS tree). The root file maps to
+ * `undefined`. The map encodes the shortest inclusion chain to each template, which
+ * callers can reconstruct by walking parent pointers.
+ *
+ * Templates whose paths cannot be resolved (e.g. `${{ ... }}` interpolation, missing
+ * files) are reported in `unresolved` as human-readable strings.
+ */
+export function findIncludedTemplates(
+	rootFile: string,
+	repoRoot: string,
+): { parents: Map<string, string | undefined>; unresolved: Set<string> } {
+	const rootAbs = path.resolve(rootFile);
+	const parents = new Map<string, string | undefined>();
+	parents.set(rootAbs, undefined);
+	const unresolved = new Set<string>();
+	const visited = new Set<string>();
+	const queue: string[] = [rootAbs];
+
+	while (queue.length > 0) {
+		const file = queue.shift() as string;
+		if (visited.has(file)) continue;
+		visited.add(file);
+
+		let content: string;
+		try {
+			content = fs.readFileSync(file, "utf8");
+		} catch (err) {
+			unresolved.add(
+				`Could not read ${path.relative(repoRoot, file)}: ${(err as Error).message}`,
+			);
+			continue;
+		}
+
+		for (const rawLine of content.split(/\r?\n/)) {
+			if (rawLine.trim().startsWith("#")) continue;
+			const line = stripInlineComment(rawLine);
+			const m = TEMPLATE_REF_REGEX.exec(line);
+			if (m === null) continue;
+			const value = stripQuotes(m[1].trim());
+
+			if (value.includes("${{")) {
+				unresolved.add(
+					`'${value}' (variable interpolation in ${path.relative(repoRoot, file)})`,
+				);
+				continue;
+			}
+
+			const atIdx = value.lastIndexOf("@");
+			const templatePath = atIdx >= 0 ? value.slice(0, atIdx) : value;
+			const resource = atIdx >= 0 ? value.slice(atIdx + 1) : "self";
+			if (resource !== "self") continue;
+
+			const absPath = templatePath.startsWith("/")
+				? path.join(repoRoot, templatePath)
+				: path.resolve(path.dirname(file), templatePath);
+
+			if (!fs.existsSync(absPath)) {
+				unresolved.add(
+					`'${value}' → '${path.relative(repoRoot, absPath)}' (referenced from '${path.relative(repoRoot, file)}', file not found)`,
+				);
+				continue;
+			}
+
+			const norm = path.resolve(absPath);
+			// First-seen wins: BFS guarantees this is a shortest chain to `norm`.
+			if (!parents.has(norm)) parents.set(norm, file);
+			if (!visited.has(norm)) queue.push(norm);
+		}
+	}
+
+	return { parents, unresolved };
+}
+
+/**
+ * Walks parent pointers from `target` up to the root, returning the inclusion chain
+ * as a list of basenames in root-to-leaf order.
+ */
+function chainBasenames(target: string, parents: Map<string, string | undefined>): string[] {
+	const chain: string[] = [];
+	let cur: string | undefined = target;
+	while (cur !== undefined) {
+		chain.unshift(path.basename(cur));
+		cur = parents.get(cur);
+	}
+	return chain;
+}
+
+// =====================================================================================
+// Coverage check
+// =====================================================================================
+
+/**
+ * Returns true if `pattern` from a `paths.include` filter covers `filePath`. ADO path
+ * filters are essentially path prefixes with two glob shorthands:
+ * - `dir/*`  matches files directly under `dir`.
+ * - `dir/**` matches everything under `dir`, recursively.
+ * - Otherwise the pattern matches the exact path or anything under it.
+ */
+export function pathMatchesPattern(filePath: string, pattern: string): boolean {
+	const f = filePath.replace(/^\/+/, "");
+	const p = pattern.replace(/^\/+/, "");
+
+	if (p.endsWith("/**")) {
+		const base = p.slice(0, -3);
+		return f === base || f.startsWith(`${base}/`);
+	}
+	if (p.endsWith("/*")) {
+		const base = p.slice(0, -2);
+		if (!f.startsWith(`${base}/`)) return false;
+		return !f.slice(base.length + 1).includes("/");
+	}
+	return f === p || f.startsWith(`${p}/`);
+}
+
+function isCovered(filePath: string, patterns: string[]): boolean {
+	return patterns.some((p) => pathMatchesPattern(filePath, p));
+}
+
+// =====================================================================================
+// Analysis
+// =====================================================================================
+
+interface Analysis {
+	/** Repo-relative paths that should be covered by trigger filters. */
+	requiredPaths: string[];
+	/** State of the `trigger:` block. */
+	trigger: BlockShape;
+	/** State of the `pr:` block. */
+	pr: BlockShape;
+	/** Human-readable issue messages — empty if there are no issues. */
+	issues: string[];
+}
+
+function toRepoRelative(absolute: string, repoRoot: string): string {
+	return path.relative(repoRoot, absolute).replaceAll(path.sep, "/");
+}
+
+export function analyzePipeline(file: string, repoRoot: string): Analysis {
+	const content = readFile(file);
+	const trigger = findTopLevelBlock(content, "trigger");
+	const pr = findTopLevelBlock(content, "pr");
+
+	const { parents, unresolved } = findIncludedTemplates(file, repoRoot);
+	// `findIncludedTemplates` already records the pipeline file itself as a root, so
+	// `parents.keys()` contains every file that should be covered by the trigger paths.
+
+	const absPaths = [...parents.keys()];
+	const relByAbs = new Map<string, string>(
+		absPaths.map((abs) => [abs, toRepoRelative(abs, repoRoot)]),
+	);
+	const absByRel = new Map<string, string>(
+		[...relByAbs.entries()].map(([abs, rel]) => [rel, abs]),
+	);
+	const requiredPaths = [...relByAbs.values()].sort();
+
+	const issues: string[] = [];
+	// Templates beyond the pipeline file itself were referenced.
+	const usesTemplates = parents.size > 1;
+
+	const formatChain = (relPath: string): string => {
+		const abs = absByRel.get(relPath);
+		if (abs === undefined) return relPath;
+		return chainBasenames(abs, parents).join(" → ");
+	};
+
+	for (const [key, block] of [
+		["trigger", trigger],
+		["pr", pr],
+	] as const) {
+		if (!usesTemplates) continue;
+		switch (block.kind) {
+			case "missing":
+				issues.push(`Missing top-level '${key}:' section.`);
+				break;
+			case "none":
+			case "branchesOnly":
+				break;
+			case "include": {
+				const missing = requiredPaths.filter((f) => !isCovered(f, block.paths.items));
+				if (missing.length > 0) {
+					issues.push(
+						`'${key}.paths.include' is missing entries (shown as inclusion chain → missing template):\n${missing
+							.map((m) => `  - ${formatChain(m)}`)
+							.join("\n")}`,
+					);
+				}
+				break;
+			}
+			default:
+				assertNever(block);
+		}
+	}
+
+	if (unresolved.size > 0) {
+		issues.push(
+			`Unresolved template references:\n${[...unresolved]
+				.sort()
+				.map((u) => `  - ${u}`)
+				.join("\n")}`,
+		);
+	}
+
+	return { requiredPaths, trigger, pr, issues };
+}
+
+function assertNever(x: never): never {
+	throw new Error(`Unexpected case: ${JSON.stringify(x)}`);
+}
+
+// =====================================================================================
+// Resolver / fixer
+// =====================================================================================
+
+const DEFAULT_BRANCHES = ["main", "next", "lts", "release/*"];
+
+/**
+ * Insert `newItems` into `existingItems` such that each new item lands at the position
+ * where it fits lexicographically (before the first existing item that is strictly
+ * greater). Existing items are not reordered.
+ */
+export function insertLexicographically(
+	existingItems: readonly string[],
+	newItems: readonly string[],
+): string[] {
+	const result = [...existingItems];
+	for (const newItem of [...newItems].sort()) {
+		let insertIdx = result.length;
+		for (let i = 0; i < result.length; i++) {
+			if (newItem < result[i]) {
+				insertIdx = i;
+				break;
+			}
+		}
+		result.splice(insertIdx, 0, newItem);
+	}
+	return result;
+}
+
+/**
+ * Given the file content and the analysis, produce a new content string with every
+ * detected issue resolved.
+ */
+export function applyFixes(content: string, analysis: Analysis): string {
+	let lines = content.split(/\r?\n/);
+	const lineEnding = content.includes("\r\n") ? "\r\n" : "\n";
+
+	// Re-find blocks each time we mutate, since line numbers shift.
+	const apply = (key: "trigger" | "pr"): void => {
+		const current = findTopLevelBlock(lines.join(lineEnding), key);
+		switch (current.kind) {
+			case "missing":
+				lines = insertNewBlock(lines, key, analysis);
+				break;
+			case "none":
+			case "branchesOnly":
+				break;
+			case "include": {
+				const missing = analysis.requiredPaths.filter(
+					(f) => !isCovered(f, current.paths.items),
+				);
+				if (missing.length > 0) {
+					lines = insertMissingItems(lines, current, missing);
+				}
+				break;
+			}
+			default:
+				assertNever(current);
+		}
+	};
+
+	apply("trigger");
+	apply("pr");
+
+	return lines.join(lineEnding);
+}
+
+/** Insert `missing` into the include list represented by `block.paths`. */
+function insertMissingItems(
+	lines: string[],
+	block: Extract<BlockShape, { kind: "include" }>,
+	missing: string[],
+): string[] {
+	const itemIndentStr = " ".repeat(block.paths.itemIndent);
+	const merged = insertLexicographically(block.paths.items, missing);
+	const missingSet = new Set(missing);
+
+	// Walk through the merged list in order. For each new item, insert it on the line
+	// right after the previous merged item (existing or already-inserted). For each
+	// existing item, locate its current line in the (mutated) result so subsequent
+	// new items anchor against the correct position.
+	const result = lines.slice();
+	// Anchor — the line of the most-recently processed merged item. New items are
+	// inserted on the line immediately after this. Initialised to the `include:` line
+	// so that an item that comes before every existing entry lands right under it.
+	let anchorLine = block.paths.includeLine;
+	let totalInserted = 0;
+
+	for (const item of merged) {
+		if (missingSet.has(item)) {
+			const insertAt = anchorLine + 1;
+			result.splice(insertAt, 0, `${itemIndentStr}- ${item}`);
+			anchorLine = insertAt;
+			totalInserted += 1;
+		} else {
+			const found = findItemLine(
+				result,
+				block.paths.itemRange.start,
+				block.paths.itemRange.end + totalInserted,
+				item,
+				block.paths.itemIndent,
+			);
+			if (found >= 0) anchorLine = found;
+		}
+	}
+
+	return result;
+}
+
+function findItemLine(
+	lines: string[],
+	start: number,
+	end: number,
+	value: string,
+	itemIndent: number,
+): number {
+	const prefix = `${" ".repeat(itemIndent)}- `;
+	for (let i = start; i < end && i < lines.length; i++) {
+		const ln = lines[i];
+		if (!ln.startsWith(prefix)) continue;
+		let v = ln.slice(prefix.length).trim();
+		v = stripInlineComment(v).trim();
+		v = stripQuotes(v);
+		if (v === value) return i;
+	}
+	return -1;
+}
+
+/**
+ * Insert a new top-level `trigger:` or `pr:` block into `lines`. Branches are copied
+ * from the sibling block when available, otherwise default to `main, next, lts, release/*`.
+ */
+function insertNewBlock(lines: string[], key: "trigger" | "pr", analysis: Analysis): string[] {
+	const sibling = key === "trigger" ? analysis.pr : analysis.trigger;
+	const branches = extractBranchesFromSibling(lines, sibling) ?? DEFAULT_BRANCHES;
+
+	const newBlockLines = renderTriggerBlock(key, branches, analysis.requiredPaths);
+
+	// Find the insertion line.
+	const insertLine = decideInsertionLine(lines, key, sibling);
+
+	const result = lines.slice();
+	const sep = result[insertLine - 1] === "" ? [] : [""];
+	result.splice(insertLine, 0, ...sep, ...newBlockLines, "");
+	return result;
+}
+
+/**
+ * Return the branches list of the sibling block if we can extract it cleanly.
+ */
+function extractBranchesFromSibling(
+	lines: string[],
+	sibling: BlockShape,
+): string[] | undefined {
+	if (sibling.kind === "missing" || sibling.kind === "none") return undefined;
+	const range = sibling.blockRange;
+	let inBranches = false;
+	let inInclude = false;
+	const branches: string[] = [];
+	for (let i = range.start + 1; i < range.end; i++) {
+		const ln = lines[i];
+		const trimmed = ln.trim();
+		if (trimmed === "" || trimmed.startsWith("#")) continue;
+		const indent = getIndent(ln);
+		if (!inBranches) {
+			if (indent === 2 && trimmed === "branches:") inBranches = true;
+			continue;
+		}
+		if (!inInclude) {
+			if (indent === 4 && trimmed === "include:") inInclude = true;
+			else if (indent <= 2) break;
+			continue;
+		}
+		if (indent < 4) break;
+		if (indent === 4 && trimmed.startsWith("- ")) {
+			let v = trimmed.slice(2).trim();
+			v = stripInlineComment(v).trim();
+			v = stripQuotes(v);
+			if (v.length > 0) branches.push(v);
+		}
+	}
+	return branches.length > 0 ? branches : undefined;
+}
+
+function renderTriggerBlock(
+	key: "trigger" | "pr",
+	branches: readonly string[],
+	paths: readonly string[],
+): string[] {
+	const out: string[] = [];
+	out.push(`${key}:`);
+	out.push("  branches:");
+	out.push("    include:");
+	for (const b of branches) out.push(`    - ${b}`);
+	out.push("  paths:");
+	out.push("    include:");
+	for (const p of [...paths].sort()) out.push(`    - ${p}`);
+	return out;
+}
+
+/**
+ * Choose where to insert a new top-level block. Preferred placement:
+ * - If sibling exists, place adjacent to it (trigger before pr; pr after trigger).
+ * - Otherwise, place before the first occurrence of any of {variables, resources, extends, stages, jobs}.
+ * - If none of those exist either, append at end of file.
+ */
+function decideInsertionLine(
+	lines: string[],
+	key: "trigger" | "pr",
+	sibling: BlockShape,
+): number {
+	if (sibling.kind !== "missing") {
+		const range = sibling as Exclude<BlockShape, { kind: "missing" }>;
+		// `none` doesn't carry a blockRange, just keyLine.
+		if (sibling.kind === "none") {
+			return key === "trigger" ? sibling.keyLine : sibling.keyLine + 1;
+		}
+		const blockRange = (range as { blockRange: LineRange }).blockRange;
+		return key === "trigger" ? blockRange.start : blockRange.end;
+	}
+
+	const sectionKeys = new Set(["variables", "resources", "extends", "stages", "jobs"]);
+	for (let i = 0; i < lines.length; i++) {
+		const ln = lines[i];
+		if (getIndent(ln) !== 0) continue;
+		const trimmed = ln.trim();
+		if (trimmed === "" || trimmed.startsWith("#")) continue;
+		const colonIdx = trimmed.indexOf(":");
+		if (colonIdx < 0) continue;
+		const k = trimmed.slice(0, colonIdx);
+		if (sectionKeys.has(k)) return i;
+	}
+	return lines.length;
+}

--- a/build-tools/packages/build-cli/src/test/library/repoPolicyCheck/pipelineTriggerPaths.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/repoPolicyCheck/pipelineTriggerPaths.test.ts
@@ -244,6 +244,8 @@ describe("pipeline-trigger-paths", () => {
 
 		it("reports an unresolved reference for variable-interpolated paths", () => {
 			const reader = makeReader({
+				// ADO pipeline variable interpolation syntax intentionally uses ${{ }}, not a JS template literal.
+				// eslint-disable-next-line no-template-curly-in-string
 				[root]: "extends:\n  template: ${{ variables.fooTemplate }}@self\n",
 			});
 

--- a/build-tools/packages/build-cli/src/test/library/repoPolicyCheck/pipelineTriggerPaths.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/repoPolicyCheck/pipelineTriggerPaths.test.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
+import { describe, it } from "mocha";
+
+import {
+	findTopLevelBlock,
+	insertLexicographically,
+	pathMatchesPattern,
+} from "../../../library/repoPolicyCheck/pipelineTriggerPaths.js";
+
+describe("pipeline-trigger-paths", () => {
+	describe("pathMatchesPattern", () => {
+		it("matches an exact file", () => {
+			expect(pathMatchesPattern("a/b/c.yml", "a/b/c.yml")).to.equal(true);
+		});
+
+		it("matches a directory prefix", () => {
+			expect(pathMatchesPattern("packages/foo/index.ts", "packages")).to.equal(true);
+		});
+
+		it("does not match an unrelated path", () => {
+			expect(pathMatchesPattern("a/b/c.yml", "a/b/d.yml")).to.equal(false);
+		});
+
+		it("does not match a sibling path that shares a prefix string", () => {
+			// `package` is a prefix string of `packages` but not a directory match.
+			expect(pathMatchesPattern("packages/foo", "package")).to.equal(false);
+		});
+
+		it("matches single-level glob (dir/*)", () => {
+			expect(pathMatchesPattern("patches/foo.patch", "patches/*")).to.equal(true);
+		});
+
+		it("does not match nested files under a single-level glob", () => {
+			expect(pathMatchesPattern("patches/sub/foo.patch", "patches/*")).to.equal(false);
+		});
+
+		it("matches recursive glob (dir/**)", () => {
+			expect(pathMatchesPattern("patches/sub/foo.patch", "patches/**")).to.equal(true);
+		});
+
+		it("strips a leading slash from the pattern", () => {
+			expect(pathMatchesPattern("a/b.yml", "/a/b.yml")).to.equal(true);
+		});
+	});
+
+	describe("insertLexicographically", () => {
+		it("inserts items in sorted order relative to existing entries", () => {
+			const result = insertLexicographically(["alpha", "delta", "echo"], ["bravo", "charlie"]);
+			expect(result).to.deep.equal(["alpha", "bravo", "charlie", "delta", "echo"]);
+		});
+
+		it("appends items that sort after every existing entry", () => {
+			const result = insertLexicographically(["alpha"], ["zeta", "yankee"]);
+			expect(result).to.deep.equal(["alpha", "yankee", "zeta"]);
+		});
+
+		it("prepends items that sort before every existing entry", () => {
+			const result = insertLexicographically(["mike", "november"], ["alpha", "bravo"]);
+			expect(result).to.deep.equal(["alpha", "bravo", "mike", "november"]);
+		});
+
+		it("places hyphen-suffixed names before dotted ones (ASCII order)", () => {
+			// Validates that a multi-segment name like 'foo-bar.yml' sorts before 'foo.yml'
+			// because '-' (0x2D) precedes '.' (0x2E).
+			const result = insertLexicographically([], ["foo.yml", "foo-bar.yml"]);
+			expect(result).to.deep.equal(["foo-bar.yml", "foo.yml"]);
+		});
+
+		it("does not reorder existing entries that are not sorted", () => {
+			const result = insertLexicographically(["zebra", "alpha"], ["mike"]);
+			// Existing relative order preserved; new item slots before the first greater entry.
+			expect(result).to.deep.equal(["mike", "zebra", "alpha"]);
+		});
+	});
+
+	describe("findTopLevelBlock", () => {
+		it("returns 'missing' when the key is not present", () => {
+			const content = `name: foo\nparameters: []\n`;
+			expect(findTopLevelBlock(content, "trigger").kind).to.equal("missing");
+		});
+
+		it("returns 'none' when the key is set to none", () => {
+			const content = `name: foo\ntrigger: none\npr:\n  branches:\n    include:\n    - main\n`;
+			const block = findTopLevelBlock(content, "trigger");
+			expect(block.kind).to.equal("none");
+		});
+
+		it("returns 'branchesOnly' when there are branches but no paths filter", () => {
+			const content = `name: foo\ntrigger:\n  branches:\n    include:\n    - main\n`;
+			const block = findTopLevelBlock(content, "trigger");
+			expect(block.kind).to.equal("branchesOnly");
+		});
+
+		it("returns 'include' with the items when paths.include is present", () => {
+			const content = [
+				"name: foo",
+				"trigger:",
+				"  branches:",
+				"    include:",
+				"    - main",
+				"  paths:",
+				"    include:",
+				"    - alpha.yml",
+				"    - bravo.yml",
+				"",
+				"pr: none",
+				"",
+			].join("\n");
+			const block = findTopLevelBlock(content, "trigger");
+			expect(block.kind).to.equal("include");
+			if (block.kind === "include") {
+				expect(block.paths.items).to.deep.equal(["alpha.yml", "bravo.yml"]);
+			}
+		});
+
+		it("ignores comment-only lines inside the include block", () => {
+			const content = [
+				"trigger:",
+				"  paths:",
+				"    include:",
+				"    # a comment",
+				"    - alpha.yml",
+				"    # another comment",
+				"    - bravo.yml",
+			].join("\n");
+			const block = findTopLevelBlock(content, "trigger");
+			expect(block.kind).to.equal("include");
+			if (block.kind === "include") {
+				expect(block.paths.items).to.deep.equal(["alpha.yml", "bravo.yml"]);
+			}
+		});
+	});
+});

--- a/build-tools/packages/build-cli/src/test/library/repoPolicyCheck/pipelineTriggerPaths.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/repoPolicyCheck/pipelineTriggerPaths.test.ts
@@ -7,10 +7,29 @@ import { expect } from "chai";
 import { describe, it } from "mocha";
 
 import {
+	analyzePipeline,
+	type FileReader,
+	findIncludedTemplates,
 	findTopLevelBlock,
 	insertLexicographically,
 	pathMatchesPattern,
 } from "../../../library/repoPolicyCheck/pipelineTriggerPaths.js";
+
+/**
+ * Builds a `FileReader` backed by an in-memory map keyed by absolute path. Tests use
+ * this to drive the pipeline analysis without scaffolding files on disk. Throws on
+ * lookup of an unmapped path, matching the production contract for missing files.
+ */
+function makeReader(files: Record<string, string>): FileReader {
+	const map = new Map<string, string>(Object.entries(files));
+	return (absPath) => {
+		const content = map.get(absPath);
+		if (content === undefined) {
+			throw new Error(`ENOENT: no such file or directory, open '${absPath}'`);
+		}
+		return content;
+	};
+}
 
 describe("pipeline-trigger-paths", () => {
 	describe("pathMatchesPattern", () => {
@@ -133,6 +152,242 @@ describe("pipeline-trigger-paths", () => {
 			if (block.kind === "include") {
 				expect(block.paths.items).to.deep.equal(["alpha.yml", "bravo.yml"]);
 			}
+		});
+	});
+
+	describe("findIncludedTemplates", () => {
+		const repoRoot = "/repo";
+		const root = "/repo/tools/pipelines/main.yml";
+
+		it("resolves a leading-slash @self reference under repoRoot", () => {
+			const reader = makeReader({
+				[root]: [
+					"trigger:",
+					"  paths:",
+					"    include:",
+					"    - x",
+					"extends:",
+					"  template: /tools/pipelines/templates/include-vars.yml@self",
+				].join("\n"),
+				"/repo/tools/pipelines/templates/include-vars.yml": "# leaf\n",
+			});
+
+			const { parents, unresolved } = findIncludedTemplates(root, repoRoot, reader);
+
+			expect([...unresolved]).to.deep.equal([]);
+			expect([...parents.keys()]).to.deep.equal([
+				root,
+				"/repo/tools/pipelines/templates/include-vars.yml",
+			]);
+			expect(parents.get("/repo/tools/pipelines/templates/include-vars.yml")).to.equal(root);
+		});
+
+		it("resolves a relative-path @self reference relative to the including file", () => {
+			const reader = makeReader({
+				[root]: "extends:\n  template: ../shared/leaf.yml@self\n",
+				"/repo/tools/shared/leaf.yml": "# leaf\n",
+			});
+
+			const { parents, unresolved } = findIncludedTemplates(root, repoRoot, reader);
+
+			expect([...unresolved]).to.deep.equal([]);
+			expect(parents.has("/repo/tools/shared/leaf.yml")).to.equal(true);
+		});
+
+		it("skips references to non-self repository resources", () => {
+			const reader = makeReader({
+				[root]: [
+					"resources:",
+					"  repositories:",
+					"    - repository: m365Pipelines",
+					"extends:",
+					"  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines",
+				].join("\n"),
+			});
+
+			const { parents, unresolved } = findIncludedTemplates(root, repoRoot, reader);
+
+			// Only the root file is recorded; the external template is ignored entirely.
+			expect([...parents.keys()]).to.deep.equal([root]);
+			expect([...unresolved]).to.deep.equal([]);
+		});
+
+		it("records BFS parent pointers for shortest inclusion chains", () => {
+			// main → A → C, main → B (C is reachable via A only). main also references C
+			// directly later — the direct edge wins because BFS visits the root first.
+			const reader = makeReader({
+				[root]: ["extends:", "  template: /a.yml@self", "  template: /b.yml@self"].join("\n"),
+				"/repo/a.yml": "template: /c.yml@self\n",
+				"/repo/b.yml": "# leaf\n",
+				"/repo/c.yml": "# leaf\n",
+			});
+
+			const { parents } = findIncludedTemplates(root, repoRoot, reader);
+
+			expect(parents.get(root)).to.equal(undefined);
+			expect(parents.get("/repo/a.yml")).to.equal(root);
+			expect(parents.get("/repo/b.yml")).to.equal(root);
+			expect(parents.get("/repo/c.yml")).to.equal("/repo/a.yml");
+		});
+
+		it("throws with parent context when the target file does not exist", () => {
+			const reader = makeReader({
+				[root]: "extends:\n  template: /tools/pipelines/templates/missing.yml@self\n",
+			});
+
+			expect(() => findIncludedTemplates(root, repoRoot, reader))
+				.to.throw(Error)
+				.with.property("message")
+				.that.matches(/missing\.yml/)
+				.and.matches(/referenced from/);
+		});
+
+		it("reports an unresolved reference for variable-interpolated paths", () => {
+			const reader = makeReader({
+				[root]: "extends:\n  template: ${{ variables.fooTemplate }}@self\n",
+			});
+
+			const { unresolved } = findIncludedTemplates(root, repoRoot, reader);
+
+			expect([...unresolved]).to.have.lengthOf(1);
+			expect([...unresolved][0]).to.include("variable interpolation");
+		});
+	});
+
+	describe("analyzePipeline", () => {
+		const repoRoot = "/repo";
+		const pipeline = "/repo/tools/pipelines/main.yml";
+		const leaf = "/repo/tools/pipelines/templates/leaf.yml";
+
+		it("flags missing entries in trigger.paths.include with chain-formatted messages", () => {
+			const reader = makeReader({
+				[pipeline]: [
+					"trigger:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"  paths:",
+					"    include:",
+					"    - tools/pipelines/main.yml",
+					"pr:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"  paths:",
+					"    include:",
+					"    - tools/pipelines/main.yml",
+					"    - tools/pipelines/templates/leaf.yml",
+					"extends:",
+					"  template: /tools/pipelines/templates/leaf.yml@self",
+				].join("\n"),
+				[leaf]: "# leaf\n",
+			});
+
+			const analysis = analyzePipeline(pipeline, repoRoot, reader);
+
+			expect(analysis.issues).to.have.lengthOf(1);
+			expect(analysis.issues[0]).to.include("trigger.paths.include");
+			expect(analysis.issues[0]).to.include("main.yml → leaf.yml");
+		});
+
+		it("flags a missing top-level section when templates are referenced", () => {
+			const reader = makeReader({
+				[pipeline]: [
+					"trigger:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"  paths:",
+					"    include:",
+					"    - tools/pipelines/main.yml",
+					"    - tools/pipelines/templates/leaf.yml",
+					"extends:",
+					"  template: /tools/pipelines/templates/leaf.yml@self",
+				].join("\n"),
+				[leaf]: "# leaf\n",
+			});
+
+			const analysis = analyzePipeline(pipeline, repoRoot, reader);
+
+			expect(analysis.issues).to.have.lengthOf(1);
+			expect(analysis.issues[0]).to.equal("Missing top-level 'pr:' section.");
+		});
+
+		it("does not flag pipelines whose triggers cover every reachable file", () => {
+			const reader = makeReader({
+				[pipeline]: [
+					"trigger:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"  paths:",
+					"    include:",
+					"    - tools/pipelines/main.yml",
+					"    - tools/pipelines/templates/leaf.yml",
+					"pr:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"  paths:",
+					"    include:",
+					"    - tools/pipelines/main.yml",
+					"    - tools/pipelines/templates/leaf.yml",
+					"extends:",
+					"  template: /tools/pipelines/templates/leaf.yml@self",
+				].join("\n"),
+				[leaf]: "# leaf\n",
+			});
+
+			const analysis = analyzePipeline(pipeline, repoRoot, reader);
+
+			expect(analysis.issues).to.deep.equal([]);
+		});
+
+		it("does not flag pipelines that reference no templates", () => {
+			// No `template:` references and no trigger blocks: nothing to enforce.
+			const reader = makeReader({ [pipeline]: "name: foo\n" });
+
+			const analysis = analyzePipeline(pipeline, repoRoot, reader);
+
+			expect(analysis.issues).to.deep.equal([]);
+		});
+
+		it("respects 'trigger: none' / 'pr: none' as an explicit opt-out", () => {
+			const reader = makeReader({
+				[pipeline]: [
+					"trigger: none",
+					"pr: none",
+					"extends:",
+					"  template: /tools/pipelines/templates/leaf.yml@self",
+				].join("\n"),
+				[leaf]: "# leaf\n",
+			});
+
+			const analysis = analyzePipeline(pipeline, repoRoot, reader);
+
+			expect(analysis.issues).to.deep.equal([]);
+		});
+
+		it("treats a branches-only block as already covering every path", () => {
+			const reader = makeReader({
+				[pipeline]: [
+					"trigger:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"pr:",
+					"  branches:",
+					"    include:",
+					"    - main",
+					"extends:",
+					"  template: /tools/pipelines/templates/leaf.yml@self",
+				].join("\n"),
+				[leaf]: "# leaf\n",
+			});
+
+			const analysis = analyzePipeline(pipeline, repoRoot, reader);
+
+			expect(analysis.issues).to.deep.equal([]);
 		});
 	});
 });

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -336,7 +336,7 @@ module.exports = {
 		handlerExclusions: {
 			"pipeline-trigger-paths": [
 				// Not immediately obvious if this needs the missing trigger section
-				"tools/pipelines/publish-api-model-artifact.yml"
+				"tools/pipelines/publish-api-model-artifact.yml",
 			],
 			"fluid-build-tasks-eslint": [
 				// This policy needs to be rethought in light of eslint 9. Disabling everywhere in the meantime.

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -334,6 +334,10 @@ module.exports = {
 		],
 		// Exclusion per handler
 		handlerExclusions: {
+			"pipeline-trigger-paths": [
+				// Not immediately obvious if this needs the missing trigger section
+				"tools/pipelines/publish-api-model-artifact.yml"
+			],
 			"fluid-build-tasks-eslint": [
 				// This policy needs to be rethought in light of eslint 9. Disabling everywhere in the meantime.
 				".*",

--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -38,7 +38,13 @@ trigger:
     - tools/pipelines/build-api-markdown-documenter.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -47,6 +53,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 pr:
@@ -65,12 +74,24 @@ pr:
     - tools/pipelines/build-api-markdown-documenter.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 variables:

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -41,7 +41,13 @@ trigger:
     - tools/pipelines/build-benchmark-tool.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -50,6 +56,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 pr:
@@ -67,12 +76,24 @@ pr:
     - tools/pipelines/build-benchmark-tool.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 variables:

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -41,7 +41,12 @@ trigger:
     - tools/pipelines/build-build-common.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -51,6 +56,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 pr:
@@ -67,12 +75,24 @@ pr:
     - tools/pipelines/build-build-common.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 variables:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -54,7 +54,13 @@ trigger:
     - tools/pipelines/build-build-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -63,6 +69,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 pr:
@@ -80,12 +89,24 @@ pr:
     - tools/pipelines/build-build-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 variables:

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -14,6 +14,9 @@ trigger:
     - lts
     - release/*
 
+# This pipeline deliberatelyonly runs for commits in main
+pr: none
+
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self
 

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -106,7 +106,11 @@ trigger:
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-client-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -117,6 +121,7 @@ trigger:
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
     - tools/pipelines/templates/upload-telemetry/*
 
 pr:
@@ -174,13 +179,22 @@ pr:
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-client-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-policy-check.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
     - tools/pipelines/templates/upload-telemetry/*
 
 variables:

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -46,7 +46,12 @@ trigger:
     - tools/pipelines/build-common-utils.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -56,6 +61,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
 
 pr:
   branches:
@@ -76,12 +84,24 @@ pr:
     - tools/pipelines/build-common-utils.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -42,7 +42,12 @@ trigger:
     - tools/pipelines/build-eslint-config-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -52,6 +57,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 pr:
@@ -69,12 +77,24 @@ pr:
     - tools/pipelines/build-eslint-config-fluid.yml # Required since eslint-config-fluid takes a `file:` dependency on this package
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 variables:

--- a/tools/pipelines/build-eslint-plugin-fluid.yml
+++ b/tools/pipelines/build-eslint-plugin-fluid.yml
@@ -42,7 +42,12 @@ trigger:
     - tools/pipelines/build-eslint-plugin-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -52,6 +57,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 pr:
@@ -69,12 +77,24 @@ pr:
     - tools/pipelines/build-eslint-plugin-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - scripts/*
 
 variables:

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -47,7 +47,12 @@ trigger:
     - tools/pipelines/build-protocol-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -57,6 +62,9 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
 
 pr:
   branches:
@@ -77,12 +85,24 @@ pr:
     - tools/pipelines/build-protocol-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-build-lint.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -35,6 +35,15 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - tools/test-tools
     - tools/pipelines/build-test-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
@@ -59,6 +68,18 @@ pr:
   paths:
     include:
     - .prettierignore
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
+    - tools/pipelines/templates/include-test-task.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
+    - tools/pipelines/templates/upload-telemetry/include-stage-upload-telemetry.yml
+    - tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml
     - tools/test-tools
     - tools/pipelines/build-test-tools.yml
     - tools/pipelines/templates/build-npm-package.yml

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -49,7 +49,12 @@ trigger:
     - server/gitrest
     - tools/pipelines/server-gitrest.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
@@ -60,6 +65,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 pr:
   branches:
@@ -75,10 +81,23 @@ pr:
     - server/gitrest
     - tools/pipelines/server-gitrest.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-generate-notice-steps.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 
 variables:

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -39,11 +39,23 @@ trigger:
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-generate-notice-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
+    - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 pr:
   branches:
@@ -59,9 +71,23 @@ pr:
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-generate-notice-steps.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
+    - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -49,7 +49,12 @@ trigger:
     - server/historian
     - tools/pipelines/server-historian.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
@@ -60,6 +65,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 pr:
   branches:
@@ -75,10 +81,23 @@ pr:
     - server/historian
     - tools/pipelines/server-historian.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-generate-notice-steps.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-dev-manifest.yml
+    - tools/pipelines/templates/upload-server-manifest.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -61,7 +61,12 @@ trigger:
     - server/routerlicious
     - tools/pipelines/server-routerlicious.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
@@ -71,6 +76,7 @@ trigger:
     - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-dev-manifest.yml
     - tools/pipelines/templates/upload-server-manifest.yml
     exclude:
     - server/routerlicious/kubernetes/routerlicious
@@ -91,10 +97,21 @@ pr:
     - tools/pipelines/server-routerlicious.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+    - tools/pipelines/templates/include-install-build-tools.yml
+    - tools/pipelines/templates/include-policy-check.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-upload-release-reports.yml
+    - tools/pipelines/templates/include-vars-docker.yml
+    - tools/pipelines/templates/include-vars-telemetry-generator.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
+    - tools/pipelines/templates/upload-dev-manifest.yml
     - tools/pipelines/templates/upload-server-manifest.yml
     exclude:
     - server/routerlicious/kubernetes/routerlicious

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -26,6 +26,7 @@ trigger:
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
     - tools/pipelines/test-perf-benchmarks.yml
+    - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-upload-npm-logs.yml
     - tools/pipelines/templates/include-use-node-version.yml


### PR DESCRIPTION
## Description

Adds a policy check handler that transitively checks ADO pipeline yml files for all the templates they use, and ensures that they are listed in the pipeline's trigger paths.

Fully courtesy of Claude, and the updates to the pipelines were from the policy check fixer.

Errors look like this:

```
WARNING: 
file failed the "pipeline-trigger-paths" policy: tools/pipelines/build-api-markdown-documenter.yml
'trigger.paths.include' is missing entries (shown as inclusion chain → missing template):
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → include-publish-npm-package-deployment.yml → include-git-tag-steps.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-install-build-tools.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-install.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-test-task.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → upload-server-manifest.yml → include-upload-release-reports.yml
  - build-api-markdown-documenter.yml → include-vars.yml → include-vars-telemetry-generator.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → upload-server-manifest.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-stage-upload-telemetry.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-steps-upload-stage-timing.yml
'pr.paths.include' is missing entries (shown as inclusion chain → missing template):
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → include-publish-npm-package-deployment.yml → include-git-tag-steps.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-install-build-tools.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-install.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → include-publish-npm-package-deployment.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → include-publish-npm-package-deployment.yml → include-publish-npm-package-steps.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-test-task.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → upload-server-manifest.yml → include-upload-release-reports.yml
  - build-api-markdown-documenter.yml → include-vars.yml → include-vars-telemetry-generator.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-publish-npm-package.yml → upload-server-manifest.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-stage-upload-telemetry.yml
  - build-api-markdown-documenter.yml → build-npm-package.yml → include-steps-upload-stage-timing.yml
```


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This is a bit over-zealous, some pipelines might never (today!) include a given template in practice because of conditionals, but keeping track of that through time when making changes to the pipelines is hard and can result in missed triggers. With this approach, the tradeoff is we'll spend more compute running some of the pipelines when maybe it wasn't strictly necessary, but compute is relatively cheap, so I think this side of the tradeoff is acceptable.
