### PR TITLE
fix(ci): pin fflate to 0.8.2 in lts publish pipeline

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -81,9 +81,16 @@ jobs:
               targetType: 'inline'
               workingDirectory: .
               script: |
+                set -eu -o pipefail
                 echo "installing version @${{ parameters.buildToolsVersionToInstall }}"
 
                 npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
+
+                # fflate 0.8.3 changed the streaming Gunzip callback semantics in a way that breaks
+                # `flub publish tarballs`. Force-downgrade the fflate nested inside the globally-installed
+                # flub to 0.8.2 as a workaround.
+                npm explore --global @fluid-tools/build-cli -- npm install --no-save --package-lock=false fflate@0.8.2
+                npm explore --global @fluid-tools/build-cli -- node -e "const v=require('./node_modules/fflate/package.json').version; if (v !== '0.8.2') throw new Error('Expected fflate 0.8.2, got ' + v);"
 
                 # This can be removed once all builds tools are moved to the build-cli library
                 npm install --global "@fluidframework/build-tools@${{ parameters.buildToolsVersionToInstall }}"

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -90,7 +90,7 @@ jobs:
                 # `flub publish tarballs`. Force-downgrade the fflate nested inside the globally-installed
                 # flub to 0.8.2 as a workaround.
                 npm explore --global @fluid-tools/build-cli -- npm install --no-save --no-package-lock fflate@0.8.2
-                npm explore --global @fluid-tools/build-cli -- node -e "const v=require('./node_modules/fflate/package.json').version; if (v !== '0.8.2') throw new Error('Expected fflate 0.8.2, got ' + v);"
+                npm ls -g fflate | grep -q "fflate@0.8.2" || { echo "##[error]fflate not pinned to 0.8.2 in flub install:"; npm ls -g fflate; exit 1; }
 
                 # This can be removed once all builds tools are moved to the build-cli library
                 npm install --global "@fluidframework/build-tools@${{ parameters.buildToolsVersionToInstall }}"

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -87,10 +87,20 @@ jobs:
                 npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
 
                 # fflate 0.8.3 changed the streaming Gunzip callback semantics in a way that breaks
-                # `flub publish tarballs`. Force-downgrade the fflate nested inside the globally-installed
-                # flub to 0.8.2 as a workaround.
-                npm explore --global @fluid-tools/build-cli -- npm install --no-save --no-package-lock fflate@0.8.2
-                npm ls -g fflate | grep -q "fflate@0.8.2" || { echo "##[error]fflate not pinned to 0.8.2 in flub install:"; npm ls -g fflate; exit 1; }
+                # `flub publish tarballs`. Replace the fflate nested inside the globally-installed flub
+                # with 0.8.2 as a workaround. We pack and extract directly because `npm install` from
+                # within the global flub directory would hoist fflate to the top of the global
+                # node_modules instead of overwriting flub's nested copy that `require()` actually loads.
+                FLUB_DIR="$(npm root -g)/@fluid-tools/build-cli"
+                TMP_PACK_DIR=$(mktemp -d)
+                ( cd "$TMP_PACK_DIR" && npm pack fflate@0.8.2 )
+                rm -rf "$FLUB_DIR/node_modules/fflate"
+                mkdir -p "$FLUB_DIR/node_modules/fflate"
+                tar -xzf "$TMP_PACK_DIR"/fflate-0.8.2.tgz --strip-components=1 -C "$FLUB_DIR/node_modules/fflate"
+                rm -rf "$TMP_PACK_DIR"
+
+                ACTUAL_FFLATE=$(node -p "require('$FLUB_DIR/node_modules/fflate/package.json').version")
+                [ "$ACTUAL_FFLATE" = "0.8.2" ] || { echo "##[error]flub's nested fflate is $ACTUAL_FFLATE, expected 0.8.2"; exit 1; }
 
                 # This can be removed once all builds tools are moved to the build-cli library
                 npm install --global "@fluidframework/build-tools@${{ parameters.buildToolsVersionToInstall }}"

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -87,17 +87,12 @@ jobs:
                 npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
 
                 # fflate 0.8.3 changed the streaming Gunzip callback semantics in a way that breaks
