### PR TITLE
fix(ci, server): Get lts server pipelines green again

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.17.1-buster AS base
+FROM node:18.17.1-bookworm AS base
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -3,7 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.17.1-buster-slim AS base
+FROM node:18.17.1-bookworm-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -632,6 +632,11 @@
 						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
+				"jsrsasign": {
+					"version": "10.9.0",
+					"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.9.0.tgz",
+					"integrity": "sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ=="
+				},
 				"uuid": {
 					"version": "8.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -1000,6 +1005,71 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
+		},
+		"@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+					"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+					"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+					"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+					"dev": true,
+					"requires": {
+						"eastasianwidth": "^0.2.0",
+						"emoji-regex": "^9.2.2",
+						"strip-ansi": "^7.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+					"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^6.2.2"
+					}
+				},
+				"wrap-ansi": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+					"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^6.1.0",
+						"string-width": "^5.0.1",
+						"strip-ansi": "^7.0.1"
+					}
+				}
+			}
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -1839,31 +1909,12 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -2263,16 +2314,6 @@
 						"yallist": "^4.0.0"
 					}
 				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
-				},
 				"npm-registry-fetch": {
 					"version": "9.0.0",
 					"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-9.0.0.tgz",
@@ -2432,31 +2473,12 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -2764,16 +2786,6 @@
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -3202,11 +3214,86 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@npmcli/agent": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+			"integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+					"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+					"dev": true
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+					"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.2",
+						"debug": "4"
+					}
+				},
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				},
+				"socks-proxy-agent": {
+					"version": "8.0.5",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+					"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.2",
+						"debug": "^4.3.4",
+						"socks": "^2.8.3"
+					}
+				}
+			}
+		},
 		"@npmcli/ci-detect": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz",
 			"integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==",
 			"dev": true
+		},
+		"@npmcli/fs": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+					"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+					"dev": true
+				}
+			}
 		},
 		"@npmcli/git": {
 			"version": "2.1.0",
@@ -3311,118 +3398,8 @@
 				"@npmcli/node-gyp": "^1.0.2",
 				"@npmcli/promise-spawn": "^1.3.2",
 				"infer-owner": "^1.0.4",
-				"node-gyp": "^7.1.0",
+				"node-gyp": "^10",
 				"read-package-json-fast": "^2.0.1"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-					"dev": true
-				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
-				"minipass": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
-				"node-gyp": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-					"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
-					"dev": true,
-					"requires": {
-						"env-paths": "^2.2.0",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.2.3",
-						"nopt": "^5.0.0",
-						"npmlog": "^4.1.2",
-						"request": "^2.88.2",
-						"rimraf": "^3.0.2",
-						"semver": "^7.3.2",
-						"tar": "^6.0.2",
-						"which": "^2.0.2"
-					}
-				},
-				"nopt": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-					"dev": true,
-					"requires": {
-						"abbrev": "1"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"tar": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-					"integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
-					"dev": true,
-					"requires": {
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"minipass": "^3.0.0",
-						"minizlib": "^2.1.1",
-						"mkdirp": "^1.0.3",
-						"yallist": "^4.0.0"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@octokit/auth-token": {
@@ -3649,7 +3626,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
 			"integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "2.4.0",
@@ -3789,6 +3767,13 @@
 			"requires": {
 				"@types/node": ">= 8"
 			}
+		},
+		"@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true
 		},
 		"@rushstack/eslint-config": {
 			"version": "2.5.1",
@@ -5153,20 +5138,10 @@
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
 		},
-		"JSONStream": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
-			"requires": {
-				"jsonparse": "^1.2.0",
-				"through": ">=2.2.7 <3"
-			}
-		},
 		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+			"integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
 			"dev": true
 		},
 		"abort-controller": {
@@ -5197,7 +5172,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"add-stream": {
 			"version": "1.0.0",
@@ -5251,7 +5227,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"amqplib": {
 			"version": "0.8.0",
@@ -5348,7 +5325,8 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"devOptional": true
 		},
 		"archy": {
 			"version": "1.0.0",
@@ -5360,6 +5338,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"devOptional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -5472,15 +5451,6 @@
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
 		"assert": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
@@ -5492,12 +5462,6 @@
 				"object-is": "^1.0.1",
 				"util": "^0.12.0"
 			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
 		},
 		"async": {
 			"version": "3.2.3",
@@ -5543,18 +5507,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
 			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
 		"axios": {
@@ -5619,15 +5571,6 @@
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
-			}
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
 			}
 		},
 		"before-after-hook": {
@@ -5897,31 +5840,12 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -6033,12 +5957,6 @@
 				"quick-lru": "^4.0.1"
 			}
 		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
-		},
 		"chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -6083,7 +6001,8 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"optional": true
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -6186,7 +6105,8 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"devOptional": true
 		},
 		"color": {
 			"version": "3.2.1",
@@ -6481,7 +6401,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"devOptional": true
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -6787,8 +6708,8 @@
 			"integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.1",
+				"JSONStream": "^1.0.4",
 				"lodash": "^4.17.15",
 				"meow": "^8.0.0",
 				"split2": "^3.0.0",
@@ -7127,15 +7048,6 @@
 			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
 			"dev": true
 		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"date-fns": {
 			"version": "2.25.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
@@ -7149,11 +7061,18 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-			"integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"requires": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				}
 			}
 		},
 		"debuglog": {
@@ -7363,7 +7282,8 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"devOptional": true
 		},
 		"denque": {
 			"version": "1.5.0",
@@ -7452,15 +7372,11 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
+		"eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
 		},
 		"ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -8233,7 +8149,8 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
 			"integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-plugin-react": {
 			"version": "7.28.0",
@@ -8518,6 +8435,12 @@
 				"homedir-polyfill": "^1.0.1"
 			}
 		},
+		"exponential-backoff": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+			"dev": true
+		},
 		"express": {
 			"version": "4.17.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -8541,7 +8464,7 @@
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.13",
+				"path-to-regexp": "0.1.7",
 				"proxy-addr": "~2.0.5",
 				"qs": "6.7.0",
 				"range-parser": "~1.2.1",
@@ -8610,12 +8533,6 @@
 				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
 			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -8993,12 +8910,6 @@
 				}
 			}
 		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
-		},
 		"form-data": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -9056,12 +8967,23 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
 			"dev": true,
 			"requires": {
-				"minipass": "^2.6.0"
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
 			}
 		},
 		"fs.realpath": {
@@ -9092,6 +9014,7 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"devOptional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -9106,12 +9029,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"devOptional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"devOptional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9120,6 +9045,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"devOptional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -9130,6 +9056,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"devOptional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9370,15 +9297,6 @@
 				}
 			}
 		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
@@ -9554,9 +9472,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
 		"handlebars": {
 			"version": "4.7.7",
@@ -9577,22 +9495,6 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
-			}
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
 			}
 		},
 		"hard-rejection": {
@@ -9648,7 +9550,8 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"devOptional": true
 		},
 		"hasha": {
 			"version": "5.2.2",
@@ -9694,9 +9597,9 @@
 			"dev": true
 		},
 		"http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
 			"dev": true
 		},
 		"http-errors": {
@@ -9743,17 +9646,6 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"https-proxy-agent": {
@@ -9904,7 +9796,8 @@
 		"ini": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-			"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
+			"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+			"devOptional": true
 		},
 		"init-package-json": {
 			"version": "2.0.3",
@@ -10127,10 +10020,10 @@
 				}
 			}
 		},
-		"ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+		"ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"dev": true
 		},
 		"ipaddr.js": {
@@ -10483,12 +10376,6 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
-		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -10667,6 +10554,16 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
+		"jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"requires": {
+				"@isaacs/cliui": "^8.0.2",
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -10688,12 +10585,6 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
 		},
 		"jsdoc-type-pratt-parser": {
 			"version": "3.1.0",
@@ -10717,12 +10608,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
-			"dev": true
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -10779,6 +10664,16 @@
 			"integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
 			"dev": true
 		},
+		"JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			}
+		},
 		"jsonwebtoken": {
 			"version": "8.5.1",
 			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -10802,23 +10697,6 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"jsrsasign": {
-			"version": "11.1.3",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.3.tgz",
-			"integrity": "sha512-nPnK5D/4lv0Dwr7TlzrKtAd8JlLZwFTqTUUB3NQCbtdobcRcohGFxjbPySDVh74iWUudcCsapYT6OxoyhJLhhA=="
 		},
 		"jsx-ast-utils": {
 			"version": "3.2.1",
@@ -11711,7 +11589,8 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+			"integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+			"devOptional": true
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -11733,22 +11612,10 @@
 			}
 		},
 		"minipass": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
-				}
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"dev": true
 		},
 		"minipass-collect": {
 			"version": "1.0.2",
@@ -11788,16 +11655,6 @@
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				}
@@ -11885,18 +11742,31 @@
 			}
 		},
 		"minizlib": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
 			"dev": true,
 			"requires": {
-				"minipass": "^2.9.0"
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
 			}
 		},
 		"mkdirp": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+			"devOptional": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -12336,29 +12206,260 @@
 			"dev": true
 		},
 		"node-gyp": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
