### PR TITLE
feat(container-runtime): re-enable batchId tracking by default

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1897,7 +1897,8 @@ export class ContainerRuntime
 		// Grouped batching is required because resubmits can produce empty batches that must
 		// still be sent on the wire as a placeholder grouped batch to preserve their batchId
 		// (see OpGroupingManager.createEmptyGroupedBatch / outbox.flushEmptyBatch).
-		// Offline Load requires both prerequisites, so a consumer that opts into it without
+		// Offline Load requires all three prerequisites (TurnBased, grouped batching, and
+		// batchId tracking not killed by config), so a consumer that opts into it without
 		// them gets an explicit UsageError rather than silent degradation.
 		const offlineLoadRequested =
 			this.mc.config.getBoolean("Fluid.Container.enableOfflineFull") === true;
@@ -1911,6 +1912,13 @@ export class ContainerRuntime
 		}
 		if (offlineLoadRequested && !this.groupedBatchingEnabled) {
 			const error = new UsageError("Offline mode requires grouped batching to be enabled");
+			this.closeFn(error);
+			throw error;
+		}
+		if (offlineLoadRequested && disableBatchIdTracking) {
+			const error = new UsageError(
+				"Offline mode requires batchId tracking; remove Fluid.ContainerRuntime.DisableBatchIdTracking",
+			);
 			this.closeFn(error);
 			throw error;
 		}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3157,40 +3157,44 @@ export class ContainerRuntime
 				const batchStart: BatchStartInfo = inboundResult.batchStart;
 				const result = this.duplicateBatchDetector?.processInboundBatch(batchStart);
 				if (result?.duplicate === true) {
+					const error = new DataCorruptionError(
+						"Duplicate batch - The same batch was sequenced twice",
+						{ batchId: batchStart.batchId },
+					);
+
+					this.mc.logger.sendTelemetryEvent(
+						{
+							eventName: "DuplicateBatch",
+							details: {
+								batchId: batchStart.batchId,
+								batchIdExplicit: batchStart.batchId !== undefined,
+								clientId: batchStart.clientId,
+								batchStartCsn: batchStart.batchStartCsn,
+								size: inboundResult.length,
+								duplicateBatchSequenceNumber: result.otherSequenceNumber,
+								// Identifying info for the ORIGINAL occurrence of this batch, so we can
+								// disambiguate the duplicate's source (e.g. resubmit vs fresh submit, same
+								// vs different wire clientId). Undefined fields indicate the original was
+								// loaded from a summary snapshot rather than seen at runtime.
+								otherClientId: result.otherBatchInfo?.clientId,
+								otherBatchStartCsn: result.otherBatchInfo?.batchStartCsn,
+								otherBatchIdExplicit: result.otherBatchInfo?.batchIdExplicit,
+								otherFromSnapshot: result.otherBatchInfo === undefined,
+								...extractSafePropertiesFromMessage(batchStart.keyMessage),
+								// For grouped batches, `keyMessage` is one of the sub-messages produced by
+								// `OpGroupingManager.ungroupOp`, which overwrites `clientSequenceNumber`
+								// with a synthetic counter (1, 2, 3, ...). Override with the real outer
+								// envelope's clientSequenceNumber so downstream telemetry doesn't get a
+								// misleading "fake csn" value.
+								messageClientSequenceNumber: batchStart.batchStartCsn,
+							},
+						},
+						error,
+					);
 					// Due to a live incident where we had a bug in the service that caused duplicate batches to be sent to clients, we want to log when we detect a duplicate batch, but we don't want to throw an error
 					// as it could hit the same service bug. We need to monitor below event to catch legitimate container forking scenarios and reenable throwing the data corruption error once the service bug is fixed and we stop seeing duplicate batches in the wild
 					// or once we are able to identify batch duplication reason (forking vs service bug).
-					// const error = new DataCorruptionError(
-					// 	"Duplicate batch - The same batch was sequenced twice",
-					// 	{ batchId: batchStart.batchId },
-					// );
-
-					this.mc.logger.sendTelemetryEvent({
-						eventName: "DuplicateBatch",
-						details: {
-							batchId: batchStart.batchId,
-							batchIdExplicit: batchStart.batchId !== undefined,
-							clientId: batchStart.clientId,
-							batchStartCsn: batchStart.batchStartCsn,
-							size: inboundResult.length,
-							duplicateBatchSequenceNumber: result.otherSequenceNumber,
-							// Identifying info for the ORIGINAL occurrence of this batch, so we can
-							// disambiguate the duplicate's source (e.g. resubmit vs fresh submit, same
-							// vs different wire clientId). Undefined fields indicate the original was
-							// loaded from a summary snapshot rather than seen at runtime.
-							otherClientId: result.otherBatchInfo?.clientId,
-							otherBatchStartCsn: result.otherBatchInfo?.batchStartCsn,
-							otherBatchIdExplicit: result.otherBatchInfo?.batchIdExplicit,
-							otherFromSnapshot: result.otherBatchInfo === undefined,
-							...extractSafePropertiesFromMessage(batchStart.keyMessage),
-							// For grouped batches, `keyMessage` is one of the sub-messages produced by
-							// `OpGroupingManager.ungroupOp`, which overwrites `clientSequenceNumber`
-							// with a synthetic counter (1, 2, 3, ...). Override with the real outer
-							// envelope's clientSequenceNumber so downstream telemetry doesn't get a
-							// misleading "fake csn" value.
-							messageClientSequenceNumber: batchStart.batchStartCsn,
-						},
-					});
+					// throw error;
 				}
 			}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1890,20 +1890,38 @@ export class ContainerRuntime
 			this.mc.config.getNumber("Fluid.ContainerRuntime.StagingModeAutoFlushThreshold") ??
 			runtimeOptions.stagingModeAutoFlushThreshold ??
 			defaultStagingModeAutoFlushThreshold;
