### PR TITLE
perf(legacy-dds): use idToEntryMap for entryId lookup in SharedArray

### DIFF
--- a/packages/dds/legacy-dds/src/array/sharedArray.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArray.ts
@@ -635,6 +635,14 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 			this.getEntryForId(entryId).isAckPending = false;
 		} else {
 			if (insertAfterEntryId !== undefined) {
+				// This call site still uses the index-returning helper because the
+				// result feeds `getInternalInsertIndexByIgnoringLocalPendingInserts`,
+				// which iterates `sharedArray` from a starting array position to skip
+				// over locally-pending inserts. Rewriting that helper in terms of an
+				// entry reference would require restructuring how local-pending state
+				// is tracked, which is out of scope for this change. Switching to
+				// `findEntryById` + `indexOf` here would not be an improvement since
+				// `indexOf` is itself O(n).
 				index = this.findIndexOfEntryId(insertAfterEntryId) + 1;
 			}
 			const newEntry = this.createNewEntry(entryId, value);
@@ -873,17 +881,30 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 		return -1;
 	}
 
+	/**
+	 * O(1) lookup of an entry by its entryId via {@link idToEntryMap}.
+	 * Returns `undefined` if the id is `undefined` or not present in the map.
+	 *
+	 * Prefer this over {@link findIndexOfEntryId} whenever the caller only needs
+	 * the entry (and not its array position), since the map-based lookup avoids
+	 * the linear scan over `sharedArray`.
+	 */
+	private findEntryById(entryId: string | undefined): SharedArrayEntry<T> | undefined {
+		if (entryId === undefined) {
+			return undefined;
+		}
+		return this.idToEntryMap.get(entryId);
+	}
+
 	private prepareToMakeEntryIdLive(entry: SharedArrayEntry<T>): void {
-		const prevIndex = this.findIndexOfEntryId(entry.prevEntryId);
-		const nextIndex = this.findIndexOfEntryId(entry.nextEntryId);
-		if (prevIndex !== -1) {
-			const prevEntry = this.sharedArray[prevIndex];
-			assert(prevEntry !== undefined, 0xb97 /* Invalid index */);
+		// We only need the neighbor entries to mutate their prev/next pointers; the
+		// array index is irrelevant here, so use the O(1) map-based lookup.
+		const prevEntry = this.findEntryById(entry.prevEntryId);
+		const nextEntry = this.findEntryById(entry.nextEntryId);
+		if (prevEntry !== undefined) {
 			prevEntry.nextEntryId = entry.nextEntryId;
 		}
-		if (nextIndex !== -1) {
-			const nextEntry = this.sharedArray[nextIndex];
-			assert(nextEntry !== undefined, 0xb98 /* Invalid index */);
+		if (nextEntry !== undefined) {
 			nextEntry.prevEntryId = entry.prevEntryId;
 		}
 		entry.prevEntryId = undefined;
@@ -958,7 +979,17 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 	): void {
 		let index = 0;
 		if (insertAfterEntryId !== undefined) {
-			index = this.findIndexOfEntryId(insertAfterEntryId) + 1;
+			// The map-based lookup is O(1); deriving the array index from the entry
+			// reference still requires `indexOf`, but that is unavoidable here since
+			// we need a position in `sharedArray` for splice insertion.
+			// If the entry is not present (matching the previous `findIndexOfEntryId`
+			// returning -1) we fall back to inserting at the front, preserving prior
+			// behavior.
+			const insertAfterEntry = this.findEntryById(insertAfterEntryId);
+			index =
+				insertAfterEntry === undefined
+					? 0
+					: this.sharedArray.indexOf(insertAfterEntry) + 1;
 		}
 		const newEntry = this.createNewEntry<SerializableTypeForSharedArray>(entryId, value);
 		newEntry.isAckPending = true;


### PR DESCRIPTION
## Description

Adds `findEntryById(entryId): SharedArrayEntry<T> | undefined` that consults the already-maintained `idToEntryMap` (kept correct on every load and `addEntry`; never deleted from). Converts hot-path callers that need an entry — not an array index — to use it.

Sites converted:

- `prepareToMakeEntryIdLive` — neighbor lookups (`prevEntryId`, `nextEntryId`) no longer touch `sharedArray`; they mutate the entries directly via `findEntryById`.
- `handleStashedInsert` — uses `findEntryById`, then `sharedArray.indexOf(entry)` only for the splice position (still O(n), but the lookup itself is O(1)).

`findIndexOfEntryId` is retained for `handleInsertOp`, which feeds the index to `getInternalInsertIndexByIgnoringLocalPendingInserts(index)`; rewriting that helper around an entry reference would require restructuring local-pending tracking and is out of scope.

## Why

Today every remote insert / move / stashed op walks `sharedArray` linearly via `findIndexOfEntryId` despite an already-maintained id → entry Map sitting next to it. For the 100K-entry scenarios called out in the SharedArray docstring, each remote op pays 100K comparisons. This change is independent of squash and stands alone on perf grounds.

## Notes

Pure perf prep — no `reSubmitSquashed`, no squash logic, no tests touched, no api-report changes.