-			"integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
+			"integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
 			"dev": true,
 			"requires": {
 				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.2",
-				"mkdirp": "^0.5.1",
-				"nopt": "^4.0.1",
-				"npmlog": "^4.1.2",
-				"request": "^2.88.0",
-				"rimraf": "^2.6.3",
-				"semver": "^5.7.1",
-				"tar": "^4.4.12",
-				"which": "^1.3.1"
+				"exponential-backoff": "^3.1.1",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^13.0.0",
+				"nopt": "^7.0.0",
+				"proc-log": "^4.1.0",
+				"semver": "^7.3.5",
+				"tar": "^6.2.1",
+				"which": "^4.0.0"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+				"brace-expansion": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+					"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"cacache": {
+					"version": "18.0.4",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+					"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+					"dev": true,
+					"requires": {
+						"@npmcli/fs": "^3.1.0",
+						"fs-minipass": "^3.0.0",
+						"glob": "^10.2.2",
+						"lru-cache": "^10.0.1",
+						"minipass": "^7.0.3",
+						"minipass-collect": "^2.0.1",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"p-map": "^4.0.0",
+						"ssri": "^10.0.0",
+						"tar": "^6.1.11",
+						"unique-filename": "^3.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+					"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					},
+					"dependencies": {
+						"which": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+							"dev": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						}
+					}
+				},
+				"foreground-child": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+					"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.6",
+						"signal-exit": "^4.0.1"
+					}
+				},
+				"fs-minipass": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+					"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+					"dev": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"glob": {
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^3.1.2",
+						"minimatch": "^9.0.4",
+						"minipass": "^7.1.2",
+						"package-json-from-dist": "^1.0.0",
+						"path-scurry": "^1.11.1"
+					}
+				},
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 					"dev": true
+				},
+				"make-fetch-happen": {
+					"version": "13.0.1",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+					"integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+					"dev": true,
+					"requires": {
+						"@npmcli/agent": "^2.0.0",
+						"cacache": "^18.0.0",
+						"http-cache-semantics": "^4.1.1",
+						"is-lambda": "^1.0.1",
+						"minipass": "^7.0.2",
+						"minipass-fetch": "^3.0.0",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"negotiator": "^0.6.3",
+						"proc-log": "^4.2.0",
+						"promise-retry": "^2.0.1",
+						"ssri": "^10.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
+					}
+				},
+				"minipass": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+					"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+					"dev": true
+				},
+				"minipass-collect": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+					"integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+					"dev": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"minipass-fetch": {
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+					"integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+					"dev": true,
+					"requires": {
+						"encoding": "^0.1.13",
+						"minipass": "^7.0.3",
+						"minipass-sized": "^1.0.3",
+						"minizlib": "^2.1.2"
+					}
+				},
+				"negotiator": {
+					"version": "0.6.4",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+					"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+					"dev": true
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+					"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"ssri": {
+					"version": "10.0.6",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+					"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+					"dev": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"unique-filename": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+					"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+					"dev": true,
+					"requires": {
+						"unique-slug": "^4.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+					"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"which": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+					"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+					"dev": true,
+					"requires": {
+						"isexe": "^3.1.1"
+					},
+					"dependencies": {
+						"isexe": {
+							"version": "3.1.5",
+							"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+							"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+							"dev": true
+						}
+					}
 				}
 			}
 		},
@@ -12428,13 +12529,12 @@
 			"optional": true
 		},
 		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+			"integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
 			"dev": true,
 			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
+				"abbrev": "^2.0.0"
 			}
 		},
 		"normalize-package-data": {
@@ -12511,7 +12611,7 @@
 			"requires": {
 				"byline": "^5.0.0",
 				"graceful-fs": "^4.1.15",
-				"node-gyp": "^5.0.2",
+				"node-gyp": "^10",
 				"resolve-from": "^4.0.0",
 				"slide": "^1.1.6",
 				"uid-number": "0.0.6",
@@ -12845,16 +12945,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -12871,6 +12961,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"devOptional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -12881,7 +12972,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"devOptional": true
 		},
 		"nyc": {
 			"version": "15.1.0",
@@ -13085,12 +13177,6 @@
 					}
 				}
 			}
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -13360,7 +13446,8 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"optional": true
 		},
 		"os-name": {
 			"version": "3.1.0",
@@ -13377,16 +13464,6 @@
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
 		},
 		"override-require": {
 			"version": "1.1.1",
@@ -13487,6 +13564,12 @@
 				"release-zalgo": "^1.0.0"
 			}
 		},
+		"package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true
+		},
 		"pacote": {
 			"version": "11.3.5",
 			"resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
@@ -13520,31 +13603,12 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -13714,9 +13778,26 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
 		},
+		"path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				}
+			}
+		},
 		"path-to-regexp": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
 			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
 		},
 		"path-type": {
@@ -13729,12 +13810,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
 		},
 		"picomatch": {
 			"version": "2.2.2",
@@ -13838,6 +13913,12 @@
 			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
 			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
 		},
+		"proc-log": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+			"integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -13927,12 +14008,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
 		"pump": {
@@ -14375,64 +14450,6 @@
 				}
 			}
 		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-					"dev": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				}
-			}
-		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
-			"dev": true
-		},
 		"require_optional": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -14453,6 +14470,23 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+			"dev": true
 		},
 		"requires-port": {
 			"version": "1.0.0",
@@ -14682,7 +14716,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"devOptional": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
@@ -14766,7 +14801,8 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+			"integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+			"devOptional": true
 		},
 		"sillyname": {
 			"version": "0.1.0",
@@ -14846,9 +14882,9 @@
 			"dev": true
 		},
 		"smart-buffer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true
 		},
 		"snappy": {
@@ -14920,13 +14956,13 @@
 			}
 		},
 		"socks": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.5",
-				"smart-buffer": "^4.1.0"
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
 			}
 		},
 		"socks-proxy-agent": {
@@ -15142,23 +15178,6 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"ssri": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -15200,6 +15219,21 @@
 			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+				}
+			}
+		},
 		"string-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
@@ -15223,6 +15257,17 @@
 						"ansi-regex": "^5.0.0"
 					}
 				}
+			}
+		},
+		"string-width-cjs": {
+			"version": "npm:string-width@4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
 			}
 		},
 		"string.prototype.matchall": {
@@ -15280,23 +15325,25 @@
 				"define-properties": "^1.1.3"
 			}
 		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+		"strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"ansi-regex": "^5.0.1"
 			},
 			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
 				}
 			}
 		},
-		"strip-ansi": {
-			"version": "6.0.1",
+		"strip-ansi-cjs": {
+			"version": "npm:strip-ansi@6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
@@ -15467,24 +15514,29 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "4.4.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
 			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.8.6",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
 			},
 			"dependencies": {
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
 				}
 			}
@@ -15639,16 +15691,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
-		"tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"dev": true,
-			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			}
-		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -15780,15 +15822,10 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -16101,17 +16138,6 @@
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
-		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -16189,6 +16215,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+			"devOptional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			},
@@ -16196,17 +16223,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"devOptional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"devOptional": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"devOptional": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -16216,6 +16246,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"devOptional": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -16343,6 +16374,43 @@
 					"requires": {
 						"ansi-regex": "^5.0.1"
 					}
+				}
+			}
+		},
+		"wrap-ansi-cjs": {
+			"version": "npm:wrap-ansi@7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				}
 			}
 		},
@@ -16478,7 +16546,8 @@
 		"ws": {
 			"version": "8.2.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-			"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+			"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+			"requires": {}
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -457,6 +457,71 @@
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
       "dev": true
     },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1249,37 +1314,12 @@
         "tar": "^6.1.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -1657,16 +1697,6 @@
             "yallist": "^4.0.0"
           }
         },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
         "npm-registry-fetch": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-9.0.0.tgz",
@@ -1820,37 +1850,12 @@
         "temp-write": "^4.0.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -2149,16 +2154,6 @@
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -2536,11 +2531,86 @@
         "fastq": "^1.6.0"
       }
     },
+    "@npmcli/agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        },
+        "socks-proxy-agent": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+          "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "^4.3.4",
+            "socks": "^2.8.3"
+          }
+        }
+      }
+    },
     "@npmcli/ci-detect": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz",
       "integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==",
       "dev": true
+    },
+    "@npmcli/fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+          "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+          "dev": true
+        }
+      }
     },
     "@npmcli/git": {
       "version": "2.1.0",
@@ -2645,118 +2715,8 @@
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
         "infer-owner": "^1.0.4",
-        "node-gyp": "^7.1.0",
+        "node-gyp": "^10",
         "read-package-json-fast": "^2.0.1"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "node-gyp": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-          "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
-            "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
-            "which": "^2.0.2"
-          }
-        },
-        "nopt": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-token": {
@@ -2983,7 +2943,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
       "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "2.4.0",
@@ -3123,6 +3084,13 @@
       "requires": {
         "@types/node": ">= 8"
       }
