### PR TITLE
build(odsp-driver): add node to test tsconfig types

### DIFF
--- a/packages/drivers/odsp-driver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-driver/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",
-		"types": ["mocha"],
+		"types": ["node", "mocha"],
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},


### PR DESCRIPTION
## Description

`packages/drivers/odsp-driver/src/test/tsconfig.json` sets `"types": ["mocha"]`, which excludes `@types/node`. However, several test files directly import Node built-ins (e.g., `import { strict as assert } from "node:assert";`), which only resolve via the ambient `declare module "node:assert"` declaration provided by `@types/node`.

The test build currently compiles only by accident: `@fluidframework/build-tools` (a devDependency referenced by the typetest generator output in `src/test/types/`) transitively pulls in `@types/glob` → `@types/node`, which loads the ambient declarations as a side effect. Any change to build-tools' exports map that removes that transitive type dependency immediately breaks the test compile with errors like:

```
src/test/.../foo.spec.ts:6:34 - error TS2307: Cannot find module 'node:assert' or its corresponding type declarations.
```

…and a cascade of `TS18046`/`TS18048` errors as the untyped `assert(...)` stops narrowing.

This change explicitly adds `"node"` to the `types` array so the dependency is declared rather than inherited by accident.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