-                # `flub publish tarballs`. Replace the fflate nested inside the globally-installed flub
-                # with 0.8.2 as a workaround. We pack and extract directly because `npm install` from
-                # within the global flub directory would hoist fflate to the top of the global
-                # node_modules instead of overwriting flub's nested copy that `require()` actually loads.
+                # `flub publish tarballs`. Force-downgrade the fflate nested inside the globally-installed
+                # flub to 0.8.2 as a workaround. We point npm at flub's own install dir so it overwrites
+                # flub's nested copy that `require()` actually loads, rather than hoisting fflate to the
+                # top of the global node_modules. `--omit=dev` avoids reifying flub's devDependencies.
                 FLUB_DIR="$(npm root -g)/@fluid-tools/build-cli"
-                TMP_PACK_DIR=$(mktemp -d)
-                ( cd "$TMP_PACK_DIR" && npm pack fflate@0.8.2 )
-                rm -rf "$FLUB_DIR/node_modules/fflate"
-                mkdir -p "$FLUB_DIR/node_modules/fflate"
-                tar -xzf "$TMP_PACK_DIR"/fflate-0.8.2.tgz --strip-components=1 -C "$FLUB_DIR/node_modules/fflate"
-                rm -rf "$TMP_PACK_DIR"
+                npm install --prefix "$FLUB_DIR" --no-save --no-package-lock --omit=dev fflate@0.8.2
 
                 ACTUAL_FFLATE=$(node -p "require('$FLUB_DIR/node_modules/fflate/package.json').version")
                 [ "$ACTUAL_FFLATE" = "0.8.2" ] || { echo "##[error]flub's nested fflate is $ACTUAL_FFLATE, expected 0.8.2"; exit 1; }

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -89,7 +89,7 @@ jobs:
                 # fflate 0.8.3 changed the streaming Gunzip callback semantics in a way that breaks
                 # `flub publish tarballs`. Force-downgrade the fflate nested inside the globally-installed
                 # flub to 0.8.2 as a workaround.
-                npm explore --global @fluid-tools/build-cli -- npm install --no-save --package-lock=false fflate@0.8.2
+                npm explore --global @fluid-tools/build-cli -- npm install --no-save --no-package-lock fflate@0.8.2
                 npm explore --global @fluid-tools/build-cli -- node -e "const v=require('./node_modules/fflate/package.json').version; if (v !== '0.8.2') throw new Error('Expected fflate 0.8.2, got ' + v);"
 
                 # This can be removed once all builds tools are moved to the build-cli library


### PR DESCRIPTION
[AB#74186](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74186)

## Description

`fflate` 0.8.3 changed the streaming `Gunzip` callback semantics in a way that breaks `flub publish tarballs`, which the lts publish pipeline runs after installing `@fluid-tools/build-cli` globally from npm. Same root cause that broke `main` and was fixed there in #27337.

This branch's pipeline is structured differently from `main`'s (global npm install of the published flub rather than a lockfile-less pnpm install with overrides), so #27337 can't be cherry-picked verbatim. Instead, this PR works around the issue by force-downgrading the `fflate` nested inside the global flub install to 0.8.2 immediately after the global install, then asserting the resulting version. The install script also gains `set -eu -o pipefail` so a failed downgrade can't silently leave `fflate` at 0.8.3.

The downgrade uses `npm install --prefix "$(npm root -g)/@fluid-tools/build-cli" --omit=dev fflate@0.8.2` rather than the more obvious `npm explore --global @fluid-tools/build-cli -- npm install ...`. `npm explore` inherits the global context, which causes npm to hoist `fflate@0.8.2` to the top of the global `node_modules` and leave flub's nested `fflate@0.8.3` (the copy that `require()` actually loads) untouched. Pointing `--prefix` at flub's install directory directly forces npm to overwrite the nested copy. `--omit=dev` keeps the install surgical: on the test build agent the only changes were `fflate` (the intended downgrade) plus two TypeScript-types-only packages with no runtime impact.

Verified end-to-end on test build [402780](https://dev.azure.com/fluidframework/internal/_build/results?buildId=402780): the `Publish Packages for tarballs` step (which runs `flub publish tarballs` and was failing before this fix) succeeded.
