### PR TITLE
Revert "ci(client): remove CJS compile to run ESM tests (#27388)"

### DIFF
--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -20,11 +20,6 @@ exports to get the versioned Fluid APIs.
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
-## Use requirements
-
-To use provided mocha configuration generation, Node v22.22.2 or later is required.
-<!-- Only 22.18 is actually required, but `syncpack lint` is unhappy with 22.18.0. -->
-
 ## Versioned combination test generation
 
 ### Layer version combinations

--- a/packages/test/test-version-utils/mocharc-common.cjs
+++ b/packages/test/test-version-utils/mocharc-common.cjs
@@ -4,8 +4,7 @@
  */
 
 "use strict";
-// Note: this uses Node 22+'s native TS support. See https://nodejs.org/learn/typescript/run-natively.
-const options = require("./src/compatOptions.ts");
+const options = require("./dist/compatOptions.js");
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 function getFluidTestVariant() {

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -136,9 +136,6 @@
 		"webpack": "^5.94.0",
 		"webpack-cli": "^5.1.4"
 	},
-	"engines": {
-		"node": ">=22.22.2"
-	},
 	"fluidBuild": {
 		"tasks": {
 			"check:exports:index": [


### PR DESCRIPTION
This reverts commit 507a2b2394763f6643826b18ebdd0803b3abb7bf. It causes issues with our current e2e/stress test setup.