### PR TITLE
build: tag untagged asserts for 2.101.0 release

### DIFF
--- a/packages/framework/react/src/undoRedo.ts
+++ b/packages/framework/react/src/undoRedo.ts
@@ -327,7 +327,10 @@ class UndoRedoManager implements UndoRedo {
 		kind: "undo" | "redo",
 		predicate: (entry: StackEntry) => boolean,
 	): void {
-		assert(this.#pendingOperation === undefined, 0xcf8 /* Unexpected pending operation during revert */);
+		assert(
+			this.#pendingOperation === undefined,
+			0xcf8 /* Unexpected pending operation during revert */,
+		);
 
 		const index = findLastIndex(stack, predicate);
 		if (index === -1) {

--- a/packages/framework/react/src/undoRedo.ts
+++ b/packages/framework/react/src/undoRedo.ts
@@ -327,7 +327,7 @@ class UndoRedoManager implements UndoRedo {
 		kind: "undo" | "redo",
 		predicate: (entry: StackEntry) => boolean,
 	): void {
-		assert(this.#pendingOperation === undefined, "Unexpected pending operation during revert");
+		assert(this.#pendingOperation === undefined, 0xcf8 /* Unexpected pending operation during revert */);
 
 		const index = findLastIndex(stack, predicate);
 		if (index === -1) {

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1936,5 +1936,6 @@ export const shortCodeMap = {
 	"0xcf4": "must not be above root",
 	"0xcf5": "Unexpected indexOfChunkStack.length",
 	"0xcf6": "Unexpected indexWithinChunkStack.length",
-	"0xcf7": "Parent chunk not found in latest summary tracking"
+	"0xcf7": "Parent chunk not found in latest summary tracking",
+	"0xcf8": "Unexpected pending operation during revert"
 };


### PR DESCRIPTION
Generated by `pnpm run policy-check:asserts` as part of release prep. 