### PR TITLE
ci(server): Try explicit networkIsolationPolicy

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -161,9 +161,12 @@ extends:
       # Tentative workaround for the occasional Credscan failures
       credscan:
         batchSize: 4
-    # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
+      # Skip tagging if Github PR coming from a fork. This skips Microsoft security checks that won't work on forks.
       skipBuildTagsForGitHubPullRequests: true
+      # The docker build steps consult registry-1.docker.io even when the actual images are baked into
+      # the build agent. Seems like the CfsClean2 set of rules blocks that at the DNS level.
+      networkIsolationPolicy: Permissive
     customBuildTags:
       - ES365AIMigrationTooling
     stages:


### PR DESCRIPTION
## Description

I haven't been able to figure out why the gitssh pipeline activates a different set of rules for network isolation policy, and the additional rules that get activated break the requests to `https://registry-1.docker.io` that happen during a docker build even if the docker images are baked into the build agent.

Trying out setting an explicit network isolation policy to see if it helps.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).