### PR TITLE
build(build-tools): add .js extensions to relative imports

### DIFF
--- a/build-tools/packages/build-tools/src/common/biome2Config.ts
+++ b/build-tools/packages/build-tools/src/common/biome2Config.ts
@@ -11,9 +11,9 @@ import multimatch from "multimatch";
 import { merge } from "ts-deepmerge";
 import type { Opaque } from "type-fest";
 
-import type { Configuration as Biome2ConfigRaw } from "./biome2ConfigTypes";
-import { getClosestBiomeConfigPath, loadRawBiomeConfigFile } from "./biomeConfigUtils";
-import type { GitRepo } from "./gitRepo";
+import type { Configuration as Biome2ConfigRaw } from "./biome2ConfigTypes.js";
+import { getClosestBiomeConfigPath, loadRawBiomeConfigFile } from "./biomeConfigUtils.js";
+import type { GitRepo } from "./gitRepo.js";
 
 /**
  * Convenience type to represent a Biome 2.x config that has been loaded while following and merging the

--- a/build-tools/packages/build-tools/src/common/biomeConfig.ts
+++ b/build-tools/packages/build-tools/src/common/biomeConfig.ts
@@ -12,9 +12,9 @@ import { merge } from "ts-deepmerge";
 // Opaque is deprecated in newer type-fest versions (replaced by Tagged); we pin type-fest 2.x for current CommonJS
 import type { Opaque } from "type-fest";
 
-import type { Configuration as BiomeConfigRaw } from "./biomeConfigTypes";
-import { getClosestBiomeConfigPath, loadRawBiomeConfigFile } from "./biomeConfigUtils";
-import type { GitRepo } from "./gitRepo";
+import type { Configuration as BiomeConfigRaw } from "./biomeConfigTypes.js";
+import { getClosestBiomeConfigPath, loadRawBiomeConfigFile } from "./biomeConfigUtils.js";
+import type { GitRepo } from "./gitRepo.js";
 
 /**
  * Convenience type to represent a Biome config that has been loaded while following and merging the

--- a/build-tools/packages/build-tools/src/common/biomeConfigUtils.ts
+++ b/build-tools/packages/build-tools/src/common/biomeConfigUtils.ts
@@ -10,7 +10,7 @@
 import { readFile } from "node:fs/promises";
 import * as JSON5 from "json5";
 
-import type { GitRepo } from "./gitRepo";
+import type { GitRepo } from "./gitRepo.js";
 
 // find-up is an ESM-only package and we're still building CJS, so this import form is required
 // so that TypeScript won't transpile it to require(). Once this package is switched to ESM, then

--- a/build-tools/packages/build-tools/src/common/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/common/gitRepo.ts
@@ -5,7 +5,7 @@
 
 import { parseISO } from "date-fns";
 import registerDebug from "debug";
-import { exec, execNoError } from "./utils";
+import { exec, execNoError } from "./utils.js";
 
 const traceGitRepo = registerDebug("fluid-build:gitRepo");
 

--- a/build-tools/packages/build-tools/src/common/logging.ts
+++ b/build-tools/packages/build-tools/src/common/logging.ts
@@ -5,7 +5,7 @@
 
 import chalk from "picocolors";
 
-import { commonOptions } from "../fluidBuild/commonOptions";
+import { commonOptions } from "../fluidBuild/commonOptions.js";
 
 /**
  * A function that logs an Error or error message.

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -9,10 +9,10 @@ import { getPackagesSync } from "@manypkg/get-packages";
 import registerDebug from "debug";
 import { readFileSync, readJsonSync } from "fs-extra";
 import YAML from "yaml";
-import type { IFluidBuildDir } from "../fluidBuild/fluidBuildConfig";
-import { defaultLogger, type Logger } from "./logging";
-import { Package } from "./npmPackage";
-import { type ExecAsyncResult, execWithErrorAsync, rimrafWithErrorAsync } from "./utils";
+import type { IFluidBuildDir } from "../fluidBuild/fluidBuildConfig.js";
+import { defaultLogger, type Logger } from "./logging.js";
+import { Package } from "./npmPackage.js";
+import { type ExecAsyncResult, execWithErrorAsync, rimrafWithErrorAsync } from "./utils.js";
 
 const traceInit = registerDebug("fluid-build:init");
 

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -12,18 +12,18 @@ import { readJsonSync, writeJsonSync } from "fs-extra";
 import chalk from "picocolors";
 import sortPackageJson from "sort-package-json";
 import type { SetRequired, PackageJson as StandardPackageJson } from "type-fest";
-import type { IFluidBuildConfig } from "../fluidBuild/fluidBuildConfig";
-import type { IFluidCompatibilityMetadata } from "../fluidBuild/fluidCompatMetadata";
-import { options } from "../fluidBuild/options";
-import { defaultLogger } from "./logging";
-import type { MonoRepo, PackageManager } from "./monoRepo";
+import type { IFluidBuildConfig } from "../fluidBuild/fluidBuildConfig.js";
+import type { IFluidCompatibilityMetadata } from "../fluidBuild/fluidCompatMetadata.js";
+import { options } from "../fluidBuild/options.js";
+import { defaultLogger } from "./logging.js";
+import type { MonoRepo, PackageManager } from "./monoRepo.js";
 import {
 	type ExecAsyncResult,
 	execWithErrorAsync,
 	isSameFileOrDir,
 	lookUpDirSync,
 	rimrafWithErrorAsync,
-} from "./utils";
+} from "./utils.js";
 
 const traceInit = registerDebug("fluid-build:init");
 

--- a/build-tools/packages/build-tools/src/common/timer.ts
+++ b/build-tools/packages/build-tools/src/common/timer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { defaultLogger } from "./logging";
+import { defaultLogger } from "./logging.js";
 
 const { log } = defaultLogger;
 

--- a/build-tools/packages/build-tools/src/common/typeTests.ts
+++ b/build-tools/packages/build-tools/src/common/typeTests.ts
@@ -4,7 +4,7 @@
  */
 
 import path from "node:path";
