### PR TITLE
Remove @msfluid-bot as codeowner for package.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,4 +102,4 @@ api-report/view-interfaces.api.md                                         @micro
 api-report/web-code-loader.api.md                                         @microsoft/fluid-cr-loader
 
 # No owners for package.json files to avoid review spam when mono-repo dependencies are updated
-package.json @msfluid-bot
+package.json


### PR DESCRIPTION
[AB#73620](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73620)

Removes `@msfluid-bot` as the codeowner for `package.json` files. The line is kept (with no owner) so the existing intent stated in the comment above — *no owner for package.json files to avoid review spam when mono-repo dependencies are updated* — is preserved via GitHub's [documented empty-owner syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).