### PR TITLE
Update FluidClientVersion docs

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -424,61 +424,22 @@ export function withSchemaValidation<
 }
 
 /**
- * Versions of Fluid Framework client packages.
+ * Versions of Fluid Framework client packages, usable as a {@link @fluidframework/runtime-definitions#MinimumVersionForCollab}.
  * @remarks
- * Used to express compatibility requirements by indicating the oldest version with which compatibility must be maintained.
- *
- * When no compatibility-impacting change is made in a given version, the value associated with its enum entry may point to the older version which it's fully compatible with.
- * Note that this can change if a future version of the framework introduces an option to use something which is only supported at a particular version. In which case, the values of the enum may shift,
- * but the semantics of keys in this enum will not change.
- *
- * Do not depend on the value of this enums's entries: only depend on the keys (enum members) themselves.
- *
- * Some release may also be omitted if there is currently no need to express that specific version.
- * If the need arises, they might be added in the future.
+ * Versions with no notable impact may be omitted, and added later if needed.
  *
  * @privateRemarks
- * The entries in these enums should document the following:
- * - The user facing impact of opting into a particular version. This will help customers decide if they want to opt into
- * a new version. For example, document if there is an encoding efficiency improvement of oping into that version or newer.
- * - Any new data formats that are introduced in that version. This will help developers tell which data formats a given
- * version will write. For example, document if a new summary or encoding format is added in a version.
- * - Whether the above features or data formats introduced in a version are enabled by default or require the
- * {@link minVersionForCollab} option to be set to that particular version.
- *
- * Versions with no notable impact can be omitted.
- *
- * This scheme assumes a single version will always be enough to communicate compatibility.
- * For this to work, compatibility has to be strictly increasing.
- * If this is violated (for example a subset of incompatible features from 3.x that are not in 3.0 are back ported to 2.x),
- * a more complex scheme may be needed to allow safely opting into incompatible features in those cases:
- * such a system can be added if/when its needed since it will be opt in and thus non-breaking.
- *
- * TODO: this should likely be defined higher in the stack and specified when creating the container, possibly as part of its schema.
- * TODO: compatibility requirements for how this enum can and cannot be changed should be clarified when/if it's used across multiple layers in the stack.
- * For example, if needed, would adding more leading zeros to the minor version break things.
+ * Each entry should document:
+ * - The user-facing impact of opting into it (e.g. encoding efficiency improvements).
+ * - Any new data formats introduced in that version.
+ * - Whether those features/formats are enabled by default or require {@link MinimumVersionForCollab | minVersionForCollab} to be set accordingly.
  * @alpha
  */
 export const FluidClientVersion = {
 	/**
-	 * Fluid Framework Client 1.4 and newer.
-	 * @remarks
-	 * This opts into support for the 1.4 LTS branch.
-	 * @privateRemarks
-	 * As long as this code is in Tree, there is no reason to have this option as SharedTree did not exist in 1.4.
-	 */
-	// v1_4 = 1.004,
-
-	/**
 	 * Fluid Framework Client 2.0 and newer.
 	 */
 	v2_0: "2.0.0",
-
-	/** Fluid Framework Client 2.1 and newer. */
-	// If we think we might want to start allowing opting into something that landed in 2.1 (without opting into something newer),
-	// we could add an entry like this to allow users to indicate that they can be opted in once we are ready,
-	// then update it to "2.001" once we actually have the opt in working.
-	// v2_1 = v2_0,
 
 	/**
 	 * Fluid Framework Client 2.43 and newer.

--- a/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
@@ -20,6 +20,11 @@
  * Since this uses the semver notion of "greater" (which might not actually mean a later release, or supporting more features), care must be taken with how this is used.
  * See remarks for {@link @fluidframework/runtime-utils#MinimumMinorSemanticVersion} for more details.
  *
+ * This scheme assumes a single version is always enough to communicate compatibility, which requires that compatibility is strictly increasing across releases.
+ * If this is violated (for example, a subset of incompatible features from 3.x is back-ported to 2.x, or compatibility depends on a patch thats not in the next minor's first release),
+ * a more complex scheme may be needed;
+ * one can be added if/when needed since it would be opt-in and thus non-breaking.
+ *
  * Since this type is marked with `@input`, it can be generalized to allow more cases in the future as a non-breaking change.
  *
  * TODO: before stabilizing this further, some restrictions should be considered (since once stabilized, this can be relaxed, but not more constrained).

--- a/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
@@ -8,7 +8,8 @@
  * @remarks
  * A string in SemVer format indicating a specific version of the Fluid Framework client package, or the special case of {@link @fluidframework/runtime-utils#defaultMinVersionForCollab}.
  *
- * When specifying a given `MinimumVersionForCollab`, collaboration with any client with a version of Fluid Framework client packages that is greater is supported.
+ * Collaboration with other clients is only supported when all Fluid Framework client packages used by the client have a version that is greater than or equal
+ * to the specified `MinimumVersionForCollab`.
  *
  * Must be at least {@link @fluidframework/runtime-utils#lowestMinVersionForCollab} and cannot exceed the version of any Fluid Framework client package in use by the local client.
  *

--- a/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
@@ -6,29 +6,33 @@
 /**
  * Oldest version of Fluid Framework client packages to support collaborating with.
  * @remarks
- * String in a SemVer format indicating a specific version of the Fluid Framework client package, or the special case of {@link @fluidframework/runtime-utils#defaultMinVersionForCollab}.
+ * A string in SemVer format indicating a specific version of the Fluid Framework client package, or the special case of {@link @fluidframework/runtime-utils#defaultMinVersionForCollab}.
  *
- * When specifying a given `MinimumVersionForCollab`, any client with a version that is greater than or equal to the specified version will be considered compatible.
+ * When specifying a given `MinimumVersionForCollab`, collaboration with any client with a version of Fluid Framework client packages that is greater is supported.
  *
- * Must be at least {@link @fluidframework/runtime-utils#lowestMinVersionForCollab} and cannot exceed the current version.
+ * Must be at least {@link @fluidframework/runtime-utils#lowestMinVersionForCollab} and cannot exceed the version of any Fluid Framework client package in use by the local client.
+ *
+ * The higher the version specified, the more features and optimizations will be enabled.
  *
  * {@link @fluidframework/runtime-utils#validateMinimumVersionForCollab} can be used to check these invariants at runtime.
- * Since TypeScript cannot enforce them all for literals in code,
- * it may be useful to use `validateMinimumVersionForCollab` values which may come from constants in the codebase typed as a `MinimumVersionForCollab`.
+ * Since TypeScript cannot enforce all of them for literals in code, it is useful for checking values sourced from constants typed as `MinimumVersionForCollab`.
  *
  * @privateRemarks
  * Since this uses the semver notion of "greater" (which might not actually mean a later release, or supporting more features), care must be taken with how this is used.
  * See remarks for {@link @fluidframework/runtime-utils#MinimumMinorSemanticVersion} for more details.
  *
  * This scheme assumes a single version is always enough to communicate compatibility, which requires that compatibility is strictly increasing across releases.
- * If this is violated (for example, a subset of incompatible features from 3.x is back-ported to 2.x, or compatibility depends on a patch thats not in the next minor's first release),
- * a more complex scheme may be needed;
- * one can be added if/when needed since it would be opt-in and thus non-breaking.
+ * There are ways this assumption could be violated (for example, a subset of incompatible features from 3.x is back-ported to 2.x, or compatibility depends on a patch that is not in the next minor's first release).
+ * In such cases, a conservative enablement strategy can be used: only enable features for a version if all greater versions (based on semver ordering) also support it.
+ * A more flexible scheme can be added if/when it's needed since it could be opt-in and thus non-breaking.
  *
- * Since this type is marked with `@input`, it can be generalized to allow more cases in the future as a non-breaking change.
+ * Since this type is marked with `@input`, it is only consumed by the framework and never returned, so widening the accepted set is a non-breaking change.
  *
  * TODO: before stabilizing this further, some restrictions should be considered (since once stabilized, this can be relaxed, but not more constrained).
- * For example it might make sense to constrain this to something like `"1.4.0" | typeof defaultMinVersionForCollab | 2.${bigint}.0"`.
+ * For example it might make sense to constrain this to something like:
+ * ```ts
+ * "1.4.0" | typeof defaultMinVersionForCollab | `2.${bigint}.0`
+ * ```
  *
  * @input
  * @beta


### PR DESCRIPTION
## Description

FluidClientVersion predates MinimumVersionForCollab: this gets its docs more aligned with MinimumVersionForCollab

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
