### PR TITLE
fix: avoid spread-into-push RangeError in GC and merge-tree snapshot load

### DIFF
--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -135,16 +135,15 @@ export class SnapshotLoader {
 				// out ok since none of these values end up being used. (specifically, the 'firstRemovedSeq' is fake
 				// for all values other than the actual first remove).
 				// This issue only affects V1 summaries, as the strategy in snapshotlegacy avoids storing merge info directly.
-				removes.push(
-					...spec.removedClientIds.map(
-						(id) =>
-							({
-								type: "setRemove",
-								seq: firstRemovedSeq,
-								clientId: this.client.getOrAddShortClientId(id),
-							}) as const,
-					),
-				);
+				// Avoid spreading into push: a large array could exceed the engine's
+				// argument-count limit and throw RangeError.
+				for (const id of spec.removedClientIds) {
+					removes.push({
+						type: "setRemove",
+						seq: firstRemovedSeq,
+						clientId: this.client.getOrAddShortClientId(id),
+					} as const);
+				}
 			}
 			if (spec.movedSeq !== undefined) {
 				assert(
@@ -156,16 +155,15 @@ export class SnapshotLoader {
 					0xb5f /* Expected same length for client ids and seqs */,
 				);
 
-				removes.push(
-					...spec.movedClientIds.map(
-						(id, i) =>
-							({
-								type: "sliceRemove",
-								seq: spec.movedSeqs![i],
-								clientId: this.client.getOrAddShortClientId(id),
-							}) as const,
-					),
-				);
+				// Avoid spreading into push: a large array could exceed the engine's
+				// argument-count limit and throw RangeError.
+				for (let i = 0; i < spec.movedClientIds.length; i++) {
+					removes.push({
+						type: "sliceRemove",
+						seq: spec.movedSeqs[i],
+						clientId: this.client.getOrAddShortClientId(spec.movedClientIds[i]),
+					} as const);
+				}
 			}
 
 			if (removes.length > 0) {
@@ -258,7 +256,11 @@ export class SnapshotLoader {
 			const newSegs = chunk.segments.map((element) => this.specToSegment(element));
 			this.extractAttribution(newSegs, chunk);
 			chunksWithAttribution += chunk.attribution === undefined ? 0 : 1;
-			segs.push(...newSegs);
+			// Avoid `push(...newSegs)`: spreading a large array into a variadic call
+			// can exceed the engine's argument-count limit and throw RangeError.
+			for (const seg of newSegs) {
+				segs.push(seg);
+			}
 		}
 
 		assert(

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -135,8 +135,6 @@ export class SnapshotLoader {
 				// out ok since none of these values end up being used. (specifically, the 'firstRemovedSeq' is fake
 				// for all values other than the actual first remove).
 				// This issue only affects V1 summaries, as the strategy in snapshotlegacy avoids storing merge info directly.
-				// Avoid spreading into push: a large array could exceed the engine's
-				// argument-count limit and throw RangeError.
 				for (const id of spec.removedClientIds) {
 					removes.push({
 						type: "setRemove",

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -843,11 +843,18 @@ export class GarbageCollector implements IGarbageCollector {
 			if (gcDataSuperSet.gcNodes[sourceNodeId] === undefined) {
 				gcDataSuperSet.gcNodes[sourceNodeId] = outboundRoutes;
 			} else {
+				// Avoid `push(...outboundRoutes)`: spreading a large array into a variadic call
+				// can exceed the engine's argument-count limit and throw RangeError.
 				// TODO: Fix this violation and remove the disable
 				// eslint-disable-next-line @fluid-internal/fluid/no-unchecked-record-access
-				gcDataSuperSet.gcNodes[sourceNodeId].push(...outboundRoutes);
+				const target = gcDataSuperSet.gcNodes[sourceNodeId];
+				for (const route of outboundRoutes) {
+					target.push(route);
+				}
 			}
-			newOutboundRoutesSinceLastRun.push(...outboundRoutes);
+			for (const route of outboundRoutes) {
+				newOutboundRoutesSinceLastRun.push(route);
+			}
 		}
 
 		/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -840,18 +840,18 @@ export class GarbageCollector implements IGarbageCollector {
 		const gcDataSuperSet = concatGarbageCollectionData(previousGCData, currentGCData);
 		const newOutboundRoutesSinceLastRun: string[] = [];
 		for (const [sourceNodeId, outboundRoutes] of this.newReferencesSinceLastRun) {
-			if (gcDataSuperSet.gcNodes[sourceNodeId] === undefined) {
+			const target: string[] | undefined = gcDataSuperSet.gcNodes[sourceNodeId];
+			if (target === undefined) {
 				gcDataSuperSet.gcNodes[sourceNodeId] = outboundRoutes;
 			} else {
 				// Avoid `push(...outboundRoutes)`: spreading a large array into a variadic call
 				// can exceed the engine's argument-count limit and throw RangeError.
-				// TODO: Fix this violation and remove the disable
-				// eslint-disable-next-line @fluid-internal/fluid/no-unchecked-record-access
-				const target = gcDataSuperSet.gcNodes[sourceNodeId];
 				for (const route of outboundRoutes) {
 					target.push(route);
 				}
 			}
+			// Avoid `push(...outboundRoutes)`: spreading a large array into a variadic call
+			// can exceed the engine's argument-count limit and throw RangeError.
 			for (const route of outboundRoutes) {
 				newOutboundRoutesSinceLastRun.push(route);
 			}


### PR DESCRIPTION
## Description

I found this bug when looking at telemetry where DDS fails to load and found sequence loading failing with the error `Maximum call stack size exceeded`. That led to look at this closely and found 2 places where we are failing - GC and sequence load.

`Array.prototype.push(...arr)` expands `arr` into individual function arguments. JS engines have a hard cap on the number of arguments per call (~125k in V8), and crossing it throws `RangeError: Maximum call stack size exceeded`. The error surfaces through the engine's call-stack path even though it's really an argument-count limit, which makes it easy to misread as runaway recursion.

This pattern appeared in two hot paths:

- **container-runtime GC** — `findAllNodesReferencedBetweenGCs` builds a superset of outbound references for the in-between-GCs reachability check. It folds `newReferencesSinceLastRun` into the working set with `target.push(...outboundRoutes)` and accumulates a flat list with `newOutboundRoutesSinceLastRun.push(...outboundRoutes)`. `newReferencesSinceLastRun` is only cleared at the start of each GC run, so a long session with many added references for a single source node can accumulate enough entries to overflow at summarize time. This was observed in production telemetry as a `Maximum call stack size exceeded` originating from the `push` on the line cited above, called from `runGC` during `submitSummary`.

- **merge-tree snapshot load** — `SnapshotLoader.initialize` spreads each chunk's segments into `segs.push(...newSegs)`, and `SnapshotLoader.loadHeader` spreads per-segment `removedClientIds` / `movedClientIds` arrays into `removes.push(...)`. Risk is lower here (per-chunk / per-segment bounds), but the same anti-pattern.

Replaced all spread-pushes in these paths with explicit `for...of` loops that push one element at a time. Behavior is unchanged; this only removes the engine-limit overflow.

### How to verify

- Container-runtime: full mocha suite passes locally (962 passing).
- Merge-tree: full mocha suite passes locally (1555 passing); snapshot tests specifically re-run after the `removes.push(...)` edits.

[AB#73802](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73802)