### PR TITLE
feat(task-manager): implement reSubmitSquashed hook via existing reSubmitCore

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -673,6 +673,21 @@ export class TaskManagerClass
 	}
 
 	/**
+	 * TaskManager's reSubmitCore already collapses volunteer+abandon pairs (it was designed for
+	 * the disconnect case, where the server drops the client from queues). The same collapse is
+	 * the correct squash for staging-mode commit: redundant pending ops are not re-emitted, and
+	 * a still-pending volunteer is re-emitted to express the final intent.
+	 *
+	 * One known limitation: an in-staging abandon for a task the client previously volunteered
+	 * to (pre-staging) is not propagated by this path, because reSubmitCore assumes the server
+	 * has already removed the client from the queue. TaskManager's queue position is inherently
+	 * tied to live connection state, so this is consistent with its overall design.
+	 */
+	protected override reSubmitSquashed(content: unknown, localOpMetadata: unknown): void {
+		this.reSubmitCore(content, localOpMetadata as number);
+	}
+
+	/**
 	 * Override resubmit core to avoid resubmission on reconnect.  On disconnect we accept our removal from the
 	 * queues, and leave it up to the user to decide whether they want to attempt to re-enter a queue on reconnect.
 	 * However, we do need to update latestPendingOps to account for the ops we will no longer be processing.


### PR DESCRIPTION
## Description

Implements `SharedObjectCore.reSubmitSquashed` on `TaskManager` by delegating to the existing `reSubmitCore`, which already collapses volunteer+abandon pairs (it was designed for the disconnect case, where the server drops the client from queues).

## Why

The collapse `TaskManager.reSubmitCore` already performs is the correct squash for a staging-mode commit: redundant pending ops are not re-emitted, and a still-pending volunteer is re-emitted to express the final intent.

The base `reSubmitSquashed` falls back to `reSubmitCore` only while the `Fluid.SharedObject.AllowStagingModeWithoutSquashing` flag is true; otherwise it throws. Explicitly opting in protects this DDS from breaking when the flag is flipped.

One known limitation, consistent with TaskManager's overall queue-position-vs-connection-state design: an in-staging abandon for a task the client previously volunteered to (pre-staging) is not propagated through this path, because `reSubmitCore` assumes the server has already removed the client from the queue.

## Notes

Prep for upcoming DDS-wide staging-mode squash work.
