### PR TITLE
fix(tree): Extend correctness-mode timeout for Multi-peer EditManager benches

### DIFF
--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -218,6 +218,10 @@ describe("EditManager - Bench", () => {
 					benchmarkIt({
 						type,
 						title: `Rebase edits from ${peerCount} peers each sending ${editsPerPeerCount} commits`,
+						// These tests run close to the default 2s mocha timeout in correctness mode and
+						// have flaked on CI (see ICM 792323064 / 787811568, ADO 72685). Extend the
+						// correctness-mode timeout while leaving perf-mode timeouts unchanged.
+						correctnessTimeoutMs: 20_000,
 						...benchmarkDurationBatchless({
 							benchmarkFn: (state) => {
 								let running: boolean;

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -219,7 +219,9 @@ describe("EditManager - Bench", () => {
 						type,
 						title: `Rebase edits from ${peerCount} peers each sending ${editsPerPeerCount} commits`,
 						// Occasionally exceeds the default 2s mocha timeout in correctness mode on
-						// slow CI agents (ICM 792323064 / 787811568, AB#72685).
+						// slow CI agents (ICM 792323064 / 787811568).
+						// TODO:AB#72685: Speed up these tests and/or address cause of occasional slowdowns on CI,
+						// and remove (or at least reduce) this timeout override.
 						correctnessTimeoutMs: 5000,
 						...benchmarkDurationBatchless({
 							benchmarkFn: (state) => {

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -218,10 +218,9 @@ describe("EditManager - Bench", () => {
 					benchmarkIt({
 						type,
 						title: `Rebase edits from ${peerCount} peers each sending ${editsPerPeerCount} commits`,
-						// These tests run close to the default 2s mocha timeout in correctness mode and
-						// have flaked on CI (see ICM 792323064 / 787811568, AB#72685). Extend the
-						// correctness-mode timeout while leaving perf-mode timeouts unchanged.
-						correctnessTimeoutMs: 20_000,
+						// Occasionally exceeds the default 2s mocha timeout in correctness mode on
+						// slow CI agents (ICM 792323064 / 787811568, AB#72685).
+						correctnessTimeoutMs: 5000,
 						...benchmarkDurationBatchless({
 							benchmarkFn: (state) => {
 								let running: boolean;

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -219,7 +219,7 @@ describe("EditManager - Bench", () => {
 						type,
 						title: `Rebase edits from ${peerCount} peers each sending ${editsPerPeerCount} commits`,
 						// These tests run close to the default 2s mocha timeout in correctness mode and
-						// have flaked on CI (see ICM 792323064 / 787811568, ADO 72685). Extend the
+						// have flaked on CI (see ICM 792323064 / 787811568, AB#72685). Extend the
 						// correctness-mode timeout while leaving perf-mode timeouts unchanged.
 						correctnessTimeoutMs: 20_000,
 						...benchmarkDurationBatchless({


### PR DESCRIPTION
## Description

The `EditManager - Bench` → `Multi-peer commit rebasing` benchmarks have occasionally flaked in correctness-mode CI runs by exceeding mocha's default 2000ms timeout (ICM 792323064 / 787811568, [AB#72685](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/72685)). Typical runs are well under 2s, but slow CI agents and inflated runtimes caused by leaked state from earlier tests in the same process (separately under investigation) push some runs over the limit.

This PR uses the `correctnessTimeoutMs` option from `@fluid-tools/benchmark` to extend the mocha timeout to 5s when these benchmarks run in correctness mode — matching the convention used in `sharedTree.bench.ts`. Performance-mode timeouts are unchanged, so this does not mask real perf regressions.

This is a follow-on to #27142, which applied the same correctness-mode mitigation to the sibling `Local`/`Peer` rebase scenarios but did not cover the `Multi-peer` block.