### PR TITLE
feat(ordered-collection): implement reSubmitSquashed hook (identity transform)

### DIFF
--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.beta.api.md
@@ -29,6 +29,7 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensus
     protected release(acquireId: string): void;
     // (undocumented)
     protected releaseCore(acquireId: string): void;
+    protected reSubmitSquashed(content: unknown, localOpMetadata: unknown): void;
     // @sealed
     protected rollback(content: unknown, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -309,6 +309,23 @@ export class ConsensusOrderedCollection<T = any>
 		}
 	}
 
+	/**
+	 * ConsensusOrderedCollection ops (add / acquire / complete / release) participate in a
+	 * server-ordered queue. Collapsing pending ops would change the queue's observable state
+	 * (e.g. an add+acquire pair is meaningfully different from no ops at all, since the queue
+	 * positions are externally observable). Squash on resubmit is therefore the identity
+	 * transform — each pending op is replayed in order via reSubmitCore.
+	 *
+	 * Known leak: `add` carries a serialized user value. A staging-mode sequence such as
+	 * `add(secret) -> acquire -> complete` (or `add(secret) -> acquire -> release`) still
+	 * transmits the `add` op on commit because identity squash replays it in order. Callers
+	 * that need leak-free staging behavior for queue values should hold the `add` locally
+	 * and only call `add` after committing the staging session.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		this.reSubmitCore(content, localOpMetadata);
+	}
+
 	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
 		const { envelope, local, messagesContent } = messagesCollection;
 		for (const messageContent of messagesContent) {


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `ConsensusOrderedCollection` as the identity transform — each pending op is replayed in submit order via `reSubmitCore`.

## Why

`ConsensusOrderedCollection` ops (`add` / `acquire` / `complete` / `release`) participate in a server-ordered queue with externally observable positions. Collapsing pending ops would change the queue's observable state, so identity is the right squash.

The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped.

A known limitation is noted in the implementation comment: a staging-mode sequence such as `add(secret) -> acquire -> complete` still transmits the `add` op on commit, because identity squash replays it in order. Callers that need leak-free staging for queue values should hold the `add` locally and only call it after committing the staging session.

## Notes

Updates `ordered-collection.legacy.beta.api.md` to reflect the new `protected` member. These api-report files are normally generated; if CI's api-extractor disagrees with the change, regenerate via `build:api-reports` and push a fixup.

Prep for upcoming DDS-wide staging-mode squash work.
