### PR TITLE
fix(tree): Optionally use UUIDs for non-finalized identifiers in tree attach summaries

### DIFF
--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -25,6 +25,22 @@ export interface ChangeEncodingContext {
 	readonly revision: RevisionTag | undefined;
 	readonly idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	/**
+	 * When true, encoders must not emit op-space compressed IDs that have not
+	 * yet been finalized (i.e. negative integers). Instead, they emit the
+	 * stable UUID form, which any reader can resolve without access to the
+	 * originator's session state.
+	 * @remarks
+	 * Set by callers producing attach summaries (where the host runtime
+	 * passes no `incrementalSummaryContext`): the resulting blob may be
+	 * reused as a handle in later summaries, after which the originating
+	 * session's local ID state is no longer available to readers.
+	 *
+	 * This flag is propagated transitively through the change codec stack
+	 * (e.g. into `FieldBatchEncodingContext.idsMustBeFinalized` for builds
+	 * and refreshers inside changesets).
+	 */
+	readonly idsMustBeFinalized?: boolean;
 }
 
 export type ChangeFamilyCodec<TChange> = IJsonCodec<

--- a/packages/dds/tree/src/core/rebase/revisionTagCodec.ts
+++ b/packages/dds/tree/src/core/rebase/revisionTagCodec.ts
@@ -5,6 +5,7 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
+import { isStableId } from "@fluidframework/id-compressor/internal";
 
 import type { JsonCodecPart } from "../../codec/index.js";
 import type { ChangeEncodingContext } from "../change-family/index.js";
@@ -21,20 +22,30 @@ export class RevisionTagCodec
 		this.localSessionId = idCompressor.localSessionId;
 	}
 
-	public encode(tag: RevisionTag): EncodedRevisionTag {
-		return tag === "root"
-			? tag
-			: (this.idCompressor.normalizeToOpSpace(tag) as EncodedRevisionTag);
+	public encode(tag: RevisionTag, context: ChangeEncodingContext): EncodedRevisionTag {
+		if (tag === "root") {
+			return tag;
+		}
+		const opSpaceId = this.idCompressor.normalizeToOpSpace(tag);
+		// In contexts that require finalization (see `ChangeEncodingContext.idsMustBeFinalized`),
+		// a negative op-space ID would be unresolvable by clients loading the blob after the
+		// originating session's local state is gone. Emit the stable UUID instead.
+		if (context.idsMustBeFinalized === true && opSpaceId < 0) {
+			return this.idCompressor.decompress(tag) as EncodedRevisionTag;
+		}
+		return opSpaceId as EncodedRevisionTag;
 	}
 	public decode(tag: EncodedRevisionTag, context: ChangeEncodingContext): RevisionTag {
 		if (tag === "root") {
 			return tag;
 		}
-
-		assert(
-			typeof tag === "number",
-			0x88d /* String revision tag must be the literal 'root' */,
-		);
+		if (typeof tag === "string") {
+			assert(
+				isStableId(tag),
+				0x88d /* String revision tag must be 'root' or a stable UUID */,
+			);
+			return this.idCompressor.recompress(tag);
+		}
 		return this.idCompressor.normalizeToSessionSpace(tag, context.originatorId);
 	}
 }

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -36,10 +36,21 @@ export const SessionIdSchema = brandedStringType<SessionId>();
  * possible on readonly clients. These clients generally don't need ids, but  must be done at tree initialization time.
  */
 export type RevisionTag = SessionSpaceCompressedId | "root";
