### PR TITLE
[release/client/2.100] fix(tree): Add option to heal unresolvable identifier IDs at doc load time

### DIFF
--- a/.changeset/petite-pillows-wave.md
+++ b/.changeset/petite-pillows-wave.md
@@ -1,0 +1,17 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": fix
+---
+Add SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode to recover documents with corrupted identifiers
+
+A SharedTree bug can result in corrupted documents due to their attach summary compressing identifier-field values in a way that cannot be uncompressed.
+This bug manifested as remote clients processing the op throwing an error with the message "Unknown op space ID.".
+
+This change adds an option (`healUnresolvableIdentifiersOnDecode`) to `configuredSharedTreeBetaLegacy` which will allow documents affected by this bug to load again when enabled.
+Enabling this option carries some risk, see documentation on the interface itself for more details.
+
+#### Who is affected
+
+Only SharedTrees attached to a container that was already attached can be impacted.
+Furthermore, this bug only occurs when the attached tree contains [`identifier`](https://fluidframework.com/docs/api/tree/schemafactory-class#identifier-property) fields which contain implicitly generated default values.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1247,7 +1247,9 @@ export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecW
 }
 
 // @beta @input
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+    readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 // @alpha @sealed
 export interface SimpleAllowedTypeAttributes<out Type extends SchemaType = SchemaType> {

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -597,7 +597,9 @@ export class SchemaUpgrade {
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
 // @beta @input
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+    readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 // @public @sealed @system
 export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCustomMetadata = unknown> {

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -609,7 +609,9 @@ export const SharedTreeAttributes: IChannelAttributes;
 export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
 
 // @beta @input
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+    readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 // @public @sealed @system
 export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCustomMetadata = unknown> {

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -7,6 +7,8 @@ import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 
 import type { ICodecFamily, IJsonCodec } from "../../codec/index.js";
 import type { SchemaAndPolicy } from "../../core/index.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Referenced by doc comments
+import type { FieldBatchEncodingContext } from "../../feature-libraries/index.js";
 import type { JsonCompatibleReadOnly } from "../../util/index.js";
 import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.js";
 
@@ -25,6 +27,29 @@ export interface ChangeEncodingContext {
 	readonly revision: RevisionTag | undefined;
 	readonly idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	/**
+	 * `true` when this context is encoding to or decoding from a summary blob.
+	 * `false` when this context is for an op (or any other non-summary path,
+	 * including utility encoders that aren't tied to persistence).
+	 *
+	 * @remarks
+	 * Used to gate decode-time recovery behavior — for example, healing of
+	 * unresolvable identifier IDs — that should only run when loading a
+	 * (possibly broken) attach-summary blob, never when applying ops.
+	 */
+	readonly isSummary: boolean;
+	/**
+	 * If `true`, identifier values that the local id-compressor cannot resolve
+	 * during decode are healed into deterministic stable UUIDs instead of
+	 * throwing. See {@link FieldBatchEncodingContext.healUnresolvableIdentifiersOnDecode}.
+	 * Only takes effect when `isSummary` is also `true`.
+	 */
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+	/**
+	 * The SharedTree's shared-object id, used as input to the deterministic
+	 * UUID derivation when {@link healUnresolvableIdentifiersOnDecode} triggers.
+	 */
+	readonly sharedObjectId?: string;
 }
 
 export type ChangeFamilyCodec<TChange> = IJsonCodec<

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV1.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV1.ts
@@ -61,6 +61,8 @@ class MajorCodec implements IJsonCodec<Major, EncodedRevisionTag> {
 			originatorId: this.revisionTagCodec.localSessionId,
 			idCompressor: this.idCompressor,
 			revision: undefined,
+			// DetachedFieldIndex codecs are only used by the summarizer.
+			isSummary: true,
 		});
 	}
 }

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV2.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV2.ts
@@ -49,6 +49,8 @@ class MajorCodec implements IJsonCodec<Major> {
 			originatorId: this.revisionTagCodec.localSessionId,
 			idCompressor: this.idCompressor,
 			revision: undefined,
+			// DetachedFieldIndex codecs are only used by the summarizer.
+			isSummary: true,
 		});
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -9,6 +9,7 @@ import type {
 	OpSpaceCompressedId,
 	SessionId,
 } from "@fluidframework/id-compressor";