+    },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
     },
     "@rushstack/eslint-config": {
       "version": "2.5.1",
@@ -4363,20 +4331,10 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "dev": true
     },
     "abort-controller": {
@@ -4398,7 +4356,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "add-stream": {
       "version": "1.0.0",
@@ -4452,7 +4411,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -4808,15 +4768,6 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "assert": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
@@ -4828,12 +4779,6 @@
         "object-is": "^1.0.1",
         "util": "^0.12.0"
       }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
     },
     "async": {
       "version": "3.2.3",
@@ -4874,18 +4819,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
     "azure-devops-node-api": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
@@ -4901,15 +4834,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "before-after-hook": {
       "version": "2.2.2",
@@ -5015,37 +4939,12 @@
         "unique-filename": "^1.1.1"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -5148,12 +5047,6 @@
         "quick-lru": "^4.0.1"
       }
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5188,9 +5081,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
     },
     "ci-info": {
@@ -5945,8 +5838,8 @@
       "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -6243,15 +6136,6 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "date-fns": {
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
@@ -6265,12 +6149,20 @@
       "dev": true
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
       }
     },
     "debuglog": {
@@ -6441,15 +6333,11 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -7127,7 +7015,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.28.0",
@@ -7391,6 +7280,12 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
+    "exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7427,12 +7322,6 @@
           }
         }
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -7749,12 +7638,6 @@
         }
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -7797,12 +7680,23 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "requires": {
-        "minipass": "^2.6.0"
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -8110,15 +8004,6 @@
         "get-intrinsic": "^1.1.1"
       }
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "git-config-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
@@ -8289,9 +8174,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "handlebars": {
@@ -8313,22 +8198,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
       }
     },
     "hard-rejection": {
@@ -8440,9 +8309,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -8470,17 +8339,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -8813,10 +8671,10 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+    "ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true
     },
     "irregular-plurals": {
@@ -9293,12 +9151,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -9477,6 +9329,16 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -9498,12 +9360,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
     },
     "jsdoc-type-pratt-parser": {
       "version": "3.1.0",
@@ -9527,12 +9383,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -9590,6 +9440,16 @@
       "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -9614,18 +9474,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "jsx-ast-utils": {
@@ -10441,22 +10289,10 @@
       }
     },
     "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true
     },
     "minipass-collect": {
       "version": "1.0.2",
@@ -10496,16 +10332,6 @@
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         }
@@ -10593,12 +10419,24 @@
       }
     },
     "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
       "requires": {
-        "minipass": "^2.9.0"
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "mkdirp": {
@@ -10621,12 +10459,6 @@
         "mkdirp": "^1.0.3"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -10882,9 +10714,9 @@
       "dev": true
     },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "dev": true
     },
     "neo-async": {
@@ -10912,29 +10744,245 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
-      "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
+      "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
-        "mkdirp": "^0.5.1",
-        "nopt": "^4.0.1",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.0",
-        "rimraf": "^2.6.3",
-        "semver": "^5.7.1",
-        "tar": "^4.4.12",
-        "which": "^1.3.1"
+        "exponential-backoff": "^3.1.1",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^13.0.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^4.1.0",
+        "semver": "^7.3.5",
+        "tar": "^6.2.1",
+        "which": "^4.0.0"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+        "brace-expansion": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "cacache": {
+          "version": "18.0.4",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+          "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^3.1.0",
+            "fs-minipass": "^3.0.0",
+            "glob": "^10.2.2",
+            "lru-cache": "^10.0.1",
+            "minipass": "^7.0.3",
+            "minipass-collect": "^2.0.1",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "p-map": "^4.0.0",
+            "ssri": "^10.0.0",
+            "tar": "^6.1.11",
+            "unique-filename": "^3.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+          "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          },
+          "dependencies": {
+            "which": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
+          }
+        },
+        "foreground-child": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+          "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.6",
+            "signal-exit": "^4.0.1"
+          }
+        },
+        "fs-minipass": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+          "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
+          }
+        },
+        "glob": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
+        },
+        "make-fetch-happen": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+          "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+          "dev": true,
+          "requires": {
+            "@npmcli/agent": "^2.0.0",
+            "cacache": "^18.0.0",
+            "http-cache-semantics": "^4.1.1",
+            "is-lambda": "^1.0.1",
+            "minipass": "^7.0.2",
+            "minipass-fetch": "^3.0.0",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "proc-log": "^4.2.0",
+            "promise-retry": "^2.0.1",
+            "ssri": "^10.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.2"
+          }
+        },
+        "minipass": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+          "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+          "dev": true
+        },
+        "minipass-collect": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+          "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
+          }
+        },
+        "minipass-fetch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+          "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.13",
+            "minipass": "^7.0.3",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.1.2"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+          "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "ssri": {
+          "version": "10.0.6",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+          "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
+          }
+        },
+        "unique-filename": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+          "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+          "dev": true,
+          "requires": {
+            "unique-slug": "^4.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+          "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "which": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+          "dev": true,
+          "requires": {
+            "isexe": "^3.1.1"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "3.1.5",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+              "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -10984,13 +11032,12 @@
       }
     },
     "nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
       "dev": true,
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "^2.0.0"
       }
     },
     "normalize-package-data": {
@@ -11062,7 +11109,7 @@
       "requires": {
         "byline": "^5.0.0",
         "graceful-fs": "^4.1.15",
-        "node-gyp": "^5.0.2",
+        "node-gyp": "^10",
         "resolve-from": "^4.0.0",
         "slide": "^1.1.6",
         "uid-number": "0.0.6",
@@ -11384,16 +11431,6 @@
           "requires": {
             "yallist": "^4.0.0"
           }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
         }
       }
     },
@@ -11626,12 +11663,6 @@
           }
         }
       }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12033,12 +12064,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -12054,16 +12079,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "override-require": {
       "version": "1.1.1",
@@ -12168,6 +12183,12 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "pacote": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
@@ -12195,37 +12216,12 @@
         "tar": "^6.1.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -12384,16 +12380,28 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -12444,6 +12452,12 @@
         "colors": "1.4.0",
         "minimist": "^1.2.0"
       }
+    },
+    "proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -12518,12 +12532,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pump": {
@@ -12892,47 +12900,6 @@
         }
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13171,19 +13138,19 @@
       "dev": true
     },
     "smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true
     },
     "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
       }
     },
     "socks-proxy-agent": {
@@ -13391,23 +13358,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -13434,6 +13384,23 @@
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -13454,6 +13421,17 @@
             "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "string.prototype.matchall": {
@@ -13559,25 +13537,25 @@
         "define-properties": "^1.1.3"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "ansi-regex": "^5.0.1"
       },
       "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         }
       }
     },
-    "strip-ansi": {
-      "version": "6.0.1",
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
@@ -13740,24 +13718,23 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "requires": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
       }
@@ -13853,16 +13830,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -13980,21 +13947,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -14256,17 +14208,6 @@
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "wcwidth": {
@@ -14589,6 +14530,43 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
+        }
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -78,5 +78,8 @@
     "supertest": "^3.3.0",
     "tslint": "^5.12.0",
     "typescript": "~4.5.5"
+  },
+  "overrides": {
+    "node-gyp": "^10"
   }
 }

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -3,7 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.17.1-buster-slim AS base
+FROM node:18.17.1-bookworm-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -5960,11 +5960,11 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"browser-stdout": {
@@ -6376,35 +6376,6 @@
 					"requires": {
 						"normalize-path": "^3.0.0",
 						"picomatch": "^2.0.4"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
 					}
 				}
 			}
@@ -9050,60 +9021,15 @@
 			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
 		},
 		"fast-glob": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-			"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
-			},
-			"dependencies": {
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
-					}
-				},
-				"picomatch": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				}
+				"micromatch": "^4.0.8"
 			}
 		},
 		"fast-json-patch": {
@@ -9199,9 +9125,9 @@
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
@@ -10442,7 +10368,8 @@
 		"interpret": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+			"dev": true
 		},
 		"ioredis": {
 			"version": "4.24.5",
@@ -12401,11 +12328,11 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"requires": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"dependencies": {
@@ -13502,19 +13429,6 @@
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
-					}
-				},
-				"fast-glob": {
-					"version": "3.2.11",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-					"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
 					}
 				},
 				"find-up": {
@@ -15101,6 +15015,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -15370,6 +15285,7 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -15633,6 +15549,7 @@
 			"version": "0.8.4",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
 			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -18174,16 +18091,97 @@
 			}
 		},
 		"zookeeper": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/zookeeper/-/zookeeper-5.3.2.tgz",
-			"integrity": "sha512-qOhlRjomHltFwsmiccxS1TWa1iHsV1AT6sACqnKqdCSlneQv7qRJgAnUnTD3TX2AjFWIgCNf9QJiX8us7rBwhw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/zookeeper/-/zookeeper-7.2.0.tgz",
+			"integrity": "sha512-4x9yk2HH1lHxLVPIh/3Ll6rkMNHEJACN4TZDI2oI9pkJDvbVEpzvn23qQK/5ctbUvS39+rSrxuAQ9NYFtG0Aig==",
 			"requires": {
 				"async": "3.2.x",
 				"decompress": "4.2.x",
 				"decompress-targz": "4.1.x",
 				"nan": "2.x",
 				"node-gyp-build": "^4.2.3",
-				"shelljs": "0.8.x"
+				"shelljs": "0.10.x"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+					"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+					"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.0",
+						"human-signals": "^2.1.0",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.1",
+						"onetime": "^5.1.2",
+						"signal-exit": "^3.0.3",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+				},
+				"shelljs": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+					"integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+					"requires": {
+						"execa": "^5.1.1",
+						"fast-glob": "^3.3.2"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		}
 	}

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -30,7 +30,7 @@
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.18.1",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
@@ -58,7 +58,7 @@
 			"requires": {
 				"@babel/types": "^7.9.6",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
+				"lodash": "^4.18.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
@@ -120,7 +120,7 @@
 				"@babel/helper-split-export-declaration": "^7.8.3",
 				"@babel/template": "^7.8.6",
 				"@babel/types": "^7.9.0",
-				"lodash": "^4.17.13"
+				"lodash": "^4.18.1"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -230,7 +230,7 @@
 				"@babel/types": "^7.9.6",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"lodash": "^4.18.1"
 			}
 		},
 		"@babel/types": {
@@ -240,7 +240,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.5",
-				"lodash": "^4.17.13",
+				"lodash": "^4.18.1",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -274,55 +274,52 @@
 				"is-negated-glob": "^1.0.0"
 			}
 		},
+		"@eslint-community/eslint-utils": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"requires": {
+				"eslint-visitor-keys": "^3.4.3"
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="
+		},
 		"@eslint/eslintrc": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-			"integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.2.0",
-				"globals": "^13.9.0",
-				"ignore": "^4.0.6",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 				},
 				"globals": {
-					"version": "13.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-					"integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+					"version": "13.24.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+					"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
 				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-				},
 				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+					"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 					"requires": {
 						"argparse": "^2.0.1"
 					}
@@ -333,6 +330,11 @@
 					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
 				}
 			}
+		},
+		"@eslint/js": {
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA=="
 		},
 		"@fluidframework/build-common": {
 			"version": "0.24.0",
@@ -447,7 +449,7 @@
 				"@types/events": "^3.0.0",
 				"base64-js": "^1.5.1",
 				"events": "^3.1.0",
-				"lodash": "^4.17.21",
+				"lodash": "^4.18.1",
 				"sha.js": "^2.4.11"
 			},
 			"dependencies": {
@@ -511,19 +513,24 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-			"integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"requires": {
-				"@humanwhocodes/object-schema": "^1.2.1",
-				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
 			}
 		},
+		"@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
+		},
 		"@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
 		},
 		"@hutson/parse-repository-url": {
 			"version": "3.0.2",
@@ -1294,7 +1301,7 @@
 					"integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.7.0",
+						"lodash": "^4.18.1",
 						"tr46": "^2.1.0",
 						"webidl-conversions": "^6.1.0"
 					}
@@ -1564,7 +1571,8 @@
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 					"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				},
 				"@octokit/plugin-rest-endpoint-methods": {
 					"version": "5.3.7",
@@ -1637,7 +1645,7 @@
 					"integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.7.0",
+						"lodash": "^4.18.1",
 						"tr46": "^2.1.0",
 						"webidl-conversions": "^6.1.0"
 					}
@@ -3185,7 +3193,7 @@
 				"@rushstack/rig-package": "0.3.10",
 				"@rushstack/ts-command-line": "4.10.9",
 				"colors": "~1.2.1",