-import type { Package } from "./npmPackage";
+import type { Package } from "./npmPackage.js";
 
 /**
  * Given a package, returns the name that should be used for the previous version of the package to generate type tests.

--- a/build-tools/packages/build-tools/src/fluidBuild/buildContext.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildContext.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { GitRepo } from "../common/gitRepo";
-import type { IFluidBuildConfig } from "./fluidBuildConfig";
+import type { GitRepo } from "../common/gitRepo.js";
+import type { IFluidBuildConfig } from "./fluidBuildConfig.js";
 
 /**
  * A context object that is passed to fluid-build tasks. It is used to provide easy access to commonly-needed metadata

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -9,15 +9,15 @@ import registerDebug from "debug";
 import chalk from "picocolors";
 import { Spinner } from "picospinner";
 import * as semver from "semver";
-import type { GitRepo } from "../common/gitRepo";
-import { defaultLogger } from "../common/logging";
-import type { Package } from "../common/npmPackage";
-import type { Timer } from "../common/timer";
-import type { BuildContext } from "./buildContext";
-import { BuildMetrics } from "./buildMetrics";
-import { BuildResult, summarizeBuildResult } from "./buildResult";
-import { FileHashCache } from "./fileHashCache";
-import type { IFluidBuildConfig } from "./fluidBuildConfig";
+import type { GitRepo } from "../common/gitRepo.js";
+import { defaultLogger } from "../common/logging.js";
+import type { Package } from "../common/npmPackage.js";
+import type { Timer } from "../common/timer.js";
+import type { BuildContext } from "./buildContext.js";
+import { BuildMetrics } from "./buildMetrics.js";
+import { BuildResult, summarizeBuildResult } from "./buildResult.js";
+import { FileHashCache } from "./fileHashCache.js";
+import type { IFluidBuildConfig } from "./fluidBuildConfig.js";
 import {
 	getDefaultTaskDefinition,
 	getTaskDefinitions,
@@ -26,11 +26,11 @@ import {
 	type TaskDefinitions,
 	type TaskDefinitionsOnDisk,
 	type TaskFileDependencies,
-} from "./fluidTaskDefinitions";
-import { options } from "./options";
-import { Task, type TaskExec } from "./tasks/task";
-import { TaskFactory } from "./tasks/taskFactory";
-import { WorkerPool } from "./tasks/workers/workerPool";
+} from "./fluidTaskDefinitions.js";
+import { options } from "./options.js";
+import { Task, type TaskExec } from "./tasks/task.js";
+import { TaskFactory } from "./tasks/taskFactory.js";
+import { WorkerPool } from "./tasks/workers/workerPool.js";
 
 const traceTaskDef = registerDebug("fluid-build:task:definition");
 const traceTaskDepTask = registerDebug("fluid-build:task:init:dep:task");

--- a/build-tools/packages/build-tools/src/fluidBuild/buildMetrics.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildMetrics.ts
@@ -8,7 +8,7 @@ import { writeFile } from "node:fs/promises";
 import chalk from "picocolors";
 import type { Opaque } from "type-fest";
 
-import { defaultLogger } from "../common/logging";
+import { defaultLogger } from "../common/logging.js";
 
 const { log } = defaultLogger;
 

--- a/build-tools/packages/build-tools/src/fluidBuild/fileHashCache.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fileHashCache.ts
@@ -4,7 +4,7 @@
  */
 
 import { readFile } from "fs/promises";
