### PR TITLE
perf(tree): binary-search by parentIndex in PathNode/SparseNode removeChild

### DIFF
--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -1226,9 +1226,8 @@ class PathNode extends ReferenceCountedBase implements AnchorNode {
 		assert(this.status === Status.Alive, 0x40e /* PathNode must be alive */);
 		const key = child.parentField;
 		const field = this.children.get(key);
-		// TODO: should do more optimized search (ex: binary search or better) using child.parentIndex()
-		// Note that this is the index in the list of child paths, not the index within the field
-		const childIndex = field?.indexOf(child) ?? -1;
+		// Note that this is the index in the list of child paths, not the index within the field.
+		const childIndex = field === undefined ? -1 : binaryFindIndex(field, child.parentIndex);
 		assert(childIndex !== -1, 0x35c /* child must be parented to be removed */);
 		field?.splice(childIndex, 1);
 		if (field?.length === 0) {
@@ -1308,6 +1307,32 @@ function binaryFind(sorted: readonly PathNode[], index: number): PathNode | unde
 		}
 	}
 	return undefined; // If we reach here, target is not in array (or array was not sorted)
+}
+
+/**
+ * Find the array index of a child PathNode by its parentIndex using a binary search.
+ * @param sorted - array of PathNode's sorted by parentIndex.
+ * @param index - parentIndex being looked for.
+ * @returns array index of the child with the requested parentIndex, or -1 if not found.
+ */
+function binaryFindIndex(sorted: readonly PathNode[], index: number): number {
+	// inclusive
+	let min = 0;
+	// exclusive
+	let max = sorted.length;
+
+	while (min !== max) {
+		const mid = Math.floor((min + max) / 2);
+		const found = sorted[mid]!.parentIndex;
+		if (found === index) {
+			return mid;
+		} else if (found > index) {
+			max = mid;
+		} else {
+			min = mid + 1;
+		}
+	}
+	return -1;
 }
 
 interface BufferedEvent {

--- a/packages/dds/tree/src/core/tree/sparseTree.ts
+++ b/packages/dds/tree/src/core/tree/sparseTree.ts
@@ -111,9 +111,8 @@ export class SparseNode<TData> implements UpPath {
 	public removeChild(child: SparseNode<TData>): void {
 		const key = child.parentField;
 		const field = this.children.get(key);
-		// TODO: should do more optimized search (ex: binary search or better) using child.parentIndex()
-		// Note that this is the index in the list of child paths, not the index within the field
-		const childIndex = field?.indexOf(child) ?? -1;
+		// Note that this is the index in the list of child paths, not the index within the field.
+		const childIndex = field === undefined ? -1 : binaryFindIndex(field, child.parentIndex);
 		assert(childIndex !== -1, 0x4a5 /* child must be parented to be removed */);
 		field?.splice(childIndex, 1);
 		if (field?.length === 0) {
@@ -143,6 +142,32 @@ export class SparseNode<TData> implements UpPath {
 		// eslint-disable-next-line unicorn/prefer-dom-node-remove -- Custom tree structure, not DOM
 		this.parentPath?.removeChild(this);
 	}
+}
+
+/**
+ * Find the array index of a child SparseNode by its parentIndex using a binary search.
+ * @param sorted - array of SparseNode's sorted by parentIndex.
+ * @param index - parentIndex being looked for.
+ * @returns array index of the child with the requested parentIndex, or -1 if not found.
+ */
+function binaryFindIndex<TData>(sorted: readonly SparseNode<TData>[], index: number): number {
+	// inclusive
+	let min = 0;
+	// exclusive
+	let max = sorted.length;
+
+	while (min !== max) {
+		const mid = Math.floor((min + max) / 2);
+		const found = sorted[mid]!.parentIndex;
+		if (found === index) {
+			return mid;
+		} else if (found > index) {
+			max = mid;
+		} else {
+			min = mid + 1;
+		}
+	}
+	return -1;
 }
 
 export function getDescendant<TData>(


### PR DESCRIPTION
## Description

Replaces the linear `indexOf` in `PathNode.removeChild` (`anchorSet.ts`) and `SparseNode.removeChild` (`sparseTree.ts`) with binary search by `child.parentIndex()`. The field arrays are already kept sorted by `parentIndex` (the existing `binaryFind` helpers on the same structs rely on it).

A local `binaryFindIndex` helper is added in each file. I did not extend the existing `binaryFind` because it returns the element (not the index) and has a tuned "guess" fast-path for dense arrays that doesn't apply to the index-by-parentIndex case. Two small focused helpers leave the benchmarked `binaryFind` untouched.

The existing TODOs at both `removeChild` sites are removed. The `splice(idx, 1)` after the search is unchanged (array remove is still O(n) but the dominant cost was the scan).

## Why

The TODO at both sites already called this out: "should do more optimized search (ex: binary search or better) using `child.parentIndex()`." This is invoked from anchor lifecycle (`considerDispose`) — every anchor free in workloads with many siblings paid the scan.

## Notes

Pure perf refactor — no behavior change. The sort-by-`parentIndex` invariant is already maintained by every field mutator (`getOrCreateChild` sorts after push; `coupleNodes` / `decoupleNodes` / `offsetChildren` preserve the order). No tests, changesets, or api-report changes.