+import { v5 as uuidV5 } from "uuid";
 
 import { DiscriminatedUnionDispatcher } from "../../../codec/index.js";
 import type {
@@ -37,7 +38,8 @@ import {
 	decode as genericDecode,
 	readStreamIdentifier,
 } from "./chunkDecodingGeneric.js";
-import type { IncrementalDecoder } from "./codecs.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Referenced by doc comments
+import type { FieldBatchEncodingContext, IncrementalDecoder } from "./codecs.js";
 import {
 	type EncodedAnyShape,
 	type EncodedChunkShapeV1OrV2,
@@ -59,13 +61,32 @@ export interface IdDecodingContext {
 	 * The creator of any local Ids to be decoded.
 	 */
 	originatorId: SessionId;
+	/**
+	 * {@inheritdoc FieldBatchEncodingContext.isSummary}
+	 */
+	isSummary: boolean;
+	/**
+	 * See {@link FieldBatchEncodingContext.healUnresolvableIdentifiersOnDecode}.
+	 */
+	healUnresolvableIdentifiersOnDecode?: boolean;
+	/**
+	 * See {@link FieldBatchEncodingContext.sharedObjectId}.
+	 */
+	sharedObjectId?: string;
 }
+
+/**
+ * Random v4 UUID generated as a namespace for the "heal an unresolvable identifier into a stable UUID"
+ * path in {@link readValue}. This scheme requires consensus across all clients to function.
+ */
+const healingNamespace = "f8a89df3-6882-400f-b913-4c1f6f0157bd";
+
 /**
  * Decode `chunk` into a TreeChunk.
  */
 export function decode(
 	chunk: EncodedFieldBatchV1OrV2,
-	idDecodingContext: { idCompressor: IIdCompressor; originatorId: SessionId },
+	idDecodingContext: IdDecodingContext,
 	incrementalDecoder?: IncrementalDecoder,
 ): TreeChunk[] {
 	return genericDecode(
@@ -126,15 +147,43 @@ export function readValue(
 				typeof streamValue === "number" || typeof streamValue === "string",
 				0x997 /* identifier must be string or number. */,
 			);
+			if (typeof streamValue === "string") {
+				return streamValue;
+			}
 			const idCompressor = idDecodingContext.idCompressor;
-			return typeof streamValue === "number"
-				? idCompressor.decompress(
-						idCompressor.normalizeToSessionSpace(
-							streamValue as OpSpaceCompressedId,
-							idDecodingContext.originatorId,
-						),
-					)
-				: streamValue;
+			// OpSpaceCompressedIds are negative, and require a session-id to compute their value.
+			// Due to a bug, we have some special casing for them (see below).
+			// TODO: isFinalId should probably be exported from id-compressor and that could be used to do the narrowing here.
+			if (idDecodingContext.isSummary === true && streamValue < 0) {
+				if (
+					idDecodingContext.healUnresolvableIdentifiersOnDecode === true &&
+					idDecodingContext.sharedObjectId !== undefined
+				) {
+					// Documents written before the encode-side fix for non-finalized identifier
+					// values can persist negative op-space IDs that are no
+					// longer resolvable once the originating session's local state has been stripped.
+					// When loading such a summary with the heal-on-decode option on, synthesize a deterministic
+					// stable UUID so all readers of the same blob agree on the resulting value.
+					//
+					// The heal path is intentionally restricted to summary loads — an
+					// unresolvable ID encountered while applying an op should still surface as
+					// an error, since it indicates a real bug rather than a recoverable state.
+					return uuidV5(
+						`${idDecodingContext.sharedObjectId}|${streamValue}`,
+						healingNamespace,
+					);
+				}
+				// See `SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode` for details on this error.
+				throw new Error(
+					"Summary could not be loaded due incorrectly encoded identifier. See SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode for mitigation.",
+				);
+			}
+			return idCompressor.decompress(
+				idCompressor.normalizeToSessionSpace(
+					streamValue as OpSpaceCompressedId,
+					idDecodingContext.originatorId,
+				),
+			);
 		} else {
 			// EncodedCounter case:
 			unreachableCase(shape, "decoding values as deltas is not yet supported");

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -106,6 +106,33 @@ export interface FieldBatchEncodingContext {
 	 * This will be defined if incremental encoding is supported and enabled.
 	 */
 	readonly incrementalEncoderDecoder?: IncrementalEncoderDecoder;
+	/**
+	 * `true` when encoding to or decoding from a summary blob. `false` for
+	 * op-stream encode/decode paths and for utility encoders that are not
+	 * tied to a persisted document. Healing behavior is gated on this flag.
+	 */
+	readonly isSummary: boolean;
+	/**
+	 * If `true`, when an op-space compressed ID encountered while decoding
+	 * cannot be resolved by the local id-compressor (e.g. the attach-summary
+	 * blob's originator session state was stripped), a deterministic stable
+	 * UUID derived from `sharedObjectId` is returned instead of throwing.
+	 * @remarks
+	 * Off by default. Used only to recover documents whose attach summary was
+	 * written with non-finalized op-space IDs before the encode-side fix
+	 * shipped. Only takes effect when `isSummary` is also `true`.
+	 * See {@link SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode}.
+	 */
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+	/**
+	 * The SharedTree's shared-object id, used as input to the deterministic
+	 * UUID derivation when `healUnresolvableIdentifiersOnDecode` triggers. Required
+	 * for that path; ignored otherwise.
+	 * @remarks
+	 * This allows us to ensure that multiple attaches,
+	 * in the same or different documents, with the same session offsets, get different UUIDs.
+	 */
+	readonly sharedObjectId?: string;
 }
 /**
  * @remarks
@@ -190,6 +217,9 @@ function makeFieldBatchCodecForVersion(
 				{
 					idCompressor: context.idCompressor,
 					originatorId: context.originatorId,
+					isSummary: context.isSummary,
+					healUnresolvableIdentifiersOnDecode: context.healUnresolvableIdentifiersOnDecode,
+					sharedObjectId: context.sharedObjectId,
 				},
 				context.incrementalEncoderDecoder,
 			).map((chunk) => chunk.cursor());

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
@@ -330,6 +330,7 @@ export function encodeDetachedNodes(
 					schema: context.schema,
 					originatorId: context.originatorId,
 					idCompressor: context.idCompressor,
+					isSummary: context.isSummary,
 				}),
 			};
 }
@@ -353,6 +354,9 @@ export function decodeDetachedNodes(
 		encodeType: chunkCompressionStrategy,
 		originatorId: context.originatorId,
 		idCompressor: context.idCompressor,
+		isSummary: context.isSummary,
+		healUnresolvableIdentifiersOnDecode: context.healUnresolvableIdentifiersOnDecode,
+		sharedObjectId: context.sharedObjectId,
 	});
 	const getChunk = (index: number): TreeChunk => {
 		assert(index < chunks.length, 0x898 /* out of bounds index for build chunk */);

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -36,6 +36,9 @@ import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	readonly isSummary: boolean;
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+	readonly sharedObjectId?: string;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -28,6 +28,20 @@ import type {
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	/**
+	 * See {@link ChangeEncodingContext.isSummary}. EditManager codec callers
+	 * always set this to `true` (the codec is only invoked for summaries),
+	 * but it is carried explicitly so downstream codecs can read it.
+	 */
+	readonly isSummary: boolean;
+	/**
+	 * See {@link ChangeEncodingContext.healUnresolvableIdentifiersOnDecode}.
+	 */
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+	/**
+	 * See {@link ChangeEncodingContext.sharedObjectId}.
+	 */
+	readonly sharedObjectId?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -53,6 +67,7 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 			originatorId: commit.sessionId,
 			idCompressor: context.idCompressor,
 			revision: undefined,
+			isSummary: context.isSummary,
 		}),
 		change: changeCodec.encode(commit.change, { ...context, revision: commit.revision }),
 	};
@@ -79,6 +94,7 @@ function decodeCommit<TChangeset, T extends EncodedCommit<JsonCompatibleReadOnly
 		originatorId: commit.sessionId,
 		idCompressor: context.idCompressor,
 		revision: undefined,
+		isSummary: context.isSummary,
 	});
 
 	return {
@@ -112,6 +128,7 @@ export function encodeSharedBranch<TChangeset>(
 				idCompressor: context.idCompressor,
 				schema: context.schema,
 				revision: undefined,
+				isSummary: context.isSummary,
 			}),
 		),
 		peers: Array.from(data.peerLocalBranches.entries(), ([sessionId, branch]) => [
@@ -121,6 +138,7 @@ export function encodeSharedBranch<TChangeset>(
 					originatorId: sessionId,
 					idCompressor: context.idCompressor,
 					revision: undefined,
+					isSummary: context.isSummary,
 				}),
 				commits: branch.commits.map((commit) =>
 					encodeCommit(changeCodec, revisionTagCodec, commit, {
@@ -128,6 +146,7 @@ export function encodeSharedBranch<TChangeset>(
 						idCompressor: context.idCompressor,
 						schema: context.schema,
 						revision: undefined,
+						isSummary: context.isSummary,
 					}),
 				),
 			},
@@ -154,6 +173,7 @@ export function encodeSharedBranch<TChangeset>(
 			originatorId,
 			idCompressor: context.idCompressor,
 			revision: undefined,
+			isSummary: context.isSummary,
 		});
 	}
 	return json;