-				"lodash": "~4.17.15",
+				"lodash": "^4.18.1",
 				"resolve": "~1.17.0",
 				"semver": "~7.3.0",
 				"source-map": "~0.6.1",
@@ -3422,19 +3430,12 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"requires": {
-				"@nodelib/fs.stat": "2.0.3",
+				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
-			},
-			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
-				}
 			}
 		},
 		"@nodelib/fs.stat": {
@@ -3443,11 +3444,11 @@
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.3",
+				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -3917,7 +3918,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "2.4.0",
@@ -5237,6 +5239,11 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
 		},
+		"@ungap/structured-clone": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -5371,7 +5378,8 @@
 		"@webpack-cli/configtest": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg=="
+			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+			"requires": {}
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.1",
@@ -5384,7 +5392,8 @@
 		"@webpack-cli/serve": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw=="
+			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+			"requires": {}
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -5395,16 +5404,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
-		},
-		"JSONStream": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
-			"requires": {
-				"jsonparse": "^1.2.0",
-				"through": ">=2.2.7 <3"
-			}
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -5431,19 +5430,21 @@
 			}
 		},
 		"acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"requires": {}
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"requires": {}
 		},
 		"add-stream": {
 			"version": "1.0.0",
@@ -5482,9 +5483,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -5496,12 +5497,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"requires": {}
 		},
 		"amqplib": {
 			"version": "0.8.0",
@@ -5559,7 +5562,8 @@
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"devOptional": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -5581,7 +5585,8 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"devOptional": true
 		},
 		"archy": {
 			"version": "1.0.0",
@@ -5593,6 +5598,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"devOptional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -5601,12 +5607,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"devOptional": true
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"devOptional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -5621,6 +5629,7 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"devOptional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -5726,11 +5735,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
 		"async": {
 			"version": "3.2.3",
@@ -6202,19 +6206,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
 		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
-		},
 		"chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -6248,11 +6239,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"chokidar": {
 			"version": "3.5.3",
@@ -6312,7 +6298,8 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"devOptional": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
@@ -6444,7 +6431,8 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
+			"integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+			"devOptional": true
 		},
 		"color": {
 			"version": "3.2.1",
@@ -6629,7 +6617,7 @@
 			"requires": {
 				"chalk": "^4.1.0",
 				"date-fns": "^2.16.1",
-				"lodash": "^4.17.21",
+				"lodash": "^4.18.1",
 				"rxjs": "^6.6.3",
 				"spawn-command": "^0.0.2-1",
 				"supports-color": "^8.1.0",
@@ -6712,7 +6700,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"devOptional": true
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -6751,7 +6740,7 @@
 				"git-raw-commits": "^2.0.8",
 				"git-remote-origin-url": "^2.0.0",
 				"git-semver-tags": "^4.1.1",
-				"lodash": "^4.17.15",
+				"lodash": "^4.18.1",
 				"normalize-package-data": "^3.0.0",
 				"q": "^1.5.1",
 				"read-pkg": "^3.0.0",
@@ -6769,7 +6758,7 @@
 						"dateformat": "^3.0.0",
 						"handlebars": "^4.7.6",
 						"json-stringify-safe": "^5.0.1",
-						"lodash": "^4.17.15",
+						"lodash": "^4.18.1",
 						"meow": "^8.0.0",
 						"semver": "^6.0.0",
 						"split": "^1.0.0",
@@ -7153,9 +7142,9 @@
 			"integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.1",
-				"lodash": "^4.17.15",
+				"JSONStream": "^1.0.4",
+				"lodash": "^4.18.1",
 				"meow": "^8.0.0",
 				"split2": "^3.0.0",
 				"through2": "^4.0.0",
@@ -7698,27 +7687,6 @@
 			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
 			"dev": true
 		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
-		"deep-equal": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-			"requires": {
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.1",
-				"is-regex": "^1.0.4",
-				"object-is": "^1.0.1",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.2.0"
-			}
-		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -7772,7 +7740,8 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"devOptional": true
 		},
 		"denque": {
 			"version": "1.4.1",
@@ -7991,7 +7960,8 @@
 				"ws": {
 					"version": "7.4.6",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+					"requires": {}
 				}
 			}
 		},
@@ -8010,14 +7980,6 @@
 			"requires": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
-			}
-		},
-		"enquirer": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-			"requires": {
-				"ansi-colors": "^4.1.1"
 			}
 		},
 		"env-paths": {
@@ -8130,48 +8092,48 @@
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"eslint": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-			"integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"requires": {
-				"@eslint/eslintrc": "^1.0.5",
-				"@humanwhocodes/config-array": "^0.9.2",
-				"ajv": "^6.10.0",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
+				"@humanwhocodes/config-array": "^0.11.13",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
-				"enquirer": "^2.3.5",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.0",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.1.0",
-				"espree": "^9.3.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^6.0.1",
-				"globals": "^13.6.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
-				"progress": "^2.0.0",
-				"regexpp": "^3.2.0",
-				"semver": "^7.2.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8238,9 +8200,9 @@
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
 				"eslint-scope": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-					"integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+					"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 					"requires": {
 						"esrecurse": "^4.3.0",
 						"estraverse": "^5.2.0"
@@ -8256,6 +8218,15 @@
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 				},
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"glob-parent": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -8265,9 +8236,9 @@
 					}
 				},
 				"globals": {
-					"version": "13.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-					"integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+					"version": "13.24.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+					"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
@@ -8277,11 +8248,6 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-				},
 				"js-yaml": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -8290,18 +8256,39 @@
 						"argparse": "^2.0.1"
 					}
 				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
 				"path-key": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -8450,13 +8437,6 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.5",
 				"ignore": "^5.0.5"
-			},
-			"dependencies": {
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-				}
 			}
 		},
 		"eslint-plugin-import": {
@@ -8514,7 +8494,8 @@
 		"eslint-plugin-promise": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
-			"integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw=="
+			"integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
+			"requires": {}
 		},
 		"eslint-plugin-react": {
 			"version": "7.28.0",
@@ -8581,7 +8562,7 @@
 				"esquery": "^1.4.0",
 				"indent-string": "^4.0.0",
 				"is-builtin-module": "^3.1.0",
-				"lodash": "^4.17.21",
+				"lodash": "^4.18.1",
 				"pluralize": "^8.0.0",
 				"read-pkg-up": "^7.0.1",
 				"regexp-tree": "^0.1.24",
@@ -8717,18 +8698,18 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-			"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA=="
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
 		},
 		"espree": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-			"integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"requires": {
-				"acorn": "^8.7.0",
-				"acorn-jsx": "^5.3.1",
-				"eslint-visitor-keys": "^3.1.0"
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"esprima": {
@@ -8738,9 +8719,9 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"requires": {
 				"estraverse": "^5.1.0"
 			},
@@ -8863,7 +8844,7 @@
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.13",
+				"path-to-regexp": "0.1.7",
 				"proxy-addr": "~2.0.5",
 				"qs": "6.7.0",
 				"range-parser": "~1.2.1",
@@ -9008,7 +8989,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
 		"fastest-levenshtein": {
 			"version": "1.0.12",
@@ -9056,7 +9037,8 @@
 		"fengari-interop": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.2.tgz",
-			"integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ=="
+			"integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ==",
+			"requires": {}
 		},
 		"figures": {
 			"version": "3.2.0",
@@ -9414,6 +9396,7 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+			"devOptional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -9428,12 +9411,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+					"devOptional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+					"devOptional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9442,6 +9427,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+					"devOptional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -9452,6 +9438,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+					"devOptional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9468,11 +9455,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-intrinsic": {
 			"version": "1.1.1",
@@ -9546,7 +9528,7 @@
 			"dev": true,
 			"requires": {
 				"dargs": "^7.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.18.1",
 				"meow": "^8.0.0",
 				"split2": "^3.0.0",
 				"through2": "^4.0.0"
@@ -9722,19 +9704,17 @@
 				"ignore": "^5.1.4",
 				"merge2": "^1.3.0",
 				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-				}
 			}
 		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+		},
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
 		"handlebars": {
 			"version": "4.7.7",
@@ -9812,7 +9792,8 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"devOptional": true
 		},
 		"hasha": {
 			"version": "5.2.0",
@@ -9992,9 +9973,9 @@
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
 		},
 		"ignore-walk": {
 			"version": "3.0.4",
@@ -10108,7 +10089,8 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"devOptional": true
 		},
 		"init-package-json": {
 			"version": "2.0.3",
@@ -10192,7 +10174,7 @@
 				"cli-width": "^3.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
-				"lodash": "^4.17.19",
+				"lodash": "^4.18.1",
 				"mute-stream": "0.0.8",
 				"run-async": "^2.4.0",
 				"rxjs": "^6.6.0",
@@ -10359,7 +10341,7 @@
 			"requires": {
 				"fengari": "^0.1.4",
 				"fengari-interop": "^0.1.2",
-				"lodash": "^4.17.20",
+				"lodash": "^4.18.1",
 				"minimatch": "^3.0.4",
 				"standard-as-callback": "^2.0.1"
 			}
@@ -10394,7 +10376,8 @@
 		"is-arguments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -10471,7 +10454,8 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"devOptional": true
 		},
 		"is-generator-function": {
 			"version": "1.0.10",
@@ -10537,6 +10521,11 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
 			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -11131,6 +11120,16 @@
 			"integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
 			"dev": true
 		},
+		"JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			}
+		},
 		"jsonwebtoken": {
 			"version": "8.5.1",
 			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -11265,7 +11264,7 @@
 				"buffermaker": "~1.2.0",
 				"debug": "^2.1.3",
 				"denque": "^1.3.0",
-				"lodash": "^4.17.4",
+				"lodash": "^4.18.1",
 				"minimatch": "^3.0.2",
 				"nested-error-stacks": "^2.0.0",
 				"optional": "^0.1.3",
@@ -11279,7 +11278,7 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
 					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"requires": {
-						"lodash": "^4.17.14"
+						"lodash": "^4.18.1"
 					}
 				},
 				"debug": {
@@ -12344,9 +12343,9 @@
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -12568,6 +12567,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"devOptional": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -12957,26 +12957,13 @@
 			}
 		},
 		"nock": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
