### PR TITLE
ci: extend 1ES PT in repo-policy-check pipeline (lts)

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -15,9 +15,6 @@ pr:
 - lts
 - release/*
 
-pool:
-  Small-eastus2
-
 variables:
 - name: pnpmStorePath
   value: $(Pipeline.Workspace)/.pnpm-store
@@ -25,41 +22,79 @@ variables:
   value: true
 - group: ado-feeds
 
-stages:
-- stage: run_policy_check
-  jobs:
-  - job: run_policy_check
-    steps:
-    # Install
-    - task: UseNode@1
-      displayName: Use Node 20.15.1
-      inputs:
-        version: 20.15.1
+# The `resources` specify the location and version of the 1ES PT.
+resources:
+  repositories:
+  - repository: m365Pipelines
+    type: git
+    name: 1ESPipelineTemplates/M365GPT
+    ref: refs/tags/release
 
-    - template: /tools/pipelines/templates/include-install-pnpm.yml@self
-      parameters:
-        buildDirectory: .
+extends:
+  # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.
+  # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  ${{ else }}:
+    # For non-production pipelines, we use "Unofficial" 1ES pipeline template
+    # The unofficial template skips some of the jobs that are irrelevant for the pipelines that do not have the potential to produce a production release candidate.(For example ARROW).
+    template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
+  parameters:
+    pool:
+      name: Small-eastus2
+      os: linux
+    sdl:
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        arrow:
+          # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
+          serviceConnection: ff-internal-arrow-sc
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-2022
+        os: windows
+      # Tentative workaround for the occasional Credscan failures
+      credscan:
+        batchSize: 4
+    # Skip tagging if Github PR coming from a fork
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
+    customBuildTags:
+      - ES365AIMigrationTooling
+    stages:
+    - stage: run_policy_check
+      jobs:
+      - job: run_policy_check
+        steps:
+        # Install
+        - task: UseNode@1
+          displayName: Use Node 20.15.1
+          inputs:
+            version: 20.15.1
 
-    - task: Bash@3
-      displayName: Install root dependencies
-      inputs:
-        targetType: 'inline'
-        workingDirectory: .
-        script: |
-          set -eu -o pipefail
-          # We only need to install the root dependencies
-          pnpm install --workspace-root --frozen-lockfile
+        - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+          parameters:
+            buildDirectory: .
 
-    - task: Npm@1
-      displayName: Policy Check
-      inputs:
-        command: 'custom'
-        customCommand: 'run policy-check'
+        - task: Bash@3
+          displayName: Install root dependencies
+          inputs:
+            targetType: 'inline'
+            workingDirectory: .
+            script: |
+              set -eu -o pipefail
+              # We only need to install the root dependencies
+              pnpm install --workspace-root --frozen-lockfile
 
-    - task: Bash@3
-      displayName: Prune pnpm store
-      inputs:
-        targetType: 'inline'
-        script: |
-          set -eu -o pipefail
-          pnpm store prune
+        - task: Npm@1
+          displayName: Policy Check
+          inputs:
+            command: 'custom'
+            customCommand: 'run policy-check'
+
+        - task: Bash@3
+          displayName: Prune pnpm store
+          inputs:
+            targetType: 'inline'
+            script: |
+              set -eu -o pipefail
+              pnpm store prune


### PR DESCRIPTION
## Description

The `repo-policy-check` pipeline running against the `lts` branch in the ADO `internal` project has been failing since early 2026 due to the 1ES Drift Management Check, which errors with:

> [1ES PT Error]: Organization: https://dev.azure.com/fluidframework/ breaks pipelines that do not extend one of the following templates - OneBranchPTUnofficial, 1ESPT, OneBranchPT.

`main` was migrated to extend the 1ES Pipeline Template in #19219 (Jan 2024) but the change was never backported to `lts`, so `lts` runs have been red ever since 1ES drift enforcement turned on. Example failing run: <https://dev.azure.com/fluidframework/internal/_build/results?buildId=397924&view=results>.

This PR backports the minimal structural change required — wrapping the existing job in an `extends: v1/M365.{Official,Unofficial}.PipelineTemplate.yml@m365Pipelines` block — keeping the existing step list (`UseNode` 20.15.1, install pnpm, install root deps, `policy-check`, prune pnpm store) intact. It is **not** a full sync with `main`'s current `repo-policy-check.yml`; the extra checks (`layer-check`, `check:format:repo`), the `FluidFrameworkDirectory` consistent-sources-directory plumbing, and the `include-policy-check.yml` template refactor are intentionally omitted as unrelated.

The same yaml file is consumed by two pipelines (`internal/repo-policy-check` id 15 and `public/repo-policy-check` id 18), so the Official vs Unofficial template choice is gated on `System.TeamProject` the same way `main` does it.

I also audited the other `tools/pipelines/*.yml` pipelines on `lts` and confirmed none of them have the same problem: every `build-*` pipeline transitively extends 1ES via `templates/build-npm-package.yml`, and the few remaining top-level pipelines that don't `extends:` are either never run on `lts` or fail for unrelated reasons (e.g. `npm install` cache issues) rather than the 1ES drift check.

Tracked by [AB#73621](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73621).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Specific things worth a careful look:

- Whether the Official/Unofficial template split based on `System.TeamProject` is the right pattern for `lts` (it mirrors `main`).
- Whether dropping the top-level `pool:` in favor of `extends.parameters.pool` is correct (1ES PT owns pool selection).
- Whether the `ff-internal-arrow-sc` service connection name is current on `lts` (it's used elsewhere on this branch already; main's 2024 PR used the long-renamed `Arrow_FluidFramework_internal`).
- Confirm the pipeline actually runs green when CI exercises this PR.