@@ -186,6 +206,9 @@ export function decodeSharedBranch<TChangeset>(
 					originatorId: commit.sessionId,
 					idCompressor: context.idCompressor,
 					revision: undefined,
+					isSummary: context.isSummary,
+					healUnresolvableIdentifiersOnDecode: context.healUnresolvableIdentifiersOnDecode,
+					sharedObjectId: context.sharedObjectId,
 				}),
 		),
 		peerLocalBranches: new Map(
@@ -196,6 +219,7 @@ export function decodeSharedBranch<TChangeset>(
 						originatorId: sessionId,
 						idCompressor: context.idCompressor,
 						revision: undefined,
+						isSummary: context.isSummary,
 					}),
 					commits: branch.commits.map((commit) =>
 						// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
@@ -207,6 +231,10 @@ export function decodeSharedBranch<TChangeset>(
 								originatorId: commit.sessionId,
 								idCompressor: context.idCompressor,
 								revision: undefined,
+								isSummary: context.isSummary,
+								healUnresolvableIdentifiersOnDecode:
+									context.healUnresolvableIdentifiersOnDecode,
+								sharedObjectId: context.sharedObjectId,
 							},
 						),
 					),
@@ -239,6 +267,7 @@ export function decodeSharedBranch<TChangeset>(
 			originatorId,
 			idCompressor: context.idCompressor,
 			revision: undefined,
+			isSummary: context.isSummary,
 		});
 	}
 	return data;

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -25,6 +25,9 @@ import { EncodedEditManager } from "./editManagerFormatV1toV4.js";
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	readonly isSummary: boolean;
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+	readonly sharedObjectId?: string;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -29,6 +29,9 @@ import { EncodedEditManager } from "./editManagerFormatVSharedBranches.js";
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
 	readonly schema?: SchemaAndPolicy;
+	readonly isSummary: boolean;
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+	readonly sharedObjectId?: string;
 }
 
 export function makeSharedBranchesCodecWithVersion<TChangeset>(

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -85,6 +85,10 @@ export class EditManagerSummarizer<TChangeset>
 		private readonly idCompressor: IIdCompressor,
 		minVersionForCollab: MinimumVersionForCollab,
 		private readonly schemaAndPolicy?: SchemaAndPolicy,
+		/** See {@link EditManagerEncodingContext.healUnresolvableIdentifiersOnDecode}. */
+		private readonly healUnresolvableIdentifiersOnDecode?: boolean,
+		/** See {@link EditManagerEncodingContext.sharedObjectId}. */
+		private readonly sharedObjectId?: string,
 	) {
 		super(
 			EditManagerSummarizer.key,
@@ -103,10 +107,13 @@ export class EditManagerSummarizer<TChangeset>
 		builder: SummaryTreeBuilder;
 	}): void {
 		const { stringify, builder } = props;
-		const context: EditManagerEncodingContext =
-			this.schemaAndPolicy === undefined
-				? { idCompressor: this.idCompressor }
-				: { schema: this.schemaAndPolicy, idCompressor: this.idCompressor };
+		const context: EditManagerEncodingContext = {
+			idCompressor: this.idCompressor,
+			schema: this.schemaAndPolicy,
+			isSummary: true,
+			healUnresolvableIdentifiersOnDecode: this.healUnresolvableIdentifiersOnDecode,
+			sharedObjectId: this.sharedObjectId,
+		};
 		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData(), context);
 		const dataString = stringify(jsonCompatible);
 		builder.addBlob(stringKey, dataString);
@@ -127,7 +134,12 @@ export class EditManagerSummarizer<TChangeset>
 		);
 
 		const summary = parse(bufferToString(schemaBuffer, "utf8")) as JsonCompatibleReadOnly;
-		const data = this.codec.decode(summary, { idCompressor: this.idCompressor });
+		const data = this.codec.decode(summary, {
+			idCompressor: this.idCompressor,
+			isSummary: true,
+			healUnresolvableIdentifiersOnDecode: this.healUnresolvableIdentifiersOnDecode,
+			sharedObjectId: this.sharedObjectId,
+		});
 		this.editManager.loadSummaryData(data);
 	}
 }

--- a/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
@@ -55,6 +55,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 					originatorId,
 					idCompressor: context.idCompressor,
 					revision: undefined,
+					isSummary: false,
 				}),
 				originatorId,
 				changeset: changeCodec.encode(commit.change, {
@@ -62,6 +63,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 					schema: context.schema,
 					idCompressor: context.idCompressor,
 					revision: commit.revision,
+					isSummary: false,
 				}),
 				version,
 			};
@@ -76,6 +78,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 				originatorId,
 				revision: undefined,
 				idCompressor: context.idCompressor,
+				isSummary: false,
 			});
 
 			return {
@@ -87,6 +90,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 						originatorId,
 						revision,
 						idCompressor: context.idCompressor,
+						isSummary: false,
 					}),
 				},
 				sessionId: originatorId,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -47,6 +47,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 						schema: context.schema,
 						idCompressor: context.idCompressor,
 						revision: message.commit.revision,
+						isSummary: false,
 					};
 
 					return {
@@ -54,6 +55,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 							originatorId: message.sessionId,
 							idCompressor: context.idCompressor,
 							revision: undefined,
+							isSummary: false,
 						}),
 						originatorId: message.sessionId,
 						changeset: changeCodec.encode(message.commit.change, changeContext),
@@ -84,10 +86,11 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				branchId: encodedBranchId,
 			} = encoded;
 
-			const changeContext = {
+			const changeContext: ChangeEncodingContext = {
 				originatorId,
 				revision: undefined,
 				idCompressor: context.idCompressor,
+				isSummary: false,
 			};
 
 			const branchId = decodeBranchId(context.idCompressor, encodedBranchId, changeContext);
@@ -107,6 +110,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 						originatorId,
 						revision,
 						idCompressor: context.idCompressor,
+						isSummary: false,
 					}),
 				},
 				branchId,

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -73,7 +73,12 @@ export interface ClonableSchemaAndPolicy extends SchemaAndPolicy {
 	schema: TreeStoredSchemaRepository;
 }
 
-export interface SharedTreeCoreOptionsInternal extends CodecWriteOptions {}
+export interface SharedTreeCoreOptionsInternal extends CodecWriteOptions {
+	/**
+	 * See {@link SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode}.
+	 */
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 export interface EnrichmentConfig<TChange> {
 	readonly enricher: ChangeEnricher<TChange>;
@@ -192,6 +197,8 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				this.idCompressor,
 				options.minVersionForCollab,
 				this.schemaAndPolicy,
+				options.healUnresolvableIdentifiersOnDecode,
+				sharedObject.id,
 			),
 			...summarizables,
 		];

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -238,6 +238,8 @@ export function createIndependentTreeAlpha<const TSchema extends ImplicitFieldSc
 			idCompressor,
 			originatorId: idCompressor.localSessionId, // Is this right? If so, why is is needed?
 			schema: { schema: newSchema, policy: defaultSchemaPolicy },
