### PR TITLE
tree: Fix bug with updating node parentage in sequence composition

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -473,6 +473,7 @@ function handleNodeChanges(
 	moveEffects: MoveEffectTable,
 ): NodeId | undefined {
 	if (newMark.changes !== undefined) {
+		moveEffects.onMoveIn(newMark.changes);
 		const baseSource = getMoveIn(baseMark);
 
 		// TODO: Make sure composeChild is not called twice on the node changes.
@@ -664,7 +665,6 @@ function getModifyAfter(
 	const effect = getMoveEffect(moveEffects, target, revision, id, 1);
 
 	if (effect.value?.modifyAfter !== undefined) {
-		moveEffects.onMoveIn(effect.value.modifyAfter);
 		return effect.value.modifyAfter;
 	}
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -589,10 +589,6 @@ export class ComposeQueue {
 	private dequeueBase(length: number = Number.POSITIVE_INFINITY): ComposeMarks {
 		const baseMark = this.baseMarks.dequeueUpTo(length);
 		const movedChanges = getMovedChangesFromMark(this.moveEffects, baseMark);
-		if (movedChanges !== undefined) {
-			this.moveEffects.onMoveIn(movedChanges);
-		}
-
 		const newMark = createNoopMark(baseMark.count, movedChanges, getOutputCellId(baseMark));
 		return { baseMark, newMark };
 	}
@@ -668,6 +664,7 @@ function getModifyAfter(
 	const effect = getMoveEffect(moveEffects, target, revision, id, 1);
 
 	if (effect.value?.modifyAfter !== undefined) {
+		moveEffects.onMoveIn(effect.value.modifyAfter);
 		return effect.value.modifyAfter;
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
@@ -242,7 +242,7 @@ const dummyCrossFieldManager: CrossFieldManager = {
 		length: count,
 	}),
 	set: () => assert.fail("Not supported"),
-	onMoveIn: () => assert.fail("Not supported"),
+	onMoveIn: () => {},
 	moveKey: () => assert.fail("Not supported"),
 };
 


### PR DESCRIPTION
## Description

Fixed a bug where sequence field failed to call `onMoveIn` in some cases when moving a node changeset during composition. This would lead to the composed changeset having incorrect node ancestry information, which could cause problems during other operations.