### PR TITLE
Align ADO pipeline package-manager install settings

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -86,8 +86,6 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/tools/api-markdown-documenter
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
     tagName: api-markdown-documenter
     taskBuild: build

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -88,9 +88,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     testCoverage: ${{ variables.testCoverage }}
-    packageManager: pnpm
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/tools/benchmark
     tagName: benchmark
     taskBuild: build

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -90,8 +90,6 @@ extends:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/build/build-common
     tagName: build-common
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
     taskBuild: false
     taskBuildDocs: false

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -102,8 +102,6 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/build-tools
     tagName: build-tools

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -28,8 +28,6 @@ extends:
     isBundleSizeArtifactsPipeline: true
     taskBuildDocs: false
     testCoverage: false
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}
     tagName: bundle-and-code-coverage-artifacts
     # This pipeline doesn't generate production artifacts but the build-npm-package template is too intertwined with

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -198,8 +198,6 @@ extends:
     packageTypesOverride: ${{ parameters.packageTypesOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     # Disabled: coverage performance regressed in Node 22 and further in Node 24, causing test timeouts
     # that need mitigation before coverage can be reenabled.
     # testCoverage: ${{ eq(variables['System.TeamProject'], 'public' ) }} # disabling code coverage for internal project since we don't use it

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -98,6 +98,4 @@ extends:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/lib/common-utils
     tagName: common-utils
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -92,8 +92,6 @@ extends:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/build/eslint-config-fluid
     tagName: eslint-config-fluid
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
     taskBuild: build
     taskBuildDocs: false

--- a/tools/pipelines/build-eslint-plugin-fluid.yml
+++ b/tools/pipelines/build-eslint-plugin-fluid.yml
@@ -92,8 +92,6 @@ extends:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/build/eslint-plugin-fluid
     tagName: eslint-plugin-fluid
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
     taskBuild: build
     taskBuildDocs: false

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -98,8 +98,6 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/lib/protocol-definitions
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     tagName: protocol-definitions
     testCoverage: false
     taskTest: [] # no tests

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -85,8 +85,6 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/tools/test-tools
-    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
-    packageManager: pnpm
     testCoverage: ${{ variables.testCoverage }}
     tagName: test-tools
     taskBuild: build

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -100,10 +100,11 @@ extends:
     releaseKind: ${{ parameters.releaseKind }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     dockerBuildBumpsVersion: true
-    packageManagerInstallCommand: 'pnpm config set recursive-install false ; pnpm i ; pnpm config set recursive-install true'
+    # Root-only install: gitrest has native deps that don't install in CI; the real build runs in Docker.
+    # Root deps are still needed for the version-setting step.
+    packageManagerInstallCommand: 'pnpm i --frozen-lockfile --workspace-root'
     # The --build-context is needed because the Dockerfile copies files from the repo root.
     additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
-    packageManager: pnpm
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/gitrest
     containerName: fluidframework/routerlicious/gitrest
     test: test

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -83,5 +83,7 @@ extends:
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/gitssh
     containerName: fluidframework/routerlicious/gitssh
     setVersion: false
+    # No package.json; skip package-manager setup.
+    packageManager: none
     enableDockerImagePull: false
     tagName: gitssh

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -101,12 +101,11 @@ extends:
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/historian
     containerName: fluidframework/routerlicious/historian
     dockerBuildBumpsVersion: true
-    # We need to install only the root dependencies; historian has native deps that don't install in CI since we use
-    # Docker to do the actual build in CI. We need the root dependencies so setting package versions works.
-    packageManagerInstallCommand: 'pnpm install --workspace-root'
+    # Root-only install: historian has native deps that don't install in CI; the real build runs in Docker.
+    # Root deps are still needed for the version-setting step.
+    packageManagerInstallCommand: 'pnpm i --frozen-lockfile --workspace-root'
     # The --build-context is needed because the Dockerfile copies files from the repo root.
     additionalBuildArguments: --build-context root=$(Pipeline.Workspace)/${{ variables.FluidFrameworkDirectory }}
-    packageManager: pnpm
     test: test
     tagName: historian
     lint: true

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -121,10 +121,9 @@ extends:
     containerName: fluidframework/routerlicious/server
     buildNumberInPatch: false
     dockerBuildBumpsVersion: true
-    # We need to install only the root dependencies; r11s has native deps that don't install in CI since we use Docker
-    # to do the actual build in CI. We need the root dependencies so setting package versions works.
-    packageManagerInstallCommand: 'pnpm install --workspace-root'
-    packageManager: pnpm
+    # Root-only install: r11s has native deps that don't install in CI; the real build runs in Docker.
+    # Root deps are still needed for the version-setting step.
+    packageManagerInstallCommand: 'pnpm i --frozen-lockfile --workspace-root'
     tagName: server
     isReleaseGroup: true
     pool: Large-eastus2

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -301,6 +301,11 @@ extends:
                 fi
               fi
 
+              if [[ "${{ parameters.packageManager }}" == "none" ]] && [[ "${{ parameters.setVersion }}" == "True" ]]; then
+                echo "##vso[task.logissue type=error]packageManager: 'none' is incompatible with setVersion: true (version-setting transitively requires a package manager)."
+                exit -1;
+              fi
+
         # for npm ci in component detection and set version
         - template: /tools/pipelines/templates/include-use-node-version.yml@self
 

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -65,13 +65,17 @@ parameters:
     type: string
     default: repo
 
+  # The package manager (if any) used by this pipeline.
   - name: packageManager
     type: string
-    default: npm
+    default: pnpm
+    values:
+      - pnpm
+      - none
 
   - name: packageManagerInstallCommand
     type: string
-    default: 'npm ci --unsafe-perm'
+    default: 'pnpm i --frozen-lockfile'
 
   # The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
   # group

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -76,7 +76,7 @@ parameters:
 
 - name: packageManager
   type: string
-  default: npm
+  default: pnpm
 
 # Parameter for modifying the 'types' field in the package.json.
 # If the value 'none' is provided, the 'types' field in package.json will remain unchanged.
@@ -86,7 +86,7 @@ parameters:
 
 - name: packageManagerInstallCommand
   type: string
-  default: 'npm ci --unsafe-perm'
+  default: 'pnpm i --frozen-lockfile'
 
 # The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
 # group

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -75,7 +75,7 @@ parameters:
 
 - name: packageManager
   type: string
-  default: npm
+  default: pnpm
 
 # Parameter for modifying the 'types' field in the package.json.
 # If the value 'none' is provided, the 'types' field in package.json will remain unchanged.
@@ -85,7 +85,7 @@ parameters:
 
 - name: packageManagerInstallCommand
   type: string
-  default: 'npm ci --unsafe-perm'
+  default: 'pnpm i --frozen-lockfile'
 
 # The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
 # group

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -6,12 +6,14 @@
 parameters:
 - name: packageManager
   type: string
+  default: pnpm
 
 - name: buildDirectory
   type: string
 
 - name: packageManagerInstallCommand
   type: string
+  default: 'pnpm i --frozen-lockfile'
 
 - name: primaryRegistry
   type: string

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -145,17 +145,13 @@ stages:
         # Install ff_pipeline_host dependencies (provides telemetry-generator and trips-setup/cleanup)
         - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
-            packageManager: pnpm
             buildDirectory: $(FFPipelineHostDirectory)
-            packageManagerInstallCommand: pnpm install
             primaryRegistry: $(ado-feeds-ff-download-only)
 
         # Install FluidFramework dependencies
         - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
-            packageManager: pnpm
             buildDirectory: $(FluidFrameworkDirectory)
-            packageManagerInstallCommand: pnpm install
             primaryRegistry: $(ado-feeds-ff-download-only)
 
         # Build the workspace so compiled test code is available for benchmarks


### PR DESCRIPTION
## Description

Followup to #27456 (which removed `--unsafe-perm` from the server Dockerfiles): the pipeline templates still passed `--unsafe-perm` on the `npm ci` install command, though in practice that command wasn't actually getting used. Cleaning that up grew naturally into aligning all the package-manager install settings across pipelines.

Pure refactor — every pipeline runs the same install behavior it ran before. As a forward-looking benefit, flipping the template defaults from `npm` / `'npm ci --unsafe-perm'` to `pnpm` / `'pnpm i --frozen-lockfile'` reduces the risk that a future caller accidentally falls back to npm or `--unsafe-perm` by omitting these parameters.

- Every active caller of `build-docker-service.yml`, `build-npm-package.yml`, `build-npm-client-package.yml`, and `include-install.yml` already set `packageManager: pnpm` and `packageManagerInstallCommand: 'pnpm i --frozen-lockfile'` (or an equivalent). Flipping the templates' defaults to match lets the explicit per-caller settings be removed.
- For `server-*` and `test-perf-benchmarks` the install command gains `--frozen-lockfile`. This is a no-op at runtime because every affected workspace `.npmrc` (root, `ff_pipeline_host`, `server/gitrest`, `server/historian`, `server/routerlicious`) already has `frozen-lockfile=true`; the CLI flag is documentation of intent.
- `server-gitssh` now explicitly sets `packageManager: none`, a new enumerated value on `build-docker-service.yml` that means "no package manager setup" (for Dockerfile-only services with no `package.json`). Behavior matches the previous `npm` default for gitssh because (a) the pnpm-gated template paths skip for any non-`pnpm` value and (b) `setVersion: false` already skipped the install step regardless.

### Mechanical removals

- 11 canonical callers drop both `packageManager` and `packageManagerInstallCommand` (`build-api-markdown-documenter`, `build-benchmark-tool`, `build-build-common`, `build-build-tools`, `build-bundle-size-artifacts`, `build-client`, `build-common-utils`, `build-eslint-config-fluid`, `build-eslint-plugin-fluid`, `build-protocol-definitions`, `build-test-tools`).
- 3 `server-*` docker callers drop `packageManager` and align on `'pnpm i --frozen-lockfile --workspace-root'` (`server-gitrest`, `server-historian`, `server-routerlicious`).
- `test-perf-benchmarks` drops per-call overrides; relies on the new `include-install.yml` defaults.

[AB#74733](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74733)