### PR TITLE
test(client-presence): cleanup type test generation

### DIFF
--- a/packages/framework/presence-definitions/package.json
+++ b/packages/framework/presence-definitions/package.json
@@ -70,8 +70,7 @@
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"tsc": "fluid-tsc commonjs --project ./tsconfig.cjs.json && copyfiles -f ./src/cjs/package.json ./dist",
-		"typetests:gen": "flub generate typetests --dir . -v",
-		"typetests:gen-disabled": "flub generate typetests --dir . -v"
+		"typetests:gen": "flub generate typetests --dir . -v"
 	},
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
@@ -105,7 +104,7 @@
 		}
 	},
 	"typeValidation": {
-		"entrypoint": "public",
+		"entrypoint": "",
 		"broken": {}
 	}
 }


### PR DESCRIPTION
- use root entrypoint (empty string - there isn't public versus beta, etc. here)
- remove dead script entry