-		this.batchIdTrackingEnabled =
-			this.mc.config.getBoolean("Fluid.Container.enableOfflineFull") ??
-			this.mc.config.getBoolean("Fluid.ContainerRuntime.enableBatchIdTracking") ??
-			false;
+		// BatchId tracking powers DuplicateBatchDetector (catching forked-container duplicates)
+		// and is also a prerequisite for the Offline Load feature. It is enabled by default
+		// when both TurnBased flush mode and grouped batching are active; the kill-switch
+		// below allows disabling it without a code change if a regression is observed.
+		// Grouped batching is required because resubmits can produce empty batches that must
+		// still be sent on the wire as a placeholder grouped batch to preserve their batchId
+		// (see OpGroupingManager.createEmptyGroupedBatch / outbox.flushEmptyBatch).
+		// Offline Load requires both prerequisites, so a consumer that opts into it without
+		// them gets an explicit UsageError rather than silent degradation.
+		const offlineLoadRequested =
+			this.mc.config.getBoolean("Fluid.Container.enableOfflineFull") === true;
+		const disableBatchIdTracking =
+			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableBatchIdTracking") === true;
 
-		if (this.batchIdTrackingEnabled && this._flushMode !== FlushMode.TurnBased) {
+		if (offlineLoadRequested && this._flushMode !== FlushMode.TurnBased) {
 			const error = new UsageError("Offline mode is only supported in turn-based mode");
 			this.closeFn(error);
 			throw error;
 		}
+		if (offlineLoadRequested && !this.groupedBatchingEnabled) {
+			const error = new UsageError("Offline mode requires grouped batching to be enabled");
+			this.closeFn(error);
+			throw error;
+		}
 
-		// DuplicateBatchDetection is only enabled if Offline Load is enabled
-		// It maintains a cache of all batchIds/sequenceNumbers within the collab window.
-		// Don't waste resources doing so if not needed.
+		this.batchIdTrackingEnabled =
+			!disableBatchIdTracking &&
+			this._flushMode === FlushMode.TurnBased &&
+			this.groupedBatchingEnabled;
+
+		// DuplicateBatchDetector maintains a cache of all batchIds/sequenceNumbers within the
+		// collab window. Skip allocating it when batchId tracking is off.
 		if (this.batchIdTrackingEnabled) {
 			this.duplicateBatchDetector = new DuplicateBatchDetector(recentBatchInfo);
 		}
@@ -3131,10 +3149,13 @@ export class ContainerRuntime
 				const batchStart: BatchStartInfo = inboundResult.batchStart;
 				const result = this.duplicateBatchDetector?.processInboundBatch(batchStart);
 				if (result?.duplicate === true) {
-					const error = new DataCorruptionError(
-						"Duplicate batch - The same batch was sequenced twice",
-						{ batchId: batchStart.batchId },
-					);
+					// Due to a live incident where we had a bug in the service that caused duplicate batches to be sent to clients, we want to log when we detect a duplicate batch, but we don't want to throw an error
+					// as it could hit the same service bug. We need to monitor below event to catch legitimate container forking scenarios and reenable throwing the data corruption error once the service bug is fixed and we stop seeing duplicate batches in the wild
+					// or once we are able to identify batch duplication reason (forking vs service bug).
+					// const error = new DataCorruptionError(
+					// 	"Duplicate batch - The same batch was sequenced twice",
+					// 	{ batchId: batchStart.batchId },
+					// );
 
 					this.mc.logger.sendTelemetryEvent(
 						{
@@ -3148,9 +3169,7 @@ export class ContainerRuntime
 								...extractSafePropertiesFromMessage(batchStart.keyMessage),
 							},
 						},
-						error,
 					);
-					throw error;
 				}
 			}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3157,34 +3157,32 @@ export class ContainerRuntime
 					// 	{ batchId: batchStart.batchId },
 					// );
 
