### PR TITLE
ci(pipelines): route server base images through container registry mirrors

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -2,10 +2,15 @@
 # Licensed under the MIT License.
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
-# That version of the base image must also be baked into the CI build agent by a repo maintainer.
-# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
+# The node base image is pulled from public Docker Hub by default so local builds and external
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
+# additionalBuildArguments in tools/pipelines/server-gitrest.yml) to point at our internal mirror,
+# because 1ES network isolation policies (CfsClean/CfsClean2) block egress to registry-1.docker.io
+# from our build pool. The mirror is byte-for-byte identical to docker.io/library, so the same
+# manifest digest pin resolves correctly against either registry. See tools/pipelines/README.md for
+# how to maintain the mirror (upgrades, additions).
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -5,12 +5,11 @@
 
 # The alpine base image is pulled from public Docker Hub by default so local builds and external
 # contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
-# additionalBuildArguments in tools/pipelines/server-gitssh.yml) to point at Microsoft Container
-# Registry's Docker Hub mirror, because 1ES network isolation policies (CfsClean/CfsClean2) block
-# egress to registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
-# docker.io/library, so the same manifest digest pin resolves correctly against either registry.
-# MCR's mirror is frozen at alpine 3.16; mirroring a supported alpine into our internal ACR is a
-# follow-up tracked by AB#73353.
+# additionalBuildArguments in tools/pipelines/server-gitssh.yml) to point at our internal mirror,
+# because 1ES network isolation policies (CfsClean/CfsClean2) block egress to registry-1.docker.io
+# from our build pool. The mirror is byte-for-byte identical to docker.io/library, so the same
+# manifest digest pin resolves correctly against either registry. See tools/pipelines/README.md for
+# how to maintain the mirror (upgrades, additions).
 ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/alpine:3.16@sha256:452e7292acee0ee16c332324d7de05fa2c99f9994ecc9f0779c602916a672ae4
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -3,10 +3,15 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
-# That version of the base image must also be baked into the CI build agent by a repo maintainer.
-# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
+# The node base image is pulled from public Docker Hub by default so local builds and external
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
+# additionalBuildArguments in tools/pipelines/server-historian.yml) to point at our internal mirror,
+# because 1ES network isolation policies (CfsClean/CfsClean2) block egress to registry-1.docker.io
+# from our build pool. The mirror is byte-for-byte identical to docker.io/library, so the same
+# manifest digest pin resolves correctly against either registry. See tools/pipelines/README.md for
+# how to maintain the mirror (upgrades, additions).
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -3,10 +3,15 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
-# That version of the base image must also be baked into the CI build agent by a repo maintainer.
-# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
+# The node base image is pulled from public Docker Hub by default so local builds and external
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
+# additionalBuildArguments in tools/pipelines/server-routerlicious.yml) to point at our internal
+# mirror, because 1ES network isolation policies (CfsClean/CfsClean2) block egress to
+# registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
+# docker.io/library, so the same manifest digest pin resolves correctly against either registry.
+# See tools/pipelines/README.md for how to maintain the mirror (upgrades, additions).
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/tools/pipelines/README.md
+++ b/tools/pipelines/README.md
@@ -1,0 +1,69 @@
+# Fluid Framework CI pipelines
+
+Azure Pipelines definitions and shared [`templates/`](./templates) for building, testing, and
+releasing the Fluid Framework.
+
+## Mirroring base container images for the server pipelines
+
+The `server-*` pipelines run on a 1ES build pool whose network isolation blocks egress to Docker
+Hub, so each server Dockerfile makes its base-image registry overridable and the matching pipeline
+points it at a mirrored copy on the internal container registry. Local builds default to Docker
+Hub and need no changes.
+
+```dockerfile
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf4...
+```
+
+```yaml
+extends:
+  template: /tools/pipelines/templates/build-docker-service.yml@self
+  parameters:
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      additionalBuildArguments: >-
+        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
+```
+
+`$(containerRegistryUrl)` comes from the `container-registry-info` variable group, loaded at the
+pipeline root. The build-arg override is gated on the `internal` project because the public project
+has no access to the internal mirror; it falls back to the Dockerfile default of `docker.io`. The
+mirror namespace `mirror/docker/library/<image>` is byte-identical to Docker Hub's path, so the same
+Dockerfile reference works against either registry.
+
+### Upgrading a pinned base image
+
+1. Resolve the new tag's Docker Hub manifest digest:
+   ```bash
+   docker buildx imagetools inspect docker.io/library/node:<new tag> \
+     --format '{{json .Manifest.Digest}}'
+   ```
+
+2. Import it into the mirror. The registry name is the value of `containerRegistryUrl` in the
+   variable group (drop the `.azurecr.io` suffix); the command requires permission to perform
+   `Microsoft.ContainerRegistry/registries/importImage/action` on the registry (held by the
+   `Contributor` role, but **not** by `AcrPush`):
+   ```bash
+   az acr import --name "$ACR_NAME" \
+     --source "docker.io/library/node@<new digest>" \
+     --image  "mirror/docker/library/node:<new tag>"
+   ```
+   (ACR's `--source` accepts a tag *or* a digest reference, but not the combined `tag@digest`
+   form — pass the digest as the source and let `--image` provide the tag on the destination.)
+
+3. Update the Dockerfile pin(s) in the same PR. The pipeline YAML doesn't change.
+
+After a green run, the previous mirrored tag can be removed with `az acr repository delete` — the
+registry has no retention policy, so old tags persist until manually deleted.
+
+### Adding a newly-mirrored base image
+
+Import as above, then in the new Dockerfile declare the build arg and prefix the upstream `FROM`:
+
+```dockerfile
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/<image>:<tag>@<digest>
+```
+
+In the pipeline YAML, append `--build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker`
+to `additionalBuildArguments` (gated on `System.TeamProject == 'internal'`, as in the example above),
+using YAML's `>-` block scalar to keep multiple args readable.

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -85,12 +85,9 @@ variables:
       publishOverride: ${{ parameters.publishOverride }}
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: true
-  # Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it inside the shared
-  # build-docker-service.yml template) but ran into issues because if it exists in the stage-level variables of the template
-  # instead of in the root-level variables of a pipeline, then the value for the ACR service connection name (which comes
-  # from the variable group) that gets passed to a Docker@1 task seems to not be available before ADO performs checks for
-  # that task, including that the specified service connection exists and the pipeline is authorized to use it. So ADO ends
-  # uplooking for a service connection named "$(containerRegistryConnection)" instead of the actual value after replacement.
+  # Loaded at the root level rather than inside the build-docker-service.yml template's variables so
+  # that $(containerRegistryConnection) is available before ADO performs service-connection pre-checks
+  # on the Docker tasks (the value is otherwise treated as a literal connection name).
   - group: container-registry-info
 
 extends:

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -104,7 +104,18 @@ extends:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     dockerBuildBumpsVersion: true
     packageManagerInstallCommand: 'pnpm config set recursive-install false ; pnpm i ; pnpm config set recursive-install true'
