### PR TITLE
[lts port] ci: Stop running server pipelines for the lts branch (#27312)

### DIFF
--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -40,8 +40,7 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
+    - release/*
   paths:
     include:
     - server/gitrest
@@ -62,8 +61,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -30,8 +30,7 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
+    - release/*
   paths:
     include:
     - server/gitssh
@@ -46,8 +45,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -40,8 +40,7 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
+    - release/*
   paths:
     include:
     - server/historian
@@ -62,8 +61,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -39,8 +39,6 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:
@@ -64,8 +62,6 @@ pr:
   branches:
     include:
     - main
-    - next
-    - lts
     - release/*
   paths:
     include:


### PR DESCRIPTION
## Description

Back-ports #27312 to the LTS branch to prevent the server pipelines from running for commits in that branch or PRs that target it. This is fine since we don't intend to ever make a server release from that branch.

Opportunistically remove the long-gone `next` branch from the triggers too.