### PR TITLE
test(test-version-utils) Removed convertRegistry from e2e test infra that implicitly converts DDS registries

### DIFF
--- a/packages/test/test-end-to-end-tests/README.md
+++ b/packages/test/test-end-to-end-tests/README.md
@@ -31,7 +31,7 @@ Fluid values used by an e2e test (DDS factories, `DataObject`, `Loader`, `Contai
 If a test imports one of the restricted symbols statically, ESLint's `@typescript-eslint/no-restricted-imports` rule will fail the build with a message like
 _"`SharedMap` import from `@fluidframework/map/internal` is restricted from being used by a pattern. Rather than import this Fluid package directly, use the 'apis' argument of describeCompat."_
 
-**For the patterns — using `apis`, the cross-client compat split (`apis.ddsForLoading` etc.), the fallback pattern for recently-added DDSes, and the legitimate exceptions where `eslint-disable` is appropriate — see [WritingCompatCorrectTests.md](./WritingCompatCorrectTests.md).**
+**For the patterns — using `apis`, the create vs. load API split (`apis.dds` / `apis.ddsForLoading` etc.) and the legitimate exceptions where `eslint-disable` is appropriate — see [WritingCompatCorrectTests.md](./WritingCompatCorrectTests.md).**
 
 For a worked example of an entire test file written this way, see [`sharedStringEndToEndTests.spec.ts`](src/test/sharedStringEndToEndTests.spec.ts). That same [directory](src/test) contains more complex examples too.
 

--- a/packages/test/test-end-to-end-tests/README.md
+++ b/packages/test/test-end-to-end-tests/README.md
@@ -24,96 +24,16 @@ The tests in this package are typically built upon:
 
 Check out the test-utils [README](../test-utils/README.md) that outlines how to write a test.
 
-Whenever possible, try to avoid importing Fluid APIs statically, since that won't fully leverage `test-version-utils`:
-the containers the test constructs will only reference code in the current version of Fluid.
-Instead, use the `apis` argument passed to `describeCompat`'s test creation function.
-This argument provides Fluid public APIs which internally reference the package version being tested under the current compatibility configuration.
-The APIs are organized roughly by layer, i.e. `apis.dds` exports the various DDS types,
-`apis.containerRuntime` exports concepts for building a container runtime (including bits of `@fluidframework/aqueduct`), etc.
+### Writing Compat-Correct Tests
 
-Less common APIs can be found on `apis.<layer-name>.packages.<package-name>` (package names are unscoped and camelCased).
-Keep in mind that if these APIs change over time, tests depending on them will either need to have a reduced compat matrix or include back-compat logic.
-See "Change contents of dds, then rehydrate and then check summary" for an example of such a test.
+Fluid values used by an e2e test (DDS factories, `DataObject`, `Loader`, `ContainerRuntime`, etc.) must come from the `apis` argument passed to the `describeCompat` callback — **not** from a static `import` of the corresponding package. Static value imports always resolve to the current version's code, which silently defeats the compat matrix: the test runs against every compat configuration but in fact only exercises the current version.
 
-### ❌ Incorrect
+If a test imports one of the restricted symbols statically, ESLint's `@typescript-eslint/no-restricted-imports` rule will fail the build with a message like
+_"`SharedMap` import from `@fluidframework/map/internal` is restricted from being used by a pattern. Rather than import this Fluid package directly, use the 'apis' argument of describeCompat."_
 
-```typescript
-import { SharedString, createOverlappingIntervalsIndex } from "@fluidframework/sequence";
+**For the patterns — using `apis`, the cross-client compat split (`apis.ddsForLoading` etc.), the fallback pattern for recently-added DDSes, and the legitimate exceptions where `eslint-disable` is appropriate — see [WritingCompatCorrectTests.md](./WritingCompatCorrectTests.md).**
 
-const registry: ChannelFactoryRegistry = [["sharedString", SharedString.getFactory()]];
-const testContainerConfig: ITestContainerConfig = {
-	fluidDataObjectType: DataObjectFactoryType.Test,
-	registry,
-};
-
-describeCompat("SharedString", "FullCompat", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	beforeEach(() => {
-		provider = getTestObjectProvider();
-	});
-
-	it("supports collaborative text with intervals", async () => {
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-		const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
-		const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-		const overlapping = createOverlappingIntervalsIndex(sharedString1);
-	});
-});
-```
-
-#### ✅ Correct
-
-```typescript
-describeCompat("SharedString", "FullCompat", (getTestObjectProvider, api) => {
-	const { SharedString } = api.dds;
-	const { createOverlappingIntervalsIndex } = api.dataRuntime.packages.sequence;
-
-	// Note that `SharedString` below is equivalent to `api.dds.SharedString`.
-	// It can be used as if you had imported it from @fluidframework/sequence at runtime.
-	const registry: ChannelFactoryRegistry = [["sharedString", SharedString.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
-	};
-
-	let provider: ITestObjectProvider;
-	beforeEach(() => {
-		provider = getTestObjectProvider();
-	});
-
-	it("supports collaborative text", async () => {
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-		const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
-		const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-		const overlapping = createOverlappingIntervalsIndex(sharedString1);
-	});
-});
-```
-
-If your code needs to refer to a DDS's type (e.g. to explicitly annotate the type of a variable), you can
-use `import type` expressions freely:
-
-```typescript
-import type { SharedString } from "@fluidframework/sequence";
-
-function insert(str: SharedString): void {
-	str.insertText(0, "hello");
-}
-```
-
-#### Exceptions
-
-Enforcement of this rule is a work in progress.
-
--   Some test-version-utils APIs such as `describeInstallVersions` don't make static import convenient.
--   Not all imports are yet enforced.
-
-### Example
-
-Take a look at the [SharedStringEndToEndTest](src/test/sharedStringEndToEndTests.spec.ts) for a basic example
-of how to write an end-to-end test.
-
-That same [directory](src/test) contains more complex examples too.
+For a worked example of an entire test file written this way, see [`sharedStringEndToEndTests.spec.ts`](src/test/sharedStringEndToEndTests.spec.ts). That same [directory](src/test) contains more complex examples too.
 
 ## Debugging
 

--- a/packages/test/test-end-to-end-tests/WritingCompatCorrectTests.md
+++ b/packages/test/test-end-to-end-tests/WritingCompatCorrectTests.md
@@ -1,0 +1,367 @@
+# Writing Compat-Correct Tests
+
+This document explains how to write Fluid Framework end-to-end tests that correctly exercise compatibility across versions. Tests that bypass these patterns may silently pass under the current version and break when run against older or cross-client compat configurations.
+
+If you arrived here from an ESLint `@typescript-eslint/no-restricted-imports` error — typically of the form
+_"`'@fluidframework/<pkg>/internal'` import is restricted from being used by a pattern. Rather than import this Fluid package directly, use the 'apis' argument of describeCompat."_
+or _"`<Name>` import from `'@fluidframework/<pkg>/internal'` is restricted from being used by a pattern. Use `apis.<layer>.<Name>` from describeCompat instead."_ — this is the doc to read.
+
+## Why this matters
+
+`describeCompat` parameterizes a test suite over a **compatibility matrix**: the same test runs against multiple combinations of Loader / Container Runtime / Data Runtime / DDS package versions. The compat matrix is what catches version-skew bugs before they reach production.
+
+The matrix only works if the test code uses the **version-aware factories and classes** that `describeCompat` provides via its `apis` argument. A statically imported `SharedMap` (for example) is fixed to the current version. When the matrix tries to run the test against an older container-runtime + older Data Runtime combination, that test still uses the current-version `SharedMap` — silently testing only the current version under the guise of the older config.
+
+For background on the compat matrix itself, see [test-version-utils's README.md](../test-version-utils/README.md) and [Compatibility.md](../../../docs/content/docs/deep/compatibility.md).
+
+## Using `apis`
+
+`describeCompat`'s callback receives `apis` as its second argument. **Use it for every value reference to a compat-versioned type** — never import these statically. Destructure what you need at the top of the callback so the rest of the test body reads naturally:
+
+```ts
+describeCompat("My Test", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedMap, SharedString } = apis.dds;
+    const { DataObject, DataObjectFactory } = apis.dataRuntime;
+    const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+    const { Loader } = apis.loader;
+    // ...
+});
+```
+
+The `apis` object is organized by layer:
+
+| Path | What's there |
+|---|---|
+| `apis.dds.*` | DDS factory classes: `SharedMap`, `SharedDirectory`, `SharedCell`, `SharedCounter`, `SharedMatrix`, `SharedString`, `SharedTree`, `ConsensusQueue`, `ConsensusRegisterCollection`, `SparseMatrix`, `SharedArray`, `SharedSignal` |
+| `apis.dataRuntime.*` | `DataObject`, `DataObjectFactory`, `FluidDataStoreRuntime`, `TestFluidObjectFactory` |
+| `apis.dataRuntime.packages.<pkg>` | Less common APIs by package: `cell`, `counter`, `datastore`, `map`, `matrix`, `orderedCollection`, `registerCollection`, `sequence`, `sequenceDeprecated`, `agentScheduler`, `tree` |
+| `apis.containerRuntime.*` | `ContainerRuntime`, `BaseContainerRuntimeFactory`, `ContainerRuntimeFactoryWithDefaultDataStore` |
+| `apis.loader.*` | `Loader` |
+
+`apis.<layer-name>.packages.<package-name>` (package names are unscoped and camelCased) holds less common exports such as helper functions and constants. Keep in mind that if these APIs change over time, tests depending on them will either need to have a reduced compat matrix or include back-compat logic. See `"Change contents of dds, then rehydrate and then check summary"` for an example of such a test.
+
+### ❌ Static import — DON'T
+
+```ts
+import { SharedString, createOverlappingIntervalsIndex } from "@fluidframework/sequence";
+
+const registry: ChannelFactoryRegistry = [["sharedString", SharedString.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    fluidDataObjectType: DataObjectFactoryType.Test,
+    registry,
+};
+
+describeCompat("SharedString", "FullCompat", (getTestObjectProvider) => {
+    // ...
+    it("supports collaborative text with intervals", async () => {
+        const container1 = await provider.makeTestContainer(testContainerConfig);
+        const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
+        const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+        const overlapping = createOverlappingIntervalsIndex(sharedString1);
+    });
+});
+```
+
+The factory registered in `testContainerConfig` is fixed to the current version even when the compat matrix tries to run this test against an older Data Runtime. The test silently passes against a version it didn't actually exercise.
+
+### ✅ Through `apis` — DO
+
+```ts
+describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedString } = apis.dds;
+    const { createOverlappingIntervalsIndex } = apis.dataRuntime.packages.sequence;
+
+    // Note that `SharedString` below is equivalent to `apis.dds.SharedString` — it can be used as
+    // if you had imported it from @fluidframework/sequence, but it will be the version under test.
+    const registry: ChannelFactoryRegistry = [["sharedString", SharedString.getFactory()]];
+    const testContainerConfig: ITestContainerConfig = {
+        fluidDataObjectType: DataObjectFactoryType.Test,
+        registry,
+    };
+
+    let provider: ITestObjectProvider;
+    beforeEach(() => {
+        provider = getTestObjectProvider();
+    });
+
+    it("supports collaborative text", async () => {
+        const container1 = await provider.makeTestContainer(testContainerConfig);
+        const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
+        const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+        const overlapping = createOverlappingIntervalsIndex(sharedString1);
+    });
+});
+```
+
+### DDS factories in a registry
+
+```ts
+describeCompat("Map test", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedMap } = apis.dds;
+    const registry: ChannelFactoryRegistry = [["map", SharedMap.getFactory()]];
+    // ...
+});
+```
+
+### Extending a DataObject
+
+```ts
+describeCompat("Custom data object", "FullCompat", (getTestObjectProvider, apis) => {
+    const { DataObject, DataObjectFactory } = apis.dataRuntime;
+
+    class MyDataObject extends DataObject {
+        protected async initializingFirstTime(): Promise<void> {
+            // ...
+        }
+    }
+
+    const factory = new DataObjectFactory({ type: "my-data-object", ctor: MyDataObject });
+    // ...
+});
+```
+
+### Building a container runtime factory
+
+```ts
+describeCompat("Runtime factory test", "FullCompat", (getTestObjectProvider, apis) => {
+    const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+    const { DataObject, DataObjectFactory } = apis.dataRuntime;
+
+    // ... build dataObjectFactory ...
+
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+        defaultFactory: dataObjectFactory,
+        registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
+    });
+});
+```
+
+### Creating a Loader
+
+```ts
+describeCompat("Loader test", "NoCompat", (getTestObjectProvider, apis) => {
+    const { Loader } = apis.loader;
+    const provider = getTestObjectProvider();
+    const loader = new Loader({
+        urlResolver: provider.urlResolver,
+        documentServiceFactory: provider.documentServiceFactory,
+        codeLoader: /* ... */,
+    });
+});
+```
+
+### SharedTree schema and tree utilities
+
+`SchemaFactory`, `TreeViewConfiguration`, and `configuredSharedTree` are exported through `apis.dataRuntime.packages.tree`. The default `SharedTree` factory is available as `apis.dds.SharedTree`, but most tests need `configuredSharedTree` so they can opt into specific behavior (shared branches, identifier handling, etc.). The returned object is a drop-in replacement for `SharedTree` and stays compat-versioned because `configuredSharedTree` itself is reached through `apis`:
+
+```ts
+describeCompat("Tree test", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SchemaFactory, TreeViewConfiguration, configuredSharedTree } =
+        apis.dataRuntime.packages.tree;
+
+    const SharedTree = configuredSharedTree({
+        healUnresolvableIdentifiersOnDecode: false,
+        enableSharedBranches: true,
+    });
+
+    const sf = new SchemaFactory("test");
+    class Root extends sf.object("Root", { id: sf.identifier }) {}
+    const treeConfig = new TreeViewConfiguration({ schema: Root });
+    // Register SharedTree.getFactory() in your data store / channel registry as usual.
+});
+```
+
+### Type-only references
+
+If your code needs to refer to a DDS's type (e.g. to annotate the type of a variable or function parameter), use `import type` freely — it has no runtime effect and the lint rule allows it:
+
+```ts
+import type { ISharedMap, SharedDirectory } from "@fluidframework/map/internal";
+import type { SharedString } from "@fluidframework/sequence";
+import type { TreeView } from "@fluidframework/tree";
+
+function insert(str: SharedString): void {
+    str.insertText(0, "hello");
+}
+
+describeCompat("Map", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedDirectory } = apis.dds;  // value comes from apis
+    // The `SharedDirectory` type-import above is fine — both names coexist in different namespaces.
+});
+```
+
+## Cross-client compat tests
+
+In **CrossClientCompat** mode (one of the configs run by `FullCompat`), the client that creates the container **will be a different version** than the client that loads it. That is the whole point of the mode.
+
+The test infrastructure handles most of this for you automatically: when `provider.makeTestContainer(...)` is called, the provider configures the loader, drivers, and other internal plumbing with the create-side versions; when `provider.loadTestContainer(...)` is called, it configures them with the load-side versions. **You only need to think about cross-client compat for the objects you pass to these APIs yourself.** Factories you put into a `ChannelFactoryRegistry`, a `DataObjectFactory`, or a custom `Loader` are *your* responsibility — they must match the side of the operation they're being used on.
+
+`apis` provides paired entries for this: each layer has a `…ForLoading` counterpart that contains the load-side version. When the test is not running cross-client, the `…ForLoading` entries are `undefined`, so a `??` fallback to the create-side keeps single-client modes correct:
+
+```ts
+const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+const dataRuntimeForLoading = apis.dataRuntimeForLoading ?? apis.dataRuntime;
+const containerRuntimeForLoading = apis.containerRuntimeForLoading ?? apis.containerRuntime;
+const loaderForLoading = apis.loaderForLoading ?? apis.loader;
+```
+
+### Pattern: separate create and load configs
+
+The most common shape — a test that calls both `makeTestContainer` and `loadTestContainer`:
+
+```ts
+describeCompat("Map", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedMap } = apis.dds;
+    // For cross-client compat: load-side may be a different version than create-side.
+    const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+
+    const createRegistry: ChannelFactoryRegistry = [["map", SharedMap.getFactory()]];
+    const loadRegistry: ChannelFactoryRegistry = [
+        ["map", ddsForLoading.SharedMap.getFactory()],
+    ];
+
+    const createContainerConfig: ITestContainerConfig = {
+        fluidDataObjectType: DataObjectFactoryType.Test,
+        registry: createRegistry,
+    };
+    const loadContainerConfig: ITestContainerConfig = {
+        fluidDataObjectType: DataObjectFactoryType.Test,
+        registry: loadRegistry,
+    };
+
+    it("syncs the map", async () => {
+        const provider = getTestObjectProvider();
+        const container1 = await provider.makeTestContainer(createContainerConfig);   // CREATE — create-side factory
+        const container2 = await provider.loadTestContainer(loadContainerConfig);     // LOAD  — load-side factory
+        // ...
+    });
+});
+```
+
+### Pattern: two `Loader` instances
+
+For tests that drive the lifecycle directly with `provider.makeTestLoader(...)` and `loader.resolve(...)` rather than `make/loadTestContainer`:
+
+```ts
+describeCompat("Attach lifecycle", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedString } = apis.dds;
+    const SharedStringForLoading = (apis.ddsForLoading ?? apis.dds).SharedString;
+
+    it("survives attach order permutations", async () => {
+        const provider = getTestObjectProvider();
+        const createRegistry: [string | undefined, IChannelFactory][] = [
+            ["sharedString", SharedString.getFactory()],
+        ];
+        const loadRegistry: [string | undefined, IChannelFactory][] = [
+            ["sharedString", SharedStringForLoading.getFactory()],
+        ];
+        const initLoader = provider.makeTestLoader({ registry: createRegistry });
+        const validationLoader = provider.makeTestLoader({ registry: loadRegistry });
+
+        // initLoader.createDetachedContainer(...) → attach → close
+        // validationLoader.resolve({ url: ... }) → verify state
+    });
+});
+```
+
+## Handling recently-added APIs
+
+Some `apis.dds.*` entries (notably `SharedArray`, `SharedSignal`, and `SharedTree`) may be undefined when running against older compat versions whose Data Runtime didn't expose them. There are two valid strategies:
+
+### Option A: Gate the test on the version (preferred when the test *is* about compat)
+
+If the test exists to exercise compat behavior of the API itself, it shouldn't fabricate the API for versions that never had it. Skip those configs explicitly using `apis.mode` and the version on `apis.dataRuntime` / `apis.dataRuntimeForLoading`. See [`treeCompat.spec.ts`](./src/test/treeCompat.spec.ts) for the established pattern:
+
+```ts
+import { lt } from "semver";
+
+describeCompat("My SharedTree compat test", "FullCompat", (getTestObjectProvider, apis) => {
+    beforeEach(function () {
+        // SharedTree was added in version 2.0.0 — skip cross-client configs whose
+        // create or load version predates that.
+        if (apis.mode === "CrossClientCompat") {
+            const version = apis.dataRuntime.version;
+            const versionForLoading = apis.dataRuntimeForLoading?.version;
+            assert(versionForLoading !== undefined, "versionForLoading must be defined in cross-client");
+            if (lt(version, "2.0.0") || lt(versionForLoading, "2.0.0")) {
+                this.skip();
+            }
+        }
+    });
+
+    // The test body can now safely assume apis.dds.SharedTree / apis.dataRuntime.packages.tree.* exist.
+});
+```
+
+This keeps the compat matrix honest: a config that genuinely couldn't run the test gets `skip()` instead of being silently rerouted to current-version code.
+
+### Option B: Fall back to the current-version import (when the test is *not* about compat of this API)
+
+If the API is incidental to what the test exercises — e.g., the test uses a `SharedTree` only as a vehicle to test something else and would behave identically against any version — fall back to the current-version import via a destructuring default:
+
+```ts
+// At top of file (the disable + comment documents the override):
+// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
+
+describeCompat("Some other behavior", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedTree = SharedTreeCurrent } = apis.dds;
+    // When apis.dds.SharedTree is defined, the compat version is used; otherwise the
+    // current-version import is substituted so the test can still run on older configs.
+});
+```
+
+Don't use this pattern if you're trying to verify the API's behavior against the compat version — substituting the current version silently changes what's being tested. When in doubt, prefer Option A.
+
+## The lint rule
+
+This package's [`eslint.config.mts`](./eslint.config.mts) enforces the patterns above via `@typescript-eslint/no-restricted-imports`. Two kinds of restriction:
+
+- **Blanket** — every value export from the package goes through `apis`. Applies to:
+  `@fluidframework/cell`, `@fluidframework/counter`, `@fluidframework/map`, `@fluidframework/matrix`, `@fluidframework/ordered-collection`, `@fluidframework/register-collection`, `@fluidframework/sequence`, `@fluid-experimental/sequence-deprecated`, `@fluidframework/datastore`. The `/internal` entry points are also covered.
+
+- **Targeted** (`importNames`) — only a subset of the package is compat-versioned; other exports are free to import directly:
+  | Package | Compat-versioned (restricted) | Free to import |
+  |---|---|---|
+  | `@fluidframework/aqueduct` | `DataObject`, `DataObjectFactory`, `BaseContainerRuntimeFactory`, `ContainerRuntimeFactoryWithDefaultDataStore` | `TreeDataObject`, `TreeDataObjectFactory`, `PureDataObjectFactory`, … |
+  | `@fluidframework/container-loader` | `Loader` | `ConnectionState`, `LoaderHeader`, `ILoaderProps`, `waitContainerToCatchUp`, … |
+  | `@fluidframework/container-runtime` | `ContainerRuntime` | `IContainerRuntimeOptions`, `CompressionAlgorithms`, `DefaultSummaryConfiguration`, `ContainerMessageType`, `IGCRuntimeOptions`, `ISummarizer`, … |
+  | `@fluidframework/tree` | `SharedTree`, `SchemaFactory`, `TreeViewConfiguration`, `configuredSharedTree` | `ITree`, `TreeView`, `ITreeAlpha`, … (all type exports) |
+
+**Type-only imports are always allowed** (`allowTypeImports: true`). If you only need a name for type annotations, convert to `import type { X } from "..."` and you're done.
+
+**Exempt directories** (no enforcement):
+
+- `src/test/benchmark/**` — benchmarks measure the current version's performance.
+- `src/test/migration-shim/**` — these tests intentionally target the current new `SharedTree` (the migration destination).
+
+## Overriding the lint rule
+
+The lint rule allows targeted overrides via `eslint-disable` with a comment explaining intent. The convention is one-line `eslint-disable-next-line` immediately above the import, prefaced by a short reason. Cases where this is appropriate:
+
+- **Migration target imports** — when the test specifically tests migration to (or compat with) the *current* version's API and substituting an older version would defeat the test. See [`migration-shim/`](./src/test/migration-shim) for the directory-level exemption.
+- **`describeInstallVersions` helpers** — `describeInstallVersions` doesn't provide `apis`. Files that use both `describeCompat` and `describeInstallVersions` may need a fallback import (see [`compression.spec.ts`](./src/test/compression.spec.ts) and [`legacyChunking.spec.ts`](./src/test/legacyChunking.spec.ts)). Tracked by AB#6558.
+- **Tests of compat infrastructure itself** — e.g., [`layerCompat.spec.ts`](./src/test/layerCompat.spec.ts) imports `dataStoreCompatDetailsForRuntime` directly because the layer-compat plumbing is what's under test.
+- **Fallback aliases for recently-added DDSes** — `import { SharedTree as SharedTreeCurrent } from "..."` for the destructuring-default fallback pattern shown above.
+
+For multi-line imports, use a block disable:
+
+```ts
+/* eslint-disable @typescript-eslint/no-restricted-imports */
+import {
+    SomeName,
+    AnotherName,
+} from "@fluidframework/aqueduct/internal";
+/* eslint-enable @typescript-eslint/no-restricted-imports */
+```
+
+Always include a `//` or `/* */` comment above the disable explaining **why**.
+
+## Quick checklist
+
+- [ ] Did I touch a value import from a compat-versioned package? → Use `apis.*`.
+- [ ] Did I only need it for type annotation? → `import type { ... }` is fine.
+- [ ] Does the test both create and load containers? → Two configs (`createContainerConfig` + `loadContainerConfig`) with `apis.dds` and `apis.ddsForLoading ?? apis.dds`.
+- [ ] Did I touch `SharedTree`/`SharedArray`/`SharedSignal`? → Consider the `= XCurrent` destructuring-default fallback.
+- [ ] Adding an `eslint-disable`? → One-line reason comment above it, or block disable for multi-line imports.

