### PR TITLE
refactor(matrix): extract reSubmitInternal with squash parameter from reSubmitCore

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -821,6 +821,14 @@ export class SharedMatrix<T = any>
 	}
 
 	protected reSubmitCore(incoming: unknown, localOpMetadata: unknown): void {
+		this.reSubmitInternal(incoming, localOpMetadata, false);
+	}
+
+	private reSubmitInternal(
+		incoming: unknown,
+		localOpMetadata: unknown,
+		squash: boolean,
+	): void {
 		const originalRefSeq = this.inFlightRefSeqs.shift();
 		assert(
 			originalRefSeq !== undefined,
@@ -868,13 +876,13 @@ export class SharedMatrix<T = any>
 			switch (content.target) {
 				case SnapshotPath.cols: {
 					this.submitColMessage(
-						this.cols.regeneratePendingOp(content, localOpMetadata, false),
+						this.cols.regeneratePendingOp(content, localOpMetadata, squash),
 					);
 					break;
 				}
 				case SnapshotPath.rows: {
 					this.submitRowMessage(
-						this.rows.regeneratePendingOp(content, localOpMetadata, false),
+						this.rows.regeneratePendingOp(content, localOpMetadata, squash),
 					);
 					break;
 				}


### PR DESCRIPTION
## Description

Extracts `reSubmitInternal(incoming, localOpMetadata, squash: boolean)` from `SharedMatrix.reSubmitCore`. `reSubmitCore` becomes a one-line delegator passing `squash = false`. The two hardcoded `false` arguments to `regeneratePendingOp` (for `SnapshotPath.cols` / `SnapshotPath.rows`) are replaced with the new `squash` parameter so the value can flow through to merge-tree.

## Why

Sets up a clean seam for the upcoming `reSubmitSquashed` override without changing observable behavior: `squash` is always `false` from the only current call site, so output is byte-identical. Pre-landing the seam removes the parameter-threading refactor from the eventual squash PR.

## Notes

Prep for upcoming DDS-wide staging-mode squash work. This PR does not add `reSubmitSquashed` or any per-cell LWW logic.
