### PR TITLE
chore(server-gitssh): bump base image to alpine 3.23.4

### DIFF
--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -10,7 +10,7 @@
 # docker.io/library, so the same manifest digest pin resolves correctly against either registry.
 # See tools/pipelines/README.md for how to maintain the mirror (upgrades, additions).
 ARG BASE_IMAGE_REGISTRY=docker.io
-FROM ${BASE_IMAGE_REGISTRY}/library/alpine:3.16@sha256:452e7292acee0ee16c332324d7de05fa2c99f9994ecc9f0779c602916a672ae4
+FROM ${BASE_IMAGE_REGISTRY}/library/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # Install Git and OpenSSH so we can run a git server
 RUN apk add --no-cache git


### PR DESCRIPTION
## Description

Alpine 3.16 is end-of-life (since May 2024). Bumps the `server-gitssh` base image to alpine 3.23.4.

3.23.4 is already pre-mirrored in the mirror ACR and pre-installed on the 1ES agent image, so no pipeline or mirror changes are needed. The image is digest-pinned and the upstream/mirror digests have been verified to match.

Smoke-tested the new image locally: `apk add git openssh`, user/group setup, `ssh-keygen -A`, and `sshd` startup all succeed; sshd advertises `SSH-2.0-OpenSSH_10.2`.

[AB#73680](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73680)