-					this.mc.logger.sendTelemetryEvent(
-						{
-							eventName: "DuplicateBatch",
-							details: {
-								batchId: batchStart.batchId,
-								batchIdExplicit: batchStart.batchId !== undefined,
-								clientId: batchStart.clientId,
-								batchStartCsn: batchStart.batchStartCsn,
-								size: inboundResult.length,
-								duplicateBatchSequenceNumber: result.otherSequenceNumber,
-								// Identifying info for the ORIGINAL occurrence of this batch, so we can
-								// disambiguate the duplicate's source (e.g. resubmit vs fresh submit, same
-								// vs different wire clientId). Undefined fields indicate the original was
-								// loaded from a summary snapshot rather than seen at runtime.
-								otherClientId: result.otherBatchInfo?.clientId,
-								otherBatchStartCsn: result.otherBatchInfo?.batchStartCsn,
-								otherBatchIdExplicit: result.otherBatchInfo?.batchIdExplicit,
-								otherFromSnapshot: result.otherBatchInfo === undefined,
-								...extractSafePropertiesFromMessage(batchStart.keyMessage),
-								// For grouped batches, `keyMessage` is one of the sub-messages produced by
-								// `OpGroupingManager.ungroupOp`, which overwrites `clientSequenceNumber`
-								// with a synthetic counter (1, 2, 3, ...). Override with the real outer
-								// envelope's clientSequenceNumber so downstream telemetry doesn't get a
-								// misleading "fake csn" value.
-								messageClientSequenceNumber: batchStart.batchStartCsn,
-							},
+					this.mc.logger.sendTelemetryEvent({
+						eventName: "DuplicateBatch",
+						details: {
+							batchId: batchStart.batchId,
+							batchIdExplicit: batchStart.batchId !== undefined,
+							clientId: batchStart.clientId,
+							batchStartCsn: batchStart.batchStartCsn,
+							size: inboundResult.length,
+							duplicateBatchSequenceNumber: result.otherSequenceNumber,
+							// Identifying info for the ORIGINAL occurrence of this batch, so we can
+							// disambiguate the duplicate's source (e.g. resubmit vs fresh submit, same
+							// vs different wire clientId). Undefined fields indicate the original was
+							// loaded from a summary snapshot rather than seen at runtime.
+							otherClientId: result.otherBatchInfo?.clientId,
+							otherBatchStartCsn: result.otherBatchInfo?.batchStartCsn,
+							otherBatchIdExplicit: result.otherBatchInfo?.batchIdExplicit,
+							otherFromSnapshot: result.otherBatchInfo === undefined,
+							...extractSafePropertiesFromMessage(batchStart.keyMessage),
+							// For grouped batches, `keyMessage` is one of the sub-messages produced by
+							// `OpGroupingManager.ungroupOp`, which overwrites `clientSequenceNumber`
+							// with a synthetic counter (1, 2, 3, ...). Override with the real outer
+							// envelope's clientSequenceNumber so downstream telemetry doesn't get a
+							// misleading "fake csn" value.
+							messageClientSequenceNumber: batchStart.batchStartCsn,
 						},
-					);
+					});
 				}
 			}
 

--- a/packages/runtime/container-runtime/src/opLifecycle/duplicateBatchDetector.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/duplicateBatchDetector.ts
@@ -29,6 +29,16 @@ export class DuplicateBatchDetector {
 	private readonly batchIdsBySeqNum = new Map<number, string>();
 
 	/**
+	 * Number of inbound batches processed since the last summary. Reset by getRecentBatchInfoForSummary.
+	 */
+	private processedBatchCount = 0;
+
+	/**
+	 * Largest tracked-batch count observed since the last summary. Reset by getRecentBatchInfoForSummary.
+	 */
+	private peakTrackedBatchCount = 0;
+
+	/**
 	 * Initialize from snapshot data if provided - otherwise initialize empty
 	 */
 	constructor(batchIdsFromSnapshot: [number, string][] | undefined) {
@@ -37,6 +47,7 @@ export class DuplicateBatchDetector {
 				this.batchIdsBySeqNum.set(seqNum, batchId);
 				this.seqNumByBatchId.set(batchId, seqNum);
 			}
+			this.peakTrackedBatchCount = this.batchIdsBySeqNum.size;
 		}
 	}
 
