### PR TITLE
feat(ink): implement reSubmitSquashed hook (identity transform)

### DIFF
--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -260,6 +260,15 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
 	}
 
 	/**
+	 * Ink ops (createStroke / stylus / clear) are append-style: each op records an intentional
+	 * user action and is never superseded by a later pending op. Squash is therefore the identity
+	 * transform — we just replay the original ops via reSubmitCore.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		this.reSubmitCore(content, localOpMetadata);
+	}
+
+	/**
 	 * Update the model for a clear operation.
 	 * @param operation - The operation object
 	 */


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `Ink` as the identity transform — each pending op (`createStroke` / `stylus` / `clear`) is resubmitted unchanged via `reSubmitCore`.

## Why

Ink ops are append-style: each op records an intentional user action and is never superseded by a later pending op. The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped.

## Notes

Prep for upcoming DDS-wide staging-mode squash work.
