### PR TITLE
ci(pipelines): remove temporary fflate publish-job override

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -80,12 +80,7 @@ jobs:
                 echo "Creating package.json with npm overrides"
 
                 # Manual overrides - add new entries here as needed, using same syntax supported by the pnpm overrides field
-                # - fflate: 0.8.3 changed the streaming Gunzip callback semantics in a way that breaks the
-                #   flub publish tarballs command. Pin to 0.8.2 here so the previously-published flub keeps
-                #   working when installed in this lockfile-less environment. Safe to drop once the
-                #   buildTools-resource artifact has been refreshed with a flub that no longer depends on
-                #   fflate's streaming Gunzip for tarball extraction.
-                manual_overrides='{"fflate":"0.8.2"}'
+                manual_overrides='{}'
                 # Build overrides for local tarballs so interdependencies resolve correctly
                 tarball_overrides='{}'
                 for tgz in *.tgz; do


### PR DESCRIPTION
## Description

#27337 added a temporary `fflate: 0.8.2` pin to the publish-job `manual_overrides` in `tools/pipelines/templates/include-publish-npm-package-deployment.yml` to break the bootstrap cycle in which `Build - build-tools` consumed its own previous broken `flub` from `buildTools-resource` and so could never go green to refresh that artifact.

That refresh has now happened. `Build - build-tools` [run 401114](https://dev.azure.com/fluidframework/internal/_build/results?buildId=401114&view=results) on main (merge commit `f3c2fe2a`) published a new `buildTools-resource` artifact whose `flub` uses `node:zlib.gunzipSync` instead of fflate's streaming `Gunzip` for tarball extraction. The pin is therefore no longer needed — the current `flub` doesn't touch fflate for that code path at all, and the publish-tarball-using pipelines (`Build - client packages`, `server-routerlicious`, `Build - test-tools`) are green on main without depending on the override.

[AB#73634](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73634)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
