### PR TITLE
Skip redundant workspace-concurrency setting

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -70,7 +70,6 @@ steps:
   inputs:
     targetType: 'inline'
     workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
-    # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
     script: |
       set -eu -o pipefail
       echo "Using node $(node --version)"
@@ -78,11 +77,12 @@ steps:
       echo "Using pnpm $(pnpm -v)"
       # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"
+      # Ensure the user .npmrc exists so the npmAuthenticate task can populate it.
+      touch "$NPM_CONFIG_USERCONFIG"
       echo "Pnpm user config location: $(pnpm config get userconfig)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
       echo "Primary registry: ${NPM_REGISTRY}"
-      pnpm config set -g workspace-concurrency 0
       pnpm config set registry "${NPM_REGISTRY}"
       if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]; then
         echo "##vso[task.setvariable variable=registryType]public"


### PR DESCRIPTION
## Description

We set `workspace-concurrency=0` in the `.npmrc` files already, so setting them in the pipeline is redundent.
We are keeping the ones in the `.npmrc` files since they also apply to local development, which is desired.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