+			// Not a summary blob — this is a synthetic decode of inline content.
+			isSummary: false,
 		};
 		const fieldCursors = fieldBatchCodec.decode(
 			options.content.tree as JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -246,6 +246,11 @@ export class SharedTreeKernel
 			encodeType: options.treeEncodeType,
 			originatorId: idCompressor.localSessionId,
 			idCompressor,
+			// ForestSummarizer is the only consumer of this context, and it
+			// only invokes the codec in summary encode / load paths.
+			isSummary: true,
+			healUnresolvableIdentifiersOnDecode: options.healUnresolvableIdentifiersOnDecode,
+			sharedObjectId: sharedObject.id,
 		};
 		const forestSummarizer = new ForestSummarizer(
 			forest,
@@ -570,7 +575,41 @@ export function getCodecTreeForSharedTreeFormat(
  * Configuration options for SharedTree.
  * @beta @input
  */
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+	/**
+	 * When `true`, when an improperly encoded identifier is encountered in a summary,
+	 * a new identifier will be generated instead of throwing an error.
+	 *
+	 * @defaultValue `false`
+	 *
+	 * @remarks
+	 * The intended use is recovering documents whose attach summary was persisted
+	 * with unresolvable node identifiers (a SharedTree-attaches-to-already-attached-container
+	 * scenario). Without this flag enabled, a client opening such a document will throw at summary load time.
+	 * With this flag enabled, unresolvable identifiers are replaced at decode time with stable UUIDs
+	 * derived deterministically from the data store id and the unresolvable op-space integer,
+	 * so every reader of the same blob (other than the originator) agrees on the resulting in-memory id.
+	 * Healed identifiers are written back out at the next summary in their stable UUID form,
+	 * so the inconsistency does not need to be re-healed on every load.
+	 *
+	 * Off by default because enabling it for documents that are not actually corrupt
+	 * would mask genuine bugs that otherwise surface as decode failures.
+	 *
+	 * This mitigation is also not perfect as the client that originated the non-finalized
+	 * will not apply the same "healing" and will continue to use the original identifier.
+	 * The difference in identifiers between the originating client and subsequent clients that load
+	 * the document is not ideal but generally benign to Fluid. However, it may have application-level
+	 * consequences (e.g. if the application stores the identifiers elsewhere, either in other parts of
+	 * Fluid data or externally). Applications should consider whether this risk is acceptable before
+	 * enabling this option.
+	 *
+	 * @privateRemarks
+	 * "Unresolvable" in the public-facing remarks corresponds to non-finalized short IDs persisted without
+	 * any corresponding context for their originating session. See id-compressor internal documentation
+	 * for more details.
+	 */
+	readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 /**
  * Configuration options for SharedTree with alpha features.
@@ -724,6 +763,7 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	disposeForksAfterTransaction: true,
 	shouldEncodeIncrementally: defaultIncrementalEncodingPolicy,
 	enableSharedBranches: false,
+	healUnresolvableIdentifiersOnDecode: false,
 	writeVersionOverrides: new Map(),
 	allowPossiblyIncompatibleWriteVersionOverrides: false,
 };

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -194,6 +194,7 @@ function makeSharedTreeChangeCodec(
 								schema: schemaAndPolicy,
 								idCompressor: context.idCompressor,
 								revision: context.revision,
+								isSummary: context.isSummary,
 							}),
 						});
 					} else if (decodedChange.type === "schema") {

--- a/packages/dds/tree/src/shared-tree/treeAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeAlpha.ts
@@ -954,6 +954,8 @@ export const TreeAlpha: TreeAlpha = {
 			idCompressor,
 			originatorId: idCompressor.localSessionId, // TODO: Why is this needed?
 			schema: { schema: storedSchema, policy: defaultSchemaPolicy },
+			// Not a summary blob — this is `TreeAlpha`'s ad-hoc encoder.
+			isSummary: false,
 		};
 		const result = codec.encode(batch, context);
 		// TODO: codecs should better track which ones can contain handles, and which cannot. When done properly, casts like this can be removed.

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -750,6 +750,7 @@ export class TreeCheckout implements ITreeCheckout {
 							idCompressor: this.idCompressor,
 							originatorId: this.idCompressor.localSessionId,
 							revision,
+							isSummary: false,
 						};
 						const encodedChange = this.changeFamily.codecs.resolve(4).encode(change, context);
 
@@ -820,6 +821,7 @@ export class TreeCheckout implements ITreeCheckout {
 			idCompressor: this.idCompressor,
 			originatorId: this.idCompressor.localSessionId,
 			revision,
+			isSummary: false,
 		};
 		const decodedChange = this.changeFamily.codecs.resolve(4).decode(change, context);
 		// Apply the change to the branch, but _not_ the `activeBranch` - we do not support squashing serialized commits in a transaction.

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -104,6 +104,7 @@ const context: FieldBatchEncodingContext = {
 	encodeType: TreeCompressionStrategy.Compressed,
 	idCompressor,
 	originatorId: idCompressor.localSessionId,
+	isSummary: false,
 	schema: { schema: jsonSequenceRootSchema, policy: defaultSchemaPolicy },
 };
 
@@ -122,6 +123,7 @@ function getIdentifierEncodingContext(id: string) {
 		encodeType: TreeCompressionStrategy.Compressed,
 		idCompressor: testIdCompressor,
 		originatorId: testIdCompressor.localSessionId,
+		isSummary: false,
 		schema: {
 			schema: flexSchema,
 			policy: defaultSchemaPolicy,
@@ -213,6 +215,7 @@ describe("End to end chunked encoding", () => {
 				{
 					idCompressor,
 					originatorId: idCompressor.localSessionId,
+					isSummary: false,
 				},
 			);
 			assert.equal(insertedChunk, chunk);
@@ -249,6 +252,7 @@ describe("End to end chunked encoding", () => {
 				{
 					idCompressor,
 					originatorId: idCompressor.localSessionId,
+					isSummary: false,
 				},
 			);
 			assert.equal(insertedChunk, chunk);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -111,10 +111,12 @@ function testDecode(
 			? {
 					idCompressor: testIdCompressor,
 					originatorId: testIdCompressor.localSessionId,
+					isSummary: false,
 				}
 			: {
 					idCompressor,
 					originatorId: idCompressor.localSessionId,
+					isSummary: false,
 				},
 		incrementalDecoder,
 	);
@@ -148,10 +150,12 @@ function testDecode(
 				? {
 						idCompressor: testIdCompressor,
 						originatorId: testIdCompressor.localSessionId,
+						isSummary: false,
 					}
 				: {
 						idCompressor,
 						originatorId: idCompressor.localSessionId,
+						isSummary: false,
 					},
 			incrementalDecoder,
 		);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
@@ -6,6 +6,8 @@
 import { strict as assert } from "node:assert";
 
 import { compareArrays } from "@fluidframework/core-utils/internal";
+import type { SessionId } from "@fluidframework/id-compressor";
+import { createIdCompressor, createSessionId } from "@fluidframework/id-compressor/internal";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import type { TreeNodeSchemaIdentifier, TreeValue } from "../../../../core/index.js";
@@ -18,6 +20,7 @@ import {
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/chunkCodecUtilities.js";
 import {
+	type IdDecodingContext,
 	InlineArrayDecoder,
 	IncrementalChunkDecoder,
 	NestedArrayDecoder,
@@ -92,6 +95,7 @@ function makeLoggingDecoder(log: string[], chunk: TreeChunk, message?: string): 
 const idDecodingContext = {
 	idCompressor: testIdCompressor,
 	originatorId: testIdCompressor.localSessionId,
+	isSummary: false,
 };
 
 describe("chunkDecoding", () => {
@@ -150,6 +154,146 @@ describe("chunkDecoding", () => {
 				const stream: StreamCursor = { data: [compressedId], offset: 0 };
 				assert.equal(readValue(stream, SpecialField.Identifier, idDecodingContext), stableId);
 				assert.equal(stream.offset, 1);
+			});
+
+			describe("healUnresolvableIdentifiersOnDecode", () => {
+				/**
+				 * Mints an op-space ID that is unresolvable by `testIdCompressor`:
+				 * generated in a fresh foreign compressor whose session is unknown
+				 * to `testIdCompressor`, so `normalizeToSessionSpace` will throw.
+				 */
+				function makeUnresolvableOpSpaceId(): {
+					opSpaceId: number;
+					originatorId: SessionId;
+				} {
+					const foreignSession = createSessionId();
+					const foreignCompressor = createIdCompressor(foreignSession);
+					const sessionSpaceId = foreignCompressor.generateCompressedId();
+					const opSpaceId = foreignCompressor.normalizeToOpSpace(sessionSpaceId);
+					return { opSpaceId, originatorId: foreignSession };
+				}
+
+				function makeStream(opSpaceId: number): StreamCursor {
+					return { data: [opSpaceId], offset: 0 };
+				}
+
+				// Error message thrown by chunkDecoding.readValue when it detects a
+				// non-finalized op-space id during a summary load and healing is not
+				// available. See `chunkDecoding.ts`.
+				const nonFinalizedDuringSummaryError =
+					/Summary could not be loaded due incorrectly encoded identifier\./;
+
+				it("throws when the heal flag is not enabled", () => {
+					const { opSpaceId, originatorId } = makeUnresolvableOpSpaceId();
+					const ctx: IdDecodingContext = {
+						idCompressor: testIdCompressor,
+						originatorId,
+						isSummary: true,
+						sharedObjectId: "doc-a",
+					};
+					assert.throws(
+						() => readValue(makeStream(opSpaceId), SpecialField.Identifier, ctx),
+						nonFinalizedDuringSummaryError,
+					);
+				});
+
+				it("heals to a stable UUID when enabled during a summary load", () => {
+					const { opSpaceId, originatorId } = makeUnresolvableOpSpaceId();
+					const ctx: IdDecodingContext = {
+						idCompressor: testIdCompressor,
+						originatorId,
+						isSummary: true,
+						healUnresolvableIdentifiersOnDecode: true,
+						sharedObjectId: "doc-a",
+					};
+					const result = readValue(makeStream(opSpaceId), SpecialField.Identifier, ctx);
+					assert.equal(typeof result, "string");
+					assert.equal(result, "d5d534e7-5e2c-53c3-b26c-9fd81e6fbc37");
+				});
+
+				it("produces the same UUID for the same (sharedObjectId, opSpaceId) inputs", () => {
+					const { opSpaceId } = makeUnresolvableOpSpaceId();
+					const originator1 = "originator-1" as SessionId;
+					const originator2 = "originator-2" as SessionId;
+					const heal = (originatorId: SessionId): unknown =>
+						readValue(makeStream(opSpaceId), SpecialField.Identifier, {
+							idCompressor: testIdCompressor,
+							originatorId,
+							isSummary: true,
+							healUnresolvableIdentifiersOnDecode: true,
+							sharedObjectId: "doc-a",
+						});
+					assert.equal(heal(originator1), heal(originator2));
+				});
+
+				it("produces different UUIDs for different sharedObjectIds", () => {
+					const { opSpaceId, originatorId } = makeUnresolvableOpSpaceId();
+					const heal = (sharedObjectId: string): unknown =>
+						readValue(makeStream(opSpaceId), SpecialField.Identifier, {
+							idCompressor: testIdCompressor,
+							originatorId,
+							isSummary: true,
+							healUnresolvableIdentifiersOnDecode: true,
+							sharedObjectId,
+						});
+					assert.notEqual(heal("doc-a"), heal("doc-b"));
+				});
+
+				it("produces different UUIDs for different op-space ids", () => {
+					const foreignSession = createSessionId();
+					const foreignCompressor = createIdCompressor(foreignSession);
+					const opSpaceA = foreignCompressor.normalizeToOpSpace(
+						foreignCompressor.generateCompressedId(),
+					);
+					const opSpaceB = foreignCompressor.normalizeToOpSpace(
+						foreignCompressor.generateCompressedId(),
+					);
+					assert.notEqual(opSpaceA, opSpaceB);
+					const heal = (opSpaceId: number): unknown =>
+						readValue(makeStream(opSpaceId), SpecialField.Identifier, {
+							idCompressor: testIdCompressor,
+							originatorId: foreignSession,
+							isSummary: true,
+							healUnresolvableIdentifiersOnDecode: true,
+							sharedObjectId: "doc-a",
+						});
+					assert.notEqual(heal(opSpaceA), heal(opSpaceB));
+				});
+
+				it("does not heal during op decode (isSummary === false)", () => {
+					const { opSpaceId, originatorId } = makeUnresolvableOpSpaceId();
+					const ctx: IdDecodingContext = {
+						idCompressor: testIdCompressor,
+						originatorId,
+						isSummary: false,
+						healUnresolvableIdentifiersOnDecode: true,
+						sharedObjectId: "doc-a",
+					};
+					// Not a summary, so chunkDecoding's non-finalized-id branch does not
+					// fire; the id-compressor's own resolution failure is the symptom.
+					// Match the *type* of failure rather than its specific message, since
+					// the id-compressor's wording varies across the scenarios that hit it.
+					assert.throws(
+						() => readValue(makeStream(opSpaceId), SpecialField.Identifier, ctx),
+						(err: unknown) => err instanceof Error,
+					);
+				});
+
+				it("returns the normally-resolved value when the id is resolvable, even with heal enabled", () => {
+					// `testIdCompressor` knows about its own session, so this id is
+					// resolvable and should never take the heal path.
+					const compressedId = testIdCompressor.generateCompressedId();
+					const opSpaceId = testIdCompressor.normalizeToOpSpace(compressedId);
+					const expected = testIdCompressor.decompress(compressedId);
+					const result = readValue(makeStream(opSpaceId), SpecialField.Identifier, {
+						idCompressor: testIdCompressor,
+						originatorId: testIdCompressor.localSessionId,
+						isSummary: true,
+						healUnresolvableIdentifiersOnDecode: true,
+						sharedObjectId: "doc-a",
+					});
+					assert.equal(result, expected);
+				});
 			});
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -121,6 +121,7 @@ const rootDecoder: ChunkDecoder = {
 const idDecodingContext = {
 	idCompressor: testIdCompressor,
 	originatorId: testIdCompressor.localSessionId,
+	isSummary: false,
 };
 
 describe("chunkDecodingGeneric", () => {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/codecs.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/codecs.spec.ts
@@ -45,6 +45,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.Uncompressed,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 
@@ -63,6 +64,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.Uncompressed,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 
@@ -84,6 +86,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.Uncompressed,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 
@@ -108,6 +111,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.CompressedIncremental,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 
@@ -124,6 +128,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.CompressedIncremental,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 
@@ -145,6 +150,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.Uncompressed,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 
@@ -164,6 +170,7 @@ describe("fieldBatchCodecBuilder", () => {
 			const context = {
 				encodeType: TreeCompressionStrategy.Uncompressed,
 				originatorId: testIdCompressor.localSessionId,
+				isSummary: false,
 				idCompressor: testIdCompressor,
 			};
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -127,6 +127,7 @@ function makeFieldBatchCodec(
 					return decode(data, {
 						idCompressor: fieldBatchContext.idCompressor,
 						originatorId: fieldBatchContext.originatorId,
+						isSummary: false,
 					}).map((chunk) => chunk.cursor());
 				},
 				schema: format,
@@ -169,11 +170,13 @@ describe("compressedEncode", () => {
 						encodeType: TreeCompressionStrategy.Compressed,
 						idCompressor: testIdCompressor,
 						originatorId: testIdCompressor.localSessionId,
+						isSummary: false,
 					});
 					const decoded = codec.decode(result, {
 						encodeType: TreeCompressionStrategy.Compressed,
 						idCompressor: testIdCompressor,
 						originatorId: testIdCompressor.localSessionId,
+						isSummary: false,
 					});
 					const decodedJson = decoded.map(jsonableTreeFromFieldCursor);
 					assert.deepEqual([[jsonable]], decodedJson);
@@ -211,6 +214,7 @@ describe("compressedEncode", () => {
 				const decoded = readValue(stream, shape, {
 					idCompressor: testIdCompressor,
 					originatorId: testIdCompressor.localSessionId,
+					isSummary: false,
 				});
 				assert(stream.offset === stream.data.length);
 				assert.deepEqual(decoded, value);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
@@ -469,6 +469,7 @@ describe("schemaBasedEncoding", () => {
 					const fieldBatchContext: FieldBatchEncodingContext = {
 						encodeType: TreeCompressionStrategy.Compressed,
 						originatorId: testIdCompressor.localSessionId,
+						isSummary: false,
 						schema: { schema: storedSchema, policy: defaultSchemaPolicy },
 						idCompressor,
 					};

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/uncompressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/uncompressedEncode.spec.ts
@@ -28,6 +28,7 @@ describe("uncompressedEncode", () => {
 				const context = {
 					encodeType: TreeCompressionStrategy.Uncompressed,
 					originatorId: testIdCompressor.localSessionId,
+					isSummary: false,
 					idCompressor: testIdCompressor,
 				};
 				const codec = fieldBatchCodecBuilder.build({

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -106,6 +106,7 @@ function createForestSummarizer(args: {
 		encodeType,
 		idCompressor: testIdCompressor,
 		originatorId: testIdCompressor.localSessionId,
+		isSummary: false,
 		schema: { schema: initialContent.schema, policy: defaultSchemaPolicy },
 	};
 	return {

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -58,6 +58,7 @@ const fieldBatchCodecCurrent = fieldBatchCodecBuilder.build(codecOptionsCurrent)
 const context = {
 	encodeType: TreeCompressionStrategy.Uncompressed,
 	originatorId: testIdCompressor.localSessionId,
+	isSummary: false,
 	idCompressor: testIdCompressor,
 };
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -204,6 +204,7 @@ describe("GenericField", () => {
 	describe("Encoding", () => {
 		const baseContext = {
 			originatorId: "session1" as SessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		};

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldSnapshots.test.ts
@@ -58,6 +58,7 @@ export function testSnapshots(): void {
 
 const baseContext = {
 	originatorId: snapshotSessionId,
+	isSummary: false,
 	revision: undefined,
 	idCompressor: testIdCompressor,
 };

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1419,6 +1419,7 @@ describe("ModularChangeFamily", () => {
 		const sessionId = "session1" as SessionId;
 		const context: ChangeEncodingContext = {
 			originatorId: sessionId,
+			isSummary: false,
 			revision: tag1,
 			idCompressor: testIdCompressor,
 		};

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -77,6 +77,7 @@ export function testCodecs(): void {
 	describe("Codecs", () => {
 		const baseContext = {
 			originatorId: "session1" as SessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		};

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
@@ -70,6 +70,7 @@ export function testSnapshots(): void {
 
 		const baseContext = {
 			originatorId: snapshotCompressor.localSessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		};

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
@@ -33,6 +33,7 @@ const tag1 = mintRevisionTag();
 const tag2 = mintRevisionTag();
 const baseContext = {
 	originatorId: "session1" as SessionId,
+	isSummary: false,
 	revision: tag1,
 	idCompressor: testIdCompressor,
 };

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
@@ -19,6 +19,7 @@ export function testSnapshots(): void {
 		const compressor = createSnapshotCompressor();
 		const baseContext = {
 			originatorId: compressor.localSessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		};

--- a/packages/dds/tree/src/test/rebase/revisionTagCodec.spec.ts
+++ b/packages/dds/tree/src/test/rebase/revisionTagCodec.spec.ts
@@ -24,6 +24,7 @@ describe("RevisionTagCodec", () => {
 		assert.deepEqual(encoded, rootRevisionTag);
 		const decoded = codec.decode(encoded, {
 			originatorId: localCompressor.localSessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		});
@@ -31,6 +32,7 @@ describe("RevisionTagCodec", () => {
 		const remoteEncoded = new RevisionTagCodec(remoteCompressor).encode(rootRevisionTag);
 		const decodedFromRemote = codec.decode(remoteEncoded, {
 			originatorId: remoteCompressor.localSessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		});
@@ -55,6 +57,7 @@ describe("RevisionTagCodec", () => {
 			localId,
 			localCodec.decode(localEncoded, {
 				originatorId: localSession,
+				isSummary: false,
 				revision: undefined,
 				idCompressor: testIdCompressor,
 			}),
@@ -64,6 +67,7 @@ describe("RevisionTagCodec", () => {
 		assert.throws(() =>
 			remoteCodec.decode(localEncoded, {
 				originatorId: localSession,
+				isSummary: false,
 				revision: undefined,
 				idCompressor: testIdCompressor,
 			}),
@@ -77,6 +81,7 @@ describe("RevisionTagCodec", () => {
 		localEncoded = localCodec.encode(localId);
 		const remoteDecoded = remoteCodec.decode(localEncoded, {
 			originatorId: localSession,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		});
@@ -89,6 +94,7 @@ describe("RevisionTagCodec", () => {
 			localEncoded,
 			remoteCodec.decode(localEncoded, {
 				originatorId: localSession,
+				isSummary: false,
 				revision: undefined,
 				idCompressor: testIdCompressor,
 			}),
@@ -98,6 +104,7 @@ describe("RevisionTagCodec", () => {
 			localId,
 			localCodec.decode(remoteEncoded, {
 				originatorId: remoteSession,
+				isSummary: false,
 				revision: undefined,
 				idCompressor: testIdCompressor,
 			}),

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -54,6 +54,7 @@ const trunkCommits: SharedBranchSummaryData<TestChange>["trunk"] = [
 // Dummy context object created to pass through the codec.
 const dummyContext = {
 	originatorId: "dummySessionID" as SessionId,
+	isSummary: false,
 	revision: undefined,
 	idCompressor: testIdCompressor,
 };

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -56,6 +56,7 @@ const commitInvalid = {
 
 const dummyContext = {
 	originatorId: testIdCompressor.localSessionId,
+	isSummary: false,
 	revision: undefined,
 	idCompressor: testIdCompressor,
 };

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -122,6 +122,7 @@ describe("sharedTreeChangeCodec", () => {
 				return decode(data, {
 					idCompressor: context.idCompressor,
 					originatorId: context.originatorId,
+					isSummary: false,
 				}).map((chunk) => chunk.cursor());
 			},
 			writeVersion: FieldBatchFormatVersion.v2,
@@ -140,6 +141,7 @@ describe("sharedTreeChangeCodec", () => {
 		const dummyTestSchema = new TreeStoredSchemaRepository();
 		const dummyContext = {
 			originatorId: "dummySessionID" as SessionId,
+			isSummary: false,
 			schema: { policy: defaultSchemaPolicy, schema: dummyTestSchema },
 			revision: undefined,
 			idCompressor: testIdCompressor,

--- a/packages/dds/tree/src/test/testChange.spec.ts
+++ b/packages/dds/tree/src/test/testChange.spec.ts
@@ -88,6 +88,7 @@ describe("TestChange", () => {
 		const empty = TestChange.emptyChange;
 		const context: ChangeEncodingContext = {
 			originatorId: "session1" as SessionId,
+			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		};

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1667,7 +1667,9 @@ export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecW
 }
 
 // @beta @input
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+    readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 // @alpha @sealed
 export interface SimpleAllowedTypeAttributes<out Type extends SchemaType = SchemaType> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -1008,7 +1008,9 @@ export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedTyp
 export const SharedTree: SharedObjectKind<ITree>;
 
 // @beta @input
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+    readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 // @public @sealed @system
 export interface SimpleNodeSchemaBase<out TNodeKind extends NodeKind, out TCustomMetadata = unknown> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -1372,7 +1372,9 @@ export type SharedStringSegment = TextSegment | Marker;
 export const SharedTree: SharedObjectKind<ITree>;
 
 // @beta @input
-export type SharedTreeOptionsBeta = ForestOptions & Partial<CodecWriteOptionsBeta>;
+export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWriteOptionsBeta> {
+    readonly healUnresolvableIdentifiersOnDecode?: boolean;
+}
 
 export { Side }
 

--- a/packages/test/test-end-to-end-tests/src/test/tree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/tree.spec.ts
@@ -1,0 +1,182 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { describeCompat } from "@fluid-private/test-version-utils";
+import {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	DataObject,
+	DataObjectFactory,
+} from "@fluidframework/aqueduct/internal";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
+import type { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
+import type { ISharedObject } from "@fluidframework/shared-object-base/internal";
+import {
+	ITestObjectProvider,
+	createContainerRuntimeFactoryWithDefaultDataStore,
+	createSummarizerFromFactory,
+	summarizeNow,
+} from "@fluidframework/test-utils/internal";
+import {
+	ITree,
+	SchemaFactory,
+	TreeViewConfiguration,
+	type TreeView,
+} from "@fluidframework/tree";
+import { configuredSharedTreeBetaLegacy } from "@fluidframework/tree/legacy";
+
+const sf = new SchemaFactory("idCompressorDetachedDataStoreTest");
+class Root extends sf.object("Root", {
+	id: sf.identifier,
+}) {}
+
+const treeConfig = new TreeViewConfiguration({ schema: Root });
+
+/**
+ * Default data store; provides a root SharedDirectory where a handle to the
+ * detached data store will be stored to trigger its attach.
+ */
+class DefaultDataObject extends DataObject {
+	public static readonly Name = "DefaultDataObject";
+
+	public get containerRuntime(): IContainerRuntimeBase {
+		return this.context.containerRuntime;
+	}
+
+	public storeHandle(key: string, handle: IFluidHandle): void {
+		this.root.set(key, handle);
+	}
+
+	public getStoredHandle<T>(key: string): IFluidHandle<T> | undefined {
+		return this.root.get<IFluidHandle<T>>(key);
+	}
+}
+
+const defaultFactory = new DataObjectFactory({
+	type: DefaultDataObject.Name,
+	ctor: DefaultDataObject,
+});
+
+/**
+ * Data store that owns a SharedTree. Its first-time initialization runs
+ * inside the detached creation flow (`createInstanceWithDataStore` then
+ * `instantiateDataStore` then `initializingFirstTime`), so the tree mutations
+ * happen while the data store is genuinely detached. The id compressor
+ * therefore allocates only local (negative / not-yet-finalized) ids.
+ */
+class TreeOwningDataObject extends DataObject {
+	public static readonly Name = "TreeOwningDataObject";
+	private static readonly treeChannelId = "tree";
+
+	#treeView: TreeView<typeof Root> | undefined;
+
+	public get treeView(): TreeView<typeof Root> {
+		assert(this.#treeView !== undefined, "treeView has not been initialized");
+		return this.#treeView;
+	}
+
+	public get dataStoreRuntime(): IFluidDataStoreRuntime {
+		return this.runtime;
+	}
+
+	protected override async initializingFirstTime(): Promise<void> {
+		// Create the SharedTree channel while the data store is detached.
+		const channel = this.runtime.createChannel(
+			TreeOwningDataObject.treeChannelId,
+			SharedTree.getFactory().type,
+		);
+		(channel as unknown as ISharedObject).bindToContext();
+		const tree = channel as unknown as ITree;
+
+		// Initialize while detached. Creating the Root node causes the
+		// runtime's id compressor to allocate a local (negative) compressed
+		// id for its `identifier` field because no finalize op has been
+		// observed yet.
+		const view = tree.viewWith(treeConfig);
+		view.initialize({});
+		this.#treeView = view;
+	}
+}
+
+const SharedTree = configuredSharedTreeBetaLegacy({
+	healUnresolvableIdentifiersOnDecode: true,
+});
+
+const treeOwningFactory = new DataObjectFactory({
+	type: TreeOwningDataObject.Name,
+	ctor: TreeOwningDataObject,
+	sharedObjects: [SharedTree.getFactory()],
+});
+
+describeCompat(
+	"SharedTree in a data store created detached and attached via op",
+	"NoCompat",
+	(getTestObjectProvider) => {
+		let provider: ITestObjectProvider;
+
+		beforeEach("getTestObjectProvider", () => {
+			provider = getTestObjectProvider();
+		});
+
+		const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
+			ContainerRuntimeFactoryWithDefaultDataStore,
+			{
+				defaultFactory,
+				registryEntries: [
+					[defaultFactory.type, Promise.resolve(defaultFactory)],
+					[treeOwningFactory.type, Promise.resolve(treeOwningFactory)],
+				],
+				runtimeOptions: {
+					// SharedTree requires the runtime id compressor.
+					enableRuntimeIdCompressor: "on",
+				},
+			},
+		);
+		// This test reproduces a bug with SharedTree's encoding/decoding. Non-finalized op-space IDs can legitimately appear
+		// in attach summaries. At the time of writing, SharedTree encoded the short ID but failed to include originator data
+		// in the same summary (so that remote clients can decompress with respect to the actual client that generated the ID).
+		// The attempt to summarize therefore failed on attempting to decode the non-finalized ID.
+		it("Summarizer creates the data store from the attach op summary and can summarize", async () => {
+			// 1. Create a container with an attached default data store.
+			const container1 = await provider.createContainer(runtimeFactory);
+			const defaultDataObject = (await container1.getEntryPoint()) as DefaultDataObject;
+			const containerRuntime = defaultDataObject.containerRuntime;
+
+			// 2. Create the data store *detached*. The factory uses
+			//    `createDetachedDataStore` + `attachRuntime` internally, and
+			//    the data object's `initializingFirstTime` (which creates and
+			//    initializes the SharedTree) runs while the data store is
+			//    still detached.
+			const treeDataStore = await treeOwningFactory.createInstance(containerRuntime);
+
+			// 3. Attach the data store by referencing its handle from
+			//    the (attached) default data store. This produces an attach op
+			//    that carries the data store's initial summary (including the
+			//    SharedTree summary, which encodes the local ids).
+			defaultDataObject.storeHandle("treeDataStore", treeDataStore.IFluidHandle);
+
+			await provider.ensureSynchronized();
+
+			// 4. Create a summarizer (which loads the data store from the
+			//    attach op's summary) and run an on-demand summary.
+			// Originallly, would fail with `Unknown op space ID` in ID compressor.
+			const { summarizer } = await createSummarizerFromFactory(
+				provider,
+				container1,
+				defaultFactory,
+				undefined /* summaryVersion */,
+				ContainerRuntimeFactoryWithDefaultDataStore,
+				[
+					[defaultFactory.type, Promise.resolve(defaultFactory)],
+					[treeOwningFactory.type, Promise.resolve(treeOwningFactory)],
+				],
+			);
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer, "afterDetachedAttach");
+		});
+	},
+);


### PR DESCRIPTION
Cherry-pick of #27281 into 2.100

## Description

When a SharedTree is attached to an already-attached container, tree identifier values generated locally before the IdCompressor has been allocated a cluster can sometimes be serialized as negative op-space IDs. This is a bug which will be fixed in a separate PR (near-term, by using the long id in these cases similarly to what we do in some other codec paths).

When other clients attempt to load SharedTrees with such summaries, they currently crash as the decode path attempts to use the local client's session ID as the originating ID, which is incorrect. In the general case, the information about which client generated the ID has been lost at this point.

This PR adds a feature flag to `configuredSharedTree` which can potentially be enabled (with some risk, see notes) to allow documents that have reached this state to continue to operate anyway. It does so by generating a v5 uuid based on the SharedObject ID + op-space unfinalized ID. This provides similar collision-resistant properties as the original intent of the ID provided unfinalized ids are only currently written at attach summary generation time (the known bug). Depending on how the application used the ID, this may break stability guarantees (e.g. if application assumed the id would remain stable and wrote it to an external store or a different data store within Fluid, but did so using the previous long form). Thus this flag should only be enabled with those risks in mind.

Behavior:
- `chunkDecoding.readValue` (the `SpecialField.Identifier` path) now wraps the `normalizeToSessionSpace` + `decompress` call in try/catch. On failure, when `healUnresolvableIdsOnDecode` is enabled and a `sharedObjectId` is available, it returns a deterministic stable UUID computed as `uuidv5("${sharedObjectId}|${opSpaceId}", healingNamespace)`. All clients loading the same blob agree on the resulting value, and the existing chunked-forest encode path (also from d43d50d7563) writes the string back out at the next summary so the healing does not need to be re-applied on subsequent loads.

Plumbing:
- `FieldBatchEncodingContext` and `IdDecodingContext` gain `healUnresolvableIdsOnDecode?: boolean` and `sharedObjectId?: string`.
- `ChangeEncodingContext` and `EditManagerEncodingContext` carry the same fields so the flag reaches chunked-forest decode for builds/refreshers inside trunk-commit changes (via `modularChangeCodecV1.decodeDetachedNodes`) in addition to `ForestSummarizer.load`.
- `EditManagerSummarizer` accepts the flag and shared-object id as constructor args.
- `SharedTreeOptionsBeta` exposes `healUnresolvableIdsOnDecode?: boolean` (default `false`) via `configuredSharedTreeBetaLegacy`. Off by default so it does not mask genuine decode failures in documents that aren't actually corrupt.

The `RevisionTagCodec` and `DetachedFieldIndex` v1/v2 codecs are left unchanged: v2 already emits long IDs when summarizing in detached state, so those codecs do not produce unresolvable persisted IDs to heal.

Adds an end-to-end test that reproduces the
SharedTree-attaches-to-attached- container scenario and verifies healed loading succeeds when the option is enabled.

## Breaking Changes

N/A -- all behavioral changes are opt-in
