### PR TITLE
build(eslint-config-fluid): bump version to 12

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [12.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v12.0.0)
+
+<!-- Add new changelog entries here. -->
+
 ## [11.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v11.0.0)
 
 ### Breaking: node 22 is now the minimum supported node version

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "11.0.0",
+	"version": "12.0.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumps the eslint-config-fluid version to 12 so we can release 11.0.0.