### PR TITLE
chore: tighten offline config flag gating

### DIFF
--- a/.changeset/snapshot-refresh-flag-gating.md
+++ b/.changeset/snapshot-refresh-flag-gating.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-loader": patch
+"__section": other
+---
+Tighten snapshot refresh config flag gating
+
+`SnapshotRefresher` now requires `Fluid.Container.enableOfflineSnapshotRefresh` to be explicitly set to `true` for snapshot refresh to be enabled. Previously it fell back to `Fluid.Container.enableOfflineFull` when `enableOfflineSnapshotRefresh` was unset.

--- a/packages/loader/container-loader/src/snapshotRefresher.ts
+++ b/packages/loader/container-loader/src/snapshotRefresher.ts
@@ -97,8 +97,7 @@ export class SnapshotRefresher implements IDisposable {
 
 		this.#snapshotRefreshEnabled =
 			this.offlineLoadEnabled &&
-			(this.mc.config.getBoolean("Fluid.Container.enableOfflineSnapshotRefresh") ??
-				this.mc.config.getBoolean("Fluid.Container.enableOfflineFull")) === true;
+			(this.mc.config.getBoolean("Fluid.Container.enableOfflineSnapshotRefresh") ?? false);
 
 		this.refreshTimer = this.#snapshotRefreshEnabled
 			? new Timer(this.snapshotRefreshTimeoutMs, () => this.tryRefreshSnapshot())


### PR DESCRIPTION
## Description

Cleans up two redundant fallbacks in offline-related config flag wiring:

- `SnapshotRefresher` now requires `Fluid.Container.enableOfflineSnapshotRefresh` to be explicitly set to `true` for snapshot refresh to be enabled. Previously it fell back to `Fluid.Container.enableOfflineFull` when `enableOfflineSnapshotRefresh` was unset.
- Removed the `Fluid.ContainerRuntime.enableBatchIdTracking` config flag entirely. Batch ID tracking is now driven solely by `Fluid.Container.enableOfflineFull` (which was already the primary signal — `enableBatchIdTracking` was only consulted when `enableOfflineFull` was unset). The flag is unused by customers, so no back-compat shim is needed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).