### PR TITLE
bug fix for chunked forest enterNode

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -245,12 +245,12 @@ export class ChunkedForest implements IEditableForest {
 				let indexOfChunk = 0;
 				let chunk = chunks[indexOfChunk] ?? oob();
 				while (indexWithinChunk >= chunk.topLevelLength) {
-					chunk = chunks[indexOfChunk] ?? oob();
 					indexWithinChunk -= chunk.topLevelLength;
 					indexOfChunk++;
 					if (indexOfChunk === chunks.length) {
 						fail(0xaf7 /* missing edited node */);
 					}
+					chunk = chunks[indexOfChunk] ?? oob();
 				}
 				let found = chunks[indexOfChunk] ?? oob();
 				if (!(found instanceof BasicChunk)) {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -207,6 +207,40 @@ describe("ChunkedForest", () => {
 			assert.equal(nodeCount(remaining), 4);
 		});
 
+		it("enterNode resolves the correct chunk in a field with multiple multi-node chunks", () => {
+			const forestSchema = new TreeStoredSchemaRepository(
+				toInitialSchema(SchemaFactory.number),
+			);
+			const chunker = makeTreeChunker(
+				forestSchema,
+				defaultSchemaPolicy,
+				defaultIncrementalEncodingPolicy,
+			);
+			const forest = buildChunkedForest(chunker);
+			forest.roots.fields.set(rootFieldKey, [
+				new UniformChunk(numberShape.withTopLevelLength(2), [0, 1]),
+				new UniformChunk(numberShape.withTopLevelLength(5), [2, 3, 4, 5, 6]),
+				new UniformChunk(numberShape.withTopLevelLength(3), [7, 8, 9]),
+			]);
+
+			const visitor = forest.acquireVisitor();
+			visitor.enterField(rootFieldKey);
+			visitor.enterNode(6);
+			visitor.exitNode(6);
+			visitor.exitField(rootFieldKey);
+			visitor.free();
+
+			// enterNode shatters the targeted UC(5) into 5 BasicChunks; the field's chunk
+			// count grows from 3 to 7, with the two flanking UniformChunks untouched.
+			const result = forest.roots.fields.get(rootFieldKey);
+			assert(result !== undefined);
+			assert.equal(result.length, 7);
+			assert(result[0] instanceof UniformChunk);
+			assert.equal(result[0].topLevelLength, 2);
+			assert(result[6] instanceof UniformChunk);
+			assert.equal(result[6].topLevelLength, 3);
+		});
+
 		it("attaches a single node into the middle of a uniform chunk", () => {
 			const forest = setupForest();
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -230,8 +230,9 @@ describe("ChunkedForest", () => {
 			visitor.exitField(rootFieldKey);
 			visitor.free();
 
-			// enterNode shatters the targeted UC(5) into 5 BasicChunks; the field's chunk
-			// count grows from 3 to 7, with the two flanking UniformChunks untouched.
+			// enterNode shatters the targeted UniformChunk (with top-level length 5) into 5 BasicChunks; the
+			// field's chunk count grows from 3 to 7, with the two flanking UniformChunks
+			// untouched.
 			const result = forest.roots.fields.get(rootFieldKey);
 			assert(result !== undefined);
 			assert.equal(result.length, 7);


### PR DESCRIPTION
## Description

Fixes `ChunkedForest`'s visitor `enterNode` when a field's `chunks` array contains multiple multi-node `UniformChunk`s of differing sizes. The loop that walks chunks to find the target index reassigned its `chunk` variable at the top of the loop body (before `indexOfChunk++`), so the next iteration's condition check used the prior chunk. 

With all chunks having `topLevelLength === 1` the off-by-one coincidentally produced the correct behavior