### PR TITLE
runtime: Add "retired" features implementation for Document Schema

### DIFF
--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -304,6 +304,55 @@ const documentSchemaSupportedConfigs = {
 };
 
 /**
+ * Entry in {@link retiredDocumentSchemaFeatures}.
+ *
+ * - `handler` validates/merges the persisted value (same as a "non-retired" feature).
+ * - `value` is the hardcoded value that this runtime will always use for the desired schema.
+ */
+interface IRetiredFeatureEntry {
+	handler: IProperty;
+	value: DocumentSchemaValueType;
+}
+
+/**
+ * Retired runtime features. A retired feature is one this runtime version no longer toggles
+ * via {@link IDocumentSchemaFeatures}, but that older documents may still carry in their
+ * persisted schema. Each entry bundles the property handler with the hardcoded value for the feature.
+ *
+ * Retired features participate in the normal merge / schema-change-op flow exactly like
+ * non-retired features — the only difference is that their values are hardcoded.
+ */
+const retiredDocumentSchemaFeatures = {} satisfies Record<string, IRetiredFeatureEntry> & {
+	// This ensures that retiredDocumentSchemaFeatures and IDocumentSchemaFeatures are mutually exclusive.
+	[K in keyof IDocumentSchemaFeatures]?: never;
+	// Note: There are currently no retired features.
+};
+
+/**
+ * Looks up the validator/merger for a given runtime property name across both supported and
+ * retired configs. Returns `undefined` if the property is unknown to this runtime.
+ */
+function getRuntimeConfigHandler(name: string): IProperty | undefined {
+	return (
+		(documentSchemaSupportedConfigs as Record<string, IProperty>)[name] ??
+		(retiredDocumentSchemaFeatures as Record<string, IRetiredFeatureEntry>)[name]?.handler
+	);
+}
+
+/**
+ * Builds the `{ key: value }` for retired features (for building the desired schema).
+ */
+function retiredFeatureValues(): Record<string, DocumentSchemaValueType> {
+	const result: Record<string, DocumentSchemaValueType> = {};
+	for (const [key, entry] of Object.entries(
+		retiredDocumentSchemaFeatures as Record<string, IRetiredFeatureEntry>,
+	)) {
+		result[key] = entry.value;
+	}
+	return result;
+}
+
+/**
  * Checks if a given schema is compatible with current code, i.e. if current code can understand all the features of that schema.
  * If schema is not compatible with current code, it throws an exception.
  * @param documentSchema - current schema
@@ -343,7 +392,7 @@ function checkRuntimeCompatibility(
 		unknownProperty = "runtime";
 	} else {
 		for (const [name, value] of Object.entries(documentSchema.runtime)) {
-			const validator = documentSchemaSupportedConfigs[name] as IProperty | undefined;
+			const validator = getRuntimeConfigHandler(name);
 			if (!(validator?.validate(value) ?? false)) {
 				unknownProperty = `runtime/${name}`;
 			}
@@ -377,7 +426,7 @@ function and(
 		...Object.keys(persistedSchema.runtime),
 		...Object.keys(providedSchema.runtime),
 	])) {
-		runtime[key] = (documentSchemaSupportedConfigs[key] as IProperty).and(
+		runtime[key] = (getRuntimeConfigHandler(key) as IProperty).and(
 			persistedSchema.runtime[key],
 			providedSchema.runtime[key],
 		);
@@ -405,7 +454,7 @@ function or(
 		...Object.keys(persistedSchema.runtime),
 		...Object.keys(providedSchema.runtime),
 	])) {
-		runtime[key] = (documentSchemaSupportedConfigs[key] as IProperty).or(
+		runtime[key] = (getRuntimeConfigHandler(key) as IProperty).or(
 			persistedSchema.runtime[key],
 			providedSchema.runtime[key],
 		);
@@ -625,6 +674,7 @@ export class DocumentsSchemaController {
 				opGroupingEnabled: boolToProp(features.opGroupingEnabled),
 				createBlobPayloadPending: features.createBlobPayloadPending,
 				disallowedVersions: arrayToProp(features.disallowedVersions),
+				...retiredFeatureValues(),
 			},
 		};
 

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -322,10 +322,13 @@ interface IRetiredFeatureEntry {
  * Retired features participate in the normal merge / schema-change-op flow exactly like
  * non-retired features — the only difference is that their values are hardcoded.
  */
-const retiredDocumentSchemaFeatures = {} satisfies Record<string, IRetiredFeatureEntry> & {
+const retiredDocumentSchemaFeatures = {
+	// Note: There are currently no retired retired features. To retire a feature, remove it from IDocumentSchemaFeatures
+	// and documentSchemaSupportedConfigs and add an entry here, e.g.:
+	//   featureFoo: { handler: new TrueOrUndefined(), value: true },
+} satisfies Record<string, IRetiredFeatureEntry> & {
 	// This ensures that retiredDocumentSchemaFeatures and IDocumentSchemaFeatures are mutually exclusive.
 	[K in keyof IDocumentSchemaFeatures]?: never;
-	// Note: There are currently no retired features.
 };
 
 /**


### PR DESCRIPTION
## Description

Adds a "retired" feature mechanism to Document Schema. A retired feature is one that was previously toggleable via `IDocumentSchemaFeatures`  but is now hardcoded to a single value by the runtime.

Why we need this: existing documents may still carry a retired feature's key in their persisted
schema, so Document Schema must continue to recognize it (otherwise `checkRuntimeCompatibility`
would fail the session on an "unknown" runtime property). At the same time, we no longer want
that feature to be part of the public `IDocumentSchemaFeatures` surface, because callers can
no longer influence it.

Retired features are tracked in a separate `retiredDocumentSchemaFeatures` map. Each entry
bundles the property handler with the runtime's hardcoded value. They participate in the
normal validate / merge / schema-change-op flow exactly like non-retired features — the only
difference is that the value comes from the map instead of from the constructor's `features`
argument. A compile-time `satisfies` constraint ensures a key cannot appear in both
`IDocumentSchemaFeatures` and `retiredDocumentSchemaFeatures`.

Note: No features are retired yet. This PR just sets up the infrastructure for when features are retired in the future.

## Misc
[AB#72041](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/72041)