### PR TITLE
Remove deprecated ILoaderOptions.enableOfflineLoad

### DIFF
--- a/.changeset/remove-enable-offline-load.md
+++ b/.changeset/remove-enable-offline-load.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/container-definitions": minor
+"@fluidframework/container-loader": minor
+"__section": legacy
+---
+
+Remove deprecated `ILoaderOptions.enableOfflineLoad`
+
+The deprecated `enableOfflineLoad` property on `ILoaderOptions` has been removed, along with the legacy `Fluid.Container.enableOfflineLoad` feature gate read from the config provider. Offline load remains enabled by default for interactive clients.
+
+To opt out, set `Fluid.Container.enableOfflineFull` to `false` via the config provider. To prevent silent misconfiguration, container load now throws a `UsageError` if a `pendingLocalState` is provided while `Fluid.Container.enableOfflineFull` is explicitly set to `false`.
+
+#### Migration
+
+- Remove any use of `enableOfflineLoad` from `ILoaderOptions` you pass to the `Loader`.
+- If you previously set `Fluid.Container.enableOfflineLoad` via the config provider, set `Fluid.Container.enableOfflineFull` instead.

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.beta.api.md
@@ -436,7 +436,6 @@ export interface ILoader extends Partial<IProvideLoader> {
 export type ILoaderOptions = {
     cache?: boolean;
     client?: IClient;
-    enableOfflineLoad?: boolean;
     provideScopeLoader?: boolean;
     maxClientLeaveWaitTime?: number;
 };

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -611,11 +611,6 @@ export type ILoaderOptions = {
 	client?: IClient;
 
 	/**
-	 * @deprecated Do not use.
-	 */
-	enableOfflineLoad?: boolean;
-
-	/**
 	 * Provide the current Loader through the scope object when creating Containers. It is added
 	 * as the `ILoader` property, and will overwrite an existing property of the same name on the
 	 * scope. Useful for when the host wants to provide the current Loader's functionality to

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -961,11 +961,14 @@ export class Container
 			enableSummarizeProtocolTree,
 		);
 
-		const offlineLoadEnabled =
-			this.isInteractiveClient &&
-			(this.mc.config.getBoolean("Fluid.Container.enableOfflineLoad") ??
-				this.mc.config.getBoolean("Fluid.Container.enableOfflineFull") ??
-				options.enableOfflineLoad !== false);
+		const explicitOfflineFull = this.mc.config.getBoolean("Fluid.Container.enableOfflineFull");
+		// paranoic defense mechanism while enableOfflineFull still exists in config.
+		if (pendingLocalState !== undefined && explicitOfflineFull === false) {
+			throw new UsageError(
+				"Cannot load from pending local state when Fluid.Container.enableOfflineFull is explicitly disabled",
+			);
+		}
+		const offlineLoadEnabled = this.isInteractiveClient && (explicitOfflineFull ?? true);
 		this.serializedStateManager = new SerializedStateManager(
 			this.subLogger,
 			this.storageAdapter,

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -34,7 +34,6 @@ const loaderOptionsMatrix: OptionsMatrix<ILoaderOptionsExperimental> = {
 	client: [undefined],
 	provideScopeLoader: booleanCases,
 	maxClientLeaveWaitTime: numberCases,
-	enableOfflineLoad: booleanCases,
 	enableOfflineSnapshotRefresh: booleanCases,
 	snapshotRefreshTimeoutMs: [undefined, 60 * 5 * 1000 /* 5min */],
 };

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -550,10 +550,7 @@ async function scheduleOffline(
 				if (container.closed) {
 					return undefined;
 				}
-				if (
-					runConfig.loaderConfig?.enableOfflineLoad === true &&
-					random.real() < stashPercent
-				) {
+				if (random.real() < stashPercent) {
 					printStatus(runConfig, "closing offline container!");
 					const pendingState = await asLegacyAlpha(container).getPendingLocalState();
 					container.close();


### PR DESCRIPTION
## Description

Removes the deprecated `enableOfflineLoad` field from `ILoaderOptions` (`@fluidframework/container-definitions`) and the legacy `Fluid.Container.enableOfflineLoad` feature-gate read from the config provider. The field was already marked `@deprecated Do not use.`; this completes its removal.

Offline-load default behavior is preserved: interactive clients still get offline load enabled by default. To opt out, set `Fluid.Container.enableOfflineFull: false` via the config provider — that is now the single control surface.

As a safety net for callers migrating from the legacy gate, `Container` load now throws a `UsageError` if `pendingLocalState` is provided while `Fluid.Container.enableOfflineFull` is explicitly set to `false`. This prevents silently loading from pending state with offline-load disabled.

Also drops the deprecated entry from the `test-service-load` options matrix and updates the stress-runner gate that referenced it.

## Breaking Changes

`ILoaderOptions.enableOfflineLoad` (`@legacy @beta`) is removed. Migration:

- Remove `enableOfflineLoad` from any `ILoaderOptions` passed to the `Loader`.
- If you previously set `Fluid.Container.enableOfflineLoad` via the config provider, set `Fluid.Container.enableOfflineFull` instead (same boolean value).

See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- This is a `@legacy @beta` break. Per the Beta-Break-Process it must land in a `.N0` minor and may need to be staged on `test/breaks/client/X.Y0/`. Confirm we're in the right release window before merging.
- `fluid-cr-api` will be auto-assigned as a required reviewer.
- The new throw-on-misconfig is a defensive guard while `enableOfflineFull` remains the control surface; happy to drop or relax it if reviewers prefer.