-export type EncodedRevisionTag = Brand<OpSpaceCompressedId, "EncodedRevisionTag"> | "root";
+/**
+ * The encoded form of a {@link RevisionTag}.
+ * @remarks
+ * - `"root"` is used for the trunk base.
+ * - A number is the finalized op-space ID emitted by
+ *   `IIdCompressor.normalizeToOpSpace`.
+ * - Any other string is the stable UUID fallback emitted when the encoder
+ *   is told `idsMustBeFinalized` and the op-space form would be negative
+ *   (i.e. the originator session has not yet been allocated a cluster).
+ *   See {@link ChangeEncodingContext.idsMustBeFinalized}.
+ */
+export type EncodedRevisionTag = Brand<OpSpaceCompressedId, "EncodedRevisionTag"> | string;
 export const RevisionTagSchema = Type.Union([
-	Type.Literal("root"),
-	brandedNumberType<Exclude<EncodedRevisionTag, string>>(),
+	Type.String(),
+	brandedNumberType<Brand<OpSpaceCompressedId, "EncodedRevisionTag">>(),
 ]);
 
 export type EncodedStableId = Brand<StableId, "EncodedStableId">;

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV1.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV1.ts
@@ -27,7 +27,14 @@ class MajorCodec implements IJsonCodec<Major, EncodedRevisionTag> {
 
 	public encode(major: Major): EncodedRevisionTag {
 		assert(major !== undefined, 0x88e /* Unexpected undefined revision */);
-		const id = this.revisionTagCodec.encode(major);
+		// The v1 schema does not allow stable-UUID strings, so pass
+		// `idsMustBeFinalized: false` and assert the result is finalized.
+		const id = this.revisionTagCodec.encode(major, {
+			originatorId: this.revisionTagCodec.localSessionId,
+			idCompressor: this.idCompressor,
+			revision: undefined,
+			idsMustBeFinalized: false,
+		});
 		/**
 		 * Preface: this codec is only used at summarization time (not for ops).
 		 * Note that the decode path must provide a session id in which to interpret the revision tag.
@@ -46,7 +53,7 @@ class MajorCodec implements IJsonCodec<Major, EncodedRevisionTag> {
 		 * The assert below will fail in such a scenario. This is addressed in the v2 codec.
 		 */
 		assert(
-			id === "root" || id >= 0,
+			id === "root" || (typeof id === "number" && id >= 0),
 			0x88f /* Expected final id on encode of detached field index revision */,
 		);
 		return id;
@@ -54,7 +61,7 @@ class MajorCodec implements IJsonCodec<Major, EncodedRevisionTag> {
 
 	public decode(major: EncodedRevisionTag): RevisionTag {
 		assert(
-			major === "root" || major >= 0,
+			major === "root" || (typeof major === "number" && major >= 0),
 			0x890 /* Expected final id on decode of detached field index revision */,
 		);
 		return this.revisionTagCodec.decode(major, {

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV2.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV2.ts
@@ -23,9 +23,16 @@ class MajorCodec implements IJsonCodec<Major> {
 
 	public encode(major: Major): EncodedRevisionTag | StableId {
 		assert(major !== undefined, 0xbfb /* Unexpected undefined revision */);
-		const id = this.revisionTagCodec.encode(major);
+		// Pass `idsMustBeFinalized: false`: this codec has its own stable-UUID
+		// fallback below, expressed in terms of the numeric op-space form.
+		const id = this.revisionTagCodec.encode(major, {
+			originatorId: this.revisionTagCodec.localSessionId,
+			idCompressor: this.idCompressor,
+			revision: undefined,
+			idsMustBeFinalized: false,
+		});
 
-		if (id !== "root" && id < 0) {
+		if (typeof id === "number" && id < 0) {
 			/**
 			 * This code path handles the case where the major revision is not finalized.
 			 * This can happen the SharedTree is being attached to an already attached container.
@@ -39,7 +46,9 @@ class MajorCodec implements IJsonCodec<Major> {
 
 	public decode(major: EncodedRevisionTag | StableId): RevisionTag {
 		assert(
-			major === "root" || (typeof major === "string" && isStableId(major)) || major >= 0,
+			major === "root" ||
+				(typeof major === "string" && isStableId(major)) ||
+				(typeof major === "number" && major >= 0),
 			0xbfd /* Expected root, stable, or final compressed id */,
 		);
 		if (typeof major === "string" && isStableId(major)) {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -106,6 +106,16 @@ export interface FieldBatchEncodingContext {
 	 * This will be defined if incremental encoding is supported and enabled.
 	 */
 	readonly incrementalEncoderDecoder?: IncrementalEncoderDecoder;
+	/**
+	 * When true, identifier values that would otherwise serialize as a non-finalized
+	 * (negative) op-space ID are emitted in their stable UUID form instead.
+	 * @remarks
+	 * Set by callers producing attach summaries (where the host runtime passes no
+	 * `incrementalSummaryContext`): the resulting blob may be reused as a handle in
+	 * later summaries, after which the originating session's local ID state is no
+	 * longer available to readers.
+	 */
+	readonly idsMustBeFinalized?: boolean;
 }
 /**
  * @remarks
@@ -125,6 +135,7 @@ function makeFieldBatchCodecForVersion(
 		fieldBatch: FieldBatch,
 		idCompressor: IIdCompressor,
 		incrementalEncoder: IncrementalEncoder | undefined,
+		idsMustBeFinalized: boolean,
 	) => EncodedFieldBatchV1OrV2,
 	encodedFieldBatchType: TSchema,
 ): CodecAndSchema<FieldBatch, FieldBatchEncodingContext> {
@@ -167,6 +178,7 @@ function makeFieldBatchCodecForVersion(
 							data,
 							context.idCompressor,
 							incrementalEncoder,
+							context.idsMustBeFinalized ?? false,
 						);
 					}
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -535,6 +535,16 @@ export class EncoderContext implements NodeEncodeBuilder, FieldEncodeBuilder {
 		 */
 		public readonly incrementalEncoder: IncrementalEncoder | undefined,
 		public readonly version: FieldBatchFormatVersion,
+		/**
+		 * When true, any encoded ID that would otherwise serialize as a non-finalized
+		 * (negative) op-space ID is emitted in its stable UUID form instead.
+		 * @remarks
+		 * Used when producing attach summaries (where `incrementalSummaryContext` is undefined):
+		 * the attach blob may be reused as a handle in later summaries with no intervening ops
+		 * to finalize local IDs, so any session-local IDs in the blob would be unresolvable
+		 * by clients that load after the IdCompressor's session state is gone.
+		 */
+		public readonly idsMustBeFinalized: boolean = false,
 	) {}
 
 	public nodeEncoderFromSchema(schemaName: TreeNodeSchemaIdentifier): NodeEncoder {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeEncoder.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeEncoder.ts
@@ -77,7 +77,15 @@ export class NodeShapeBasedEncoder
 			if (isStableId(cursor.value)) {
 				const sessionSpaceCompressedId = context.idCompressor.tryRecompress(cursor.value);
 				if (sessionSpaceCompressedId !== undefined) {
-					return context.idCompressor.normalizeToOpSpace(sessionSpaceCompressedId);
+					const opSpaceId = context.idCompressor.normalizeToOpSpace(sessionSpaceCompressedId);
+					// In attach-summary contexts (see EncoderContext.idsMustBeFinalized) a non-finalized
+					// (negative) op-space ID would be unresolvable by clients that load the blob after
+					// the originating session's local state is gone. Emit the stable UUID instead — the
+					// identifier-field decode path already accepts either a number or a string.
+					if (context.idsMustBeFinalized && opSpaceId < 0) {
+						return cursor.value;
+					}
+					return opSpaceId;
 				}
 			}
 		}

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
@@ -54,6 +54,8 @@ export function schemaCompressedEncodeV1(
 	policy: SchemaPolicy,
 	fieldBatch: FieldBatch,
 	idCompressor: IIdCompressor,
+	_incrementalEncoder: IncrementalEncoder | undefined,
+	idsMustBeFinalized: boolean,
 ): EncodedFieldBatchV1 {
 	const encoded: EncodedFieldBatchV1OrV2 = schemaCompressedEncode(
 		schema,
@@ -62,6 +64,7 @@ export function schemaCompressedEncodeV1(
 		idCompressor,
 		undefined /* incrementalEncoder */,
 		brand(FieldBatchFormatVersion.v1),
+		idsMustBeFinalized,
 	);
 	// Since incrementalEncoder was not provided, no V2 features should be used, and this cast should be safe.
 	return encoded as EncodedFieldBatchV1;
@@ -78,6 +81,7 @@ export function schemaCompressedEncodeV2(
 	fieldBatch: FieldBatch,
 	idCompressor: IIdCompressor,
 	incrementalEncoder: IncrementalEncoder | undefined,
+	idsMustBeFinalized: boolean,
 ): EncodedFieldBatchV2 {
 	return schemaCompressedEncode(
 		schema,
@@ -86,6 +90,7 @@ export function schemaCompressedEncodeV2(
 		idCompressor,
 		incrementalEncoder,
 		brand(FieldBatchFormatVersion.v2),
+		idsMustBeFinalized,
 	);
 }
 
@@ -106,10 +111,11 @@ function schemaCompressedEncode(
 	idCompressor: IIdCompressor,
 	incrementalEncoder: IncrementalEncoder | undefined,
 	version: FieldBatchFormatVersion,
+	idsMustBeFinalized: boolean,
 ): EncodedFieldBatchV1OrV2 {
 	return compressedEncode(
 		fieldBatch,
-		buildContext(schema, policy, idCompressor, incrementalEncoder, version),
+		buildContext(schema, policy, idCompressor, incrementalEncoder, version, idsMustBeFinalized),
 	);
 }
 
@@ -119,6 +125,7 @@ export function buildContext(
 	idCompressor: IIdCompressor,
 	incrementalEncoder: IncrementalEncoder | undefined,
 	version: FieldBatchFormatVersion,
+	idsMustBeFinalized: boolean = false,
 ): EncoderContext {
 	const context: EncoderContext = new EncoderContext(
 		(fieldBuilder: FieldEncodeBuilder, schemaName: TreeNodeSchemaIdentifier) =>
@@ -129,6 +136,7 @@ export function buildContext(
 		idCompressor,
 		incrementalEncoder,
 		version,
+		idsMustBeFinalized,
 	);
 	return context;
 }

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -164,6 +164,12 @@ export class ForestSummarizer
 				incrementalSummaryBehavior === ForestIncrementalSummaryBehavior.Incremental
 					? this.incrementalSummaryBuilder
 					: undefined,
+			// An undefined `incrementalSummaryContext` indicates this is an attach summary (or a GC
+			// pass). Attach summary blobs can be reused as handles in later summaries with no
+			// intervening ops to finalize local IDs, after which the originating session's local
+			// ID state is no longer available to readers — so any non-finalized identifier must
+			// be encoded as its stable UUID instead.
+			idsMustBeFinalized: incrementalSummaryContext === undefined,
 		};
 		const encoded = this.codec.encode(fieldMap, encoderContext);
 		for (const value of fieldMap.values()) {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
@@ -330,6 +330,10 @@ export function encodeDetachedNodes(
 					schema: context.schema,
 					originatorId: context.originatorId,
 					idCompressor: context.idCompressor,
+					// Propagate so that identifier-typed values in build / refresher trees
+					// emit stable UUIDs when this change is being persisted as part of an
+					// attach summary. See {@link ChangeEncodingContext.idsMustBeFinalized}.
+					idsMustBeFinalized: context.idsMustBeFinalized,
 				}),
 			};
 }

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -36,6 +36,7 @@ import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	readonly idsMustBeFinalized?: boolean;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -28,6 +28,12 @@ import type {
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	/**
+	 * When true, encoders must emit stable UUID forms for any compressed ID
+	 * that has not yet been finalized. See
+	 * {@link ChangeEncodingContext.idsMustBeFinalized}.
+	 */
+	readonly idsMustBeFinalized?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -53,6 +59,7 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 			originatorId: commit.sessionId,
 			idCompressor: context.idCompressor,
 			revision: undefined,
+			idsMustBeFinalized: context.idsMustBeFinalized,
 		}),
 		change: changeCodec.encode(commit.change, { ...context, revision: commit.revision }),
 	};
@@ -112,6 +119,7 @@ export function encodeSharedBranch<TChangeset>(
 				idCompressor: context.idCompressor,
 				schema: context.schema,
 				revision: undefined,
+				idsMustBeFinalized: context.idsMustBeFinalized,
 			}),
 		),
 		peers: Array.from(data.peerLocalBranches.entries(), ([sessionId, branch]) => [
@@ -121,6 +129,7 @@ export function encodeSharedBranch<TChangeset>(
 					originatorId: sessionId,
 					idCompressor: context.idCompressor,
 					revision: undefined,
+					idsMustBeFinalized: context.idsMustBeFinalized,
 				}),
 				commits: branch.commits.map((commit) =>
 					encodeCommit(changeCodec, revisionTagCodec, commit, {
@@ -128,6 +137,7 @@ export function encodeSharedBranch<TChangeset>(
 						idCompressor: context.idCompressor,
 						schema: context.schema,
 						revision: undefined,
+						idsMustBeFinalized: context.idsMustBeFinalized,
 					}),
 				),
 			},
@@ -154,6 +164,7 @@ export function encodeSharedBranch<TChangeset>(
 			originatorId,
 			idCompressor: context.idCompressor,
 			revision: undefined,
+			idsMustBeFinalized: context.idsMustBeFinalized,
 		});
 	}
 	return json;

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -25,6 +25,7 @@ import { EncodedEditManager } from "./editManagerFormatV1toV4.js";
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	readonly idsMustBeFinalized?: boolean;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -51,11 +51,17 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 	const codec: CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> = {
 		schema,
 		encode: (data: SummaryData<TChangeset>, context: EditManagerEncodingContext) => {
+			// vSharedBranches stores the summary's originator at the top level,
+			// and the decode path threads that originator down to each child codec.
+			// Stable-UUID fallbacks are therefore unnecessary here even when this is
+			// an attach summary, so suppress `idsMustBeFinalized` for the inner codec
+			// calls regardless of what the caller passed.
+			const innerContext = { ...context, idsMustBeFinalized: false };
 			const mainBranch = encodeSharedBranch(
 				changeCodec,
 				revisionTagCodec,
 				data.main,
-				context,
+				innerContext,
 				data.originator,
 			);
 			assert(
@@ -75,7 +81,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 							changeCodec,
 							revisionTagCodec,
 							branch,
-							context,
+							innerContext,
 							data.originator,
 						),
 					);

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -102,11 +102,21 @@ export class EditManagerSummarizer<TChangeset>
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;
 		builder: SummaryTreeBuilder;
 	}): void {
-		const { stringify, builder } = props;
+		const { stringify, builder, incrementalSummaryContext } = props;
+		// An undefined `incrementalSummaryContext` indicates this is an attach summary (or a GC
+		// pass). Attach summary blobs can be reused as handles in later summaries with no
+		// intervening ops to finalize local IDs, after which the originating session's local
+		// ID state is no longer available to readers — so any compressed ID we persist must be
+		// in a form (stable UUID) that does not depend on session state.
+		const idsMustBeFinalized = incrementalSummaryContext === undefined;
 		const context: EditManagerEncodingContext =
 			this.schemaAndPolicy === undefined
-				? { idCompressor: this.idCompressor }
-				: { schema: this.schemaAndPolicy, idCompressor: this.idCompressor };
+				? { idCompressor: this.idCompressor, idsMustBeFinalized }
+				: {
+						schema: this.schemaAndPolicy,
+						idCompressor: this.idCompressor,
+						idsMustBeFinalized,
+					};
 		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData(), context);
 		const dataString = stringify(jsonCompatible);
 		builder.addBlob(stringKey, dataString);

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -1289,7 +1289,14 @@ export class TreeCheckout implements ITreeCheckout {
 			const tree = jsonableTreeFromCursor(cursor);
 			// This method is used for tree consistency comparison.
 			const { major, minor } = id;
-			const finalizedMajor = major === undefined ? major : this.revisionTagCodec.encode(major);
+			const finalizedMajor =
+				major === undefined
+					? major
+					: this.revisionTagCodec.encode(major, {
+							originatorId: this.revisionTagCodec.localSessionId,
+							idCompressor: this.idCompressor,
+							revision: undefined,
+						});
 			trees.push([finalizedMajor, minor, tree]);
 		}
 		cursor.free();

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeEncoder.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeEncoder.spec.ts
@@ -5,6 +5,8 @@
 
 import { strict as assert, fail } from "node:assert";
 
+import { createIdCompressor } from "@fluidframework/id-compressor/internal";
+
 import type { JsonableTree } from "../../../../core/index.js";
 import {
 	Counter,
@@ -26,7 +28,7 @@ import { NodeShapeBasedEncoder } from "../../../../feature-libraries/chunked-for
 import { fieldKinds } from "../../../../feature-libraries/default-schema/index.js";
 import { FieldBatchFormatVersion } from "../../../../feature-libraries/index.js";
 import { brand } from "../../../../util/index.js";
-import { testIdCompressor } from "../../../utils.js";
+import { assertIsSessionId, testIdCompressor } from "../../../utils.js";
 
 import { checkNodeEncode } from "./checkEncode.js";
 
@@ -158,6 +160,101 @@ describe("nodeShape", () => {
 
 			const encodedChunk = checkNodeEncode(shape, context, tree);
 			assert.deepEqual(encodedChunk, ["value", "v", [6]]);
+		});
+
+		// Repro for the attach-summary ID bug: an identifier value generated locally by a session
+		// that hasn't yet been allocated a cluster will normalize to a negative op-space ID. If we
+		// emit that into an attach summary blob that is later reused as a handle, no client that
+		// loads the persisted IdCompressor state (which excludes session-local data) can resolve
+		// the ID. With `idsMustBeFinalized: true`, the encoder must instead emit the stable UUID.
+		describe("idsMustBeFinalized for SpecialField.Identifier", () => {
+			function makeIdentifierShape(): NodeShapeBasedEncoder {
+				return new NodeShapeBasedEncoder(brand("id"), 0 /* SpecialField.Identifier */, [], undefined);
+			}
+
+			it("emits negative op-space IDs when the flag is false (default)", () => {
+				const compressor = createIdCompressor(
+					assertIsSessionId("00000000-0000-4000-8000-000000000001"),
+				);
+				const localId = compressor.generateCompressedId();
+				assert(localId < 0, "test setup requires a non-finalized (negative) ID");
+				const stableId = compressor.decompress(localId);
+
+				const context = new EncoderContext(
+					() => fail(),
+					() => fail(),
+					fieldKinds,
+					compressor,
+					undefined /* incrementalEncoder */,
+					fieldBatchVersion,
+				);
+
+				const encoded = checkNodeEncode(makeIdentifierShape(), context, {
+					type: brand("id"),
+					value: stableId,
+				});
+				assert.deepEqual(
+					encoded,
+					[compressor.normalizeToOpSpace(localId)],
+					"default behavior must preserve the existing on-wire form",
+				);
+			});
+
+			it("falls back to the stable UUID when the flag is true and the ID is not finalized", () => {
+				const compressor = createIdCompressor(
+					assertIsSessionId("00000000-0000-4000-8000-000000000002"),
+				);
+				const localId = compressor.generateCompressedId();
+				assert(localId < 0, "test setup requires a non-finalized (negative) ID");
+				const stableId = compressor.decompress(localId);
+
+				const context = new EncoderContext(
+					() => fail(),
+					() => fail(),
+					fieldKinds,
+					compressor,
+					undefined /* incrementalEncoder */,
+					fieldBatchVersion,
+					true /* idsMustBeFinalized */,
+				);
+
+				const encoded = checkNodeEncode(makeIdentifierShape(), context, {
+					type: brand("id"),
+					value: stableId,
+				});
+				assert.deepEqual(
+					encoded,
+					[stableId],
+					"non-finalized IDs must be emitted as their stable UUID",
+				);
+			});
+
+			it("still emits the final op-space ID when the flag is true and the ID is finalized", () => {
+				// testIdCompressor uses a permanent ghost session so every generated ID is final.
+				const finalId = testIdCompressor.generateCompressedId();
+				assert(finalId >= 0, "test setup requires an already-finalized ID");
+				const stableId = testIdCompressor.decompress(finalId);
+
+				const context = new EncoderContext(
+					() => fail(),
+					() => fail(),
+					fieldKinds,
+					testIdCompressor,
+					undefined /* incrementalEncoder */,
+					fieldBatchVersion,
+					true /* idsMustBeFinalized */,
+				);
+
+				const encoded = checkNodeEncode(makeIdentifierShape(), context, {
+					type: brand("id"),
+					value: stableId,
+				});
+				assert.deepEqual(
+					encoded,
+					[testIdCompressor.normalizeToOpSpace(finalId)],
+					"finalized IDs must still be emitted as op-space numbers",
+				);
+			});
 		});
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
@@ -36,8 +36,8 @@ const baseContext = {
 	revision: tag1,
 	idCompressor: testIdCompressor,
 };
-const encodedTag1 = testRevisionTagCodec.encode(tag1);
-const encodedTag2 = testRevisionTagCodec.encode(tag2);
+const encodedTag1 = testRevisionTagCodec.encode(tag1, baseContext);
+const encodedTag2 = testRevisionTagCodec.encode(tag2, baseContext);
 const context: FieldChangeEncodingContext = {
 	baseContext,
 	encodeNode: (node) => TestNodeId.encode(node, baseContext),

--- a/packages/dds/tree/src/test/rebase/revisionTagCodec.spec.ts
+++ b/packages/dds/tree/src/test/rebase/revisionTagCodec.spec.ts
@@ -20,7 +20,11 @@ describe("RevisionTagCodec", () => {
 		const localCompressor = createIdCompressor(createSessionId());
 		const remoteCompressor = createIdCompressor(createSessionId());
 		const codec = new RevisionTagCodec(localCompressor);
-		const encoded = codec.encode(rootRevisionTag);
+		const encoded = codec.encode(rootRevisionTag, {
+			originatorId: localCompressor.localSessionId,
+			revision: undefined,
+			idCompressor: localCompressor,
+		});
 		assert.deepEqual(encoded, rootRevisionTag);
 		const decoded = codec.decode(encoded, {
 			originatorId: localCompressor.localSessionId,
@@ -28,7 +32,11 @@ describe("RevisionTagCodec", () => {
 			idCompressor: testIdCompressor,
 		});
 		assert.deepEqual(decoded, rootRevisionTag);
-		const remoteEncoded = new RevisionTagCodec(remoteCompressor).encode(rootRevisionTag);
+		const remoteEncoded = new RevisionTagCodec(remoteCompressor).encode(rootRevisionTag, {
+			originatorId: remoteCompressor.localSessionId,
+			revision: undefined,
+			idCompressor: remoteCompressor,
+		});
 		const decodedFromRemote = codec.decode(remoteEncoded, {
 			originatorId: remoteCompressor.localSessionId,
 			revision: undefined,
@@ -48,7 +56,11 @@ describe("RevisionTagCodec", () => {
 		const localId = localCompressor.generateCompressedId();
 
 		// The encoded ID will not have a final ID form
-		let localEncoded = localCodec.encode(localId);
+		let localEncoded = localCodec.encode(localId, {
+			originatorId: localSession,
+			revision: undefined,
+			idCompressor: localCompressor,
+		});
 
 		assert.deepEqual(localId, localEncoded);
 		assert.deepEqual(
@@ -74,13 +86,21 @@ describe("RevisionTagCodec", () => {
 		toIdCompressorWithCore(localCompressor).finalizeCreationRange(range);
 		toIdCompressorWithCore(remoteCompressor).finalizeCreationRange(range);
 		// Locally encoding will have the final ID form, as will the remote client
-		localEncoded = localCodec.encode(localId);
+		localEncoded = localCodec.encode(localId, {
+			originatorId: localSession,
+			revision: undefined,
+			idCompressor: localCompressor,
+		});
 		const remoteDecoded = remoteCodec.decode(localEncoded, {
 			originatorId: localSession,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		});
-		const remoteEncoded = remoteCodec.encode(remoteDecoded);
+		const remoteEncoded = remoteCodec.encode(remoteDecoded, {
+			originatorId: remoteSession,
+			revision: undefined,
+			idCompressor: remoteCompressor,
+		});
 
 		assert.notDeepEqual(localId, localEncoded);
 		assert.deepEqual(localEncoded, remoteDecoded);


### PR DESCRIPTION
When a SharedTree is attached to an already-attached container, tree identifier values generated locally before the IdCompressor has been allocated a cluster can sometimes be serialized as negative op-space IDs. This is a bug which will be fixed in a separate PR (near-term, by using the long id in these cases similarly to what we do in some other codec paths).

When other clients attempt to load SharedTrees with such summaries, they currently crash as the decode path attempts to use the local client's session ID as the originating ID, which is incorrect. In the general case, the information about which client generated the ID has been lost at this point.

This PR adds a feature flag to `configuredSharedTree` which can potentially be enabled (with some risk, see notes) to allow documents that have reached this state to continue to operate anyway. It does so by generating a v5 uuid based on the SharedObject ID + op-space unfinalized ID. This provides similar collision-resistant properties as the original intent of the ID provided unfinalized ids are only currently written at attach summary generation time (the known bug). Depending on how the application used the ID, this may break stability guarantees (e.g. if application assumed the id would remain stable and wrote it to an external store or a different data store within Fluid, but did so using the previous long form). Thus this flag should only be enabled with those risks in mind.
