### PR TITLE
feat(datastore): Decorate and log errors thrown during DataStore entrypoint initialization

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -75,6 +75,7 @@ import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";
 import {
 	addBlobToSummary,
 	isSnapshotFetchRequiredForLoadingGroupId,
+	dataStoreLoadTelemetryProps,
 } from "@fluidframework/runtime-utils/internal";
 import {
 	DataProcessingError,
@@ -587,12 +588,7 @@ export abstract class FluidDataStoreContext
 					error,
 					"realizeFluidDataStoreContext",
 				);
-				errorWrapped.addTelemetryProperties(
-					tagCodeArtifacts({
-						fullPackageName: this.pkg?.join("/"),
-						fluidDataStoreId: this.id,
-					}),
-				);
+				errorWrapped.addTelemetryProperties(dataStoreLoadTelemetryProps(this));
 				this.mc.logger.sendErrorEvent({ eventName: "RealizeError" }, errorWrapped);
 				throw errorWrapped;
 			});

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -588,7 +588,9 @@ export abstract class FluidDataStoreContext
 					error,
 					"realizeFluidDataStoreContext",
 				);
-				errorWrapped.addTelemetryProperties(dataStoreLoadTelemetryProps(this));
+				errorWrapped.addTelemetryProperties(
+					dataStoreLoadTelemetryProps({ id: this.id, packagePath: this.pkg ?? [] }),
+				);
 				this.mc.logger.sendErrorEvent({ eventName: "RealizeError" }, errorWrapped);
 				throw errorWrapped;
 			});

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -509,12 +509,18 @@ export class FluidDataStoreRuntime
 		this.entryPoint = new FluidObjectHandle<FluidObject>(
 			new LazyPromise(async () =>
 				provideEntryPoint(this).catch((error) => {
+					let packagePath: readonly string[] = [];
+					try {
+						packagePath = this.dataStoreContext.packagePath;
+					} catch {
+						// `packagePath` may not be available during early load failures.
+					}
 					const errorWrapped = DataProcessingError.wrapIfUnrecognized(
 						error,
 						"entryPointInitialization",
 					);
 					errorWrapped.addTelemetryProperties(
-						dataStoreLoadTelemetryProps(this.dataStoreContext),
+						dataStoreLoadTelemetryProps({ id: this.dataStoreContext.id, packagePath }),
 					);
 					this.mc.logger.sendErrorEvent(
 						{ eventName: "EntryPointInitializationFailure" },

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -506,7 +506,25 @@ export class FluidDataStoreRuntime
 		}
 
 		this.entryPoint = new FluidObjectHandle<FluidObject>(
-			new LazyPromise(async () => provideEntryPoint(this)),
+			new LazyPromise(async () =>
+				provideEntryPoint(this).catch((error) => {
+					const errorWrapped = DataProcessingError.wrapIfUnrecognized(
+						error,
+						"entryPointInitialization",
+					);
+					errorWrapped.addTelemetryProperties(
+						tagCodeArtifacts({
+							fullPackageName: this.dataStoreContext.packagePath.join("/"),
+							fluidDataStoreId: this.id,
+						}),
+					);
+					this.mc.logger.sendErrorEvent(
+						{ eventName: "EntryPointInitializationFailure" },
+						errorWrapped,
+					);
+					throw errorWrapped;
+				}),
+			),
 			"",
 			this.objectsRoutingContext,
 		);

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -78,6 +78,7 @@ import {
 	exceptionToResponse,
 	generateHandleContextPath,
 	processAttachMessageGCData,
+	dataStoreLoadTelemetryProps,
 	toFluidHandleInternal,
 	unpackChildNodesUsedRoutes,
 	toDeltaManagerErased,
@@ -513,10 +514,7 @@ export class FluidDataStoreRuntime
 						"entryPointInitialization",
 					);
 					errorWrapped.addTelemetryProperties(
-						tagCodeArtifacts({
-							fullPackageName: this.dataStoreContext.packagePath.join("/"),
-							fluidDataStoreId: this.id,
-						}),
+						dataStoreLoadTelemetryProps(this.dataStoreContext),
 					);
 					this.mc.logger.sendErrorEvent(
 						{ eventName: "EntryPointInitializationFailure" },

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -22,6 +22,11 @@ import type {
 	MinimumVersionForCollab,
 } from "@fluidframework/runtime-definitions/internal";
 import {
+	isFluidError,
+	MockLogger,
+	TelemetryDataTag,
+} from "@fluidframework/telemetry-utils/internal";
+import {
 	MockFluidDataStoreContext,
 	validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
@@ -68,6 +73,7 @@ describe("FluidDataStoreRuntime Tests", () => {
 		// back-compat 0.38 - DataStoreRuntime looks in container runtime for certain properties that are unavailable
 		// in the data store context.
 		dataStoreContext.containerRuntime = {} as unknown as IContainerRuntimeBase;
+		dataStoreContext.packagePath = [];
 		sharedObjectRegistry = {
 			get(type: string) {
 				return {
@@ -225,6 +231,81 @@ describe("FluidDataStoreRuntime Tests", () => {
 			(await dataStoreRuntime.entryPoint?.get()) === myObj,
 			"entryPoint was not initialized",
 		);
+	});
+
+	describe("entryPoint initialization failure", () => {
+		it("entryPoint provider is not invoked until entryPoint is consumed", () => {
+			let invoked = false;
+			createRuntime(dataStoreContext, sharedObjectRegistry, async () => {
+				invoked = true;
+				return {};
+			});
+			assert.strictEqual(
+				invoked,
+				false,
+				"entryPoint provider should not run during construction",
+			);
+		});
+
+		it("rejected entryPoint provider is wrapped and logged", async () => {
+			const mockLogger = new MockLogger();
+			const contextWithMockLogger = new MockFluidDataStoreContext(
+				"testDataStoreId",
+				false,
+				mockLogger.toTelemetryLogger(),
+			);
+			contextWithMockLogger.containerRuntime = {} as unknown as IContainerRuntimeBase;
+			contextWithMockLogger.packagePath = ["pkgA", "pkgB"];
+			const dataStoreRuntime = createRuntime(
+				contextWithMockLogger,
+				sharedObjectRegistry,
+				async () => {
+					throw new Error("entryPoint failed");
+				},
+			);
+			await assert.rejects(
+				async () => dataStoreRuntime.entryPoint.get(),
+				(error: IErrorBase) => {
+					assert.strictEqual(
+						error.errorType,
+						ContainerErrorTypes.dataProcessingError,
+						"thrown error should be a DataProcessingError",
+					);
+					assert(isFluidError(error), "thrown error should be a Fluid error");
+					const props = error.getTelemetryProperties();
+					assert.deepStrictEqual(
+						props.fluidDataStoreId,
+						{ value: "testDataStoreId", tag: TelemetryDataTag.CodeArtifact },
+						"error should carry tagged fluidDataStoreId",
+					);
+					assert.deepStrictEqual(
+						props.fullPackageName,
+						{ value: "pkgA/pkgB", tag: TelemetryDataTag.CodeArtifact },
+						"error should carry tagged fullPackageName",
+					);
+					return true;
+				},
+			);
+			const failureEvent = mockLogger.events.find(
+				(event) =>
+					typeof event.eventName === "string" &&
+					event.eventName.endsWith("EntryPointInitializationFailure"),
+			);
+			assert(
+				failureEvent !== undefined,
+				"EntryPointInitializationFailure event should have been logged",
+			);
+			assert.deepStrictEqual(
+				failureEvent.fluidDataStoreId,
+				{ value: "testDataStoreId", tag: TelemetryDataTag.CodeArtifact },
+				"event should include tagged fluidDataStoreId",
+			);
+			assert.deepStrictEqual(
+				failureEvent.fullPackageName,
+				{ value: "pkgA/pkgB", tag: TelemetryDataTag.CodeArtifact },
+				"event should include tagged fullPackageName",
+			);
+		});
 	});
 });
 

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -12,7 +12,6 @@ import type {
 import type {
 	ContainerRuntimeBaseAlpha,
 	IContainerRuntimeBase,
-	IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	generateErrorWithStack,
@@ -151,21 +150,15 @@ export function createResponseError(
  * consistent property names.
  * @internal
  */
-export function dataStoreLoadTelemetryProps(
-	context: IFluidDataStoreContext,
-): ITelemetryPropertiesExt {
-	// `packagePath` is typed as always defined, but its implementation asserts on the package being
-	// set — and during early load-failure paths (e.g. realize() rejecting before pkg is read) it
-	// can throw. Swallow that so error decoration never replaces the underlying error.
-	let fullPackageName: string | undefined;
-	try {
-		fullPackageName = context.packagePath.join("/");
-	} catch {
-		// `packagePath` is unset during early failures; leave fullPackageName undefined.
-	}
+export function dataStoreLoadTelemetryProps(props: {
+	id: string;
+	packagePath: readonly string[];
+}): ITelemetryPropertiesExt {
+	const { id, packagePath } = props;
+	const fullPackageName = packagePath.length > 0 ? packagePath.join("/") : undefined;
 	return tagCodeArtifacts({
 		fullPackageName,
-		fluidDataStoreId: context.id,
+		fluidDataStoreId: id,
 	});
 }
 

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -12,8 +12,13 @@ import type {
 import type {
 	ContainerRuntimeBaseAlpha,
 	IContainerRuntimeBase,
+	IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions/internal";
-import { generateErrorWithStack } from "@fluidframework/telemetry-utils/internal";
+import {
+	generateErrorWithStack,
+	tagCodeArtifacts,
+	type ITelemetryPropertiesExt,
+} from "@fluidframework/telemetry-utils/internal";
 
 interface IResponseException extends Error {
 	errorFromRequestFluidObject: true;
@@ -138,6 +143,21 @@ export function createResponseError(
 		},
 		headers,
 	};
+}
+
+/**
+ * Returns the canonical set of code-artifact-tagged telemetry properties identifying a data store.
+ * Use this anywhere a data store identity needs to appear in telemetry, so all such logs use
+ * consistent property names.
+ * @internal
+ */
+export function dataStoreLoadTelemetryProps(
+	context: IFluidDataStoreContext,
+): ITelemetryPropertiesExt {
+	return tagCodeArtifacts({
+		fullPackageName: context.packagePath.join("/"),
+		fluidDataStoreId: context.id,
+	});
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -154,8 +154,17 @@ export function createResponseError(
 export function dataStoreLoadTelemetryProps(
 	context: IFluidDataStoreContext,
 ): ITelemetryPropertiesExt {
+	// `packagePath` is typed as always defined, but its implementation asserts on the package being
+	// set — and during early load-failure paths (e.g. realize() rejecting before pkg is read) it
+	// can throw. Swallow that so error decoration never replaces the underlying error.
+	let fullPackageName: string | undefined;
+	try {
+		fullPackageName = context.packagePath.join("/");
+	} catch {
+		// `packagePath` is unset during early failures; leave fullPackageName undefined.
+	}
 	return tagCodeArtifacts({
-		fullPackageName: context.packagePath.join("/"),
+		fullPackageName,
 		fluidDataStoreId: context.id,
 	});
 }

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -10,6 +10,7 @@ export {
 	exceptionToResponse,
 	responseToException,
 	asLegacyAlpha,
+	dataStoreLoadTelemetryProps,
 } from "./dataStoreHelpers.js";
 export {
 	compareFluidHandles,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -296,7 +296,16 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		);
 	});
 
-	it("full initialization of data object should not happen by default", async () => {
+	itExpects(
+		"full initialization of data object should not happen by default",
+		[
+			{
+				eventName:
+					"fluid:telemetry:FluidDataStoreRuntime:EntryPointInitializationFailure",
+				error: "Non interactive/summarizer client's data object should not be initialized",
+			},
+		],
+		async () => {
 		const dataStoreFactory1 = new DataObjectFactory({
 			type: "@fluid-example/test-dataStore1",
 			ctor: TestDataObject1,
@@ -349,7 +358,8 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			container2.getEntryPoint(),
 			"Initial creation of container and data store should succeed.",
 		);
-	});
+		},
+	);
 
 	/**
 	 * This test validates that the first summary for a container by the first summarizer client does not violate

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -324,7 +324,8 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 				"Initial creation of container and data store should succeed.",
 			);
 
-			// Create a summarizer for the container and do a summary shouldn't throw.
+			// Create a summarizer for the container and do a summary.
+			// The DataStore is realized and loaded, but the entryPoint is not fully initialized so it shouldn't throw.
 			const createSummarizerResult = await createSummarizerFromFactory(
 				provider,
 				container1,
@@ -338,7 +339,8 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 				"Summarizing should not throw",
 			);
 
-			// In summarizer, load the data store should fail.
+			// In summarizer, if we _force_ the data store to fully load, it should fail
+			// based on the test configuration.  This failure is accounted for in itExpects as well.
 			await assert.rejects(
 				async () => {
 					const runtime = (createSummarizerResult.summarizer as any)

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -300,64 +300,64 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		"full initialization of data object should not happen by default",
 		[
 			{
-				eventName:
-					"fluid:telemetry:FluidDataStoreRuntime:EntryPointInitializationFailure",
+				eventName: "fluid:telemetry:FluidDataStoreRuntime:EntryPointInitializationFailure",
 				error: "Non interactive/summarizer client's data object should not be initialized",
 			},
 		],
 		async () => {
-		const dataStoreFactory1 = new DataObjectFactory({
-			type: "@fluid-example/test-dataStore1",
-			ctor: TestDataObject1,
-		});
-		const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
-			[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
-		]);
-		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
-			defaultFactory: dataStoreFactory1,
-			registryEntries: registryStoreEntries,
-		});
+			const dataStoreFactory1 = new DataObjectFactory({
+				type: "@fluid-example/test-dataStore1",
+				ctor: TestDataObject1,
+			});
+			const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
+				[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
+			]);
+			const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+				defaultFactory: dataStoreFactory1,
+				registryEntries: registryStoreEntries,
+			});
 
-		// Create a container for the first client.
-		const container1 = await provider.createContainer(runtimeFactory);
-		await assert.doesNotReject(
-			container1.getEntryPoint(),
-			"Initial creation of container and data store should succeed.",
-		);
+			// Create a container for the first client.
+			const container1 = await provider.createContainer(runtimeFactory);
+			await assert.doesNotReject(
+				container1.getEntryPoint(),
+				"Initial creation of container and data store should succeed.",
+			);
 
-		// Create a summarizer for the container and do a summary shouldn't throw.
-		const createSummarizerResult = await createSummarizerFromFactory(
-			provider,
-			container1,
-			dataStoreFactory1,
-			undefined,
-			ContainerRuntimeFactoryWithDefaultDataStore,
-			registryStoreEntries,
-		);
-		await assert.doesNotReject(
-			summarizeNow(createSummarizerResult.summarizer, "test"),
-			"Summarizing should not throw",
-		);
+			// Create a summarizer for the container and do a summary shouldn't throw.
+			const createSummarizerResult = await createSummarizerFromFactory(
+				provider,
+				container1,
+				dataStoreFactory1,
+				undefined,
+				ContainerRuntimeFactoryWithDefaultDataStore,
+				registryStoreEntries,
+			);
+			await assert.doesNotReject(
+				summarizeNow(createSummarizerResult.summarizer, "test"),
+				"Summarizing should not throw",
+			);
 
-		// In summarizer, load the data store should fail.
-		await assert.rejects(
-			async () => {
-				const runtime = (createSummarizerResult.summarizer as any).runtime as ContainerRuntime;
-				const dsEntryPoint = await runtime.getAliasedDataStoreEntryPoint("default");
-				await dsEntryPoint?.get();
-			},
-			(e: Error) =>
-				e.message ===
-				"Non interactive/summarizer client's data object should not be initialized",
-			"Loading data store in summarizer did not throw as it should, or threw an unexpected error.",
-		);
+			// In summarizer, load the data store should fail.
+			await assert.rejects(
+				async () => {
+					const runtime = (createSummarizerResult.summarizer as any)
+						.runtime as ContainerRuntime;
+					const dsEntryPoint = await runtime.getAliasedDataStoreEntryPoint("default");
+					await dsEntryPoint?.get();
+				},
+				(e: Error) =>
+					e.message ===
+					"Non interactive/summarizer client's data object should not be initialized",
+				"Loading data store in summarizer did not throw as it should, or threw an unexpected error.",
+			);
 
-		// Load second container, load the data store will also call initializingFromExisting and succeed.
-		const container2 = await provider.loadContainer(runtimeFactory);
-		await assert.doesNotReject(
-			container2.getEntryPoint(),
-			"Initial creation of container and data store should succeed.",
-		);
+			// Load second container, load the data store will also call initializingFromExisting and succeed.
+			const container2 = await provider.loadContainer(runtimeFactory);
+			await assert.doesNotReject(
+				container2.getEntryPoint(),
+				"Initial creation of container and data store should succeed.",
+			);
 		},
 	);
 

--- a/packages/utils/telemetry-utils/src/error.ts
+++ b/packages/utils/telemetry-utils/src/error.ts
@@ -295,8 +295,7 @@ export class DataProcessingError extends LoggingError implements IErrorBase, IFl
 		messageLike?: MessageLike,
 	): IFluidErrorBase {
 		return wrapDataProcessingErrorIfUnrecognized(
-			(errorMessage: string, props?: ITelemetryBaseProperties) =>
-				new DataProcessingError(errorMessage, props),
+			(errorMessage: string) => new DataProcessingError(errorMessage),
 			originalError,
 			dataProcessingCodepath,
 			messageLike,


### PR DESCRIPTION
## Description

Component load failures are one of the top  scenarios our partners need to be able to monitor and diagnose in production. This PR closes a long-standing gap where errors thrown during entryPoint initialization (e.g. for `PureDataObject`, that includes the initalization hooks) are not logged to FF tables.

While host applications can and do log these errors, there is context that's only readily available within FF that is really important for investigation - All the common ContainerRuntime props (notably clientType - is it the Summarizer?), as well as the DataStore's packagePath (indicates the component type) and id.

This PR logs an error event with all these props, and additionally annotates the error object* with the dataStore package/id info.

\* _Note: In testing I found that these telemetry props get stripped off on the way up by roundtripping through `exceptionToResponse` and `responseToException`.  A bit curious to look into that flow and if we could cut out those tranforms._