### PR TITLE
Fix end to end perf tests, adding missing build dependency.

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -148,12 +148,13 @@
 		"typescript": "~5.4.5"
 	},
 	"fluidBuild": {
-		"_tasks_comment": "test-driver-definitions CJS build is required for ESM builds as test-driver-definitions is globally imported via TypeScript \"types\" module which only resolves CJS types (at least as of TS 5.4).",
+		"_tasks_comment": "test-driver-definitions CJS build is required for ESM builds as test-driver-definitions is globally imported via TypeScript \"types\" module which only resolves CJS types (at least as of TS 5.4). test-version-utils CJS build is required because mocharc-common.cjs requires ./dist/compatOptions.js which is produced by its tsc task.",
 		"tasks": {
 			"build:test:esm": [
 				"^build:esnext",
 				"build:genver",
-				"@fluid-internal/test-driver-definitions#tsc"
+				"@fluid-internal/test-driver-definitions#tsc",
+				"@fluid-private/test-version-utils#tsc"
 			]
 		}
 	},


### PR DESCRIPTION
## Description

This fixes failing Perforance benchmarks pipeline (example error from a recent commit): https://dev.azure.com/fluidframework/internal/_build/results?buildId=401966&view=logs&j=e3692cd0-efaa-5893-0f26-144e0d777cf6&t=f2c96dea-05f0-5622-1b27-0012e536e036

This solution was worked out by copilot, and might not be ideal: I do not fully understand the situation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
