### PR TITLE
build(build-tools): update ts-morph and typescript dependencies

### DIFF
--- a/build-tools/.syncpackrc.yml
+++ b/build-tools/.syncpackrc.yml
@@ -116,6 +116,7 @@ semverGroups:
       - "less"
       - "prettier"
       - "typescript"
+      - "typescript-*"
       - "vue"
       - "webpack-dev-server"
     packages:

--- a/build-tools/DEV.md
+++ b/build-tools/DEV.md
@@ -2,11 +2,12 @@
 
 ## Dependencies
 
-This document tracks dependencies that cannot be upgraded to their latest major versions due to technical limitations.
+This document tracks dependencies that are specially managed for technical reasons.
 
 ### Dependencies Blocked from Major Version Upgrades
 
-The following dependencies are pinned to older major versions because newer versions are incompatible with the current CommonJS-based codebase. Most of these packages have migrated to ESM-only in their latest versions.
+The following dependencies are pinned to older major versions because newer versions may be incompatible with the current CommonJS-based codebase. Most of these packages have migrated to ESM-only in their latest versions and compatibility with "module-sync" has not been investigated.
+Migrating to ESM is recommended resolution.
 
 #### ESM-Only Dependencies (Cannot upgrade until build-tools migrates to ESM)
 
@@ -92,19 +93,7 @@ The following dependencies are pinned to older major versions because newer vers
     - Solution: pnpm override `@types/glob>@types/minimatch@~5.1.2` only affects the @types/glob dependency chain
     - Note: Targeted override allows rest of codebase to use modern minimatch/types while maintaining compatibility for glob types
 
-13. **typescript** - Pinned to `~5.4.5`
-    - Latest: `~5.7.x`
-    - Issue: Version 5.9+ has stricter type checking that exposes issues with @octokit dependencies
-    - Error: `Cannot find name 'ErrorOptions'`
-    - Used in: `build-cli` (devDependency)
-
-14. **ts-morph** - Pinned to `^22.x`
-    - Latest: `^27.x`
-    - Issue: Version 27+ requires newer TypeScript lib types
-    - Error: `Cannot find name 'MapIterator'`
-    - Used in: `build-cli`
-
-15. **azure-devops-node-api** - Pinned to `^11.x`
+13. **azure-devops-node-api** - Pinned to `^11.x`
     - Latest: `^15.x`
     - Issue: Version 15 has incompatible type definitions and breaks bundle size analysis tools
     - Error: `Types have separate declarations of a private property` and `Type is missing properties`
@@ -113,22 +102,28 @@ The following dependencies are pinned to older major versions because newer vers
 
 #### API/Structure Breaking Changes
 
-16. **eslint** - Upgraded to `^9.x` ✅
+14. **eslint** - Upgraded to `^9.x` ✅
     - Latest: `^9.x`
     - Previously pinned to `~8.57.0` due to flat config migration required
     - **Note**: Successfully migrated to ESLint 9 flat config system
 
-17. **eslint-config-oclif** - Removed ✅
+15. **eslint-config-oclif** - Removed ✅
     - Previously used `eslint-config-oclif@^5.x` and `eslint-config-oclif-typescript@^3.x`
     - **Note**: Permanently removed. The oclif ESLint configs don't provide oclif-specific rules—they're general Node.js/TypeScript style configs (XO-based) that conflict with `@fluidframework/eslint-config-fluid`. The v6 config redefines the `@typescript-eslint` plugin causing ESLint errors.
     - Oclif-specific overrides (default exports, etc.) are handled in per-package `eslint.config.mts` files.
 
-18. **npm-check-updates** - Pinned to `^16.x`
+16. **npm-check-updates** - Pinned to `^16.x`
     - Latest: `^19.x`
     - Highest compatible: `^16.x` (v17+ changed internal module structure)
     - Issue: Version 17+ changed internal module structure and removed exported types
     - Error: `Cannot find module 'npm-check-updates/build/src/types/IndexType.js'` and type errors
     - Used in: `build-cli`
+
+### `build-cli` sets skipLibCheck for `vscode-jsonrpc`
+
+`vscode-jsonrpc` (transitive dep via `@github/copilot-sdk`) uses `IterableIterator` in its `LinkedMap` types, which is incompatible with TS 5.6+'s `MapIterator`.
+See https://github.com/microsoft/vscode-languageserver-node/issues/1590 tracking the issue.
+Fix will be in `vscode-jsonrpc` 9.0.0 which has not been released as of 2026-05-10.
 
 ### Linked Dependency: ESLint Config
 

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -95,7 +95,7 @@
 		"rimraf": "^6.1.3",
 		"run-script-os": "^1.1.6",
 		"syncpack": "^13.0.4",
-		"typescript": "~5.4.5"
+		"typescript": "~5.9.3"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -141,7 +141,7 @@
 		"sort-package-json": "1.57.0",
 		"strip-ansi": "^7.1.2",
 		"table": "^6.9.0",
-		"ts-morph": "^22.0.0",
+		"ts-morph": "^27.0.2",
 		"unist-util-visit": "^5.0.0",
 		"xml2js": "^0.6.2",
 		"yaml": "^2.8.1"
