### PR TITLE
fix(pipelines): set workingDirectory in copy-dev-dependencies pnpm install

### DIFF
--- a/tools/pipelines/templates/include-copy-dev-dependencies.yml
+++ b/tools/pipelines/templates/include-copy-dev-dependencies.yml
@@ -58,4 +58,5 @@ steps:
   retryCountOnTaskFailure: 10
   inputs:
     targetType: 'inline'
+    workingDirectory: ${{ parameters.destPackageLocation }}
     script: 'pnpm install --no-frozen-lockfile'


### PR DESCRIPTION
## Description

The `pnpm install - extra dependencies for test files` task in `tools/pipelines/templates/include-copy-dev-dependencies.yml` did not set a `workingDirectory`, so it ran in the agent default cwd (`/mnt/vss/_work/1/s`), which does not contain a `package.json` — only the `ff_pipeline_host/` subdir checked out by the surrounding pipeline does.

Adding `workingDirectory: ${{ parameters.destPackageLocation }}` fixes both
symptoms at once:
1. pnpm finds a `package.json` at cwd → no more `ERR_PNPM_NO_PKG_MANIFEST`.
2. Corepack honors the `packageManager` field → re-pins to `pnpm@10.33.0` and
   protects against future agent image drift.

This matches the pattern used by every surrounding pnpm task in `include-test-real-service.yml` (lines 290–297, 319–325, 335–344, 415, 450).

Observed in[ IcM 794217615 (Test - DDS Stress / tree_stress_tests failure, Sev 4).](https://portal.microsofticm.com/imp/v5/incidents/details/794217615/summary)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The template `include-copy-dev-dependencies.yml` is included from exactly one place (`include-test-real-service.yml:389`), where `destPackageLocation` is passed as `$(Pipeline.Workspace)/$(FFPipelineHostDirectory)` — the directory whose `package.json` carries the `packageManager` pin. So this change is contained and low-risk.
- Manual validation will be a rerun of the failing DDS Stress pipeline after merge.