### PR TITLE
fix(docs): Increase lvl1 search weight and improves API name ranking

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -18,9 +18,10 @@ const TYPESENSE_API_KEY = process.env.TYPESENSE_API_KEY;
 
 const isTypesenseConfigured = TYPESENSE_HOST !== undefined && TYPESENSE_API_KEY !== undefined;
 
-// Each entry is [field, weight, numTypos]. Order determines priority: first = highest ranked.
-const typesenseSearchFields: [field: string, weight: number, numTypos: number][] = [
-	["hierarchy.lvl1", 6, 1],
+// Each entry is [field, weight, allowedTypos]. Order determines priority: first = highest ranked.
+// allowedTypos controls typo tolerance per field: 0 = exact match only, 1 = one typo allowed.
+const typesenseSearchFields: [field: string, weight: number, allowedTypos: number][] = [
+	["hierarchy.lvl1", 10, 1],
 	["hierarchy.lvl2", 5, 1],
 	["hierarchy.lvl3", 4, 1],
 	["hierarchy.lvl4", 3, 1],
@@ -29,7 +30,7 @@ const typesenseSearchFields: [field: string, weight: number, numTypos: number][]
 ];
 const typesenseQueryBy = typesenseSearchFields.map(([field]) => field).join(",");
 const typesenseQueryByWeights = typesenseSearchFields.map(([, weight]) => weight).join(",");
-const typesenseNumTypos = typesenseSearchFields.map(([, , typos]) => typos).join(",");
+const typesenseAllowedTypos = typesenseSearchFields.map(([, , allowedTypos]) => allowedTypos).join(",");
 
 const githubUrl = "https://github.com/microsoft/FluidFramework";
 const githubMainBranchUrl = `${githubUrl}/tree/main`;
@@ -208,7 +209,8 @@ const config: Config = {
 					query_by_weights: typesenseQueryByWeights,
 					sort_by: "_text_match:desc",
 					prioritize_exact_match: true,
-					num_typos: typesenseNumTypos,
+					prioritize_token_position: true,
+					num_typos: typesenseAllowedTypos,
 				},
 			},
 		}),


### PR DESCRIPTION
## Description

The Tree variable was ranking 30th when searching "Tree" despite prioritize_exact_match being set. This is because prioritize_exact_match only boosts results where the query matches the entire field value — "Tree Variable" ≠ "Tree", so it received no boost. With ~30 pages having "Tree" as a prefix in their title all scoring similarly, the exact result was buried.

Changes:

Increased lvl1 weight from 6 → 10 to more strongly boost page title matches over lower hierarchy levels
Added prioritize_token_position: true — boosts results where the matched token appears at the start of the field, so "Tree Variable" (exact token "Tree" at position 0) ranks above prefix matches like "TreeArrayNode Interface"