### PR TITLE
Pull gitssh base image from MCR mirror in CI to unblock 1ES build

### DIFF
--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -3,10 +3,16 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
-# That version of the base image must also be baked into the CI build agent by a repo maintainer.
-# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
+# The alpine base image is pulled from public Docker Hub by default so local builds and external
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
+# additionalBuildArguments in tools/pipelines/server-gitssh.yml) to point at Microsoft Container
+# Registry's Docker Hub mirror, because 1ES network isolation policies (CfsClean/CfsClean2) block
+# egress to registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
+# docker.io/library, so the same manifest digest pin resolves correctly against either registry.
+# MCR's mirror is frozen at alpine 3.16; mirroring a supported alpine into our internal ACR is a
+# follow-up tracked by AB#73353.
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/alpine:3.16@sha256:452e7292acee0ee16c332324d7de05fa2c99f9994ecc9f0779c602916a672ae4
 
 # Install Git and OpenSSH so we can run a git server
 RUN apk add --no-cache git

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -91,3 +91,7 @@ extends:
     setVersion: false
     enableDockerImagePull: false
     tagName: gitssh
+    # Override the default Docker Hub registry in the Dockerfile to pull the base image from MCR's
+    # Docker Hub mirror instead, since 1ES network isolation policies (CfsClean/CfsClean2) block
+    # egress to registry-1.docker.io from our build pool. See AB#73353 for the broader migration.
+    additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=mcr.microsoft.com/mirror/docker


### PR DESCRIPTION
## What

Switch `server/gitssh/Dockerfile` to pull the alpine base image from Microsoft Container Registry's Docker Hub mirror (`mcr.microsoft.com/mirror/docker/library/alpine`) in CI, while keeping the default `FROM` pointed at public Docker Hub so local builds and external contributors still get the canonical upstream image.

## Why

The `server-gitssh` pipeline has been failing on every PR since ~2026-05-14 because 1ES network isolation policies (CfsClean / CfsClean2) now block egress to `registry-1.docker.io` from our build pool. BuildKit's `[internal] load metadata for docker.io/library/alpine:3.12@...` step hits Docker Hub for the manifest and times out:

```
ERROR: failed to copy: httpReadSeeker: failed open: failed to do request:
  Get "https://registry-1.docker.io/v2/library/alpine/blobs/sha256:...":
  dial tcp 192.0.2.29:443: i/o timeout
```

Example failing build: https://dev.azure.com/fluidframework/public/_build/results?buildId=400915

Per [SFI guidance](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/flagged-endpoints), Docker base images must come from MCR or our internal ACR rather than Docker Hub.

## How

- `server/gitssh/Dockerfile`: introduces `ARG BASE_IMAGE_REGISTRY=docker.io` and rewrites `FROM` as `${BASE_IMAGE_REGISTRY}/library/alpine:3.16@sha256:452e...`. The default still resolves to Docker Hub, preserving the local-dev / external-contributor flow.
- `tools/pipelines/server-gitssh.yml`: passes `additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=mcr.microsoft.com/mirror/docker`, so CI builds resolve `FROM` against MCR.

This follows the same default-public / override-in-CI pattern as the existing `${REGISTRY_URL:-mcr.microsoft.com}` usage in [`server/docker-compose.yml`](https://github.com/microsoft/FluidFramework/blob/main/server/docker-compose.yml#L19).

The MCR mirror's manifest digest matches Docker Hub byte-for-byte (`sha256:452e7292acee0ee16c332324d7de05fa2c99f9994ecc9f0779c602916a672ae4` from both registries), so the digest pin still works as a reproducibility guarantee regardless of which registry serves the request.

Opportunistically also bumps alpine from the long-EOL 3.12 to 3.16 — the newest tag MCR's mirror carries. (`apk add git` / `apk add openssh` and all subsequent user/ssh setup steps work unchanged on 3.16.)

## Validation

- `docker build .` from `server/gitssh/` — succeeds against Docker Hub (default).
- `docker build --build-arg BASE_IMAGE_REGISTRY=mcr.microsoft.com/mirror/docker .` — succeeds against the MCR mirror.
- Traced `additionalBuildArguments` through `tools/pipelines/templates/build-docker-service.yml`: lands on the final `1ES.BuildContainerImage@1` task (line 517) via `$(DockerBuildArgs.output)`, the same code path historian/gitrest/routerlicious already use.

## Follow-ups (out of scope, tracked by [AB#73353](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73353))

- MCR's Docker Hub mirror is frozen at alpine 3.16 (also EOL). Mirror a currently-supported alpine into our internal ACR and point gitssh at it.
- Preemptively migrate `routerlicious`, `historian`, and `gitrest` off Docker Hub before they trip the same network policy (today they only work because `node:22.22.2-bookworm-slim` is baked into the agent).

[AB#73629](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73629)
