### PR TITLE
Update marocchino/sticky-pull-request-comment to v3 (Node 24)

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Required but missing
         if: fromJson(steps.changeset.outputs.CHANGESET).required == true && fromJson(steps.changeset.outputs.CHANGESET).changesetFound == false
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: changeset
           number: ${{ fromJson(steps.changeset.outputs.CHANGESET).pr }}
@@ -48,8 +48,8 @@ jobs:
 
       - name: Required and present
         if: fromJson(steps.changeset.outputs.CHANGESET).required == true && fromJson(steps.changeset.outputs.CHANGESET).changesetFound == true
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: changeset
           number: ${{ fromJson(steps.changeset.outputs.CHANGESET).pr }}
@@ -59,8 +59,8 @@ jobs:
 
       - name: Changeset not required
         if: fromJson(steps.changeset.outputs.CHANGESET).required == false && fromJson(steps.changeset.outputs.CHANGESET).changesetFound == true
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: changeset
           number: ${{ fromJson(steps.changeset.outputs.CHANGESET).pr }}

--- a/.github/workflows/linkcheck-reporter.yml
+++ b/.github/workflows/linkcheck-reporter.yml
@@ -29,8 +29,8 @@ jobs:
         run: echo "pr=$(cat pr)" >> $GITHUB_OUTPUT
         working-directory: ./results
       - name: Post report in comment
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: linkreport
           recreate: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -28,8 +28,8 @@ jobs:
           submodules: false
 
       - name: Post warning in comment
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: release-warning
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md

--- a/.github/workflows/pr-review-auto-route.yml
+++ b/.github/workflows/pr-review-auto-route.yml
@@ -166,8 +166,8 @@ jobs:
 
       - name: Post confirmation comment
         if: steps.prior.outputs.start_checked != 'true'
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-review-confirm
           path: /tmp/confirm-body.md

--- a/.github/workflows/pr-review-fleet.yml
+++ b/.github/workflows/pr-review-fleet.yml
@@ -159,8 +159,8 @@ jobs:
           EOF
 
       - name: Post in-progress comment
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-review-fleet
           number: ${{ steps.params.outputs.pr_number }}
@@ -354,8 +354,8 @@ jobs:
           EOF
 
       - name: Post or update PR comment
-        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.4
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-review-fleet
           number: ${{ needs.setup.outputs.pr_number }}


### PR DESCRIPTION
## Description

Bumps the `marocchino/sticky-pull-request-comment` action from v2.9.4 to v3.0.4 across all workflows that use it.

The motivation is that v2.9.4 runs on Node.js 20, which is now end-of-life. v3.x runs on Node.js 24. There are no other meaningful changes in v3.x for our usage — all inputs and outputs we pass remain the same; v3 only adds a new optional `number_force` input that we don't consume.

Affected workflows:
- `.github/workflows/changeset-reporter.yml` (3 usages)
- `.github/workflows/linkcheck-reporter.yml`
- `.github/workflows/pr-release-branch-warning.yml`
- `.github/workflows/pr-review-auto-route.yml`
- `.github/workflows/pr-review-fleet.yml` (2 usages)

The pinned SHA, the `# ratchet:...@vN` comment, and the release-notes-link comment were all updated together.

Tracked by [AB#73596](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73596).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).