--- a/packages/test/test-end-to-end-tests/WritingCompatCorrectTests.md
+++ b/packages/test/test-end-to-end-tests/WritingCompatCorrectTests.md
@@ -8,52 +8,48 @@ or _"`<Name>` import from `'@fluidframework/<pkg>/internal'` is restricted from 
 
 ## Why this matters
 
-`describeCompat` parameterizes a test suite over a **compatibility matrix**: the same test runs against multiple combinations of Loader / Container Runtime / Data Runtime / DDS package versions. The compat matrix is what catches version-skew bugs before they reach production.
+`describeCompat` parameterizes a test suite over a **compatibility matrix**: the same test runs against many combinations of Loader / Container Runtime / Data Runtime / DDS package versions. This includes **cross-client compat** configs, where the client that *creates* a container runs a different version of these layers than the client that *loads* it. The matrix is what catches version-skew bugs before they reach production.
 
-The matrix only works if the test code uses the **version-aware factories and classes** that `describeCompat` provides via its `apis` argument. A statically imported `SharedMap` (for example) is fixed to the current version. When the matrix tries to run the test against an older container-runtime + older Data Runtime combination, that test still uses the current-version `SharedMap` — silently testing only the current version under the guise of the older config.
+It only works if the test uses the **version-aware factories and classes** that `describeCompat` supplies via its `apis` argument. A statically imported `SharedMap`, for example, is pinned to the current version — so a test that uses it silently exercises only the current version, whatever config the matrix selects.
 
