### PR TITLE
test(test-version-utils) Update the compat mode title to include versions of all layers

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -86,6 +86,8 @@ const defaultVersionsForCrossClientCompat = {
 // Currently we only want to support 2.0.0.internal.3.y.z. and above
 const defaultNumOfDriverVersionsAboveV2Int1 = 2;
 
+const currentVersionStr = `${baseVersion} (N)`;
+
 function genConfig(compatVersion: number | string): CompatConfig[] {
 	if (compatVersion === 0) {
 		return [
@@ -111,52 +113,52 @@ function genConfig(compatVersion: number | string): CompatConfig[] {
 			: `${getRequestedVersion(baseVersion, compatVersion)} (N${compatVersion})`;
 	return [
 		{
-			name: `compat ${compatVersionStr} - old loader`,
+			name: `compat - loader ${compatVersionStr}, other layers ${currentVersionStr}`,
 			kind: CompatKind.Loader,
 			compatVersion,
 			loader: compatVersion,
 		},
 		{
-			name: `compat ${compatVersionStr} - new loader`,
+			name: `compat - loader ${currentVersionStr}, other layers ${compatVersionStr}`,
 			kind: CompatKind.NewLoader,
 			compatVersion,
 			...allOld,
 			loader: undefined,
 		},
 		{
-			name: `compat ${compatVersionStr} - old driver`,
+			name: `compat - driver ${compatVersionStr}, other layers ${currentVersionStr}`,
 			kind: CompatKind.Driver,
 			compatVersion,
 			driver: compatVersion,
 		},
 		{
-			name: `compat ${compatVersionStr} - new driver`,
+			name: `compat - driver ${currentVersionStr}, other layers ${compatVersionStr}`,
 			kind: CompatKind.NewDriver,
 			compatVersion,
 			...allOld,
 			driver: undefined,
 		},
 		{
-			name: `compat ${compatVersionStr} - old container runtime`,
+			name: `compat - container runtime ${compatVersionStr}, other layers ${currentVersionStr}`,
 			kind: CompatKind.ContainerRuntime,
 			compatVersion,
 			containerRuntime: compatVersion,
 		},
 		{
-			name: `compat ${compatVersionStr} - new container runtime`,
+			name: `compat - container runtime ${currentVersionStr}, other layers ${compatVersionStr}`,
 			kind: CompatKind.NewContainerRuntime,
 			compatVersion,
 			...allOld,
 			containerRuntime: undefined,
 		},
 		{
-			name: `compat ${compatVersionStr} - old data runtime`,
+			name: `compat - data store runtime ${compatVersionStr}, other layers ${currentVersionStr}`,
 			kind: CompatKind.DataRuntime,
 			compatVersion,
 			dataRuntime: compatVersion,
 		},
 		{
-			name: `compat ${compatVersionStr} - new data runtime`,
+			name: `compat - data store runtime ${currentVersionStr}, other layers ${compatVersionStr}`,
 			kind: CompatKind.NewDataRuntime,
 			compatVersion,
 			...allOld,
@@ -168,13 +170,13 @@ function genConfig(compatVersion: number | string): CompatConfig[] {
 const genOldestCompatibleConfig = (compatVersion: number | string): CompatConfig[] => {
 	return [
 		{
-			name: `compat OCV ${compatVersion} - old loader`,
+			name: `compat - loader ${compatVersion} (OCV), other layers ${currentVersionStr}`,
 			kind: CompatKind.Loader,
 			compatVersion,
 			loader: compatVersion,
 		},
 		{
-			name: `compat OCV ${compatVersion} - old loader + old driver`,
+			name: `compat - loader & driver ${compatVersion} (OCV), other layers ${currentVersionStr}`,
 			kind: CompatKind.LoaderDriver,
 			compatVersion,
 			driver: compatVersion,
@@ -191,7 +193,7 @@ const genLoaderBackCompatConfig = (compatVersion: number): CompatConfig[] => {
 
 	return [
 		{
-			name: `compat back ${compatVersionStr} - older loader`,
+			name: `compat back - loader ${compatVersionStr}, other layers ${currentVersionStr}`,
 			kind: CompatKind.Loader,
 			compatVersion,
 			loader: compatVersion,
@@ -206,7 +208,7 @@ const genDriverLoaderBackCompatConfig = (compatVersion: number): CompatConfig[] 
 			: `${getRequestedVersion(baseVersion, compatVersion)} (N${compatVersion})`;
 	return [
 		{
-			name: `compat back ${compatVersionStr} - older loader + older driver`,
+			name: `compat back - loader & driver ${compatVersionStr}, other layers ${currentVersionStr}`,
 			kind: CompatKind.LoaderDriver,
 			compatVersion,
 			driver: compatVersion,


### PR DESCRIPTION
When e2e tests run in various layer compat modes, the title has the version of the layer that is different (old or new) from other layers. However, this still can still be confusing at times. For example, consider the title of two modes in which the test runs:
- compat 2.93.0 (N-1) - old loader
- compat 2.93.0 (N-1) - new loader

The first one in intuitive where loader is old and version 2.93.0. However, the second one is not intuitive - the layers other than the loader are version 2.93.0 and loader is new (N). This is confusing and I often get tripped by this.

In this change, the title clearly states the versions of the layers. The same example as above looks like this:
- compat - loader 2.93.0 (N-1), other layers 2.103.0 (N)
- compat - loader 2.103.0 (N), other layers 2.93.0 (N-1)

Instead of saying old or new, it says the version of loader and whether it's N / N-1 and the version of other layers.