-			"integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+			"version": "13.5.6",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+			"integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
 			"requires": {
-				"chai": "^4.1.2",
 				"debug": "^4.1.0",
-				"deep-equal": "^1.0.0",
 				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.5",
-				"mkdirp": "^0.5.0",
-				"propagate": "^1.0.0",
-				"qs": "^6.5.1",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
+				"propagate": "^2.0.0"
 			}
 		},
 		"node-abi": {
@@ -13241,18 +13228,6 @@
 				"validate-npm-package-name": "^3.0.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13360,12 +13335,6 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"ignore": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-					"dev": true
 				},
 				"is-core-module": {
 					"version": "2.9.0",
@@ -13598,6 +13567,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"devOptional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -13608,7 +13578,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
+			"integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+			"devOptional": true
 		},
 		"nyc": {
 			"version": "15.0.1",
@@ -13864,6 +13835,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
 			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
@@ -13984,22 +13956,23 @@
 			"integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw=="
 		},
 		"optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"requires": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"word-wrap": "^1.2.5"
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="
+			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+			"devOptional": true
 		},
 		"os-name": {
 			"version": "3.1.0",
@@ -14400,19 +14373,13 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
 			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
 		},
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -14550,11 +14517,6 @@
 				"fromentries": "^1.2.0"
 			}
 		},
-		"progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -14599,9 +14561,9 @@
 			}
 		},
 		"propagate": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
 		},
 		"proto-list": {
 			"version": "1.2.4",
@@ -14681,6 +14643,11 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
 			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
 		"quick-lru": {
 			"version": "4.0.1",
@@ -15075,15 +15042,6 @@
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
 				"string-width": {
 					"version": "4.2.3",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -15176,17 +15134,6 @@
 				}
 			}
 		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
-		},
 		"require_optional": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -15207,6 +15154,17 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
 		},
 		"requires-port": {
 			"version": "1.0.0",
@@ -15277,9 +15235,12 @@
 			"dev": true
 		},
 		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
 		},
 		"run-script-os": {
 			"version": "1.1.5",
@@ -15328,19 +15289,6 @@
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
 				"ajv-keywords": "^3.5.2"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				}
 			}
 		},
 		"secure-keys": {
@@ -15440,7 +15388,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"devOptional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -15762,7 +15711,7 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
 					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"requires": {
-						"lodash": "^4.17.14"
+						"lodash": "^4.18.1"
 					}
 				}
 			}
@@ -15962,6 +15911,11 @@
 			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
 		"string-argv": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -15977,6 +15931,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"devOptional": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -16015,15 +15970,11 @@
 				"define-properties": "^1.1.3"
 			}
 		},
-		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"devOptional": true,
 			"requires": {
 				"ansi-regex": "^3.0.0"
 			}
@@ -16726,8 +16677,7 @@
 		"typescript": {
 			"version": "4.5.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-			"dev": true
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
 		},
 		"typescript-formatter": {
 			"version": "7.1.0",
@@ -16935,11 +16885,6 @@
 			"version": "8.3.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
 			"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
-		},
-		"v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -17402,6 +17347,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"devOptional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -17503,9 +17449,9 @@
 			}
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
 		},
 		"wordwrap": {
 			"version": "1.0.0",
@@ -17716,7 +17662,8 @@
 		"ws": {
 			"version": "7.5.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-			"integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+			"integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+			"requires": {}
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -538,6 +538,71 @@
 			"integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
 			"dev": true
 		},
+		"@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+					"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+					"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+					"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+					"dev": true,
+					"requires": {
+						"eastasianwidth": "^0.2.0",
+						"emoji-regex": "^9.2.2",
+						"strip-ansi": "^7.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+					"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^6.2.2"
+					}
+				},
+				"wrap-ansi": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+					"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^6.1.0",
+						"string-width": "^5.0.1",
+						"strip-ansi": "^7.0.1"
+					}
+				}
+			}
+		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -1464,15 +1529,6 @@
 						"universalify": "^2.0.0"
 					}
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"jsonfile": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1489,16 +1545,6 @@
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -1535,12 +1581,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-					"dev": true
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -1968,15 +2008,6 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"http-proxy-agent": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -2027,16 +2058,6 @@
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -2102,12 +2123,6 @@
 						"mkdirp": "^1.0.3",
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -2310,31 +2325,12 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -2357,12 +2353,6 @@
 						"mkdirp": "^1.0.3",
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -2603,15 +2593,6 @@
 						"universalify": "^2.0.0"
 					}
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"http-proxy-agent": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -2672,16 +2653,6 @@
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -2761,12 +2732,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-					"dev": true
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -3452,11 +3417,101 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@npmcli/agent": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+			"integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+					"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.4.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+					"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.3"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+					"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.2",
+						"debug": "4"
+					}
+				},
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
+				},
+				"socks-proxy-agent": {
+					"version": "8.0.5",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+					"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.2",
+						"debug": "^4.3.4",
+						"socks": "^2.8.3"
+					}
+				}
+			}
+		},
 		"@npmcli/ci-detect": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz",
 			"integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==",
 			"dev": true
+		},
+		"@npmcli/fs": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+					"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+					"dev": true
+				}
+			}
 		},
 		"@npmcli/git": {
 			"version": "2.1.0",
@@ -3561,124 +3616,8 @@
 				"@npmcli/node-gyp": "^1.0.2",
 				"@npmcli/promise-spawn": "^1.3.2",
 				"infer-owner": "^1.0.4",
-				"node-gyp": "^7.1.0",
+				"node-gyp": "^10",
 				"read-package-json-fast": "^2.0.1"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-					"dev": true
-				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
-				"minipass": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
-				"node-gyp": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-					"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
-					"dev": true,
-					"requires": {
-						"env-paths": "^2.2.0",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.2.3",
-						"nopt": "^5.0.0",
-						"npmlog": "^4.1.2",
-						"request": "^2.88.2",
-						"rimraf": "^3.0.2",
-						"semver": "^7.3.2",
-						"tar": "^6.0.2",
-						"which": "^2.0.2"
-					}
-				},
-				"nopt": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-					"dev": true,
-					"requires": {
-						"abbrev": "1"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"tar": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-					"integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
-					"dev": true,
-					"requires": {
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"minipass": "^3.0.0",
-						"minizlib": "^2.1.1",
-						"mkdirp": "^1.0.3",
-						"yallist": "^4.0.0"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
 			}
 		},
 		"@octokit/auth-token": {
@@ -4028,6 +3967,13 @@
 			"requires": {
 				"@types/node": ">= 8"
 			}
+		},
+		"@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true
 		},
 		"@rushstack/eslint-config": {
 			"version": "2.5.1",
@@ -5406,9 +5352,9 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+			"integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
 			"dev": true
 		},
 		"abort-controller": {
@@ -6129,6 +6075,174 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
+		"cacache": {
+			"version": "18.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+			"dev": true,
+			"requires": {
+				"@npmcli/fs": "^3.1.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^4.0.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^3.0.0"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+					"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+					"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"foreground-child": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+					"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.6",
+						"signal-exit": "^4.0.1"
+					}
+				},
+				"fs-minipass": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+					"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+					"dev": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"glob": {
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^3.1.2",
+						"minimatch": "^9.0.4",
+						"minipass": "^7.1.2",
+						"package-json-from-dist": "^1.0.0",
+						"path-scurry": "^1.11.1"
+					}
+				},
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
+					}
+				},
+				"minipass": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+					"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+					"dev": true
+				},
+				"minipass-collect": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+					"integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+					"dev": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"unique-filename": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+					"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+					"dev": true,
+					"requires": {
+						"unique-slug": "^4.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+					"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"caching-transform": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -6299,7 +6413,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"devOptional": true
+			"optional": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
@@ -7833,6 +7947,12 @@
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
+		"eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -8821,6 +8941,12 @@
 				"homedir-polyfill": "^1.0.1"
 			}
 		},
+		"exponential-backoff": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+			"dev": true
+		},
 		"express": {
 			"version": "4.17.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -8875,6 +9001,11 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"path-to-regexp": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+					"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
 				},
 				"qs": {
 					"version": "6.7.0",
@@ -9345,12 +9476,23 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
 			"dev": true,
 			"requires": {
-				"minipass": "^2.6.0"
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
 			}
 		},
 		"fs.realpath": {
@@ -9707,9 +9849,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
 		"graphemer": {
 			"version": "1.4.0",
@@ -9851,9 +9993,9 @@
 			"dev": true
 		},
 		"http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
 			"dev": true
 		},
 		"http-errors": {
@@ -10346,10 +10488,10 @@
 				"standard-as-callback": "^2.0.1"
 			}
 		},
-		"ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+		"ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"dev": true
 		},
 		"ipaddr.js": {
@@ -10997,6 +11139,16 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
+		"jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"requires": {
+				"@isaacs/cliui": "^8.0.2",
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
 		"jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -11469,12 +11621,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -11548,12 +11694,6 @@
 					"requires": {
 						"minipass": "^3.1.1"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -11873,13 +12013,6 @@
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"requires": {
 				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
 			}
 		},
 		"macos-release": {
@@ -11960,15 +12093,6 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"http-proxy-agent": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -11996,16 +12120,6 @@
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -12055,12 +12169,6 @@
 						"mkdirp": "^1.0.3",
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -12375,14 +12483,10 @@
 			}
 		},
 		"minipass": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"dev": true
 		},
 		"minipass-collect": {
 			"version": "1.0.2",
@@ -12401,12 +12505,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -12430,22 +12528,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -12466,12 +12548,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -12493,12 +12569,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -12519,12 +12589,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -12545,22 +12609,28 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
 		"minizlib": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
 			"dev": true,
 			"requires": {
-				"minipass": "^2.9.0"
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
 			}
 		},
 		"mkdirp": {
@@ -12999,29 +13069,180 @@
 			}
 		},
 		"node-gyp": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
