### PR TITLE
Suppress minimumReleaseAge check on CI to workaround bad publish times

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -118,3 +118,7 @@ steps:
       # Disable pnpm trust downgrade checks in CI as a workaround.
       echo "Disabling pnpm trust policy as workaround for npm mirror limitations"
       echo "##vso[task.setvariable variable=PNPM_CONFIG_TRUST_POLICY]off"
+      # Some mirrored registries also have unreliable publish timestamps.
+      # Disable minimum release age checks in CI to avoid false positives.
+      echo "Disabling pnpm minimumReleaseAge check as workaround for npm mirror publish time issues"
+      echo "##vso[task.setvariable variable=PNPM_CONFIG_MINIMUM_RELEASE_AGE]0"


### PR DESCRIPTION
## Description

Our internal CI pipelines use a package mirror with its own package ingestion delay/quarantine, so this check is rather redundant there. It also doesn't work, and having users apply the check when installing new package versions should also be sufficient.

Therefor suppressing this check on CI seems reasonable and necessary.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
