### PR TITLE
build(server): fix Docker builds under 1ES network isolation

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -61,16 +61,13 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
     && npm install -g "$PNPM_VERSION"
 
-# Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
-# can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
-# and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
 # pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
 # (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install --unsafe-perm
+    pnpm install
 
 COPY . .
 

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -52,13 +52,14 @@ ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
 #
-# NPM_REGISTRY redirects pnpm/npm to a custom registry. CI overrides it to an
-# anonymous-readable internal mirror because the build container has no egress
-# to registry.npmjs.org under 1ES network isolation. Local builds use the
+# CI has no egress to registry.npmjs.org under 1ES network isolation, so it
+# provides an authenticated .npmrc (pointing at our ADO npm mirror) as a
+# BuildKit secret. The mount is marked required=false so local `docker build`
+# invocations that don't pass --secret still work, falling back to npm's
 # default public registry.
-ARG NPM_REGISTRY=https://registry.npmjs.org/
-RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
-    && npm install -g "$PNPM_VERSION" --registry="$NPM_REGISTRY"
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
@@ -68,7 +69,8 @@ RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.pack
 # (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --unsafe-perm --registry="$NPM_REGISTRY"
+    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    pnpm install --unsafe-perm
 
 COPY . .
 

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -49,12 +49,6 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 
-# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
-# The NPM registry recently rotated some keys but non-latest corepack versions (like those distributed with Node18)
-# have hardcoded references to the old keys and thus fail to install packages that were signed with the new keys.
-# So install the latest corepack globally to work around the problem.
-RUN npm install -g corepack && corepack enable
-
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -51,14 +51,20 @@ ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
-RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+# The secret mount lets CI provide an authenticated .npmrc (pointing at our ADO npm
+# mirror) since the build container has no egress to registry.npmjs.org. The mount
+# is marked optional (required=false) so local `docker build` invocations that do
+# not pass --secret still work and fall back to the default npm registry.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
     && npm install -g "$PNPM_VERSION"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store\
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     pnpm install --unsafe-perm
 
 COPY . .

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -64,8 +64,11 @@ RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.pack
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
+# pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
+# (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
+# matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --unsafe-perm --registry="$NPM_REGISTRY" --store-dir=/pnpm/store
+    pnpm install --unsafe-perm --registry="$NPM_REGISTRY"
 
 COPY . .
 

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -49,6 +49,11 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 
+# Install the pnpm version pinned in package.json's "packageManager" field.
+# Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
+RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION"
+
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -51,21 +51,21 @@ ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
-# The secret mount lets CI provide an authenticated .npmrc (pointing at our ADO npm
-# mirror) since the build container has no egress to registry.npmjs.org. The mount
-# is marked optional (required=false) so local `docker build` invocations that do
-# not pass --secret still work and fall back to the default npm registry.
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
-    && npm install -g "$PNPM_VERSION"
+#
+# NPM_REGISTRY redirects pnpm/npm to a custom registry. CI overrides it to an
+# anonymous-readable internal mirror because the build container has no egress
+# to registry.npmjs.org under 1ES network isolation. Local builds use the
+# default public registry.
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION" --registry="$NPM_REGISTRY"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install --unsafe-perm
+    pnpm install --unsafe-perm --registry="$NPM_REGISTRY" --store-dir=/pnpm/store
 
 COPY . .
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -60,21 +60,21 @@ ENV PATH="$PNPM_HOME:$HISTORIAN_ROOT/node_modules/.bin:$PATH"
 
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
-# The secret mount lets CI provide an authenticated .npmrc (pointing at our ADO npm
-# mirror) since the build container has no egress to registry.npmjs.org. The mount
-# is marked optional (required=false) so local `docker build` invocations that do
-# not pass --secret still work and fall back to the default npm registry.
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
-    && npm install -g "$PNPM_VERSION"
+#
+# NPM_REGISTRY redirects pnpm/npm to a custom registry. CI overrides it to an
+# anonymous-readable internal mirror because the build container has no egress
+# to registry.npmjs.org under 1ES network isolation. Local builds use the
+# default public registry.
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION" --registry="$NPM_REGISTRY"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install --unsafe-perm
+    pnpm install --unsafe-perm --registry="$NPM_REGISTRY" --store-dir=/pnpm/store
 
 COPY . .
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -61,13 +61,14 @@ ENV PATH="$PNPM_HOME:$HISTORIAN_ROOT/node_modules/.bin:$PATH"
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
 #
