### PR TITLE
Add beta entry point to core-utils

### DIFF
--- a/packages/common/core-utils/README.md
+++ b/packages/common/core-utils/README.md
@@ -31,6 +31,8 @@ For more information on the related support guarantees, see [API Support Levels]
 
 To access the `public` ([SemVer](https://semver.org/)) APIs, import via `@fluidframework/core-utils` like normal.
 
+To access the `beta` APIs, import via `@fluidframework/core-utils/beta`.
+
 To access the `alpha` APIs, import via `@fluidframework/core-utils/alpha`.
 
 To access the `legacy` APIs, import via `@fluidframework/core-utils/legacy`.

--- a/packages/common/core-utils/api-extractor/api-extractor-lint-beta.cjs.json
+++ b/packages/common/core-utils/api-extractor/api-extractor-lint-beta.cjs.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/dist/beta.d.ts"
+}

--- a/packages/common/core-utils/api-extractor/api-extractor-lint-beta.esm.json
+++ b/packages/common/core-utils/api-extractor/api-extractor-lint-beta.esm.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/beta.d.ts"
+}

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -33,6 +33,16 @@
 				"default": "./dist/index.js"
 			}
 		},
+		"./beta": {
+			"import": {
+				"types": "./lib/beta.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/beta.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
 		"./legacy": {
 			"import": {
 				"types": "./lib/legacy.d.ts",
@@ -78,9 +88,11 @@
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.cjs.json",
+		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
 		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
 		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
 		"check:exports:esm:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.esm.json",
+		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
 		"check:exports:esm:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json",
 		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -69,8 +69,6 @@ export type {
 	FluidMap,
 	FluidReadonlyMap,
 } from "@fluidframework/core-interfaces/internal";
-
-// This is a beta API, but core-utils doesn't have a beta entry point so it's imported from "internal".
 export { onAssertionFailure } from "@fluidframework/core-utils/internal";
 
 export type { isFluidHandle } from "@fluidframework/runtime-utils";


### PR DESCRIPTION
## Description

Add beta entry point to core-utils: it has a beta API now (as ofd https://github.com/microsoft/FluidFramework/pull/27282), and the changeset for that API documents using it via this previously non existent entry point.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
