### PR TITLE
perf(tree): return bound off() from KernelEventBuffer.on

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -447,7 +447,7 @@ class KernelEventBuffer implements Listenable<KernelEvents> {
 
 		this.#events.on(eventName, listener);
 		// Return a bound method instead of an arrow closure. A bound function captures
-		// (target, thisArg, ...boundArgs) in a fixed shape that V8 can optimise more
+		// (target, thisArg, ...boundArgs) in a fixed shape that V8 can optimize more
 		// uniformly than a closure that captures its lexical context.
 		return this.off.bind(this, eventName, listener);
 	}

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -446,7 +446,10 @@ class KernelEventBuffer implements Listenable<KernelEvents> {
 		}
 
 		this.#events.on(eventName, listener);
-		return () => this.off(eventName, listener);
+		// Return a bound method instead of an arrow closure. A bound function captures
+		// (target, thisArg, ...boundArgs) in a fixed shape that V8 can optimise more
+		// uniformly than a closure that captures its lexical context.
+		return this.off.bind(this, eventName, listener);
 	}
 
 	public off(eventName: keyof KernelEvents, listener: KernelEvents[typeof eventName]): void {


### PR DESCRIPTION
## Overview

Replace the per-subscription `() => this.off(eventName, listener)` arrow returned by `KernelEventBuffer.on` with `this.off.bind(this, eventName, listener)`.

A V8 `JSBoundFunction` stores `(target, thisArg, ...boundArgs)` in a fixed shape and is significantly more compact than a fresh arrow + Context pair, which captures the surrounding lexical scope. Functionally identical — both forms invoke `this.off(eventName, listener)` with no other state.

No public API surface change; internal-only.