-# NPM_REGISTRY redirects pnpm/npm to a custom registry. CI overrides it to an
-# anonymous-readable internal mirror because the build container has no egress
-# to registry.npmjs.org under 1ES network isolation. Local builds use the
+# CI has no egress to registry.npmjs.org under 1ES network isolation, so it
+# provides an authenticated .npmrc (pointing at our ADO npm mirror) as a
+# BuildKit secret. The mount is marked required=false so local `docker build`
+# invocations that don't pass --secret still work, falling back to npm's
 # default public registry.
-ARG NPM_REGISTRY=https://registry.npmjs.org/
-RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
-    && npm install -g "$PNPM_VERSION" --registry="$NPM_REGISTRY"
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
@@ -77,7 +78,8 @@ RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.pack
 # (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --unsafe-perm --registry="$NPM_REGISTRY"
+    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    pnpm install --unsafe-perm
 
 COPY . .
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -58,6 +58,11 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$HISTORIAN_ROOT/node_modules/.bin:$PATH"
 
+# Install the pnpm version pinned in package.json's "packageManager" field.
+# Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
+RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION"
+
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -60,14 +60,20 @@ ENV PATH="$PNPM_HOME:$HISTORIAN_ROOT/node_modules/.bin:$PATH"
 
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
-RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+# The secret mount lets CI provide an authenticated .npmrc (pointing at our ADO npm
+# mirror) since the build container has no egress to registry.npmjs.org. The mount
+# is marked optional (required=false) so local `docker build` invocations that do
+# not pass --secret still work and fall back to the default npm registry.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
     && npm install -g "$PNPM_VERSION"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store\
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     pnpm install --unsafe-perm
 
 COPY . .

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -70,16 +70,13 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
     && npm install -g "$PNPM_VERSION"
 
-# Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
-# can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
-# and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
 # pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
 # (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install --unsafe-perm
+    pnpm install
 
 COPY . .
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -58,12 +58,6 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$HISTORIAN_ROOT/node_modules/.bin:$PATH"
 
-# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
-# The NPM registry recently rotated some keys but non-latest corepack versions (like those distributed with Node18)
-# have hardcoded references to the old keys and thus fail to install packages that were signed with the new keys.
-# So install the latest corepack globally to work around the problem.
-RUN npm install -g corepack && corepack enable
-
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -73,8 +73,11 @@ RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.pack
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
+# pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
+# (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
+# matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --unsafe-perm --registry="$NPM_REGISTRY" --store-dir=/pnpm/store
+    pnpm install --unsafe-perm --registry="$NPM_REGISTRY"
 
 COPY . .
 

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -89,21 +89,21 @@ ENV PATH="$PNPM_HOME:$ROUTERLICIOUS_ROOT/node_modules/.bin:$PATH"
 
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
-# The secret mount lets CI provide an authenticated .npmrc (pointing at our ADO npm
-# mirror) since the build container has no egress to registry.npmjs.org. The mount
-# is marked optional (required=false) so local `docker build` invocations that do
-# not pass --secret still work and fall back to the default npm registry.
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
-    && npm install -g "$PNPM_VERSION"
+#
+# NPM_REGISTRY redirects pnpm/npm to a custom registry. CI overrides it to an
+# anonymous-readable internal mirror because the build container has no egress
+# to registry.npmjs.org under 1ES network isolation. Local builds use the
+# default public registry.
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION" --registry="$NPM_REGISTRY"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install --unsafe-perm
+    pnpm install --unsafe-perm --registry="$NPM_REGISTRY" --store-dir=/pnpm/store
 
 # And now copy over our actual code and build
 COPY . .

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -99,16 +99,13 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
     && npm install -g "$PNPM_VERSION"
 
-# Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
-# can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
-# and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
 # pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
 # (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install --unsafe-perm
+    pnpm install
 
 # And now copy over our actual code and build
 COPY . .

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -89,14 +89,20 @@ ENV PATH="$PNPM_HOME:$ROUTERLICIOUS_ROOT/node_modules/.bin:$PATH"
 
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
-RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+# The secret mount lets CI provide an authenticated .npmrc (pointing at our ADO npm
+# mirror) since the build container has no egress to registry.npmjs.org. The mount
+# is marked optional (required=false) so local `docker build` invocations that do
+# not pass --secret still work and fall back to the default npm registry.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
     && npm install -g "$PNPM_VERSION"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store\
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     pnpm install --unsafe-perm
 
 # And now copy over our actual code and build

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -90,13 +90,14 @@ ENV PATH="$PNPM_HOME:$ROUTERLICIOUS_ROOT/node_modules/.bin:$PATH"
 # Install the pnpm version pinned in package.json's "packageManager" field.
 # Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
 #
-# NPM_REGISTRY redirects pnpm/npm to a custom registry. CI overrides it to an
-# anonymous-readable internal mirror because the build container has no egress
-# to registry.npmjs.org under 1ES network isolation. Local builds use the
+# CI has no egress to registry.npmjs.org under 1ES network isolation, so it
+# provides an authenticated .npmrc (pointing at our ADO npm mirror) as a
+# BuildKit secret. The mount is marked required=false so local `docker build`
+# invocations that don't pass --secret still work, falling back to npm's
 # default public registry.
-ARG NPM_REGISTRY=https://registry.npmjs.org/
-RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
-    && npm install -g "$PNPM_VERSION" --registry="$NPM_REGISTRY"
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION"
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
@@ -106,7 +107,8 @@ RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.pack
 # (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --unsafe-perm --registry="$NPM_REGISTRY"
+    --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    pnpm install --unsafe-perm
 
 # And now copy over our actual code and build
 COPY . .

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -87,12 +87,6 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$ROUTERLICIOUS_ROOT/node_modules/.bin:$PATH"
 
-# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
-# The NPM registry recently rotated some keys but non-latest corepack versions (like those distributed with Node18)
-# have hardcoded references to the old keys and thus fail to install packages that were signed with the new keys.
-# So install the latest corepack globally to work around the problem.
-RUN npm install -g corepack && corepack enable
-
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -102,8 +102,11 @@ RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.pack
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.
 # Using a cache mount for the pnpm store improves the incremental docker build.
+# pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
+# (https://pnpm.io/settings#storedir), so the mount target /pnpm/store already
+# matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --unsafe-perm --registry="$NPM_REGISTRY" --store-dir=/pnpm/store
+    pnpm install --unsafe-perm --registry="$NPM_REGISTRY"
 
 # And now copy over our actual code and build
 COPY . .

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -87,6 +87,11 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$ROUTERLICIOUS_ROOT/node_modules/.bin:$PATH"
 
+# Install the pnpm version pinned in package.json's "packageManager" field.
+# Mirrors the approach used by tools/pipelines/templates/include-install-pnpm.yml.
+RUN PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])") \
+    && npm install -g "$PNPM_VERSION"
+
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files
 # and be able to change them.

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -388,12 +388,12 @@ extends:
               dockerfile: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/Dockerfile
               context: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
               image: $(baseContainerTag)
-              # Pass the authenticated .npmrc set up by include-install-pnpm.yml as a BuildKit
-              # secret so the Dockerfile's npm/pnpm steps can install from our ADO npm mirror.
-              # The build container has no egress to registry.npmjs.org. Only emit --secret
-              # for pnpm release groups; gitssh and any future non-pnpm Dockerfiles don't need it.
+              # CI's build container has no egress to registry.npmjs.org under 1ES network
+              # isolation, so override NPM_REGISTRY to our anonymous-readable ADO mirror.
+              # Only the pnpm Dockerfiles declare NPM_REGISTRY; non-pnpm ones (gitssh) don't
+              # consume it, so we skip the build-arg for them to avoid an "unused" warning.
               ${{ if eq(parameters.packageManager, 'pnpm') }}:
-                buildArguments: --target base $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
+                buildArguments: --target base $(DockerBuildArgs.output) --build-arg NPM_REGISTRY=$(ado-feeds-primary-registry)
               ${{ else }}:
                 buildArguments: --target base $(DockerBuildArgs.output)
               useBuildKit: true
@@ -536,11 +536,10 @@ extends:
             dockerfile: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/Dockerfile
             context: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
             image: $(containerTag)
-            # See note on the base-image build above for the rationale behind --secret.
-            # Passed here too because a cache miss could cause the base stage layers to
-            # re-execute during this build.
+            # See the base-image build above for the rationale. Passed here too because
+            # a cache miss could re-execute the base stage layers during this build.
             ${{ if eq(parameters.packageManager, 'pnpm') }}:
-              buildArguments: $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
+              buildArguments: $(DockerBuildArgs.output) --build-arg NPM_REGISTRY=$(ado-feeds-primary-registry)
             ${{ else }}:
               buildArguments: $(DockerBuildArgs.output)
             useBuildKit: true

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -392,7 +392,7 @@ extends:
               # isolation. Pass the authenticated .npmrc set up by include-install-pnpm.yml
               # as a BuildKit secret so the Dockerfile's npm/pnpm steps can install from our
               # ADO npm mirror. Only emit --secret for pnpm release groups; non-pnpm
-              # Dockerfiles (gitssh) don't consume it.
+              # Dockerfiles don't consume it. (gitssh is already excluded one level up.)
               ${{ if eq(parameters.packageManager, 'pnpm') }}:
                 buildArguments: --target base $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
               ${{ else }}:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -388,7 +388,14 @@ extends:
               dockerfile: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/Dockerfile
               context: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
               image: $(baseContainerTag)
-              buildArguments: --target base $(DockerBuildArgs.output)
+              # Pass the authenticated .npmrc set up by include-install-pnpm.yml as a BuildKit
+              # secret so the Dockerfile's npm/pnpm steps can install from our ADO npm mirror.
+              # The build container has no egress to registry.npmjs.org. Only emit --secret
+              # for pnpm release groups; gitssh and any future non-pnpm Dockerfiles don't need it.
+              ${{ if eq(parameters.packageManager, 'pnpm') }}:
+                buildArguments: --target base $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
+              ${{ else }}:
+                buildArguments: --target base $(DockerBuildArgs.output)
               useBuildKit: true
               enableNetwork: true
               enableCache: true
@@ -529,7 +536,13 @@ extends:
             dockerfile: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/Dockerfile
             context: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
             image: $(containerTag)
-            buildArguments: $(DockerBuildArgs.output)
+            # See note on the base-image build above for the rationale behind --secret.
+            # Passed here too because a cache miss could cause the base stage layers to
+            # re-execute during this build.
+            ${{ if eq(parameters.packageManager, 'pnpm') }}:
+              buildArguments: $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
+            ${{ else }}:
+              buildArguments: $(DockerBuildArgs.output)
             useBuildKit: true
             enableNetwork: true
             enableCache: true

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -389,11 +389,12 @@ extends:
               context: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
               image: $(baseContainerTag)
               # CI's build container has no egress to registry.npmjs.org under 1ES network
-              # isolation, so override NPM_REGISTRY to our anonymous-readable ADO mirror.
-              # Only the pnpm Dockerfiles declare NPM_REGISTRY; non-pnpm ones (gitssh) don't
-              # consume it, so we skip the build-arg for them to avoid an "unused" warning.
+              # isolation. Pass the authenticated .npmrc set up by include-install-pnpm.yml
+              # as a BuildKit secret so the Dockerfile's npm/pnpm steps can install from our
+              # ADO npm mirror. Only emit --secret for pnpm release groups; non-pnpm
+              # Dockerfiles (gitssh) don't consume it.
               ${{ if eq(parameters.packageManager, 'pnpm') }}:
-                buildArguments: --target base $(DockerBuildArgs.output) --build-arg NPM_REGISTRY=$(ado-feeds-primary-registry)
+                buildArguments: --target base $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
               ${{ else }}:
                 buildArguments: --target base $(DockerBuildArgs.output)
               useBuildKit: true
@@ -539,7 +540,7 @@ extends:
             # See the base-image build above for the rationale. Passed here too because
             # a cache miss could re-execute the base stage layers during this build.
             ${{ if eq(parameters.packageManager, 'pnpm') }}:
-              buildArguments: $(DockerBuildArgs.output) --build-arg NPM_REGISTRY=$(ado-feeds-primary-registry)
+              buildArguments: $(DockerBuildArgs.output) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
             ${{ else }}:
               buildArguments: $(DockerBuildArgs.output)
             useBuildKit: true


### PR DESCRIPTION
## Description

The `server/{routerlicious,historian,gitrest}` Dockerfiles each carried a year-plus-old corepack workaround:

```dockerfile
# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
# ...
RUN npm install -g corepack && corepack enable
```

Under 1ES `CfsClean` network isolation, this `RUN` (and any other call to `registry.npmjs.org` from inside the BuildKit container) now `ETIMEDOUT`s because egress to the public npm registry is sinkholed. See e.g. failed build [403599](https://dev.azure.com/fluidframework/public/_build/results?buildId=403599&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=a1aa9649-a94b-5ac4-3f5e-9bb6223edb04).

This PR fixes the three server Docker builds in three layered steps:

1. **Remove the stale corepack workaround.** The underlying corepack key-rotation bug has long since been resolved upstream, and we don't actually use corepack in these images.
2. **Install `pnpm` directly via npm**, pinned to the version from each package's `packageManager` field (mirroring [`include-install-pnpm.yml`](../blob/main/tools/pipelines/templates/include-install-pnpm.yml)). Removing `corepack enable` also removed the `pnpm` shim, so the subsequent `pnpm install --unsafe-perm` would otherwise fail with `pnpm: not found`.
3. **Forward the agent's authenticated `.npmrc` into the BuildKit container as a secret.** `include-install-pnpm.yml` already writes an `.npmrc` (path exposed via `NPM_CONFIG_USERCONFIG`) that points at each project's ADO npm mirror — anonymously-readable on the `public` project, authenticated on the `internal` project. The pipeline forwards that file into the Docker build via `--secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)` so the in-container `npm install -g pnpm` and `pnpm install --unsafe-perm` steps resolve through the same mirror. The mount is marked `required=false` so local `pnpm build:docker` invocations (which don't pass `--secret`) still work, falling back to npm's default registry. The pipeline only emits the secret for pnpm release groups; `server-gitssh` (which doesn't use pnpm) is unaffected.

Tracked by [AB#74619](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74619).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- **`.npmrc` exposure to pnpm install scripts.** The `--secret id=npmrc` mount is BuildKit-scoped (never lands in any image layer), but `pnpm install --unsafe-perm` does execute package lifecycle scripts inside the same `RUN`, so they can read `/root/.npmrc` while the mount is live. This matches the trust posture of the existing agent-level `pnpm install` in `include-install-pnpm.yml`, which runs the same dependency set against the same `.npmrc`.
- **Pnpm store cache mount.** The `--mount=type=cache,id=pnpm,target=/pnpm/store` on the `pnpm install` step does take effect even though `--store-dir` is not passed, because `ENV PNPM_HOME=/pnpm` is set higher up in each Dockerfile and pnpm's documented `storeDir` default is `$PNPM_HOME/store` when `PNPM_HOME` is set (https://pnpm.io/settings#storedir). The cache mount is BuildKit-internal and never lands in the runtime image.
- **Verified end-to-end.** Pipeline runs in both the `public` and `internal` ADO projects exercise all four server pipelines against this branch. Local `pnpm build:docker` also builds green with no `--secret` argument, confirming the local fallback.