-			"integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
+			"integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
 			"dev": true,
 			"requires": {
 				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.2",
-				"mkdirp": "^0.5.1",
-				"nopt": "^4.0.1",
-				"npmlog": "^4.1.2",
-				"request": "^2.88.0",
-				"rimraf": "^2.6.3",
-				"semver": "^5.7.1",
-				"tar": "^4.4.12",
-				"which": "^1.3.1"
+				"exponential-backoff": "^3.1.1",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^13.0.0",
+				"nopt": "^7.0.0",
+				"proc-log": "^4.1.0",
+				"semver": "^7.3.5",
+				"tar": "^6.2.1",
+				"which": "^4.0.0"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+				"brace-expansion": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+					"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+					"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					},
+					"dependencies": {
+						"which": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+							"dev": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						}
+					}
+				},
+				"foreground-child": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+					"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.6",
+						"signal-exit": "^4.0.1"
+					}
+				},
+				"glob": {
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^3.1.2",
+						"minimatch": "^9.0.4",
+						"minipass": "^7.1.2",
+						"package-json-from-dist": "^1.0.0",
+						"path-scurry": "^1.11.1"
+					}
+				},
+				"make-fetch-happen": {
+					"version": "13.0.1",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+					"integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+					"dev": true,
+					"requires": {
+						"@npmcli/agent": "^2.0.0",
+						"cacache": "^18.0.0",
+						"http-cache-semantics": "^4.1.1",
+						"is-lambda": "^1.0.1",
+						"minipass": "^7.0.2",
+						"minipass-fetch": "^3.0.0",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"negotiator": "^0.6.3",
+						"proc-log": "^4.2.0",
+						"promise-retry": "^2.0.1",
+						"ssri": "^10.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
+					}
+				},
+				"minipass": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+					"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 					"dev": true
+				},
+				"minipass-fetch": {
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+					"integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+					"dev": true,
+					"requires": {
+						"encoding": "^0.1.13",
+						"minipass": "^7.0.3",
+						"minipass-sized": "^1.0.3",
+						"minizlib": "^2.1.2"
+					}
+				},
+				"negotiator": {
+					"version": "0.6.4",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+					"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+					"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"which": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+					"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+					"dev": true,
+					"requires": {
+						"isexe": "^3.1.1"
+					},
+					"dependencies": {
+						"isexe": {
+							"version": "3.1.5",
+							"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+							"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+							"dev": true
+						}
+					}
 				}
 			}
 		},
@@ -13070,13 +13291,12 @@
 			"optional": true
 		},
 		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+			"integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
 			"dev": true,
 			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
+				"abbrev": "^2.0.0"
 			}
 		},
 		"normalize-package-data": {
@@ -13158,7 +13378,7 @@
 			"requires": {
 				"byline": "^5.0.0",
 				"graceful-fs": "^4.1.15",
-				"node-gyp": "^5.0.2",
+				"node-gyp": "^10",
 				"resolve-from": "^4.0.0",
 				"slide": "^1.1.6",
 				"uid-number": "0.0.6",
@@ -13535,22 +13755,6 @@
 					"requires": {
 						"yallist": "^4.0.0"
 					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -13972,7 +14176,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-			"devOptional": true
+			"optional": true
 		},
 		"os-name": {
 			"version": "3.1.0",
@@ -13988,16 +14192,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
 		},
 		"override-require": {
 			"version": "1.1.1",
@@ -14096,6 +14290,12 @@
 				"release-zalgo": "^1.0.0"
 			}
 		},
+		"package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true
+		},
 		"pacote": {
 			"version": "11.3.5",
 			"resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
@@ -14154,31 +14354,12 @@
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -14228,12 +14409,6 @@
 						"mkdirp": "^1.0.3",
 						"yallist": "^4.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -14372,9 +14547,23 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
-		"path-to-regexp": {
-			"version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+		"path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				}
+			}
 		},
 		"path-type": {
 			"version": "4.0.0",
@@ -14502,6 +14691,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
 			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+		},
+		"proc-log": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+			"integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -15547,9 +15742,9 @@
 			"dev": true
 		},
 		"smart-buffer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true
 		},
 		"snappy": {
@@ -15602,13 +15797,13 @@
 			}
 		},
 		"socks": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.5",
-				"smart-buffer": "^4.1.0"
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
 			}
 		},
 		"socks-proxy-agent": {
@@ -15890,6 +16085,23 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"ssri": {
+			"version": "10.0.6",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+			"dev": true,
+			"requires": {
+				"minipass": "^7.0.3"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+					"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+					"dev": true
+				}
+			}
+		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -15937,6 +16149,46 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
+		"string-width-cjs": {
+			"version": "npm:string-width@4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
 		"string.prototype.matchall": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
@@ -15977,6 +16229,23 @@
 			"devOptional": true,
 			"requires": {
 				"ansi-regex": "^3.0.0"
+			}
+		},
+		"strip-ansi-cjs": {
+			"version": "npm:strip-ansi@6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				}
 			}
 		},
 		"strip-bom": {
@@ -16133,18 +16402,31 @@
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
 		},
 		"tar": {
-			"version": "4.4.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
 			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.8.6",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				}
 			}
 		},
 		"tar-fs": {
@@ -17530,6 +17812,81 @@
 				}
 			}
 		},
+		"wrap-ansi-cjs": {
+			"version": "npm:wrap-ansi@7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -17677,10 +18034,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yaml": {
 			"version": "1.10.2",

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -374,6 +374,71 @@
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
       "dev": true
     },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -1244,12 +1309,6 @@
         "tar": "^6.1.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -1260,15 +1319,6 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
-          }
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
           }
         },
         "jsonfile": {
@@ -1287,16 +1337,6 @@
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -1736,16 +1776,6 @@
             "yallist": "^4.0.0"
           }
         },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
         "npm-registry-fetch": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-9.0.0.tgz",
@@ -1959,37 +1989,12 @@
         "temp-write": "^4.0.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -2244,16 +2249,6 @@
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -2886,6 +2881,64 @@
         "fastq": "^1.6.0"
       }
     },
+    "@npmcli/agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        },
+        "socks-proxy-agent": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+          "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "^4.3.4",
+            "socks": "^2.8.3"
+          }
+        }
+      }
+    },
     "@npmcli/ci-detect": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz",
@@ -3005,109 +3058,8 @@
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
         "infer-owner": "^1.0.4",
-        "node-gyp": "^7.1.0",
+        "node-gyp": "^10",
         "read-package-json-fast": "^2.0.1"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "node-gyp": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-          "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
-            "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
-            "which": "^2.0.2"
-          }
-        },
-        "nopt": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-token": {
@@ -3455,6 +3407,13 @@
         "@types/node": ">= 8"
       }
     },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
+    },
     "@rushstack/node-core-library": {
       "version": "3.45.3",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.3.tgz",
@@ -3637,9 +3596,9 @@
       "dev": true
     },
     "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "dev": true
     },
     "abort-controller": {
@@ -3821,15 +3780,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "assert": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
@@ -3841,12 +3791,6 @@
         "object-is": "^1.0.1",
         "util": "^0.12.0"
       }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true
     },
     "async": {
       "version": "3.2.4",
@@ -3887,18 +3831,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
     "azure-devops-node-api": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
@@ -3914,15 +3846,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "before-after-hook": {
       "version": "2.2.2",
@@ -4011,37 +3934,12 @@
         "unique-filename": "^1.1.1"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.6",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
           "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -4144,12 +4042,6 @@
         "quick-lru": "^4.0.1"
       }
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4168,9 +4060,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
     },
     "ci-info": {
@@ -4990,15 +4882,6 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
@@ -5160,15 +5043,11 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -5366,10 +5245,10 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+    "exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true
     },
     "extend-shallow": {
@@ -5402,12 +5281,6 @@
           }
         }
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -5573,12 +5446,6 @@
         }
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "dev": true
-    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -5615,12 +5482,23 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "requires": {
-        "minipass": "^2.6.0"
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -5793,15 +5671,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "git-config-path": {
@@ -6047,22 +5916,6 @@
         "wordwrap": "^1.0.0"
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -6175,9 +6028,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -6205,17 +6058,6 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -6493,10 +6335,10 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
-    "ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+    "ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true
     },
     "irregular-plurals": {
@@ -6820,12 +6662,6 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
-    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -7006,6 +6842,16 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -7028,12 +6874,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7050,12 +6890,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -7138,18 +6972,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
       }
     },
     "jszip": {
@@ -7762,22 +7584,10 @@
       }
     },
     "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true
     },
     "minipass-collect": {
       "version": "1.0.2",
@@ -7817,16 +7627,6 @@
           "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         }
@@ -7914,12 +7714,24 @@
       }
     },
     "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
       "requires": {
-        "minipass": "^2.9.0"
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "mkdirp": {
@@ -7937,14 +7749,6 @@
         "chownr": "^2.0.0",
         "infer-owner": "^1.0.4",
         "mkdirp": "^1.0.3"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        }
       }
     },
     "modify-values": {
@@ -8032,38 +7836,248 @@
       }
     },
     "node-gyp": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