-import { sha256 } from "./hash";
+import { sha256 } from "./hash.js";
 
 type hashFn = (buffer: Buffer) => string;
 export class FileHashCache {

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -6,16 +6,16 @@
 import chalk from "picocolors";
 import { Spinner } from "picospinner";
 
-import { GitRepo } from "../common/gitRepo";
-import { defaultLogger } from "../common/logging";
-import { Timer } from "../common/timer";
-import type { BuildGraph } from "./buildGraph";
-import { BuildResult } from "./buildResult";
-import { commonOptions } from "./commonOptions";
-import { DEFAULT_FLUIDBUILD_CONFIG } from "./fluidBuildConfig";
-import { FluidRepoBuild } from "./fluidRepoBuild";
-import { getFluidBuildConfig, getResolvedFluidRoot } from "./fluidUtils";
-import { options, parseOptions } from "./options";
+import { GitRepo } from "../common/gitRepo.js";
+import { defaultLogger } from "../common/logging.js";
+import { Timer } from "../common/timer.js";
+import type { BuildGraph } from "./buildGraph.js";
+import { BuildResult } from "./buildResult.js";
+import { commonOptions } from "./commonOptions.js";
+import { DEFAULT_FLUIDBUILD_CONFIG } from "./fluidBuildConfig.js";
+import { FluidRepoBuild } from "./fluidRepoBuild.js";
+import { getFluidBuildConfig, getResolvedFluidRoot } from "./fluidUtils.js";
+import { options, parseOptions } from "./options.js";
 
 const { log, errorLog: error, warning: warn } = defaultLogger;
 

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuildConfig.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuildConfig.ts
@@ -8,7 +8,7 @@ import type {
 	GitIgnoreSetting,
 	TaskDefinitionsOnDisk,
 	TaskFileDependencies,
-} from "./fluidTaskDefinitions";
+} from "./fluidTaskDefinitions.js";
 
 /**
  * Token that can be used in file paths and globs to represent the repository root directory.

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepo.ts
@@ -8,7 +8,11 @@ import * as path from "path";
 import { MonoRepo } from "../common/monoRepo.js";
 import { type Package, Packages } from "../common/npmPackage.js";
 import type { ExecAsyncResult } from "../common/utils.js";
-import type { IFluidBuildDir, IFluidBuildDirEntry, IFluidBuildDirs } from "./fluidBuildConfig.js";
+import type {
+	IFluidBuildDir,
+	IFluidBuildDirEntry,
+	IFluidBuildDirs,
+} from "./fluidBuildConfig.js";
 
 /**
  * @deprecated Should not be used outside the build-tools package.

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepo.ts
@@ -5,10 +5,10 @@
 
 import * as path from "path";
 
-import { MonoRepo } from "../common/monoRepo";
-import { type Package, Packages } from "../common/npmPackage";
-import type { ExecAsyncResult } from "../common/utils";
-import type { IFluidBuildDir, IFluidBuildDirEntry, IFluidBuildDirs } from "./fluidBuildConfig";
+import { MonoRepo } from "../common/monoRepo.js";
+import { type Package, Packages } from "../common/npmPackage.js";
+import type { ExecAsyncResult } from "../common/utils.js";
+import type { IFluidBuildDir, IFluidBuildDirEntry, IFluidBuildDirs } from "./fluidBuildConfig.js";
 
 /**
  * @deprecated Should not be used outside the build-tools package.

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -8,16 +8,16 @@ import * as path from "node:path";
 import registerDebug from "debug";
 import chalk from "picocolors";
 
-import { defaultLogger } from "../common/logging";
-import { MonoRepo } from "../common/monoRepo";
-import { type Package, Packages } from "../common/npmPackage";
-import { type ExecAsyncResult, isSameFileOrDir, lookUpDirSync } from "../common/utils";
-import type { BuildContext } from "./buildContext";
-import { BuildGraph } from "./buildGraph";
-import { FluidRepo } from "./fluidRepo";
-import { getFluidBuildConfig } from "./fluidUtils";
-import { NpmDepChecker } from "./npmDepChecker";
-import { globFn } from "./tasks/taskUtils";
+import { defaultLogger } from "../common/logging.js";
+import { MonoRepo } from "../common/monoRepo.js";
+import { type Package, Packages } from "../common/npmPackage.js";
+import { type ExecAsyncResult, isSameFileOrDir, lookUpDirSync } from "../common/utils.js";
+import type { BuildContext } from "./buildContext.js";
+import { BuildGraph } from "./buildGraph.js";
+import { FluidRepo } from "./fluidRepo.js";
+import { getFluidBuildConfig } from "./fluidUtils.js";
+import { NpmDepChecker } from "./npmDepChecker.js";
+import { globFn } from "./tasks/taskUtils.js";
 
 const traceInit = registerDebug("fluid-build:init");
 

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { PackageJson } from "../common/npmPackage";
-import { isConcurrentlyCommand, parseConcurrentlyCommand } from "./parseCommands";
+import type { PackageJson } from "../common/npmPackage.js";
+import { isConcurrentlyCommand, parseConcurrentlyCommand } from "./parseCommands.js";
 
 /**
  * Task definitions (type `TaskDefinitions`) is an object describing build tasks for fluid-build.

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTsc/fluidTsc.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTsc/fluidTsc.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { defaultLogger } from "../../common/logging";
-import { tsCompile } from "../tsCompile";
+import { defaultLogger } from "../../common/logging.js";
+import { tsCompile } from "../tsCompile.js";
 
 const { log, errorLog: error } = defaultLogger;
 

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidUtils.ts
@@ -12,13 +12,13 @@ import registerDebug from "debug";
 import { readJson } from "fs-extra";
 import { lilconfigSync } from "lilconfig";
 
-import { defaultLogger } from "../common/logging";
-import { commonOptions } from "./commonOptions";
+import { defaultLogger } from "../common/logging.js";
+import { commonOptions } from "./commonOptions.js";
 import {
 	DEFAULT_FLUIDBUILD_CONFIG,
 	FLUIDBUILD_CONFIG_VERSION,
 	type IFluidBuildConfig,
-} from "./fluidBuildConfig";
+} from "./fluidBuildConfig.js";
 
 // switch to regular import once building ESM
 const findUp = import("find-up");

--- a/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
@@ -5,7 +5,7 @@
 
 import { readFile } from "node:fs/promises";
 import registerDebug from "debug";
-import type { Package } from "../common/npmPackage";
+import type { Package } from "../common/npmPackage.js";
 
 const traceDepCheck = registerDebug("fluid-build:depCheck");
 

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -7,10 +7,10 @@ import { existsSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { defaultLogger } from "../common/logging";
-import { commonOptionString, parseOption } from "./commonOptions";
-import type { IPackageMatchedOptions } from "./fluidRepoBuild";
-import { defaultBuildTaskName, defaultCleanTaskName } from "./fluidTaskDefinitions";
+import { defaultLogger } from "../common/logging.js";
+import { commonOptionString, parseOption } from "./commonOptions.js";
+import type { IPackageMatchedOptions } from "./fluidRepoBuild.js";
+import { defaultBuildTaskName, defaultCleanTaskName } from "./fluidTaskDefinitions.js";
 
 const { log, errorLog } = defaultLogger;
 

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/groupTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/groupTask.ts
@@ -5,11 +5,11 @@
 
 import type { AsyncPriorityQueue } from "async";
 
-import type { BuildContext } from "../buildContext";
-import type { BuildPackage } from "../buildGraph";
-import { BuildResult } from "../buildResult";
-import type { LeafTask } from "./leaf/leafTask";
-import { Task, type TaskExec } from "./task";
+import type { BuildContext } from "../buildContext.js";
+import type { BuildPackage } from "../buildGraph.js";
+import { BuildResult } from "../buildResult.js";
+import type { LeafTask } from "./leaf/leafTask.js";
+import { Task, type TaskExec } from "./task.js";
 
 export class GroupTask extends Task {
 	constructor(

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/biomeTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/biomeTasks.ts
@@ -6,8 +6,8 @@
 import {
 	type BiomeConfigReader,
 	createBiomeConfigReader,
-} from "../../../common/biomeConfigUtils";
-import { LeafWithFileStatDoneFileTask } from "./leafTask";
+} from "../../../common/biomeConfigUtils.js";
+import { LeafWithFileStatDoneFileTask } from "./leafTask.js";
 
 /**
  * This task enables incremental build support for Biome formatting tasks. It reads Biome configuration files to load

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/declarativeTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/declarativeTask.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import type { BuildContext } from "../../buildContext";
-import type { BuildPackage } from "../../buildGraph";
+import type { BuildContext } from "../../buildContext.js";
+import type { BuildPackage } from "../../buildGraph.js";
 import {
 	type DeclarativeTask,
 	gitignoreDefaultValue,
 	replaceRepoRootTokens,
-} from "../../fluidBuildConfig";
-import type { GitIgnoreSetting } from "../../fluidTaskDefinitions";
-import { LeafWithGlobInputOutputDoneFileTask } from "./leafTask";
+} from "../../fluidBuildConfig.js";
+import type { GitIgnoreSetting } from "../../fluidTaskDefinitions.js";
+import { LeafWithGlobInputOutputDoneFileTask } from "./leafTask.js";
 
 export class DeclarativeLeafTask extends LeafWithGlobInputOutputDoneFileTask {
 	constructor(

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/flubTasks.ts
@@ -6,9 +6,9 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { GitRepo } from "../../../common/gitRepo";
-import { sha256 } from "../../hash";
-import { LeafWithDoneFileTask } from "./leafTask";
+import { GitRepo } from "../../../common/gitRepo.js";
+import { sha256 } from "../../hash.js";
+import { LeafWithDoneFileTask } from "./leafTask.js";
 
 export class FlubListTask extends LeafWithDoneFileTask {
 	private getReleaseGroup(): string | undefined {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/generateEntrypointsTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/generateEntrypointsTask.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { getInstalledPackageVersion } from "../taskUtils";
-import { TscDependentTask } from "./tscTask";
+import { getInstalledPackageVersion } from "../taskUtils.js";
+import { TscDependentTask } from "./tscTask.js";
 
 export class GenerateEntrypointsTask extends TscDependentTask {
 	protected get taskSpecificConfigFiles(): string[] {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -12,26 +12,26 @@ import registerDebug from "debug";
 import * as path from "path";
 import chalk from "picocolors";
 
-import { defaultLogger } from "../../../common/logging";
+import { defaultLogger } from "../../../common/logging.js";
 import {
 	type ExecAsyncResult,
 	execAsync,
 	getExecutableFromCommand,
-} from "../../../common/utils";
-import type { BuildContext } from "../../buildContext";
-import type { BuildPackage } from "../../buildGraph";
-import type { Seconds } from "../../buildMetrics";
-import { TaskCacheOutcome } from "../../buildMetrics";
-import { BuildResult, summarizeBuildResult } from "../../buildResult";
+} from "../../../common/utils.js";
+import type { BuildContext } from "../../buildContext.js";
+import type { BuildPackage } from "../../buildGraph.js";
+import type { Seconds } from "../../buildMetrics.js";
+import { TaskCacheOutcome } from "../../buildMetrics.js";
+import { BuildResult, summarizeBuildResult } from "../../buildResult.js";
 import {
 	type GitIgnoreSettingValue,
 	gitignoreDefaultValue,
 	replaceRepoRootToken,
-} from "../../fluidBuildConfig";
-import type { GitIgnoreSetting } from "../../fluidTaskDefinitions";
-import { options } from "../../options";
-import { Task, type TaskExec } from "../task";
-import { globWithGitignore } from "../taskUtils";
+} from "../../fluidBuildConfig.js";
+import type { GitIgnoreSetting } from "../../fluidTaskDefinitions.js";
+import { options } from "../../options.js";
+import { Task, type TaskExec } from "../task.js";
+import { globWithGitignore } from "../taskUtils.js";
 
 const { log } = defaultLogger;
 const traceTaskTrigger = registerDebug("fluid-build:task:trigger");

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { getEsLintConfigFilePath, getInstalledPackageVersion } from "../taskUtils";
-import { TscDependentTask } from "./tscTask";
+import { getEsLintConfigFilePath, getInstalledPackageVersion } from "../taskUtils.js";
+import { TscDependentTask } from "./tscTask.js";
 
 export class EsLintTask extends TscDependentTask {
 	private _configFileFullPath: string | undefined;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -7,11 +7,11 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 
 import picomatch from "picomatch";
-import { getTypeTestPreviousPackageDetails } from "../../../common/typeTests";
-import type { BuildContext } from "../../buildContext";
-import type { BuildPackage } from "../../buildGraph";
-import { globFn, toPosixPath } from "../taskUtils";
-import { LeafTask, LeafWithFileStatDoneFileTask } from "./leafTask";
+import { getTypeTestPreviousPackageDetails } from "../../../common/typeTests.js";
+import type { BuildContext } from "../../buildContext.js";
+import type { BuildPackage } from "../../buildGraph.js";
+import { globFn, toPosixPath } from "../taskUtils.js";
+import { LeafTask, LeafWithFileStatDoneFileTask } from "./leafTask.js";
 
 function unquote(str: string): string {
 	if (str.length >= 2 && str[0] === '"' && str[str.length - 1] === '"') {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
@@ -8,10 +8,10 @@ import { readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 import ignore from "ignore";
 
-import type { BuildContext } from "../../buildContext";
-import type { BuildPackage } from "../../buildGraph";
-import { getInstalledPackageVersion, getRecursiveFiles, globFn } from "../taskUtils";
-import { LeafWithDoneFileTask } from "./leafTask";
+import type { BuildContext } from "../../buildContext.js";
+import type { BuildPackage } from "../../buildGraph.js";
+import { getInstalledPackageVersion, getRecursiveFiles, globFn } from "../taskUtils.js";
+import { LeafWithDoneFileTask } from "./leafTask.js";
 
 export class PrettierTask extends LeafWithDoneFileTask {
 	private parsed: boolean = false;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/ts2EsmTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/ts2EsmTask.ts
@@ -8,8 +8,8 @@ import path from "node:path";
 import * as JSON5 from "json5";
 import type { TsConfigJson } from "type-fest";
 
-import { globFn } from "../taskUtils";
-import { LeafWithFileStatDoneFileTask } from "./leafTask";
+import { globFn } from "../taskUtils.js";
+import { LeafWithFileStatDoneFileTask } from "./leafTask.js";
 
 export class Ts2EsmTask extends LeafWithFileStatDoneFileTask {
 	/**

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -11,9 +11,9 @@ import isEqual from "lodash.isequal";
 import type * as ts54Types from "typescript-5.4";
 import type * as ts59Types from "typescript-5.9";
 
-import { getTscUtils, type TscUtil } from "../../tscUtils";
-import { getInstalledPackageVersion } from "../taskUtils";
-import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
+import { getTscUtils, type TscUtil } from "../../tscUtils.js";
+import { getInstalledPackageVersion } from "../taskUtils.js";
+import { LeafTask, LeafWithDoneFileTask } from "./leafTask.js";
 
 type tsTypes = typeof ts54Types | typeof ts59Types;
 type tsParsedCommandLine = ts54Types.ParsedCommandLine | ts59Types.ParsedCommandLine;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/webpackTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/webpackTask.ts
@@ -7,8 +7,8 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 
-import { globFn, loadModule, toPosixPath } from "../taskUtils";
-import { LeafWithDoneFileTask } from "./leafTask";
+import { globFn, loadModule, toPosixPath } from "../taskUtils.js";
+import { LeafWithDoneFileTask } from "./leafTask.js";
 
 interface DoneFileContent {
 	version: string;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/task.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/task.ts
@@ -6,12 +6,12 @@
 import * as assert from "assert";
 import { type AsyncPriorityQueue, priorityQueue } from "async";
 import registerDebug from "debug";
-import type { Package } from "../../common/npmPackage";
-import type { BuildContext } from "../buildContext";
-import type { BuildPackage } from "../buildGraph";
-import { BuildResult } from "../buildResult";
-import { options } from "../options";
-import type { LeafTask } from "./leaf/leafTask";
+import type { Package } from "../../common/npmPackage.js";
+import type { BuildContext } from "../buildContext.js";
+import type { BuildPackage } from "../buildGraph.js";
+import { BuildResult } from "../buildResult.js";
+import { options } from "../options.js";
+import type { LeafTask } from "./leaf/leafTask.js";
 
 const traceTaskInit = registerDebug("fluid-build:task:init");
 const traceTaskExec = registerDebug("fluid-build:task:exec");

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -3,19 +3,19 @@
  * Licensed under the MIT License.
  */
 
