### PR TITLE
build: route server-* base-image pulls through fluidpublicmirror ACR

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -3,12 +3,11 @@
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
 # The node base image is pulled from public Docker Hub by default so local builds and external
-# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
-# additionalBuildArguments in tools/pipelines/server-gitrest.yml) to point at our internal mirror,
-# because 1ES network isolation policies (CfsClean/CfsClean2) block egress to registry-1.docker.io
-# from our build pool. The mirror is byte-for-byte identical to docker.io/library, so the same
-# manifest digest pin resolves correctly against either registry. See tools/pipelines/README.md for
-# how to maintain the mirror (upgrades, additions).
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY to
+# point at our mirror ACR, because 1ES network isolation policies (CfsClean/CfsClean2) block egress
+# to registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
+# docker.io/library, so the same manifest digest pin resolves correctly against either registry.
+# See tools/pipelines/README.md for how to maintain the mirror (upgrades, additions).
 ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 

--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -4,12 +4,11 @@
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
 # The alpine base image is pulled from public Docker Hub by default so local builds and external
-# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
-# additionalBuildArguments in tools/pipelines/server-gitssh.yml) to point at our internal mirror,
-# because 1ES network isolation policies (CfsClean/CfsClean2) block egress to registry-1.docker.io
-# from our build pool. The mirror is byte-for-byte identical to docker.io/library, so the same
-# manifest digest pin resolves correctly against either registry. See tools/pipelines/README.md for
-# how to maintain the mirror (upgrades, additions).
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY to
+# point at our mirror ACR, because 1ES network isolation policies (CfsClean/CfsClean2) block egress
+# to registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
+# docker.io/library, so the same manifest digest pin resolves correctly against either registry.
+# See tools/pipelines/README.md for how to maintain the mirror (upgrades, additions).
 ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/alpine:3.16@sha256:452e7292acee0ee16c332324d7de05fa2c99f9994ecc9f0779c602916a672ae4
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -4,12 +4,11 @@
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
 # The node base image is pulled from public Docker Hub by default so local builds and external
-# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
-# additionalBuildArguments in tools/pipelines/server-historian.yml) to point at our internal mirror,
-# because 1ES network isolation policies (CfsClean/CfsClean2) block egress to registry-1.docker.io
-# from our build pool. The mirror is byte-for-byte identical to docker.io/library, so the same
-# manifest digest pin resolves correctly against either registry. See tools/pipelines/README.md for
-# how to maintain the mirror (upgrades, additions).
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY to
+# point at our mirror ACR, because 1ES network isolation policies (CfsClean/CfsClean2) block egress
+# to registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
+# docker.io/library, so the same manifest digest pin resolves correctly against either registry.
+# See tools/pipelines/README.md for how to maintain the mirror (upgrades, additions).
 ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383 AS runnerbase
 

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -4,10 +4,9 @@
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
 # The node base image is pulled from public Docker Hub by default so local builds and external
-# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY (via
-# additionalBuildArguments in tools/pipelines/server-routerlicious.yml) to point at our internal
-# mirror, because 1ES network isolation policies (CfsClean/CfsClean2) block egress to
-# registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
+# contributors get the canonical upstream image. Our CI pipeline overrides BASE_IMAGE_REGISTRY to
+# point at our mirror ACR, because 1ES network isolation policies (CfsClean/CfsClean2) block egress
+# to registry-1.docker.io from our build pool. The mirror is byte-for-byte identical to
 # docker.io/library, so the same manifest digest pin resolves correctly against either registry.
 # See tools/pipelines/README.md for how to maintain the mirror (upgrades, additions).
 ARG BASE_IMAGE_REGISTRY=docker.io

--- a/tools/pipelines/README.md
+++ b/tools/pipelines/README.md
@@ -6,29 +6,26 @@ releasing the Fluid Framework.
 ## Mirroring base container images for the server pipelines
 
 The `server-*` pipelines run on a 1ES build pool whose network isolation blocks egress to Docker
-Hub, so each server Dockerfile makes its base-image registry overridable and the matching pipeline
-points it at a mirrored copy on the internal container registry. Local builds default to Docker
-Hub and need no changes.
+Hub, so each server Dockerfile makes its base-image registry overridable via
+`ARG BASE_IMAGE_REGISTRY` and CI overrides it to a mirrored copy on a public-accessible ACR
+(`fluidpublicmirror-ccbba5fhdscnchft.azurecr.io`). The same mirror is used by both the `internal`
+and `public` ADO projects. Local builds default to Docker Hub and need no changes.
 
 ```dockerfile
 ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/node:22.22.2-bookworm-slim@sha256:f3a68cf4...
 ```
 
