### PR TITLE
perf(dds-map): back PendingKeyLifetime.keySets with DoublyLinkedList

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/prefer-optional-chain */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { DoublyLinkedList, assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -241,11 +241,11 @@ interface PendingKeyLifetime {
 	key: string;
 	path: string;
 	/**
-	 * A non-empty array of pending key sets that occurred during this lifetime.  If the list
+	 * A non-empty list of pending key sets that occurred during this lifetime.  If the list
 	 * becomes empty (e.g. during processing or rollback), the lifetime no longer exists and
 	 * must be removed from the pending data.
 	 */
-	keySets: PendingKeySet[];
+	keySets: DoublyLinkedList<PendingKeySet>;
 	subdir: SubDirectory;
 }
 
@@ -1246,7 +1246,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				type: "lifetime",
 				path: this.absolutePath,
 				key,
-				keySets: [],
+				keySets: new DoublyLinkedList<PendingKeySet>(),
 				subdir: this,
 			};
 			this.pendingStorageData.push(latestPendingEntry);
@@ -1757,7 +1757,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					if (nextPendingEntryIndex > mostRecentDeleteOrClearIndex) {
 						const latestPendingValue =
 							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							nextPendingEntry.keySets[nextPendingEntry.keySets.length - 1]!;
+							nextPendingEntry.keySets.last!.data;
 						// Skip iterating if we would have would have already iterated it as part of the sequenced data.
 						// This is not a perfect check in the case the map has changed since the iterator was created
 						// (e.g. if a remote client added the same key in the meantime).
@@ -1799,7 +1799,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		} else if (latestPendingEntry.type === "lifetime") {
 			const latestPendingSet =
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				latestPendingEntry.keySets[latestPendingEntry.keySets.length - 1]!;
+				latestPendingEntry.keySets.last!.data;
 			return latestPendingSet.value;
 		} else {
 			// Delete or clear
@@ -2041,15 +2041,15 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				pendingEntry !== undefined && pendingEntry.type === "lifetime",
 				0xc06 /* Couldn't match local set message to pending lifetime */,
 			);
-			const pendingKeySet = pendingEntry.keySets.shift();
+			const pendingKeySetNode = pendingEntry.keySets.shift();
 			assert(
-				pendingKeySet !== undefined && pendingKeySet === localOpMetadata,
+				pendingKeySetNode !== undefined && pendingKeySetNode.data === localOpMetadata,
 				0xc07 /* Got a local set message we weren't expecting */,
 			);
 			if (pendingEntry.keySets.length === 0) {
 				this.pendingStorageData.splice(pendingEntryIndex, 1);
 			}
-			this.sequencedStorageData.set(key, pendingKeySet.value);
+			this.sequencedStorageData.set(key, pendingKeySetNode.data.value);
 		} else {
 			// Get the previous value before setting the new value
 			const previousValue: unknown = this.sequencedStorageData.get(key);
@@ -2302,7 +2302,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 						entry.key === op.key &&
 						// We also check that the keySets include the localOpMetadata. It's possible we have new
 						// pending key sets that are not the op we are looking for.
-						entry.keySets.includes(localOpMetadata as PendingKeySet)
+						entry.keySets.find((node) => node.data === (localOpMetadata as PendingKeySet)) !==
+							undefined
 				: entry.type === "delete" && entry.key === op.key;
 		});
 		const pendingEntry = this.pendingStorageData[pendingEntryIndex];