-    additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+    # The --build-context is needed because the Dockerfile copies files from the repo root.
+    # On the internal project, also override the default docker.io registry in the Dockerfile to pull the base
+    # image from our internal mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress
+    # to registry-1.docker.io from our build pool. containerRegistryUrl comes from the container-registry-info
+    # variable group. See tools/pipelines/README.md. The public project falls back to the
+    # Dockerfile default of docker.io because it has no access to the internal mirror.
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      additionalBuildArguments: >-
+        --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
+    ${{ else }}:
+      additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
     packageManager: pnpm
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/gitrest
     containerName: fluidframework/routerlicious/gitrest

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -67,12 +67,9 @@ variables:
       publishOverride: ${{ parameters.publishOverride }}
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: true
-  # Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it inside the shared
-  # build-docker-service.yml template) but ran into issues because if it exists in the stage-level variables of the template
-  # instead of in the root-level variables of a pipeline, then the value for the ACR service connection name (which comes
-  # from the variable group) that gets passed to a Docker@1 task seems to not be available before ADO performs checks for
-  # that task, including that the specified service connection exists and the pipeline is authorized to use it. So ADO ends
-  # uplooking for a service connection named "$(containerRegistryConnection)" instead of the actual value after replacement.
+  # Loaded at the root level rather than inside the build-docker-service.yml template's variables so
+  # that $(containerRegistryConnection) is available before ADO performs service-connection pre-checks
+  # on the Docker tasks (the value is otherwise treated as a literal connection name).
   - group: container-registry-info
 
 extends:

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -88,7 +88,14 @@ extends:
     setVersion: false
     enableDockerImagePull: false
     tagName: gitssh
