### PR TITLE
Remove deprecated CompatibilityMode APIs

### DIFF
--- a/.changeset/happy-states-work.md
+++ b/.changeset/happy-states-work.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/fluid-static": minor
+"@fluidframework/azure-client": minor
+"@fluidframework/tinylicious-client": minor
+"__section": legacy
+---
+
+Remove deprecated CompatibilityMode APIs
+
+Deprecated `CompatibilityMode` exports and overloads have been removed from `@fluidframework/fluid-static`, `@fluidframework/azure-client`, and `@fluidframework/tinylicious-client`.
+
+Use `MinimumVersionForCollab` SemVer strings instead:
+
+- Pass `minVersionForCollaboration` to `createTreeContainerRuntimeFactory`.
+- Pass a `MinimumVersionForCollab` argument to `AzureClient.createContainer`, `AzureClient.getContainer`, `AzureClient.viewContainerVersion`, `TinyliciousClient.createContainer`, and `TinyliciousClient.getContainer`.
+- Replace legacy mode values `"1"` and `"2"` with `"1.0.0"` and `"2.0.0"`.

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
-
 // @public
 export type ContainerAttachProps<T = unknown> = T;
 

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
-
 // @public
 export type ContainerAttachProps<T = unknown> = T;
 

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
-
 // @public
 export type ContainerAttachProps<T = unknown> = T;
 
@@ -22,15 +19,6 @@ export function createTreeContainerRuntimeFactory(props: {
     readonly minVersionForCollaboration: MinimumVersionForCollab;
     readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
     readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-}): IRuntimeFactory;
