### PR TITLE
Disable some slow low value lints for tests in tree

### DIFF
--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -47,6 +47,18 @@ const config: Linter.Config[] = [
 			"unicorn/consistent-function-scoping": "off",
 			// Test files frequently use `as any` casts to access internal/hidden properties for testing
 			"@typescript-eslint/no-unsafe-member-access": "off",
+
+			//#region Lints disabled due to being slow and low value for tests
+			// Promise lint rules are useful in production paths but are disproportionately expensive in tests.
+			"@typescript-eslint/no-misused-promises": "off",
+			"@typescript-eslint/no-floating-promises": "off",
+			// This is currently the largest lint hotspot in test files and adds limited value there.
+			"@typescript-eslint/strict-boolean-expressions": "off",
+			// Import namespace validation is also expensive and low-value for test-only imports.
+			"import-x/namespace": "off",
+			// Regex optimization suggestions are not important for test code paths.
+			"unicorn/better-regex": "off",
+			//#endregion
 		},
 	},
 ];

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -48,7 +48,7 @@ const config: Linter.Config[] = [
 			// Test files frequently use `as any` casts to access internal/hidden properties for testing
 			"@typescript-eslint/no-unsafe-member-access": "off",
 
-			//#region Lints disabled due to being slow and low value for tests
+			// #region Lints disabled due to being slow and low value for tests
 			// Since our build ignores "warn" level lints, but they might be useful to devs interactively (and thats not where we have perf issues),
 			// these are kept as "warn" instead of simply "off".
 			// Promise lint rules are useful in production paths but are disproportionately expensive in tests.
@@ -60,7 +60,7 @@ const config: Linter.Config[] = [
 			"import-x/namespace": "warn",
 			// Regex optimization suggestions are not important for test code paths.
 			"unicorn/better-regex": "warn",
-			//#endregion
+			// #endregion
 		},
 	},
 ];

--- a/packages/dds/tree/eslint.config.mts
+++ b/packages/dds/tree/eslint.config.mts
@@ -49,15 +49,17 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-unsafe-member-access": "off",
 
 			//#region Lints disabled due to being slow and low value for tests
+			// Since our build ignores "warn" level lints, but they might be useful to devs interactively (and thats not where we have perf issues),
+			// these are kept as "warn" instead of simply "off".
 			// Promise lint rules are useful in production paths but are disproportionately expensive in tests.
-			"@typescript-eslint/no-misused-promises": "off",
-			"@typescript-eslint/no-floating-promises": "off",
+			"@typescript-eslint/no-misused-promises": "warn",
+			"@typescript-eslint/no-floating-promises": "warn",
 			// This is currently the largest lint hotspot in test files and adds limited value there.
-			"@typescript-eslint/strict-boolean-expressions": "off",
+			"@typescript-eslint/strict-boolean-expressions": "warn",
 			// Import namespace validation is also expensive and low-value for test-only imports.
-			"import-x/namespace": "off",
+			"import-x/namespace": "warn",
 			// Regex optimization suggestions are not important for test code paths.
-			"unicorn/better-regex": "off",
+			"unicorn/better-regex": "warn",
 			//#endregion
 		},
 	},


### PR DESCRIPTION
## Description

This improves lint time for tree from 53 seconds to 44 (or 27 to 22.5 when combined with https://github.com/microsoft/FluidFramework/pull/27431

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

