### PR TITLE
build: bump client-utils layer generation to 7 for 2.102.0 release

### DIFF
--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -260,9 +260,9 @@
 		}
 	},
 	"fluidCompatMetadata": {
-		"generation": 6,
-		"releaseDate": "2026-04-13",
-		"releasePkgVersion": "2.93.0"
+		"generation": 7,
+		"releaseDate": "2026-05-27",
+		"releasePkgVersion": "2.102.0"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/common/client-utils/src/layerGenerationState.ts
+++ b/packages/common/client-utils/src/layerGenerationState.ts
@@ -9,4 +9,4 @@
  * The generation number for Fluid layer compatibility.
  * @internal
  */
-export const generation = 6;
+export const generation = 7;


### PR DESCRIPTION
## Description

Bump `@fluidframework/client-utils` layer compatibility generation from 6 to 7
as part of the 2.102.0 minor release prep. Generated by
`pnpm -r run layerGeneration:gen`.

Files touched:
- `packages/common/client-utils/package.json` (`fluidCompatMetadata`)
- `packages/common/client-utils/src/layerGenerationState.ts`

This PR is one of four release-prep PRs for 2.102.0. It must merge before the
version-bump PR.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).