### PR TITLE
perf(dds-map): use metadata identity for local set/delete ack lookups

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1974,15 +1974,14 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			return;
 		}
 		if (local) {
-			const pendingEntryIndex = this.pendingStorageData.findIndex(
-				(entry) => entry.type !== "clear" && entry.key === op.key,
-			);
-			const pendingEntry = this.pendingStorageData[pendingEntryIndex];
 			assert(
-				pendingEntry !== undefined &&
-					pendingEntry.type === "delete" &&
-					pendingEntry.key === op.key,
-				0xc05 /* Got a local delete message we weren't expecting */,
+				localOpMetadata !== undefined && localOpMetadata.type === "delete",
+				"Got a local delete message we weren't expecting",
+			);
+			const pendingEntryIndex = this.pendingStorageData.indexOf(localOpMetadata);
+			assert(
+				pendingEntryIndex !== -1,
+				"Local delete metadata not found in pending storage data",
 			);
 			this.pendingStorageData.splice(pendingEntryIndex, 1);
 			this.sequencedStorageData.delete(op.key);
@@ -2033,20 +2032,27 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		const { key } = op;
 
 		if (local) {
-			const pendingEntryIndex = this.pendingStorageData.findIndex(
-				(entry) => entry.type !== "clear" && entry.key === key,
-			);
-			const pendingEntry = this.pendingStorageData[pendingEntryIndex];
 			assert(
-				pendingEntry !== undefined && pendingEntry.type === "lifetime",
-				0xc06 /* Couldn't match local set message to pending lifetime */,
+				localOpMetadata !== undefined && localOpMetadata.type === "set",
+				"Got a local set message we weren't expecting",
+			);
+			// Locate the parent lifetime by reference identity: it is the entry whose
+			// keySets array contains this exact PendingKeySet instance as its head.
+			const pendingEntry = this.pendingStorageData.find(
+				(entry): entry is PendingKeyLifetime =>
+					entry.type === "lifetime" && entry.keySets[0] === localOpMetadata,
+			);
+			assert(
+				pendingEntry !== undefined,
+				"Couldn't match local set message to pending lifetime",
 			);
 			const pendingKeySet = pendingEntry.keySets.shift();
 			assert(
-				pendingKeySet !== undefined && pendingKeySet === localOpMetadata,
-				0xc07 /* Got a local set message we weren't expecting */,
+				pendingKeySet === localOpMetadata,
+				"Got a local set message we weren't expecting",
 			);
 			if (pendingEntry.keySets.length === 0) {
+				const pendingEntryIndex = this.pendingStorageData.indexOf(pendingEntry);
 				this.pendingStorageData.splice(pendingEntryIndex, 1);
 			}
 			this.sequencedStorageData.set(key, pendingKeySet.value);

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -767,16 +767,14 @@ export class MapKernel {
 				const { key } = op;
 
 				if (local) {
-					const pendingEntryIndex = this.pendingData.findIndex(
-						(entry) => entry.type !== "clear" && entry.key === key,
-					);
-					const pendingEntry = this.pendingData[pendingEntryIndex];
 					assert(
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
-						pendingEntry !== undefined &&
-							pendingEntry.type === "delete" &&
-							pendingEntry === localOpMetadata,
-						0xbf7 /* Got a local delete message we weren't expecting */,
+						localOpMetadata !== undefined && localOpMetadata.type === "delete",
+						"Got a local delete message we weren't expecting",
+					);
+					const pendingEntryIndex = this.pendingData.indexOf(localOpMetadata);
+					assert(
+						pendingEntryIndex !== -1,
+						"Local delete metadata not found in pending data",
 					);
 					this.pendingData.splice(pendingEntryIndex, 1);
 
@@ -808,21 +806,27 @@ export class MapKernel {
 				const { key, value } = op;
 
 				if (local) {
-					const pendingEntryIndex = this.pendingData.findIndex(
-						(entry) => entry.type !== "clear" && entry.key === key,
-					);
-					const pendingEntry = this.pendingData[pendingEntryIndex];
 					assert(
-						// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- using ?. could change behavior
-						pendingEntry !== undefined && pendingEntry.type === "lifetime",
-						0xbf8 /* Couldn't match local set message to pending lifetime */,
+						localOpMetadata !== undefined && localOpMetadata.type === "set",
+						"Got a local set message we weren't expecting",
+					);
+					// Locate the parent lifetime by reference identity: it is the entry whose
+					// keySets array contains this exact PendingKeySet instance as its head.
+					const pendingEntry = this.pendingData.find(
+						(entry): entry is PendingKeyLifetime =>
+							entry.type === "lifetime" && entry.keySets[0] === localOpMetadata,
+					);
+					assert(
+						pendingEntry !== undefined,
+						"Couldn't match local set message to pending lifetime",
 					);
 					const pendingKeySet = pendingEntry.keySets.shift();
 					assert(
-						pendingKeySet !== undefined && pendingKeySet === localOpMetadata,
-						0xbf9 /* Got a local set message we weren't expecting */,
+						pendingKeySet === localOpMetadata,
+						"Got a local set message we weren't expecting",
 					);
 					if (pendingEntry.keySets.length === 0) {
+						const pendingEntryIndex = this.pendingData.indexOf(pendingEntry);
 						this.pendingData.splice(pendingEntryIndex, 1);
 					}
 


### PR DESCRIPTION
## Description

Eliminates the `pendingData.findIndex(entry => entry.type !== "clear" && entry.key === op.key)` scans at four local-op-ack sites in `MapKernel` and `SubDirectory`. The `localOpMetadata` already carries the relevant `PendingKeyDelete` / `PendingKeySet`; the new code uses reference identity instead.

Sites converted:

- `mapKernel.ts` delete-ack: `localOpMetadata` IS the `PendingKeyDelete`; locate with `pendingData.indexOf(localOpMetadata)`.
- `mapKernel.ts` set-ack: `localOpMetadata` is the `PendingKeySet`; locate its parent lifetime via `find(entry => entry.type === "lifetime" && entry.keySets[0] === localOpMetadata)`.
- Same conversions in `directory.ts` for both ack paths.

The empty-lifetime splice still falls back to `pendingData.indexOf(pendingEntry)`, but only after the lifetime has been located by reference equality.

## Why

The read/process counterpart to the rollback fix already landed on `prep-map`. Today each local-op ack walks `pendingData` linearly by key; with the metadata in hand, the lookup is direct.

A future follow-up that adds a `lifetime` back-pointer on `PendingKeySet` (or that hands the ListNode through `localOpMetadata`) makes the set-ack lookup O(1) too — out of scope here.

## Notes

Pure perf prep — no `reSubmitSquashed`, no squash logic, no tests touched, no api-report changes.