-
-// @beta @deprecated @legacy
-export function createTreeContainerRuntimeFactory(props: {
-    readonly schema: TreeContainerSchema;
-    readonly compatibilityMode: CompatibilityMode;
-    readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
-    readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-    readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory;
 
 // @public

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
-
 // @public
 export type ContainerAttachProps<T = unknown> = T;
 

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
-
 // @public
 export type ContainerAttachProps<T = unknown> = T;
 

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -171,7 +171,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "public"
 	}
 }

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -22,7 +22,6 @@ export { createDOProviderContainerRuntimeFactory } from "./rootDataObject.js";
 export { createServiceAudience } from "./serviceAudience.js";
 export { createTreeContainerRuntimeFactory } from "./treeRootDataObject.js";
 export type {
-	CompatibilityMode,
 	ContainerSchema,
 	ContainerAttachProps,
 	IConnection,
@@ -33,7 +32,4 @@ export type {
 	Myself,
 	TreeContainerSchema,
 } from "./types.js";
-export {
-	isTreeContainerSchema,
-	resolveCompatibilityModeToMinVersionForCollab,
-} from "./utils.js";
+export { isTreeContainerSchema } from "./utils.js";

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -132,6 +132,7 @@ declare type current_as_old_for_Interface_IServiceAudienceEvents = requireAssign
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<old.CompatibilityMode>, TypeOnly<current.CompatibilityMode>>
 
 /*
@@ -141,6 +142,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*

--- a/packages/framework/fluid-static/src/treeRootDataObject.ts
+++ b/packages/framework/fluid-static/src/treeRootDataObject.ts
@@ -33,8 +33,6 @@ import type { SharedObjectKind } from "@fluidframework/shared-object-base/intern
 
 import { defaultRuntimeOptionsForMinVersion } from "./compatibilityConfiguration.js";
 import type {
-	// eslint-disable-next-line import-x/no-deprecated
-	CompatibilityMode,
 	IRootDataObject,
 	IStaticEntryPoint,
 	LoadableObjectKind,
@@ -48,7 +46,6 @@ import {
 	isSharedObjectKind,
 	makeFluidObject,
 	parseDataObjectsFromSharedObjects,
-	resolveCompatibilityModeToMinVersionForCollab,
 } from "./utils.js";
 
 /**
@@ -225,80 +222,15 @@ export function createTreeContainerRuntimeFactory(props: {
 	readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
 }): IRuntimeFactory;
 
-/**
- * Creates an {@link @fluidframework/aqueduct#IRuntimeFactory} which constructs containers
- * with an entry point containing single tree-based root data object.
- *
- * @remarks
- * The entry point is opaque to caller.
- * The root data object's registry and shared objects are configured based on the provided
- * SharedTree and optional data store registry.
- *
- * @deprecated Pass `minVersionForCollaboration` directly instead of using `compatibilityMode`.
- *
- * @legacy @beta
- */
-export function createTreeContainerRuntimeFactory(props: {
-	/**
-	 * The schema for the container.
-	 */
-	readonly schema: TreeContainerSchema;
-
-	/**
-	 * Legacy compatibility mode for the container.
-	 */
-	// eslint-disable-next-line import-x/no-deprecated
-	readonly compatibilityMode: CompatibilityMode;
-	/**
-	 * Optional registry of data stores to pass to the DataObject factory.
-	 * If not provided, one will be created based on the schema.
-	 */
-	readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
-	/**
-	 * Optional overrides for the container runtime options.
-	 * If not provided, only the default options for the given compatibilityMode will be used.
-	 */
-	readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-	/**
-	 * Optional override for minimum version for collaboration.
-	 * @remarks
-	 * If not provided, the default for the given compatibilityMode will be used.
-	 * Rather than defining this, omit `compatibilityMode` and pass `minVersionForCollaboration` directly.
-	 */
-	readonly minVersionForCollabOverride?: MinimumVersionForCollab;
-}): IRuntimeFactory;
-
 // Implementation
 export function createTreeContainerRuntimeFactory(props: {
 	readonly schema: TreeContainerSchema;
-	// eslint-disable-next-line import-x/no-deprecated
-	readonly compatibilityMode?: CompatibilityMode;
-	readonly minVersionForCollaboration?: MinimumVersionForCollab;
+	readonly minVersionForCollaboration: MinimumVersionForCollab;
 	readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
 	readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-	readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory {
-	const {
-		compatibilityMode,
-		minVersionForCollaboration,
-		minVersionForCollabOverride,
-		rootDataStoreRegistry,
-		runtimeOptionOverrides,
-		schema,
-	} = props;
-
-	let minVersionForCollab: MinimumVersionForCollab;
-	if (minVersionForCollaboration !== undefined) {
-		minVersionForCollab = minVersionForCollaboration;
-	} else if (compatibilityMode === undefined) {
-		throw new Error(
-			"Either minVersionForCollaboration or compatibilityMode (deprecated) must be provided.",
-		);
-	} else {
-		minVersionForCollab =
-			minVersionForCollabOverride ??
-			resolveCompatibilityModeToMinVersionForCollab(compatibilityMode);
-	}
+	const { minVersionForCollaboration, rootDataStoreRegistry, runtimeOptionOverrides, schema } =
+		props;
 
 	const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(schema);
 	const registry = rootDataStoreRegistry ?? new FluidDataStoreRegistry(registryEntries);
@@ -307,7 +239,7 @@ export function createTreeContainerRuntimeFactory(props: {
 		new TreeRootDataObjectFactory(sharedObjects, registry),
 		{
 			runtimeOptions: runtimeOptionOverrides,
-			minVersionForCollab,
+			minVersionForCollab: minVersionForCollaboration,
 		},
 	);
 }

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -18,21 +18,6 @@ import type {
 import type { ITree } from "@fluidframework/tree";
 
 /**
- * Determines the set of runtime options that Fluid Framework will use when running.
- * In "1" mode we support full interop between 2.x clients and 1.x clients,
- * while in "2" mode we only support interop between 2.x clients.
- *
- * @deprecated Specify the minimum Fluid Framework version directly via the
- * `minVersionForCollab` parameter, which accepts a
- * {@link @fluidframework/runtime-definitions#MinimumVersionForCollab} SemVer string. The
- * legacy mode "1" is equivalent to `minVersionForCollab: "1.0.0"`; mode "2" is
- * equivalent to `"2.0.0"`.
- *
- * @public
- */
-export type CompatibilityMode = "1" | "2";
-
-/**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.
  */
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;

--- a/packages/framework/fluid-static/src/utils.ts
+++ b/packages/framework/fluid-static/src/utils.ts
@@ -12,20 +12,13 @@ import type {
 } from "@fluidframework/datastore-definitions/internal";
 import type {
 	IFluidDataStoreContext,
-	MinimumVersionForCollab,
 	NamedFluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions/internal";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { SharedTreeFactoryType } from "@fluidframework/tree/internal";
 
-import type {
-	// eslint-disable-next-line import-x/no-deprecated
-	CompatibilityMode,
-	ContainerSchema,
-	LoadableObjectKind,
-	TreeContainerSchema,
-} from "./types.js";
+import type { ContainerSchema, LoadableObjectKind, TreeContainerSchema } from "./types.js";
 
 /**
  * Runtime check to determine if an object is a {@link DataObjectKind}.
@@ -145,26 +138,6 @@ export function makeFluidObject<
 	K extends FluidObjectKeys<T> = FluidObjectKeys<T>,
 >(object: Omit<T, K>, providerKey: K): T {
 	return Object.defineProperty(object, providerKey, { value: object }) as T;
-}
-
-/**
- * Resolves the `compatibilityMode` input — either a `MinimumVersionForCollab`
- * SemVer string or a legacy `CompatibilityMode` value — into a precise
- * `MinimumVersionForCollab`.
- *
- * TODO: AB#73679: This can be removed when the deprecated CompatibilityMode is removed
- *
- * @internal
- */
-export function resolveCompatibilityModeToMinVersionForCollab(
-	// eslint-disable-next-line import-x/no-deprecated
-	compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
-): MinimumVersionForCollab {
-	return compatibilityMode === "1"
-		? "1.0.0"
-		: compatibilityMode === "2"
-			? "2.0.0"
-			: compatibilityMode;
 }
 
 /**

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -11,26 +11,12 @@ export class AzureClient {
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
-    // @deprecated
-    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-    }>;
-    // @deprecated
-    viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
 }
@@ -86,9 +72,6 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     tenantId: string;
     type: "remote";
 }
-
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
@@ -11,26 +11,12 @@ export class AzureClient {
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
-    // @deprecated
-    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-    }>;
-    // @deprecated
-    viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
 }
@@ -86,9 +72,6 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     tenantId: string;
     type: "remote";
 }
-
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -11,26 +11,12 @@ export class AzureClient {
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
-    // @deprecated
-    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-    }>;
-    // @deprecated
-    viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
 }
@@ -86,9 +72,6 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     tenantId: string;
     type: "remote";
 }
-
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -11,26 +11,12 @@ export class AzureClient {
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
-    // @deprecated
-    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: AzureContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-    }>;
-    // @deprecated
-    viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
 }
@@ -86,9 +72,6 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     tenantId: string;
     type: "remote";
 }
-
-// @public @deprecated
-export type CompatibilityMode = "1" | "2";
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -130,7 +130,12 @@
 		"uuid": "^11.1.0"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -26,17 +26,11 @@ import type {
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 import { applyStorageCompression } from "@fluidframework/driver-utils/internal";
-import type {
-	ContainerSchema,
-	IFluidContainer,
-	// eslint-disable-next-line import-x/no-deprecated
-	CompatibilityMode,
-} from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import {
 	createDOProviderContainerRuntimeFactory,
 	createFluidContainer,
 	createServiceAudience,
-	resolveCompatibilityModeToMinVersionForCollab,
 } from "@fluidframework/fluid-static/internal";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions";
@@ -152,33 +146,14 @@ export class AzureClient {
 		container: IFluidContainer<TContainerSchema>;
 		services: AzureContainerServices;
 	}>;
-	/**
-	 * Creates a new detached container instance in the Azure Fluid Relay.
-	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
-	 * This does not normally need to be specified explicitly.
-	 * @param containerSchema - Container schema for the new container.
-	 * @param compatibilityMode - Legacy {@link @fluidframework/fluid-static#CompatibilityMode} value.
-	 * @returns New detached container instance along with associated services.
-	 * @deprecated Pass a `MinimumVersionForCollab` SemVer string (e.g. `"2.0.0"`) instead. The legacy
-	 * values `"1"` and `"2"` correspond to `"1.0.0"` and `"2.0.0"` respectively.
-	 */
 	public async createContainer<const TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: CompatibilityMode,
-	): Promise<{
-		container: IFluidContainer<TContainerSchema>;
-		services: AzureContainerServices;
-	}>;
-	public async createContainer<const TContainerSchema extends ContainerSchema>(
-		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
+		minVersionForCollab: MinimumVersionForCollab,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: AzureContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, minVersionForCollab);
 
 		const container = await createDetachedContainer({
 			...loaderProps,
@@ -214,36 +189,15 @@ export class AzureClient {
 		container: IFluidContainer<TContainerSchema>;
 		services: AzureContainerServices;
 	}>;
-	/**
-	 * Accesses the existing container given its unique ID in the Azure Fluid Relay.
-	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
-	 * (normally not explicitly specified.)
-	 * @param id - Unique ID of the container in Azure Fluid Relay.
-	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @param compatibilityMode - Legacy {@link @fluidframework/fluid-static#CompatibilityMode} value.
-	 * @returns Existing container instance along with associated services.
-	 * @deprecated Pass a `MinimumVersionForCollab` SemVer string (e.g. `"2.0.0"`) instead. The legacy
-	 * values `"1"` and `"2"` correspond to `"1.0.0"` and `"2.0.0"` respectively.
-	 */
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: CompatibilityMode,
-	): Promise<{
-		container: IFluidContainer<TContainerSchema>;
-		services: AzureContainerServices;
-	}>;
-	public async getContainer<TContainerSchema extends ContainerSchema>(
-		id: string,
-		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
+		minVersionForCollab: MinimumVersionForCollab,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: AzureContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, minVersionForCollab);
 		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
@@ -282,37 +236,15 @@ export class AzureClient {
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 	}>;
-	/**
-	 * Load a specific version of a container for viewing only.
-	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
-	 * (normally not explicitly specified.)
-	 * @param id - Unique ID of the source container in Azure Fluid Relay.
-	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @param version - Unique version of the source container in Azure Fluid Relay.
-	 * @param compatibilityMode - Legacy {@link @fluidframework/fluid-static#CompatibilityMode} value.
-	 * @returns Loaded container instance at the specified version.
-	 * @deprecated Pass a `MinimumVersionForCollab` SemVer string (e.g. `"2.0.0"`) instead. The legacy
-	 * values `"1"` and `"2"` correspond to `"1.0.0"` and `"2.0.0"` respectively.
-	 */
 	public async viewContainerVersion<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
 		version: AzureContainerVersion,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: CompatibilityMode,
-	): Promise<{
-		container: IFluidContainer<TContainerSchema>;
-	}>;
-	public async viewContainerVersion<TContainerSchema extends ContainerSchema>(
-		id: string,
-		containerSchema: TContainerSchema,
-		version: AzureContainerVersion,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
+		minVersionForCollab: MinimumVersionForCollab,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, minVersionForCollab);
 		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
@@ -377,19 +309,16 @@ export class AzureClient {
 
 	private getLoaderProps(
 		schema: ContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
+		minVersionForCollab: MinimumVersionForCollab,
 	): ILoaderProps {
-		const minVersionForCollaboration =
-			resolveCompatibilityModeToMinVersionForCollab(compatibilityMode);
 		const runtimeFactory = this.createContainerRuntimeFactory
 			? this.createContainerRuntimeFactory({
 					schema,
-					minVersionForCollaboration,
+					minVersionForCollaboration: minVersionForCollab,
 				})
 			: createDOProviderContainerRuntimeFactory({
 					schema,
-					minVersionForCollaboration,
+					minVersionForCollaboration: minVersionForCollab,
 				});
 
 		const load = async (): Promise<IFluidModuleWithDetails> => {

--- a/packages/service-clients/azure-client/src/index.ts
+++ b/packages/service-clients/azure-client/src/index.ts
@@ -33,6 +33,3 @@ export type {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-
-// Re-export so developers have access to parameter types for createContainer/getContainer without pulling in fluid-static
-export type { CompatibilityMode } from "@fluidframework/fluid-static";

--- a/packages/service-clients/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
+++ b/packages/service-clients/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
@@ -303,6 +303,7 @@ declare type current_as_old_for_TypeAlias_AzureConnectionConfigType = requireAss
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<old.CompatibilityMode>, TypeOnly<current.CompatibilityMode>>
 
 /*
@@ -312,6 +313,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-export { CompatibilityMode }
-
 // @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
@@ -16,17 +14,7 @@ export class TinyliciousClient {
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;
-    // @deprecated
-    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: TinyliciousContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: TinyliciousContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-export { CompatibilityMode }
-
 // @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
@@ -16,17 +14,7 @@ export class TinyliciousClient {
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;
-    // @deprecated
-    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: TinyliciousContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: TinyliciousContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-export { CompatibilityMode }
-
 // @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
@@ -16,17 +14,7 @@ export class TinyliciousClient {
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;
-    // @deprecated
-    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: TinyliciousContainerServices;
-    }>;
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
-        container: IFluidContainer<TContainerSchema>;
-        services: TinyliciousContainerServices;
-    }>;
-    // @deprecated
-    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -124,7 +124,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "beta"
 	}
 }

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -19,17 +19,11 @@ import type {
 	IDocumentServiceFactory,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
-import type {
-	ContainerSchema,
-	IFluidContainer,
-	// eslint-disable-next-line import-x/no-deprecated
-	CompatibilityMode,
-} from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import {
 	createDOProviderContainerRuntimeFactory,
 	createFluidContainer,
 	createServiceAudience,
-	resolveCompatibilityModeToMinVersionForCollab,
 } from "@fluidframework/fluid-static/internal";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver/internal";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions";
@@ -86,34 +80,14 @@ export class TinyliciousClient {
 		container: IFluidContainer<TContainerSchema>;
 		services: TinyliciousContainerServices;
 	}>;
-	/**
-	 * Creates a new detached container instance in Tinylicious server.
-	 * @param containerSchema - Container schema for the new container.
-	 * @param compatibilityMode - Legacy {@link @fluidframework/fluid-static#CompatibilityMode} value.
-	 * @returns New detached container instance along with associated services.
-	 * @deprecated Pass a `MinimumVersionForCollab` SemVer string (e.g. `"2.0.0"`) instead. The legacy
-	 * values `"1"` and `"2"` correspond to `"1.0.0"` and `"2.0.0"` respectively.
-	 */
 	public async createContainer<TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: CompatibilityMode,
-	): Promise<{
-		container: IFluidContainer<TContainerSchema>;
-		services: TinyliciousContainerServices;
-	}>;
-	public async createContainer<TContainerSchema extends ContainerSchema>(
-		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
+		minVersionForCollab: MinimumVersionForCollab,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: TinyliciousContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(
-			containerSchema,
-			resolveCompatibilityModeToMinVersionForCollab(compatibilityMode),
-		);
+		const loaderProps = this.getLoaderProps(containerSchema, minVersionForCollab);
 
 		// We're not actually using the code proposal (our code loader always loads the same module
 		// regardless of the proposal), but the Container will only give us a NullRuntime if there's
@@ -166,37 +140,15 @@ export class TinyliciousClient {
 		container: IFluidContainer<TContainerSchema>;
 		services: TinyliciousContainerServices;
 	}>;
-	/**
-	 * Accesses the existing container given its unique ID in the tinylicious server.
-	 * @param id - Unique ID of the container.
-	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @param compatibilityMode - Legacy {@link @fluidframework/fluid-static#CompatibilityMode} value.
-	 * @returns Existing container instance along with associated services.
-	 * @deprecated Pass a `MinimumVersionForCollab` SemVer string (e.g. `"2.0.0"`) instead. The legacy
-	 * values `"1"` and `"2"` correspond to `"1.0.0"` and `"2.0.0"` respectively.
-	 */
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: CompatibilityMode,
-	): Promise<{
-		container: IFluidContainer<TContainerSchema>;
-		services: TinyliciousContainerServices;
-	}>;
-	public async getContainer<TContainerSchema extends ContainerSchema>(
-		id: string,
-		containerSchema: TContainerSchema,
-		// eslint-disable-next-line import-x/no-deprecated
-		compatibilityMode: MinimumVersionForCollab | CompatibilityMode,
+		minVersionForCollab: MinimumVersionForCollab,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: TinyliciousContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(
-			containerSchema,
-			resolveCompatibilityModeToMinVersionForCollab(compatibilityMode),
-		);
+		const loaderProps = this.getLoaderProps(containerSchema, minVersionForCollab);
 		const container = await loadExistingContainer({ ...loaderProps, request: { url: id } });
 		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,

--- a/packages/service-clients/tinylicious-client/src/index.ts
+++ b/packages/service-clients/tinylicious-client/src/index.ts
@@ -23,6 +23,3 @@ export {
 	type TinyliciousUser,
 } from "./interfaces.js";
 export { TinyliciousClient } from "./TinyliciousClient.js";
-
-// Re-export so developers have access to parameter types for createContainer/getContainer without pulling in fluid-static
-export type { CompatibilityMode } from "@fluidframework/fluid-static";

--- a/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
+++ b/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
@@ -87,6 +87,7 @@ declare type current_as_old_for_Interface_TinyliciousUser = requireAssignableTo<
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<old.CompatibilityMode>, TypeOnly<current.CompatibilityMode>>
 
 /*
@@ -96,6 +97,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*


### PR DESCRIPTION
## Description

Removes the deprecated `CompatibilityMode` type and the deprecated `compatibilityMode`-based overloads from `@fluidframework/fluid-static`, `@fluidframework/azure-client`, and `@fluidframework/tinylicious-client`. Consumers should pass a `MinimumVersionForCollab` SemVer string directly instead.