-For background on the compat matrix itself, see [test-version-utils's README.md](../test-version-utils/README.md) and [Compatibility.md](../../../docs/content/docs/deep/compatibility.md).
+For background, see [test-version-utils's README.md](../test-version-utils/README.md) and [Compatibility.md](../../../docs/content/docs/deep/compatibility.md).
 
 ## Using `apis`
 
-`describeCompat`'s callback receives `apis` as its second argument. **Use it for every value reference to a compat-versioned type** — never import these statically. Destructure what you need at the top of the callback so the rest of the test body reads naturally:
+`describeCompat`'s callback receives `apis` as its second argument. **Use it for every value reference to a compat-versioned type** — never import these statically.
 
-```ts
-describeCompat("My Test", "FullCompat", (getTestObjectProvider, apis) => {
-    const { SharedMap, SharedString } = apis.dds;
-    const { DataObject, DataObjectFactory } = apis.dataRuntime;
-    const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
-    const { Loader } = apis.loader;
-    // ...
-});
-```
+A typical e2e test **creates** containers and (optionally) **loads** them. In a cross-client compat config those two operations run different versions, so `apis` carries a separate set of APIs for each. The single rule that keeps a test compat-correct is:
 
-The `apis` object is organized by layer:
+**Rule:** Build create-time objects from the create-side APIs, and load-time objects from the load-side APIs.
 
-| Path | What's there |
+The test infrastructure already applies it to everything it owns: `provider.makeTestContainer(...)` wires up the loader, driver, and other internal plumbing from the create-side versions, and `provider.loadTestContainer(...)` wires them up from the load-side versions. **The only thing left to you is the objects you construct and pass in yourself** — DDS and their factories, data object facttory, conatainer runtime factory, custom loader, etc.
+
+Each create-side layer has a `…ForLoading` counterpart for the load side:
+
+| Create-side | Load-side |
 |---|---|
-| `apis.dds.*` | DDS factory classes: `SharedMap`, `SharedDirectory`, `SharedCell`, `SharedCounter`, `SharedMatrix`, `SharedString`, `SharedTree`, `ConsensusQueue`, `ConsensusRegisterCollection`, `SparseMatrix`, `SharedArray`, `SharedSignal` |
-| `apis.dataRuntime.*` | `DataObject`, `DataObjectFactory`, `FluidDataStoreRuntime`, `TestFluidObjectFactory` |
-| `apis.dataRuntime.packages.<pkg>` | Less common APIs by package: `cell`, `counter`, `datastore`, `map`, `matrix`, `orderedCollection`, `registerCollection`, `sequence`, `sequenceDeprecated`, `agentScheduler`, `tree` |
-| `apis.containerRuntime.*` | `ContainerRuntime`, `BaseContainerRuntimeFactory`, `ContainerRuntimeFactoryWithDefaultDataStore` |
-| `apis.loader.*` | `Loader` |
+| `apis.dds` | `apis.ddsForLoading` |
+| `apis.dataRuntime` | `apis.dataRuntimeForLoading` |
+| `apis.containerRuntime` | `apis.containerRuntimeForLoading` |
+| `apis.loader` | `apis.loaderForLoading` |
+| `apis.driver` | `apis.driverForLoading` |
 
-`apis.<layer-name>.packages.<package-name>` (package names are unscoped and camelCased) holds less common exports such as helper functions and constants. Keep in mind that if these APIs change over time, tests depending on them will either need to have a reduced compat matrix or include back-compat logic. See `"Change contents of dds, then rehydrate and then check summary"` for an example of such a test.
+Both sides are always present, so reference them directly. Destructure what you need at the top of the callback so the rest of the test body reads naturally.
+
+`apis.<layer-name>.packages.<package-name>` (package names are unscoped and camelCased) holds less common exports such as helper functions and constants — e.g. `apis.dataRuntime.packages.sequence`.
 
 ### ❌ Static import — DON'T
 
 ```ts
 import { SharedString, createOverlappingIntervalsIndex } from "@fluidframework/sequence";
 
-const registry: ChannelFactoryRegistry = [["sharedString", SharedString.getFactory()]];
 const testContainerConfig: ITestContainerConfig = {
     fluidDataObjectType: DataObjectFactoryType.Test,
-    registry,
+    [["sharedString", SharedString.getFactory()]],
 };
 
 describeCompat("SharedString", "FullCompat", (getTestObjectProvider) => {
-    // ...
-    it("supports collaborative text with intervals", async () => {
+    it("supports collaborative text", async () => {
         const container1 = await provider.makeTestContainer(testContainerConfig);
         const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
         const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
@@ -71,18 +67,10 @@ describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
     const { SharedString } = apis.dds;
     const { createOverlappingIntervalsIndex } = apis.dataRuntime.packages.sequence;
 
-    // Note that `SharedString` below is equivalent to `apis.dds.SharedString` — it can be used as
-    // if you had imported it from @fluidframework/sequence, but it will be the version under test.
-    const registry: ChannelFactoryRegistry = [["sharedString", SharedString.getFactory()]];
     const testContainerConfig: ITestContainerConfig = {
         fluidDataObjectType: DataObjectFactoryType.Test,
-        registry,
+        [["sharedString", SharedString.getFactory()]],
     };
-
-    let provider: ITestObjectProvider;
-    beforeEach(() => {
-        provider = getTestObjectProvider();
-    });
 
     it("supports collaborative text", async () => {
         const container1 = await provider.makeTestContainer(testContainerConfig);
@@ -171,51 +159,14 @@ describeCompat("Tree test", "FullCompat", (getTestObjectProvider, apis) => {
 });
 ```
 
-### Type-only references
-
-If your code needs to refer to a DDS's type (e.g. to annotate the type of a variable or function parameter), use `import type` freely — it has no runtime effect and the lint rule allows it:
-
-```ts
-import type { ISharedMap, SharedDirectory } from "@fluidframework/map/internal";
-import type { SharedString } from "@fluidframework/sequence";
-import type { TreeView } from "@fluidframework/tree";
-
-function insert(str: SharedString): void {
-    str.insertText(0, "hello");
-}
-
-describeCompat("Map", "FullCompat", (getTestObjectProvider, apis) => {
-    const { SharedDirectory } = apis.dds;  // value comes from apis
-    // The `SharedDirectory` type-import above is fine — both names coexist in different namespaces.
-});
-```
-
-## Cross-client compat tests
-
-In **CrossClientCompat** mode (one of the configs run by `FullCompat`), the client that creates the container **will be a different version** than the client that loads it. That is the whole point of the mode.
-
-The test infrastructure handles most of this for you automatically: when `provider.makeTestContainer(...)` is called, the provider configures the loader, drivers, and other internal plumbing with the create-side versions; when `provider.loadTestContainer(...)` is called, it configures them with the load-side versions. **You only need to think about cross-client compat for the objects you pass to these APIs yourself.** Factories you put into a `ChannelFactoryRegistry`, a `DataObjectFactory`, or a custom `Loader` are *your* responsibility — they must match the side of the operation they're being used on.
-
-`apis` provides paired entries for this: each layer has a `…ForLoading` counterpart that contains the load-side version. When the test is not running cross-client, the `…ForLoading` entries are `undefined`, so a `??` fallback to the create-side keeps single-client modes correct:
-
-```ts
-const ddsForLoading = apis.ddsForLoading ?? apis.dds;
-const dataRuntimeForLoading = apis.dataRuntimeForLoading ?? apis.dataRuntime;
-const containerRuntimeForLoading = apis.containerRuntimeForLoading ?? apis.containerRuntime;
-const loaderForLoading = apis.loaderForLoading ?? apis.loader;
-```
-
-### Pattern: separate create and load configs
-
-The most common shape — a test that calls both `makeTestContainer` and `loadTestContainer`:
+### Creating and loading containers
 
 ```ts
 describeCompat("Map", "FullCompat", (getTestObjectProvider, apis) => {
-    const { SharedMap } = apis.dds;
-    // For cross-client compat: load-side may be a different version than create-side.
-    const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+    const dds = apis.dds;            // create-side
+    const ddsForLoading = apis.ddsForLoading;  // load-side
 
-    const createRegistry: ChannelFactoryRegistry = [["map", SharedMap.getFactory()]];
+    const createRegistry: ChannelFactoryRegistry = [["map", dds.SharedMap.getFactory()]];
     const loadRegistry: ChannelFactoryRegistry = [
         ["map", ddsForLoading.SharedMap.getFactory()],
     ];
@@ -238,14 +189,14 @@ describeCompat("Map", "FullCompat", (getTestObjectProvider, apis) => {
 });
 ```
 
-### Pattern: two `Loader` instances
+### Two `Loader` instances
 
 For tests that drive the lifecycle directly with `provider.makeTestLoader(...)` and `loader.resolve(...)` rather than `make/loadTestContainer`:
 
 ```ts
 describeCompat("Attach lifecycle", "FullCompat", (getTestObjectProvider, apis) => {
-    const { SharedString } = apis.dds;
-    const SharedStringForLoading = (apis.ddsForLoading ?? apis.dds).SharedString;
+    const SharedString = apis.dds.SharedString;                      // create-side
+    const SharedStringForLoading = apis.ddsForLoading.SharedString;  // load-side
 
     it("survives attach order permutations", async () => {
         const provider = getTestObjectProvider();
@@ -255,37 +206,31 @@ describeCompat("Attach lifecycle", "FullCompat", (getTestObjectProvider, apis) =
         const loadRegistry: [string | undefined, IChannelFactory][] = [
             ["sharedString", SharedStringForLoading.getFactory()],
         ];
-        const initLoader = provider.makeTestLoader({ registry: createRegistry });
-        const validationLoader = provider.makeTestLoader({ registry: loadRegistry });
+        const createSideLoader = provider.makeTestLoader({ registry: createRegistry });
+        const loadSideLoader = provider.makeTestLoader({ registry: loadRegistry });
 
-        // initLoader.createDetachedContainer(...) → attach → close
-        // validationLoader.resolve({ url: ... }) → verify state
+        const container1 = await createSideLoader.createDetachedContainer(...) // Create - create-side loader
+        const container2 = await loadSideLoader.resolve({ url: ... })          // LOAD  — load-side loader
     });
 });
 ```
 
 ## Handling recently-added APIs
 
-Some `apis.dds.*` entries (notably `SharedArray`, `SharedSignal`, and `SharedTree`) may be undefined when running against older compat versions whose Data Runtime didn't expose them. There are two valid strategies:
+Some `apis.dds.*` entries (for example, `SharedArray`, `SharedSignal`, and `SharedTree`) — and the matching `apis.dataRuntime.packages.*` packages — may be undefined when running against older compat versions whose Data Runtime didn't expose them.
 
-### Option A: Gate the test on the version (preferred when the test *is* about compat)
-
-If the test exists to exercise compat behavior of the API itself, it shouldn't fabricate the API for versions that never had it. Skip those configs explicitly using `apis.mode` and the version on `apis.dataRuntime` / `apis.dataRuntimeForLoading`. See [`treeCompat.spec.ts`](./src/test/treeCompat.spec.ts) for the established pattern:
+When this happens, **skip the config** — don't fabricate the API for versions that never had it. In a `beforeEach`, check whether the object you need is present on **both** the create-side and load-side APIs, and `skip()` if either is missing. Because this checks for the API directly, the test runs in exactly the compat modes where it exists. See [`treeCompat.spec.ts`](./src/test/treeCompat.spec.ts) for the established pattern:
 
 ```ts
-import { lt } from "semver";
-
 describeCompat("My SharedTree compat test", "FullCompat", (getTestObjectProvider, apis) => {
     beforeEach(function () {
-        // SharedTree was added in version 2.0.0 — skip cross-client configs whose
-        // create or load version predates that.
-        if (apis.mode === "CrossClientCompat") {
-            const version = apis.dataRuntime.version;
-            const versionForLoading = apis.dataRuntimeForLoading?.version;
-            assert(versionForLoading !== undefined, "versionForLoading must be defined in cross-client");
-            if (lt(version, "2.0.0") || lt(versionForLoading, "2.0.0")) {
-                this.skip();
-            }
+        // SharedTree was added in version 2.0.0; older versions don't expose the tree package.
+        // Skip if either the create-side or load-side APIs lack it.
+        if (
+            apis.dataRuntime.packages.tree === undefined ||
+            apis.dataRuntimeForLoading.packages.tree === undefined
+        ) {
+            this.skip();
         }
     });
 
@@ -293,41 +238,32 @@ describeCompat("My SharedTree compat test", "FullCompat", (getTestObjectProvider
 });
 ```
 
-This keeps the compat matrix honest: a config that genuinely couldn't run the test gets `skip()` instead of being silently rerouted to current-version code.
+### Type-only references
 
-### Option B: Fall back to the current-version import (when the test is *not* about compat of this API)
-
-If the API is incidental to what the test exercises — e.g., the test uses a `SharedTree` only as a vehicle to test something else and would behave identically against any version — fall back to the current-version import via a destructuring default:
+If your code needs to refer to a DDS's type (e.g. to annotate the type of a variable or function parameter), use `import type` freely — it has no runtime effect and the lint rule allows it:
 
 ```ts
-// At top of file (the disable + comment documents the override):
-// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
+import type { ISharedMap, SharedDirectory } from "@fluidframework/map/internal";
+import type { SharedString } from "@fluidframework/sequence";
+import type { TreeView } from "@fluidframework/tree";
 
-describeCompat("Some other behavior", "FullCompat", (getTestObjectProvider, apis) => {
-    const { SharedTree = SharedTreeCurrent } = apis.dds;
-    // When apis.dds.SharedTree is defined, the compat version is used; otherwise the
-    // current-version import is substituted so the test can still run on older configs.
+function insert(str: SharedString): void {
+    str.insertText(0, "hello");
+}
+
+describeCompat("Map", "FullCompat", (getTestObjectProvider, apis) => {
+    const { SharedDirectory } = apis.dds;  // value comes from apis
+    // The `SharedDirectory` type-import above is fine — both names coexist in different namespaces.
 });
 ```
-
-Don't use this pattern if you're trying to verify the API's behavior against the compat version — substituting the current version silently changes what's being tested. When in doubt, prefer Option A.
 
 ## The lint rule
 
 This package's [`eslint.config.mts`](./eslint.config.mts) enforces the patterns above via `@typescript-eslint/no-restricted-imports`. Two kinds of restriction:
 
-- **Blanket** — every value export from the package goes through `apis`. Applies to:
-  `@fluidframework/cell`, `@fluidframework/counter`, `@fluidframework/map`, `@fluidframework/matrix`, `@fluidframework/ordered-collection`, `@fluidframework/register-collection`, `@fluidframework/sequence`, `@fluid-experimental/sequence-deprecated`, `@fluidframework/datastore`. The `/internal` entry points are also covered.
+- **Blanket** — every value export from the package must go through `apis`. For example, importing `SharedMap` from `@fluidframework/map` (or `@fluidframework/map/internal`) is restricted.
 
-- **Targeted** (`importNames`) — only a subset of the package is compat-versioned; other exports are free to import directly:
-  | Package | Compat-versioned (restricted) | Free to import |
-  |---|---|---|
-  | `@fluidframework/aqueduct` | `DataObject`, `DataObjectFactory`, `BaseContainerRuntimeFactory`, `ContainerRuntimeFactoryWithDefaultDataStore` | `TreeDataObject`, `TreeDataObjectFactory`, `PureDataObjectFactory`, … |
-  | `@fluidframework/container-loader` | `Loader` | `ConnectionState`, `LoaderHeader`, `ILoaderProps`, `waitContainerToCatchUp`, … |
-  | `@fluidframework/container-runtime` | `ContainerRuntime` | `IContainerRuntimeOptions`, `CompressionAlgorithms`, `DefaultSummaryConfiguration`, `ContainerMessageType`, `IGCRuntimeOptions`, `ISummarizer`, … |
-  | `@fluidframework/tree` | `SharedTree`, `SchemaFactory`, `TreeViewConfiguration`, `configuredSharedTree` | `ITree`, `TreeView`, `ITreeAlpha`, … (all type exports) |
+- **Targeted** (`importNames`) — only specific exports are compat-versioned; the rest are free to import directly. For example, from `@fluidframework/aqueduct`, only `DataObject`, `DataObjectFactory`, `BaseContainerRuntimeFactory` and `ContainerRuntimeFactoryWithDefaultDataStore` are restricted.
 
 **Type-only imports are always allowed** (`allowTypeImports: true`). If you only need a name for type annotations, convert to `import type { X } from "..."` and you're done.
 
@@ -341,9 +277,7 @@ This package's [`eslint.config.mts`](./eslint.config.mts) enforces the patterns 
 The lint rule allows targeted overrides via `eslint-disable` with a comment explaining intent. The convention is one-line `eslint-disable-next-line` immediately above the import, prefaced by a short reason. Cases where this is appropriate:
 
 - **Migration target imports** — when the test specifically tests migration to (or compat with) the *current* version's API and substituting an older version would defeat the test. See [`migration-shim/`](./src/test/migration-shim) for the directory-level exemption.
-- **`describeInstallVersions` helpers** — `describeInstallVersions` doesn't provide `apis`. Files that use both `describeCompat` and `describeInstallVersions` may need a fallback import (see [`compression.spec.ts`](./src/test/compression.spec.ts) and [`legacyChunking.spec.ts`](./src/test/legacyChunking.spec.ts)). Tracked by AB#6558.
 - **Tests of compat infrastructure itself** — e.g., [`layerCompat.spec.ts`](./src/test/layerCompat.spec.ts) imports `dataStoreCompatDetailsForRuntime` directly because the layer-compat plumbing is what's under test.
-- **Fallback aliases for recently-added DDSes** — `import { SharedTree as SharedTreeCurrent } from "..."` for the destructuring-default fallback pattern shown above.
 
 For multi-line imports, use a block disable:
 
@@ -362,6 +296,6 @@ Always include a `//` or `/* */` comment above the disable explaining **why**.
 
 - [ ] Did I touch a value import from a compat-versioned package? → Use `apis.*`.
 - [ ] Did I only need it for type annotation? → `import type { ... }` is fine.
-- [ ] Does the test both create and load containers? → Two configs (`createContainerConfig` + `loadContainerConfig`) with `apis.dds` and `apis.ddsForLoading ?? apis.dds`.
-- [ ] Did I touch `SharedTree`/`SharedArray`/`SharedSignal`? → Consider the `= XCurrent` destructuring-default fallback.
+- [ ] Does the test both create and load containers? → Two configs (`createContainerConfig` + `loadContainerConfig`) with `apis.dds` and `apis.ddsForLoading`.
+- [ ] Does the test use a recently-added API? → `skip()` in `beforeEach` when it's absent on the create-side **or** load-side APIs.
 - [ ] Adding an `eslint-disable`? → One-line reason comment above it, or block disable for multi-line imports.

--- a/packages/test/test-end-to-end-tests/eslint.config.mts
+++ b/packages/test/test-end-to-end-tests/eslint.config.mts
@@ -17,65 +17,123 @@ const config: Linter.Config[] = [
 			"@typescript-eslint/no-restricted-imports": [
 				"error",
 				{
-					"paths": [
+					// All entries use `patterns` (rather than `paths`) so each rule covers both the
+					// public entrypoint and the `/internal` entrypoint (which is what most tests
+					// actually import from). Test directories that legitimately need direct imports
+					// (benchmark/, migration-shim/) are exempted via file-pattern overrides below.
+					"patterns": [
+						// --- Blanket restrictions ---
+						// All value exports from these packages are compat-versioned via apis.dds.*
+						// (or apis.dataRuntime.packages.*), so any value import from them should
+						// go through `apis` rather than being imported directly.
 						{
-							"name": "@fluidframework/cell",
+							"group": ["@fluidframework/cell", "@fluidframework/cell/*"],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/counter",
+							"group": ["@fluidframework/counter", "@fluidframework/counter/*"],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/map",
+							"group": ["@fluidframework/map", "@fluidframework/map/*"],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/matrix",
+							"group": ["@fluidframework/matrix", "@fluidframework/matrix/*"],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/ordered-collection",
+							"group": [
+								"@fluidframework/ordered-collection",
+								"@fluidframework/ordered-collection/*",
+							],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/register-collection",
+							"group": [
+								"@fluidframework/register-collection",
+								"@fluidframework/register-collection/*",
+							],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/sequence",
+							"group": ["@fluidframework/sequence", "@fluidframework/sequence/*"],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluid-experimental/sequence-deprecated",
+							"group": [
+								"@fluid-experimental/sequence-deprecated",
+								"@fluid-experimental/sequence-deprecated/*",
+							],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
 						{
-							"name": "@fluidframework/aqueduct",
+							"group": ["@fluidframework/datastore", "@fluidframework/datastore/*"],
 							"message":
 								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
 							"allowTypeImports": true,
 						},
+						// --- Targeted restrictions ---
+						// Only a subset of these packages' exports are compat-versioned; other
+						// exports remain valid for direct import.
 						{
-							"name": "@fluidframework/datastore",
+							"group": ["@fluidframework/aqueduct", "@fluidframework/aqueduct/*"],
+							"importNames": [
+								"BaseContainerRuntimeFactory",
+								"ContainerRuntimeFactoryWithDefaultDataStore",
+								"DataObject",
+								"DataObjectFactory",
+							],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Use apis.dataRuntime.{DataObject,DataObjectFactory} / apis.containerRuntime.{BaseContainerRuntimeFactory,ContainerRuntimeFactoryWithDefaultDataStore} from describeCompat instead. Other aqueduct exports (e.g. TreeDataObject) are not compat-versioned and remain unrestricted.",
+							"allowTypeImports": true,
+						},
+						{
+							"group": [
+								"@fluidframework/container-loader",
+								"@fluidframework/container-loader/*",
+							],
+							"importNames": ["Loader"],
+							"message":
+								"Use apis.loader.Loader from describeCompat instead. Other container-loader exports (ConnectionState, LoaderHeader, ILoaderProps, waitContainerToCatchUp, etc.) are not compat-versioned and remain unrestricted.",
+							"allowTypeImports": true,
+						},
+						{
+							"group": [
+								"@fluidframework/container-runtime",
+								"@fluidframework/container-runtime/*",
+							],
+							"importNames": ["ContainerRuntime"],
+							"message":
+								"Use apis.containerRuntime.ContainerRuntime from describeCompat instead. Other container-runtime exports (IContainerRuntimeOptions, CompressionAlgorithms, DefaultSummaryConfiguration, ContainerMessageType, IGCRuntimeOptions, ISummarizer, etc.) are not compat-versioned and remain unrestricted.",
+							"allowTypeImports": true,
+						},
+						{
+							"group": ["@fluidframework/tree", "@fluidframework/tree/*"],
+							"importNames": [
+								"SchemaFactory",
+								"SharedTree",
+								"TreeViewConfiguration",
+								"configuredSharedTree",
+							],
+							"message":
+								"Use apis.dds.SharedTree / apis.dataRuntime.packages.tree.{SchemaFactory,TreeViewConfiguration,configuredSharedTree} from describeCompat instead. Tree type exports (ITree, TreeView, ITreeAlpha, etc.) are not affected.",
 							"allowTypeImports": true,
 						},
 					],
@@ -125,6 +183,15 @@ const config: Linter.Config[] = [
 	},
 	{
 		files: ["src/test/benchmark/**"],
+		rules: {
+			"@typescript-eslint/no-restricted-imports": "off",
+		},
+	},
+	{
+		// Migration-shim tests intentionally target the current new SharedTree (the migration
+		// destination), so they import directly rather than via apis (which would substitute an
+		// older version under compat configs).
+		files: ["src/test/migration-shim/**"],
 		rules: {
 			"@typescript-eslint/no-restricted-imports": "off",
 		},

--- a/packages/test/test-end-to-end-tests/eslint.config.mts
+++ b/packages/test/test-end-to-end-tests/eslint.config.mts
@@ -29,25 +29,25 @@ const config: Linter.Config[] = [
 						{
 							"group": ["@fluidframework/cell", "@fluidframework/cell/*"],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
 							"group": ["@fluidframework/counter", "@fluidframework/counter/*"],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
 							"group": ["@fluidframework/map", "@fluidframework/map/*"],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
 							"group": ["@fluidframework/matrix", "@fluidframework/matrix/*"],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
@@ -56,7 +56,7 @@ const config: Linter.Config[] = [
 								"@fluidframework/ordered-collection/*",
 							],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
@@ -65,13 +65,13 @@ const config: Linter.Config[] = [
 								"@fluidframework/register-collection/*",
 							],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
 							"group": ["@fluidframework/sequence", "@fluidframework/sequence/*"],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
@@ -80,13 +80,13 @@ const config: Linter.Config[] = [
 								"@fluid-experimental/sequence-deprecated/*",
 							],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
 							"group": ["@fluidframework/datastore", "@fluidframework/datastore/*"],
 							"message":
-								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",
+								"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						// --- Targeted restrictions ---
@@ -101,7 +101,7 @@ const config: Linter.Config[] = [
 								"DataObjectFactory",
 							],
 							"message":
-								"Use apis.dataRuntime.{DataObject,DataObjectFactory} / apis.containerRuntime.{BaseContainerRuntimeFactory,ContainerRuntimeFactoryWithDefaultDataStore} from describeCompat instead. Other aqueduct exports (e.g. TreeDataObject) are not compat-versioned and remain unrestricted.",
+								"Use apis.dataRuntime.{DataObject,DataObjectFactory} / apis.containerRuntime.{BaseContainerRuntimeFactory,ContainerRuntimeFactoryWithDefaultDataStore} from describeCompat instead. Other aqueduct exports (e.g. TreeDataObject) are not compat-versioned and remain unrestricted. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
@@ -111,7 +111,7 @@ const config: Linter.Config[] = [
 							],
 							"importNames": ["Loader"],
 							"message":
-								"Use apis.loader.Loader from describeCompat instead. Other container-loader exports (ConnectionState, LoaderHeader, ILoaderProps, waitContainerToCatchUp, etc.) are not compat-versioned and remain unrestricted.",
+								"Use apis.loader.Loader from describeCompat instead. Other container-loader exports (ConnectionState, LoaderHeader, ILoaderProps, waitContainerToCatchUp, etc.) are not compat-versioned and remain unrestricted. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
@@ -121,7 +121,7 @@ const config: Linter.Config[] = [
 							],
 							"importNames": ["ContainerRuntime"],
 							"message":
-								"Use apis.containerRuntime.ContainerRuntime from describeCompat instead. Other container-runtime exports (IContainerRuntimeOptions, CompressionAlgorithms, DefaultSummaryConfiguration, ContainerMessageType, IGCRuntimeOptions, ISummarizer, etc.) are not compat-versioned and remain unrestricted.",
+								"Use apis.containerRuntime.ContainerRuntime from describeCompat instead. Other container-runtime exports (IContainerRuntimeOptions, CompressionAlgorithms, DefaultSummaryConfiguration, ContainerMessageType, IGCRuntimeOptions, ISummarizer, etc.) are not compat-versioned and remain unrestricted. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 						{
@@ -133,7 +133,7 @@ const config: Linter.Config[] = [
 								"configuredSharedTree",
 							],
 							"message":
-								"Use apis.dds.SharedTree / apis.dataRuntime.packages.tree.{SchemaFactory,TreeViewConfiguration,configuredSharedTree} from describeCompat instead. Tree type exports (ITree, TreeView, ITreeAlpha, etc.) are not affected.",
+								"Use apis.dds.SharedTree / apis.dataRuntime.packages.tree.{SchemaFactory,TreeViewConfiguration,configuredSharedTree} from describeCompat instead. Tree type exports (ITree, TreeView, ITreeAlpha, etc.) are not affected. See WritingCompatCorrectTests.md (in this package) for the patterns and rationale.",
 							"allowTypeImports": true,
 						},
 					],

--- a/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
@@ -43,9 +43,9 @@ describeCompat("Validate Attach lifecycle", "FullCompat", (getTestObjectProvider
 	const { SharedString } = apis.dds;
 	// In cross-client compat, the validation loader (which loads the previously-created container)
 	// may be a different version than the init loader (which created the container). Use
-	// ddsForLoading (falling back to apis.dds when not cross-client) so the validation loader
-	// reconstructs SharedString factories from the load-side version.
-	const SharedStringForLoading = (apis.ddsForLoading ?? apis.dds).SharedString;
+	// ddsForLoading so the validation loader reconstructs SharedString factories from the load-side
+	// version. (Outside cross-client compat it matches apis.dds.)
+	const SharedStringForLoading = apis.ddsForLoading.SharedString;
 	before(function () {
 		const provider = getTestObjectProvider();
 		switch (provider.driver.type) {

--- a/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
@@ -41,6 +41,11 @@ const testConfigs = generatePairwiseOptions({
 
 describeCompat("Validate Attach lifecycle", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
+	// In cross-client compat, the validation loader (which loads the previously-created container)
+	// may be a different version than the init loader (which created the container). Use
+	// ddsForLoading (falling back to apis.dds when not cross-client) so the validation loader
+	// reconstructs SharedString factories from the load-side version.
+	const SharedStringForLoading = (apis.ddsForLoading ?? apis.dds).SharedString;
 	before(function () {
 		const provider = getTestObjectProvider();
 		switch (provider.driver.type) {
@@ -59,14 +64,19 @@ describeCompat("Validate Attach lifecycle", "FullCompat", (getTestObjectProvider
 			const provider = getTestObjectProvider();
 			let containerUrl: IResolvedUrl | undefined;
 			const sharedStringFactory = SharedString.getFactory();
-			const channelFactoryRegistry: [string | undefined, IChannelFactory][] = [
+			const sharedStringFactoryForLoading = SharedStringForLoading.getFactory();
+			const createChannelFactoryRegistry: [string | undefined, IChannelFactory][] = [
 				[sharedStringFactory.type, sharedStringFactory],
 			];
-			const containerConfig = { registry: channelFactoryRegistry };
+			const loadChannelFactoryRegistry: [string | undefined, IChannelFactory][] = [
+				[sharedStringFactoryForLoading.type, sharedStringFactoryForLoading],
+			];
+			const createContainerConfig = { registry: createChannelFactoryRegistry };
+			const loadContainerConfig = { registry: loadChannelFactoryRegistry };
 
 			// act code block
 			{
-				const initLoader = provider.makeTestLoader(containerConfig);
+				const initLoader = provider.makeTestLoader(createContainerConfig);
 
 				const initContainer = await initLoader.createDetachedContainer(
 					provider.defaultCodeDetails,
@@ -169,7 +179,7 @@ describeCompat("Validate Attach lifecycle", "FullCompat", (getTestObjectProvider
 
 			// validation code block
 			{
-				const validationLoader = provider.makeTestLoader(containerConfig);
+				const validationLoader = provider.makeTestLoader(loadContainerConfig);
 				const validationContainer = await validationLoader.resolve({
 					url: await provider.driver.createContainerUrl(provider.documentId, containerUrl),
 				});

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -11,7 +11,7 @@ import type {
 	IContainer,
 	IFluidCodeDetails,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import type { Loader } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import type { ISharedMap } from "@fluidframework/map/internal";
 import {
@@ -57,6 +57,7 @@ describeCompat(
 	"NoCompat" /* 2.0.0-internal.8.0.0 */,
 	(getTestObjectProvider, apis) => {
 		const { SharedMap } = apis.dds;
+		const { Loader } = apis.loader;
 		const codeDetails: IFluidCodeDetails = {
 			package: "detachedContainerTestPackage1",
 			config: {},

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -4,8 +4,8 @@
  */
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { SharedMatrix } from "@fluidframework/matrix/internal";
-import { SharedString } from "@fluidframework/sequence/internal";
+import type { SharedMatrix } from "@fluidframework/matrix/internal";
+import type { SharedString } from "@fluidframework/sequence/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,
@@ -13,18 +13,15 @@ import {
 
 import { IBenchmarkParameters, benchmarkAll } from "./DocumentCreator.js";
 
-function createLocalMatrix(
-	id: string,
-	dataStoreRuntime: MockFluidDataStoreRuntime,
-): SharedMatrix {
-	return SharedMatrix.create(dataStoreRuntime, id);
-}
+describeCompat("PAS Test", "NoCompat", (_getTestObjectProvider, apis) => {
+	const { SharedMatrix, SharedString } = apis.dds;
 
-function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime): SharedString {
-	return SharedString.create(dataStoreRuntime, id);
-}
+	const createLocalMatrix = (id: string, runtime: MockFluidDataStoreRuntime): SharedMatrix =>
+		SharedMatrix.create(runtime, id);
 
-describeCompat("PAS Test", "NoCompat", () => {
+	const createString = (id: string, runtime: MockFluidDataStoreRuntime): SharedString =>
+		SharedString.create(runtime, id);
+
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({
 		registry: [SharedMatrix.getFactory(), SharedString.getFactory()],
 	});

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -20,72 +20,77 @@ import { v4 as uuid } from "uuid";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObjectProvider, apis) => {
-	const { Loader } = apis.loader;
-	let provider: ITestObjectProvider;
-	let loader: Loader;
-	let fileName: string;
-	let containerUrl: IResolvedUrl;
+describeCompat(
+	"Container - memory usage benchmarks",
+	"NoCompat",
+	(getTestObjectProvider, apis) => {
+		const { Loader } = apis.loader;
+		let provider: ITestObjectProvider;
+		let loader: Loader;
+		let fileName: string;
+		let containerUrl: IResolvedUrl;
 
-	const loaderContainerTracker = new LoaderContainerTracker();
+		const loaderContainerTracker = new LoaderContainerTracker();
 
-	function createLoader(props?: Partial<ILoaderProps>): Loader {
-		return new Loader({
-			...props,
-			logger: provider.logger,
-			urlResolver: props?.urlResolver ?? provider.urlResolver,
-			documentServiceFactory: props?.documentServiceFactory ?? provider.documentServiceFactory,
-			codeLoader:
-				props?.codeLoader ??
-				new LocalCodeLoader([[codeDetails, new TestFluidObjectFactory([])]]),
+		function createLoader(props?: Partial<ILoaderProps>): Loader {
+			return new Loader({
+				...props,
+				logger: provider.logger,
+				urlResolver: props?.urlResolver ?? provider.urlResolver,
+				documentServiceFactory:
+					props?.documentServiceFactory ?? provider.documentServiceFactory,
+				codeLoader:
+					props?.codeLoader ??
+					new LocalCodeLoader([[codeDetails, new TestFluidObjectFactory([])]]),
+			});
+		}
+
+		before(async () => {
+			provider = getTestObjectProvider();
+			loader = createLoader();
+			loaderContainerTracker.add(loader);
+			const container = await loader.createDetachedContainer(codeDetails);
+
+			fileName = uuid();
+			await container.attach(provider.driver.createCreateNewRequest(fileName));
+			assert(container.resolvedUrl);
+			containerUrl = container.resolvedUrl;
 		});
-	}
+		afterEach(() => {
+			loaderContainerTracker.reset();
+		});
 
-	before(async () => {
-		provider = getTestObjectProvider();
-		loader = createLoader();
-		loaderContainerTracker.add(loader);
-		const container = await loader.createDetachedContainer(codeDetails);
+		benchmarkIt({
+			title: "Create loader",
+			...benchmarkMemoryUse(memoryUseOfValue(() => createLoader())),
+		}).timeout(60000);
 
-		fileName = uuid();
-		await container.attach(provider.driver.createCreateNewRequest(fileName));
-		assert(container.resolvedUrl);
-		containerUrl = container.resolvedUrl;
-	});
-	afterEach(() => {
-		loaderContainerTracker.reset();
-	});
+		benchmarkIt({
+			title: "Create detached container",
+			...benchmarkMemoryUse(
+				memoryUseOfValue(async () => loader.createDetachedContainer(codeDetails)),
+			),
+		}).timeout(60000);
 
-	benchmarkIt({
-		title: "Create loader",
-		...benchmarkMemoryUse(memoryUseOfValue(() => createLoader())),
-	}).timeout(60000);
+		benchmarkIt({
+			title: "Create detached container and attach it",
+			...benchmarkMemoryUse(
+				memoryUseOfValue(async () => {
+					const container = await loader.createDetachedContainer(codeDetails);
+					await container.attach(provider.driver.createCreateNewRequest("containerTest"));
+					return container;
+				}),
+			),
+		}).timeout(60000);
 
-	benchmarkIt({
-		title: "Create detached container",
-		...benchmarkMemoryUse(
-			memoryUseOfValue(async () => loader.createDetachedContainer(codeDetails)),
-		),
-	}).timeout(60000);
-
-	benchmarkIt({
-		title: "Create detached container and attach it",
-		...benchmarkMemoryUse(
-			memoryUseOfValue(async () => {
-				const container = await loader.createDetachedContainer(codeDetails);
-				await container.attach(provider.driver.createCreateNewRequest("containerTest"));
-				return container;
-			}),
-		),
-	}).timeout(60000);
-
-	benchmarkIt({
-		title: "Load existing container",
-		...benchmarkMemoryUse(
-			memoryUseOfValue(async () => {
-				const requestUrl = await provider.driver.createContainerUrl(fileName, containerUrl);
-				return loader.resolve({ url: requestUrl });
-			}),
-		),
-	}).timeout(60000);
-});
+		benchmarkIt({
+			title: "Load existing container",
+			...benchmarkMemoryUse(
+				memoryUseOfValue(async () => {
+					const requestUrl = await provider.driver.createContainerUrl(fileName, containerUrl);
+					return loader.resolve({ url: requestUrl });
+				}),
+			),
+		}).timeout(60000);
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { benchmarkIt, benchmarkMemoryUse, memoryUseOfValue } from "@fluid-tools/benchmark";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import type { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import {
 	ITestObjectProvider,
@@ -20,7 +20,8 @@ import { v4 as uuid } from "uuid";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObjectProvider, apis) => {
+	const { Loader } = apis.loader;
 	let provider: ITestObjectProvider;
 	let loader: Loader;
 	let fileName: string;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { benchmarkDuration, benchmarkIt } from "@fluid-tools/benchmark";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import type { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
 	ITestObjectProvider,
@@ -20,7 +20,8 @@ import { v4 as uuid } from "uuid";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeCompat("Container - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Container - runtime benchmarks", "NoCompat", (getTestObjectProvider, apis) => {
+	const { Loader } = apis.loader;
 	const loaderContainerTracker = new LoaderContainerTracker();
 
 	function createLoader(provider: ITestObjectProvider, props?: Partial<ILoaderProps>): Loader {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/counter.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/counter.time.spec.ts
@@ -5,7 +5,7 @@
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { benchmarkDuration, benchmarkIt } from "@fluid-tools/benchmark";
-import { ISharedCounter, SharedCounter } from "@fluidframework/counter/internal";
+import type { ISharedCounter, SharedCounter } from "@fluidframework/counter/internal";
 import {
 	ChannelFactoryRegistry,
 	DataObjectFactoryType,
@@ -15,52 +15,57 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 const counterId = "counterKey";
-const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
-const testContainerConfig: ITestContainerConfig = {
-	fluidDataObjectType: DataObjectFactoryType.Test,
-	registry,
-};
 
-describeCompat("SharedCounter - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
-	async function setup(): Promise<{
-		provider: ITestObjectProvider;
-		counters: ISharedCounter[];
-	}> {
-		const provider = getTestObjectProvider();
-		const counters: ISharedCounter[] = [];
+describeCompat(
+	"SharedCounter - runtime benchmarks",
+	"NoCompat",
+	(getTestObjectProvider, apis) => {
+		const { SharedCounter } = apis.dds;
+		const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
+		};
+		async function setup(): Promise<{
+			provider: ITestObjectProvider;
+			counters: ISharedCounter[];
+		}> {
+			const provider = getTestObjectProvider();
+			const counters: ISharedCounter[] = [];
 
-		// Create a Container for the first client.
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-		const dataStore1 = (await container1.getEntryPoint()) as ITestFluidObject;
-		counters[0] = await dataStore1.getSharedObject<SharedCounter>(counterId);
+			// Create a Container for the first client.
+			const container1 = await provider.makeTestContainer(testContainerConfig);
+			const dataStore1 = (await container1.getEntryPoint()) as ITestFluidObject;
+			counters[0] = await dataStore1.getSharedObject<SharedCounter>(counterId);
 
-		// Load the Container that was created by the first client.
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-		counters[1] = await dataStore2.getSharedObject<SharedCounter>(counterId);
+			// Load the Container that was created by the first client.
+			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			counters[1] = await dataStore2.getSharedObject<SharedCounter>(counterId);
 
-		// Load the Container that was created by the first client.
-		const container3 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
-		counters[2] = await dataStore3.getSharedObject<SharedCounter>(counterId);
+			// Load the Container that was created by the first client.
+			const container3 = await provider.loadTestContainer(testContainerConfig);
+			const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
+			counters[2] = await dataStore3.getSharedObject<SharedCounter>(counterId);
 
-		await provider.ensureSynchronized();
-		return { provider, counters };
-	}
+			await provider.ensureSynchronized();
+			return { provider, counters };
+		}
 
-	benchmarkIt({
-		title: "increment value in 3 containers",
-		...benchmarkDuration({
-			benchmarkFnCustom: async (state) => {
-				const { provider, counters } = await setup();
-				await state.timeAllBatchesAsync(async () => {
-					counters[0].increment(1);
-					await provider.ensureSynchronized();
-					// Something in the way the benchmark tool works makes it so we can't try to verify values;
-					// the check might pass the first time, but at some point during the samples/iterations the
-					// validation will fail and we'll see a (supposedly) successful test but an exit status 1.
-				});
-			},
-		}),
-	});
-});
+		benchmarkIt({
+			title: "increment value in 3 containers",
+			...benchmarkDuration({
+				benchmarkFnCustom: async (state) => {
+					const { provider, counters } = await setup();
+					await state.timeAllBatchesAsync(async () => {
+						counters[0].increment(1);
+						await provider.ensureSynchronized();
+						// Something in the way the benchmark tool works makes it so we can't try to verify values;
+						// the check might pass the first time, but at some point during the samples/iterations the
+						// validation will fail and we'll see a (supposedly) successful test but an exit status 1.
+					});
+				},
+			}),
+		});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/opCriticalPath.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/opCriticalPath.time.spec.ts
@@ -14,7 +14,7 @@ import {
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
 	CompressionAlgorithms,
-	ContainerRuntime,
+	type ContainerRuntime,
 } from "@fluidframework/container-runtime/internal";
 import {
 	toIDeltaManagerFull,

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -10,7 +10,7 @@ import { ITestDataObject, describeCompat } from "@fluid-private/test-version-uti
 import { benchmarkIt, benchmarkMemoryUse, memoryUseOfValue } from "@fluid-tools/benchmark";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime/internal";
 import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -10,7 +10,7 @@ import { ITestDataObject, describeCompat } from "@fluid-private/test-version-uti
 import { benchmarkDuration, benchmarkIt } from "@fluid-tools/benchmark";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime/internal";
 import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -103,10 +103,10 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 		"FullCompat",
 		(getTestObjectProvider, apis) => {
 			const { SharedString } = apis.dds;
-			// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-			// (which falls back to apis.dds when not cross-client) so loadTestContainer reconstructs
-			// DDS factories from the correct version.
-			const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+			// In cross-client compat, the loading client may be a different version than the creating
+			// client. Use ddsForLoading so loadTestContainer reconstructs DDS factories from the
+			// correct version. (Outside cross-client compat it matches apis.dds.)
+			const ddsForLoading = apis.ddsForLoading;
 			const createContainerConfig = makeTestContainerConfig(
 				[["sharedString", SharedString.getFactory()]],
 				createBlobPayloadPending,

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -103,8 +103,16 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 		"FullCompat",
 		(getTestObjectProvider, apis) => {
 			const { SharedString } = apis.dds;
-			const testContainerConfig = makeTestContainerConfig(
+			// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+			// (which falls back to apis.dds when not cross-client) so loadTestContainer reconstructs
+			// DDS factories from the correct version.
+			const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+			const createContainerConfig = makeTestContainerConfig(
 				[["sharedString", SharedString.getFactory()]],
+				createBlobPayloadPending,
+			);
+			const loadContainerConfig = makeTestContainerConfig(
+				[["sharedString", ddsForLoading.SharedString.getFactory()]],
 				createBlobPayloadPending,
 			);
 
@@ -121,7 +129,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 			});
 
 			it("attach sends an op", async function () {
-				const container = await provider.makeTestContainer(testContainerConfig);
+				const container = await provider.makeTestContainer(createContainerConfig);
 
 				const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
 
@@ -153,14 +161,14 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 				}
 				const testString = "this is a test string";
 				const testKey = "a blob";
-				const container1 = await provider.makeTestContainer(testContainerConfig);
+				const container1 = await provider.makeTestContainer(createContainerConfig);
 
 				const dataStore1 = await getContainerEntryPointBackCompat<ITestDataObject>(container1);
 
 				const blob = await dataStore1._runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
 				dataStore1._root.set(testKey, blob);
 
-				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const container2 = await provider.loadTestContainer(loadContainerConfig);
 				const dataStore2 = await getContainerEntryPointBackCompat<ITestDataObject>(container2);
 
 				await provider.ensureSynchronized();
@@ -175,8 +183,8 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 				if (provider.type === "TestObjectProviderWithVersionedLoad") {
 					this.skip();
 				}
-				const container1 = await provider.makeTestContainer(testContainerConfig);
-				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const container1 = await provider.makeTestContainer(createContainerConfig);
+				const container2 = await provider.loadTestContainer(loadContainerConfig);
 				const testString = "this is a test string";
 				// setup
 				{
@@ -222,7 +230,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 				for (const container of [
 					container1,
 					container2,
-					await provider.loadTestContainer(testContainerConfig),
+					await provider.loadTestContainer(loadContainerConfig),
 				]) {
 					const dataStore2 =
 						await getContainerEntryPointBackCompat<ITestDataObject>(container);
@@ -238,7 +246,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 			});
 
 			it("correctly handles simultaneous identical blob upload on one container", async () => {
-				const container = await provider.makeTestContainer(testContainerConfig);
+				const container = await provider.makeTestContainer(createContainerConfig);
 				const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
 				const blob = stringToBuffer("some different yet still random text", "utf-8");
 
@@ -264,7 +272,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 					}
 
 					const runtimeOptions: IContainerRuntimeOptionsInternal = {
-						...testContainerConfig.runtimeOptions,
+						...createContainerConfig.runtimeOptions,
 						compressionOptions: {
 							minimumBatchSizeInBytes: enableGroupedBatching ? 1 : Number.POSITIVE_INFINITY,
 							compressionAlgorithm: CompressionAlgorithms.lz4,
@@ -273,7 +281,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 					};
 
 					const container = await provider.makeTestContainer({
-						...testContainerConfig,
+						...createContainerConfig,
 						runtimeOptions,
 					});
 

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "@fluid-private/test-version-utils";
 import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { AttributionInfo } from "@fluidframework/runtime-definitions/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -28,11 +28,22 @@ const cellId = "cellKey";
 
 describeCompat("SharedCell", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedCell } = apis.dds;
+	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+	// loadTestContainer reconstructs DDS factories from the correct version.
+	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 
-	const registry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
+	const createRegistry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
+	const loadRegistry: ChannelFactoryRegistry = [
+		[cellId, ddsForLoading.SharedCell.getFactory()],
+	];
+	const createContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
+		registry: createRegistry,
+	};
+	const loadContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry: loadRegistry,
 	};
 
 	let provider: ITestObjectProvider;
@@ -50,17 +61,17 @@ describeCompat("SharedCell", "FullCompat", (getTestObjectProvider, apis) => {
 
 	beforeEach("setup", async () => {
 		// Create a Container for the first client.
-		const container1 = await provider.makeTestContainer(testContainerConfig);
+		const container1 = await provider.makeTestContainer(createContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 		sharedCell1 = await dataObject1.getSharedObject<ISharedCell>(cellId);
 
 		// Load the Container that was created by the first client.
-		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const container2 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		sharedCell2 = await dataObject2.getSharedObject<ISharedCell>(cellId);
 
 		// Load the Container that was created by the first client.
-		const container3 = await provider.loadTestContainer(testContainerConfig);
+		const container3 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 		sharedCell3 = await dataObject3.getSharedObject<ISharedCell>(cellId);
 

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -28,10 +28,10 @@ const cellId = "cellKey";
 
 describeCompat("SharedCell", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedCell } = apis.dds;
-	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-	// loadTestContainer reconstructs DDS factories from the correct version.
-	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+	// In cross-client compat, the loading client may be a different version than the creating
+	// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+	// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+	const ddsForLoading = apis.ddsForLoading;
 
 	const createRegistry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
 	const loadRegistry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -19,6 +19,8 @@ import {
 } from "@fluidframework/container-runtime/internal";
 // SharedMap is used as a fallback for the describeInstallVersions path which does not provide `apis`.
 // For describeCompat callers, the compat-version-aware factory is read from apis.dds.SharedMap below.
+// TODO:AB#6558: Once describeInstallVersions supports `apis`, this fallback can be removed.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { SharedMap, type ISharedMap } from "@fluidframework/map/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {
@@ -32,7 +34,12 @@ import {
 import { pkgVersion } from "../packageVersion.js";
 
 const compressionSuite = (getProvider, apis?): void => {
-	const SharedMapFactory = apis?.dds.SharedMap ?? SharedMap;
+	// In cross-client compat, the local (creating) and remote (loading) clients may be different
+	// versions. Use the create-side factory for makeTestContainer and the load-side factory for
+	// loadTestContainer. Both fall back to the directly-imported SharedMap when apis is not
+	// available (describeInstallVersions path) or when ddsForLoading is not set (non-cross-client).
+	const SharedMapForCreate = apis?.dds.SharedMap ?? SharedMap;
+	const SharedMapForLoad = apis?.ddsForLoading?.SharedMap ?? apis?.dds.SharedMap ?? SharedMap;
 	describe("Compression", () => {
 		let provider: ITestObjectProvider;
 		let localDataObject: ITestFluidObject;
@@ -61,18 +68,22 @@ const compressionSuite = (getProvider, apis?): void => {
 			runtimeOptions: IContainerRuntimeOptionsInternal = defaultRuntimeOptions,
 			minVersionForCollab: MinimumVersionForCollab | undefined = undefined,
 		): Promise<void> {
-			const containerConfig: ITestContainerConfig = {
-				registry: [["mapKey", SharedMapFactory.getFactory()]],
+			const createContainerConfig: ITestContainerConfig = {
+				registry: [["mapKey", SharedMapForCreate.getFactory()]],
 				runtimeOptions,
 				fluidDataObjectType: DataObjectFactoryType.Test,
 				minVersionForCollab,
 			};
-			const localContainer = await provider.makeTestContainer(containerConfig);
+			const loadContainerConfig: ITestContainerConfig = {
+				...createContainerConfig,
+				registry: [["mapKey", SharedMapForLoad.getFactory()]],
+			};
+			const localContainer = await provider.makeTestContainer(createContainerConfig);
 			localDataObject =
 				await getContainerEntryPointBackCompat<ITestFluidObject>(localContainer);
 			localMap = await localDataObject.getSharedObject<ISharedMap>("mapKey");
 
-			const remoteContainer = await provider.loadTestContainer(containerConfig);
+			const remoteContainer = await provider.loadTestContainer(loadContainerConfig);
 			const remoteDataObject =
 				await getContainerEntryPointBackCompat<ITestFluidObject>(remoteContainer);
 			remoteMap = await remoteDataObject.getSharedObject<ISharedMap>("mapKey");

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -17,8 +17,9 @@ import {
 	type IContainerRuntimeOptions,
 	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
-// TODO:AB#6558: This should be provided based on the compatibility configuration.
-import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
+// SharedMap is used as a fallback for the describeInstallVersions path which does not provide `apis`.
+// For describeCompat callers, the compat-version-aware factory is read from apis.dds.SharedMap below.
+import { SharedMap, type ISharedMap } from "@fluidframework/map/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import {
 	DataObjectFactoryType,
@@ -31,6 +32,7 @@ import {
 import { pkgVersion } from "../packageVersion.js";
 
 const compressionSuite = (getProvider, apis?): void => {
+	const SharedMapFactory = apis?.dds.SharedMap ?? SharedMap;
 	describe("Compression", () => {
 		let provider: ITestObjectProvider;
 		let localDataObject: ITestFluidObject;
@@ -60,7 +62,7 @@ const compressionSuite = (getProvider, apis?): void => {
 			minVersionForCollab: MinimumVersionForCollab | undefined = undefined,
 		): Promise<void> {
 			const containerConfig: ITestContainerConfig = {
-				registry: [["mapKey", SharedMap.getFactory()]],
+				registry: [["mapKey", SharedMapFactory.getFactory()]],
 				runtimeOptions,
 				fluidDataObjectType: DataObjectFactoryType.Test,
 				minVersionForCollab,

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -37,9 +37,9 @@ const compressionSuite = (getProvider, apis?): void => {
 	// In cross-client compat, the local (creating) and remote (loading) clients may be different
 	// versions. Use the create-side factory for makeTestContainer and the load-side factory for
 	// loadTestContainer. Both fall back to the directly-imported SharedMap when apis is not
-	// available (describeInstallVersions path) or when ddsForLoading is not set (non-cross-client).
+	// available (describeInstallVersions path). (Outside cross-client compat ddsForLoading matches dds.)
 	const SharedMapForCreate = apis?.dds.SharedMap ?? SharedMap;
-	const SharedMapForLoad = apis?.ddsForLoading?.SharedMap ?? apis?.dds.SharedMap ?? SharedMap;
+	const SharedMapForLoad = apis?.ddsForLoading.SharedMap ?? SharedMap;
 	describe("Compression", () => {
 		let provider: ITestObjectProvider;
 		let localDataObject: ITestFluidObject;

--- a/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -25,14 +25,26 @@ function generate(name: string, input: any[], output: any[]): void {
 		const { SharedMap, ConsensusQueue } = apis.dds;
 		const { acquireAndComplete, ConsensusResult, waitAcquireAndComplete } =
 			apis.dataRuntime.packages.orderedCollection;
+		// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+		// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+		// loadTestContainer reconstructs DDS factories from the correct version.
+		const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 
-		const registry: ChannelFactoryRegistry = [
+		const createRegistry: ChannelFactoryRegistry = [
 			[mapId, SharedMap.getFactory()],
 			[undefined, ConsensusQueue.getFactory()],
 		];
-		const testContainerConfig: ITestContainerConfig = {
+		const loadRegistry: ChannelFactoryRegistry = [
+			[mapId, ddsForLoading.SharedMap.getFactory()],
+			[undefined, ddsForLoading.ConsensusQueue.getFactory()],
+		];
+		const createContainerConfig: ITestContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
-			registry,
+			registry: createRegistry,
+		};
+		const loadContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry: loadRegistry,
 		};
 
 		let provider: ITestObjectProvider;
@@ -48,12 +60,12 @@ function generate(name: string, input: any[], output: any[]): void {
 
 		beforeEach("createSharedMaps", async () => {
 			// Create a Container for the first client.
-			const container1 = await provider.makeTestContainer(testContainerConfig);
+			const container1 = await provider.makeTestContainer(createContainerConfig);
 			dataStore1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 			sharedMap1 = await dataStore1.getSharedObject<ISharedMap>(mapId);
 
 			// Load the Container that was created by the first client.
-			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const container2 = await provider.loadTestContainer(loadContainerConfig);
 			dataStore2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 			sharedMap2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
 			closeContainer2 = () => {
@@ -62,7 +74,7 @@ function generate(name: string, input: any[], output: any[]): void {
 			};
 
 			// Load the Container that was created by the first client.
-			const container3 = await provider.loadTestContainer(testContainerConfig);
+			const container3 = await provider.loadTestContainer(loadContainerConfig);
 			const dataStore3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 			sharedMap3 = await dataStore3.getSharedObject<ISharedMap>(mapId);
 		});

--- a/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -25,10 +25,10 @@ function generate(name: string, input: any[], output: any[]): void {
 		const { SharedMap, ConsensusQueue } = apis.dds;
 		const { acquireAndComplete, ConsensusResult, waitAcquireAndComplete } =
 			apis.dataRuntime.packages.orderedCollection;
-		// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-		// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-		// loadTestContainer reconstructs DDS factories from the correct version.
-		const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+		// In cross-client compat, the loading client may be a different version than the creating
+		// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+		// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+		const ddsForLoading = apis.ddsForLoading;
 
 		const createRegistry: ChannelFactoryRegistry = [
 			[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -28,14 +28,26 @@ const mapId = "mapKey";
 describeCompat("ConsensusRegisterCollection", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap, ConsensusRegisterCollection } = apis.dds;
 	const { ReadPolicy } = apis.dataRuntime.packages.registerCollection;
+	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+	// loadTestContainer reconstructs DDS factories from the correct version.
+	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 
-	const registry: ChannelFactoryRegistry = [
+	const createRegistry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],
 		[undefined, ConsensusRegisterCollection.getFactory()],
 	];
-	const testContainerConfig: ITestContainerConfig = {
+	const loadRegistry: ChannelFactoryRegistry = [
+		[mapId, ddsForLoading.SharedMap.getFactory()],
+		[undefined, ddsForLoading.ConsensusRegisterCollection.getFactory()],
+	];
+	const createContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
+		registry: createRegistry,
+	};
+	const loadContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry: loadRegistry,
 	};
 
 	let provider: ITestObjectProvider;
@@ -50,17 +62,17 @@ describeCompat("ConsensusRegisterCollection", "FullCompat", (getTestObjectProvid
 
 	beforeEach("createSharedMaps", async () => {
 		// Create a Container for the first client.
-		container1 = await provider.makeTestContainer(testContainerConfig);
+		container1 = await provider.makeTestContainer(createContainerConfig);
 		dataStore1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 		sharedMap1 = await dataStore1.getSharedObject<ISharedMap>(mapId);
 
 		// Load the Container that was created by the first client.
-		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const container2 = await provider.loadTestContainer(loadContainerConfig);
 		const dataStore2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		sharedMap2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
 
 		// Load the Container that was created by the first client.
-		const container3 = await provider.loadTestContainer(testContainerConfig);
+		const container3 = await provider.loadTestContainer(loadContainerConfig);
 		const dataStore3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 		sharedMap3 = await dataStore3.getSharedObject<ISharedMap>(mapId);
 	});

--- a/packages/test/test-end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -28,10 +28,10 @@ const mapId = "mapKey";
 describeCompat("ConsensusRegisterCollection", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap, ConsensusRegisterCollection } = apis.dds;
 	const { ReadPolicy } = apis.dataRuntime.packages.registerCollection;
-	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-	// loadTestContainer reconstructs DDS factories from the correct version.
-	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+	// In cross-client compat, the loading client may be a different version than the creating
+	// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+	// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+	const ddsForLoading = apis.ddsForLoading;
 
 	const createRegistry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -22,7 +22,6 @@ import {
 import {
 	ConnectionState,
 	type ILoaderProps,
-	Loader,
 	waitContainerToCatchUp,
 } from "@fluidframework/container-loader/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
@@ -68,7 +67,8 @@ const codeDetails: IFluidCodeDetails = { package: "test" };
 const timeoutMs = 500;
 
 // REVIEW: enable compat testing?
-describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Container", "NoCompat", (getTestObjectProvider, apis) => {
+	const { Loader } = apis.loader;
 	let provider: ITestObjectProvider;
 	const loaderContainerTracker = new LoaderContainerTracker();
 	before(function () {

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -23,11 +23,22 @@ const counterId = "counterKey";
 
 describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedCounter } = apis.dds;
+	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+	// loadTestContainer reconstructs DDS factories from the correct version.
+	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 
-	const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
+	const createRegistry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+	const loadRegistry: ChannelFactoryRegistry = [
+		[counterId, ddsForLoading.SharedCounter.getFactory()],
+	];
+	const createContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
+		registry: createRegistry,
+	};
+	const loadContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry: loadRegistry,
 	};
 
 	let provider: ITestObjectProvider;
@@ -51,13 +62,13 @@ describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 
 	// Create a container representing the first client
 	beforeEach("Create container", async () => {
-		container1 = await provider.makeTestContainer(testContainerConfig);
+		container1 = await provider.makeTestContainer(createContainerConfig);
 	});
 
 	// Load the container that was created by the first client
 	beforeEach("Load containers", async () => {
-		container2 = await provider.loadTestContainer(testContainerConfig);
-		container3 = await provider.loadTestContainer(testContainerConfig);
+		container2 = await provider.loadTestContainer(loadContainerConfig);
+		container3 = await provider.loadTestContainer(loadContainerConfig);
 	});
 
 	// Get all three data stores

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -23,10 +23,10 @@ const counterId = "counterKey";
 
 describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedCounter } = apis.dds;
-	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-	// loadTestContainer reconstructs DDS factories from the correct version.
-	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+	// In cross-client compat, the loading client may be a different version than the creating
+	// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+	// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+	const ddsForLoading = apis.ddsForLoading;
 
 	const createRegistry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
 	const loadRegistry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -14,7 +14,7 @@ import {
 	ISummaryConfiguration,
 	SummaryCollection,
 } from "@fluidframework/container-runtime/internal";
-import { ISharedDirectory } from "@fluidframework/map/internal";
+import type { ISharedDirectory } from "@fluidframework/map/internal";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
 import { MockLogger, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
@@ -10,7 +10,7 @@ import type { IContainer } from "@fluidframework/container-definitions/internal"
 import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
-import { SharedCounter } from "@fluidframework/counter/internal";
+import type { SharedCounter } from "@fluidframework/counter/internal";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
 import {
 	getRequiredPendingLocalState,
@@ -20,6 +20,7 @@ import {
 describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) => {
 	const { DataObjectFactory, DataObject } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+	const { SharedCounter } = apis.dds;
 
 	// A Test Data Object that exposes some basic functionality.
 	class TestDataObject extends DataObject {

--- a/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
-import { ISharedDirectory } from "@fluidframework/map/internal";
+import type { ISharedDirectory } from "@fluidframework/map/internal";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITestObjectProvider,

--- a/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
@@ -6,7 +6,6 @@
 import { LocalServerTestDriver } from "@fluid-private/test-drivers";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, IHostLoader } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
 import {
 	ChannelCollectionFactory,
 	ISummarizer,
@@ -37,6 +36,7 @@ interface IDataStores extends IFluidDataStoreChannel {
 describeCompat("Nested DataStores", "NoCompat", (getTestObjectProvider, apis) => {
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 	const { SharedMap } = apis.dds;
+	const { Loader } = apis.loader;
 
 	let provider: ITestObjectProvider;
 	let containers: IContainer[] = [];

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -9,7 +9,7 @@ import type { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import type { Loader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import type { SharedCounter } from "@fluidframework/counter/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";

--- a/packages/test/test-end-to-end-tests/src/test/deltaManagerProxy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deltaManagerProxy.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ILoaderProps } from "@fluidframework/container-loader/internal";
 import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
-import { Side, type SharedString } from "@fluidframework/sequence/internal";
+import type { SharedString } from "@fluidframework/sequence/internal";
 import {
 	TestFluidObjectFactory,
 	createTestConfigProvider,
@@ -21,6 +21,7 @@ const configProvider = createTestConfigProvider();
 describeCompat("Container", "NoCompat", (getTestObjectProvider, apis) => {
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 	const { SharedString } = apis.dds;
+	const { Side } = apis.dataRuntime.packages.sequence;
 	configProvider.set("Fluid.Sequence.intervalStickinessEnabled", true);
 	const loaderProps: Partial<ILoaderProps> = {
 		configProvider,

--- a/packages/test/test-end-to-end-tests/src/test/deltaManagerProxy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deltaManagerProxy.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ILoaderProps } from "@fluidframework/container-loader/internal";
 import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
-import { SharedString, Side } from "@fluidframework/sequence/internal";
+import { Side, type SharedString } from "@fluidframework/sequence/internal";
 import {
 	TestFluidObjectFactory,
 	createTestConfigProvider,
@@ -20,6 +20,7 @@ const configProvider = createTestConfigProvider();
 // configProvider.set("Fluid.ContainerRuntime.DeltaManagerOpsProxy", false);
 describeCompat("Container", "NoCompat", (getTestObjectProvider, apis) => {
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+	const { SharedString } = apis.dds;
 	configProvider.set("Fluid.Sequence.intervalStickinessEnabled", true);
 	const loaderProps: Partial<ILoaderProps> = {
 		configProvider,

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -15,7 +15,7 @@ import {
 	IRuntimeFactory,
 } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { Loader } from "@fluidframework/container-loader/internal";
+import type { Loader } from "@fluidframework/container-loader/internal";
 import { ContainerMessageType } from "@fluidframework/container-runtime/internal";
 import { FluidObject, IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
@@ -869,6 +869,7 @@ describeCompat("Detached Container", "NoCompat", (getTestObjectProvider, apis) =
 		ConsensusQueue,
 		SparseMatrix,
 	} = apis.dds;
+	const { Loader } = apis.loader;
 
 	const registry: ChannelFactoryRegistry = [
 		[sharedStringId, SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -32,10 +32,10 @@ import {
 
 describeCompat("SharedDirectory", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory } = apis.dds;
-	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-	// loadTestContainer reconstructs DDS factories from the correct version.
-	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+	// In cross-client compat, the loading client may be a different version than the creating
+	// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+	// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+	const ddsForLoading = apis.ddsForLoading;
 	const directoryId = "directoryKey";
 	const createRegistry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
 	const loadRegistry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -32,11 +32,22 @@ import {
 
 describeCompat("SharedDirectory", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory } = apis.dds;
+	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+	// loadTestContainer reconstructs DDS factories from the correct version.
+	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 	const directoryId = "directoryKey";
-	const registry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
+	const createRegistry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
+	const loadRegistry: ChannelFactoryRegistry = [
+		[directoryId, ddsForLoading.SharedDirectory.getFactory()],
+	];
+	const createContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
+		registry: createRegistry,
+	};
+	const loadContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry: loadRegistry,
 	};
 
 	let provider: ITestObjectProvider;
@@ -50,17 +61,17 @@ describeCompat("SharedDirectory", "FullCompat", (getTestObjectProvider, apis) =>
 
 	beforeEach("createContainers", async () => {
 		// Create a Container for the first client.
-		const container1 = await provider.makeTestContainer(testContainerConfig);
+		const container1 = await provider.makeTestContainer(createContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 		sharedDirectory1 = await dataObject1.getSharedObject<SharedDirectory>(directoryId);
 
 		// Load the Container that was created by the first client.
-		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const container2 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		sharedDirectory2 = await dataObject2.getSharedObject<SharedDirectory>(directoryId);
 
 		// Load the Container that was created by the first client.
-		const container3 = await provider.loadTestContainer(testContainerConfig);
+		const container3 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 		sharedDirectory3 = await dataObject3.getSharedObject<SharedDirectory>(directoryId);
 

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -10,16 +10,21 @@ import {
 	describeInstallVersions,
 	getVersionedTestObjectProvider,
 } from "@fluid-private/test-version-utils";
-// TODO:AB#6558: describeInstallVersions doesn't support dynamically providing package APIs.
+// TODO:AB#6558: describeInstallVersions doesn't support dynamically providing package APIs. Until
+// that gap is closed, this file deliberately uses direct aqueduct imports because the shared
+// TestDataObject/createContainer helpers are reused by both describeCompat (which has `apis`) and
+// describeInstallVersions (which does not).
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import {
 	ContainerRuntimeFactoryWithDefaultDataStore,
 	DataObject,
 	DataObjectFactory,
 } from "@fluidframework/aqueduct/internal";
+/* eslint-enable @typescript-eslint/no-restricted-imports */
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
-import { IDirectory } from "@fluidframework/map/internal";
+import type { IDirectory } from "@fluidframework/map/internal";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
 

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -10,7 +10,7 @@ import {
 	ContainerErrorTypes,
 	IContainer,
 } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import type { ILoaderProps } from "@fluidframework/container-loader/internal";
 import {
 	IDocumentServiceFactory,
 	IResolvedUrl,
@@ -28,7 +28,8 @@ import { v4 as uuid } from "uuid";
 import { wrapObjectAndOverride } from "../mocking.js";
 
 // REVIEW: enable compat testing?
-describeCompat("Errors Types", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Errors Types", "NoCompat", (getTestObjectProvider, apis) => {
+	const { Loader } = apis.loader;
 	let provider: ITestObjectProvider;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { blobManagerBasePath } from "@fluidframework/container-runtime/internal/test/blobManager";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -11,7 +11,7 @@ import {
 	describeCompat,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -11,7 +11,7 @@ import {
 	describeCompat,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ISummarizer } from "@fluidframework/container-runtime/internal";
+import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import { IGarbageCollectionState } from "@fluidframework/container-runtime/internal/test/gc";
 import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";
 import { gcBlobPrefix, gcTreeKey } from "@fluidframework/runtime-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -11,7 +11,7 @@ import {
 	TestDataObjectType,
 	describeCompat,
 } from "@fluid-private/test-version-utils";
-import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -15,8 +15,8 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
-import {
-	type ContainerRuntime,
+import type {
+	ContainerRuntime,
 	ISummarizer,
 } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -15,7 +15,10 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime, ISummarizer } from "@fluidframework/container-runtime/internal";
+import {
+	type ContainerRuntime,
+	ISummarizer,
+} from "@fluidframework/container-runtime/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import { delay } from "@fluidframework/core-utils/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -12,7 +12,10 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime, ISummarizer } from "@fluidframework/container-runtime/internal";
+import {
+	type ContainerRuntime,
+	ISummarizer,
+} from "@fluidframework/container-runtime/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -12,8 +12,8 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import {
-	type ContainerRuntime,
+import type {
+	ContainerRuntime,
 	ISummarizer,
 } from "@fluidframework/container-runtime/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummary.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	IContainerRuntimeOptions,
 } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	IGCRuntimeOptions,
 	IGCStats,
 } from "@fluidframework/container-runtime/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -10,7 +10,7 @@ import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import {
 	ContainerMessageType,
-	ContainerRuntime,
+	type ContainerRuntime,
 	IGCRuntimeOptions,
 } from "@fluidframework/container-runtime/internal";
 import { blobsTreeName } from "@fluidframework/container-runtime/internal/test/blobManager";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -16,7 +16,7 @@ import {
 import { blobsTreeName } from "@fluidframework/container-runtime/internal/test/blobManager";
 import { ISweepMessage } from "@fluidframework/container-runtime/internal/test/gc";
 import {
-	ISummarizer,
+	type ISummarizer,
 	RetriableSummaryError,
 	defaultMaxAttemptsForSubmitFailures,
 } from "@fluidframework/container-runtime/internal/test/summary";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -17,7 +17,7 @@ import {
 	type ContainerRuntime,
 	IGCRuntimeOptions,
 	IOnDemandSummarizeOptions,
-	ISummarizer,
+	type ISummarizer,
 	DeletedResponseHeaderKey,
 } from "@fluidframework/container-runtime/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -14,7 +14,7 @@ import {
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import {
 	ContainerMessageType,
-	ContainerRuntime,
+	type ContainerRuntime,
 	IGCRuntimeOptions,
 	IOnDemandSummarizeOptions,
 	ISummarizer,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -9,7 +9,7 @@ import { stringToBuffer } from "@fluid-internal/client-utils";
 import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	IGCRuntimeOptions,
 } from "@fluidframework/container-runtime/internal";
 import { delay } from "@fluidframework/core-utils/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -17,7 +17,7 @@ import {
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import {
 	AllowTombstoneRequestHeaderKey,
-	ContainerRuntime,
+	type ContainerRuntime,
 	IOnDemandSummarizeOptions,
 	ISummarizer,
 	TombstoneResponseHeaderKey,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -19,7 +19,7 @@ import {
 	AllowTombstoneRequestHeaderKey,
 	type ContainerRuntime,
 	IOnDemandSummarizeOptions,
-	ISummarizer,
+	type ISummarizer,
 	TombstoneResponseHeaderKey,
 } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle, IRequest, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -11,9 +11,9 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	ContainerRuntime,
-	type ISummarizer,
+	ISummarizer,
 } from "@fluidframework/container-runtime/internal";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import type {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -7,12 +7,13 @@ import { strict as assert } from "assert";
 
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 // This test doesn't care to test compat of the Fluid handle implementation, it's just used for convenience
 // to simulate an unknown object.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
 import { FluidHandleBase } from "@fluidframework/runtime-utils/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
@@ -11,7 +11,7 @@ import {
 	describeCompat,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ISummarizer } from "@fluidframework/container-runtime/internal";
+import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	IContainerRuntimeOptions,
 	ISummarizer,
 } from "@fluidframework/container-runtime/internal";

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { ISharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import type { IContainer, IHostLoader } from "@fluidframework/container-definitions/internal";
 import {
 	IFluidHandle,
@@ -19,13 +19,10 @@ import type {
 	IChannel,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISharedMap, type ISharedDirectory } from "@fluidframework/map/internal";
-import { SharedMatrixFactory, type ISharedMatrix } from "@fluidframework/matrix/internal";
+import type { ISharedMap, ISharedDirectory } from "@fluidframework/map/internal";
+import type { ISharedMatrix } from "@fluidframework/matrix/internal";
 import type { ConsensusQueue } from "@fluidframework/ordered-collection/internal";
-import {
-	ConsensusRegisterCollectionFactory,
-	type IConsensusRegisterCollection,
-} from "@fluidframework/register-collection/internal";
+import type { IConsensusRegisterCollection } from "@fluidframework/register-collection/internal";
 import { IDataStore } from "@fluidframework/runtime-definitions/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 import type { SharedString } from "@fluidframework/sequence/internal";
@@ -42,13 +39,20 @@ import {
 	type ITestObjectProvider,
 	timeoutAwait,
 } from "@fluidframework/test-utils/internal";
+// SchemaFactory and TreeViewConfiguration are used at file scope below to define the test schema
+// `class Bar` and the corresponding TreeView config. Moving them inside the describeCompat callback
+// would require non-trivial restructuring; tests in this file run NoCompat so the current versions
+// are equivalent to apis.dataRuntime.packages.tree.* anyway.
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import {
 	ITree,
 	SchemaFactory,
 	TreeViewConfiguration,
 	type TreeView,
 } from "@fluidframework/tree";
-import { SharedTree } from "@fluidframework/tree/internal";
+// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
+import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
+/* eslint-enable @typescript-eslint/no-restricted-imports */
 
 const mapId = "map";
 const stringId = "sharedString";
@@ -180,6 +184,9 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 		SharedMatrix,
 		ConsensusRegisterCollection,
 		ConsensusQueue,
+		// SharedTree was added recently and may not exist on apis.dds when running against older
+		// compat versions; fall back to the directly-imported current version.
+		SharedTree = SharedTreeCurrent,
 	} = apis.dds;
 
 	let provider: ITestObjectProvider;
@@ -306,7 +313,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 		},
 		{
 			id: matrixId,
-			type: SharedMatrixFactory.Type,
+			type: SharedMatrix.getFactory().type,
 			createDDS(runtime) {
 				const matrix = runtime.createChannel(undefined, SharedMatrix.getFactory().type);
 				return this.downCast(matrix);
@@ -351,7 +358,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 		},
 		{
 			id: registerId,
-			type: ConsensusRegisterCollectionFactory.Type,
+			type: ConsensusRegisterCollection.getFactory().type,
 			createDDS(runtime) {
 				const register = runtime.createChannel(
 					undefined,

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -50,8 +50,6 @@ import {
 	TreeViewConfiguration,
 	type TreeView,
 } from "@fluidframework/tree";
-// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
-import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
 /* eslint-enable @typescript-eslint/no-restricted-imports */
 
 const mapId = "map";
@@ -184,9 +182,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 		SharedMatrix,
 		ConsensusRegisterCollection,
 		ConsensusQueue,
-		// SharedTree was added recently and may not exist on apis.dds when running against older
-		// compat versions; fall back to the directly-imported current version.
-		SharedTree = SharedTreeCurrent,
+		SharedTree,
 	} = apis.dds;
 
 	let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -33,7 +33,7 @@ import {
 	SessionSpaceCompressedId,
 	StableId,
 } from "@fluidframework/id-compressor";
-import { ISharedDirectory, ISharedMap } from "@fluidframework/map/internal";
+import type { ISharedDirectory, ISharedMap } from "@fluidframework/map/internal";
 import type {
 	IFluidDataStoreContext,
 	IRuntimeMessageCollection,

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -18,7 +18,7 @@ import {
 	IContainer,
 	type IFluidCodeDetails,
 } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import type { Loader } from "@fluidframework/container-loader/internal";
 import {
 	IContainerRuntimeOptions,
 	IdCompressorMode,

--- a/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
@@ -34,6 +34,9 @@ import {
 	FluidErrorTypes,
 	type ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces/internal";
+// This file tests the layer-compat infrastructure itself, so it imports the compat-detail symbols
+// directly from each layer rather than via apis (the apis abstraction is the thing under test).
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import {
 	dataStoreCompatDetailsForRuntime,
 	dataStoreCoreCompatDetails,

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -12,6 +12,8 @@ import {
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 // TODO:AB#6558: This should be provided based on the compatibility configuration.
+// describeInstallVersions (used below) doesn't expose `apis`, so the current SharedMap is imported directly.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -13,7 +13,7 @@ import type { SharedCounter } from "@fluidframework/counter/internal";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions/internal";
-import { SharedStringClass, type SharedString } from "@fluidframework/sequence/internal";
+import type { SharedString } from "@fluidframework/sequence/internal";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
@@ -31,6 +31,7 @@ const counterKey = "count";
 describeCompat("LocalLoader", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedCounter, SharedString } = apis.dds;
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
+	const { SharedStringClass } = apis.dataRuntime.packages.sequence;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
 	/**

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -22,10 +22,10 @@ import {
 
 describeCompat("SharedMap", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
-	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-	// loadTestContainer reconstructs DDS factories from the correct version.
-	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+	// In cross-client compat, the loading client may be a different version than the creating
+	// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+	// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+	const ddsForLoading = apis.ddsForLoading;
 	const mapId = "mapKey";
 	const createRegistry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
 	const loadRegistry: ChannelFactoryRegistry = [[mapId, ddsForLoading.SharedMap.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -22,11 +22,20 @@ import {
 
 describeCompat("SharedMap", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
+	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+	// loadTestContainer reconstructs DDS factories from the correct version.
+	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 	const mapId = "mapKey";
-	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
+	const createRegistry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
+	const loadRegistry: ChannelFactoryRegistry = [[mapId, ddsForLoading.SharedMap.getFactory()]];
+	const createContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
+		registry: createRegistry,
+	};
+	const loadContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry: loadRegistry,
 	};
 
 	let provider: ITestObjectProvider;
@@ -40,15 +49,15 @@ describeCompat("SharedMap", "FullCompat", (getTestObjectProvider, apis) => {
 	let sharedMap3: ISharedMap;
 
 	beforeEach("createContainers", async () => {
-		const container1 = await provider.makeTestContainer(testContainerConfig);
+		const container1 = await provider.makeTestContainer(createContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 		sharedMap1 = await dataObject1.getSharedObject<ISharedMap>(mapId);
 
-		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const container2 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		sharedMap2 = await dataObject2.getSharedObject<ISharedMap>(mapId);
 
-		const container3 = await provider.loadTestContainer(testContainerConfig);
+		const container3 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 		sharedMap3 = await dataObject3.getSharedObject<ISharedMap>(mapId);
 

--- a/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
@@ -16,7 +16,7 @@ import type {
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import { SharedMap, type ISharedMap } from "@fluidframework/map/internal";
+import type { ISharedMap } from "@fluidframework/map/internal";
 import {
 	DataObjectFactoryType,
 	ITestFluidObject,
@@ -52,6 +52,7 @@ const timeoutMs = 100;
 const realServiceTimeoutMs = 1000;
 
 describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedMap } = apis.dds;
 	const mapId = "map";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
 	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -69,8 +69,10 @@ import {
 	toIDeltaManagerFull,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
-import { SchemaFactory, ITree, TreeViewConfiguration } from "@fluidframework/tree";
-import { SharedTree } from "@fluidframework/tree/internal";
+import type { ITree } from "@fluidframework/tree";
+// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
 
 import { generatePendingState, loadContainerOffline } from "./offlineTestsUtils.js";
 
@@ -141,12 +143,14 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		SharedCounter,
 		SharedString,
 		SharedCell,
-		// SharedArray and SharedSignal were added recently and may not exist on apis.dds when
-		// running against older compat versions; fall back to the directly-imported current versions.
+		// SharedArray, SharedSignal, and SharedTree were added recently and may not exist on apis.dds
+		// when running against older compat versions; fall back to the directly-imported current versions.
 		SharedArray = SharedArrayCurrent,
 		SharedSignal = SharedSignalCurrent,
+		SharedTree = SharedTreeCurrent,
 	} = apis.dds;
 	const { getTextAndMarkers } = apis.dataRuntime.packages.sequence;
+	const { SchemaFactory, TreeViewConfiguration } = apis.dataRuntime.packages.tree;
 
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -30,9 +30,7 @@ import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import {
 	OperationType,
-	SharedArray as SharedArrayCurrent,
 	SharedArrayRevertible,
-	SharedSignal as SharedSignalCurrent,
 	type IRevertible,
 	type ISharedArray,
 	type ISharedSignal,
@@ -70,9 +68,6 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 import type { ITree } from "@fluidframework/tree";
-// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
 
 import { generatePendingState, loadContainerOffline } from "./offlineTestsUtils.js";
 
@@ -143,11 +138,9 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		SharedCounter,
 		SharedString,
 		SharedCell,
-		// SharedArray, SharedSignal, and SharedTree were added recently and may not exist on apis.dds
-		// when running against older compat versions; fall back to the directly-imported current versions.
-		SharedArray = SharedArrayCurrent,
-		SharedSignal = SharedSignalCurrent,
-		SharedTree = SharedTreeCurrent,
+		SharedArray,
+		SharedSignal,
+		SharedTree,
 	} = apis.dds;
 	const { getTextAndMarkers } = apis.dataRuntime.packages.sequence;
 	const { SchemaFactory, TreeViewConfiguration } = apis.dataRuntime.packages.tree;

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -30,9 +30,9 @@ import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import {
 	OperationType,
-	SharedArray,
+	SharedArray as SharedArrayCurrent,
 	SharedArrayRevertible,
-	SharedSignal,
+	SharedSignal as SharedSignalCurrent,
 	type IRevertible,
 	type ISharedArray,
 	type ISharedSignal,
@@ -135,7 +135,17 @@ const pendingBlobsFromPendingState = (pendingState: string): Record<string, any>
 // Introduced in 0.37
 // REVIEW: enable compat testing
 describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory, SharedCounter, SharedString, SharedCell } = apis.dds;
+	const {
+		SharedMap,
+		SharedDirectory,
+		SharedCounter,
+		SharedString,
+		SharedCell,
+		// SharedArray and SharedSignal were added recently and may not exist on apis.dds when
+		// running against older compat versions; fall back to the directly-imported current versions.
+		SharedArray = SharedArrayCurrent,
+		SharedSignal = SharedSignalCurrent,
+	} = apis.dds;
 	const { getTextAndMarkers } = apis.dataRuntime.packages.sequence;
 
 	const registry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
@@ -36,9 +36,6 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 import type { ITree } from "@fluidframework/tree";
-// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
 
 import { loadContainerOffline, generatePendingState } from "./offlineTestsUtils.js";
 
@@ -70,9 +67,7 @@ describeCompat(
 	(getTestObjectProvider, apis) => {
 		const mapId = "map";
 		const treeId = "tree";
-		// SharedTree was added recently and may not exist on apis.dds when running against older
-		// compat versions; fall back to the directly-imported current version.
-		const { SharedMap, SharedTree = SharedTreeCurrent } = apis.dds;
+		const { SharedMap, SharedTree } = apis.dds;
 		const { SchemaFactory, TreeViewConfiguration } = apis.dataRuntime.packages.tree;
 		const registry: ChannelFactoryRegistry = [
 			[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
@@ -35,8 +35,10 @@ import {
 	type ITestObjectProvider,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
-import { SchemaFactory, ITree, TreeViewConfiguration } from "@fluidframework/tree";
-import { SharedTree } from "@fluidframework/tree/internal";
+import type { ITree } from "@fluidframework/tree";
+// Used only as a fallback for older compat versions where apis.dds.SharedTree may be undefined.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { SharedTree as SharedTreeCurrent } from "@fluidframework/tree/internal";
 
 import { loadContainerOffline, generatePendingState } from "./offlineTestsUtils.js";
 
@@ -68,7 +70,10 @@ describeCompat(
 	(getTestObjectProvider, apis) => {
 		const mapId = "map";
 		const treeId = "tree";
-		const { SharedMap } = apis.dds;
+		// SharedTree was added recently and may not exist on apis.dds when running against older
+		// compat versions; fall back to the directly-imported current version.
+		const { SharedMap, SharedTree = SharedTreeCurrent } = apis.dds;
+		const { SchemaFactory, TreeViewConfiguration } = apis.dataRuntime.packages.tree;
 		const registry: ChannelFactoryRegistry = [
 			[mapId, SharedMap.getFactory()],
 			[treeId, SharedTree.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { SharedCounter } from "@fluidframework/counter/internal";
 import type { ISharedMap, SharedDirectory } from "@fluidframework/map/internal";
 import type { SharedMatrix } from "@fluidframework/matrix/internal";

--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -8,7 +8,6 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { Loader } from "@fluidframework/container-loader/internal";
 import {
 	ITestObjectProvider,
 	LoaderContainerTracker,
@@ -21,7 +20,8 @@ import {
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
 describe("Pong", () => {
-	describeCompat("Pong", "NoCompat", (getTestObjectProvider) => {
+	describeCompat("Pong", "NoCompat", (getTestObjectProvider, apis) => {
+		const { Loader } = apis.loader;
 		let provider: ITestObjectProvider;
 		const loaderContainerTracker = new LoaderContainerTracker();
 

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import type { Loader } from "@fluidframework/container-loader/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces/internal";
 import { IDataStore } from "@fluidframework/runtime-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/serializeAfterFailedAttach.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/serializeAfterFailedAttach.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
-import { Loader } from "@fluidframework/container-loader/internal";
+import type { Loader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import type { ISharedMap } from "@fluidframework/map/internal";
@@ -32,6 +32,7 @@ describeCompat(
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap, SharedString } = apis.dds;
+		const { Loader } = apis.loader;
 
 		const codeDetails: IFluidCodeDetails = {
 			package: "detachedContainerTestPackage1",

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -27,11 +27,22 @@ const stringId = "sharedStringKey";
 
 describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
+	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
+	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
+	// loadTestContainer reconstructs DDS factories from the correct version.
+	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
 
-	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
+	const createRegistry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+	const loadRegistry: ChannelFactoryRegistry = [
+		[stringId, ddsForLoading.SharedString.getFactory()],
+	];
+	const createContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
+		registry: createRegistry,
+	};
+	const loadContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry: loadRegistry,
 	};
 
 	let provider: ITestObjectProvider;
@@ -44,11 +55,11 @@ describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
 	let dataObject1: ITestFluidObject;
 
 	beforeEach("setupSharedStrings", async () => {
-		const container1 = await provider.makeTestContainer(testContainerConfig);
+		const container1 = await provider.makeTestContainer(createContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 		sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
 
-		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const container2 = await provider.loadTestContainer(loadContainerConfig);
 		const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
 	});
@@ -82,7 +93,7 @@ describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
 		);
 
 		// Create a initialize a new container with the same id.
-		const newContainer = await provider.loadTestContainer(testContainerConfig);
+		const newContainer = await provider.loadTestContainer(loadContainerConfig);
 		const newComponent =
 			await getContainerEntryPointBackCompat<ITestFluidObject>(newContainer);
 		const newSharedString = await newComponent.getSharedObject<SharedString>(stringId);

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -27,10 +27,10 @@ const stringId = "sharedStringKey";
 
 describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
-	// In cross-client compat, the loading client may be a different version. Use ddsForLoading
-	// (which falls back to apis.dds when not cross-client) to build the load-side registry so
-	// loadTestContainer reconstructs DDS factories from the correct version.
-	const ddsForLoading = apis.ddsForLoading ?? apis.dds;
+	// In cross-client compat, the loading client may be a different version than the creating
+	// client. Use ddsForLoading to build the load-side registry so loadTestContainer reconstructs
+	// DDS factories from the correct version. (Outside cross-client compat it matches apis.dds.)
+	const ddsForLoading = apis.ddsForLoading;
 
 	const createRegistry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
 	const loadRegistry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
-import { Loader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IDocumentServiceFactory,
@@ -30,6 +29,7 @@ import { pkgVersion } from "../packageVersion.js";
 // REVIEW: enable compat testing?
 describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
+	const { Loader } = apis.loader;
 
 	itExpects(
 		"Failure to Load in Shared String",

--- a/packages/test/test-end-to-end-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stagingMode.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-version-utils";
-import { DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
@@ -26,6 +25,7 @@ describeCompat(
 	"StagingMode: readonlyInStagingMode",
 	"FullCompat",
 	function (getTestObjectProvider, apis) {
+		const { DataObjectFactory } = apis.dataRuntime;
 		const createContainer = async ({
 			test,
 			readonlyInStagingMode,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -13,10 +13,10 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import {
-	type ContainerRuntime,
+import type {
+	ContainerRuntime,
 	ISummarizeResults,
-	type ISummarizer,
+	ISummarizer,
 } from "@fluidframework/container-runtime/internal";
 import { ISummaryBlob, ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import { ISummaryContext } from "@fluidframework/driver-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	ISummarizeResults,
 	type ISummarizer,
 } from "@fluidframework/container-runtime/internal";

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizationFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizationFetchValidation.spec.ts
@@ -7,7 +7,10 @@ import { strict as assert } from "assert";
 
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ISummarizeResults, ISummarizer } from "@fluidframework/container-runtime/internal";
+import type {
+	ISummarizeResults,
+	ISummarizer,
+} from "@fluidframework/container-runtime/internal";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
 import { ISummaryContext, ISnapshotTree } from "@fluidframework/driver-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementally.spec.ts
@@ -11,7 +11,7 @@ import {
 	describeCompat,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ISummarizer } from "@fluidframework/container-runtime/internal";
+import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import {
 	IContainerRuntimeBase,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { describeCompat, getContainerRuntimeApi } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	IContainerRuntimeOptions,
 	ISummarizer,
 } from "@fluidframework/container-runtime/internal";

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithLocalChanges.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	DefaultSummaryConfiguration,
 	IContainerRuntimeOptions,
 	ISummaryConfiguration,

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithOutOfOrderDataStoreRealization.spec.ts
@@ -7,12 +7,12 @@ import { strict as assert } from "assert";
 
 import { describeCompat, type ITestDataObject } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
-import {
+import type {
 	IContainerRuntimeOptions,
 	ISummarizer,
-	type ContainerRuntime,
-	type ISubmitSummaryOptions,
-	type SubmitSummaryResult,
+	ContainerRuntime,
+	ISubmitSummaryOptions,
+	SubmitSummaryResult,
 } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { FluidDataStoreRuntime } from "@fluidframework/datastore/internal";

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithSearch.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
-	ContainerRuntime,
+	type ContainerRuntime,
 	type ISummarizer,
 	SummaryCollection,
 	neverCancelledSummaryToken,

--- a/packages/test/test-end-to-end-tests/src/test/tree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/tree.spec.ts
@@ -5,12 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { describeCompat } from "@fluid-private/test-version-utils";
-import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
-	DataObject,
-	DataObjectFactory,
-} from "@fluidframework/aqueduct/internal";
+import { describeCompat, type CompatApis } from "@fluid-private/test-version-utils";
 import type { ISharedDirectory } from "@fluidframework/map/internal";
 import type {
 	IContainerRuntimeBase,
@@ -23,115 +18,142 @@ import {
 	summarizeNow,
 	type ContainerRuntimeFactoryWithDefaultDataStoreProps,
 } from "@fluidframework/test-utils/internal";
-import { SchemaFactory, TreeViewConfiguration, type TreeView } from "@fluidframework/tree";
+import type { TreeView } from "@fluidframework/tree";
 import type { ITree, ITreeAlpha } from "@fluidframework/tree/alpha";
-import { configuredSharedTree } from "@fluidframework/tree/internal";
 
 /**
- * Default data store; provides a root SharedDirectory where a handle to the
- * detached data store will be stored to trigger its attach.
+ * Build the per-test setup using compat-versioned APIs from `apis`. Called from
+ * each describeCompat callback so the DataObject/DataObjectFactory/runtime factory
+ * and tree APIs versions match the compat configuration under test.
  */
-class DefaultDataObject extends DataObject {
-	public static readonly Name = "DefaultDataObject";
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- captures closure types from per-version apis
+function makeTestSetup(apis: CompatApis) {
+	const { DataObject, DataObjectFactory } = apis.dataRuntime;
+	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+	const { SchemaFactory, TreeViewConfiguration, configuredSharedTree } =
+		apis.dataRuntime.packages.tree;
 
-	public get _root(): ISharedDirectory {
-		return this.root;
+	const sf = new SchemaFactory("idCompressorDetachedDataStoreTest");
+	class Root extends sf.object("Root", {
+		id: sf.identifier,
+	}) {}
+
+	const treeConfig = new TreeViewConfiguration({ schema: Root });
+
+	const SharedTree = configuredSharedTree({
+		// This is the default value. Before the write-side fix for "Summarizer creates the data store from the attach op summary and can summarize"
+		// was shipped, setting this to "true" also provided some verification that the read-side mitigation for the bug worked. The e2e test no longer
+		// covers this case (unit tests do), but the test still helps prevent regressions for the scenario.
+		healUnresolvableIdentifiersOnDecode: false,
+		enableSharedBranches: true,
+	});
+
+	/**
+	 * Default data store; provides a root SharedDirectory where a handle to the
+	 * detached data store will be stored to trigger its attach.
+	 */
+	class DefaultDataObject extends DataObject {
+		public static readonly Name = "DefaultDataObject";
+
+		public get _root(): ISharedDirectory {
+			return this.root;
+		}
+
+		public get containerRuntime(): IContainerRuntimeBase {
+			return this.context.containerRuntime;
+		}
 	}
 
-	public get containerRuntime(): IContainerRuntimeBase {
-		return this.context.containerRuntime;
-	}
-}
+	const defaultFactory = new DataObjectFactory({
+		type: DefaultDataObject.Name,
+		ctor: DefaultDataObject,
+	});
 
-const defaultFactory = new DataObjectFactory({
-	type: DefaultDataObject.Name,
-	ctor: DefaultDataObject,
-});
+	/**
+	 * Data store that owns a SharedTree. Its first-time initialization runs
+	 * inside the detached creation flow (`createInstanceWithDataStore` then
+	 * `instantiateDataStore` then `initializingFirstTime`), so the tree mutations
+	 * happen while the data store is genuinely detached. The id compressor
+	 * therefore allocates only local (negative / not-yet-finalized) ids.
+	 */
+	class TreeOwningDataObject extends DataObject {
+		public static readonly Name = "TreeOwningDataObject";
 
-const sf = new SchemaFactory("idCompressorDetachedDataStoreTest");
-class Root extends sf.object("Root", {
-	id: sf.identifier,
-}) {}
+		#treeView: TreeView<typeof Root> | undefined;
+		#tree: ITree | undefined;
 
-const treeConfig = new TreeViewConfiguration({ schema: Root });
+		public get tree(): ITree {
+			assert(this.#tree !== undefined, "tree has not been initialized");
+			return this.#tree;
+		}
 
-const SharedTree = configuredSharedTree({
-	// This is the default value. Before the write-side fix for "Summarizer creates the data store from the attach op summary and can summarize"
-	// was shipped, setting this to "true" also provided some verification that the read-side mitigation for the bug worked. The e2e test no longer
-	// covers this case (unit tests do), but the test still helps prevent regressions for the scenario.
-	healUnresolvableIdentifiersOnDecode: false,
-	enableSharedBranches: true,
-});
+		public get treeView(): TreeView<typeof Root> {
+			assert(this.#treeView !== undefined, "treeView has not been initialized");
+			return this.#treeView;
+		}
 
-/**
- * Data store that owns a SharedTree. Its first-time initialization runs
- * inside the detached creation flow (`createInstanceWithDataStore` then
- * `instantiateDataStore` then `initializingFirstTime`), so the tree mutations
- * happen while the data store is genuinely detached. The id compressor
- * therefore allocates only local (negative / not-yet-finalized) ids.
- */
-class TreeOwningDataObject extends DataObject {
-	public static readonly Name = "TreeOwningDataObject";
+		protected override async initializingFirstTime(): Promise<void> {
+			// Create the SharedTree while the data store is detached.
+			const tree = SharedTree.create(this.runtime);
+			this.root.set("tree", tree.handle);
 
-	#treeView: TreeView<typeof Root> | undefined;
-	#tree: ITree | undefined;
-
-	public get tree(): ITree {
-		assert(this.#tree !== undefined, "tree has not been initialized");
-		return this.#tree;
-	}
-
-	public get treeView(): TreeView<typeof Root> {
-		assert(this.#treeView !== undefined, "treeView has not been initialized");
-		return this.#treeView;
+			// Initialize while detached. Creating the Root node causes the
+			// runtime's id compressor to allocate a local (negative) compressed
+			// id for its `identifier` field because no finalize op has been
+			// observed yet.
+			const view = tree.viewWith(treeConfig);
+			view.initialize({});
+			this.#tree = tree;
+			this.#treeView = view;
+		}
 	}
 
-	protected override async initializingFirstTime(): Promise<void> {
-		// Create the SharedTree while the data store is detached.
-		const tree = SharedTree.create(this.runtime);
-		this.root.set("tree", tree.handle);
+	const treeOwningFactory = new DataObjectFactory({
+		type: TreeOwningDataObject.Name,
+		ctor: TreeOwningDataObject,
+		sharedObjects: [SharedTree.getFactory()],
+	});
 
-		// Initialize while detached. Creating the Root node causes the
-		// runtime's id compressor to allocate a local (negative) compressed
-		// id for its `identifier` field because no finalize op has been
-		// observed yet.
-		const view = tree.viewWith(treeConfig);
-		view.initialize({});
-		this.#tree = tree;
-		this.#treeView = view;
-	}
-}
+	const registryEntries: NamedFluidDataStoreRegistryEntries = [
+		[defaultFactory.type, Promise.resolve(defaultFactory)],
+		[treeOwningFactory.type, Promise.resolve(treeOwningFactory)],
+	];
 
-const treeOwningFactory = new DataObjectFactory({
-	type: TreeOwningDataObject.Name,
-	ctor: TreeOwningDataObject,
-	sharedObjects: [SharedTree.getFactory()],
-});
-
-const registryEntries: NamedFluidDataStoreRegistryEntries = [
-	[defaultFactory.type, Promise.resolve(defaultFactory)],
-	[treeOwningFactory.type, Promise.resolve(treeOwningFactory)],
-];
-
-const runtimeProps: ContainerRuntimeFactoryWithDefaultDataStoreProps = {
-	defaultFactory,
-	registryEntries,
-	runtimeOptions: {
-		// SharedTree requires the runtime id compressor.
-		enableRuntimeIdCompressor: "on",
-		// Disable summaries for regular clients so they don't interfere with on demand summaries.
-		summaryOptions: {
-			summaryConfigOverrides: {
-				state: "disabled",
+	const runtimeProps: ContainerRuntimeFactoryWithDefaultDataStoreProps = {
+		defaultFactory,
+		registryEntries,
+		runtimeOptions: {
+			// SharedTree requires the runtime id compressor.
+			enableRuntimeIdCompressor: "on",
+			// Disable summaries for regular clients so they don't interfere with on demand summaries.
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
 			},
 		},
-	},
-};
+	};
+
+	return {
+		ContainerRuntimeFactoryWithDefaultDataStore,
+		DefaultDataObject,
+		defaultFactory,
+		treeOwningFactory,
+		runtimeProps,
+	};
+}
 
 describeCompat(
 	"SharedTree with identifier in a data store created detached and attached via op",
 	"NoCompat",
-	(getTestObjectProvider) => {
+	(getTestObjectProvider, apis) => {
+		const {
+			ContainerRuntimeFactoryWithDefaultDataStore,
+			DefaultDataObject,
+			defaultFactory,
+			treeOwningFactory,
+			runtimeProps,
+		} = makeTestSetup(apis);
 		let provider: ITestObjectProvider;
 
 		beforeEach("getTestObjectProvider", () => {
@@ -150,7 +172,9 @@ describeCompat(
 		it("Summarizer loads data store from the attach op summary and can summarize", async () => {
 			// 1. Create a container with an attached default data store.
 			const container1 = await provider.createContainer(runtimeFactory);
-			const defaultDataObject = (await container1.getEntryPoint()) as DefaultDataObject;
+			const defaultDataObject = (await container1.getEntryPoint()) as InstanceType<
+				typeof DefaultDataObject
+			>;
 
 			// 2. Create the data store *detached*. The factory uses
 			//    `createDetachedDataStore` + `attachRuntime` internally, and
@@ -192,7 +216,14 @@ describeCompat(
 describeCompat(
 	"SharedTree with shared branches in a data store created detached and attached via op",
 	"NoCompat",
-	(getTestObjectProvider) => {
+	(getTestObjectProvider, apis) => {
+		const {
+			ContainerRuntimeFactoryWithDefaultDataStore,
+			DefaultDataObject,
+			defaultFactory,
+			treeOwningFactory,
+			runtimeProps,
+		} = makeTestSetup(apis);
 		let provider: ITestObjectProvider;
 
 		beforeEach("getTestObjectProvider", () => {
@@ -207,7 +238,9 @@ describeCompat(
 		it("Summarizer creates the data store from the attach op summary and can summarize", async () => {
 			// 1. Create a container with an attached default data store.
 			const container1 = await provider.createContainer(runtimeFactory);
-			const defaultDataObject = (await container1.getEntryPoint()) as DefaultDataObject;
+			const defaultDataObject = (await container1.getEntryPoint()) as InstanceType<
+				typeof DefaultDataObject
+			>;
 
 			// 2. Create the data store *detached*. The factory uses
 			//    `createDetachedDataStore` + `attachRuntime` internally, and

--- a/packages/test/test-end-to-end-tests/src/test/treeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/treeCompat.spec.ts
@@ -15,7 +15,6 @@ import {
 	type ITestObjectProvider,
 } from "@fluidframework/test-utils/internal";
 import type { ITree } from "@fluidframework/tree";
-import { lt } from "semver";
 
 const treeId = "sharedTree";
 const baseTestContainerConfig: ITestContainerConfig = {
@@ -76,13 +75,13 @@ describeCompat(
 
 		beforeEach(function () {
 			provider = getTestObjectProvider();
-			// SharedTree was added in version 2.0.0. Skip all cross-client compat tests in this suite for older versions.
-			if (apis.mode === "CrossClientCompat") {
-				const version = apis.dataRuntime.version;
-				const versionForLoading = apis.dataRuntimeForLoading.version;
-				if (lt(version, "2.0.0") || lt(versionForLoading, "2.0.0")) {
-					this.skip();
-				}
+			// SharedTree was added in version 2.0.0. In previous versions, it is not available.
+			// If either the creating or loading version APIs don't have the tree package, skip the test.
+			if (
+				apis.dataRuntime.packages.tree === undefined ||
+				apis.dataRuntimeForLoading.packages.tree === undefined
+			) {
+				this.skip();
 			}
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/treeDataObject.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/treeDataObject.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
 	PureDataObjectFactory,
 	TreeDataObject,
 	TreeDataObjectFactory,
@@ -17,61 +16,60 @@ import {
 	createContainerRuntimeFactoryWithDefaultDataStore,
 	getContainerEntryPointBackCompat,
 } from "@fluidframework/test-utils/internal";
-import {
-	SchemaFactory,
-	SharedTree,
-	TreeViewConfiguration,
-	type TreeView,
-} from "@fluidframework/tree/internal";
-
-const schemaFactory = new SchemaFactory("test");
-class TestSchema extends schemaFactory.object("TestSchema", {
-	foo: [schemaFactory.string, schemaFactory.number],
-}) {}
-
-const treeViewConfig = new TreeViewConfiguration({ schema: TestSchema });
-
-class TestTreeDataObject extends TreeDataObject {
-	public static readonly type = "TestTreeDataObject";
-
-	public static getFactory(): PureDataObjectFactory<TestTreeDataObject> {
-		return TestTreeDataObject.factory;
-	}
-
-	private static readonly factory = new TreeDataObjectFactory({
-		type: TestTreeDataObject.type,
-		ctor: TestTreeDataObject,
-		sharedObjects: [SharedTree.getFactory()],
-	});
-
-	#treeView: TreeView<typeof TestSchema> | undefined;
-
-	/**
-	 * The schema-aware view of the tree.
-	 */
-	public get treeView(): TreeView<typeof TestSchema> {
-		if (this.#treeView === undefined) {
-			throw new Error("treeView has not been initialized.");
-		}
-		return this.#treeView;
-	}
-
-	protected override async initializingFirstTime(): Promise<void> {
-		this.#treeView = this.tree.viewWith(treeViewConfig);
-		assert(this.treeView.compatibility.canInitialize, "Incompatible schema");
-
-		this.treeView.initialize({ foo: "Hello world" });
-	}
-
-	protected override async initializingFromExisting(): Promise<void> {
-		this.#treeView = this.tree.viewWith(treeViewConfig);
-		assert(this.treeView.compatibility.canView, "Incompatible schema");
-	}
-}
+import type { TreeView } from "@fluidframework/tree/internal";
 
 // Note: ideally these tests would live directly in the `aqueduct` package,
 // but much of the test infrastructure used below is not reachable from that package.
-describeCompat("TreeDataObject", "NoCompat", (getTestObjectProvider) => {
+describeCompat("TreeDataObject", "NoCompat", (getTestObjectProvider, apis) => {
+	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+	const { SchemaFactory, TreeViewConfiguration } = apis.dataRuntime.packages.tree;
+	const { SharedTree } = apis.dds;
+
+	const schemaFactory = new SchemaFactory("test");
+	class TestSchema extends schemaFactory.object("TestSchema", {
+		foo: [schemaFactory.string, schemaFactory.number],
+	}) {}
+
+	const treeViewConfig = new TreeViewConfiguration({ schema: TestSchema });
+
+	class TestTreeDataObject extends TreeDataObject {
+		public static readonly type = "TestTreeDataObject";
+
+		public static getFactory(): PureDataObjectFactory<TestTreeDataObject> {
+			return TestTreeDataObject.factory;
+		}
+
+		private static readonly factory = new TreeDataObjectFactory({
+			type: TestTreeDataObject.type,
+			ctor: TestTreeDataObject,
+			sharedObjects: [SharedTree.getFactory()],
+		});
+
+		#treeView: TreeView<typeof TestSchema> | undefined;
+
+		/**
+		 * The schema-aware view of the tree.
+		 */
+		public get treeView(): TreeView<typeof TestSchema> {
+			if (this.#treeView === undefined) {
+				throw new Error("treeView has not been initialized.");
+			}
+			return this.#treeView;
+		}
+
+		protected override async initializingFirstTime(): Promise<void> {
+			this.#treeView = this.tree.viewWith(treeViewConfig);
+			assert(this.treeView.compatibility.canInitialize, "Incompatible schema");
+
+			this.treeView.initialize({ foo: "Hello world" });
+		}
+
+		protected override async initializingFromExisting(): Promise<void> {
+			this.#treeView = this.tree.viewWith(treeViewConfig);
+			assert(this.treeView.compatibility.canView, "Incompatible schema");
+		}
+	}
+
 	// Runtime ID compression is required to use SharedTree.
 	const runtimeOptions: IContainerRuntimeOptions = {
 		enableRuntimeIdCompressor: "on",

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -13,10 +13,7 @@ import { FluidTestDriverConfig, createFluidTestDriver } from "@fluid-private/tes
 import { FluidObject, IFluidLoadable, IRequest } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext, type IResponse } from "@fluidframework/core-interfaces/internal";
 import { unreachableCase } from "@fluidframework/core-utils/internal";
-import {
-	IFluidDataStoreRuntime,
-	IChannelFactory,
-} from "@fluidframework/datastore-definitions/internal";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import { ISharedDirectory } from "@fluidframework/map/internal";
 import {
 	IContainerRuntimeBase,
@@ -27,7 +24,6 @@ import {
 import {
 	ITestContainerConfig,
 	DataObjectFactoryType,
-	ChannelFactoryRegistry,
 	createTestContainerRuntimeFactory,
 	TestObjectProvider,
 	TestObjectProviderWithVersionedLoad,
@@ -114,32 +110,8 @@ function createGetDataStoreFactoryFunction(
 		}
 	}
 
-	const registryMapping = {};
-	for (const value of Object.values(api.dds)) {
-		/**
-		 * Skip dds that may not be available in this version of the api.
-		 * Not all versions have all dds. See {@link PackageToInstall} for details.
-		 */
-		if (value?.getFactory === undefined) {
-			continue;
-		}
-		registryMapping[value.getFactory().type] = value.getFactory();
-	}
-
-	function convertRegistry(registry: ChannelFactoryRegistry = []): ChannelFactoryRegistry {
-		const oldRegistry: [string | undefined, IChannelFactory][] = [];
-		for (const [key, factory] of registry) {
-			const oldFactory = registryMapping[factory.type];
-			if (oldFactory === undefined) {
-				throw Error(`Invalid or unimplemented channel factory: ${factory.type}`);
-			}
-			oldRegistry.push([key, oldFactory]);
-		}
-		return oldRegistry;
-	}
-
 	return function (containerOptions?: ITestContainerConfig): IFluidDataStoreFactory {
-		const registry = convertRegistry(containerOptions?.registry);
+		const registry = containerOptions?.registry ?? [];
 		const fluidDataObjectType = containerOptions?.fluidDataObjectType;
 		switch (fluidDataObjectType) {
 			case undefined:


### PR DESCRIPTION
## Description

The `convertRegistry` function in the test infra that replaces DDS registries passed in by tests with a versioned one as per the compat version the test is running in. For example, if the test is running in layer compat version mode where `DataStore` version is 1.4.0, it replaces the registry with its 1.4.0 version.
This works in most cases but has a few shortcomings:
1. If a test creates a custom DDS registry (say a tree registry via `configuredSharedTree`), this is replaced with the base registry losing all the custom configurations.
2. This happens explicitly and the test authors may not know about this. This can lead to unintended consequences where the DDS is versioned but the other objects like container runtime, data store, loader, etc. may not be. The tests can fail with seemingly unrelated and random errors.

This change fixes some of the above problems by doing the following:
- Removed the `convertRegistry` function.
- Updated almost all tests to use the correct version of the APIs exposed by `describeCompat`. There are a few tests which still use the latest APIs - added comments / tagged task items for them.
- There is a lint rule that notify test authors if they don't use the compat APIs. It was not working for all cases. Updated it to work for all knowns cases.
- Added documentation on the correct pattern to use for various scenarios. Also, pointed the lint rule error message to this document.

[AB#74635](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74635)

## Future work

The test infra still implcitily uses compat versions of other objects - driver, loader, runtime, data store, DDS, etc. when tests don't create these objects explicitly. But these don't happen for all patterns - for example, a test can create a loader of a particular version and use it to create different versions of container runtimes and other objects leading to an unexpected mismatch.
One approach to fix this is to have APIs that explicitly tell the test which API is being used - old / new, for create / load, etc. That combined with the lint rules should make it clearer and more intuitive to test authors when they use incorrect APIs or incorrect version combinations of objects.