### PR TITLE
Opt into confirmModulesPurge in test-version-utils

### DIFF
--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -43,7 +43,7 @@
 		"eslint:fix": "eslint --quiet --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
-		"postinstall": "pnpm --dir compat-workspaces/full install --frozen-lockfile",
+		"postinstall": "pnpm --dir compat-workspaces/full install --frozen-lockfile --config.confirmModulesPurge=false",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",


### PR DESCRIPTION
## Description

Sometiems, like when then pnpm version changes, pnpm needs to regenerated the node moduels folder.
This setting prevents such cases from failing due to the post install script thich triggers another nested install in test-version-utils.

This should have no impact on CI as it would start with an empty node modules: this is just to make the devX better across pnpm updates.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
