### PR TITLE
ci: Stop running server pipelines for the lts branch

### DIFF
--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -40,8 +40,7 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
+    - release/*
   paths:
     include:
     - .prettierignore
@@ -65,8 +64,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -30,8 +30,7 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
+    - release/*
   paths:
     include:
     - .prettierignore
@@ -49,8 +48,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -40,8 +40,7 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
+    - release/*
   paths:
     include:
     - .prettierignore
@@ -65,8 +64,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -50,8 +50,6 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:
@@ -79,8 +77,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:


### PR DESCRIPTION
## Description

Server releases will never be made from the LTS branch, so having the pipelines trigger for PRs to it / commits in it is not necessary. Arguably, we could remove the whole server/ folder in LTS, but I did not try to be that aggressive with this PR.

This just makes it so:
- Those pipelines don't run for the `lts` branch.
- The long-gone `next` branch is removed from the triggers section
- Pipelines that used to run for PRs into `release/*` branches but not on commits to those branches (historian, gitrest, gitssh), now also run for commits on the branches. The routerlicious pipeline already behaves like this. Not clear why we wouldn't want the others to do the same.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