-      "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
+      "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
-        "mkdirp": "^0.5.1",
-        "nopt": "^4.0.1",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.0",
-        "rimraf": "^2.6.3",
-        "semver": "^5.7.1",
-        "tar": "^4.4.12",
-        "which": "^1.3.1"
+        "exponential-backoff": "^3.1.1",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^13.0.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^4.1.0",
+        "semver": "^7.3.5",
+        "tar": "^6.2.1",
+        "which": "^4.0.0"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+        "@npmcli/fs": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+          "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "semver": "^7.3.5"
           }
         },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+        "brace-expansion": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "cacache": {
+          "version": "18.0.4",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+          "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^3.1.0",
+            "fs-minipass": "^3.0.0",
+            "glob": "^10.2.2",
+            "lru-cache": "^10.0.1",
+            "minipass": "^7.0.3",
+            "minipass-collect": "^2.0.1",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "p-map": "^4.0.0",
+            "ssri": "^10.0.0",
+            "tar": "^6.1.11",
+            "unique-filename": "^3.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+          "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          },
+          "dependencies": {
+            "which": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
+          }
+        },
+        "foreground-child": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+          "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.6",
+            "signal-exit": "^4.0.1"
+          }
+        },
+        "fs-minipass": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+          "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
+          }
+        },
+        "glob": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
+        },
+        "make-fetch-happen": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+          "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+          "dev": true,
+          "requires": {
+            "@npmcli/agent": "^2.0.0",
+            "cacache": "^18.0.0",
+            "http-cache-semantics": "^4.1.1",
+            "is-lambda": "^1.0.1",
+            "minipass": "^7.0.2",
+            "minipass-fetch": "^3.0.0",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "proc-log": "^4.2.0",
+            "promise-retry": "^2.0.1",
+            "ssri": "^10.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.2"
+          }
+        },
+        "minipass": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+          "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+          "dev": true
+        },
+        "minipass-collect": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+          "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
+          }
+        },
+        "minipass-fetch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+          "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.13",
+            "minipass": "^7.0.3",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.1.2"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "ssri": {
+          "version": "10.0.6",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+          "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+          "dev": true,
+          "requires": {
+            "minipass": "^7.0.3"
+          }
+        },
+        "unique-filename": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+          "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+          "dev": true,
+          "requires": {
+            "unique-slug": "^4.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+          "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "which": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+          "dev": true,
+          "requires": {
+            "isexe": "^3.1.1"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "3.1.5",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+              "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -8113,13 +8127,12 @@
       }
     },
     "nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
       "dev": true,
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "^2.0.0"
       }
     },
     "normalize-package-data": {
@@ -8166,7 +8179,7 @@
       "requires": {
         "byline": "^5.0.0",
         "graceful-fs": "^4.1.15",
-        "node-gyp": "^5.0.2",
+        "node-gyp": "^10",
         "resolve-from": "^4.0.0",
         "slide": "^1.1.6",
         "uid-number": "0.0.6",
@@ -8311,16 +8324,6 @@
           "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         }
@@ -8510,12 +8513,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8592,12 +8589,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-      "dev": true
-    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -8613,16 +8604,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "override-require": {
       "version": "1.1.1",
@@ -8727,6 +8708,12 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "pacote": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
@@ -8754,37 +8741,12 @@
         "tar": "^6.1.0"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "dev": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass": {
           "version": "3.1.6",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
           "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
@@ -8926,16 +8888,28 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true
     },
     "picomatch": {
@@ -8983,6 +8957,12 @@
         "colors": "1.4.0",
         "minimist": "^1.2.0"
       }
+    },
+    "proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -9034,12 +9014,6 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-      "dev": true
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pump": {
@@ -9382,53 +9356,6 @@
         }
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "qs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-          "dev": true
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9646,12 +9573,12 @@
       "dev": true
     },
     "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       }
     },
@@ -9874,23 +9801,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -9951,6 +9861,17 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
@@ -9975,6 +9896,15 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
@@ -10060,35 +9990,17 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "requires": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       }
     },
     "temp-dir": {
@@ -10196,16 +10108,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -10245,21 +10147,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "type-fest": {
@@ -10495,25 +10382,6 @@
       "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true
     },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "dependencies": {
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-          "dev": true
-        }
-      }
-    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -10607,6 +10475,43 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -31,7 +31,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -68,7 +68,7 @@
       "requires": {
         "@babel/types": "^7.9.6",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.18.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -130,7 +130,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.6",
         "@babel/types": "^7.9.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -242,7 +242,7 @@
         "@babel/types": "^7.9.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       },
       "dependencies": {
         "debug": {
@@ -263,7 +263,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.5",
-        "lodash": "^4.17.13",
+        "lodash": "^4.18.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1089,7 +1089,7 @@
           "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.7.0",
+            "lodash": "^4.18.1",
             "tr46": "^2.1.0",
             "webidl-conversions": "^6.1.0"
           }
@@ -1354,7 +1354,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
           "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "5.3.7",
@@ -1421,7 +1422,7 @@
           "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.7.0",
+            "lodash": "^4.18.1",
             "tr46": "^2.1.0",
             "webidl-conversions": "^6.1.0"
           }
@@ -2672,7 +2673,7 @@
         "@rushstack/rig-package": "0.3.10",
         "@rushstack/ts-command-line": "4.10.9",
         "colors": "~1.2.1",
-        "lodash": "~4.17.15",
+        "lodash": "^4.18.1",
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
@@ -3334,7 +3335,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "2.4.0",
@@ -3634,16 +3636,6 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3711,7 +3703,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -4368,7 +4361,7 @@
       "requires": {
         "chalk": "^4.1.0",
         "date-fns": "^2.16.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "rxjs": "^6.6.3",
         "spawn-command": "^0.0.2-1",
         "supports-color": "^8.1.0",
@@ -4493,7 +4486,7 @@
         "git-raw-commits": "^2.0.8",
         "git-remote-origin-url": "^2.0.0",
         "git-semver-tags": "^4.1.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "normalize-package-data": "^3.0.0",
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
@@ -4678,7 +4671,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -4754,9 +4747,9 @@
       "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
-        "lodash": "^4.17.15",
+        "JSONStream": "^1.0.4",
+        "lodash": "^4.18.1",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -5835,7 +5828,7 @@
       "dev": true,
       "requires": {
         "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -6417,7 +6410,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.18.1",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -7110,6 +7103,16 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
       "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -9914,6 +9917,23 @@
       "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -9951,23 +9971,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -89,6 +89,7 @@
     "typescript": "~4.5.5"
   },
   "overrides": {
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "node-gyp": "^10"
   }
 }

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -90,6 +90,7 @@
   },
   "overrides": {
     "lodash": "^4.18.1",
-    "node-gyp": "^10"
+    "node-gyp": "^10",
+    "zookeeper": "^7.2.0"
   }
 }

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -68,7 +68,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -83,7 +83,7 @@
     "@types/nconf": "^0.10.2",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -77,7 +77,7 @@
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.1.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nock": "^13.3.3",
     "nyc": "^15.0.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -81,7 +81,7 @@
     "@types/mocha": "^9.1.1",
     "@types/uuid": "^8.3.0",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -74,7 +74,7 @@
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.1.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -105,7 +105,7 @@
     "@types/uuid": "^8.3.0",
     "@types/ws": "^6.0.1",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -74,7 +74,7 @@
     "@types/node": "^14.18.0",
     "@types/request": "^2.47.1",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -84,7 +84,7 @@
     "axios-mock-adapter": "^1.19.0",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.1.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^14.18.0",
     "@types/sinon": "^9.0.9",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^14.18.0",
     "@types/sinon": "^9.0.9",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -42,7 +42,7 @@
     "@types/node": "^14.18.0",
     "@types/sinon": "^9.0.9",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/server-services-core": "^0.1037.0",
-    "zookeeper": "^5.3.2"
+    "zookeeper": "^7.2.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -85,7 +85,7 @@
     "@types/node": "^14.18.0",
     "@types/supertest": "^2.0.5",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "express": "^4.16.3",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -67,7 +67,7 @@
     "@types/supertest": "^2.0.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -83,7 +83,7 @@
     "@types/node": "^14.18.0",
     "@types/supertest": "^2.0.5",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -87,7 +87,7 @@
     "@types/sinon": "^9.0.9",
     "@types/uuid": "^8.3.0",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "ioredis-mock": "^5.2.5",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -72,7 +72,7 @@
     "@types/sinon": "^9.0.9",
     "@types/string-hash": "^1.1.1",
     "concurrently": "^6.2.0",
-    "eslint": "~8.6.0",
+    "eslint": "~8.55.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -34,7 +34,7 @@ parameters:
 - name: buildToolsVersionToInstall
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
-  default: "^0.5.0"
+  default: "^0.55.0"
 
 trigger:
   branches:

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -24,7 +24,7 @@ parameters:
 - name: buildToolsVersionToInstall
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
-  default: "^0.5.0"
+  default: "^0.55.0"
 
 trigger:
   branches:

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -34,7 +34,7 @@ parameters:
 - name: buildToolsVersionToInstall
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
-  default: "^0.5.0"
+  default: "^0.55.0"
 
 trigger:
   branches:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -33,7 +33,7 @@ parameters:
 - name: buildToolsVersionToInstall
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
-  default: "^0.5.0"
+  default: "^0.55.0"
 
 trigger:
   branches:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -66,6 +66,12 @@ parameters:
   type: string
   default: "^0.5.0"
 
+# The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
+# group
+- name: interdependencyRange
+  type: string
+  default: "^"
+
 trigger: none
 
 variables:
@@ -227,6 +233,7 @@ stages:
           buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
           buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
           tagName: ${{ parameters.tagName }}
+          interdependencyRange: ${{ parameters.interdependencyRange }}
     - ${{ if eq(parameters.setVersion, false) }}:
       - task: Bash@3
         name: SetVersion

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -207,9 +207,9 @@ stages:
 
     # for npm ci in component detection and set version
     - task: UseNode@1
-      displayName: Use Node 18.17.1
+      displayName: Use Node 20.15.1
       inputs:
-        version: 18.17.1
+        version: 20.15.1
 
     - task: Npm@1
       displayName: Install npm 10

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -64,7 +64,7 @@ parameters:
 
 - name: buildToolsVersionToInstall
   type: string
-  default: "^0.5.0"
+  default: "^0.55.0"
 
 # The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
 # group


### PR DESCRIPTION
## Description

