### PR TITLE
ci(client): remove CJS compile to run ESM tests

### DIFF
--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -22,7 +22,8 @@ exports to get the versioned Fluid APIs.
 
 ## Use requirements
 
-To use provided mocha configuration generation, Node v22.18 or later is required.
+To use provided mocha configuration generation, Node v22.22.2 or later is required.
+<!-- Only 22.18 is actually required, but `syncpack lint` is unhappy with 22.18.0. -->
 
 ## Versioned combination test generation
 

--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -20,6 +20,10 @@ exports to get the versioned Fluid APIs.
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
+## Use requirements
+
+To use provided mocha configuration generation, Node v22.18 or later is required.
+
 ## Versioned combination test generation
 
 ### Layer version combinations

--- a/packages/test/test-version-utils/mocharc-common.cjs
+++ b/packages/test/test-version-utils/mocharc-common.cjs
@@ -4,6 +4,7 @@
  */
 
 "use strict";
+// Note: this uses Node 22+'s native TS support. See https://nodejs.org/learn/typescript/run-natively.
 const options = require("./src/compatOptions.ts");
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 

--- a/packages/test/test-version-utils/mocharc-common.cjs
+++ b/packages/test/test-version-utils/mocharc-common.cjs
@@ -4,7 +4,7 @@
  */
 
 "use strict";
-const options = require("./dist/compatOptions.js");
+const options = require("./src/compatOptions.ts");
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 function getFluidTestVariant() {

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -12,9 +12,6 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"type": "module",
-	"engines": {
-		"node": ">=22.18.0"
-	},
 	"exports": {
 		".": {
 			"types": "./lib/index.d.ts",
@@ -138,6 +135,9 @@
 		"uuid": "^11.1.0",
 		"webpack": "^5.94.0",
 		"webpack-cli": "^5.1.4"
+	},
+	"engines": {
+		"node": ">=22.18.0"
 	},
 	"fluidBuild": {
 		"tasks": {

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -137,7 +137,7 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"engines": {
-		"node": ">=22.18.0"
+		"node": ">=22.22.2"
 	},
 	"fluidBuild": {
 		"tasks": {

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -12,6 +12,9 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"type": "module",
+	"engines": {
+		"node": ">=22.18.0"
+	},
 	"exports": {
 		".": {
 			"types": "./lib/index.d.ts",


### PR DESCRIPTION
Leverage Node 22 https://nodejs.org/learn/typescript/run-natively mode to avoid need to compile compatOptions.ts for CJS to run ESM tests.

This addresses pipeline failure from recent scoped build improvements in #27265.