@@ -182,7 +182,7 @@
 		"ts-node": "^10.9.2",
 		"tslib": "^2.8.1",
 		"type-fest": "^2.19.0",
-		"typescript": "~5.4.5"
+		"typescript": "~5.9.3"
 	},
 	"engines": {
 		"node": ">=22.22.2"

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -180,8 +180,9 @@ async function extractPackageJsonFromTarball(
 	let unzipped: Uint8Array;
 
 	{
-		// eslint-disable-next-line no-return-assign -- assigning the chunk to unzipped is intentional
-		const gunzip = new Gunzip((chunk: Uint8Array) => (unzipped = chunk));
+		const gunzip = new Gunzip((chunk: Uint8Array) => {
+			unzipped = chunk;
+		});
 		gunzip.push(tarball, /* final */ true);
 	}
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -185,7 +185,7 @@ async function extractPackageJsonFromTarball(
 		gunzip.push(tarball, /* final */ true);
 	}
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const data = untar(unzipped!);
+	const data = untar(unzipped!.buffer as ArrayBuffer);
 	// eslint-disable-next-line unicorn/prefer-string-slice -- substring is clearer than slice in this case
 	const prefix = data[0].filename.substring(0, data[0].filename.indexOf("/") + 1);
 	const packageJsonText = data.find((f) => f.filename === `${prefix}package.json`)?.fileData;

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildDatabase.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildDatabase.ts
@@ -165,7 +165,7 @@ function tscOutput(
 		configJson,
 		ts.sys,
 		configDir,
-		commandOptions,
+		tscUtils.castOptionsUnionToIntersection(commandOptions),
 		configFile,
 	);
 

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -685,16 +685,17 @@ function getTscCommandDependencies(
 	command: string,
 	packageMap: ReadonlyMap<string, Package>,
 ): (string | string[])[] {
+	const tscUtils = TscUtils.getTscUtils(packageDir);
 	// If the project has a referenced project, depend on that instead of the default
-	const parsedCommand = TscUtils.parseCommandLine(command);
+	const parsedCommand = tscUtils.parseCommandLine(command);
 	if (!parsedCommand) {
 		throw new Error(`Error parsing tsc command for script '${script}': ${command}`);
 	}
-	const configFile = TscUtils.findConfigFile(packageDir, parsedCommand);
+	const configFile = tscUtils.findConfigFile(packageDir, parsedCommand);
 	if (configFile === undefined) {
 		throw new Error(`Could not find config file for script '${script}' in ${packageDir}`);
 	}
-	const configJson = TscUtils.readConfigFile(configFile) as TsConfigJson;
+	const configJson = tscUtils.readConfigFile(configFile) as TsConfigJson;
 	if (configJson === undefined) {
 		throw new Error(`Failed to load config file '${configFile}'`);
 	}
@@ -876,12 +877,13 @@ export const handlers: Handler[] = [
 				file,
 				root,
 				({ packageDir, script, command }: BuildDepsCallbackContext) => {
+					const tscUtils = TscUtils.getTscUtils(packageDir);
 					// If the project has a referenced project, depend on that instead of the default
-					const parsedCommand = TscUtils.parseCommandLine(command);
+					const parsedCommand = tscUtils.parseCommandLine(command);
 					if (!parsedCommand) {
 						throw new Error(`Error parsing tsc command for script '${script}': ${command}`);
 					}
-					const configFile = TscUtils.findConfigFile(packageDir, parsedCommand);
+					const configFile = tscUtils.findConfigFile(packageDir, parsedCommand);
 					if (configFile === undefined) {
 						throw new Error(
 							`Could not find config file for script '${script}' in ${packageDir}`,

--- a/build-tools/packages/build-cli/tsconfig.json
+++ b/build-tools/packages/build-cli/tsconfig.json
@@ -11,5 +11,10 @@
 		"target": "ES2022",
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
+		// vscode-jsonrpc (transitive dep via @github/copilot-sdk) uses IterableIterator in its
+		// LinkedMap types, which is incompatible with TS 5.6+'s MapIterator.
+		// See https://github.com/microsoft/vscode-languageserver-node/issues/1590 tracking the issue.
+		// Fix will be in vscode-jsonrpc 9.0.0 which has not been released as of 2026-05-10.
+		"skipLibCheck": true,
 	},
 }

--- a/build-tools/packages/build-infrastructure/package.json
+++ b/build-tools/packages/build-infrastructure/package.json
@@ -76,7 +76,7 @@
 		"simple-git": "^3.32.3",
 		"sort-package-json": "1.57.0",
 		"type-fest": "^2.19.0",
-		"typescript": "~5.4.5"
+		"typescript": "~5.9.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~2.4.5",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -63,7 +63,7 @@
 		"sort-package-json": "1.57.0",
 		"ts-deepmerge": "^7.0.3",
 		"type-fest": "^2.19.0",
-		"typescript": "~5.4.5",
+		"typescript": "~5.9.3",
 		"yaml": "^2.8.1"
 	},
 	"devDependencies": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -63,7 +63,8 @@
 		"sort-package-json": "1.57.0",
 		"ts-deepmerge": "^7.0.3",
 		"type-fest": "^2.19.0",
-		"typescript": "~5.9.3",
+		"typescript-5.4": "npm:typescript@~5.4.5",
+		"typescript-5.9": "npm:typescript@~5.9.3",
 		"yaml": "^2.8.1"
 	},
 	"devDependencies": {
@@ -79,7 +80,8 @@
 		"@types/semver": "^7.7.1",
 		"eslint": "~9.39.2",
 		"json-schema-to-typescript": "^15.0.4",
-		"mocha": "^11.7.5"
+		"mocha": "^11.7.5",
+		"typescript": "~5.9.3"
 	},
 	"engines": {
 		"node": ">=22.22.2"

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -8,11 +8,15 @@ import { type BigIntStats, existsSync, lstatSync, type Stats } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import isEqual from "lodash.isequal";
-import type * as tsTypes from "typescript";
+import type * as ts54Types from "typescript-5.4";
+import type * as ts59Types from "typescript-5.9";
 
 import { getTscUtils, type TscUtil } from "../../tscUtils";
 import { getInstalledPackageVersion } from "../taskUtils";
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
+
+type tsTypes = typeof ts54Types | typeof ts59Types;
+type tsParsedCommandLine = ts54Types.ParsedCommandLine | ts59Types.ParsedCommandLine;
 
 interface ITsBuildInfo {
 	program: {
@@ -30,7 +34,7 @@ interface ITsBuildInfo {
 export class TscTask extends LeafTask {
 	private _tsBuildInfoFullPath: string | undefined;
 	private _tsBuildInfo: ITsBuildInfo | undefined;
-	private _tsConfig: tsTypes.ParsedCommandLine | undefined;
+	private _tsConfig: tsParsedCommandLine | undefined;
 	private _tsConfigFullPath: string | undefined;
 	private _projectReference: TscTask | undefined;
 	private _sourceStats: (Stats | BigIntStats)[] | undefined;
@@ -222,7 +226,7 @@ export class TscTask extends LeafTask {
 		return this.checkTsConfig(tsBuildInfoFileDirectory, tsBuildInfo, config);
 	}
 
-	private remapSrcDeclFile(fullPath: string, config: tsTypes.ParsedCommandLine): string {
+	private remapSrcDeclFile(fullPath: string, config: tsParsedCommandLine): string {
 		if (!this._sourceStats) {
 			this._sourceStats = config ? config.fileNames.map((v) => lstatSync(v)) : [];
 		}
@@ -239,7 +243,7 @@ export class TscTask extends LeafTask {
 	private checkTsConfig(
 		tsBuildInfoFileDirectory: string,
 		tsBuildInfo: ITsBuildInfo,
-		options: tsTypes.ParsedCommandLine,
+		options: tsParsedCommandLine,
 	): boolean {
 		const configFileFullPath = this.configFileFullPath;
 		if (!configFileFullPath) {
@@ -272,7 +276,7 @@ export class TscTask extends LeafTask {
 		return true;
 	}
 
-	private readTsConfig(): tsTypes.ParsedCommandLine | undefined {
+	private readTsConfig(): tsParsedCommandLine | undefined {
 		if (this._tsConfig == undefined) {
 			const parsedCommand = this.parsedCommandLine;
 			if (!parsedCommand) {
@@ -305,7 +309,7 @@ export class TscTask extends LeafTask {
 				config,
 				ts.sys,
 				configDir,
-				commandOptions,
+				tscUtils.castOptionsUnionToIntersection(commandOptions),
 				configFileFullPath,
 			);
 
@@ -337,7 +341,7 @@ export class TscTask extends LeafTask {
 		return this._tsConfigFullPath;
 	}
 
-	private get parsedCommandLine(): tsTypes.ParsedCommandLine | undefined {
+	private get parsedCommandLine(): tsParsedCommandLine | undefined {
 		const parsedCommand = this.getTscUtils().parseCommandLine(this.command);
 		if (!parsedCommand) {
 			this.traceError(`ts fail to parse command line ${this.command}`);
@@ -387,7 +391,7 @@ export class TscTask extends LeafTask {
 	}
 
 	private remapOutFile(
-		options: tsTypes.ParsedCommandLine,
+		options: tsParsedCommandLine,
 		directory: string,
 		fileName: string,
 	): string {

--- a/build-tools/packages/build-tools/src/fluidBuild/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tsCompile.ts
@@ -4,9 +4,19 @@
  */
 
 import path from "path";
-import type * as tsTypes from "typescript";
+import type * as ts54Types from "typescript-5.4";
+import type * as ts59Types from "typescript-5.9";
 import { defaultLogger } from "../common/logging.js";
+import type { UnionToIntersection } from "./tscUtils.js";
 import { getTscUtils, normalizeSlashes } from "./tscUtils.js";
+
+type tsDiagnostic = ts54Types.Diagnostic | ts59Types.Diagnostic;
+
+function castDiagnosticsUnionArrayToIntersection(
+	diagnostics: tsDiagnostic[],
+): UnionToIntersection<tsDiagnostic>[] {
+	return diagnostics as unknown as UnionToIntersection<tsDiagnostic>[];
+}
 
 interface TsCompileOptions {
 	/**
@@ -53,16 +63,20 @@ export function tsCompile(
 	let commandLine = tscUtils.parseCommandLine(command);
 	let configFileName: string | undefined;
 	const currentDirectorySystem = { ...ts.sys, getCurrentDirectory: () => cwd };
-	const diagnostics: tsTypes.Diagnostic[] = [];
+	const diagnostics: tsDiagnostic[] = [];
 	if (commandLine) {
 		configFileName = tscUtils.findConfigFile(cwd, commandLine);
 		if (configFileName) {
-			commandLine = ts.getParsedCommandLineOfConfigFile(configFileName, commandLine.options, {
-				...currentDirectorySystem,
-				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsTypes.Diagnostic) => {
-					diagnostics.push(diagnostic);
+			commandLine = ts.getParsedCommandLineOfConfigFile(
+				configFileName,
+				tscUtils.castOptionsUnionToIntersection(commandLine.options),
+				{
+					...currentDirectorySystem,
+					onUnRecoverableConfigFileDiagnostic: (diagnostic: tsDiagnostic) => {
+						diagnostics.push(diagnostic);
+					},
 				},
-			});
+			);
 		} else {
 			throw new Error("Unknown config file in command line");
 		}
@@ -77,8 +91,10 @@ export function tsCompile(
 			? undefined
 			: (
 					host:
-						| tsTypes.CompilerHost
-						| tsTypes.WatchCompilerHostOfConfigFile<tsTypes.EmitAndSemanticDiagnosticsBuilderProgram>,
+						| ts54Types.CompilerHost
+						| ts59Types.CompilerHost
+						| ts54Types.WatchCompilerHostOfConfigFile<ts54Types.EmitAndSemanticDiagnosticsBuilderProgram>
+						| ts59Types.WatchCompilerHostOfConfigFile<ts59Types.EmitAndSemanticDiagnosticsBuilderProgram>,
 				): void => {
 					const originalReadFile = host.readFile;
 					const packageJsonPath = normalizeSlashes(path.join(cwd, "package.json"));
@@ -97,6 +113,11 @@ export function tsCompile(
 					};
 				};
 
+		// The remainder of this block mostly uses a single version of TypeScript - a base
+		// version that is meant to represent the earliest supported version. `ts` should
+		// be used directly when allowed.
+		const baseTs = tscUtils.baseTs(ts);
+
 		if (commandLine.options.watch) {
 			if (allowWatch !== "allow-watch") {
 				throw new Error(
@@ -107,31 +128,40 @@ export function tsCompile(
 				throw new Error("A config file is required when --watch option is specified.");
 			}
 
-			const host = ts.createWatchCompilerHost(
+			const host = baseTs.createWatchCompilerHost(
 				configFileName,
-				commandLine.options,
+				tscUtils.castOptionsUnionToIntersection(commandLine.options),
 				currentDirectorySystem,
-				ts.createEmitAndSemanticDiagnosticsBuilderProgram,
+				baseTs.createEmitAndSemanticDiagnosticsBuilderProgram,
 			);
 			applyPackageJsonTypeOverride?.(host);
-			ts.createWatchProgram(host);
+			baseTs.createWatchProgram(host);
 			return undefined;
 		}
 
 		const incremental = !!(commandLine.options.incremental || commandLine.options.composite);
 
+		// baseTs is used here so that host is a specific version and can be passed to .create*Program params below.
 		const host = incremental
-			? ts.createIncrementalCompilerHost(commandLine.options)
-			: ts.createCompilerHost(commandLine.options);
+			? baseTs.createIncrementalCompilerHost(
+					tscUtils.castOptionsUnionToIntersection(commandLine.options),
+				)
+			: baseTs.createCompilerHost(
+					tscUtils.castOptionsUnionToIntersection(commandLine.options),
+				);
 		applyPackageJsonTypeOverride?.(host);
 
 		const param = {
 			rootNames: commandLine.fileNames,
-			options: tscUtils.convertOptionPaths(commandLine.options, cwd, path.resolve),
+			options: tscUtils.castOptionsUnionToIntersection(
+				tscUtils.convertOptionPaths(commandLine.options, cwd, path.resolve),
+			),
 			host,
 			projectReferences: commandLine.projectReferences,
 		};
-		const program = incremental ? ts.createIncrementalProgram(param) : ts.createProgram(param);
+		const program = incremental
+			? baseTs.createIncrementalProgram(param)
+			: baseTs.createProgram(param);
 
 		diagnostics.push(...program.getConfigFileParsingDiagnostics());
 		diagnostics.push(...program.getSyntacticDiagnostics());
@@ -159,9 +189,13 @@ export function tsCompile(
 	}
 
 	if (diagnostics.length > 0) {
-		const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
+		const sortedDiagnostics = tscUtils
+			.baseTs(ts)
+			.sortAndDeduplicateDiagnostics(castDiagnosticsUnionArrayToIntersection(diagnostics));
 
-		const formatDiagnosticsHost: tsTypes.FormatDiagnosticsHost = {
+		const formatDiagnosticsHost:
+			| ts54Types.FormatDiagnosticsHost
+			| ts59Types.FormatDiagnosticsHost = {
 			getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
 			getCanonicalFileName: tscUtils.getCanonicalFileName,
 			getNewLine: () => ts.sys.newLine,

--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -5,13 +5,11 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import * as ts from "typescript";
+import type * as ts54Types from "typescript-5.4";
+import type * as ts59Types from "typescript-5.9";
 import { sha256 } from "./hash";
 
-const defaultTscUtil = createTscUtil(ts);
-export const parseCommandLine = defaultTscUtil.parseCommandLine;
-export const findConfigFile = defaultTscUtil.findConfigFile;
-export const readConfigFile = defaultTscUtil.readConfigFile;
+type tsTypes = typeof ts54Types | typeof ts59Types;
 
 /**
  * Matches fluid-tsc command start.
@@ -102,11 +100,13 @@ function filterIncrementalOptions(options: any): Record<string, unknown> {
 	return newOptions;
 }
 
-function convertOptionPaths(
-	options: ts.CompilerOptions,
+function convertOptionPaths<
+	TCompilerOptions extends ts54Types.CompilerOptions | ts59Types.CompilerOptions,
+>(
+	options: TCompilerOptions,
 	base: string,
 	convert: (base: string, path: string) => string,
-): ts.CompilerOptions {
+): TCompilerOptions {
 	// Shallow clone 'CompilerOptions' before modifying.
 	const result = { ...options };
 
@@ -145,14 +145,14 @@ function toLowerCase(x: string): string {
 // eslint-disable-next-line no-useless-escape
 const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
 
-function createGetCanonicalFileName(tsLib: typeof ts): (x: string) => string {
+function createGetCanonicalFileName(tsLib: tsTypes): (x: string) => string {
 	return tsLib.sys.useCaseSensitiveFileNames
 		? (x: string): string => x
 		: (x: string): string =>
 				fileNameLowerCaseRegExp.test(x) ? x.replace(fileNameLowerCaseRegExp, toLowerCase) : x;
 }
 
-function createGetSourceFileVersion(tsLib: typeof ts): (buffer: Buffer) => string {
+function createGetSourceFileVersion(tsLib: tsTypes): (buffer: Buffer) => string {
 	// The TypeScript compiler performs some light preprocessing of the source file
 	// text before calculating the file hashes that appear in *.tsbuildinfo.
 	//
@@ -186,26 +186,64 @@ function createGetSourceFileVersion(tsLib: typeof ts): (buffer: Buffer) => strin
 }
 
 /**
+ * Convert a union of types to an intersection of types.
+ *
+ * @privateRemarks
+ * First an always true extends clause is used (T extends T) to distribute T
+ * into to a union of types contravariant over each member of the T union.
+ * Then the constraint on the type parameter in this new context is inferred,
+ * giving the intersection.
+ *
+ * See {@link https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types|Distributive conditional types}
+ * and {@link https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types|Inference in conditional types} in TS Handbook for more details and examples.
+ */
+export type UnionToIntersection<T> = (T extends T ? (k: T) => unknown : never) extends (
+	k: infer U,
+) => unknown
+	? U
+	: never;
+
+/**
  * TypeScript compiler utilities created for a specific TypeScript library instance.
  */
-export interface TscUtil {
-	tsLib: typeof ts;
-	parseCommandLine: (command: string) => ts.ParsedCommandLine | undefined;
+export interface TscUtil<TSTypes extends tsTypes = tsTypes> {
+	tsLib: TSTypes;
+	parseCommandLine: (command: string) => ReturnType<TSTypes["parseCommandLine"]> | undefined;
 	findConfigFile: (
 		directory: string,
-		parsedCommand: ts.ParsedCommandLine | undefined,
+		parsedCommand: ReturnType<TSTypes["parseCommandLine"]> | undefined,
 	) => string | undefined;
 	readConfigFile: (path: string) => unknown;
 	filterIncrementalOptions: typeof filterIncrementalOptions;
 	convertOptionPaths: typeof convertOptionPaths;
 	getCanonicalFileName: (x: string) => string;
 	getSourceFileVersion: (buffer: Buffer) => string;
+	/**
+	 * Cast helper for generic use context that always targets a single TypeScript version.
+	 *
+	 * @remarks
+	 * options value give should always originate from the version that will consume the output.
+	 *
+	 * @param options Options specific to certain version of TypeScript
+	 * @returns Casted version of options that can be given to any TypeScript and therefore also to the specific version.
+	 */
+	castOptionsUnionToIntersection: (
+		options: ReturnType<TSTypes["parseCommandLine"]>["options"],
+	) => UnionToIntersection<ReturnType<TSTypes["parseCommandLine"]>["options"]>;
+	/**
+	 * Cast helper to most basic version of TypeScript (oldest supported)
+	 * @param ts Any of the supported typescript modules
+	 * @returns Most basic version of typescript
+	 */
+	baseTs: (ts: TSTypes) => typeof ts54Types;
 }
 
-function createTscUtil(tsLib: typeof ts): TscUtil {
+function createTscUtil<TSTypes extends tsTypes>(tsLib: TSTypes): TscUtil<TSTypes> {
 	return {
 		tsLib,
-		parseCommandLine: (command: string): ts.ParsedCommandLine | undefined => {
+		parseCommandLine: (
+			command: string,
+		): ReturnType<TSTypes["parseCommandLine"]> | undefined => {
 			// TODO: parse the command line for real, split space for now.
 			// In case of fluid-tsc, replace those parts with 'tsc' before split.
 			const args = command.replace(fluidTscRegEx, "tsc").split(" ");
@@ -232,12 +270,12 @@ function createTscUtil(tsLib: typeof ts): TscUtil {
 				return undefined;
 			}
 
-			return parsedCommand;
+			return parsedCommand as ReturnType<TSTypes["parseCommandLine"]>;
 		},
 
 		findConfigFile: (
 			directory: string,
-			parsedCommand: ts.ParsedCommandLine | undefined,
+			parsedCommand: ReturnType<TSTypes["parseCommandLine"]> | undefined,
 		): string | undefined => {
 			let tsConfigFullPath: string | undefined;
 			const project = parsedCommand?.options.project;
@@ -275,6 +313,13 @@ function createTscUtil(tsLib: typeof ts): TscUtil {
 		convertOptionPaths,
 		getCanonicalFileName: createGetCanonicalFileName(tsLib),
 		getSourceFileVersion: createGetSourceFileVersion(tsLib),
+		castOptionsUnionToIntersection: (
+			options: ReturnType<TSTypes["parseCommandLine"]>["options"],
+		) =>
+			options as unknown as UnionToIntersection<
+				ReturnType<TSTypes["parseCommandLine"]>["options"]
+			>,
+		baseTs: (ts: TSTypes) => ts as typeof ts54Types,
 	};
 }
 
@@ -296,7 +341,7 @@ export function getTscUtils(path: string): TscUtil {
 		}
 
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const tsLib: typeof ts = require(tsPath);
+		const tsLib: tsTypes = require(tsPath);
 		const tscUtil = createTscUtil(tsLib);
 		tscUtilPathCache.set(path, tscUtil);
 		tscUtilLibPathCache.set(tsPath, tscUtil);

--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -215,7 +215,9 @@ export interface TscUtil<TSTypes extends tsTypes = tsTypes> {
 	) => string | undefined;
 	readConfigFile: (path: string) => unknown;
 	filterIncrementalOptions: typeof filterIncrementalOptions;
-	convertOptionPaths: typeof convertOptionPaths;
+	convertOptionPaths: typeof convertOptionPaths<
+		ReturnType<TSTypes["parseCommandLine"]>["options"]
+	>;
 	getCanonicalFileName: (x: string) => string;
 	getSourceFileVersion: (buffer: Buffer) => string;
 	/**

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -104,7 +104,7 @@
 		"rimraf": "^6.1.3",
 		"ts-node": "^10.9.2",
 		"tslib": "^2.8.1",
-		"typescript": "~5.4.5"
+		"typescript": "~5.9.3"
 	},
 	"engines": {
 		"node": ">=22.22.2"

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -45,13 +45,13 @@ importers:
         version: 2.4.5
       '@commitlint/cli':
         specifier: ^20.1.0
-        version: 20.1.0(@types/node@22.19.17)(typescript@5.4.5)
+        version: 20.1.0(@types/node@22.19.17)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^20.0.0
         version: 20.0.0
       '@commitlint/cz-commitlint':
         specifier: ^20.1.0
-        version: 20.1.0(@types/node@22.19.17)(commitizen@4.3.1(@types/node@22.19.17)(typescript@5.4.5))(inquirer@9.3.8(@types/node@22.19.17))(typescript@5.4.5)
+        version: 20.1.0(@types/node@22.19.17)(commitizen@4.3.1(@types/node@22.19.17)(typescript@5.9.3))(inquirer@9.3.8(@types/node@22.19.17))(typescript@5.9.3)
       '@fluid-tools/build-cli':
         specifier: ~0.63.0
         version: 0.63.0(@types/node@22.19.17)(encoding@0.1.13)
@@ -72,7 +72,7 @@ importers:
         version: 10.1.3
       commitizen:
         specifier: ^4.3.1
-        version: 4.3.1(@types/node@22.19.17)(typescript@5.4.5)
+        version: 4.3.1(@types/node@22.19.17)(typescript@5.9.3)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -87,7 +87,7 @@ importers:
         version: 2.4.1
       cz-conventional-changelog:
         specifier: ^3.3.0
-        version: 3.3.0(@types/node@22.19.17)(typescript@5.4.5)
+        version: 3.3.0(@types/node@22.19.17)(typescript@5.9.3)
       cz-customizable:
         specifier: ^7.5.4
         version: 7.5.4
@@ -108,10 +108,10 @@ importers:
         version: 1.1.6
       syncpack:
         specifier: ^13.0.4
-        version: 13.0.4(typescript@5.4.5)
+        version: 13.0.4(typescript@5.9.3)
       typescript:
-        specifier: ~5.4.5
-        version: 5.4.5
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/build-cli:
     dependencies:
@@ -284,8 +284,8 @@ importers:
         specifier: ^6.9.0
         version: 6.9.0
       ts-morph:
-        specifier: ^22.0.0
-        version: 22.0.0
+        specifier: ^27.0.2
+        version: 27.0.2
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -394,7 +394,7 @@ importers:
         version: 6.1.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.17)(typescript@5.4.5)
+        version: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -402,8 +402,8 @@ importers:
         specifier: ^2.19.0
         version: 2.19.0
       typescript:
-        specifier: ~5.4.5
-        version: 5.4.5
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/build-infrastructure:
     dependencies:
@@ -456,8 +456,8 @@ importers:
         specifier: ^2.19.0
         version: 2.19.0
       typescript:
-        specifier: ~5.4.5
-        version: 5.4.5
+        specifier: ~5.9.3
+        version: 5.9.3
     devDependencies:
       '@biomejs/biome':
         specifier: ~2.4.5
@@ -527,13 +527,13 @@ importers:
         version: 6.1.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.17)(typescript@5.4.5)
+        version: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
       typedoc:
         specifier: ^0.28.14
-        version: 0.28.15(typescript@5.4.5)
+        version: 0.28.15(typescript@5.9.3)
       typedoc-plugin-markdown:
         specifier: ^4.9.0
-        version: 4.9.0(typedoc@0.28.15(typescript@5.4.5))
+        version: 4.9.0(typedoc@0.28.15(typescript@5.9.3))
 
   packages/build-tools:
     dependencies:
@@ -607,8 +607,8 @@ importers:
         specifier: ^2.19.0
         version: 2.19.0
       typescript:
-        specifier: ~5.4.5
-        version: 5.4.5
+        specifier: ~5.9.3
+        version: 5.9.3
       yaml:
         specifier: ^2.8.1
         version: 2.8.1
@@ -727,13 +727,13 @@ importers:
         version: 6.1.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.17)(typescript@5.4.5)
+        version: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
       typescript:
-        specifier: ~5.4.5
-        version: 5.4.5
+        specifier: ~5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -1916,6 +1916,9 @@ packages:
   '@ts-morph/common@0.23.0':
     resolution: {integrity: sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==}
 
+  '@ts-morph/common@0.28.1':
+    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+
   '@tsconfig/node10@1.0.9':
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
 
@@ -2603,6 +2606,9 @@ packages:
 
   code-block-writer@13.0.1:
     resolution: {integrity: sha512-c5or4P6erEA69TxaxTNcHUNcIn+oyxSRTOWV+pSYF+z4epXqNvwvJ70XPGjPNgue83oAFAPBRQYwpAJ/Hpe/Sg==}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
@@ -5619,6 +5625,9 @@ packages:
   ts-morph@22.0.0:
     resolution: {integrity: sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==}
 
+  ts-morph@27.0.2:
+    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -6116,11 +6125,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@20.1.0(@types/node@22.19.17)(typescript@5.4.5)':
+  '@commitlint/cli@20.1.0(@types/node@22.19.17)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 20.0.0
       '@commitlint/lint': 20.0.0
-      '@commitlint/load': 20.1.0(@types/node@22.19.17)(typescript@5.4.5)
+      '@commitlint/load': 20.1.0(@types/node@22.19.17)(typescript@5.9.3)
       '@commitlint/read': 20.0.0
       '@commitlint/types': 20.0.0
       tinyexec: 1.0.2
@@ -6139,13 +6148,13 @@ snapshots:
       '@commitlint/types': 20.0.0
       ajv: 8.18.0
 
-  '@commitlint/cz-commitlint@20.1.0(@types/node@22.19.17)(commitizen@4.3.1(@types/node@22.19.17)(typescript@5.4.5))(inquirer@9.3.8(@types/node@22.19.17))(typescript@5.4.5)':
+  '@commitlint/cz-commitlint@20.1.0(@types/node@22.19.17)(commitizen@4.3.1(@types/node@22.19.17)(typescript@5.9.3))(inquirer@9.3.8(@types/node@22.19.17))(typescript@5.9.3)':
     dependencies:
       '@commitlint/ensure': 20.0.0
-      '@commitlint/load': 20.1.0(@types/node@22.19.17)(typescript@5.4.5)
+      '@commitlint/load': 20.1.0(@types/node@22.19.17)(typescript@5.9.3)
       '@commitlint/types': 20.0.0
       chalk: 5.6.2
-      commitizen: 4.3.1(@types/node@22.19.17)(typescript@5.4.5)
+      commitizen: 4.3.1(@types/node@22.19.17)(typescript@5.9.3)
       inquirer: 9.3.8(@types/node@22.19.17)
       lodash.isplainobject: 4.0.6
       word-wrap: 1.2.5
@@ -6181,15 +6190,15 @@ snapshots:
       '@commitlint/rules': 20.0.0
       '@commitlint/types': 20.0.0
 
-  '@commitlint/load@20.1.0(@types/node@22.19.17)(typescript@5.4.5)':
+  '@commitlint/load@20.1.0(@types/node@22.19.17)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 20.0.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.1.0
       '@commitlint/types': 20.0.0
       chalk: 5.6.2
-      cosmiconfig: 9.0.0(typescript@5.4.5)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@22.19.17)(cosmiconfig@9.0.0(typescript@5.4.5))(typescript@5.4.5)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@22.19.17)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -7513,6 +7522,12 @@ snapshots:
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 
+  '@ts-morph/common@0.28.1':
+    dependencies:
+      minimatch: 10.2.4
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.15
+
   '@tsconfig/node10@1.0.9': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -8245,6 +8260,8 @@ snapshots:
 
   code-block-writer@13.0.1: {}
 
+  code-block-writer@13.0.3: {}
+
   code-excerpt@4.0.0:
     dependencies:
       convert-to-spaces: 2.0.1
@@ -8283,10 +8300,10 @@ snapshots:
 
   commander@9.5.0: {}
 
-  commitizen@4.3.1(@types/node@22.19.17)(typescript@5.4.5):
+  commitizen@4.3.1(@types/node@22.19.17)(typescript@5.9.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@22.19.17)(typescript@5.4.5)
+      cz-conventional-changelog: 3.3.0(@types/node@22.19.17)(typescript@5.9.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -8462,21 +8479,21 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@22.19.17)(cosmiconfig@9.0.0(typescript@5.4.5))(typescript@5.4.5):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@22.19.17)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@types/node': 22.19.17
-      cosmiconfig: 9.0.0(typescript@5.4.5)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
-      typescript: 5.4.5
+      typescript: 5.9.3
 
-  cosmiconfig@9.0.0(typescript@5.4.5):
+  cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.9.3
 
   create-require@1.1.1: {}
 
@@ -8492,16 +8509,16 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@22.19.17)(typescript@5.4.5):
+  cz-conventional-changelog@3.3.0(@types/node@22.19.17)(typescript@5.9.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@22.19.17)(typescript@5.4.5)
+      commitizen: 4.3.1(@types/node@22.19.17)(typescript@5.9.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 20.1.0(@types/node@22.19.17)(typescript@5.4.5)
+      '@commitlint/load': 20.1.0(@types/node@22.19.17)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -11682,12 +11699,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  syncpack@13.0.4(typescript@5.4.5):
+  syncpack@13.0.4(typescript@5.9.3):
     dependencies:
       chalk: 5.6.2
       chalk-template: 1.1.0
       commander: 13.1.0
-      cosmiconfig: 9.0.0(typescript@5.4.5)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       effect: 3.19.6
       enquirer: 2.4.1
       fast-check: 3.23.2
@@ -11827,7 +11844,12 @@ snapshots:
       '@ts-morph/common': 0.23.0
       code-block-writer: 13.0.1
 
-  ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5):
+  ts-morph@27.0.2:
+    dependencies:
+      '@ts-morph/common': 0.28.1
+      code-block-writer: 13.0.3
+
+  ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -11841,7 +11863,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.4.5
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -11897,17 +11919,17 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-plugin-markdown@4.9.0(typedoc@0.28.15(typescript@5.4.5)):
+  typedoc-plugin-markdown@4.9.0(typedoc@0.28.15(typescript@5.9.3)):
     dependencies:
-      typedoc: 0.28.15(typescript@5.4.5)
+      typedoc: 0.28.15(typescript@5.9.3)
 
-  typedoc@0.28.15(typescript@5.4.5):
+  typedoc@0.28.15(typescript@5.9.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.17.0
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.9
-      typescript: 5.4.5
+      typescript: 5.9.3
       yaml: 2.8.1
 
   typescript@5.4.5: {}

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -606,9 +606,12 @@ importers:
       type-fest:
         specifier: ^2.19.0
         version: 2.19.0
-      typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+      typescript-5.4:
+        specifier: npm:typescript@~5.4.5
+        version: typescript@5.4.5
+      typescript-5.9:
+        specifier: npm:typescript@~5.9.3
+        version: typescript@5.9.3
       yaml:
         specifier: ^2.8.1
         version: 2.8.1
@@ -652,6 +655,9 @@ importers:
       mocha:
         specifier: ^11.7.5
         version: 11.7.5
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/version-tools:
     dependencies:


### PR DESCRIPTION
Update:
 - ts-morph to ^27.0.2
 - typescript to ~5.9.3 (same as api-extractor)

Replace `typescript` module types exposed through `TscUtils` with 5.4 and 5.9 union expecting the consumers use either.
  - no runtime check performed; just as none was previously, nor were peerDependencies specified
  - some helpers were added to `TscUtil` interface to help with using non-specific TypeScript version

Set skipLibCheck in build-cli per @github/copilot-sdk use of vscode-jsonrpc that does not have release supporting TS 5.6+.