### PR TITLE
build(docs): apply prettier to docusaurus.config.ts

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -30,7 +30,9 @@ const typesenseSearchFields: [field: string, weight: number, allowedTypos: numbe
 ];
 const typesenseQueryBy = typesenseSearchFields.map(([field]) => field).join(",");
 const typesenseQueryByWeights = typesenseSearchFields.map(([, weight]) => weight).join(",");
-const typesenseAllowedTypos = typesenseSearchFields.map(([, , allowedTypos]) => allowedTypos).join(",");
+const typesenseAllowedTypos = typesenseSearchFields
+	.map(([, , allowedTypos]) => allowedTypos)
+	.join(",");
 
 const githubUrl = "https://github.com/microsoft/FluidFramework";
 const githubMainBranchUrl = `${githubUrl}/tree/main`;


### PR DESCRIPTION
## Description

The docs site CI runs `prettier --check` against the docs package and was failing on a long-line in docusaurus.config.ts that the client-release-group root format script doesn't cover (docs is a separate workspace package). Fix is the canonical prettier --write output: wrap the typesenseAllowedTypos chained calls.