### PR TITLE
chore(container-loader): tighten snapshot refresh config flag gating

### DIFF
--- a/packages/loader/container-loader/src/snapshotRefresher.ts
+++ b/packages/loader/container-loader/src/snapshotRefresher.ts
@@ -97,8 +97,7 @@ export class SnapshotRefresher implements IDisposable {
 
 		this.#snapshotRefreshEnabled =
 			this.offlineLoadEnabled &&
-			(this.mc.config.getBoolean("Fluid.Container.enableOfflineSnapshotRefresh") ??
-				this.mc.config.getBoolean("Fluid.Container.enableOfflineFull")) === true;
+			(this.mc.config.getBoolean("Fluid.Container.enableOfflineSnapshotRefresh") ?? false);
 
 		this.refreshTimer = this.#snapshotRefreshEnabled
 			? new Timer(this.snapshotRefreshTimeoutMs, () => this.tryRefreshSnapshot())

--- a/packages/loader/container-loader/src/test/snapshotRefresher.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotRefresher.spec.ts
@@ -60,6 +60,12 @@ function enableOfflineSnapshotRefresh(logger: ITelemetryBaseLogger): ITelemetryB
 	}).logger;
 }
 
+function enableOfflineFullOnly(logger: ITelemetryBaseLogger): ITelemetryBaseLogger {
+	return mixinMonitoringContext(logger, {
+		getRawConfig: (name) => (name === "Fluid.Container.enableOfflineFull" ? true : undefined),
+	}).logger;
+}
+
 class MockStorageAdapter implements ISerializedStateManagerDocumentStorageService {
 	public readonly blobs = new Map<string, ArrayBuffer>();
 	private snapshot: ISnapshotTree;
@@ -325,6 +331,23 @@ describe("SnapshotRefresher", () => {
 				mockStorage.getVersionsCallCount,
 				0,
 				"getVersions should not be called when snapshot refresh is not enabled",
+			);
+
+			refresher.dispose();
+		});
+
+		it("should not trigger refresh when only enableOfflineFull is set", () => {
+			const logger = enableOfflineFullOnly(mockLogger);
+			const timeout = 1000;
+			const refresher = createRefresher(true, () => true, timeout, logger);
+
+			refresher.startTimer();
+			clock.tick(timeout);
+
+			assert.strictEqual(
+				mockStorage.getVersionsCallCount,
+				0,
+				"getVersions should not be called when only enableOfflineFull is set (enableOfflineSnapshotRefresh must be opted in explicitly)",
 			);
 
 			refresher.dispose();


### PR DESCRIPTION
## Description

Removes the `Fluid.Container.enableOfflineFull` fallback from `SnapshotRefresher`'s `#snapshotRefreshEnabled` gating. Snapshot refresh now requires `Fluid.Container.enableOfflineSnapshotRefresh` to be explicitly set to `true`; without it, refresh stays disabled even when `enableOfflineFull` is on.

This decouples snapshot refresh from the broader offline-full kill switch so the two can be rolled forward and back independently.

Adds a unit test pinning the new gating: with only `enableOfflineFull=true`, the refresh timer does not fire and no storage calls are made.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).