-import { getExecutableFromCommand } from "../../common/utils";
-import type { BuildContext } from "../buildContext";
-import type { BuildPackage } from "../buildGraph";
-import type { TaskFileDependencies } from "../fluidTaskDefinitions";
-import { isConcurrentlyCommand, parseConcurrentlyCommand } from "../parseCommands";
-import { GroupTask } from "./groupTask";
-import { ApiExtractorTask } from "./leaf/apiExtractorTask";
-import { BiomeTask } from "./leaf/biomeTasks";
-import { DeclarativeLeafTask } from "./leaf/declarativeTask";
-import { FlubCheckLayerTask, FlubCheckPolicyTask, FlubListTask } from "./leaf/flubTasks";
+import { getExecutableFromCommand } from "../../common/utils.js";
+import type { BuildContext } from "../buildContext.js";
+import type { BuildPackage } from "../buildGraph.js";
+import type { TaskFileDependencies } from "../fluidTaskDefinitions.js";
+import { isConcurrentlyCommand, parseConcurrentlyCommand } from "../parseCommands.js";
+import { GroupTask } from "./groupTask.js";
+import { ApiExtractorTask } from "./leaf/apiExtractorTask.js";
+import { BiomeTask } from "./leaf/biomeTasks.js";
+import { DeclarativeLeafTask } from "./leaf/declarativeTask.js";
+import { FlubCheckLayerTask, FlubCheckPolicyTask, FlubListTask } from "./leaf/flubTasks.js";
 import { GenerateEntrypointsTask } from "./leaf/generateEntrypointsTask.js";
