### PR TITLE
Rename ClientVersionDispatchingCodecBuilder to VersionDispatchingCodecBuilder

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -388,7 +388,7 @@ export const unitCodec: IJsonCodec<
  * Wraps a codec with JSON schema validation for its encoded type.
  * @returns An {@link IJsonCodec} which validates the data it encodes and decodes matches the provided schema.
  * @remarks
- * Eventually all codecs should use the same pattern implemented by ClientVersionDispatchingCodecBuilder, resulting in that having the only use of this API.
+ * Eventually all codecs should use the same pattern implemented by VersionDispatchingCodecBuilder, resulting in that having the only use of this API.
  */
 export function withSchemaValidation<
 	TInMemoryFormat,

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -38,7 +38,8 @@ export {
 export {
 	Versioned,
 	makeDiscontinuedCodecAndSchema,
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
+	type VersionDispatchingCodec,
 	type CodecVersion,
 	type CodecAndSchema,
 	versionField,

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -211,7 +211,7 @@ export interface NormalizedCodecVersion<
 /**
  * {@link NormalizedCodecVersion} after applying the build options.
  * @remarks
- * Produced by {@link ClientVersionDispatchingCodecBuilder.applyOptions}.
+ * Produced by {@link VersionDispatchingCodecBuilder.applyOptions}.
  */
 interface EvaluatedCodecVersion<TDecoded, TContext, TFormatVersion extends FormatVersion>
 	extends CodecVersionBase<CodecAndSchema<TDecoded, TContext>, TFormatVersion> {}
@@ -251,12 +251,34 @@ function normalizeCodecVersion<
 }
 
 /**
- * Creates a codec which dispatches to the appropriate member of a codec family based on the `minVersionForCollab` for encode and the
- * version number in data it encounters for decode.
- * @privateRemarks
- * This is a two stage builder so the first stage can encapsulate all codec specific details and the second can bring in configuration.
+ * A codec that can read multiple format versions and write a single selected version.
+ * @remarks
+ * Produced by {@link VersionDispatchingCodecBuilder.build}.
+ *
+ * @typeParam TDecoded - The in memory (not encoded) format.
+ * @typeParam TContext - Context type passed to encode/decode operations.
+ * @typeParam TFormatVersion - The type of format version identifiers used by this codec.
  */
-export class ClientVersionDispatchingCodecBuilder<
+export interface VersionDispatchingCodec<
+	TDecoded,
+	TContext,
+	TFormatVersion extends FormatVersion,
+> extends IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext> {
+	/**
+	 * The format version which this codec writes.
+	 * @remarks
+	 * Selected by {@link VersionDispatchingCodecBuilder.build} based on the provided options.
+	 */
+	readonly writeVersion: TFormatVersion;
+}
+
+/**
+ * Creates a {@link VersionDispatchingCodec} using a {@link CodecVersion} to select the {@link VersionDispatchingCodec.writeVersion}.
+ * @privateRemarks
+ * This is a two stage builder so the first stage (the static build) can encapsulate all codec specific details and
+ * the second (the instance build) can bring in configuration.
+ */
+export class VersionDispatchingCodecBuilder<
 	TBuildOptions extends ICodecOptions = ICodecOptions,
 	TDecoded = unknown,
 	TContext = unknown,
@@ -333,7 +355,7 @@ export class ClientVersionDispatchingCodecBuilder<
 	}
 
 	/**
-	 * Applies the provided options to the codec registry to produce a list of evaluated codecs.
+	 * Applies `options` to the codec registry to produce a list of evaluated codecs.
 	 * @remarks
 	 * This is used by build, which is what production code should use.
 	 * This is only exposed for testing purposes.
@@ -349,21 +371,12 @@ export class ClientVersionDispatchingCodecBuilder<
 	}
 
 	/**
-	 * Produce a single codec which can read any supported format, and writes a version selected based on the provided options.
+	 * Builds a complete {@link VersionDispatchingCodec} that can decode all registered versions
+	 * and encode a version selected by the provided options.
 	 */
