### PR TITLE
build: tag untagged asserts for 2.102.0 release

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -636,7 +636,7 @@ export function splitFieldAtIndex(
 		// their own refs from chunkRange, so the slot's ref to the original needs to be released.
 		chunk.referenceRemoved();
 	}
-	assert(remaining === 0, "nodeIndex exceeds total node count in field");
+	assert(remaining === 0, 0xcf9 /* nodeIndex exceeds total node count in field */);
 	return chunks.length;
 }
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -203,7 +203,7 @@ export class ChunkedForest implements IEditableForest {
 				this.forest.#events.emit("beforeChange");
 				const parent = this.getParent();
 				const sourceField = parent.mutableChunk.fields.get(parent.key) ?? [];
-				assert(source.start <= source.end, "detach range start must not exceed end");
+				assert(source.start <= source.end, 0xcf8 /* detach range start must not exceed end */);
 
 				const policy: ChunkCompressor = {
 					policy: this.forest.chunker,

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1937,5 +1937,6 @@ export const shortCodeMap = {
 	"0xcf5": "Unexpected indexOfChunkStack.length",
 	"0xcf6": "Unexpected indexWithinChunkStack.length",
 	"0xcf7": "Parent chunk not found in latest summary tracking",
-	"0xcf8": "Unexpected pending operation during revert"
+	"0xcf8": "detach range start must not exceed end",
+	"0xcf9": "nodeIndex exceeds total node count in field"
 };


### PR DESCRIPTION
## Description

Tag two previously-untagged asserts in `@fluidframework/tree` as part of the
2.102.0 minor release prep. Generated by `pnpm run policy-check:asserts`.

Files touched:
- `packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts`
- `packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts`
- `packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts`

This PR is one of four release-prep PRs for 2.102.0. It must merge before the
version-bump PR.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).