Tracked by [AB#73288](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73288).

The server pipelines on `lts` (`server-gitrest`, `server-historian`, `server-routerlicious`) have been failing since at least Dec. 2, 2025 — presumably since #25537 ("Replacing Lerna with pnpm on LTS") was merged, but there were no runs between that change landing and Dec. 2 to confirm earlier.

Seven distinct issues are addressed here, surfaced one after the other as each previous blocker was unblocked. Issues 1–3 and 5 are direct fallout from #25537; Issue 4 is unrelated bit-rot exposed once the pipelines started running again, and Issues 6 and 7 are longstanding latent issues exposed by Issue 4's distro bump (Python 3.11 in Issue 6, OpenSSL 3 in Issue 7).

(`server-gitssh` sets `setVersion: false`, so it skips the failing template invocation and is unaffected by Issues 1–3; it is touched only for default consistency.)

## Issue 1 — `interdependencyRange` not forwarded through `build-docker-service.yml`

### Symptom

Pipelines fail at queue time before any job runs:

> A value for the `interdependencyRange` parameter must be provided.

### Cause

#25537 updated `tools/pipelines/templates/include-set-package-version.yml` to declare a required `interdependencyRange` parameter, but did not update `tools/pipelines/templates/build-docker-service.yml` (which invokes that template) to declare or forward it. None of the server pipelines that extend `build-docker-service.yml` pass it, so ADO refuses to expand the templates.

### Fix

Mirror the wiring already present on `main`:

- Declare `interdependencyRange` (default `"^"`) on `build-docker-service.yml`.
- Forward it to `include-set-package-version.yml` in the `setVersion: true` branch.

### Runtime impact

None. None of the server release groups on `lts` have a `.releaseGroup` file, so `scripts/update-package-version.sh` always takes the "independent package" branch and never reads `INTERDEPENDENCY_RANGE`. This is purely a YAML wiring repair so ADO can expand the templates again.

## Issue 2 — `flub generate buildVersion` can't find the repo root

### Symptom

After Issue 1 is fixed, the pipelines now run far enough to fail in the `Set Package Version` step:

> ERROR: Unknown repo root. Specify it with `--root` or environment variable `_FLUID_ROOT_`

### Cause

The server pipelines were pinned to `buildToolsVersionToInstall: "^0.5.0"`. flub `0.5.x` relied on the root `lerna.json` to identify the repo root. #25537 removed that file when migrating to pnpm. The newer flub `0.55.x` understands the post-pnpm layout — `build-client.yml` on `lts` was already bumped to `"^0.55.0"` as part of #25537 and is green today.

### Fix

Mirror the `build-client.yml` pattern: bump the `buildToolsVersionToInstall` default from `"^0.5.0"` → `"^0.55.0"` on:

- `tools/pipelines/server-gitrest.yml`
- `tools/pipelines/server-historian.yml`
- `tools/pipelines/server-routerlicious.yml`
- `tools/pipelines/server-gitssh.yml` (consistency only)
- `tools/pipelines/templates/build-docker-service.yml` (template default)

## Issue 3 — Node 18 is incompatible with flub `0.55.x`

### Symptom

After Issue 2 is fixed, the pipelines now run far enough to fail in `Check Build Tools Installation` (right after the `flub commands` invocation):

> SyntaxError: Invalid regular expression flags

### Cause

The `npm install` of `@fluid-tools/build-cli@0.55.0` emits an explicit warning:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@fluid-tools/build-cli@0.55.0',
npm warn EBADENGINE   required: { node: '>=20.15.1' },
npm warn EBADENGINE   current: { node: 'v18.17.1', npm: '10.9.8' }
npm warn EBADENGINE }
```

flub `0.55` uses regex syntax (likely the `v` flag) that Node 18 doesn't recognize. The agent in `build-docker-service.yml` was still on Node 18.17.1. `build-npm-package.yml` (used by `build-client.yml`, green on `lts` today) already runs Node 20.15.1.

### Fix

Bump the `UseNode@1` step in `tools/pipelines/templates/build-docker-service.yml` from 18.17.1 → 20.15.1 to match `build-npm-package.yml` and satisfy flub's engine requirement.

## Issue 4 — Debian 10 ("buster") base image is archived

### Symptom

After Issue 3 is fixed, the pipelines now run far enough to fail in `Docker Build - base`:

> E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.

### Cause

The `server/{gitrest,historian,routerlicious}/Dockerfile` files all `FROM` Debian 10 ("buster") variants of the Node image. Debian 10 reached end-of-life and was archived from `deb.debian.org`, so `apt-get update` returns 404 for the buster repositories and the build fails before installing the build dependencies. (`main` has long since moved these to `node:22.22.2-bookworm-slim`.)

### Fix

Minimal bump to the Debian distro only — keep Node 18.17.1 and the existing slim/full variant unchanged:

- `server/gitrest/Dockerfile`: `node:18.17.1-buster` → `node:18.17.1-bookworm`
- `server/historian/Dockerfile`: `node:18.17.1-buster-slim` → `node:18.17.1-bookworm-slim`
- `server/routerlicious/Dockerfile`: `node:18.17.1-buster-slim` → `node:18.17.1-bookworm-slim`

The apt packages each Dockerfile installs (`build-essential`, `libssl-dev`, `python3`, `libcurl4-openssl-dev`, `make`, `git`, `curl`, `g++`, `openssl`, `ca-certificates`) are all available in bookworm.

## Issue 5 — `eslint` version inconsistency in `server/routerlicious` blocks `lerna bootstrap --strict --hoist`

### Symptom

After Issue 4 is fixed, `server-routerlicious` now runs as far as `Docker Build - base` and aborts during the root `npm install --unsafe-perm`'s `postinstall` step:

```
lerna WARN EHOIST_PKG_VERSION "@fluidframework/server-kafka-orderer" package depends on eslint@~8.55.0, which differs from the hoisted eslint@~8.6.0.
lerna ERR! EHOISTSTRICT Package version inconsistencies found while hoisting. Fix the above warnings and retry.
```

### Cause

PR #25537 bumped only `server/routerlicious/packages/kafka-orderer/package.json`'s `eslint` devDependency from `~8.6.0` to `~8.55.0`, leaving the other 18 sibling packages in the release group still at `~8.6.0`. `lerna bootstrap --strict --hoist` (run from the root `postinstall:lerna` script as part of the Docker image build) refuses to hoist when subpackages declare incompatible version ranges for the same dependency. The same script in earlier-known-good builds succeeded only because all 19 packages then agreed on `~8.6.0`.

### Fix

Align the other 18 routerlicious subpackages to `eslint@~8.55.0` (the newer of the two pinned ranges, matching `kafka-orderer`) and regenerate `server/routerlicious/lerna-package-lock.json` and `server/routerlicious/package-lock.json` accordingly. Lockfile format (`lockfileVersion: 1`) is preserved (`npm install --lockfile-version=1`) to avoid an unrelated lockfile-format churn. No source files are changed; the new eslint surfaces only warnings (no errors), which the existing `npm run lint` does not enforce.

## Issue 6 — `node-gyp@5.1.1` (hoisted via deprecated `npm-lifecycle`) is incompatible with Bookworm's Python 3.11

### Symptom

After Issue 5 is fixed, `server-historian` and `server-routerlicious` both reach the `node-rdkafka` native module rebuild during the root `npm install --unsafe-perm` and fail:

```
npm ERR! command sh -c node-gyp rebuild
npm ERR! gyp info using node-gyp@5.1.1
npm ERR! gyp info using node@18.17.1 | linux | x64
npm ERR! gyp info find Python using Python version 3.11.2 found at "/usr/bin/python3"
...
npm ERR! ValueError: invalid mode: 'rU' while trying to load binding.gyp
npm ERR! gyp ERR! configure error
```

### Cause

The hoisted `node-gyp@5.1.1` is pulled in transitively by `npm-lifecycle@3.1.5` (a dep of `@lerna/run-lifecycle@4.0.0`). `node-gyp 5.x`'s bundled gyp opens `binding.gyp` with mode `'rU'`, which Python 3.11 (Debian Bookworm's default — newly in the image after Issue 4) removed. `node-gyp >=8` dropped that mode. `npm-lifecycle` is itself deprecated and pinned at its final `3.1.5`, so bumping it would mean upgrading Lerna 4 -> 5+ — well out of scope for this PR.

(`server-gitrest` is unaffected because it doesn't depend on `node-rdkafka` or any other native module that triggers a node-gyp rebuild.)

### Fix

Add a minimal npm `overrides` entry forcing `node-gyp` to `^10` in the root `package.json` of both `server/historian` and `server/routerlicious`, and regenerate their `lerna-package-lock.json` / `package-lock.json` files (`lockfileVersion: 1` preserved) so the hoisted `node-gyp` resolves to `10.3.1`. `node-gyp@10` supports Node `>=18` and Python 3.6–3.13, covering both the current Node 18.17.1 image and Bookworm's Python 3.11.

## Issue 7 — `node-zookeeper@5.3.2` fails to link against OpenSSL 3 in Bookworm

### Symptom

After Issue 6 unblocks routerlicious's install, the build fails when compiling the bundled `node-zookeeper` C client:

```
/usr/bin/ld: ./.libs/libzookeeper_st.a(zookeeper.o): in function `init_ssl_for_socket':
zookeeper.c:(.text+0x52c8): undefined reference to `FIPS_mode'
collect2: error: ld returned 1 exit status
```

### Cause

`zookeeper@5.3.2` bundles a libzookeeper C client (Apache ZooKeeper 3.5/3.6 era) that calls `FIPS_mode()`. That symbol was removed in OpenSSL 3.0. Debian Bookworm (now in the image after Issue 4) ships OpenSSL 3.x; Buster and Bullseye shipped OpenSSL 1.1.1 where `FIPS_mode` still existed. Apache ZooKeeper 3.8.2 added OpenSSL 3 support (ZOOKEEPER-4541), and `node-zookeeper@6.0.0` was the first npm release to bundle ZK C 3.8.2. `7.0.x` and `7.1.x` still failed to compile in some environments, so the safe pin is `^7.2.0` — the same range `main` settled on in #26493.

### Fix

Bump `zookeeper` from `^5.3.2` to `^7.2.0` in `services-ordering-zookeeper/package.json` and regenerate `server/routerlicious/lerna-package-lock.json` (`lockfileVersion: 1` preserved). Also mirror `main`'s defense-in-depth and add a workspace-level `"zookeeper": "^7.2.0"` override in `server/routerlicious/package.json` so any future transitive consumer cannot pin the build back to a non-OpenSSL-3-compatible version. The API surface used by `services-ordering-zookeeper` (`new ZooKeeper`, `init`, `get`, `close`, `once`, `removeAllListeners`) is unchanged across `5.x -> 7.x`, so no source changes are needed.

## Validation

- Issues 1–4 are YAML- or Dockerfile-only and each mirror a pattern already proven on `main` (Issues 1, 4) or on `lts`'s `build-client.yml` (Issues 2 and 3); Issue 4 is the minimum bump that keeps Node 18 in the image. Issue 5 is the smallest in-tree alignment that lets `lerna bootstrap --strict --hoist` succeed without altering build behavior. Issue 6 is a transitive-dep override scoped to two packages that addresses the only `node-gyp`-using path in the install graph. Issue 7 mirrors the `zookeeper` bump and root override that `main` adopted in #26493 for the same OpenSSL 3 incompatibility.
- After each commit, the previously-blocked pipelines progress past the prior step and surface the next issue. Verify via the queued ADO runs on this PR.




