### PR TITLE
Add numUnsummarizedOps to container load telemetry

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1592,6 +1592,7 @@ export class Container
 		version: string | undefined;
 		dmLastProcessedSeqNumber: number;
 		dmLastKnownSeqNumber: number;
+		numUnsummarizedOps: number;
 	}> {
 		const timings: Record<string, number> = { phase1: performanceNow() };
 		this.service = await this.createDocumentService(resolvedUrl, { mode: "load" });
@@ -1759,6 +1760,12 @@ export class Container
 			version: version?.id,
 			dmLastProcessedSeqNumber: this._deltaManager.lastSequenceNumber,
 			dmLastKnownSeqNumber: this._deltaManager.lastKnownSeqNumber,
+			// Ops known since the last summary (including queued/unprocessed). The loaded snapshot's
+			// sequence number corresponds to the last summary's reference sequence number under normal
+			// "latest" load paths (the runtime asserts this match unless pendingLocalState is used or
+			// sequence number verification is bypassed), so this approximates numUnsummarizedOps at
+			// the loader level without requiring access to runtime summary metadata.
+			numUnsummarizedOps: this._deltaManager.lastKnownSeqNumber - attributes.sequenceNumber,
 		};
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2187,6 +2187,14 @@ export class ContainerRuntime
 			telemetryDocumentId: this.telemetryDocumentId,
 			groupedBatchingEnabled: this.groupedBatchingEnabled,
 			initialSequenceNumber: this.deltaManager.initialSequenceNumber,
+			// Number of ops since the last summary that this client is aware of (including ops still
+			// queued for processing). Computed as the gap between the latest known op sequence number
+			// and the sequence number of the message at which the last summary was taken (per snapshot
+			// metadata). Falls back to lastKnownSeqNumber when no prior summary message is recorded
+			// (e.g. new container or older snapshot without metadata).
+			numUnsummarizedOps:
+				this.deltaManager.lastKnownSeqNumber -
+				(this.messageAtLastSummary?.sequenceNumber ?? 0),
 			minVersionForCollab: this.minVersionForCollab,
 			// logging hardware telemetry
 			deviceSpec: { ...getDeviceSpec() },


### PR DESCRIPTION
## Description

Adds a new `numUnsummarizedOps` field to telemetry events emitted during container load, exposing the number of ops since the last summary to non-summarizer clients. Previously this was only tracked on the summarizer client via summarizer heuristics (`numUnsummarizedRuntimeOps` / `numUnsummarizedNonRuntimeOps`), so it was invisible for the vast majority of clients.

The field is added in two places:

- **`ContainerLoadStats`** (container-runtime): authoritative value computed as
  `deltaManager.lastKnownSeqNumber - messageAtLastSummary.sequenceNumber`, using the runtime's snapshot metadata. Falls back to `lastKnownSeqNumber` when no prior summary message is recorded (new container or older snapshot without metadata).
- **`Load`** (container-loader): loader-level proxy computed as
  `deltaManager.lastKnownSeqNumber - attributes.sequenceNumber`. The runtime asserts that snapshot's `sequenceNumber` equals `messageAtLastSummary.sequenceNumber` for normal "latest" load paths, so the two values match in the common case. They may differ for `pendingLocalState` loads or when sequence-number verification is bypassed.

"Known" sequence number is used rather than "processed" so the value reflects the total catch-up gap (including ops still queued for processing), not just what's been processed at the moment the telemetry event is emitted in the load flow.

[AB#61854](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/61854)