### PR TITLE
feat(pact-map): implement reSubmitSquashed hook (identity transform)

### DIFF
--- a/packages/dds/pact-map/src/pactMap.ts
+++ b/packages/dds/pact-map/src/pactMap.ts
@@ -368,6 +368,17 @@ export class PactMapClass<T = unknown>
 	protected onDisconnect(): void {}
 
 	/**
+	 * PactMap implements consensus over proposed values: each set is a proposal that must be
+	 * accepted by all connected clients at the time it was sequenced. Collapsing pending
+	 * proposals would change observable consensus semantics (and PactMap already drops a new
+	 * set early if there is an outstanding pending proposal for the same key, so the squash
+	 * surface is small in practice). Squash on resubmit is the identity transform.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		this.reSubmitCore(content, localOpMetadata);
+	}
+
+	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObjectCore.reSubmitCore}
 	 */
 	protected reSubmitCore(content: unknown, localOpMetadata: unknown): void {


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `PactMap` as the identity transform — each pending op is resubmitted unchanged via `reSubmitCore`.

## Why

`PactMap` implements consensus over proposed values, and `set` already drops a new write early if there is an outstanding pending proposal for the same key, so the squash surface is small in practice. Collapsing pending proposals beyond the existing rule would change observable consensus semantics, so identity is the right squash.

The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped.

## Notes

Prep for upcoming DDS-wide staging-mode squash work.
