### PR TITLE
ci: build CommonJS test-version-utils for perf runs

### DIFF
--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -137,7 +137,12 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"fluidBuild": {
+		"_tasks_comment": "build:esnext is configured to depend on tsc task as mocharc-common.cjs require()s ./dist/compatOptions.js at mocha runtime. Building CommonJS when ESM is requested ensures the CommonJS expectation is satisfied.",
 		"tasks": {
+			"build:esnext": [
+				"...",
+				"tsc"
+			],
 			"check:exports:index": [
 				"build:esnext"
 			]

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -137,12 +137,7 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"fluidBuild": {
-		"_tasks_comment": "build:esnext is configured to depend on tsc task as mocharc-common.cjs requires ./dist/compatOptions.js at mocha runtime. Building CommonJS when ESM is requested ensures the CommonJS expectation is satisfied.",
 		"tasks": {
-			"build:esnext": [
-				"...",
-				"tsc"
-			],
 			"check:exports:index": [
 				"build:esnext"
 			]

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -137,7 +137,7 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"fluidBuild": {
-		"_tasks_comment": "build:esnext is configured to depend on tsc task as mocharc-common.cjs require()s ./dist/compatOptions.js at mocha runtime. Building CommonJS when ESM is requested ensures the CommonJS expectation is satisfied.",
+		"_tasks_comment": "build:esnext is configured to depend on tsc task as mocharc-common.cjs requires ./dist/compatOptions.js at mocha runtime. Building CommonJS when ESM is requested ensures the CommonJS expectation is satisfied.",
 		"tasks": {
 			"build:esnext": [
 				"...",

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -158,6 +158,18 @@ stages:
             packageManagerInstallCommand: pnpm install
             primaryRegistry: $(ado-feeds-ff-download-only)
 
+        # Pre-build test-version-utils so its CommonJS sibling (dist/compatOptions.js) exists when
+        # mocha loads .mocharc.cjs -> test-version-utils/mocharc-common.cjs at test time.
+        # TODO: remove once mocharc-common.cjs no longer requires its own CJS sibling at runtime.
+        - task: Bash@3
+          displayName: Pre-build test-version-utils CommonJS (perf-pipeline temp workaround)
+          inputs:
+            targetType: 'inline'
+            workingDirectory: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
+            script: |
+              set -eu -o pipefail
+              pnpm exec fluid-build packages/test/test-version-utils --task compile --worker
+
         # Build the workspace so compiled test code is available for benchmarks
         - task: Bash@3
           displayName: Build workspace


### PR DESCRIPTION
## Description

Fixes the Performance benchmarks pipeline (`perf_e2e_local`, `perf_e2e_frs`, `perf_e2e_odsp`),
which has failed continuously on `main` since #27265 with:

Error: Unable to read/parse .../test-end-to-end-tests/.mocharc.cjs:
Error: Cannot find module './dist/compatOptions.js'

### Root cause

The perf pipeline runs `pnpm exec fluid-build --nolint --task build:test:esm --worker`.
`@fluid-private/test-version-utils/mocharc-common.cjs` `require()`s its own `./dist/compatOptions.js` (CommonJS) at mocha load time, but #27265 narrowed `test-end-to-end-tests`'s `build:test:esm` override from `"^tsc"` (every ancestor's CJS build) to a single explicit ancestor, dropping the transitive CJS build of `test-version-utils`. The CJS artifact stopped being produced and mocha failed to load its config.

 ### Fix

Add a one-time pre-build step in `tools/pipelines/test-perf-benchmarks.yml` that runs
`fluid-build packages/test/test-version-utils --task compile` before the main
`build:test:esm` step. This warms `test-version-utils`'s `dist/` so the runtime
`require()` from `mocharc-common.cjs` resolves.

Because the new step lives inside the `${{ each job in parameters.benchmarkJobs }}:`
template, the single source-line addition applies to all 5 stages.