### PR TITLE
feat(counter): implement reSubmitSquashed hook (identity transform)

### DIFF
--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -208,6 +208,16 @@ export class SharedCounter
 	}
 
 	/**
+	 * Counter increments are commutative and additive — each pending increment carries the user's
+	 * intent to add that amount to the counter. No increment is "subsumed" by a later one (a later
+	 * `+3` doesn't cancel an earlier `+5`), so the squash on resubmit is the identity transform:
+	 * each pending increment is resubmitted unchanged.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		this.reSubmitCore(content, localOpMetadata);
+	}
+
+	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.rollback}
 	 * @sealed
 	 */


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `SharedCounter` as the identity transform — each pending increment is resubmitted unchanged via `reSubmitCore`.

## Why

Counter increments are commutative and additive (a later `+3` never cancels an earlier `+5`), so the squash on resubmit is the identity transform. The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped.

## Notes

Prep for upcoming DDS-wide staging-mode squash work.