@@ -50,6 +61,7 @@ export class DuplicateBatchDetector {
 		batchStart: BatchStartInfo,
 	): { duplicate: true; otherSequenceNumber: number } | { duplicate: false } {
 		const { sequenceNumber, minimumSequenceNumber } = batchStart.keyMessage;
+		this.processedBatchCount++;
 
 		// Glance at this batch's MSN. Any batchIds we're tracking with a lower sequence number are now safe to forget.
 		// Why? Because any other client holding the same batch locally would have seen the earlier batch and closed before submitting its duplicate.
@@ -80,6 +92,9 @@ export class DuplicateBatchDetector {
 		// Add new batch
 		this.batchIdsBySeqNum.set(sequenceNumber, batchId);
 		this.seqNumByBatchId.set(batchId, sequenceNumber);
+		if (this.batchIdsBySeqNum.size > this.peakTrackedBatchCount) {
+			this.peakTrackedBatchCount = this.batchIdsBySeqNum.size;
+		}
 
 		return { duplicate: false };
 	}
@@ -108,15 +123,21 @@ export class DuplicateBatchDetector {
 	public getRecentBatchInfoForSummary(
 		telemetryContext?: ITelemetryContext,
 	): [number, string][] | undefined {
+		if (telemetryContext !== undefined) {
+			const prefix = "fluid_DuplicateBatchDetector_";
+			telemetryContext.set(prefix, "recentBatchCount", this.batchIdsBySeqNum.size);
+			telemetryContext.set(prefix, "peakRecentBatchCount", this.peakTrackedBatchCount);
+			telemetryContext.set(prefix, "processedBatchCount", this.processedBatchCount);
+		}
+
+		// Reset per-window perf counters so each summary covers only the activity since the
+		// previous one. Peak resets to the current size (the floor for the next window).
+		this.processedBatchCount = 0;
+		this.peakTrackedBatchCount = this.batchIdsBySeqNum.size;
+
 		if (this.batchIdsBySeqNum.size === 0) {
 			return undefined;
 		}
-
-		telemetryContext?.set(
-			"fluid_DuplicateBatchDetector_",
-			"recentBatchCount",
-			this.batchIdsBySeqNum.size,
-		);
 
 		return [...this.batchIdsBySeqNum.entries()];
 	}

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -437,11 +437,7 @@ describe("Runtime", () => {
 				let batchEnd = 0;
 				let callsToEnsure = 0;
 				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
-					context: getMockContext({
-						settings: {
-							"Fluid.ContainerRuntime.enableBatchIdTracking": true,
-						},
-					}) as IContainerContext,
+					context: getMockContext() as IContainerContext,
 					registry: new FluidDataStoreRegistry([]),
 					existing: false,
 					runtimeOptions: {},
@@ -481,13 +477,19 @@ describe("Runtime", () => {
 				assert.strictEqual(containerRuntime.isDirty, false);
 			});
 
-			for (const enableBatchIdTracking of [true, undefined])
-				it("Replaying ops should resend in correct order, with batch ID if applicable", async () => {
+			// BatchId tracking is on by default (TurnBased mode); the kill-switch suppresses stamping.
+			for (const variant of [
+				{ name: "default (no settings)", settings: {}, expectStamped: true },
+				{
+					name: "kill-switch active",
+					settings: { "Fluid.ContainerRuntime.DisableBatchIdTracking": true },
+					expectStamped: false,
+				},
+			])
+				it(`Replaying ops should resend in correct order, with batch ID if applicable (${variant.name})`, async () => {
 					const { runtime } = await ContainerRuntime.loadRuntime2({
 						context: getMockContext({
-							settings: {
-								"Fluid.ContainerRuntime.enableBatchIdTracking": enableBatchIdTracking, // batchId only stamped if true
-							},
+							settings: variant.settings,
 						}) as IContainerContext,
 						registry: new FluidDataStoreRegistry([]),
 						existing: false,
@@ -525,7 +527,7 @@ describe("Runtime", () => {
 						);
 					}
 
-					if (enableBatchIdTracking === true) {
+					if (variant.expectStamped) {
 						assert(
 							batchIdMatchesUnsentFormat(
 								// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -921,8 +923,20 @@ describe("Runtime", () => {
 							{ batch: false },
 						];
 
+						// In TurnBased mode batchId tracking is on by default, so resubmitted batches
+						// will also carry a batchId on their first message. Strip it before comparing
+						// — this test cares about batch boundaries, not batchId stamping.
+						const normalizedMetadata = submittedOpsMetadata.map((m) => {
+							if (m === undefined) {
+								return undefined;
+							}
+							// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unsafe-assignment
+							const { batchId: _ignored, ...rest } = m as { batchId?: string };
+							return Object.keys(rest).length === 0 ? undefined : rest;
+						});
+
 						assert.deepStrictEqual(
-							submittedOpsMetadata,
+							normalizedMetadata,
 							expectedBatchMetadata,
 							"batch metadata does not match",
 						);
@@ -2343,13 +2357,19 @@ describe("Runtime", () => {
 		});
 
 		describe("Duplicate Batch Detection", () => {
-			for (const enableBatchIdTracking of [undefined, true]) {
-				it(`DuplicateBatchDetector is disabled if Batch Id Tracking isn't needed (${enableBatchIdTracking === true ? "ENABLED" : "DISABLED"})`, async () => {
+			// BatchId tracking is on by default (TurnBased); the kill-switch suppresses detection.
+			for (const variant of [
+				{ name: "default (no settings)", settings: {}, expectDetection: true },
+				{
+					name: "kill-switch active",
+					settings: { "Fluid.ContainerRuntime.DisableBatchIdTracking": true },
+					expectDetection: false,
+				},
+			]) {
+				it(`DuplicateBatchDetector reflects batch-id tracking enablement (${variant.name})`, async () => {
 					const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
 						context: getMockContext({
-							settings: {
-								"Fluid.ContainerRuntime.enableBatchIdTracking": enableBatchIdTracking,
-							},
+							settings: variant.settings,
 						}) as IContainerContext,
 						registry: new FluidDataStoreRegistry([]),
 						existing: false,
@@ -2370,8 +2390,9 @@ describe("Runtime", () => {
 						false,
 					);
 					// Process a duplicate batch "batchId1" with different seqNum 234
-					const assertThrowsOnlyIfExpected =
-						enableBatchIdTracking === true ? assert.throws : assert.doesNotThrow;
+					const assertThrowsOnlyIfExpected = variant.expectDetection
+						? assert.throws
+						: assert.doesNotThrow;
 					const errorPredicate = (e: Error) =>
 						e.message === "Duplicate batch - The same batch was sequenced twice";
 					assertThrowsOnlyIfExpected(
@@ -2387,20 +2408,141 @@ describe("Runtime", () => {
 							);
 						},
 						errorPredicate,
-						"Expected duplicate batch detection to match Offline Load enablement",
+						"Expected duplicate batch detection to match enablement",
 					);
 				});
 			}
 
-			it("Can roundrip DuplicateBatchDetector state through summary/snapshot", async () => {
-				// Duplicate Batch Detection requires OfflineLoad enabled
-				const settings_enableOfflineLoad = {
-					"Fluid.ContainerRuntime.enableBatchIdTracking": true,
-				};
+			it("Default-on tracking is silently skipped in FlushMode.Immediate (no UsageError)", async () => {
 				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
-					context: getMockContext({
-						settings: settings_enableOfflineLoad,
-					}) as IContainerContext,
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: {
+						flushMode: FlushMode.Immediate,
+						enableRuntimeIdCompressor: "on",
+					},
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+				// Sending a duplicate batchId should not throw because tracking is inactive in Immediate mode.
+				containerRuntime.process(
+					{
+						sequenceNumber: 123,
+						type: MessageType.Operation,
+						contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+						metadata: { batchId: "batchId1" },
+					} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+					false,
+				);
+				assert.doesNotThrow(() =>
+					containerRuntime.process(
+						{
+							sequenceNumber: 234,
+							type: MessageType.Operation,
+							contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+							metadata: { batchId: "batchId1" },
+						} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+						false,
+					),
+				);
+			});
+
+			it("Offline Load opt-in still errors in FlushMode.Immediate (back-compat)", async () => {
+				const containerErrors: ICriticalContainerError[] = [];
+				const context = {
+					...getMockContext({
+						settings: {
+							"Fluid.Container.enableOfflineFull": true,
+						},
+					}),
+					closeFn: (error?: ICriticalContainerError): void => {
+						if (error !== undefined) {
+							containerErrors.push(error);
+						}
+					},
+				};
+				await assert.rejects(
+					ContainerRuntime.loadRuntime2({
+						context: context as IContainerContext,
+						registry: new FluidDataStoreRegistry([]),
+						existing: false,
+						runtimeOptions: { flushMode: FlushMode.Immediate },
+						provideEntryPoint: mockProvideEntryPoint,
+					}),
+					(error: Error) => error instanceof UsageError,
+				);
+				assert.strictEqual(containerErrors.length, 1);
+			});
+
+			// Regression: enabling default-on batchId tracking when grouped batching is disabled
+			// asserts 0xa00 in OpGroupingManager.createEmptyGroupedBatch the first time a resubmit
+			// produces an empty batch. Tracking must be silently skipped in that configuration.
+			it("Default-on tracking is silently skipped when grouped batching is disabled", async () => {
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: {
+						enableGroupedBatching: false,
+						enableRuntimeIdCompressor: "on",
+					},
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+				// Sending a duplicate batchId should not throw because tracking is inactive
+				// when grouped batching is off.
+				containerRuntime.process(
+					{
+						sequenceNumber: 123,
+						type: MessageType.Operation,
+						contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+						metadata: { batchId: "batchId1" },
+					} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+					false,
+				);
+				assert.doesNotThrow(() =>
+					containerRuntime.process(
+						{
+							sequenceNumber: 234,
+							type: MessageType.Operation,
+							contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+							metadata: { batchId: "batchId1" },
+						} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+						false,
+					),
+				);
+			});
+
+			it("Offline Load opt-in errors when grouped batching is disabled", async () => {
+				const containerErrors: ICriticalContainerError[] = [];
+				const context = {
+					...getMockContext({
+						settings: {
+							"Fluid.Container.enableOfflineFull": true,
+						},
+					}),
+					closeFn: (error?: ICriticalContainerError): void => {
+						if (error !== undefined) {
+							containerErrors.push(error);
+						}
+					},
+				};
+				await assert.rejects(
+					ContainerRuntime.loadRuntime2({
+						context: context as IContainerContext,
+						registry: new FluidDataStoreRegistry([]),
+						existing: false,
+						runtimeOptions: { enableGroupedBatching: false },
+						provideEntryPoint: mockProvideEntryPoint,
+					}),
+					(error: Error) => error instanceof UsageError,
+				);
+				assert.strictEqual(containerErrors.length, 1);
+			});
+
+			it("Can roundtrip DuplicateBatchDetector state through summary/snapshot", async () => {
+				// Duplicate Batch Detection is on by default in TurnBased mode.
+				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
 					registry: new FluidDataStoreRegistry([]),
 					existing: false,
 					runtimeOptions: {
@@ -2432,7 +2574,6 @@ describe("Runtime", () => {
 				};
 				const { runtime: containerRuntime2 } = await ContainerRuntime.loadRuntime2({
 					context: getMockContext({
-						settings: settings_enableOfflineLoad,
 						baseSnapshot: {
 							trees: {},
 							blobs: { [recentBatchInfoBlobName]: "nonempty_id_ignored_by_mockStorage" },

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2547,6 +2547,33 @@ describe("Runtime", () => {
 				assert.strictEqual(containerErrors.length, 1);
 			});
 
+			it("Offline Load opt-in errors when batchId tracking is disabled via kill-switch", async () => {
+				const containerErrors: ICriticalContainerError[] = [];
+				const context = {
+					...getMockContext({
+						settings: {
+							"Fluid.Container.enableOfflineFull": true,
+							"Fluid.ContainerRuntime.DisableBatchIdTracking": true,
+						},
+					}),
+					closeFn: (error?: ICriticalContainerError): void => {
+						if (error !== undefined) {
+							containerErrors.push(error);
+						}
+					},
+				};
+				await assert.rejects(
+					ContainerRuntime.loadRuntime2({
+						context: context as IContainerContext,
+						registry: new FluidDataStoreRegistry([]),
+						existing: false,
+						provideEntryPoint: mockProvideEntryPoint,
+					}),
+					(error: Error) => error instanceof UsageError,
+				);
+				assert.strictEqual(containerErrors.length, 1);
+			});
+
 			it("Can roundtrip DuplicateBatchDetector state through summary/snapshot", async () => {
 				// Duplicate Batch Detection is on by default in TurnBased mode.
 				const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2367,8 +2367,10 @@ describe("Runtime", () => {
 				},
 			]) {
 				it(`DuplicateBatchDetector reflects batch-id tracking enablement (${variant.name})`, async () => {
+					const logger = new MockLogger();
 					const { runtime: containerRuntime } = await ContainerRuntime.loadRuntime2({
 						context: getMockContext({
+							logger,
 							settings: variant.settings,
 						}) as IContainerContext,
 						registry: new FluidDataStoreRegistry([]),
@@ -2389,27 +2391,33 @@ describe("Runtime", () => {
 						} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
 						false,
 					);
-					// Process a duplicate batch "batchId1" with different seqNum 234
-					const assertThrowsOnlyIfExpected = variant.expectDetection
-						? assert.throws
-						: assert.doesNotThrow;
-					const errorPredicate = (e: Error) =>
-						e.message === "Duplicate batch - The same batch was sequenced twice";
-					assertThrowsOnlyIfExpected(
-						() => {
-							containerRuntime.process(
-								{
-									sequenceNumber: 234,
-									type: MessageType.Operation,
-									contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-									metadata: { batchId: "batchId1" },
-								} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
-								false,
-							);
-						},
-						errorPredicate,
-						"Expected duplicate batch detection to match enablement",
+					// Duplicate-batch handling is currently log-only (the DataCorruptionError throw is
+					// suppressed while a live service bug can produce duplicates). So processing the
+					// duplicate should never throw; we instead verify the DuplicateBatch telemetry
+					// event is emitted iff detection is enabled for this variant.
+					assert.doesNotThrow(() =>
+						containerRuntime.process(
+							{
+								sequenceNumber: 234,
+								type: MessageType.Operation,
+								contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+								metadata: { batchId: "batchId1" },
+							} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+							false,
+						),
 					);
+					const duplicateEvent = { eventName: "ContainerRuntime:DuplicateBatch" };
+					if (variant.expectDetection) {
+						logger.assertMatchAny(
+							[duplicateEvent],
+							"Expected DuplicateBatch telemetry when tracking is enabled",
+						);
+					} else {
+						logger.assertMatchNone(
+							[duplicateEvent],
+							"DuplicateBatch telemetry should not fire when tracking is disabled",
+						);
+					}
 				});
 			}
 
@@ -2572,8 +2580,10 @@ describe("Runtime", () => {
 					// Hardcode readblob fn to return the blob contents put in the summary
 					readBlob: async (_id) => stringToBuffer(blob.content as string, "utf8"),
 				};
+				const logger = new MockLogger();
 				const { runtime: containerRuntime2 } = await ContainerRuntime.loadRuntime2({
 					context: getMockContext({
+						logger,
 						baseSnapshot: {
 							trees: {},
 							blobs: { [recentBatchInfoBlobName]: "nonempty_id_ignored_by_mockStorage" },
@@ -2588,20 +2598,22 @@ describe("Runtime", () => {
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				// Process an op with a duplicate batchId to what was loaded with
-				assert.throws(
-					() => {
-						containerRuntime2.process(
-							{
-								sequenceNumber: 234,
-								type: MessageType.Operation,
-								contents: { type: ContainerMessageType.Rejoin, contents: undefined },
-								metadata: { batchId: "batchId1" },
-							} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
-							false,
-						);
-					},
-					(e: Error) => e.message === "Duplicate batch - The same batch was sequenced twice",
+				// Process an op with a duplicate batchId to what was loaded with.
+				// Detection is currently log-only (the DataCorruptionError throw is suppressed),
+				// so verify via telemetry rather than an exception.
+				assert.doesNotThrow(() =>
+					containerRuntime2.process(
+						{
+							sequenceNumber: 234,
+							type: MessageType.Operation,
+							contents: { type: ContainerMessageType.Rejoin, contents: undefined },
+							metadata: { batchId: "batchId1" },
+						} satisfies Partial<ISequencedDocumentMessage> as ISequencedDocumentMessage,
+						false,
+					),
+				);
+				logger.assertMatchAny(
+					[{ eventName: "ContainerRuntime:DuplicateBatch" }],
 					"Expected duplicate batch detected after loading with recentBatchInfo",
 				);
 			});

--- a/packages/runtime/container-runtime/src/test/opLifecycle/duplicateBatchDetector.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/duplicateBatchDetector.spec.ts
@@ -217,13 +217,11 @@ describe("DuplicateBatchDetector", () => {
 			detector.processInboundBatch(inboundBatch1);
 			detector.processInboundBatch(inboundBatch2);
 
-			let setCalled = 0;
+			const telemetrySets = new Map<string, unknown>();
 			const telemetryContext = {
 				set: (key: string, subKey: string, value: unknown) => {
-					++setCalled;
 					assert.equal(key, "fluid_DuplicateBatchDetector_");
-					assert.equal(subKey, "recentBatchCount");
-					assert.equal(value, 2);
+					telemetrySets.set(subKey, value);
 				},
 			} satisfies Partial<ITelemetryContext> as ITelemetryContext;
 
@@ -237,7 +235,57 @@ describe("DuplicateBatchDetector", () => {
 				],
 				"Incorrect recentBatchInfo",
 			);
-			assert.equal(setCalled, 1, "Expected telemetryContext.set to be called once");
+			assert.equal(telemetrySets.get("recentBatchCount"), 2);
+			assert.equal(telemetrySets.get("peakRecentBatchCount"), 2);
+			assert.equal(telemetrySets.get("processedBatchCount"), 2);
+		});
+
+		it("Per-window perf counters reset after each summary", () => {
+			detector.processInboundBatch(
+				makeBatch({
+					sequenceNumber: seqNum++, // 1
+					minimumSequenceNumber: 0,
+					batchId: "batch1",
+				}),
+			);
+			detector.processInboundBatch(
+				makeBatch({
+					sequenceNumber: seqNum++, // 2
+					minimumSequenceNumber: 0,
+					batchId: "batch2",
+				}),
+			);
+
+			const firstWindow = new Map<string, unknown>();
+			detector.getRecentBatchInfoForSummary({
+				set: (_key: string, subKey: string, value: unknown) => {
+					firstWindow.set(subKey, value);
+				},
+			} satisfies Partial<ITelemetryContext> as ITelemetryContext);
+			assert.equal(firstWindow.get("processedBatchCount"), 2);
+			assert.equal(firstWindow.get("peakRecentBatchCount"), 2);
+
+			// Process one more batch; MSN advances enough to drop both prior entries.
+			detector.processInboundBatch(
+				makeBatch({
+					sequenceNumber: seqNum++, // 3
+					minimumSequenceNumber: 3,
+					batchId: "batch3",
+				}),
+			);
+
+			const secondWindow = new Map<string, unknown>();
+			detector.getRecentBatchInfoForSummary({
+				set: (_key: string, subKey: string, value: unknown) => {
+					secondWindow.set(subKey, value);
+				},
+			} satisfies Partial<ITelemetryContext> as ITelemetryContext);
+			// Only one batch processed since the prior summary.
+			assert.equal(secondWindow.get("processedBatchCount"), 1);
+			// Peak in this window starts at the size carried over from the prior window (2)
+			// — peak only ever grows during a window. Current size after cleanup is 1.
+			assert.equal(secondWindow.get("peakRecentBatchCount"), 2);
+			assert.equal(secondWindow.get("recentBatchCount"), 1);
 		});
 	});
 });

--- a/packages/test/functional-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional-tests/src/test/containerRuntime.spec.ts
@@ -97,6 +97,7 @@ describe("Container Runtime", () => {
 			for (let i = 0; i < count; i++) {
 				const message: Partial<ISequencedDocumentMessage> = {
 					clientId,
+					clientSequenceNumber: seq,
 					minimumSequenceNumber: 0,
 					sequenceNumber: seq++,
 					type: MessageType.Operation,

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -105,7 +105,7 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 		registry,
 		loaderProps: {
 			configProvider: configProvider({
-				"Fluid.ContainerRuntime.enableBatchIdTracking": true,
+				"Fluid.Container.enableOfflineFull": true,
 			}),
 		},
 	};

--- a/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
@@ -164,7 +164,13 @@ describeCompat("Fewer batches", "NoCompat", (getTestObjectProvider, apis) => {
 		"Op reentry submits two batches due to flush before processing",
 		expectedErrors,
 		async () => {
-			await processOutOfOrderOp({});
+			// The fake sequenced op injected below reuses a sequence number that the
+			// DuplicateBatchDetector has already seen, which would trip its invariants and
+			// short-circuit the flow before the deltaManager's non-Sequential check fires.
+			// Disable batchId tracking here so the test can exercise its actual scenario.
+			await processOutOfOrderOp({
+				"Fluid.ContainerRuntime.DisableBatchIdTracking": true,
+			});
 			assert.strictEqual(capturedBatches.length, 2);
 		},
 	);


### PR DESCRIPTION
## Description

Re-enables batchId tracking by default in `ContainerRuntime` after the prior attempts (#27216, #27262) were reverted. BatchId tracking powers `DuplicateBatchDetector` (catching forked-container duplicates) and is a prerequisite for Offline Load.

Key changes vs. the previous attempts:

- **Default-on with kill-switch.** `batchIdTrackingEnabled` now defaults to on when both `FlushMode.TurnBased` and grouped batching are active. A new config flag, `Fluid.ContainerRuntime.DisableBatchIdTracking`, disables it without a code change if a regression appears in the wild.
- **Explicit Offline Load prerequisites.** Opting into `Fluid.Container.enableOfflineFull` now throws a clear `UsageError` if either prerequisite (TurnBased flush mode, grouped batching) is missing, instead of silently degrading.
- **Duplicate batch is logged, not thrown.** Because of a known service-side bug that produces duplicates on the wire, the `DataCorruptionError` throw on detected duplicates is temporarily commented out — we still emit telemetry so we can monitor legitimate forking vs. the service issue. Throwing will be re-enabled once the service bug is fixed or we can distinguish the two sources.
- **Perf telemetry on the detector.** `DuplicateBatchDetector.getRecentBatchInfoForSummary` now also reports `peakRecentBatchCount` and `processedBatchCount` per summary window, with per-window reset, alongside the existing `recentBatchCount`.

Tests were updated in `containerRuntime.spec.ts`, `duplicateBatchDetector.spec.ts`, and a couple of op-lifecycle/batching specs that asserted the old default-off behavior.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The "log-only, do not throw" change for duplicate batch detection is intentional but temporary — please confirm you're comfortable with the comment-out approach vs. a runtime flag.
- The gating switch from "opt-in by flag" to "on when prerequisites hold" is the main behavior shift; the explicit `UsageError`s for Offline Load are meant to keep that misconfiguration loud.