### PR TITLE
feat(register-collection): implement reSubmitSquashed hook (identity transform)

### DIFF
--- a/packages/dds/register-collection/api-report/register-collection.legacy.beta.api.md
+++ b/packages/dds/register-collection/api-report/register-collection.legacy.beta.api.md
@@ -25,6 +25,7 @@ export class ConsensusRegisterCollectionClass<T> extends SharedObject<IConsensus
     read(key: string, readPolicy?: ReadPolicy): T | undefined;
     // (undocumented)
     readVersions(key: string): T[] | undefined;
+    protected reSubmitSquashed(content: unknown, localOpMetadata: unknown): void;
     // @sealed
     protected rollback(content: unknown, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -275,6 +275,19 @@ export class ConsensusRegisterCollection<T>
 
 	protected onDisconnect(): void {}
 
+	/**
+	 * ConsensusRegisterCollection writes participate in server-side consensus and the version
+	 * history is exposed via readVersions(). Collapsing pending writes would change observable
+	 * semantics, so squash on resubmit is intentionally the identity transform (replay each
+	 * pending write in order via reSubmitCore).
+	 *
+	 * If callers need staging-mode-like behavior with no intermediate version exposure, they
+	 * should hold writes locally and apply only the final value when committing.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		this.reSubmitCore(content, localOpMetadata);
+	}
+
 	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
 		const { envelope, local, messagesContent } = messagesCollection;
 		for (const messageContent of messagesContent) {


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `ConsensusRegisterCollection` as the identity transform — each pending write is replayed in submit order via `reSubmitCore`.

## Why

`ConsensusRegisterCollection` writes participate in server-side consensus, and the version history is exposed via `readVersions()`. Collapsing pending writes would change observable semantics, so identity is the right squash.

The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped.

## Notes

Updates `register-collection.legacy.beta.api.md` to reflect the new `protected` member. These api-report files are normally generated; if CI's api-extractor disagrees with the change, regenerate via `build:api-reports` and push a fixup.

Prep for upcoming DDS-wide staging-mode squash work.
