### PR TITLE
Avoid unneeded export for detachedFieldIndexCodecName

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -105,7 +105,6 @@ export {
 	tryGetChunk,
 	type ChunkedCursor,
 	DetachedFieldIndexFormatVersion,
-	detachedFieldIndexCodecName,
 	detachedFieldIndexCodecBuilder,
 	areDetachedNodeIdsEqual,
 	deltaFieldMapHasVisibleChanges,

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
@@ -22,13 +22,8 @@ type BuildData = ICodecOptions & {
 	readonly idCompressor: IIdCompressor;
 };
 
-/**
- * Codec name used to identify the detachedFieldIndex codec, see {@link detachedFieldIndexCodecBuilder}.
- */
-export const detachedFieldIndexCodecName = "DetachedFieldIndex";
-
 export const detachedFieldIndexCodecBuilder = VersionDispatchingCodecBuilder.build(
-	detachedFieldIndexCodecName,
+	"DetachedFieldIndex",
 	[
 		{
 			minVersionForCollab: lowestMinVersionForCollab,

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -127,10 +127,7 @@ export {
 	type ReadOnlyDetachedFieldIndex,
 } from "./detachedFieldIndex.js";
 
-export {
-	detachedFieldIndexCodecName,
-	detachedFieldIndexCodecBuilder,
-} from "./detachedFieldIndexCodecs.js";
+export { detachedFieldIndexCodecBuilder } from "./detachedFieldIndexCodecs.js";
 export { DetachedFieldIndexFormatVersion } from "./detachedFieldIndexFormatCommon.js";
 export { type FormatV1 } from "./detachedFieldIndexFormatV1.js";
 

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -17,7 +17,10 @@ import {
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { FluidClientVersion, type FormatVersion } from "./codec/index.js";
-import { detachedFieldIndexCodecName, DetachedFieldIndexFormatVersion } from "./core/index.js";
+import {
+	detachedFieldIndexCodecBuilder,
+	DetachedFieldIndexFormatVersion,
+} from "./core/index.js";
 import {
 	SharedTreeKernel,
 	type ITreePrivate,
@@ -228,7 +231,7 @@ const sharedBranchesOptions: SharedTreeOptionsInternal = {
 	writeVersionOverrides: new Map<string, FormatVersion>([
 		[editManagerCodecName, EditManagerFormatVersion.vSharedBranches],
 		[messageCodecName, MessageFormatVersion.vSharedBranches],
-		[detachedFieldIndexCodecName, DetachedFieldIndexFormatVersion.v2],
+		[detachedFieldIndexCodecBuilder.name, DetachedFieldIndexFormatVersion.v2],
 	]),
 	allowPossiblyIncompatibleWriteVersionOverrides: true,
 };


### PR DESCRIPTION
## Description

Avoid unneeded export for detachedFieldIndexCodecName.
Accessing it off the detachedFieldIndexCodecBuilder avoids the need to assoiate the two exports, simplifying things slightly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