-    # Override the default Docker Hub registry in the Dockerfile to pull the base image from MCR's
-    # Docker Hub mirror instead, since 1ES network isolation policies (CfsClean/CfsClean2) block
-    # egress to registry-1.docker.io from our build pool. See AB#73353 for the broader migration.
-    additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=mcr.microsoft.com/mirror/docker
+    # Override the default docker.io registry in the Dockerfile to pull the base image from a
+    # mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress to
+    # registry-1.docker.io from our build pool. On the internal project, use our internal ACR
+    # mirror (containerRegistryUrl comes from the container-registry-info variable group). On the
+    # public project, fall back to MCR's Docker Hub mirror — it's frozen at alpine 3.16 which
+    # happens to match our pin, and it's the only mirror reachable from public build pools.
+    # See tools/pipelines/README.md.
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
+    ${{ else }}:
+      additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=mcr.microsoft.com/mirror/docker

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -107,7 +107,18 @@ extends:
     # We need to install only the root dependencies; historian has native deps that don't install in CI since we use
     # Docker to do the actual build in CI. We need the root dependencies so setting package versions works.
     packageManagerInstallCommand: 'pnpm install --workspace-root'
-    additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+    # The --build-context is needed because the Dockerfile copies files from the repo root.
+    # On the internal project, also override the default docker.io registry in the Dockerfile to pull the base
+    # image from our internal mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress
+    # to registry-1.docker.io from our build pool. containerRegistryUrl comes from the container-registry-info
+    # variable group. See tools/pipelines/README.md. The public project falls back to the
+    # Dockerfile default of docker.io because it has no access to the internal mirror.
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      additionalBuildArguments: >-
+        --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
+    ${{ else }}:
+      additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
     packageManager: pnpm
     test: test
     tagName: historian

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -84,12 +84,9 @@ variables:
       publishOverride: ${{ parameters.publishOverride }}
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: true
-  # Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it inside the shared
-  # build-docker-service.yml template) but ran into issues because if it exists in the stage-level variables of the template
-  # instead of in the root-level variables of a pipeline, then the value for the ACR service connection name (which comes
-  # from the variable group) that gets passed to a Docker@1 task seems to not be available before ADO performs checks for
-  # that task, including that the specified service connection exists and the pipeline is authorized to use it. So ADO ends
-  # uplooking for a service connection named "$(containerRegistryConnection)" instead of the actual value after replacement.
+  # Loaded at the root level rather than inside the build-docker-service.yml template's variables so
+  # that $(containerRegistryConnection) is available before ADO performs service-connection pre-checks
+  # on the Docker tasks (the value is otherwise treated as a literal connection name).
   - group: container-registry-info
 
 extends:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -143,5 +143,16 @@ extends:
     - prettier
     - check:versions
     - generate:packageList
-    additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+    # The --build-context is needed because the Dockerfile copies files from the repo root.
+    # On the internal project, also override the default docker.io registry in the Dockerfile to pull the base
+    # image from our internal mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress
+    # to registry-1.docker.io from our build pool. containerRegistryUrl comes from the container-registry-info
+    # variable group. See tools/pipelines/README.md. The public project falls back to the
+    # Dockerfile default of docker.io because it has no access to the internal mirror.
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      additionalBuildArguments: >-
+        --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
+    ${{ else }}:
+      additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
     enableDockerImagePull: false

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -102,12 +102,9 @@ variables:
       publishOverride: ${{ parameters.publishOverride }}
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: false
-  # Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it inside the shared
-  # build-docker-service.yml template) but ran into issues because if it exists in the stage-level variables of the template
-  # instead of in the root-level variables of a pipeline, then the value for the ACR service connection name (which comes
-  # from the variable group) that gets passed to a Docker@1 task seems to not be available before ADO performs checks for
-  # that task, including that the specified service connection exists and the pipeline is authorized to use it. So ADO ends
-  # uplooking for a service connection named "$(containerRegistryConnection)" instead of the actual value after replacement.
+  # Loaded at the root level rather than inside the build-docker-service.yml template's variables so
+  # that $(containerRegistryConnection) is available before ADO performs service-connection pre-checks
+  # on the Docker tasks (the value is otherwise treated as a literal connection name).
   - group: container-registry-info
 
 extends:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -263,7 +263,7 @@ stages:
           - task: Docker@2
             displayName: 'Login to container registry'
             inputs:
-              containerRegistry: 'Fluid Container Registry'
+              containerRegistry: $(containerRegistryConnection)
               command: 'login'
           - task: DockerCompose@1
             displayName: 'Start routerlicious environment in docker'
@@ -274,7 +274,7 @@ stages:
               dockerComposeCommand: 'up -d --wait'
               projectName: 'routerlicious'
             env:
-              REGISTRY_URL: fluidcr.azurecr.io/build
+              REGISTRY_URL: $(containerRegistryUrl)/build
               ALFRED_IMAGE_TAG: ${{ parameters.alfredImageTag }}
               HISTORIAN_IMAGE_TAG: ${{ parameters.historianImageTag }}
               GITREST_IMAGE_TAG: ${{ parameters.gitrestImageTag }}

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -38,10 +38,9 @@ resources:
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self
 - group: prague-key-vault
-# Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it
-# inside templates we depend on) but ran into issues because if it exists in stage-level variables
-# instead of root-level pipeline variables, the value for the ACR service connection name passed
-# to Docker tasks isn't available before ADO performs checks for that task.
+# Loaded at the root level rather than as stageVariables inside include-test-real-service.yml so
+# that $(containerRegistryConnection) is available before ADO performs service-connection pre-checks
+# on the Docker login task (the value is otherwise treated as a literal connection name).
 - group: container-registry-info
 - name: testPackage
   value: "@fluid-private/test-end-to-end-tests"

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -38,6 +38,11 @@ resources:
 variables:
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self
 - group: prague-key-vault
+# Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it
+# inside templates we depend on) but ran into issues because if it exists in stage-level variables
+# instead of root-level pipeline variables, the value for the ACR service connection name passed
+# to Docker tasks isn't available before ADO performs checks for that task.
+- group: container-registry-info
 - name: testPackage
   value: "@fluid-private/test-end-to-end-tests"
   readonly: true
@@ -101,8 +106,6 @@ stages:
       continueOnError: true
       timeoutInMinutes: 360
       testCommand: test:realsvc:r11s:docker
-      stageVariables:
-        - group: container-registry-info
       splitTestVariants:
         - name: Non-compat
           flags: --compatVersion=0


### PR DESCRIPTION
Adds an overridable `BASE_IMAGE_REGISTRY` build arg to the four `server-*` Dockerfiles (gitssh, gitrest, historian, routerlicious), defaulting to `docker.io` so local and external-contributor builds are unchanged. Each `server-*` pipeline overrides the arg via `additionalBuildArguments` to pull from a mirror reachable from its build pool, avoiding the 1ES network-isolation block on `registry-1.docker.io`.

The override is selected per project:

- **internal**: all four pipelines target our internal ACR mirror via `$(containerRegistryUrl)/mirror/docker` (from the `container-registry-info` variable group). This is the long-term home for our pinned base images.
- **public**:
  - `gitssh` targets `mcr.microsoft.com/mirror/docker`, which carries the pinned `alpine:3.16` digest.
  - `gitrest`, `historian`, `routerlicious` use Node 22, which MCR's mirror does not carry, so they fall back to the Dockerfile default of `docker.io`. They have not been observed hitting the netiso block on public to date; mirroring Node 22 into a public-accessible registry is tracked as part of the long-term fix below.

Also adds `tools/pipelines/README.md` documenting how to upgrade or add mirrored base images going forward.

Verified locally: `pnpm run build:docker` succeeds for gitrest/historian/routerlicious and `docker build` succeeds for gitssh, with all four resolving base images from `docker.io` via the Dockerfile default — confirming the fallback path for normal contributors.

This PR is the interim fix tracked by [AB#73954](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73954). The broader long-term migration (including a public-accessible Node 22 mirror) remains tracked by [AB#73353](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73353).

[AB#73954](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73954)