-import { type LeafTask, UnknownLeafTask } from "./leaf/leafTask";
-import { EsLintTask } from "./leaf/lintTasks";
+import { type LeafTask, UnknownLeafTask } from "./leaf/leafTask.js";
+import { EsLintTask } from "./leaf/lintTasks.js";
 import {
 	CopyfilesTask,
 	DepCruiseTask,
@@ -24,13 +24,13 @@ import {
 	GoodFence,
 	LesscTask,
 	TypeValidationTask,
-} from "./leaf/miscTasks";
-import { PrettierTask } from "./leaf/prettierTask";
-import { Ts2EsmTask } from "./leaf/ts2EsmTask";
-import { TscTask } from "./leaf/tscTask";
-import { WebpackTask } from "./leaf/webpackTask";
-import type { Task } from "./task";
-import type { TaskHandler } from "./taskHandlers";
+} from "./leaf/miscTasks.js";
+import { PrettierTask } from "./leaf/prettierTask.js";
+import { Ts2EsmTask } from "./leaf/ts2EsmTask.js";
+import { TscTask } from "./leaf/tscTask.js";
+import { WebpackTask } from "./leaf/webpackTask.js";
+import type { Task } from "./task.js";
+import type { TaskHandler } from "./taskHandlers.js";
 
 // Map of executable name to LeafTasks
 const executableToLeafTask: {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskHandlers.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskHandlers.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type { BuildContext } from "../buildContext";
-import type { BuildPackage } from "../buildGraph";
-import type { LeafTask } from "./leaf/leafTask";
+import type { BuildContext } from "../buildContext.js";
+import type { BuildPackage } from "../buildGraph.js";
+import type { LeafTask } from "./leaf/leafTask.js";
 
 /**
  * The definition of a constructor function that returns a LeafTask subclass.

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskUtils.ts
@@ -10,8 +10,8 @@ import * as glob from "glob";
 import globby from "globby";
 import * as path from "path";
 
-import type { PackageJson } from "../../common/npmPackage";
-import { lookUpDirSync } from "../../common/utils";
+import type { PackageJson } from "../../common/npmPackage.js";
+import { lookUpDirSync } from "../../common/utils.js";
 
 export function getEsLintConfigFilePath(dir: string): string | undefined {
 	// ESLint 9 flat config files (checked first as they take precedence)

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { WorkerExecResult, WorkerMessage } from "./worker";
+import type { WorkerExecResult, WorkerMessage } from "./worker.js";
 
 export async function lint(message: WorkerMessage): Promise<WorkerExecResult> {
 	const oldArgv = process.argv;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/worker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/worker.ts
@@ -5,9 +5,9 @@
 
 import { parentPort } from "worker_threads";
 
-import { apiExtractorWorker } from "./apiExtractorWorker";
-import { lint } from "./eslintWorker";
-import { compile, fluidCompile } from "./tscWorker";
+import { apiExtractorWorker } from "./apiExtractorWorker.js";
+import { lint } from "./eslintWorker.js";
+import { compile, fluidCompile } from "./tscWorker.js";
 
 export interface WorkerMessage {
 	workerName: string;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/workerPool.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/workerPool.ts
@@ -9,7 +9,7 @@ import { freemem } from "node:os";
 import type { Readable } from "node:stream";
 import { Worker } from "node:worker_threads";
 
-import type { WorkerExecResult, WorkerMessage } from "./worker";
+import type { WorkerExecResult, WorkerMessage } from "./worker.js";
 
 export interface WorkerExecResultWithOutput extends WorkerExecResult {
 	stdout: string;

--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type * as ts54Types from "typescript-5.4";
 import type * as ts59Types from "typescript-5.9";
-import { sha256 } from "./hash";
+import { sha256 } from "./hash.js";
 
 type tsTypes = typeof ts54Types | typeof ts59Types;
 

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-export { GitRepo } from "./common/gitRepo";
-export type { Logger } from "./common/logging";
-export { MonoRepo } from "./common/monoRepo";
+export { GitRepo } from "./common/gitRepo.js";
+export type { Logger } from "./common/logging.js";
+export { MonoRepo } from "./common/monoRepo.js";
 export {
 	Package,
 	type PackageJson,
-} from "./common/npmPackage";
+} from "./common/npmPackage.js";
 /**
  * The types defined here cannot be in build-cli because it is an ESM-only package, and these types are imported in
  * packages that are dual-emit or CJS-only. Long term these types should move to a shared library between build-cli and
@@ -21,19 +21,19 @@ export type {
 	requireAssignableTo,
 	SkipUniqueSymbols,
 	TypeOnly,
-} from "./common/typeCompatibility";
-export { getTypeTestPreviousPackageDetails } from "./common/typeTests";
-export { type IFluidBuildConfig } from "./fluidBuild/fluidBuildConfig";
-export { type IFluidCompatibilityMetadata } from "./fluidBuild/fluidCompatMetadata";
-export { FluidRepo } from "./fluidBuild/fluidRepo";
+} from "./common/typeCompatibility.js";
+export { getTypeTestPreviousPackageDetails } from "./common/typeTests.js";
+export { type IFluidBuildConfig } from "./fluidBuild/fluidBuildConfig.js";
+export { type IFluidCompatibilityMetadata } from "./fluidBuild/fluidCompatMetadata.js";
+export { FluidRepo } from "./fluidBuild/fluidRepo.js";
 // For repo policy check
 export {
 	getTaskDefinitions,
 	normalizeGlobalTaskDefinitions,
-} from "./fluidBuild/fluidTaskDefinitions";
-export { getFluidBuildConfig, getResolvedFluidRoot } from "./fluidBuild/fluidUtils";
+} from "./fluidBuild/fluidTaskDefinitions.js";
+export { getFluidBuildConfig, getResolvedFluidRoot } from "./fluidBuild/fluidUtils.js";
 export {
 	getApiExtractorConfigFilePath,
 	getEsLintConfigFilePath,
-} from "./fluidBuild/tasks/taskUtils";
-export * as TscUtils from "./fluidBuild/tscUtils";
+} from "./fluidBuild/tasks/taskUtils.js";
+export * as TscUtils from "./fluidBuild/tscUtils.js";

--- a/build-tools/packages/build-tools/src/test/biome2Config.test.ts
+++ b/build-tools/packages/build-tools/src/test/biome2Config.test.ts
@@ -14,10 +14,10 @@ import {
 	getBiome2FormattedFilesFromDirectory,
 	getOrderedPatternsFromBiome2Config,
 	loadBiome2Config,
-} from "../common/biome2Config";
-import { GitRepo } from "../common/gitRepo";
-import { getResolvedFluidRoot } from "../fluidBuild/fluidUtils";
-import { testDataPath } from "./init";
+} from "../common/biome2Config.js";
+import { GitRepo } from "../common/gitRepo.js";
+import { getResolvedFluidRoot } from "../fluidBuild/fluidUtils.js";
+import { testDataPath } from "./init.js";
 
 describe("Biome 2.x config loading", () => {
 	describe("Biome2ConfigReader class", () => {

--- a/build-tools/packages/build-tools/src/test/biomeConfig.test.ts
+++ b/build-tools/packages/build-tools/src/test/biomeConfig.test.ts
@@ -9,19 +9,19 @@
 
 import { strict as assert } from "node:assert/strict";
 import path from "node:path";
-import { Biome2ConfigReader } from "../common/biome2Config";
+import { Biome2ConfigReader } from "../common/biome2Config.js";
 import {
 	BiomeConfigReaderV1,
 	type BiomeConfigResolved,
 	getBiomeFormattedFilesFromDirectory,
 	getSettingValuesFromBiomeConfig,
 	loadBiomeConfig,
-} from "../common/biomeConfig";
-import type { Configuration as BiomeConfigOnDisk } from "../common/biomeConfigTypes";
-import { createBiomeConfigReader } from "../common/biomeConfigUtils";
-import { GitRepo } from "../common/gitRepo";
-import { getResolvedFluidRoot } from "../fluidBuild/fluidUtils";
-import { testDataPath } from "./init";
+} from "../common/biomeConfig.js";
+import type { Configuration as BiomeConfigOnDisk } from "../common/biomeConfigTypes.js";
+import { createBiomeConfigReader } from "../common/biomeConfigUtils.js";
+import { GitRepo } from "../common/gitRepo.js";
+import { getResolvedFluidRoot } from "../fluidBuild/fluidUtils.js";
+import { testDataPath } from "./init.js";
 
 describe("Biome config loading", () => {
 	describe("BiomeConfigReaderV1 class", () => {

--- a/build-tools/packages/build-tools/src/test/biomeVersion.test.ts
+++ b/build-tools/packages/build-tools/src/test/biomeVersion.test.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert/strict";
 import path from "node:path";
-import { detectBiomeVersion } from "../common/biomeVersion";
-import { testDataPath } from "./init";
+import { detectBiomeVersion } from "../common/biomeVersion.js";
+import { testDataPath } from "./init.js";
 
 describe("biomeVersion", () => {
 	describe("detectBiomeVersion", () => {

--- a/build-tools/packages/build-tools/src/test/globPatterns.test.ts
+++ b/build-tools/packages/build-tools/src/test/globPatterns.test.ts
@@ -8,8 +8,8 @@ import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach } from "mocha";
-import { globFn, globWithGitignore, toPosixPath } from "../fluidBuild/tasks/taskUtils";
-import { testDataPath } from "./init";
+import { globFn, globWithGitignore, toPosixPath } from "../fluidBuild/tasks/taskUtils.js";
+import { testDataPath } from "./init.js";
 
 const globTestDataPath = path.resolve(testDataPath, "glob");
 

--- a/build-tools/packages/build-tools/src/test/npmPackage.test.ts
+++ b/build-tools/packages/build-tools/src/test/npmPackage.test.ts
@@ -6,8 +6,8 @@
 import * as path from "node:path";
 import { strict as assert } from "assert";
 
-import { type PackageJson, readPackageJsonAndIndent } from "../common/npmPackage";
-import { testDataPath } from "./init";
+import { type PackageJson, readPackageJsonAndIndent } from "../common/npmPackage.js";
+import { testDataPath } from "./init.js";
 
 /**
  * A transformer function that does nothing.

--- a/build-tools/packages/build-tools/src/test/repoRootToken.test.ts
+++ b/build-tools/packages/build-tools/src/test/repoRootToken.test.ts
@@ -8,7 +8,7 @@ import {
 	REPO_ROOT_TOKEN,
 	replaceRepoRootToken,
 	replaceRepoRootTokens,
-} from "../fluidBuild/fluidBuildConfig";
+} from "../fluidBuild/fluidBuildConfig.js";
 
 describe("Repo Root Token", () => {
 	const testRepoRoot = "/home/user/repo";

--- a/build-tools/packages/build-tools/src/test/taskDefinitions.test.ts
+++ b/build-tools/packages/build-tools/src/test/taskDefinitions.test.ts
@@ -4,12 +4,12 @@
  */
 
 import { strict as assert } from "assert";
-import type { PackageJson } from "../common/npmPackage";
+import type { PackageJson } from "../common/npmPackage.js";
 import {
 	getTaskDefinitions,
 	normalizeGlobalTaskDefinitions,
 	type TaskDefinitionsOnDisk,
-} from "../fluidBuild/fluidTaskDefinitions";
+} from "../fluidBuild/fluidTaskDefinitions.js";
 
 describe("Task Definitions", () => {
 	describe("File Dependencies Extension", () => {


### PR DESCRIPTION
## Description

Adds explicit `.js` file extensions to all relative `import` and `export` specifiers in `@fluidframework/build-tools/src/**/*.ts` (192 specifiers across 50 files).

The package's `tsconfig.json` already uses `"module": "node16"` / `"moduleResolution": "node16"`, under which:
- **CommonJS packages** (the current state): `.js` extensions on relative imports are *accepted* by the resolver and emitted as-is in the `require(...)` calls — which Node CJS happily resolves to the actual `.js` files.
- **ESM packages**: `.js` extensions are *required*.

So this change is a behavioral no-op today but unblocks a later flip to `"type": "module"` without simultaneously rewriting every import in one mega-diff. It also aligns with the convention already in use across the rest of the repo's ESM packages.

### Validation

From `build-tools/packages/build-tools`:
- `pnpm run tsc` — clean
- `pnpm run eslint` — clean
- `pnpm test:mocha` — 137/137 passing
- `pnpm build core-utils` from the repo root — full client-release-group build still succeeds, `fluid-build` / `fluid-tsc` / leaf tasks all run normally

No `.cts`/`.cjs` files were touched (those already use the correct extension), and no bare-specifier imports were modified.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Mechanical change — easiest to review by spot-checking a few files and confirming the diff only adds `.js` to relative specifiers.