-	public build(options: TBuildOptions & CodecWriteOptions): IJsonCodec<
-		TDecoded,
-		JsonCompatibleReadOnly,
-		JsonCompatibleReadOnly,
-		TContext
-	> & {
-		/**
-		 * The format version which this codec writes.
-		 * @remarks
-		 * This is selected based on the provided {@link CodecWriteOptions}.
-		 */
-		readonly writeVersion: TFormatVersion;
-	} {
+	public build(
+		options: TBuildOptions & CodecWriteOptions,
+	): VersionDispatchingCodec<TDecoded, TContext, TFormatVersion> {
 		const [applied, decoder] = this.buildDecoderInternal(options);
 		const writeVersion = getWriteVersion(this.name, options, applied);
 		return {
@@ -408,14 +421,18 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 	}
 
 	/**
-	 * Produce a single codec which can read any supported format.
+	 * Builds a decoder-only codec that can decode any supported format without encoding capability.
+	 *
+	 * @remarks
+	 * The returned codec contains only the `decode` method and can be used when only decoding is needed.
+	 * This is useful for scenarios where reading/decoding versioned data is sufficient.
+	 *
+	 * @param options - Build options (typically containing the `jsonValidator`)
+	 * @returns An object with a `decode` method that can handle any supported format version
 	 */
 	public buildDecoder(
 		options: TBuildOptions,
-	): Pick<
-		IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext>,
-		"decode"
-	> {
+	): Pick<VersionDispatchingCodec<TDecoded, TContext, TFormatVersion>, "decode"> {
 		return this.buildDecoderInternal(options)[1];
 	}
 
@@ -429,11 +446,20 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 	}
 
 	/**
-	 * Builds a ClientVersionDispatchingCodecBuilder from the provided registry.
+	 * Creates a new VersionDispatchingCodecBuilder from the provided codec registry.
+	 *
 	 * @remarks
 	 * This static method infers the types of the builder from the provided registry,
 	 * making it easier to create builders without needing to explicitly specify all type parameters.
 	 * This gets better type inference than the constructor.
+	 *
+	 * @example
+	 * ```typescript
+	 * const builder = VersionDispatchingCodecBuilder.build('myCodec', [
+	 *   { minVersionForCollab: lowestMinVersionForCollab, formatVersion: 1, codec: { encode, decode, schema } },
+	 *   { minVersionForCollab: '2.100.0', formatVersion: 2, codec: { encode, decode, schema } },
+	 * ]);
+	 * ```
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 	public static build<
@@ -459,7 +485,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 
 		const input = inputRegistry as readonly unknown[] as readonly CodecFinal[];
 
-		const builder = new ClientVersionDispatchingCodecBuilder<
+		const builder = new VersionDispatchingCodecBuilder<
 			TBuildOptions2,
 			TDecoded2,
 			unknown extends TContext2 ? void : TContext2,

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -293,7 +293,7 @@ export class VersionDispatchingCodecBuilder<
 	>[];
 
 	/**
-	 * Use {@link ClientVersionDispatchingCodecBuilder.build} to create an instance of this class.
+	 * Use {@link VersionDispatchingCodecBuilder.build} to create an instance of this class.
 	 * @remarks
 	 * Inputs to this are assumed to be constants in the code controlled by the developers of this package,
 	 * and constructed at least once during tests.

--- a/packages/dds/tree/src/codec/versioned/index.ts
+++ b/packages/dds/tree/src/codec/versioned/index.ts
@@ -6,7 +6,8 @@
 export { Versioned, versionField } from "./format.js";
 export {
 	makeDiscontinuedCodecAndSchema,
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
+	type VersionDispatchingCodec,
 	type CodecVersion,
 	type CodecAndSchema,
 } from "./codec.js";

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
@@ -7,7 +7,7 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	FluidClientVersion,
 	type ICodecOptions,
 } from "../../codec/index.js";
@@ -27,7 +27,7 @@ type BuildData = ICodecOptions & {
  */
 export const detachedFieldIndexCodecName = "DetachedFieldIndex";
 
-export const detachedFieldIndexCodecBuilder = ClientVersionDispatchingCodecBuilder.build(
+export const detachedFieldIndexCodecBuilder = VersionDispatchingCodecBuilder.build(
 	detachedFieldIndexCodecName,
 	[
 		{

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -9,8 +9,9 @@ import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/interna
 import type { TSchema } from "@sinclair/typebox";
 
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	type CodecAndSchema,
+	type VersionDispatchingCodec,
 	FluidClientVersion,
 } from "../../../codec/index.js";
 import {
@@ -138,7 +139,11 @@ export interface FieldBatchEncodingContext {
  * @remarks
  * Fields in this batch currently don't have field schema for the root, which limits optimizations.
  */
-export type FieldBatchCodec = ReturnType<typeof fieldBatchCodecBuilder.build>;
+export type FieldBatchCodec = VersionDispatchingCodec<
+	FieldBatch,
+	FieldBatchEncodingContext,
+	FieldBatchFormatVersion
+>;
 
 /**
  * Creates the encode/decode functions for a specific FieldBatch format version.
@@ -231,30 +236,27 @@ function makeFieldBatchCodecForVersion(
 }
 
 /**
- * {@link ClientVersionDispatchingCodecBuilder} for field batch codecs.
+ * {@link VersionDispatchingCodecBuilder} for field batch codecs.
  */
-export const fieldBatchCodecBuilder = ClientVersionDispatchingCodecBuilder.build(
-	"FieldBatch",
-	[
-		{
-			minVersionForCollab: lowestMinVersionForCollab,
-			formatVersion: FieldBatchFormatVersion.v1,
-			codec: makeFieldBatchCodecForVersion(
-				FieldBatchFormatVersion.v1,
-				uncompressedEncodeV1,
-				schemaCompressedEncodeV1,
-				EncodedFieldBatchV1,
-			),
-		},
-		{
-			minVersionForCollab: FluidClientVersion.v2_73,
-			formatVersion: FieldBatchFormatVersion.v2,
-			codec: makeFieldBatchCodecForVersion(
-				FieldBatchFormatVersion.v2,
-				uncompressedEncodeV2,
-				schemaCompressedEncodeV2,
-				EncodedFieldBatchV2,
-			),
-		},
-	],
-);
+export const fieldBatchCodecBuilder = VersionDispatchingCodecBuilder.build("FieldBatch", [
+	{
+		minVersionForCollab: lowestMinVersionForCollab,
+		formatVersion: FieldBatchFormatVersion.v1,
+		codec: makeFieldBatchCodecForVersion(
+			FieldBatchFormatVersion.v1,
+			uncompressedEncodeV1,
+			schemaCompressedEncodeV1,
+			EncodedFieldBatchV1,
+		),
+	},
+	{
+		minVersionForCollab: FluidClientVersion.v2_73,
+		formatVersion: FieldBatchFormatVersion.v2,
+		codec: makeFieldBatchCodecForVersion(
+			FieldBatchFormatVersion.v2,
+			uncompressedEncodeV2,
+			schemaCompressedEncodeV2,
+			EncodedFieldBatchV2,
+		),
+	},
+]);

--- a/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
@@ -7,9 +7,10 @@ import { assert, oob } from "@fluidframework/core-utils/internal";
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	type CodecAndSchema,
 	type CodecWriteOptions,
+	type VersionDispatchingCodec,
 	FluidClientVersion,
 } from "../../codec/index.js";
 import type { FieldKey, ITreeCursorSynchronous } from "../../core/index.js";
@@ -24,7 +25,11 @@ import { ForestFormatVersion, FormatCommon } from "./formatCommon.js";
  * Uses field cursors
  */
 export type FieldSet = ReadonlyMap<FieldKey, ITreeCursorSynchronous>;
-export type ForestCodec = ReturnType<typeof forestCodecBuilder.build>;
+export type ForestCodec = VersionDispatchingCodec<
+	FieldSet,
+	FieldBatchEncodingContext,
+	ForestFormatVersion
+>;
 
 function makeForestSummarizerCodec(
 	options: CodecWriteOptions,
@@ -64,9 +69,9 @@ function makeForestSummarizerCodec(
 }
 
 /**
- * {@link ClientVersionDispatchingCodecBuilder} for forest summarizer codecs.
+ * {@link VersionDispatchingCodecBuilder} for forest summarizer codecs.
  */
-export const forestCodecBuilder = ClientVersionDispatchingCodecBuilder.build("Forest", [
+export const forestCodecBuilder = VersionDispatchingCodecBuilder.build("Forest", [
 	{
 		minVersionForCollab: lowestMinVersionForCollab,
 		formatVersion: ForestFormatVersion.v1,

--- a/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
@@ -6,10 +6,7 @@
 import { fail } from "@fluidframework/core-utils/internal";
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
-import {
-	ClientVersionDispatchingCodecBuilder,
-	FluidClientVersion,
-} from "../../codec/index.js";
+import { VersionDispatchingCodecBuilder, FluidClientVersion } from "../../codec/index.js";
 import {
 	SchemaFormatVersion,
 	type TreeNodeSchemaIdentifier,
@@ -100,7 +97,7 @@ function decodeV2(f: FormatV2): TreeStoredSchema {
 /**
  * Creates a codec which performs synchronous monolithic encoding of schema content.
  */
-export const schemaCodecBuilder = ClientVersionDispatchingCodecBuilder.build("Schema", [
+export const schemaCodecBuilder = VersionDispatchingCodecBuilder.build("Schema", [
 	{
 		minVersionForCollab: lowestMinVersionForCollab,
 		formatVersion: SchemaFormatVersion.v1,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -8,7 +8,7 @@ import type { MinimumVersionForCollab } from "@fluidframework/runtime-definition
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	type CodecTree,
 	type CodecVersion,
 	type DependentFormatVersion,
@@ -64,11 +64,9 @@ interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
 }
 
 /**
- * Creates a {@link ClientVersionDispatchingCodecBuilder} encoding for {@link SummaryData}.
+ * Creates a {@link VersionDispatchingCodecBuilder} encoding for {@link SummaryData}.
  */
-export function makeEditManagerCodecBuilder<
-	TChangeset,
->(): ClientVersionDispatchingCodecBuilder<
+export function makeEditManagerCodecBuilder<TChangeset>(): VersionDispatchingCodecBuilder<
 	EditManagerCodecOptions<TChangeset>,
 	SummaryData<TChangeset>,
 	EditManagerEncodingContext,
@@ -137,7 +135,7 @@ export function makeEditManagerCodecBuilder<
 		},
 	];
 
-	return ClientVersionDispatchingCodecBuilder.build(editManagerCodecName, versions);
+	return VersionDispatchingCodecBuilder.build(editManagerCodecName, versions);
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -8,7 +8,7 @@ import type { MinimumVersionForCollab } from "@fluidframework/runtime-definition
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	type CodecTree,
 	type CodecVersion,
 	type DependentFormatVersion,
@@ -58,9 +58,9 @@ interface MessageCodecBuilderOptions<TChangeset> extends ICodecOptions {
 }
 
 /**
- * Creates a {@link ClientVersionDispatchingCodecBuilder} for encoding/decoding messages.
+ * Creates a {@link VersionDispatchingCodecBuilder} for encoding/decoding messages.
  */
-export function makeMessageCodecBuilder<TChangeset>(): ClientVersionDispatchingCodecBuilder<
+export function makeMessageCodecBuilder<TChangeset>(): VersionDispatchingCodecBuilder<
 	MessageCodecBuilderOptions<TChangeset>,
 	DecodedMessage<TChangeset>,
 	MessageEncodingContext,
@@ -129,7 +129,7 @@ export function makeMessageCodecBuilder<TChangeset>(): ClientVersionDispatchingC
 		},
 	];
 
-	return ClientVersionDispatchingCodecBuilder.build(messageCodecName, versions);
+	return VersionDispatchingCodecBuilder.build(messageCodecName, versions);
 }
 
 export function getCodecTreeForMessageFormatWithChange(

--- a/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
@@ -14,7 +14,7 @@ import {
 
 import { FluidClientVersion, Versioned } from "../../../codec/index.js";
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	type CodecAndSchema,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../codec/versioned/codec.js";
@@ -22,7 +22,7 @@ import { FormatValidatorBasic } from "../../../external-utilities/index.js";
 import { pkgVersion } from "../../../packageVersion.js";
 
 describe("versioned Codecs", () => {
-	describe("ClientVersionDispatchingCodecBuilder", () => {
+	describe("VersionDispatchingCodecBuilder", () => {
 		interface V1 {
 			version: 1;
 			value1: number;
@@ -51,7 +51,7 @@ describe("versioned Codecs", () => {
 			schema: Versioned,
 		};
 
-		const builder = ClientVersionDispatchingCodecBuilder.build("Test", [
+		const builder = VersionDispatchingCodecBuilder.build("Test", [
 			{
 				minVersionForCollab: lowestMinVersionForCollab,
 				formatVersion: 1,
@@ -143,7 +143,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 		});
 
 		it("good builds", () => {
-			ClientVersionDispatchingCodecBuilder.build("Test", [
+			VersionDispatchingCodecBuilder.build("Test", [
 				{
 					minVersionForCollab: lowestMinVersionForCollab,
 					formatVersion: 1,
@@ -177,7 +177,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 			if (nonProductionConditionalsIncluded()) {
 				assert.throws(
 					() =>
-						ClientVersionDispatchingCodecBuilder.build("Test", [
+						VersionDispatchingCodecBuilder.build("Test", [
 							{
 								minVersionForCollab: lowestMinVersionForCollab,
 								formatVersion: "1",
@@ -191,7 +191,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 
 				assert.throws(
 					() =>
-						ClientVersionDispatchingCodecBuilder.build("Test", [
+						VersionDispatchingCodecBuilder.build("Test", [
 							{
 								minVersionForCollab: undefined,
 								formatVersion: 1,
@@ -205,7 +205,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 
 				assert.throws(
 					() =>
-						ClientVersionDispatchingCodecBuilder.build("Test", [
+						VersionDispatchingCodecBuilder.build("Test", [
 							{
 								minVersionForCollab: lowestMinVersionForCollab,
 								formatVersion: 1,
@@ -224,7 +224,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 
 				assert.throws(
 					() =>
-						ClientVersionDispatchingCodecBuilder.build("Test", [
+						VersionDispatchingCodecBuilder.build("Test", [
 							{
 								minVersionForCollab: lowestMinVersionForCollab,
 								formatVersion: 1,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -14,7 +14,7 @@ import {
 import type { TSchema } from "@sinclair/typebox";
 
 import {
-	ClientVersionDispatchingCodecBuilder,
+	VersionDispatchingCodecBuilder,
 	type ICodecOptions,
 	type IJsonCodec,
 } from "../../../../codec/index.js";
@@ -108,7 +108,7 @@ function makeFieldBatchCodec(
 	JsonCompatibleReadOnly,
 	FieldBatchEncodingContext
 > {
-	const builder = ClientVersionDispatchingCodecBuilder.build("TestCompressedFieldBatch", [
+	const builder = VersionDispatchingCodecBuilder.build("TestCompressedFieldBatch", [
 		{
 			minVersionForCollab: lowestMinVersionForCollab,
 			formatVersion: version,

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -11,10 +11,7 @@ import path from "node:path";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import { cleanedPackageVersion } from "@fluidframework/runtime-utils/internal";
 
-import type {
-	ClientVersionDispatchingCodecBuilder,
-	ICodecOptions,
-} from "../../codec/index.js";
+import type { VersionDispatchingCodecBuilder, ICodecOptions } from "../../codec/index.js";
 import {
 	snapshotSchemaCompatibility,
 	type TreeViewConfiguration,
@@ -192,7 +189,7 @@ export function testSchemaCompatibilitySnapshots(
  * @param options - The options to apply to the codec before snapshotting.
  */
 export function snapshotCodecFormats<TBuildOptions extends Record<string, unknown>>(
-	codec: ClientVersionDispatchingCodecBuilder<TBuildOptions & ICodecOptions>,
+	codec: VersionDispatchingCodecBuilder<TBuildOptions & ICodecOptions>,
 	options: TBuildOptions,
 ): void {
 	const versions = codec


### PR DESCRIPTION
## Description

Rename ClientVersionDispatchingCodecBuilder to VersionDispatchingCodecBuilder (mostly to have a shorter name) and related cleanup.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

