### PR TITLE
feat(cell): implement reSubmitSquashed hook with last-write-wins semantics

### DIFF
--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -335,6 +335,23 @@ export class SharedCell<T = any>
 	}
 
 	/**
+	 * Cell is last-write-wins: any pending op other than the latest is superseded.
+	 * We drop superseded ops entirely (no wire emission) and resubmit only the final pending op,
+	 * which by construction represents the cell's tip state.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		const cellOpMetadata = localOpMetadata as ICellLocalOpMetadata;
+		const lastPendingMessageId = this.pendingMessageIds[this.pendingMessageIds.length - 1];
+		if (cellOpMetadata.pendingMessageId === lastPendingMessageId) {
+			this.submitLocalMessage(content, localOpMetadata);
+		} else {
+			const index = this.pendingMessageIds.indexOf(cellOpMetadata.pendingMessageId);
+			assert(index !== -1, 0xd01 /* Pending message id missing from queue during squash */);
+			this.pendingMessageIds.splice(index, 1);
+		}
+	}
+
+	/**
 	 * Rollback a local op.
 	 *
 	 * @param content - The operation to rollback.


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `SharedCell` with last-write-wins semantics: any pending op other than the latest is dropped (its value never reaches the wire), and the final pending op is resubmitted as the cell's tip state.

## Why

The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped, and pre-lands the cell-specific squash semantics so they are not part of the broader squash PR.

## Notes

Prep for upcoming DDS-wide staging-mode squash work — this PR does not add any new squash machinery, it only implements the hook for `SharedCell`.
