### PR TITLE
refactor (tree): clarify move logic

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob } from "@fluidframework/core-utils/internal";
+import { assert, fail, oob } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { CodecWriteOptions, ICodecFamily } from "../../codec/index.js";
@@ -333,29 +333,28 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		} else {
 			const detachPath = topDownPath(sourceField.parent);
 			const attachPath = topDownPath(destinationField.parent);
+			/** The number of elements, starting from the root, that both paths have in common */
 			const sharedDepth = getSharedPrefixLength(detachPath, attachPath);
 			let adjustedAttachField = destinationField;
-			// After the above loop, `sharedDepth` is the number of elements, starting from the root,
-			// that both paths have in common.
 			if (sharedDepth === detachPath.length) {
-				const attachField = attachPath[sharedDepth]?.parentField ?? destinationField.field;
-				if (attachField === sourceField.field) {
+				const firstDifferentAttachAncestor = attachPath[sharedDepth];
+				// The source and destination fields are different and the detach occurs under the lowest common ancestor,
+				// so the attach path must be at least one level deeper than the shared depth.
+				assert(firstDifferentAttachAncestor !== undefined, "Truncated attach path");
+				if (firstDifferentAttachAncestor.parentField === sourceField.field) {
 					// The detach occurs in an ancestor field of the field where the attach occurs.
-					let attachAncestorIndex = attachPath[sharedDepth]?.parentIndex ?? sourceIndex;
-					if (attachAncestorIndex < sourceIndex) {
+					if (firstDifferentAttachAncestor.parentIndex < sourceIndex) {
 						// The attach path runs through a node located before the detached nodes.
 						// No need to adjust the attach path.
-					} else if (sourceIndex + count <= attachAncestorIndex) {
+					} else if (sourceIndex + count <= firstDifferentAttachAncestor.parentIndex) {
 						// The attach path runs through a node located after the detached nodes.
 						// adjust the index for the node at that depth of the path, so that it is interpreted correctly
 						// in the composition performed by `submitChanges`.
-						attachAncestorIndex -= count;
-						let parent: UpPath | undefined = attachPath[sharedDepth - 1];
-						const parentField = attachPath[sharedDepth] ?? oob();
+						let parent = firstDifferentAttachAncestor.parent;
 						parent = {
 							parent,
-							parentIndex: attachAncestorIndex,
-							parentField: parentField.parentField,
+							parentIndex: firstDifferentAttachAncestor.parentIndex - count,
+							parentField: firstDifferentAttachAncestor.parentField,
 						};
 						for (let i = sharedDepth + 1; i < attachPath.length; i += 1) {
 							parent = {

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, fail, oob } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { CodecWriteOptions, ICodecFamily } from "../../codec/index.js";

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -1627,11 +1627,66 @@ describe("Editing", () => {
 			expectJsonTree(tree, expectedState);
 		});
 
-		it("can move a node out from a field and into a field under a sibling", () => {
-			const tree = makeTreeFromJsonSequence(["A", {}]);
-			tree.editor.move(rootField, 0, 1, { parent: rootNode2, field: brand("foo") }, 0);
+		it("can move a node out from a field and into a field under a sibling at a lower index", () => {
+			const tree = makeTreeFromJsonSequence([{}, "A"]);
+			tree.editor.move(rootField, 1, 1, { parent: rootNode, field: brand("foo") }, 0);
 			const expectedState: JsonCompatible = [{ foo: "A" }];
 			expectJsonTree(tree, expectedState);
+		});
+
+		describe("can move a node out from a field and into a field under a sibling at a higher index", () => {
+			it("no further ancestry, shallow destination", () => {
+				const tree = makeTreeFromJsonSequence(["A", {}]);
+				tree.editor.move(rootField, 0, 1, { parent: rootNode2, field: brand("foo") }, 0);
+				const expectedState: JsonCompatible = [{ foo: "A" }];
+				expectJsonTree(tree, expectedState);
+			});
+
+			it("with further ancestry, shallow destination", () => {
+				const tree = makeTreeFromJsonSequence([{ foo: { bar: ["A", {}] } }]);
+				const fooNode: NormalizedUpPath = {
+					parent: rootNode,
+					parentField: brand("foo"),
+					parentIndex: 0,
+				};
+				const barArray: NormalizedUpPath = {
+					parent: fooNode,
+					parentField: brand("bar"),
+					parentIndex: 0,
+				};
+				tree.editor.move(
+					{ parent: barArray, field: EmptyKey },
+					0,
+					1,
+					{
+						parent: { parent: barArray, parentField: EmptyKey, parentIndex: 1 },
+						field: brand("baz"),
+					},
+					0,
+				);
+				const expectedState: JsonCompatible = [{ foo: { bar: [{ baz: "A" }] } }];
+				expectJsonTree(tree, expectedState);
+			});
+
+			it("no further ancestry, deep destination", () => {
+				const tree = makeTreeFromJsonSequence(["A", { foo: { bar: {} } }]);
+				tree.editor.move(
+					rootField,
+					0,
+					1,
+					{
+						parent: {
+							parent: { parent: rootNode2, parentField: brand("foo"), parentIndex: 0 },
+							parentField: brand("bar"),
+							parentIndex: 0,
+						},
+						field: brand("baz"),
+					},
+					0,
+				);
+				const expectedState: JsonCompatible = [{ foo: { bar: { baz: "A" } } }];
+				expectJsonTree(tree, expectedState);
+			});
 		});
 
 		it("can rebase a move over the deletion of the source parent", () => {

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -1627,6 +1627,21 @@ describe("Editing", () => {
 			expectJsonTree(tree, expectedState);
 		});
 
+		describe("can move a node to a different index in the same field", () => {
+			for (const srcElementIndex of [0, 1]) {
+				for (const dstGapIndex of [0, 1, 2]) {
+					it(`from index ${srcElementIndex} to gap ${dstGapIndex}`, () => {
+						const tree = makeTreeFromJsonSequence(["A", "B"]);
+						tree.editor.move(rootField, srcElementIndex, 1, rootField, dstGapIndex);
+						const vector = dstGapIndex - srcElementIndex;
+						const expectedState: JsonCompatible =
+							vector === 0 || vector === 1 ? ["A", "B"] : ["B", "A"];
+						expectJsonTree(tree, expectedState);
+					});
+				}
+			}
+		});
+
 		it("can move a node out from a field and into a field under a sibling at a lower index", () => {
 			const tree = makeTreeFromJsonSequence([{}, "A"]);
 			tree.editor.move(rootField, 1, 1, { parent: rootNode, field: brand("foo") }, 0);


### PR DESCRIPTION
## Description

Clarifies the logic of `DefaultEditBuilder.move` in preparation for other changes.
Adds more test coverage.

## Breaking Changes

None