-```yaml
-extends:
-  template: /tools/pipelines/templates/build-docker-service.yml@self
-  parameters:
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      additionalBuildArguments: >-
-        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
-```
+The pipeline doesn't need to set anything explicitly — `build-docker-service.yml` injects the
+build-arg automatically via its `baseImageRegistry` parameter, which defaults to the mirror's
+FQDN. Callers can override it if they need a different mirror (e.g. for testing).
 
-`$(containerRegistryUrl)` comes from the `container-registry-info` variable group, loaded at the
-pipeline root. The build-arg override is gated on the `internal` project because the public project
-has no access to the internal mirror; it falls back to the Dockerfile default of `docker.io`. The
-mirror namespace `mirror/docker/library/<image>` is byte-identical to Docker Hub's path, so the same
-Dockerfile reference works against either registry.
+The mirror namespace `mirror/docker/library/<image>` is byte-identical to Docker Hub's path, so the
+same Dockerfile reference works against either registry. Anonymous pull is disabled on the mirror,
+so credentials for the `Fluid Public Mirror Container Registry` ADO service connection are flowed
+into the docker build step via `templateContext.authenticatedContainerRegistries` in
+[`templates/build-docker-service.yml`](./templates/build-docker-service.yml). Each ADO project has
+its own service connection (same name) backed by its own AcrPull-only service principal.
 
 ### Upgrading a pinned base image
 
@@ -38,12 +35,11 @@ Dockerfile reference works against either registry.
      --format '{{json .Manifest.Digest}}'
    ```
 
-2. Import it into the mirror. The registry name is the value of `containerRegistryUrl` in the
-   variable group (drop the `.azurecr.io` suffix); the command requires permission to perform
-   `Microsoft.ContainerRegistry/registries/importImage/action` on the registry (held by the
-   `Contributor` role, but **not** by `AcrPush`):
+2. Import it into the mirror. The command requires permission to perform
+   `Microsoft.ContainerRegistry/registries/importImage/action` on `fluidpublicmirror` (held by the
+   `Contributor` role, but **not** by `AcrPull`):
    ```bash
-   az acr import --name "$ACR_NAME" \
+   az acr import --name fluidpublicmirror \
      --source "docker.io/library/node@<new digest>" \
      --image  "mirror/docker/library/node:<new tag>"
    ```
@@ -64,6 +60,5 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/<image>:<tag>@<digest>
 ```
 
-In the pipeline YAML, append `--build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker`
-to `additionalBuildArguments` (gated on `System.TeamProject == 'internal'`, as in the example above),
-using YAML's `>-` block scalar to keep multiple args readable.
+No pipeline YAML changes are needed — `build-docker-service.yml` will pass `BASE_IMAGE_REGISTRY`
+through to the build automatically.

--- a/tools/pipelines/README.md
+++ b/tools/pipelines/README.md
@@ -8,8 +8,10 @@ releasing the Fluid Framework.
 The `server-*` pipelines run on a 1ES build pool whose network isolation blocks egress to Docker
 Hub, so each server Dockerfile makes its base-image registry overridable via
 `ARG BASE_IMAGE_REGISTRY` and CI overrides it to a mirrored copy on a public-accessible ACR
