### PR TITLE
build: bump client versions to 2.101.1

### DIFF
--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-local-service",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Local implementation of the Azure Fluid Relay service for testing/development use",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-service-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Helper service-side utilities for connecting to Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/blobs",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Example of using blobs in Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/collaborative-textarea",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "A minimal example using the react collaborative-textarea",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/contact-collection",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Example of using a Fluid Object as a collection of items",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/data-object-grid",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Data object grid creates child data objects from a registry and lays them out in a grid.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/diceroller/package.json
+++ b/examples/apps/diceroller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/diceroller",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Object sample to implement a collaborative dice roller.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/presence-tracker",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Example application that tracks page focus and mouse position using the Fluid Framework presence features.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/staging",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Using the experimental staging feature.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/task-selection",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Example demonstrating selecting a unique task amongst connected Fluid clients",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-cli-app/package.json
+++ b/examples/apps/tree-cli-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-cli-app",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "SharedTree CLI app demo",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-comparison",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Comparing API usage in legacy SharedTree and new SharedTree.",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-baseline",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-common",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/experimental-tree/package.json
+++ b/examples/benchmarks/bubblebench/experimental-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-experimental-tree",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-ot",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/shared-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-shared-tree",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/tablebench",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Table focused benchmarks",
 	"homepage": "https://fluidframework.com",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-insights-logger",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Provides a simple Fluid application with a UI view written in React to test the Fluid App Insights telemetry logger that will route typical Fluid telemetry to configured Azure App Insights",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/canvas",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Fluid ink canvas",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/clicker",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal Fluid component sample to implement a collaborative counter.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/codemirror",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/inventory-app",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal sample of SharedTree/React integration.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/monaco",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Monaco code editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-model",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Constellation model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-view",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-container",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Container for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-model",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Coordinate model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-interface",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Interface for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-plot-coordinate-view",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-slider-coordinate-view",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-triangle-view",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/prosemirror",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "ProseMirror",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/smde",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-document",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Chaincode component containing a table's data",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/examples/data-objects/table-tree/package.json
+++ b/examples/data-objects/table-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-tree",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Simple table example app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/text-editor/package.json
+++ b/examples/data-objects/text-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/text-editor",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal sample of SharedTree/React text editor integration.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/todo",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Simple todo canvas.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webflow",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Collaborative markdown editor.",
 	"homepage": "https://fluidframework.com",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-data",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Integrating an external data source with Fluid data.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-controller",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/todo-list/package.json
