### PR TITLE
docs: document fluid-build env vars and in-repo build-tools linking

### DIFF
--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -247,17 +247,19 @@ the current state and previous build will determine whether the task needs to be
 
 ### Environment Variables
 
-The following environment variables can be used to control incremental build behavior. By default, some tasks use
-file timestamps for incremental detection. Setting these variables to `"1"` enables content-based hashing instead,
-which avoids false rebuilds when timestamps change without meaningful content modification (e.g., after git operations
-or file copies).
+The following environment variables can be used to control `fluid-build` behavior. By default, some tasks use file
+timestamps for incremental detection. Setting the `FLUID_BUILD_ENABLE_*_HASH` variables to `"1"` enables content-based
+hashing instead, which avoids false rebuilds when timestamps change without meaningful content modification (e.g., after
+git operations or file copies).
 
-| Variable | Task | Description |
-|----------|------|-------------|
-| `FLUID_BUILD_ENABLE_COPYFILES_HASH` | CopyfilesTask | Enables content hashing for copyfiles tasks |
-| `FLUID_BUILD_ENABLE_TYPEVALIDATION_HASH` | TypeValidationTask | Enables content hashing for type validation tasks |
-| `FLUID_BUILD_ENABLE_GOODFENCE_HASH` | GoodFence | Enables content hashing for good-fence tasks |
-| `FLUID_BUILD_ENABLE_DEPCRUISE_HASH` | DepCruiseTask | Enables content hashing for dependency-cruiser tasks |
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `FLUID_BUILD_ENABLE_COPYFILES_HASH` | `1` | Enables content hashing for copyfiles tasks |
+| `FLUID_BUILD_ENABLE_TYPEVALIDATION_HASH` | `1` | Enables content hashing for type validation tasks |
+| `FLUID_BUILD_ENABLE_GOODFENCE_HASH` | `1` | Enables content hashing for good-fence tasks |
+| `FLUID_BUILD_ENABLE_DEPCRUISE_HASH` | `1` | Enables content hashing for dependency-cruiser tasks |
+| `FLUID_BUILD_EXTENDED_METRICS_DISPLAY` | `true` or `1` | Displays extended build cache metrics |
+| `FLUID_BUILD_TEST_RANDOM_ORDER` | `true` | Randomizes glob result ordering to help detect ordering dependencies in tests |
 
 Example:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,6 +113,12 @@ overrides:
   # GHSA-34x7-hfp2-rc4v).
   tar: ^7.5.11
 
+  # Uncomment the lines below and run pnpm install to link the in-repo copy of build tools
+  # See https://github.com/microsoft/FluidFramework/blob/main/build-tools/README.md#testing-build-tools-changes-in-the-client-release-group
+  # "@fluid-tools/build-cli": "link:./build-tools/packages/build-cli"
+  # "@fluid-tools/version-tools": "link:./build-tools/packages/version-tools"
+  # "@fluidframework/build-tools": "link:./build-tools/packages/build-tools"
+
 packages:
   - "azure/packages/**"
   - "examples/**"


### PR DESCRIPTION
## Description

Documentation-only updates for `fluid-build` configuration.

- **`build-tools/packages/build-tools/README.md`** — Refresh the environment variables section: rename the table's `Task` column to `Value` and document each variable's expected value, add the previously undocumented `FLUID_BUILD_EXTENDED_METRICS_DISPLAY` and `FLUID_BUILD_TEST_RANDOM_ORDER` variables, and clarify the surrounding prose.
- **`pnpm-workspace.yaml`** — Add commented-out `overrides` entries (with a link to the build-tools README) that contributors can uncomment to link the in-repo copies of the build tools for local testing.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).