@@ -2500,9 +2501,9 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 					this.emit("containedValueChanged", containedEvent, true, this);
 				}
 			} else if (pendingEntry.type === "lifetime") {
-				const pendingKeySet = pendingEntry.keySets.pop();
+				const pendingKeySetNode = pendingEntry.keySets.pop();
 				assert(
-					pendingKeySet !== undefined && pendingKeySet === localOpMetadata,
+					pendingKeySetNode !== undefined && pendingKeySetNode.data === localOpMetadata,
 					0xc0c /* Unexpected set rollback */,
 				);
 				if (pendingEntry.keySets.length === 0) {
@@ -2511,12 +2512,12 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				const event: IDirectoryValueChanged = {
 					key: directoryOp.key,
 					path: this.absolutePath,
-					previousValue: pendingKeySet.value,
+					previousValue: pendingKeySetNode.data.value,
 				};
 				this.directory.emit("valueChanged", event, true, this.directory);
 				const containedEvent: IValueChanged = {
 					key: directoryOp.key,
-					previousValue: pendingKeySet.value,
+					previousValue: pendingKeySetNode.data.value,
 				};
 				this.emit("containedValueChanged", containedEvent, true, this);
 			}

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -5,7 +5,7 @@
 
 import type { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { DoublyLinkedList, assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import { ValueType } from "@fluidframework/shared-object-base/internal";
 
@@ -89,11 +89,11 @@ interface PendingKeyLifetime {
 	type: "lifetime";
 	key: string;
 	/**
-	 * A non-empty array of pending key sets that occurred during this lifetime.  If the list
+	 * A non-empty list of pending key sets that occurred during this lifetime.  If the list
 	 * becomes empty (e.g. during processing or rollback), the lifetime no longer exists and
 	 * must be removed from the pending data.
 	 */
-	keySets: PendingKeySet[];
+	keySets: DoublyLinkedList<PendingKeySet>;
 }
 
 /**
@@ -219,7 +219,7 @@ export class MapKernel {
 					if (nextPendingEntryIndex > mostRecentDeleteOrClearIndex) {
 						const latestPendingValue =
 							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							nextPendingEntry.keySets[nextPendingEntry.keySets.length - 1]!;
+							nextPendingEntry.keySets.last!.data;
 						// Skip iterating if we would have would have already iterated it as part of the sequenced data.
 						// This is not a perfect check in the case the map has changed since the iterator was created
 						// (e.g. if a remote client added the same key in the meantime).
@@ -357,7 +357,7 @@ export class MapKernel {
 		} else if (latestPendingEntry.type === "lifetime") {
 			const latestPendingSet =
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				latestPendingEntry.keySets[latestPendingEntry.keySets.length - 1]!;
+				latestPendingEntry.keySets.last!.data;
 			return latestPendingSet.value;
 		} else {
 			// Delete or clear
@@ -419,7 +419,7 @@ export class MapKernel {
 			latestPendingEntry.type === "delete" ||
 			latestPendingEntry.type === "clear"
 		) {
-			latestPendingEntry = { type: "lifetime", key, keySets: [] };
+			latestPendingEntry = { type: "lifetime", key, keySets: new DoublyLinkedList<PendingKeySet>() };
 			this.pendingData.push(latestPendingEntry);
 		}
 		const pendingKeySet: PendingKeySet = {
@@ -681,9 +681,9 @@ export class MapKernel {
 					);
 				}
 			} else if (pendingEntry.type === "lifetime") {
-				const pendingKeySet = pendingEntry.keySets.pop();
+				const pendingKeySetNode = pendingEntry.keySets.pop();
 				assert(
-					pendingKeySet !== undefined && pendingKeySet === typedLocalOpMetadata,
+					pendingKeySetNode !== undefined && pendingKeySetNode.data === typedLocalOpMetadata,
 					0xbf5 /* Unexpected set rollback */,
 				);
 				if (pendingEntry.keySets.length === 0) {
@@ -691,7 +691,7 @@ export class MapKernel {
 				}
 				this.eventEmitter.emit(
 					"valueChanged",
-					{ key: mapOp.key, previousValue: pendingKeySet.value.value },
+					{ key: mapOp.key, previousValue: pendingKeySetNode.data.value.value },
 					true,
 					this.eventEmitter,
 				);
@@ -817,16 +817,16 @@ export class MapKernel {
 						pendingEntry !== undefined && pendingEntry.type === "lifetime",
 						0xbf8 /* Couldn't match local set message to pending lifetime */,
 					);
-					const pendingKeySet = pendingEntry.keySets.shift();
+					const pendingKeySetNode = pendingEntry.keySets.shift();
 					assert(
-						pendingKeySet !== undefined && pendingKeySet === localOpMetadata,
+						pendingKeySetNode !== undefined && pendingKeySetNode.data === localOpMetadata,
 						0xbf9 /* Got a local set message we weren't expecting */,
 					);
 					if (pendingEntry.keySets.length === 0) {
 						this.pendingData.splice(pendingEntryIndex, 1);
 					}
 
-					this.sequencedData.set(key, pendingKeySet.value);
+					this.sequencedData.set(key, pendingKeySetNode.data.value);
 				} else {
 					migrateIfSharedSerializable(value, this.serializer, this.handle);
 					const localValue: ILocalValue = { value: value.value };


### PR DESCRIPTION
## Description

Replaces `PendingKeyLifetime.keySets: PendingKeySet[]` with `DoublyLinkedList<PendingKeySet>` in both `mapKernel.ts` and `directory.ts`.

Sites converted:

- Field declaration in both files.
- Construction: `new DoublyLinkedList<PendingKeySet>()`.
- ACK `shift()` (`mapKernel.ts:set` ack, `directory.ts:set` ack): `list.shift()?.data` — O(1) instead of `Array.shift()`'s O(k).
- Rollback `pop()`: `list.pop()?.data`.
- Last-element reads: `list.last!.data`.
- `.includes(localOpMetadata)` in `directory.ts:resubmitKeyMessage`: translated to a `find` over the list comparing `.data` identity. Same O(k) as before; a future follow-up that captures the `ListNode` on `localOpMetadata` would make this O(1) too.
- `.length === 0` checks compatible (DoublyLinkedList exposes `length`).

## Why

`Array.shift()` is O(k) per ack on a lifetime with k queued keySets. For a hot key written k times before any ack, draining k acks was O(k²). `DoublyLinkedList.shift()` is O(1).

## Notes

Pure perf prep — no `reSubmitSquashed`, no squash logic, no tests touched, no api-report changes.