-(`fluidpublicmirror-ccbba5fhdscnchft.azurecr.io`). The same mirror is used by both the `internal`
-and `public` ADO projects. Local builds default to Docker Hub and need no changes.
+(`fluidpublicmirror-ccbba5fhdscnchft.azurecr.io`; the suffix is ACR's Domain Name Label (DNL)
+hash, added to the login-server FQDN to prevent subdomain-takeover attacks — `az acr` CLI
+commands still take the bare registry name `fluidpublicmirror`). The same mirror is used by both
+the `internal` and `public` ADO projects. Local builds default to Docker Hub and need no changes.
 
 ```dockerfile
 ARG BASE_IMAGE_REGISTRY=docker.io

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -102,17 +102,7 @@ extends:
     dockerBuildBumpsVersion: true
     packageManagerInstallCommand: 'pnpm config set recursive-install false ; pnpm i ; pnpm config set recursive-install true'
     # The --build-context is needed because the Dockerfile copies files from the repo root.
-    # On the internal project, also override the default docker.io registry in the Dockerfile to pull the base
-    # image from our internal mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress
-    # to registry-1.docker.io from our build pool. containerRegistryUrl comes from the container-registry-info
-    # variable group. See tools/pipelines/README.md. The public project falls back to the
-    # Dockerfile default of docker.io because it has no access to the internal mirror.
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      additionalBuildArguments: >-
-        --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
-        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
-    ${{ else }}:
-      additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+    additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
     packageManager: pnpm
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/gitrest
     containerName: fluidframework/routerlicious/gitrest

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -85,14 +85,3 @@ extends:
     setVersion: false
     enableDockerImagePull: false
     tagName: gitssh
-    # Override the default docker.io registry in the Dockerfile to pull the base image from a
-    # mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress to
-    # registry-1.docker.io from our build pool. On the internal project, use our internal ACR
-    # mirror (containerRegistryUrl comes from the container-registry-info variable group). On the
-    # public project, fall back to MCR's Docker Hub mirror — it's frozen at alpine 3.16 which
-    # happens to match our pin, and it's the only mirror reachable from public build pools.
-    # See tools/pipelines/README.md.
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
-    ${{ else }}:
-      additionalBuildArguments: --build-arg BASE_IMAGE_REGISTRY=mcr.microsoft.com/mirror/docker

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -105,17 +105,7 @@ extends:
     # Docker to do the actual build in CI. We need the root dependencies so setting package versions works.
     packageManagerInstallCommand: 'pnpm install --workspace-root'
     # The --build-context is needed because the Dockerfile copies files from the repo root.
-    # On the internal project, also override the default docker.io registry in the Dockerfile to pull the base
-    # image from our internal mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress
-    # to registry-1.docker.io from our build pool. containerRegistryUrl comes from the container-registry-info
-    # variable group. See tools/pipelines/README.md. The public project falls back to the
-    # Dockerfile default of docker.io because it has no access to the internal mirror.
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      additionalBuildArguments: >-
-        --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
-        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
-    ${{ else }}:
-      additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+    additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
     packageManager: pnpm
     test: test
     tagName: historian

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -141,15 +141,5 @@ extends:
     - check:versions
     - generate:packageList
     # The --build-context is needed because the Dockerfile copies files from the repo root.
-    # On the internal project, also override the default docker.io registry in the Dockerfile to pull the base
-    # image from our internal mirror, since 1ES network isolation policies (CfsClean/CfsClean2) block egress
-    # to registry-1.docker.io from our build pool. containerRegistryUrl comes from the container-registry-info
-    # variable group. See tools/pipelines/README.md. The public project falls back to the
-    # Dockerfile default of docker.io because it has no access to the internal mirror.
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      additionalBuildArguments: >-
-        --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
-        --build-arg BASE_IMAGE_REGISTRY=$(containerRegistryUrl)/mirror/docker
-    ${{ else }}:
-      additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
+    additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
     enableDockerImagePull: false

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -90,6 +90,13 @@ parameters:
     type: string
     default: ""
 
+  # Registry (and namespace prefix) for the base image referenced by ${BASE_IMAGE_REGISTRY} in each
+  # server-* Dockerfile. The default points at our public-accessible mirror ACR, reachable from both
+  # internal and public 1ES build pools (egress to docker.io is blocked by network isolation policies).
+  - name: baseImageRegistry
+    type: string
+    default: 'fluidpublicmirror-ccbba5fhdscnchft.azurecr.io/mirror/docker'
+
   # If the build is running for a test branch
   - name: testBuild
     type: boolean
@@ -222,6 +229,7 @@ extends:
 
               Other parameters:
                 additionalBuildArguments=${{ parameters.additionalBuildArguments }}
+                baseImageRegistry=${{ parameters.baseImageRegistry }}
                 buildNumberInPatch=${{ parameters.buildNumberInPatch }}
                 buildToolsVersionToInstall=${{ parameters.buildToolsVersionToInstall }}
                 containerBaseDir=${{ parameters.containerBaseDir }}
@@ -344,16 +352,18 @@ extends:
               script: |
                 set -eu -o pipefail
                 echo "Template additionalBuildArguments: ${{ parameters.additionalBuildArguments }}"
+                echo "BASE_IMAGE_REGISTRY=${{ parameters.baseImageRegistry }}"
                 echo "SETVERSION_VERSION=$(SetVersion.version)"
                 echo "SETVERSION_CODEVERSION=$(SetVersion.codeversion)"
                 echo "INTERDEPENDENCY_RANGE=${{ parameters.interdependencyRange }}"
                 echo "RELEASE_GROUP=${{ parameters.tagName }}"
-                echo "##vso[task.setvariable variable=output;isOutput=true]${{ parameters.additionalBuildArguments }} --build-arg SETVERSION_VERSION=$(SetVersion.version) --build-arg SETVERSION_CODEVERSION=$(SetVersion.codeversion) --build-arg INTERDEPENDENCY_RANGE=${{ parameters.interdependencyRange }} --build-arg RELEASE_GROUP=${{ parameters.tagName }}"
+                echo "##vso[task.setvariable variable=output;isOutput=true]${{ parameters.additionalBuildArguments }} --build-arg BASE_IMAGE_REGISTRY=${{ parameters.baseImageRegistry }} --build-arg SETVERSION_VERSION=$(SetVersion.version) --build-arg SETVERSION_CODEVERSION=$(SetVersion.codeversion) --build-arg INTERDEPENDENCY_RANGE=${{ parameters.interdependencyRange }} --build-arg RELEASE_GROUP=${{ parameters.tagName }}"
             ${{ else }}:
               script: |
                 set -eu -o pipefail
                 echo "Template additionalBuildArguments: ${{ parameters.additionalBuildArguments }}"
-                echo "##vso[task.setvariable variable=output;isOutput=true]${{ parameters.additionalBuildArguments }}"
+                echo "BASE_IMAGE_REGISTRY=${{ parameters.baseImageRegistry }}"
+                echo "##vso[task.setvariable variable=output;isOutput=true]${{ parameters.additionalBuildArguments }} --build-arg BASE_IMAGE_REGISTRY=${{ parameters.baseImageRegistry }}"
 
         # The 1ES.BuildContainerImage task apparently expects to see the CredScan suppressions file not in the root of
         # the repo, but in the folder used as its 'context' input. So we need to copy it there before building any images.
@@ -568,12 +578,16 @@ extends:
                 pnpm store prune
 
         templateContext:
-          ${{ if eq(parameters.shouldPushDockerImage, true) }}:
+          # 'Fluid Public Mirror Container Registry' is required on every run for base-image pulls
+          # (anonymous pull disabled). The push connection $(containerRegistryConnection) is only
+          # added when pushing in the internal project (it's empty in the public project).
+          ${{ if and(eq(parameters.shouldPushDockerImage, true), eq(variables['System.TeamProject'], 'internal')) }}:
             authenticatedContainerRegistries:
-            # $(containerRegistryConnection) comes from the container-registry-info variable group and needs to be
-            # specified as a runtime variable (variables from variable groups apparently are never available "statically"
-            # at parse/compile time, so can't be used with template-expression syntax ( '${{ }}' )).
             - serviceConnection: $(containerRegistryConnection)
+            - serviceConnection: 'Fluid Public Mirror Container Registry'
+          ${{ else }}:
+            authenticatedContainerRegistries:
+            - serviceConnection: 'Fluid Public Mirror Container Registry'
           outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
           - ${{ if eq(parameters.pack, true) }}:


### PR DESCRIPTION
## Description

The four `server-*` Docker pipelines previously pulled their Dockerfile base images differently per project: internal pulled from an internal ACR mirror of `docker.io/library/*`, and public pulled directly from `docker.io` (or MCR for gitssh). The public side was failing under 1ES network isolation because egress to `registry-1.docker.io` is blocked, and MCR doesn't track modern Alpine versions (blocking the gitssh upgrade).

Unify both projects onto a new public-accessible ACR (`fluidpublicmirror-ccbba5fhdscnchft.azurecr.io`) that hosts the same `mirror/docker/library/<image>` namespace and is reachable from both internal and public build pools. Credentials flow into the docker build step via the new `Fluid Public Mirror Container Registry` service connection (one per ADO project, both with `AcrPull`-only access on the mirror ACR).

The mirror URL itself is injected via a new `baseImageRegistry` parameter on the shared `build-docker-service.yml` template (defaulting to the mirror ACR's `mirror/docker` namespace) rather than being passed by each pipeline's `additionalBuildArguments`. Local Dockerfile builds outside of CI continue to use the in-Dockerfile `ARG` default (`docker.io`) and are unaffected.

**Hardened a pre-existing latent bug:** the push-creds branch of `authenticatedContainerRegistries` previously only gated on `shouldPushDockerImage`, which could pass an empty runtime variable into the parser if `publishOverride: force` ever ran in public. Now also gated on `System.TeamProject == 'internal'` (where the push-side variable group is set).

Follow-up to #27346, which shipped a stopgap per-project mirror split to unblock the immediate breakage; this PR delivers the longer-term unified-mirror fix.

[AB#73353](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73353)

