### PR TITLE
test(test-version-utils): make CompatApis "ForLoading" APIs required

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -26,14 +26,12 @@ const forceWriteMode = async (scheduler: IAgentScheduler): Promise<void> =>
 
 describeCompat("AgentScheduler", "FullCompat", (getTestObjectProvider, apis) => {
 	const getContainerRuntimeFactory = (forLoad: boolean): fluidEntryPoint => {
-		const runtime =
-			forLoad && apis.containerRuntimeForLoading !== undefined
-				? apis.containerRuntimeForLoading.ContainerRuntime
-				: apis.containerRuntime.ContainerRuntime;
-		const agentSchedulerFactory =
-			forLoad && apis.dataRuntimeForLoading !== undefined
-				? apis.dataRuntimeForLoading?.packages.agentScheduler.AgentSchedulerFactory
-				: apis.dataRuntime.packages.agentScheduler.AgentSchedulerFactory;
+		const runtime = forLoad
+			? apis.containerRuntimeForLoading.ContainerRuntime
+			: apis.containerRuntime.ContainerRuntime;
+		const agentSchedulerFactory = forLoad
+			? apis.dataRuntimeForLoading.packages.agentScheduler.AgentSchedulerFactory
+			: apis.dataRuntime.packages.agentScheduler.AgentSchedulerFactory;
 
 		const TestContainerRuntimeFactory = createTestContainerRuntimeFactory(runtime);
 		return {

--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -57,8 +57,6 @@ describeCompat(
 			let crash = false;
 			let crash2 = false;
 			if (provider.type === "TestObjectProviderWithVersionedLoad") {
-				assert(apis.containerRuntime !== undefined);
-				assert(apis.containerRuntimeForLoading !== undefined);
 				// 1st container is defined by apis.containerRuntime, 2nd and 3rd are defined by apis.containerRuntimeForLoading.
 				// If first container is running 1.3, then it does not understand neither compression or document schema ops,
 				// and thus it will see either of those.
@@ -311,7 +309,6 @@ describeCompat(
 		it.skip("sends a warning telemetry event for clients less than minVersionForCollab", async function () {
 			const releaseMinVersionForCollabWarningAdded = "2.43.0";
 			if (
-				apis.containerRuntimeForLoading === undefined ||
 				semverGt(
 					releaseMinVersionForCollabWarningAdded,
 					apis.containerRuntimeForLoading.version,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -63,9 +63,9 @@ describeCompat(
 		};
 
 		const version2Apis: LayerApis = {
-			containerRuntime: compatApis.containerRuntimeForLoading ?? compatApis.containerRuntime,
-			dataRuntime: compatApis.dataRuntimeForLoading ?? compatApis.dataRuntime,
-			loader: compatApis.loaderForLoading ?? compatApis.loader,
+			containerRuntime: compatApis.containerRuntimeForLoading,
+			dataRuntime: compatApis.dataRuntimeForLoading,
+			loader: compatApis.loaderForLoading,
 		};
 
 		let provider: ITestObjectProvider;
@@ -113,8 +113,8 @@ describeCompat(
 			// nacks them. So, skip the test for those combinations.
 			if (provider.driver.type === "odsp") {
 				const loaderVersion = compatApis.loader.version;
-				const loaderVersionForLoading = compatApis.loaderForLoading?.version;
-				if (loaderVersion.startsWith("1.") || loaderVersionForLoading?.startsWith("1.")) {
+				const loaderVersionForLoading = compatApis.loaderForLoading.version;
+				if (loaderVersion.startsWith("1.") || loaderVersionForLoading.startsWith("1.")) {
 					this.skip();
 				}
 			}

--- a/packages/test/test-end-to-end-tests/src/test/treeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/treeCompat.spec.ts
@@ -57,7 +57,7 @@ async function createContainerAndGetTreeView(provider: ITestObjectProvider, apis
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- TODO: extract schema definition and provide explicit return type
 async function loadContainerAndGetTreeView(provider: ITestObjectProvider, apis: CompatApis) {
-	const dataRuntimeApi = apis.dataRuntimeForLoading ?? apis.dataRuntime;
+	const dataRuntimeApi = apis.dataRuntimeForLoading;
 	const { SharedTree } = dataRuntimeApi.dds;
 	const testContainerConfig: ITestContainerConfig = {
 		...baseTestContainerConfig,
@@ -79,11 +79,7 @@ describeCompat(
 			// SharedTree was added in version 2.0.0. Skip all cross-client compat tests in this suite for older versions.
 			if (apis.mode === "CrossClientCompat") {
 				const version = apis.dataRuntime.version;
-				const versionForLoading = apis.dataRuntimeForLoading?.version;
-				assert(
-					versionForLoading !== undefined,
-					"Loading version must be defined for cross-client tests",
-				);
+				const versionForLoading = apis.dataRuntimeForLoading.version;
 				if (lt(version, "2.0.0") || lt(versionForLoading, "2.0.0")) {
 					this.skip();
 				}

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -72,8 +72,8 @@ function getMinVersionForCollab(
 ): MinimumVersionForCollab {
 	assertValidMinVersionForCollab(runtimeVersion);
 	assertValidMinVersionForCollab(runtimeVersionForLoading);
-	// If `containerRuntimeForLoading` is defined, we will use the lower of the two versions to ensure
-	// compatibility between the two runtimes.
+	// Use the lower of the two versions to ensure compatibility between the two runtimes.
+	// (Outside of cross-client compat the two versions are the same, so this is a no-op.)
 	return semver.compare(runtimeVersion, runtimeVersionForLoading) <= 0
 		? runtimeVersion
 		: runtimeVersionForLoading;

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -12,7 +12,7 @@ import {
 import { FluidTestDriverConfig, createFluidTestDriver } from "@fluid-private/test-drivers";
 import { FluidObject, IFluidLoadable, IRequest } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext, type IResponse } from "@fluidframework/core-interfaces/internal";
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	IFluidDataStoreRuntime,
 	IChannelFactory,
@@ -50,14 +50,13 @@ import { getRequestedVersion } from "./versionUtils.js";
 export const TestDataObjectType = "@fluid-example/test-dataStore";
 
 /**
- * Determines the MinimumVersionForCollab that should be used for cross-client compatibility tests.
+ * Determines the MinimumVersionForCollab that should be used for compatibility tests.
  *
- * In cross-client compat tests, a different version of the runtime is being used to create and load
- * containers. The MinimumVersionForCollab returned will be the lesser of the two versions:
+ * The MinimumVersionForCollab returned will be the lesser of the two versions:
  * - runtimeVersion: The version of the runtime that is being used to create the container.
  * - runtimeVersionForLoading: The version of the runtime that is being used to load the container.
- * Additionally, runtimeVersionForLoading is only defined in cross-client compat tests, so if it's undefined
- * we will just use runtimeVersion.
+ * Outside of cross-client compat tests these two versions are the same, so the result is simply that
+ * shared version.
  *
  * Note: The MinimumVersionForCollab returned will only be used if a minVersionForCollab was not provided
  * in the ITestContainerConfig object.
@@ -69,14 +68,9 @@ export const TestDataObjectType = "@fluid-example/test-dataStore";
  */
 function getMinVersionForCollab(
 	runtimeVersion: string,
-	runtimeVersionForLoading: string | undefined,
+	runtimeVersionForLoading: string,
 ): MinimumVersionForCollab {
 	assertValidMinVersionForCollab(runtimeVersion);
-	if (runtimeVersionForLoading === undefined) {
-		// If `containerRuntimeForLoading` is not defined, then this is not a cross-client compat scenario.
-		// In this case, we can use the `runtimeVersion` as the default minVersionForCollab.
-		return runtimeVersion;
-	}
 	assertValidMinVersionForCollab(runtimeVersionForLoading);
 	// If `containerRuntimeForLoading` is defined, we will use the lower of the two versions to ensure
 	// compatibility between the two runtimes.
@@ -179,7 +173,7 @@ export const getDataStoreFactory = createGetDataStoreFactoryFunction(
  * @internal
  */
 export async function getVersionedTestObjectProviderFromApis(
-	apis: Omit<CompatApis, "dds" | "mode">,
+	apis: Omit<CompatApis, "dds" | "ddsForLoading" | "mode">,
 	driverConfig?: {
 		type?: TestDriverTypes;
 		config?: FluidTestDriverConfig;
@@ -205,7 +199,7 @@ export async function getVersionedTestObjectProviderFromApis(
 			containerOptions?.minVersionForCollab ??
 				getMinVersionForCollab(
 					apis.containerRuntime.version,
-					apis.containerRuntimeForLoading?.version,
+					apis.containerRuntimeForLoading.version,
 				),
 		);
 	};
@@ -227,14 +221,24 @@ export async function getVersionedTestObjectProvider(
 	runtimeVersion?: number | string,
 	dataRuntimeVersion?: number | string,
 ): Promise<TestObjectProvider> {
+	// This path is not cross-client compat, so the same set of APIs is used for both creating and
+	// loading containers; the "ForLoading" APIs mirror the ones used for creating.
+	const loader = getLoaderApi(getRequestedVersion(baseVersion, loaderVersion));
+	const containerRuntime = getContainerRuntimeApi(
+		getRequestedVersion(baseVersion, runtimeVersion),
+	);
+	const dataRuntime = getDataRuntimeApi(getRequestedVersion(baseVersion, dataRuntimeVersion));
+	const driver = getDriverApi(getRequestedVersion(baseVersion, driverConfig?.version));
 	return getVersionedTestObjectProviderFromApis(
 		{
-			loader: getLoaderApi(getRequestedVersion(baseVersion, loaderVersion)),
-			containerRuntime: getContainerRuntimeApi(
-				getRequestedVersion(baseVersion, runtimeVersion),
-			),
-			dataRuntime: getDataRuntimeApi(getRequestedVersion(baseVersion, dataRuntimeVersion)),
-			driver: getDriverApi(getRequestedVersion(baseVersion, driverConfig?.version)),
+			loader,
+			loaderForLoading: loader,
+			containerRuntime,
+			containerRuntimeForLoading: containerRuntime,
+			dataRuntime,
+			dataRuntimeForLoading: dataRuntime,
+			driver,
+			driverForLoading: driver,
 		},
 		driverConfig,
 	);
@@ -250,10 +254,6 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 		config: FluidTestDriverConfig;
 	},
 ): Promise<TestObjectProviderWithVersionedLoad> {
-	assert(apis.driverForLoading !== undefined, "driverForLoading must be defined");
-	assert(apis.loaderForLoading !== undefined, "loaderForLoading must be defined");
-	assert(apis.dataRuntimeForLoading !== undefined, "dataRuntimeForLoading must be defined");
-
 	const driverForCreating = await createFluidTestDriver(
 		driverConfig.type,
 		driverConfig.config,
@@ -283,7 +283,7 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 	// We want to ensure that we are testing all latest runtime features, but only if both runtimes
 	// (one that creates containers and one that loads them) support them.
 	//
-	// Theoretically it should be fine to use config for apis.containerRuntimeForLoading?.version.
+	// Theoretically it should be fine to use config for apis.containerRuntimeForLoading.version.
 	// If it's higher then apis.containerRuntime, then unknown to lower version of apis.containerRuntime
 	// would be ignored.
 	//
@@ -292,10 +292,8 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 	// Many use non-first container instance to send ops, so that screws things up.
 	//
 	// As result, we absolutly need to use the min between two versions!
-	const versionForCreating = apis.containerRuntime?.version;
-	assert(versionForCreating !== undefined, "versionForCreating");
-	const versionForLoading = apis.containerRuntimeForLoading?.version;
-	assert(versionForLoading !== undefined, "versionForLoading");
+	const versionForCreating = apis.containerRuntime.version;
+	const versionForLoading = apis.containerRuntimeForLoading.version;
 
 	const minVersion =
 		// First, check if any of the versions is current version of the package.
@@ -322,7 +320,7 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 			containerOptions?.minVersionForCollab ??
 				getMinVersionForCollab(
 					apis.containerRuntime.version,
-					apis.containerRuntimeForLoading?.version,
+					apis.containerRuntimeForLoading.version,
 				),
 			[innerRequestHandler],
 		);
@@ -334,10 +332,6 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 		}
 
 		const dataStoreFactory = getDataStoreFactoryFnForLoading(containerOptions);
-		assert(
-			apis.containerRuntimeForLoading !== undefined,
-			"containerRuntimeForLoading must be defined",
-		);
 		const factoryCtor = createTestContainerRuntimeFactory(
 			apis.containerRuntimeForLoading.ContainerRuntime,
 		);

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -227,18 +227,32 @@ function getVersionedApis(config: CompatConfig): CompatApis {
 		};
 	}
 
+	// Outside of cross-client compat, the same set of APIs is used for both creating and loading
+	// containers, so the "ForLoading" APIs mirror the ones above.
 	const dataRuntimeApi = getDataRuntimeApi(
 		getRequestedVersion(testBaseVersion(config.dataRuntime), config.dataRuntime),
 	);
+	const containerRuntimeApi = getContainerRuntimeApi(
+		getRequestedVersion(testBaseVersion(config.containerRuntime), config.containerRuntime),
+	);
+	const driverApi = getDriverApi(
+		getRequestedVersion(testBaseVersion(config.driver), config.driver),
+	);
+	const loaderApi = getLoaderApi(
+		getRequestedVersion(testBaseVersion(config.loader), config.loader),
+	);
 	return {
 		mode,
-		containerRuntime: getContainerRuntimeApi(
-			getRequestedVersion(testBaseVersion(config.containerRuntime), config.containerRuntime),
-		),
+		containerRuntime: containerRuntimeApi,
+		containerRuntimeForLoading: containerRuntimeApi,
 		dataRuntime: dataRuntimeApi,
+		dataRuntimeForLoading: dataRuntimeApi,
 		dds: dataRuntimeApi.dds,
-		driver: getDriverApi(getRequestedVersion(testBaseVersion(config.driver), config.driver)),
-		loader: getLoaderApi(getRequestedVersion(testBaseVersion(config.loader), config.loader)),
+		ddsForLoading: dataRuntimeApi.dds,
+		driver: driverApi,
+		driverForLoading: driverApi,
+		loader: loaderApi,
+		loaderForLoading: loaderApi,
 	};
 }
 

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -366,25 +366,35 @@ function createE2EDocCompatSuite(
 				describe(name, function () {
 					let provider: TestObjectProvider;
 					let resetAfterEach: boolean;
+					// These docs tests are not cross-client compat, so the same set of APIs is used for
+					// both creating and loading containers; the "ForLoading" APIs mirror the ones above.
 					const dataRuntimeApi = getDataRuntimeApi(
 						getRequestedVersion(testBaseVersion(config.dataRuntime), config.dataRuntime),
 					);
+					const containerRuntimeApi = getContainerRuntimeApi(
+						getRequestedVersion(
+							testBaseVersion(config.containerRuntime),
+							config.containerRuntime,
+						),
+					);
+					const driverApi = getDriverApi(
+						getRequestedVersion(testBaseVersion(config.driver), config.driver),
+					);
+					const loaderApi = getLoaderApi(
+						getRequestedVersion(testBaseVersion(config.loader), config.loader),
+					);
 					const apis: CompatApis = {
 						mode: getCompatModeFromKind(config.kind),
-						containerRuntime: getContainerRuntimeApi(
-							getRequestedVersion(
-								testBaseVersion(config.containerRuntime),
-								config.containerRuntime,
-							),
-						),
+						containerRuntime: containerRuntimeApi,
+						containerRuntimeForLoading: containerRuntimeApi,
 						dataRuntime: dataRuntimeApi,
+						dataRuntimeForLoading: dataRuntimeApi,
 						dds: dataRuntimeApi.dds,
-						driver: getDriverApi(
-							getRequestedVersion(testBaseVersion(config.driver), config.driver),
-						),
-						loader: getLoaderApi(
-							getRequestedVersion(testBaseVersion(config.loader), config.loader),
-						),
+						ddsForLoading: dataRuntimeApi.dds,
+						driver: driverApi,
+						driverForLoading: driverApi,
+						loader: loaderApi,
+						loaderForLoading: loaderApi,
 					};
 
 					before("Create TestObjectProvider", async function () {

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -539,10 +539,12 @@ export interface CompatApis {
 	driver: ReturnType<typeof getDriverApi>;
 	loader: ReturnType<typeof getLoaderApi>;
 
-	// Cross-Client Compat APIs
-	containerRuntimeForLoading?: ReturnType<typeof getContainerRuntimeApi>;
-	dataRuntimeForLoading?: ReturnType<typeof getDataRuntimeApi>;
-	ddsForLoading?: ReturnType<typeof getDataRuntimeApi>["dds"];
-	driverForLoading?: ReturnType<typeof getDriverApi>;
-	loaderForLoading?: ReturnType<typeof getLoaderApi>;
+	// APIs used for loading containers. Tests always use one set of APIs for creating containers
+	// and another for loading them. In cross-client compat mode these are different versions from the
+	// APIs above; in all other modes they are the same versions as the APIs above.
+	containerRuntimeForLoading: ReturnType<typeof getContainerRuntimeApi>;
+	dataRuntimeForLoading: ReturnType<typeof getDataRuntimeApi>;
+	ddsForLoading: ReturnType<typeof getDataRuntimeApi>["dds"];
+	driverForLoading: ReturnType<typeof getDriverApi>;
+	loaderForLoading: ReturnType<typeof getLoaderApi>;
 }


### PR DESCRIPTION
## Description

Make the `*ForLoading` APIs in `CompatApis` required instead of optional.

Previously the `containerRuntimeForLoading` / `dataRuntimeForLoading` / `ddsForLoading` / `driverForLoading` / `loaderForLoading` fields were optional and left `undefined` outside of cross-client compat, which forced consumers to scatter `?? fallback` / `?.` / `=== undefined` guards and made the contract ambiguous.
The pattern is simpler now - Tests should always use one set of APIs for creating containers and another for loading them. This will take care of all compat requirements.

Now:
- In cross-client compat mode the loading APIs are different versions from the create-side APIs (unchanged behavior).
- In all other modes the loading APIs mirror the create-side APIs.

This populates the `ForLoading` fields at every `CompatApis` construction site (`describeCompat`, `describeE2eDocs`, `getVersionedTestObjectProvider`) and removes the now-redundant fallbacks/guards in the consuming e2e tests (`treeCompat`, `agentScheduler`, `gcContainerRuntimeCompat`, `containerRuntime`). No runtime behavior change — in non-cross-client mode the loading APIs equal the create APIs, exactly what the old fallbacks resolved to.

Both affected packages (`@fluid-private/test-version-utils`, `@fluid-private/test-end-to-end-tests`) are private test packages, so no changeset is required.

[AB#74635](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74635)