### PR TITLE
Split TEncodeContext and TDecodeContext

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -196,9 +196,10 @@ export interface IJsonCodec<
 	TDecoded,
 	TEncoded = JsonCompatibleReadOnly,
 	TValidate = TEncoded,
-	TContext = void,
-> extends IEncoder<TDecoded, TEncoded, TContext>,
-		IDecoder<TDecoded, TValidate, TContext> {
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
+> extends IEncoder<TDecoded, TEncoded, TEncodeContext>,
+		IDecoder<TDecoded, TValidate, TDecodeContext> {
 	encodedSchema?: TAnySchema;
 }
 
@@ -211,9 +212,13 @@ export interface IJsonCodec<
  *
  * This portion of a codec is not responsible for managing versioning or validation of the data against the schema.
  */
-export interface JsonCodecPart<TDecoded, TEncodedSchema extends TAnySchema, TContext = void>
-	extends IEncoder<TDecoded, Static<TEncodedSchema>, TContext>,
-		IDecoder<TDecoded, Static<TEncodedSchema>, TContext> {
+export interface JsonCodecPart<
+	TDecoded,
+	TEncodedSchema extends TAnySchema,
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
+> extends IEncoder<TDecoded, Static<TEncodedSchema>, TEncodeContext>,
+		IDecoder<TDecoded, Static<TEncodedSchema>, TDecodeContext> {
 	/**
 	 * TypeBox schema which describes the encoded format for this chunk of data.
 	 * @remarks
@@ -230,11 +235,18 @@ export function eraseEncodedType<
 	TDecoded,
 	TEncoded = JsonCompatibleReadOnly,
 	TValidate = TEncoded,
-	TContext = void,
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
 >(
-	codec: IJsonCodec<TDecoded, TEncoded, TValidate, TContext>,
-): IJsonCodec<TDecoded, TValidate, TValidate, TContext> {
-	return codec as unknown as IJsonCodec<TDecoded, TValidate, TValidate, TContext>;
+	codec: IJsonCodec<TDecoded, TEncoded, TValidate, TEncodeContext, TDecodeContext>,
+): IJsonCodec<TDecoded, TValidate, TValidate, TEncodeContext, TDecodeContext> {
+	return codec as unknown as IJsonCodec<
+		TDecoded,
+		TValidate,
+		TValidate,
+		TEncodeContext,
+		TDecodeContext
+	>;
 }
 
 /**
@@ -246,11 +258,15 @@ export function eraseEncodedType<
  * allows avoiding some duplicate work at encode/decode time, since the vast majority of document usage will not
  * involve mixed format versions.
  *
- * @privateRemarks This interface currently assumes all codecs in a family require the same encode/decode context,
- * which isn't necessarily true.
- * This may need to be relaxed in the future.
+ * @privateRemarks
+ * Encode and decode can be parameterized independently — the encode-side context type need not equal the decode-side context type.
+ * `TDecodeContext` defaults to `TEncodeContext` so callers that share a single context shape (the common case) don't need to specify it.
  */
-export interface ICodecFamily<TDecoded, TContext = void> {
+export interface ICodecFamily<
+	TDecoded,
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
+> {
 	/**
 	 * @returns a codec that can be used to encode and decode data in the specified format.
 	 * @throws if the format version is not supported by this family.
@@ -260,7 +276,13 @@ export interface ICodecFamily<TDecoded, TContext = void> {
 	 */
 	resolve(
 		formatVersion: FormatVersion,
-	): IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext>;
+	): IJsonCodec<
+		TDecoded,
+		JsonCompatibleReadOnly,
+		JsonCompatibleReadOnly,
+		TEncodeContext,
+		TDecodeContext
+	>;
 
 	/**
 	 * @returns an iterable of all format versions supported by this family.
@@ -338,17 +360,29 @@ export const DependentFormatVersion = {
 /**
  * Creates a codec family from a registry of codecs.
  */
-export function makeCodecFamily<TDecoded, TContext>(
+export function makeCodecFamily<TDecoded, TEncodeContext, TDecodeContext = TEncodeContext>(
 	registry: Iterable<
 		[
 			formatVersion: FormatVersion,
-			codec: IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext>,
+			codec: IJsonCodec<
+				TDecoded,
+				JsonCompatibleReadOnly,
+				JsonCompatibleReadOnly,
+				TEncodeContext,
+				TDecodeContext
+			>,
 		]
 	>,
-): ICodecFamily<TDecoded, TContext> {
+): ICodecFamily<TDecoded, TEncodeContext, TDecodeContext> {
 	const codecs: Map<
 		FormatVersion,
-		IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext>
+		IJsonCodec<
+			TDecoded,
+			JsonCompatibleReadOnly,
+			JsonCompatibleReadOnly,
+			TEncodeContext,
+			TDecodeContext
+		>
 	> = new Map();
 	for (const [formatVersion, codec] of registry) {
 		if (codecs.has(formatVersion)) {
@@ -360,7 +394,13 @@ export function makeCodecFamily<TDecoded, TContext>(
 	return {
 		resolve(
 			formatVersion: FormatVersion,
-		): IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext> {
+		): IJsonCodec<
+			TDecoded,
+			JsonCompatibleReadOnly,
+			JsonCompatibleReadOnly,
+			TEncodeContext,
+			TDecodeContext
+		> {
 			const codec = codecs.get(formatVersion);
 			assert(codec !== undefined, 0x5e6 /* Requested codec for unsupported format. */);
 			return codec;
@@ -395,25 +435,32 @@ export function withSchemaValidation<
 	EncodedSchema extends TSchema,
 	TEncodedFormat,
 	TValidate,
-	TContext,
+	TEncodeContext,
+	TDecodeContext = TEncodeContext,
 >(
 	schema: EncodedSchema,
-	codec: IJsonCodec<TInMemoryFormat, TEncodedFormat, TValidate, TContext>,
+	codec: IJsonCodec<
+		TInMemoryFormat,
+		TEncodedFormat,
+		TValidate,
+		TEncodeContext,
+		TDecodeContext
+	>,
 	validator?: JsonValidator | FormatValidator,
-): IJsonCodec<TInMemoryFormat, TEncodedFormat, TValidate, TContext> {
+): IJsonCodec<TInMemoryFormat, TEncodedFormat, TValidate, TEncodeContext, TDecodeContext> {
 	if (!validator) {
 		return codec;
 	}
 	const compiledFormat = extractJsonValidator(validator).compile(schema);
 	return {
-		encode: (obj: TInMemoryFormat, context: TContext): TEncodedFormat => {
+		encode: (obj: TInMemoryFormat, context: TEncodeContext): TEncodedFormat => {
 			const encoded = codec.encode(obj, context);
 			if (!compiledFormat.check(encoded)) {
 				fail(0xac0 /* Encoded data should validate */);
 			}
 			return encoded;
 		},
-		decode: (encoded: TValidate, context: TContext): TInMemoryFormat => {
+		decode: (encoded: TValidate, context: TDecodeContext): TInMemoryFormat => {
 			if (!compiledFormat.check(encoded)) {
 				fail(0xac1 /* Data being decoded should validate */);
 			}

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -173,8 +173,9 @@ export interface CodecWriteOptions extends ICodecOptions, CodecWriteOptionsBeta 
 }
 
 /**
- * `TContext` allows passing context to the codec which may configure how data is encoded/decoded.
- * This parameter is typically used for:
+ * `TEncodeContext` and `TDecodeContext` allow passing context to the codec which may configure how data is encoded/decoded.
+ * `TDecodeContext` defaults to `TEncodeContext`; specify them separately when encode and decode need different context (for example, when encoding uses heuristics that are unneeded when decoding).
+ * These parameters are typically used for:
  * - Codecs which can pick from multiple encoding options, and imbue the encoded data with information about which option was used.
  * The caller of such a codec can provide context about which encoding choice to make as part of the `encode` call without creating
  * additional codecs. Note that this pattern can always be implemented by having the caller create multiple codecs and selecting the

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -121,13 +121,11 @@ function makeVersionedValidatedCodec<
  */
 export function makeDiscontinuedCodecAndSchema<
 	TDecoded,
-	TEncodeContext,
 	TFormatVersion extends FormatVersion = FormatVersion,
-	TDecodeContext = TEncodeContext,
 >(
 	discontinuedVersion: TFormatVersion,
 	discontinuedSince: SemanticVersion,
-): CodecVersion<TDecoded, TEncodeContext, TFormatVersion, ICodecOptions, TDecodeContext> {
+): CodecVersion<TDecoded, unknown, TFormatVersion, ICodecOptions, unknown> {
 	return {
 		minVersionForCollab: undefined,
 		formatVersion: discontinuedVersion,

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -48,14 +48,15 @@ function makeVersionedCodec<
 	TDecoded,
 	TEncoded extends Versioned = VersionedJson,
 	TValidate = TEncoded,
-	TContext = void,
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
 >(
 	supportedVersions: Set<FormatVersion>,
 	{ jsonValidator: validator }: ICodecOptions,
-	inner: IJsonCodec<TDecoded, TEncoded, TValidate, TContext>,
-): IJsonCodec<TDecoded, TEncoded, TValidate, TContext> {
+	inner: IJsonCodec<TDecoded, TEncoded, TValidate, TEncodeContext, TDecodeContext>,
+): IJsonCodec<TDecoded, TEncoded, TValidate, TEncodeContext, TDecodeContext> {
 	const codec = {
-		encode: (data: TDecoded, context: TContext): TEncoded => {
+		encode: (data: TDecoded, context: TEncodeContext): TEncoded => {
 			const encoded = inner.encode(data, context);
 			assert(
 				supportedVersions.has(encoded.version),
@@ -63,7 +64,7 @@ function makeVersionedCodec<
 			);
 			return encoded;
 		},
-		decode: (data: TValidate, context: TContext): TDecoded => {
+		decode: (data: TValidate, context: TDecodeContext): TDecoded => {
 			const versioned = data as Versioned; // Validated by withSchemaValidation
 			if (!supportedVersions.has(versioned.version)) {
 				throw new UsageError(
@@ -96,14 +97,15 @@ function makeVersionedValidatedCodec<
 	TDecoded,
 	TEncoded extends Versioned = VersionedJson,
 	TValidate = TEncoded,
-	TContext = void,
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
 >(
 	options: ICodecOptions,
 	supportedVersions: Set<FormatVersion>,
 	schema: EncodedSchema,
-	codec: IJsonCodec<TDecoded, TEncoded, TValidate, TContext>,
-): IJsonCodec<TDecoded, TEncoded, TValidate, TContext> &
-	Pick<CodecAndSchema<TDecoded, TContext>, "schema"> {
+	codec: IJsonCodec<TDecoded, TEncoded, TValidate, TEncodeContext, TDecodeContext>,
+): IJsonCodec<TDecoded, TEncoded, TValidate, TEncodeContext, TDecodeContext> &
+	Pick<CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext>, "schema"> {
 	return {
 		...makeVersionedCodec(
 			supportedVersions,
@@ -119,12 +121,13 @@ function makeVersionedValidatedCodec<
  */
 export function makeDiscontinuedCodecAndSchema<
 	TDecoded,
-	TContext,
+	TEncodeContext,
 	TFormatVersion extends FormatVersion = FormatVersion,
+	TDecodeContext = TEncodeContext,
 >(
 	discontinuedVersion: TFormatVersion,
 	discontinuedSince: SemanticVersion,
-): CodecVersion<TDecoded, TContext, TFormatVersion> {
+): CodecVersion<TDecoded, TEncodeContext, TFormatVersion, ICodecOptions, TDecodeContext> {
 	return {
 		minVersionForCollab: undefined,
 		formatVersion: discontinuedVersion,
@@ -150,9 +153,19 @@ export function makeDiscontinuedCodecAndSchema<
  * The codec should not perform its own schema validation.
  * The schema validation gets added when normalizing to {@link NormalizedCodecVersion}.
  */
-export type CodecAndSchema<TDecoded, TContext = void> = {
+export type CodecAndSchema<
+	TDecoded,
+	TEncodeContext = void,
+	TDecodeContext = TEncodeContext,
+> = {
 	readonly schema: TSchema;
-} & IJsonCodec<TDecoded, VersionedJson, JsonCompatibleReadOnly, TContext>;
+} & IJsonCodec<
+	TDecoded,
+	VersionedJson,
+	JsonCompatibleReadOnly,
+	TEncodeContext,
+	TDecodeContext
+>;
 
 /**
  * A codec alongside its format version and schema.
@@ -183,12 +196,13 @@ export interface CodecVersionBase<
  */
 export interface CodecVersion<
 	TDecoded,
-	TContext,
+	TEncodeContext,
 	TFormatVersion extends FormatVersion,
 	TBuildOptions extends ICodecOptions = ICodecOptions,
+	TDecodeContext = TEncodeContext,
 > extends CodecVersionBase<
-		| CodecAndSchema<TDecoded, TContext>
-		| ((options: TBuildOptions) => CodecAndSchema<TDecoded, TContext>),
+		| CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext>
+		| ((options: TBuildOptions) => CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext>),
 		TFormatVersion
 	> {}
 
@@ -200,11 +214,12 @@ export interface CodecVersion<
  */
 export interface NormalizedCodecVersion<
 	TDecoded,
-	TContext,
+	TEncodeContext,
 	TFormatVersion extends FormatVersion,
 	TBuildOptions extends ICodecOptions,
+	TDecodeContext = TEncodeContext,
 > extends CodecVersionBase<
-		(options: TBuildOptions) => CodecAndSchema<TDecoded, TContext>,
+		(options: TBuildOptions) => CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext>,
 		TFormatVersion
 	> {}
 
@@ -213,8 +228,15 @@ export interface NormalizedCodecVersion<
  * @remarks
  * Produced by {@link VersionDispatchingCodecBuilder.applyOptions}.
  */
-interface EvaluatedCodecVersion<TDecoded, TContext, TFormatVersion extends FormatVersion>
-	extends CodecVersionBase<CodecAndSchema<TDecoded, TContext>, TFormatVersion> {}
+interface EvaluatedCodecVersion<
+	TDecoded,
+	TEncodeContext,
+	TFormatVersion extends FormatVersion,
+	TDecodeContext = TEncodeContext,
+> extends CodecVersionBase<
+		CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext>,
+		TFormatVersion
+	> {}
 
 /**
  * Normalize the codec to a single format.
@@ -223,17 +245,34 @@ interface EvaluatedCodecVersion<TDecoded, TContext, TFormatVersion extends Forma
  */
 function normalizeCodecVersion<
 	TDecoded,
-	TContext,
+	TEncodeContext,
 	TFormatVersion extends FormatVersion,
 	TBuildOptions extends ICodecOptions,
+	TDecodeContext = TEncodeContext,
 >(
-	codecVersion: CodecVersion<TDecoded, TContext, TFormatVersion, TBuildOptions>,
-): NormalizedCodecVersion<TDecoded, TContext, TFormatVersion, TBuildOptions> {
-	const codecBuilder: (options: TBuildOptions) => CodecAndSchema<TDecoded, TContext> =
+	codecVersion: CodecVersion<
+		TDecoded,
+		TEncodeContext,
+		TFormatVersion,
+		TBuildOptions,
+		TDecodeContext
+	>,
+): NormalizedCodecVersion<
+	TDecoded,
+	TEncodeContext,
+	TFormatVersion,
+	TBuildOptions,
+	TDecodeContext
+> {
+	const codecBuilder: (
+		options: TBuildOptions,
+	) => CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext> =
 		typeof codecVersion.codec === "function"
 			? codecVersion.codec
-			: () => codecVersion.codec as CodecAndSchema<TDecoded, TContext>;
-	const codec = (options: TBuildOptions): CodecAndSchema<TDecoded, TContext> => {
+			: () => codecVersion.codec as CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext>;
+	const codec = (
+		options: TBuildOptions,
+	): CodecAndSchema<TDecoded, TEncodeContext, TDecodeContext> => {
 		const built = codecBuilder(options);
 		return makeVersionedValidatedCodec(
 			options,
@@ -261,9 +300,16 @@ function normalizeCodecVersion<
  */
 export interface VersionDispatchingCodec<
 	TDecoded,
-	TContext,
+	TEncodeContext,
 	TFormatVersion extends FormatVersion,
-> extends IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext> {
+	TDecodeContext = TEncodeContext,
+> extends IJsonCodec<
+		TDecoded,
+		JsonCompatibleReadOnly,
+		JsonCompatibleReadOnly,
+		TEncodeContext,
+		TDecodeContext
+	> {
 	/**
 	 * The format version which this codec writes.
 	 * @remarks
@@ -281,15 +327,17 @@ export interface VersionDispatchingCodec<
 export class VersionDispatchingCodecBuilder<
 	TBuildOptions extends ICodecOptions = ICodecOptions,
 	TDecoded = unknown,
-	TContext = unknown,
+	TEncodeContext = unknown,
 	TFormatVersion extends FormatVersion = FormatVersion,
 	TName extends CodecName = string,
+	TDecodeContext = TEncodeContext,
 > {
 	public readonly registry: readonly NormalizedCodecVersion<
 		TDecoded,
-		TContext,
+		TEncodeContext,
 		TFormatVersion,
-		TBuildOptions
+		TBuildOptions,
+		TDecodeContext
 	>[];
 
 	/**
@@ -308,13 +356,20 @@ export class VersionDispatchingCodecBuilder<
 		/**
 		 * The registry of codecs which this builder can use to encode and decode data.
 		 */
-		inputRegistry: readonly CodecVersion<TDecoded, TContext, TFormatVersion, TBuildOptions>[],
+		inputRegistry: readonly CodecVersion<
+			TDecoded,
+			TEncodeContext,
+			TFormatVersion,
+			TBuildOptions,
+			TDecodeContext
+		>[],
 	) {
 		type Normalized = NormalizedCodecVersion<
 			TDecoded,
-			TContext,
+			TEncodeContext,
 			TFormatVersion,
-			TBuildOptions
+			TBuildOptions,
+			TDecodeContext
 		>;
 		const normalizedRegistry: Normalized[] = [];
 		const formats: Set<FormatVersion> = new Set();
@@ -362,7 +417,7 @@ export class VersionDispatchingCodecBuilder<
 	 */
 	public applyOptions(
 		options: TBuildOptions,
-	): EvaluatedCodecVersion<TDecoded, TContext, TFormatVersion>[] {
+	): EvaluatedCodecVersion<TDecoded, TEncodeContext, TFormatVersion, TDecodeContext>[] {
 		return this.registry.map((codec) => ({
 			minVersionForCollab: codec.minVersionForCollab,
 			formatVersion: codec.formatVersion,
@@ -376,12 +431,12 @@ export class VersionDispatchingCodecBuilder<
 	 */
 	public build(
 		options: TBuildOptions & CodecWriteOptions,
-	): VersionDispatchingCodec<TDecoded, TContext, TFormatVersion> {
+	): VersionDispatchingCodec<TDecoded, TEncodeContext, TFormatVersion, TDecodeContext> {
 		const [applied, decoder] = this.buildDecoderInternal(options);
 		const writeVersion = getWriteVersion(this.name, options, applied);
 		return {
 			...decoder,
-			encode: (data: TDecoded, context: TContext): JsonCompatibleReadOnly => {
+			encode: (data: TDecoded, context: TEncodeContext): JsonCompatibleReadOnly => {
 				return writeVersion.codec.encode(data, context);
 			},
 			writeVersion: writeVersion.formatVersion,
@@ -391,21 +446,27 @@ export class VersionDispatchingCodecBuilder<
 	private buildDecoderInternal(
 		options: TBuildOptions,
 	): [
-		EvaluatedCodecVersion<TDecoded, TContext, TFormatVersion>[],
+		EvaluatedCodecVersion<TDecoded, TEncodeContext, TFormatVersion, TDecodeContext>[],
 		Pick<
-			IJsonCodec<TDecoded, JsonCompatibleReadOnly, JsonCompatibleReadOnly, TContext>,
+			IJsonCodec<
+				TDecoded,
+				JsonCompatibleReadOnly,
+				JsonCompatibleReadOnly,
+				TEncodeContext,
+				TDecodeContext
+			>,
 			"decode"
 		>,
 	] {
 		const applied = this.applyOptions(options);
 		const fromFormatVersion = new Map<
 			FormatVersion,
-			EvaluatedCodecVersion<TDecoded, TContext, TFormatVersion>
+			EvaluatedCodecVersion<TDecoded, TEncodeContext, TFormatVersion, TDecodeContext>
 		>(applied.map((codec) => [codec.formatVersion, codec]));
 		return [
 			applied,
 			{
-				decode: (data: JsonCompatibleReadOnly, context: TContext): TDecoded => {
+				decode: (data: JsonCompatibleReadOnly, context: TDecodeContext): TDecoded => {
 					const versioned = data as Partial<Versioned>;
 					const codec = fromFormatVersion.get(versioned.version);
 					if (codec === undefined) {
@@ -432,7 +493,10 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 	 */
 	public buildDecoder(
 		options: TBuildOptions,
-	): Pick<VersionDispatchingCodec<TDecoded, TContext, TFormatVersion>, "decode"> {
+	): Pick<
+		VersionDispatchingCodec<TDecoded, TEncodeContext, TFormatVersion, TDecodeContext>,
+		"decode"
+	> {
 		return this.buildDecoderInternal(options)[1];
 	}
 
@@ -464,23 +528,33 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 	public static build<
 		Name extends CodecName,
-		Entry extends CodecVersion<unknown, unknown, FormatVersion, never>,
+		Entry extends CodecVersion<unknown, unknown, FormatVersion, never, unknown>,
 	>(name: Name, inputRegistry: readonly Entry[]) {
 		type TDecoded2 =
-			Entry extends CodecVersion<infer D, unknown, FormatVersion, never> ? D : never;
-		type TContext2 =
-			Entry extends CodecVersion<unknown, infer C, FormatVersion, never> ? C : never;
+			Entry extends CodecVersion<infer D, unknown, FormatVersion, never, unknown> ? D : never;
+		type TEncodeContext2 =
+			Entry extends CodecVersion<unknown, infer C, FormatVersion, never, unknown> ? C : never;
 		type TFormatVersion2 =
-			Entry extends CodecVersion<unknown, unknown, infer F, never> ? F : never;
+			Entry extends CodecVersion<unknown, unknown, infer F, never, unknown> ? F : never;
 		type TBuildOptions2 =
-			Entry extends CodecVersion<unknown, unknown, FormatVersion, infer B> ? B : never;
+			Entry extends CodecVersion<unknown, unknown, FormatVersion, infer B, unknown>
+				? B
+				: never;
+		type TDecodeContext2 =
+			Entry extends CodecVersion<unknown, unknown, FormatVersion, never, infer D> ? D : never;
+
+		type ResolvedEncodeContext = unknown extends TEncodeContext2 ? void : TEncodeContext2;
+		type ResolvedDecodeContext = unknown extends TDecodeContext2
+			? ResolvedEncodeContext
+			: TDecodeContext2;
 
 		type CodecFinal = CodecVersion<
 			TDecoded2,
 			// If it does not matter what context is provided, undefined is fine, so allow it to be omitted.
-			unknown extends TContext2 ? void : TContext2,
+			ResolvedEncodeContext,
 			TFormatVersion2,
-			TBuildOptions2
+			TBuildOptions2,
+			ResolvedDecodeContext
 		>;
 
 		const input = inputRegistry as readonly unknown[] as readonly CodecFinal[];
@@ -488,9 +562,10 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 		const builder = new VersionDispatchingCodecBuilder<
 			TBuildOptions2,
 			TDecoded2,
-			unknown extends TContext2 ? void : TContext2,
+			ResolvedEncodeContext,
 			TFormatVersion2,
-			Name
+			Name,
+			ResolvedDecodeContext
 		>(name, input);
 		return builder;
 	}

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -293,8 +293,9 @@ function normalizeCodecVersion<
  * Produced by {@link VersionDispatchingCodecBuilder.build}.
  *
  * @typeParam TDecoded - The in memory (not encoded) format.
- * @typeParam TContext - Context type passed to encode/decode operations.
+ * @typeParam TEncodeContext - Context type passed to encode operations.
  * @typeParam TFormatVersion - The type of format version identifiers used by this codec.
+ * @typeParam TDecodeContext - Context type passed to decode operations. Defaults to `TEncodeContext`.
  */
 export interface VersionDispatchingCodec<
 	TDecoded,

--- a/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
@@ -149,13 +149,13 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 			interface DecodeContext {
 				decodeOffset: number;
 			}
-			interface VC {
+			interface Encoded {
 				version: 1;
 				value: number;
 			}
 			const contextualCodec: CodecAndSchema<number, EncodeContext, DecodeContext> = {
-				encode: (x, ctx) => ({ version: 1, value: x + ctx.encodeOffset }),
-				decode: (data, ctx) => (data as unknown as VC).value + ctx.decodeOffset,
+				encode: (value, context) => ({ version: 1, value: value + context.encodeOffset }),
+				decode: (data, context) => (data as unknown as Encoded).value + context.decodeOffset,
 				schema: Versioned,
 			};
 			const contextualBuilder = VersionDispatchingCodecBuilder.build("Contextual", [

--- a/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
@@ -142,6 +142,39 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 			);
 		});
 
+		it("distinct encode and decode context types", () => {
+			interface EncodeContext {
+				encodeOffset: number;
+			}
+			interface DecodeContext {
+				decodeOffset: number;
+			}
+			interface VC {
+				version: 1;
+				value: number;
+			}
+			const contextualCodec: CodecAndSchema<number, EncodeContext, DecodeContext> = {
+				encode: (x, ctx) => ({ version: 1, value: x + ctx.encodeOffset }),
+				decode: (data, ctx) => (data as unknown as VC).value + ctx.decodeOffset,
+				schema: Versioned,
+			};
+			const contextualBuilder = VersionDispatchingCodecBuilder.build("Contextual", [
+				{
+					minVersionForCollab: lowestMinVersionForCollab,
+					formatVersion: 1,
+					codec: contextualCodec,
+				},
+			]);
+			const codec = contextualBuilder.build({
+				minVersionForCollab: "2.0.0",
+				jsonValidator: FormatValidatorBasic,
+			});
+
+			const encoded = codec.encode(5, { encodeOffset: 10 });
+			assert.deepEqual(encoded, { version: 1, value: 15 });
+			assert.equal(codec.decode(encoded, { decodeOffset: -10 }), 5);
+		});
+
 		it("good builds", () => {
 			VersionDispatchingCodecBuilder.build("Test", [
 				{


### PR DESCRIPTION
## Description

Allow codecs to have distinct encode and decode context types, to allow for better management of id-compressor sessions, and other compression and session related inputs in the future.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