+++ b/examples/service-clients/azure-client/todo-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/azure-client-todo-list",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal Fluid Container sample demonstrating the use of SharedTree and nested DDSs via a simple to-do list application.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/shared-tree-demo",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "A shared tree demo using react and odsp client",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bundle-size-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "A package for understanding the bundle size of Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-driver/package.json
+++ b/examples/utils/example-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Simplified drivers used by examples in the FluidFramework repo.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Shared utilities used by examples.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-webpack-integration/package.json
+++ b/examples/utils/example-webpack-integration/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-webpack-integration",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Webpack configuration used by examples in the FluidFramework repo.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/import-testing",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "import-testing",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/migration-tools",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Tools for migrating data",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/typescript-versions-host/package.json
+++ b/examples/utils/typescript-versions-host/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/typescript-versions-host",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Provides aliased TypeScript versions for build tests",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webpack-fluid-loader",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Fluid object loader for webpack-dev-server",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-live-schema-upgrade",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Example application that demonstrates how to add a data object to a live container.",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-same-container",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in the same container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-separate-container",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in a new container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-shim",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Migrating from legacy SharedTree to new SharedTree using a tree shim.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-container-views",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal Fluid Container & data store sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-views",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Minimal Fluid Container & data store sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/view-framework-sampler",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Example of integrating a Fluid data object with a variety of view frameworks.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-changeset",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "property changeset definitions and related functionalities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-common",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "common functions used in properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/platform-dependent",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Helper package that separates code for browser and server.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-dds",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "definition of the property distributed data store",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-properties",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "definitions of properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ot",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/src/packageVersion.ts
+++ b/experimental/dds/ot/ot/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ot";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sharejs-json1",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
+++ b/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sharejs-json1";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sequence-deprecated",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Deprecated distributed sequences",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/sequence-deprecated/src/packageVersion.ts
+++ b/experimental/dds/sequence-deprecated/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sequence-deprecated";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/tree",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-objects",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A collection of ready to use Fluid Data Objects",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/last-edited",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Tracks the last edited information in the Container.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "client-release-group-root",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/client-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Not intended for use outside the Fluid Framework.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid container definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-interfaces",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid object interfaces",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Not intended for use outside the Fluid client repo.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid driver definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/cell",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed data structure for a single value",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/src/packageVersion.ts
+++ b/packages/dds/cell/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/cell";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/counter",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Counter DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/counter/src/packageVersion.ts
+++ b/packages/dds/counter/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/counter";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ink",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Ink DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ink/src/packageVersion.ts
+++ b/packages/dds/ink/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ink";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/legacy-dds/package.json
+++ b/packages/dds/legacy-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/legacy-dds",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Legacy DDSs for the Fluid Framework. These are not intended for use in new code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/legacy-dds/src/packageVersion.ts
+++ b/packages/dds/legacy-dds/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/legacy-dds";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/map",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed map",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/map/src/packageVersion.ts
+++ b/packages/dds/map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/map";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/matrix",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed matrix",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/matrix/src/packageVersion.ts
+++ b/packages/dds/matrix/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/matrix";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/merge-tree",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Merge tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ordered-collection",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Consensus Collection",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/src/packageVersion.ts
+++ b/packages/dds/ordered-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/ordered-collection";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/pact-map",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed data structure for key-value pairs using pact consensus",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/pact-map/src/packageVersion.ts
+++ b/packages/dds/pact-map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/pact-map";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/register-collection",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Consensus Register",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/register-collection/src/packageVersion.ts
+++ b/packages/dds/register-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/register-collection";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/sequence",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed sequence",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/sequence/src/packageVersion.ts
+++ b/packages/dds/sequence/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/sequence";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-object-base",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid base class for shared distributed data structures",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-object-base/src/packageVersion.ts
+++ b/packages/dds/shared-object-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-object-base";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-summary-block",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A DDS that does not generate ops but is part of summary",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-summary-block/src/packageVersion.ts
+++ b/packages/dds/shared-summary-block/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-summary-block";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/task-manager",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed data structure for queueing exclusive tasks",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/task-manager/src/packageVersion.ts
+++ b/packages/dds/task-manager/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/task-manager";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-dds-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid DDS test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/src/packageVersion.ts
+++ b/packages/dds/tree/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tree";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/debugger",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid Debugger - a tool to play through history of a file",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-base",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Shared driver code for Fluid driver implementations",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/src/packageVersion.ts
+++ b/packages/drivers/driver-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-base";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-web-cache",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Implementation of the driver caching API for a web browser",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-web-cache/src/packageVersion.ts
+++ b/packages/drivers/driver-web-cache/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-web-cache";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/file-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A driver that reads/write from/to local file storage.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/local-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid local driver",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/src/packageVersion.ts
+++ b/packages/drivers/local-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/local-driver";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/src/packageVersion.ts
+++ b/packages/drivers/odsp-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-driver";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-urlresolver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Url Resolver for odsp urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/replay-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Document replay version of Socket.IO implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Socket.IO + Git implementation of Fluid service API",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-driver/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-driver";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-urlresolver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Url Resolver for routerlicious urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-driver",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Driver for tinylicious",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/agent-scheduler",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Built in runtime object for distributing agents across instances of a container",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/aqueduct",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A set of implementations for Fluid Framework interfaces.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/attributor",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Operation attributor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/app-insights-logger",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Contains a Fluid logging client that sends telemetry events to Azure App Insights",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-telemetry",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Customer facing Fluid telemetry types and classes for both producing and consuming said telemetry",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-object-base",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Data object base for synchronously and lazily loaded object scenarios",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/dds-interceptions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Distributed Data Structures that support an interception callback",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluid-framework",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "The main entry point into Fluid Framework public packages",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-static",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A tool to enable consumption of Fluid Data Objects without requiring custom container code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/oldest-client-observer",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Data object to determine if the local client is the oldest amongst connected clients",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence-definitions/package.json
+++ b/packages/framework/presence-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/presence-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Core type definitions and interfaces for Fluid Framework presence",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence-runtime/package.json
+++ b/packages/framework/presence-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/presence-runtime",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Core runtime implementation for Fluid Framework presence",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence-runtime/src/packageVersion.ts
+++ b/packages/framework/presence-runtime/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/presence-runtime";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/presence",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A component for lightweight data sharing within a single session",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/quill-react/package.json
+++ b/packages/framework/quill-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/quill-react",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Utilities for integrating content powered by the Fluid Framework into React applications that utilize the Quill rich text editor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/react",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Utilities for integrating content powered by the Fluid Framework into React applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/request-handler",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A simple request handling library for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/synthesize",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A library for synthesizing scope objects.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent-langchain/package.json
+++ b/packages/framework/tree-agent-langchain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent-langchain",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "LangChain integration helpers for @fluidframework/tree-agent",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent-ses/package.json
+++ b/packages/framework/tree-agent-ses/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent-ses",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "SES integration helpers for @fluidframework/tree-agent",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/tree-agent/package.json
+++ b/packages/framework/tree-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree-agent",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Experimental package to simplify integrating AI into Fluid-based applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/type-factory/package.json
+++ b/packages/framework/type-factory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/type-factory",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Shared types for exposing schema methods and properties to an LLM agent",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/undo-redo",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Undo Redo",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-loader",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid container loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/container-loader/src/packageVersion.ts
+++ b/packages/loader/container-loader/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-loader";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Collection of utility functions for Fluid drivers",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/driver-utils/src/packageVersion.ts
+++ b/packages/loader/driver-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-utils";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-loader-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Mocks and other test utilities for the Fluid Framework Loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid container runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/src/packageVersion.ts
+++ b/packages/runtime/container-runtime/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-runtime";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid data store definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid data store implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore/src/packageVersion.ts
+++ b/packages/runtime/datastore/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/datastore";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/id-compressor",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "ID compressor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/id-compressor/src/packageVersion.ts
+++ b/packages/runtime/id-compressor/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/id-compressor";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Collection of utility functions for Fluid Runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-utils/src/packageVersion.ts
+++ b/packages/runtime/runtime-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/runtime-utils";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-runtime-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid runtime test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-client",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-end-to-end-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Azure client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/odsp-end-to-end-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Odsp client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-client",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the ODSP service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-client",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Tinylicious service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/functional-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Functional tests",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-stress-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Stress tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/mocha-test-setup",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/mocha-test-setup/src/packageVersion.ts
+++ b/packages/test/mocha-test-setup/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/mocha-test-setup";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-snapshots",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Comprehensive test of snapshot logic.",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/snapshots/src/packageVersion.ts
+++ b/packages/test/snapshots/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-snapshots";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/stochastic-test-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Utilities for stochastic tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-driver-definitions",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-drivers",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/src/packageVersion.ts
+++ b/packages/test/test-drivers/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-drivers";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-end-to-end-tests",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-end-to-end-tests";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-pairwise-generator",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-service-load",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Service load tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/src/packageVersion.ts
+++ b/packages/test/test-service-load/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-service-load";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-utils/src/packageVersion.ts
+++ b/packages/test/test-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-utils";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-version-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-version-utils/src/packageVersion.ts
+++ b/packages/test/test-version-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-version-utils";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/test/types_jest-environment-puppeteer/package.json
+++ b/packages/test/types_jest-environment-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types/jest-environment-puppeteer",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "TypeScript `globals` definitions fix-up for jest-environment-puppeteer",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/changelog-generator-wrapper/package.json
+++ b/packages/tools/changelog-generator-wrapper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/changelog-generator-wrapper",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-browser-extension",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "A browser extension for visualizing Fluid Framework stats and operations",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools-core",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid Framework developer tools core functionality",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-core/src/packageVersion.ts
+++ b/packages/tools/devtools/devtools-core/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/devtools-core";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/tools/devtools/devtools-test-app/package.json
+++ b/packages/tools/devtools/devtools-test-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/devtools-test-app",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "An example application demonstrating how Fluid's devtools can be integrated into an application",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-view",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Contains a visualization suite for use alongside the Fluid Devtools",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Fluid Framework developer tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/fetch-tool",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Console tool to fetch Fluid data from relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-runner",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Utility for running various functionality inside a Fluid Framework environment",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/replay-tool",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "A tool that lets the user to replay ops.",
 	"homepage": "https://fluidframework.com",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-doclib-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "ODSP utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/odsp-doclib-utils/src/packageVersion.ts
+++ b/packages/utils/odsp-doclib-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-doclib-utils";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/telemetry-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Collection of telemetry relates utilities for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tool-utils",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"description": "Common utilities for Fluid tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/src/packageVersion.ts
+++ b/packages/utils/tool-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tool-utils";
-export const pkgVersion = "2.101.0";
+export const pkgVersion = "2.101.1";

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/markdown-magic",
-	"version": "2.101.0",
+	"version": "2.101.1",
 	"private": true,
 	"description": "Contains shared utilities for Markdown content generation and embedding using markdown-magic.",
 	"homepage": "https://fluidframework.com",


### PR DESCRIPTION
## Description

Patch bump on release/client/2.101 after the 2.101.0 release. Generated by `pnpm -r --include-workspace-root exec npm pkg set version=2.101.1`, followed by `pnpm install --no-frozen-lockfile` and `pnpm -r run build:genver`. Bumps all 207 client release-group package.json and packageVersion.ts files from 2.101.0 to 2.101.1.