### PR TITLE
fix(docs): improve Typesense search ranking and reduce index noise

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -18,9 +18,10 @@ const TYPESENSE_API_KEY = process.env.TYPESENSE_API_KEY;
 
 const isTypesenseConfigured = TYPESENSE_HOST !== undefined && TYPESENSE_API_KEY !== undefined;
 
-// Each entry is [field, weight, numTypos]. Order determines priority: first = highest ranked.
-const typesenseSearchFields: [field: string, weight: number, numTypos: number][] = [
-	["hierarchy.lvl1", 6, 1],
+// Each entry is [field, weight, allowedTypos]. Order determines priority: first = highest ranked.
+// allowedTypos controls typo tolerance per field: 0 = exact match only, 1 = one typo allowed.
+const typesenseSearchFields: [field: string, weight: number, allowedTypos: number][] = [
+	["hierarchy.lvl1", 10, 1],
 	["hierarchy.lvl2", 5, 1],
 	["hierarchy.lvl3", 4, 1],
 	["hierarchy.lvl4", 3, 1],
@@ -29,7 +30,7 @@ const typesenseSearchFields: [field: string, weight: number, numTypos: number][]
 ];
 const typesenseQueryBy = typesenseSearchFields.map(([field]) => field).join(",");
 const typesenseQueryByWeights = typesenseSearchFields.map(([, weight]) => weight).join(",");
-const typesenseNumTypos = typesenseSearchFields.map(([, , typos]) => typos).join(",");
+const typesenseAllowedTypos = typesenseSearchFields.map(([, , allowedTypos]) => allowedTypos).join(",");
 
 const githubUrl = "https://github.com/microsoft/FluidFramework";
 const githubMainBranchUrl = `${githubUrl}/tree/main`;
@@ -208,7 +209,8 @@ const config: Config = {
 					query_by_weights: typesenseQueryByWeights,
 					sort_by: "_text_match:desc",
 					prioritize_exact_match: true,
-					num_typos: typesenseNumTypos,
+					prioritize_token_position: true,
+					num_typos: typesenseAllowedTypos,
 				},
 			},
 		}),

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -29,7 +29,9 @@ const typesenseSearchFields: [field: string, weight: number, allowedTypos: numbe
 ];
 const typesenseQueryBy = typesenseSearchFields.map(([field]) => field).join(",");
 const typesenseQueryByWeights = typesenseSearchFields.map(([, weight]) => weight).join(",");
-const typesenseAllowedTypos = typesenseSearchFields.map(([, , allowedTypos]) => allowedTypos).join(",");
+const typesenseAllowedTypos = typesenseSearchFields
+	.map(([, , allowedTypos]) => allowedTypos)
+	.join(",");
 
 const githubUrl = "https://github.com/microsoft/FluidFramework";
 const githubMainBranchUrl = `${githubUrl}/tree/main`;

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -21,11 +21,7 @@ const isTypesenseConfigured = TYPESENSE_HOST !== undefined && TYPESENSE_API_KEY 
 // Each entry is [field, weight, allowedTypos]. Order determines priority: first = highest ranked.
 // allowedTypos controls typo tolerance per field: 0 = exact match only, 1 = one typo allowed.
 const typesenseSearchFields: [field: string, weight: number, allowedTypos: number][] = [
-<<<<<<< HEAD
 	["hierarchy.lvl1", 20, 1],
-=======
-	["hierarchy.lvl1", 10, 1],
->>>>>>> main
 	["hierarchy.lvl2", 5, 1],
 	["hierarchy.lvl3", 4, 1],
 	["hierarchy.lvl4", 3, 1],

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -21,12 +21,11 @@ const isTypesenseConfigured = TYPESENSE_HOST !== undefined && TYPESENSE_API_KEY 
 // Each entry is [field, weight, allowedTypos]. Order determines priority: first = highest ranked.
 // allowedTypos controls typo tolerance per field: 0 = exact match only, 1 = one typo allowed.
 const typesenseSearchFields: [field: string, weight: number, allowedTypos: number][] = [
-	["hierarchy.lvl1", 10, 1],
+	["hierarchy.lvl1", 20, 1],
 	["hierarchy.lvl2", 5, 1],
 	["hierarchy.lvl3", 4, 1],
 	["hierarchy.lvl4", 3, 1],
 	["hierarchy.lvl5", 2, 1],
-	["content", 1, 0],
 ];
 const typesenseQueryBy = typesenseSearchFields.map(([field]) => field).join(",");
 const typesenseQueryByWeights = typesenseSearchFields.map(([, weight]) => weight).join(",");
@@ -204,10 +203,10 @@ const config: Config = {
 					apiKey: TYPESENSE_API_KEY,
 				},
 				contextualSearch: true,
-				additionalSearchParameters: {
+				typesenseSearchParameters: {
 					query_by: typesenseQueryBy,
 					query_by_weights: typesenseQueryByWeights,
-					sort_by: "_text_match:desc",
+					sort_by: "_text_match(buckets:10):desc,item_priority:desc",
 					prioritize_exact_match: true,
 					prioritize_token_position: true,
 					num_typos: typesenseAllowedTypos,


### PR DESCRIPTION
## Description

Improves Typesense search result ranking for the docs site.

- Remove content from query_by — page body text was being searched, causing results like the Summarizer page to outrank the actual Tree interface when searching Tree. Searching by hierarchy fields only (h1–h5) gives accurate symbol-name matching.
- Increase hierarchy.lvl1 weight from 10 → 20 — doubles the ranking signal for page titles relative to lower heading levels, helping exact API symbol names rank above partial matches in sub-headings.
- Switch additionalSearchParameters → typesenseSearchParameters — corrects the config key name to match the current docusaurus-theme-search-typesense API.
- Improve sort_by — replaces _text_match:desc (no bucketing, no secondary sort) with _text_match(buckets:10): desc,item_priority:desc, adding a secondary sort by page priority so that when multiple results have similar text match scores, more prominent pages (e.g. top-level API pages) rank above deeply nested ones.