### PR TITLE
(refactor): Migrate all internal ITelemetryLoggerExt use to TelemetryLoggerExt

### DIFF
--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -6,7 +6,7 @@
 import { IDisposable, IErrorEvent, ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { assert } from '@fluidframework/core-utils/internal';
 import {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	EventEmitterWithErrorHandling,
 	createChildLogger,
 } from '@fluidframework/telemetry-utils/internal';
@@ -121,7 +121,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	 */
 	private currentEdit?: GenericTransaction;
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	public disposed: boolean = false;
 

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -6,7 +6,7 @@
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 import type { IEvent } from '@fluidframework/core-interfaces';
 import { assert, compareArrays } from '@fluidframework/core-utils/internal';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
+import { TelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 import { BTree } from '@tylerbu/sorted-btree-es6';
 
 import type { ChangeCompressor } from './ChangeCompression.js';
@@ -265,7 +265,7 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 	 */
 	public constructor(
 		summary: EditLogSummary<TChange, EditHandle<TChange>> = { editIds: [], editChunks: [] },
-		private readonly logger?: ITelemetryLoggerExt,
+		private readonly logger?: TelemetryLoggerExt,
 		editAddedHandlers: readonly EditAddedHandler<TChange>[] = [],
 		private readonly targetLength = Infinity,
 		private readonly evictionFrequency = targetLength * 2,

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from '@fluidframework/core-utils/internal';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
+import { TelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 
 import { StablePlace } from './ChangeTypes.js';
 import { fail } from './Common.js';
@@ -53,7 +53,7 @@ export enum HistoryEditFactoryEvents {
 export function revert(
 	changes: readonly ChangeInternal[],
 	before: RevisionView,
-	logger?: ITelemetryLoggerExt,
+	logger?: TelemetryLoggerExt,
 	emit?: (event: string, ...args: any[]) => void
 ): ChangeInternal[] | undefined {
 	const result: ChangeInternal[] = [];

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -5,7 +5,7 @@
 
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { assert } from '@fluidframework/core-utils/internal';
-import { ITelemetryLoggerExt, createChildLogger } from '@fluidframework/telemetry-utils/internal';
+import { TelemetryLoggerExt, createChildLogger } from '@fluidframework/telemetry-utils/internal';
 import { BTree } from '@tylerbu/sorted-btree-es6';
 // eslint-disable-next-line import-x/no-internal-modules
 import { diffAgainst } from '@tylerbu/sorted-btree-es6/extended/diffAgainst';
@@ -385,7 +385,7 @@ export class IdCompressor {
 		compareFiniteNumbers
 	);
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	/**
 	 * @param localSessionId - the `IdCompressor`'s current local session ID.

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -25,7 +25,7 @@ import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/
 import { toDeltaManagerInternal } from "@fluidframework/runtime-utils/internal";
 import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	LoggingError,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -193,7 +193,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 */
 	constructor(
 		public readonly specToSegment: (spec: IJSONSegment) => ISegment,
-		public readonly logger: ITelemetryLoggerExt,
+		public readonly logger: TelemetryLoggerExt,
 		options?: IMergeTreeOptionsInternal & PropertySet,
 		private readonly getMinInFlightRefSeq: () => number | undefined = (): undefined =>
 			undefined,

--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -7,7 +7,7 @@
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { SerializedAttributionCollection } from "./attributionCollection.js";
 import type { IJSONSegment } from "./ops.js";
@@ -85,7 +85,7 @@ export function hasMergeInfo(
 export function serializeAsMinSupportedVersion(
 	path: string,
 	chunk: VersionedMergeTreeChunk,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	options: PropertySet | undefined,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
@@ -141,7 +141,7 @@ export function serializeAsMinSupportedVersion(
 export function serializeAsMaxSupportedVersion(
 	path: string,
 	chunk: VersionedMergeTreeChunk,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	options: PropertySet | undefined,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
@@ -153,7 +153,7 @@ export function serializeAsMaxSupportedVersion(
 export function toLatestVersion(
 	path: string,
 	chunk: VersionedMergeTreeChunk,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	options: PropertySet | undefined,
 ): MergeTreeChunkV1 {
 	switch (chunk.version) {

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -15,7 +15,7 @@ import type {
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	UsageError,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
@@ -43,14 +43,14 @@ import type { RemoveOperationStamp } from "./stamps.js";
 import * as opstampUtils from "./stamps.js";
 
 export class SnapshotLoader {
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	constructor(
 		private readonly runtime: IFluidDataStoreRuntime,
 
 		private readonly client: Client,
 		private readonly mergeTree: MergeTree,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly serializer: IFluidSerializer,
 	) {
 		this.logger = createChildLogger({ logger, namespace: "SnapshotLoader" });

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -14,7 +14,7 @@ import type {
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -52,12 +52,12 @@ export class SnapshotV1 {
 	private readonly segments: JsonSegmentSpecs[];
 	private readonly segmentLengths: number[];
 	private readonly attributionCollections: IAttributionCollection<AttributionKey>[];
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private readonly chunkSize: number;
 
 	constructor(
 		public mergeTree: MergeTree,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly getLongClientId: (id: number) => string,
 		public filename?: string,
 		public onCompletion?: () => void,
@@ -367,7 +367,7 @@ export class SnapshotV1 {
 	public static async loadChunk(
 		storage: IChannelStorageService,
 		path: string,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		options: PropertySet | undefined,
 		serializer?: IFluidSerializer,
 	): Promise<MergeTreeChunkV1> {
@@ -379,7 +379,7 @@ export class SnapshotV1 {
 	public static processChunk(
 		path: string,
 		chunk: string,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		options: PropertySet | undefined,
 		serializer?: IFluidSerializer,
 	): MergeTreeChunkV1 {

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -12,7 +12,7 @@ import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -57,12 +57,12 @@ export class SnapshotLegacy {
 	private header: SnapshotHeader | undefined;
 	private seq: number | undefined;
 	private segments: ISegmentPrivate[] | undefined;
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private readonly chunkSize: number;
 
 	constructor(
 		public mergeTree: MergeTree,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		public filename?: string,
 		public onCompletion?: () => void,
 	) {

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -9,7 +9,7 @@ import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { SessionId } from "@fluidframework/id-compressor";
 import {
 	TelemetryEventBatcher,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 import { BTree } from "@tylerbu/sorted-btree-es6";
 
@@ -123,7 +123,7 @@ export class EditManager<
 		public readonly localSessionId: SessionId,
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly onSharedBranchCreated?: (branchId: BranchId) => void,
-		logger?: ITelemetryLoggerExt,
+		logger?: TelemetryLoggerExt,
 	) {
 		this.trunkBase = {
 			revision: rootRevision,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -13,10 +13,7 @@ import type {
 	IFluidSerializer,
 	SharedKernel,
 } from "@fluidframework/shared-object-base/internal";
-import {
-	UsageError,
-	type ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils/internal";
+import { UsageError, type TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	type CodecTree,
@@ -201,7 +198,7 @@ export class SharedTreeKernel
 		submitLocalMessage: (content: unknown, localOpMetadata?: unknown) => void,
 		lastSequenceNumber: () => number | undefined,
 		initialSequenceNumber: number,
-		private readonly logger: ITelemetryLoggerExt | undefined,
+		private readonly logger: TelemetryLoggerExt | undefined,
 		idCompressor: IIdCompressor,
 		optionsParam: SharedTreeOptionsInternal,
 	) {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -8,10 +8,7 @@ import type { IFluidHandle, Listenable } from "@fluidframework/core-interfaces/i
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 import { isStableId } from "@fluidframework/id-compressor/internal";
-import {
-	UsageError,
-	type ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils/internal";
+import { UsageError, type TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	FluidClientVersion,
@@ -309,7 +306,7 @@ export function createTreeCheckout(
 		fieldBatchCodec?: FieldBatchCodec;
 		removedRoots?: DetachedFieldIndex;
 		chunkCompressionStrategy?: TreeCompressionStrategy;
-		logger?: ITelemetryLoggerExt;
+		logger?: TelemetryLoggerExt;
 		breaker?: Breakable;
 		disposeForksAfterTransaction?: boolean;
 		codecOptions?: Partial<CodecWriteOptions>;
@@ -528,7 +525,7 @@ export class TreeCheckout implements ITreeCheckout {
 			idCompressor,
 		),
 		/** Optional logger for telemetry. */
-		private readonly logger?: ITelemetryLoggerExt,
+		private readonly logger?: TelemetryLoggerExt,
 		public readonly breaker: Breakable = new Breakable("TreeCheckout"),
 		public readonly disposeForksAfterTransaction = true,
 	) {

--- a/packages/drivers/odsp-driver/src/createFile/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createFile.ts
@@ -15,7 +15,7 @@ import {
 	type IOdspUrlParts,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	loggerToMonitoringContext,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
@@ -55,7 +55,7 @@ const isInvalidFileName = (fileName: string): boolean => {
 export async function createNewFluidFile(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	createNewSummary: ISummaryTree | undefined,
 	epochTracker: EpochTracker,
 	fileEntry: IFileEntry,
@@ -204,7 +204,7 @@ function encodeFilePath(path: string | undefined): string {
 export async function createNewEmptyFluidFile(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	epochTracker: EpochTracker,
 ): Promise<{ itemId: string; fileName: string }> {
 	const filePath = encodeFilePath(newFileInfo.filePath);
@@ -272,7 +272,7 @@ export async function renameEmptyFluidFile(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	odspParts: IOdspUrlParts,
 	requestedFileName: string,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	epochTracker: EpochTracker,
 ): Promise<IRenameFileResponse> {
 	const initialUrl = `${getApiRoot(new URL(odspParts.siteUrl))}/drives/${
@@ -332,7 +332,7 @@ export async function renameEmptyFluidFile(
 export async function createNewFluidFileFromSummary(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	createNewSummary: ISummaryTree,
 	epochTracker: EpochTracker,
 	forceAccessTokenViaAuthorizationHeader: boolean,

--- a/packages/drivers/odsp-driver/src/createFile/createNewContainerOnExistingFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createNewContainerOnExistingFile.ts
@@ -11,7 +11,7 @@ import type {
 	InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -46,7 +46,7 @@ import {
 export async function createNewContainerOnExistingFile(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	fileInfo: IExistingFileInfo,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	createNewSummary: ISummaryTree | undefined,
 	epochTracker: EpochTracker,
 	fileEntry: IFileEntry,

--- a/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
@@ -19,7 +19,7 @@ import {
 } from "@fluidframework/driver-utils/internal";
 import type { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
@@ -205,7 +205,7 @@ function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): IOdspS
 export async function createNewFluidContainerCore<T>(args: {
 	containerSnapshot: IOdspSummaryPayload;
 	getAuthHeader: InstrumentedStorageTokenFetcher;
-	logger: ITelemetryLoggerExt;
+	logger: TelemetryLoggerExt;
 	initialUrl: string;
 	forceAccessTokenViaAuthorizationHeader: boolean;
 	epochTracker: EpochTracker;

--- a/packages/drivers/odsp-driver/src/createFile/index.ts
+++ b/packages/drivers/odsp-driver/src/createFile/index.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 export async function useCreateNewModule<T = void>(
-	odspLogger: ITelemetryLoggerExt,
+	odspLogger: TelemetryLoggerExt,
 	func: (
 		// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 		m: typeof import("./createNewModule.js") /* webpackChunkName: "createNewModule" */,

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -14,7 +14,7 @@ import {
 	type IOdspResolvedUrl,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 	isFluidError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -47,7 +47,7 @@ export const getFileLink = mockify(
 	async (
 		getToken: TokenFetcher<OdspResourceTokenFetchOptions>,
 		resolvedUrl: IOdspResolvedUrl,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): Promise<string> => {
 		const cacheKey = `${resolvedUrl.siteUrl}_${resolvedUrl.driveId}_${resolvedUrl.itemId}`;
 		const maybeFileLinkCacheEntry = fileLinkCache.get(cacheKey);
@@ -120,7 +120,7 @@ export const getFileLink = mockify(
 async function getFileLinkWithLocationRedirectionHandling(
 	getToken: TokenFetcher<OdspResourceTokenFetchOptions>,
 	resolvedUrl: IOdspResolvedUrl,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 ): Promise<string> {
 	// We can have chains of location redirection one after the other, so have a for loop
 	// so that we can keep handling the same type of error. Set max number of redirection to 5.
@@ -165,7 +165,7 @@ async function getFileLinkWithLocationRedirectionHandling(
 async function getFileLinkCore(
 	getToken: TokenFetcher<OdspResourceTokenFetchOptions>,
 	odspUrlParts: IOdspUrlParts,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	fileItem: FileItemLite,
 ): Promise<string> {
 	// ODSP link requires extra call to return link that is resistant to file being renamed or moved to different folder
@@ -262,7 +262,7 @@ const isFileItemLite = (maybeFileItemLite: unknown): maybeFileItemLite is FileIt
 async function getFileItemLite(
 	getToken: TokenFetcher<OdspResourceTokenFetchOptions>,
 	odspUrlParts: IOdspUrlParts,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 ): Promise<FileItemLite> {
 	return PerformanceEvent.timedExecAsync(
 		logger,

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDeltaStorageService.ts
@@ -10,14 +10,14 @@ import type {
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { Queue, emptyMessageStream } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * Implementation of IDocumentDeltaStorageService that will return snapshot ops when fetching messages
  */
 export class LocalOdspDeltaStorageService implements IDocumentDeltaStorageService {
 	constructor(
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private snapshotOps: ISequencedDocumentMessage[],
 	) {}
 

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentService.ts
@@ -14,7 +14,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
 import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { LocalOdspDeltaStorageService } from "./localOdspDeltaStorageService.js";
 import { LocalOdspDocumentStorageService } from "./localOdspDocumentStorageManager.js";
@@ -31,7 +31,7 @@ export class LocalOdspDocumentService
 
 	constructor(
 		private readonly odspResolvedUrl: IOdspResolvedUrl,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly localSnapshot: Uint8Array | string,
 	) {
 		super();

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentServiceFactory.ts
@@ -10,7 +10,7 @@ import type {
 	IResolvedUrl,
 } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { ICacheAndTracker } from "../epochTracker.js";
 import { OdspDocumentServiceFactoryCore } from "../odspDocumentServiceFactoryCore.js";
@@ -25,7 +25,7 @@ import { LocalOdspDocumentService } from "./localOdspDocumentService.js";
  * content directly.
  */
 export class LocalOdspDocumentServiceFactory extends OdspDocumentServiceFactoryCore {
-	private readonly logger: ITelemetryLoggerExt = createOdspLogger();
+	private readonly logger: TelemetryLoggerExt = createOdspLogger();
 
 	constructor(private readonly localSnapshot: Uint8Array | string) {
 		super(
@@ -57,7 +57,7 @@ export class LocalOdspDocumentServiceFactory extends OdspDocumentServiceFactoryC
 
 	protected async createDocumentServiceCore(
 		resolvedUrl: IResolvedUrl,
-		odspLogger: ITelemetryLoggerExt,
+		odspLogger: TelemetryLoggerExt,
 		_cacheAndTrackerArg?: ICacheAndTracker,
 		_clientIsSummarizer?: boolean,
 	): Promise<IDocumentService> {

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
@@ -13,7 +13,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -30,7 +30,7 @@ export class LocalOdspDocumentStorageService extends OdspDocumentStorageServiceB
 	private snapshotTreeId: string | undefined;
 
 	constructor(
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly localSnapshot: Uint8Array | string,
 	) {
 		super(loggerToMonitoringContext(logger).config);

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -16,7 +16,7 @@ import type {
 import { requestOps, streamObserver } from "@fluidframework/driver-utils/internal";
 import type { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
@@ -34,7 +34,7 @@ export class OdspDeltaStorageService {
 		private readonly deltaFeedUrl: string,
 		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
 		private readonly epochTracker: EpochTracker,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {}
 
 	/**
@@ -140,7 +140,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 
 	public constructor(
 		private snapshotOps: ISequencedDocumentMessage[] | undefined,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly batchSize: number,
 		private readonly concurrency: number,
 		private readonly getFromStorage: (

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -21,7 +21,7 @@ import { createGenericNetworkError } from "@fluidframework/driver-utils/internal
 import type { OdspError } from "@fluidframework/odsp-driver-definitions/internal";
 import {
 	type IFluidErrorBase,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import type { Socket } from "socket.io-client";
@@ -67,7 +67,7 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
 	// Map of all existing socket io sockets. [url, tenantId, documentId] -> socket
 	private static readonly socketIoSockets: Map<string, SocketReference> = new Map();
 
-	public static find(key: string, logger: ITelemetryLoggerExt): SocketReference | undefined {
+	public static find(key: string, logger: TelemetryLoggerExt): SocketReference | undefined {
 		const socketReference = SocketReference.socketIoSockets.get(key);
 
 		// Verify the socket is healthy before reusing it
@@ -254,7 +254,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		token: string | null,
 		client: IClient,
 		url: string,
-		telemetryLogger: ITelemetryLoggerExt,
+		telemetryLogger: TelemetryLoggerExt,
 		timeoutMs: number,
 		epochTracker: EpochTracker,
 		socketReferenceKeyPrefix: string | undefined,
@@ -389,7 +389,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		enableMultiplexing: boolean,
 		tenantId: string,
 		documentId: string,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): SocketReference {
 		// eslint-disable-next-line unicorn/no-array-method-this-argument
 		const existingSocketReference = SocketReference.find(key, logger);
@@ -421,7 +421,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		socket: Socket,
 		documentId: string,
 		socketReference: SocketReference,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly enableMultiplexing?: boolean,
 		connectionId?: string,
 	) {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -24,7 +24,7 @@ import type {
 	TokenFetchOptions,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type MonitoringContext,
 	createChildMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
@@ -80,7 +80,7 @@ export class OdspDocumentService
 		getAuthHeader: InstrumentedStorageTokenFetcher,
 		// eslint-disable-next-line @rushstack/no-new-null
 		getWebsocketToken: ((options: TokenFetchOptions) => Promise<string | null>) | undefined,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		cache: IOdspCache,
 		hostPolicy: HostStoragePolicy,
 		epochTracker: EpochTracker,
@@ -128,7 +128,7 @@ export class OdspDocumentService
 		private readonly getWebsocketToken:
 			| ((options: TokenFetchOptions) => Promise<string | null>)
 			| undefined,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly cache: IOdspCache,
 		hostPolicy: HostStoragePolicy,
 		private readonly epochTracker: EpochTracker,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -29,7 +29,7 @@ import {
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 	generateStack,
 	loggerToMonitoringContext,
@@ -107,7 +107,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 	constructor(
 		private readonly odspResolvedUrl: IOdspResolvedUrl,
 		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly fetchFullSnapshot: boolean,
 		private readonly cache: IOdspCache,
 		private readonly hostPolicy: HostStoragePolicyInternal,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -16,7 +16,7 @@ import type {
 	OdspResourceTokenFetchOptions,
 	TokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { type OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic.js";
 import { createOdspUrl } from "./createOdspUrl.js";
@@ -58,7 +58,7 @@ export interface ShareLinkFetcherProps {
  * @beta
  */
 export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private readonly sharingLinkCache = new PromiseCache<string, string>();
 	private readonly shareLinkFetcherProps: ShareLinkFetcherProps | undefined;
 

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -17,7 +17,7 @@ import {
 } from "@fluidframework/driver-utils/internal";
 import type { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type MonitoringContext,
 	PerformanceEvent,
 	loggerToMonitoringContext,
@@ -47,7 +47,7 @@ export class OdspSummaryUploadManager {
 	constructor(
 		private readonly snapshotUrl: string,
 		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly epochTracker: EpochTracker,
 		private readonly relayServiceTenantAndSessionId: () => string | undefined,
 	) {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -47,7 +47,7 @@ import {
 import {
 	type IConfigProvider,
 	type IFluidErrorBase,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 	TelemetryDataTag,
 	createChildLogger,
@@ -347,7 +347,7 @@ export function isOdspResolvedUrl(resolvedUrl: IResolvedUrl): resolvedUrl is IOd
 	return "odspResolvedUrl" in resolvedUrl && resolvedUrl.odspResolvedUrl === true;
 }
 
-export const createOdspLogger = (logger?: ITelemetryBaseLogger): ITelemetryLoggerExt =>
+export const createOdspLogger = (logger?: ITelemetryBaseLogger): TelemetryLoggerExt =>
 	createChildLogger({
 		logger,
 		namespace: "OdspDriver",
@@ -363,7 +363,7 @@ export const createOdspLogger = (logger?: ITelemetryBaseLogger): ITelemetryLogge
  * Storage token can not be empty - if original delegate (tokenFetcher argument) returns null result, exception will be thrown
  */
 export function toInstrumentedOdspStorageTokenFetcher(
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	resolvedUrlParts: IOdspUrlParts,
 	tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
 ): InstrumentedStorageTokenFetcher {
@@ -385,7 +385,7 @@ export function toInstrumentedOdspStorageTokenFetcher(
  * @param returnPlainToken - When true, tokenResponse.token is returned. When false, tokenResponse.authorizationHeader is returned or an authorization header value is created based on tokenResponse.token
  */
 export function toInstrumentedOdspTokenFetcher(
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	resolvedUrlParts: IOdspUrlParts,
 	tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
 	throwOnNullToken: boolean,

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -4,7 +4,7 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 // ISequencedDocumentMessage
 export interface IMessage {
@@ -34,7 +34,7 @@ export class OpsCache {
 
 	constructor(
 		startingSequenceNumber: number,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly cache: ICache,
 		private readonly batchSize: number,
 		private readonly timerGranularity: number,

--- a/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
+++ b/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
@@ -17,7 +17,7 @@ import type {
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	LoggingError,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -28,7 +28,7 @@ export class RetryErrorsStorageAdapter implements IDocumentStorageService, IDisp
 	private _disposed = false;
 	constructor(
 		private readonly internalStorageService: IDocumentStorageService,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {}
 
 	public get policies(): IDocumentStorageServicePolicies | undefined {

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -10,7 +10,7 @@ import {
 	getRetryDelayFromError,
 } from "@fluidframework/driver-utils/internal";
 import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { Odsp409Error } from "./epochTracker.js";
 
@@ -20,7 +20,7 @@ import { Odsp409Error } from "./epochTracker.js";
 export async function runWithRetry<T>(
 	api: () => Promise<T>,
 	callName: string,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	checkDisposed?: () => void,
 ): Promise<T> {
 	let retryAfter = 1000;

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -10,7 +10,7 @@ import type {
 	InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
@@ -48,7 +48,7 @@ export const fetchJoinSession = mockify(
 		urlParts: IOdspUrlParts,
 		path: string,
 		method: "GET" | "POST",
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		getAuthHeader: InstrumentedStorageTokenFetcher,
 		epochTracker: EpochTracker,
 		requestSocketToken: boolean,

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -12,7 +12,7 @@ import { Uint8ArrayToArrayBuffer, Uint8ArrayToString } from "@fluid-internal/cli
 import { assert } from "@fluidframework/core-utils/internal";
 import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { ReadBuffer } from "./ReadBufferUtils.js";
 import { measure } from "./odspUtils.js";
@@ -408,7 +408,7 @@ export class NodeCore {
 	 */
 	protected load(
 		buffer: ReadBuffer,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): {
 		durationStructure: number;
 		durationStrings: number;
@@ -428,7 +428,7 @@ export class NodeCore {
 	 */
 	protected loadStructure(
 		buffer: ReadBuffer,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): IStringElementInternal[] {
 		const stack: NodeTypes[][] = [];
 		const stringsToResolve: IStringElementInternal[] = [];
@@ -532,7 +532,7 @@ export class NodeCore {
 	private loadStrings(
 		buffer: ReadBuffer,
 		stringsToResolve: IStringElementInternal[],
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): void {
 		/**
 		 * Process all the strings at once!
@@ -584,7 +584,7 @@ export class NodeCore {
 export class TreeBuilder extends NodeCore {
 	static load(
 		buffer: ReadBuffer,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): {
 		builder: TreeBuilder;
 		telemetryProps: {

--- a/packages/drivers/replay-driver/src/storageImplementations.ts
+++ b/packages/drivers/replay-driver/src/storageImplementations.ts
@@ -19,7 +19,7 @@ import type {
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import { buildSnapshotTree } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { EmptyDeltaStorageService } from "./emptyDeltaStorageService.js";
 import { ReadDocumentStorageServiceBase } from "./replayController.js";
@@ -176,7 +176,7 @@ export class StaticStorageDocumentServiceFactory implements IDocumentServiceFact
 
 	public async createDocumentService(
 		fileURL: IResolvedUrl,
-		logger?: ITelemetryLoggerExt,
+		logger?: TelemetryLoggerExt,
 		clientIsSummarizer?: boolean,
 	): Promise<IDocumentService> {
 		return new StaticStorageDocumentService(fileURL, this.storage);
@@ -186,7 +186,7 @@ export class StaticStorageDocumentServiceFactory implements IDocumentServiceFact
 	public async createContainer(
 		createNewSummary: ISummaryTree,
 		resolvedUrl: IResolvedUrl,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		clientIsSummarizer?: boolean,
 	): Promise<IDocumentService> {
 		throw new Error("Not implemented");

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -18,7 +18,7 @@ import {
 	requestOps,
 	streamObserver,
 } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils/internal";
 
 import type { DocumentStorageService } from "./documentStorageService.js";
@@ -42,7 +42,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 		private readonly id: string,
 		private readonly deltaStorageService: IDeltaStorageService,
 		private readonly documentStorageService: DocumentStorageService,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {
 		this.logtailSha = documentStorageService.logTailSha;
 	}
@@ -138,7 +138,7 @@ export class DeltaStorageService implements IDeltaStorageService {
 	constructor(
 		private readonly url: string,
 		private readonly restWrapper: RestWrapper,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly getRestWrapper: () => Promise<RestWrapper> = async () => this.restWrapper,
 		private readonly getDeltaStorageUrl: () => string = () => this.url,
 	) {}

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -11,7 +11,7 @@ import type {
 	IConnect,
 } from "@fluidframework/driver-definitions/internal";
 import type { DriverErrorTelemetryProps } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import type { Socket } from "socket.io-client";
 
 import type { IR11sSocketError } from "./errorUtils.js";
@@ -32,7 +32,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection {
 		io: typeof SocketIOClientStatic,
 		client: IClient,
 		url: string,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		timeoutMs = 20000,
 		enableLongPollingDowngrade = true,
 	): Promise<IDocumentDeltaConnection> {
@@ -74,7 +74,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection {
 	private constructor(
 		socket: Socket,
 		documentId: string,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly url: string,
 		enableLongPollingDowngrades?: boolean,
 	) {

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -21,7 +21,7 @@ import {
 	RateLimiter,
 	canRetryOnError,
 } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { PerformanceEvent, wrapError } from "@fluidframework/telemetry-utils/internal";
 
 import type { ICache } from "./cache.js";
@@ -69,7 +69,7 @@ export class DocumentService
 		private deltaStorageUrl: string,
 		private deltaStreamUrl: string,
 		private storageUrl: string,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		protected tokenProvider: ITokenProvider,
 		protected tenantId: string,
 		protected documentId: string,

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -14,7 +14,7 @@ import {
 	DocumentStorageServiceProxy,
 	PrefetchDocumentStorageService,
 } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { ICache } from "./cache.js";
 import type { INormalizedWholeSnapshot } from "./contracts.js";
@@ -34,7 +34,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 	private static loadInternalDocumentStorageService(
 		id: string,
 		manager: GitManager,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
@@ -78,7 +78,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 	constructor(
 		public readonly id: string,
 		public manager: GitManager,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -14,7 +14,7 @@ import {
 	RestLessClient,
 	getAuthorizationTokenFromCredentials,
 } from "@fluidframework/server-services-client";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { PerformanceEvent, numberFromString } from "@fluidframework/telemetry-utils/internal";
 import safeStringify from "json-stringify-safe";
 
@@ -118,7 +118,7 @@ class RouterliciousRestWrapper extends RestWrapper {
 	private readonly retryCounter = new Map<string, number>();
 
 	constructor(
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly rateLimiter: RateLimiter,
 		private readonly fetchRefreshedToken: TokenFetcher,
 		private readonly getAuthorizationHeader: AuthorizationHeaderGetter,
@@ -318,7 +318,7 @@ class RouterliciousRestWrapper extends RestWrapper {
 
 export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
 	private constructor(
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		rateLimiter: RateLimiter,
 		fetchToken: TokenFetcher,
 		getAuthorizationHeader: AuthorizationHeaderGetter,
@@ -342,7 +342,7 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
 	public static load(
 		tenantId: string,
 		tokenFetcher: TokenFetcher,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		rateLimiter: RateLimiter,
 		useRestLess: boolean,
 		baseurl?: string,
@@ -377,7 +377,7 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
 
 export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
 	private constructor(
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		rateLimiter: RateLimiter,
 		fetchToken: TokenFetcher,
 		getAuthorizationHeader: AuthorizationHeaderGetter,
@@ -400,7 +400,7 @@ export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
 
 	public static load(
 		tokenFetcher: TokenFetcher,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		rateLimiter: RateLimiter,
 		useRestLess: boolean,
 		baseurl?: string,
@@ -430,7 +430,7 @@ export function toInstrumentedR11sOrdererTokenFetcher(
 	tenantId: string,
 	documentId: string | undefined,
 	tokenProvider: ITokenProvider,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 ): TokenFetcher {
 	const fetchOrdererToken = async (refreshToken?: boolean): Promise<ITokenResponse> => {
 		return PerformanceEvent.timedExecAsync(
@@ -457,7 +457,7 @@ export function toInstrumentedR11sStorageTokenFetcher(
 	tenantId: string,
 	documentId: string,
 	tokenProvider: ITokenProvider,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 ): TokenFetcher {
 	const fetchStorageToken = async (refreshToken?: boolean): Promise<ITokenResponse> => {
 		return PerformanceEvent.timedExecAsync(

--- a/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
@@ -15,7 +15,7 @@ import type {
 	IWholeSummaryPayload,
 	IWriteSummaryResponse,
 } from "@fluidframework/server-services-client";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { IWholeFlatSnapshot } from "./contracts.js";
 import type { IR11sResponse } from "./restWrapper.js";
@@ -24,7 +24,7 @@ import type { IGitManager } from "./storageContracts.js";
 export class RetriableGitManager implements IGitManager {
 	constructor(
 		private readonly internalGitManager: IGitManager,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {}
 
 	public async getCommits(

--- a/packages/drivers/routerlicious-driver/src/sessionInfoManager.ts
+++ b/packages/drivers/routerlicious-driver/src/sessionInfoManager.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import { getW3CData } from "@fluidframework/driver-base/internal";
 import type { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import type { ISession } from "@fluidframework/server-services-client";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils/internal";
 
 import type { RouterliciousOrdererRestWrapper } from "./restWrapper.js";
@@ -26,7 +26,7 @@ interface IGetSessionInfoParams {
 	documentId: string;
 	tenantId: string;
 	ordererRestWrapper: RouterliciousOrdererRestWrapper;
-	logger: ITelemetryLoggerExt;
+	logger: TelemetryLoggerExt;
 }
 
 export interface IGetSessionInfoResponse {

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -15,7 +15,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import { buildGitTreeHierarchy } from "@fluidframework/driver-utils/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -59,7 +59,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
 	constructor(
 		protected readonly id: string,
 		protected readonly manager: GitManager,
-		protected readonly logger: ITelemetryLoggerExt,
+		protected readonly logger: TelemetryLoggerExt,
 		public readonly policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,

--- a/packages/drivers/routerlicious-driver/src/test/sessionInfoManager.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/sessionInfoManager.spec.ts
@@ -7,10 +7,7 @@ import { strict as assert } from "node:assert";
 
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import { ISession } from "@fluidframework/server-services-client";
-import {
-	MockLogger,
-	type ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils/internal";
+import { MockLogger, type TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 
 import { RouterliciousOrdererRestWrapper } from "../restWrapper.js";
@@ -70,7 +67,7 @@ describe("SessionInfoManager", () => {
 		documentId: string;
 		tenantId: string;
 		ordererRestWrapper: RouterliciousOrdererRestWrapper;
-		logger: ITelemetryLoggerExt;
+		logger: TelemetryLoggerExt;
 		session: ISession | undefined;
 	} {
 		return {

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -20,7 +20,7 @@ import type {
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -57,7 +57,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 	constructor(
 		protected readonly id: string,
 		protected readonly manager: GitManager,
-		protected readonly logger: ITelemetryLoggerExt,
+		protected readonly logger: TelemetryLoggerExt,
 		public readonly policies: IDocumentStorageServicePolicies,
 		private readonly driverPolicies?: IRouterliciousDriverPolicies,
 		private readonly blobCache: ICache<ArrayBufferLike> = new InMemoryCache(),

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -30,7 +30,7 @@ import type {
 	NamedFluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	UsageError,
 	createChildLogger,
 	tagCodeArtifacts,
@@ -105,7 +105,7 @@ export class AgentScheduler
 		return this;
 	}
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	private get clientId(): string {
 		if (this.runtime.attachState === AttachState.Detached) {

--- a/packages/framework/attributor/src/runtimeAttributorDataStoreChannel.ts
+++ b/packages/framework/attributor/src/runtimeAttributorDataStoreChannel.ts
@@ -30,7 +30,7 @@ import {
 	type IRuntimeMessageCollection,
 } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type MonitoringContext,
 	raiseConnectedEvent,
 	createChildMonitoringContext,
@@ -94,7 +94,7 @@ export class RuntimeAttributorDataStoreChannel
 	public visibilityState: VisibilityState;
 	private readonly deferredAttached = new Deferred<void>();
 	private readonly mc: MonitoringContext;
-	public get logger(): ITelemetryLoggerExt {
+	public get logger(): TelemetryLoggerExt {
 		return this.mc.logger;
 	}
 

--- a/packages/framework/presence-runtime/src/runtime/presenceDatastoreManager.ts
+++ b/packages/framework/presence-runtime/src/runtime/presenceDatastoreManager.ts
@@ -32,7 +32,7 @@ import type {
 import type { InboundExtensionMessage } from "@fluidframework/container-runtime-definitions/internal";
 import type { IEmitter } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { objectEntries, TimerManager } from "@fluid-internal/presence-runtime/utils";
 import {
@@ -238,7 +238,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	public constructor(
 		private readonly attendeeId: AttendeeId,
 		private readonly runtime: IEphemeralRuntime,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly events: IEmitter<PresenceEvents>,
 		private readonly presence: Presence,
 		systemWorkspaceDatastore: SystemWorkspaceDatastore,

--- a/packages/framework/presence-runtime/src/runtime/presenceManager.ts
+++ b/packages/framework/presence-runtime/src/runtime/presenceManager.ts
@@ -25,7 +25,7 @@ import type { IEmitter, Listenable } from "@fluidframework/core-interfaces/inter
 import { assert } from "@fluidframework/core-utils/internal";
 import { createSessionId } from "@fluidframework/id-compressor/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import { createChildMonitoringContext } from "@fluidframework/telemetry-utils/internal";
@@ -223,7 +223,7 @@ function setupSubComponents(
 	runtime: IEphemeralRuntime,
 	events: Listenable<PresenceEvents & AttendeesEvents> &
 		IEmitter<PresenceEvents & AttendeesEvents>,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	presence: Presence,
 ): [PresenceDatastoreManager, SystemWorkspace] {
 	const systemWorkspaceDatastore: SystemWorkspaceDatastore = {

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -46,7 +46,7 @@ import {
 	type ThrottlingError,
 } from "@fluidframework/driver-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	GenericError,
 	UsageError,
 	formatTick,
@@ -346,7 +346,7 @@ export class ConnectionManager implements IConnectionManager {
 		public readonly containerDirty: () => boolean,
 		private readonly client: IClient,
 		reconnectAllowed: boolean,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly props: IConnectionManagerFactoryArgs,
 		private maxInitialConnectionAttempts?: number,
 	) {

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -11,7 +11,7 @@ import type { IClient, ISequencedClient } from "@fluidframework/driver-definitio
 import type { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import {
 	type TelemetryEventCategory,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type MonitoringContext,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
@@ -33,7 +33,7 @@ const JoinSignalTimeoutMs = 10000;
  * Constructor parameter type for passing in dependencies needed by the ConnectionStateHandler
  */
 export interface IConnectionStateHandlerInputs {
-	logger: ITelemetryLoggerExt;
+	logger: TelemetryLoggerExt;
 	mc: MonitoringContext;
 	/**
 	 * Log to telemetry any change in state, included to Connecting
@@ -201,7 +201,7 @@ class ConnectionStateHandlerPassThrough
 
 	// #region IConnectionStateHandlerInputs
 
-	public get logger(): ITelemetryLoggerExt {
+	public get logger(): TelemetryLoggerExt {
 		return this.inputs.logger;
 	}
 	public get mc(): MonitoringContext {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -32,7 +32,7 @@ import type {
 	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { ConnectionState } from "./connectionState.js";
 import { loaderCompatDetailsForRuntime } from "./loaderLayerCompatState.js";
@@ -69,7 +69,7 @@ export interface IContainerContextConfig
 	readonly getAttachState: () => AttachState;
 	readonly getConnected: () => boolean;
 	readonly existing: boolean;
-	readonly taggedLogger: ITelemetryLoggerExt;
+	readonly taggedLogger: TelemetryLoggerExt;
 	// This "overrides" IContainerContext.snapshotWithContents to be required but allow `undefined`.
 	readonly snapshotWithContents: IContainerContext["snapshotWithContents"] | undefined;
 }
@@ -136,7 +136,7 @@ export class ContainerContext
 	public readonly getAbsoluteUrl: (relativeUrl: string) => Promise<string | undefined>;
 	public readonly clientDetails: IClientDetails;
 	public readonly existing: boolean;
-	public readonly taggedLogger: ITelemetryLoggerExt;
+	public readonly taggedLogger: TelemetryLoggerExt;
 	public readonly pendingLocalState: unknown;
 	public readonly snapshotWithContents?: ISnapshot;
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -24,7 +24,7 @@ import type {
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import { isInstanceOfISnapshot, UsageError } from "@fluidframework/driver-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { MemoryDetachedBlobStorage } from "./memoryBlobStorage.js";
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService.js";
@@ -107,7 +107,7 @@ export class ContainerStorageAdapter
 	 */
 	public constructor(
 		detachedBlobStorage: MemoryDetachedBlobStorage | undefined,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private loadingGroupIdSnapshotsFromPendingState:
 			| Record<string, SerializedSnapshotInfo>
 			| undefined,
@@ -276,7 +276,7 @@ export class ContainerStorageAdapter
 class BlobOnlyStorage implements IDocumentStorageService {
 	constructor(
 		private readonly detachedStorage: MemoryDetachedBlobStorage | undefined,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {}
 
 	public async createBlob(content: ArrayBufferLike): Promise<ICreateBlobResponse> {

--- a/packages/loader/container-loader/src/debugLogger.ts
+++ b/packages/loader/container-loader/src/debugLogger.ts
@@ -10,7 +10,7 @@ import type {
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type ITelemetryLoggerPropertyBags,
 	createMultiSinkLogger,
 	eventNamespaceSeparator,
@@ -38,7 +38,7 @@ export class DebugLogger implements ITelemetryBaseLogger {
 		namespace: string,
 		baseLogger?: ITelemetryBaseLogger,
 		properties?: ITelemetryLoggerPropertyBags,
-	): ITelemetryLoggerExt {
+	): TelemetryLoggerExt {
 		// Setup base logger upfront, such that host can disable it (if needed)
 		const debug = registerDebug(namespace);
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -36,7 +36,7 @@ import { NonRetryableError, isRuntimeMessage } from "@fluidframework/driver-util
 import {
 	type ITelemetryErrorEventExt,
 	type ITelemetryGenericEventExt,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	DataCorruptionError,
 	DataProcessingError,
 	UsageError,
@@ -133,7 +133,7 @@ function isClientMessage(message: ISequencedDocumentMessage | IDocumentMessage):
  */
 function logIfFalse(
 	condition: boolean,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	event: string | ITelemetryGenericEventExt,
 ): condition is true {
 	if (condition) {
@@ -420,7 +420,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
 	constructor(
 		private readonly serviceProvider: () => IDocumentService | undefined,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly _active: () => boolean,
 		createConnectionManager: (props: IConnectionManagerFactoryArgs) => TConnectionManager,
 	) {

--- a/packages/loader/container-loader/src/error.ts
+++ b/packages/loader/container-loader/src/error.ts
@@ -8,7 +8,7 @@ import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import type { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
 import {
 	type IFluidErrorBase,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	LoggingError,
 	wrapErrorAndLog,
 } from "@fluidframework/telemetry-utils/internal";
@@ -40,7 +40,7 @@ export class ThrottlingWarning
 	public static wrap(
 		error: unknown,
 		retryAfterSeconds: number,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): IThrottlingWarning {
 		const newErrorFn = (errMsg: string): ThrottlingWarning =>
 			new ThrottlingWarning(errMsg, retryAfterSeconds);

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -19,7 +19,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import { runWithRetry } from "@fluidframework/driver-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	GenericError,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -29,7 +29,7 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
 	private internalStorageService: IDocumentStorageService | undefined;
 	constructor(
 		private readonly internalStorageServiceP: Promise<IDocumentStorageService>,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly maxRetries?: number,
 	) {
 		this.internalStorageServiceP

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -20,7 +20,7 @@ import {
 	type IStreamResult,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	MockLogger,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
@@ -36,7 +36,7 @@ describe("Loader", () => {
 		describe("Delta Manager", () => {
 			let clock: SinonFakeTimers;
 			let deltaManager: DeltaManager<ConnectionManager>;
-			let logger: ITelemetryLoggerExt;
+			let logger: TelemetryLoggerExt;
 			let deltaConnection: MockDocumentDeltaConnection;
 			let clientSeqNumber = 0;
 			let emitter: EventEmitter;
@@ -51,7 +51,7 @@ describe("Loader", () => {
 
 			async function startDeltaManager(
 				reconnectAllowed = true,
-				dmLogger: ITelemetryLoggerExt = logger,
+				dmLogger: TelemetryLoggerExt = logger,
 				deltaStorageFactory?: () => IDocumentDeltaStorageService,
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {

--- a/packages/runtime/container-runtime/src/batchTracker.ts
+++ b/packages/runtime/container-runtime/src/batchTracker.ts
@@ -9,14 +9,14 @@ import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
 type BatchTrackerMessage = Pick<ISequencedDocumentMessage, "sequenceNumber">;
 
 export class BatchTracker {
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private startBatchSequenceNumber: number | undefined;
 	private trackedBatchCount: number = 0;
 	private batchProcessingStartTimeStamp: number | undefined;
@@ -75,7 +75,7 @@ export class BatchTracker {
  * Track batch sizes in terms of op counts and processing times
  *
  * @param batchEventEmitter - event emitter which tracks the lifecycle of batch operations
- * @param logger - See {@link @fluidframework/core-interfaces#ITelemetryLoggerExt}
+ * @param logger - See {@link @fluidframework/core-interfaces#TelemetryLoggerExt}
  * @param batchLengthThreshold - threshold for the length of a batch when to send an error event
  * @param batchCountSamplingRate - rate for batches for which to send an event with its characteristics
  */

--- a/packages/runtime/container-runtime/src/blobManager/blobManagerSnapSum.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManagerSnapSum.ts
@@ -7,7 +7,7 @@ import type { IContainerContext } from "@fluidframework/container-definitions/in
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * Information from a snapshot needed to load BlobManager
@@ -58,7 +58,7 @@ const loadV1 = async (
 
 export const toRedirectTable = (
 	blobManagerLoadInfo: IBlobManagerLoadInfo,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 ): Map<string, string> => {
 	const count = blobManagerLoadInfo.ids?.length ?? 0;
 	const redirectTableLength = blobManagerLoadInfo.redirectTable?.length ?? 0;

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -17,7 +17,7 @@ import {
 import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 import {
 	type IEventSampler,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type ISampledTelemetryLogger,
 	createChildLogger,
 	createSampledLogger,
@@ -105,7 +105,7 @@ class OpPerfTelemetry {
 	 */
 	private processedOpSizeForTelemetry = 0;
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	private static readonly OP_LATENCY_SAMPLE_RATE = 500;
 	private readonly opLatencyLogger: ISampledTelemetryLogger;
@@ -151,7 +151,7 @@ class OpPerfTelemetry {
 		/**
 		 * Telemetry logger to write events to.
 		 */
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	) {
 		this.logger = createChildLogger({ logger, namespace: "OpPerf" });
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -152,7 +152,7 @@ import type {
 	IEventSampler,
 	IFluidErrorBase,
 	ITelemetryGenericEventExt,
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -735,7 +735,7 @@ function lastMessageFromMetadata(
  * to understand if/when it is hit.
  * We only want to log this once, to avoid spamming telemetry if we are wrong and these cases are hit commonly.
  */
-export let getSingleUseLegacyLogCallback = (logger: ITelemetryLoggerExt, type: string) => {
+export let getSingleUseLegacyLogCallback = (logger: TelemetryLoggerExt, type: string) => {
 	return (codePath: string): void => {
 		logger.sendTelemetryEvent({
 			eventName: "LegacyMessageFormat",
@@ -4086,7 +4086,7 @@ export class ContainerRuntime
 		/**
 		 * Logger to use for correlated summary events
 		 */
-		summaryLogger?: ITelemetryLoggerExt;
+		summaryLogger?: TelemetryLoggerExt;
 		/**
 		 * True to run garbage collection before summarizing; defaults to true
 		 */
@@ -4295,7 +4295,7 @@ export class ContainerRuntime
 			/**
 			 * Logger to use for logging GC events
 			 */
-			logger?: ITelemetryLoggerExt;
+			logger?: TelemetryLoggerExt;
 			/**
 			 * True to run GC sweep phase after the mark phase
 			 */
@@ -4726,7 +4726,7 @@ export class ContainerRuntime
 	 * @returns failed summarize result (IBaseSummarizeResult) if summary should be failed, undefined otherwise.
 	 */
 	private async shouldFailSummaryOnPendingOps(
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		referenceSequenceNumber: number,
 		minimumSequenceNumber: number,
 		finalAttempt: boolean,
@@ -5236,7 +5236,7 @@ export class ContainerRuntime
 	private async fetchLatestSnapshotAndMaybeClose(
 		targetRefSeq: number,
 		targetAckHandle: string,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): Promise<void> {
 		const fetchedSnapshotRefSeq = await PerformanceEvent.timedExecAsync(
 			logger,

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -13,7 +13,7 @@ import type {
 	IFluidDataStoreChannel,
 } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	TelemetryDataTag,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -58,7 +58,7 @@ export const channelToDataStore = (
 	fluidDataStoreChannel: IFluidDataStoreChannel,
 	internalId: string,
 	channelCollection: ChannelCollection,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 ): IDataStore => new DataStore(fluidDataStoreChannel, internalId, channelCollection, logger);
 
 enum AliasState {
@@ -194,7 +194,7 @@ class DataStore implements IDataStore {
 		private readonly fluidDataStoreChannel: IFluidDataStoreChannel,
 		private readonly internalId: string,
 		private readonly channelCollection: ChannelCollection,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly parentContext = channelCollection.parentContext,
 	) {
 		this.pendingAliases = channelCollection.pendingAliases;

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -6,7 +6,7 @@
 import type { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Deferred, Lazy } from "@fluidframework/core-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -68,7 +68,7 @@ export class DataStoreContexts
 		}
 	});
 
-	private readonly _logger: ITelemetryLoggerExt;
+	private readonly _logger: TelemetryLoggerExt;
 
 	constructor(baseLogger: ITelemetryBaseLogger) {
 		this._logger = createChildLogger({ logger: baseLogger });

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -7,10 +7,7 @@ import { performanceNow, type TypedEventEmitter } from "@fluid-internal/client-u
 import type { IDeltaManagerFull } from "@fluidframework/container-definitions/internal";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type { IContainerRuntimeBaseEvents } from "@fluidframework/runtime-definitions/internal";
-import {
-	type ITelemetryLoggerExt,
-	formatTick,
-} from "@fluidframework/telemetry-utils/internal";
+import { type TelemetryLoggerExt, formatTick } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * DeltaScheduler is responsible for the scheduling of inbound delta queue in cases where there
@@ -55,7 +52,7 @@ export class DeltaScheduler {
 	constructor(
 		private readonly deltaManager: IDeltaManagerFull,
 		private readonly runtimeEventsEmitter: TypedEventEmitter<IContainerRuntimeBaseEvents>,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {
 		this.deltaManager.inbound.on("idle", this.inboundQueueIdle);
 		runtimeEventsEmitter.on("batchBegin", this.batchBegin);

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -19,7 +19,7 @@ import {
 	responseToException,
 } from "@fluidframework/runtime-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	DataProcessingError,
 	type MonitoringContext,
 	PerformanceEvent,
@@ -498,7 +498,7 @@ export class GarbageCollector implements IGarbageCollector {
 			/**
 			 * Logger to use for logging GC events
 			 */
-			logger?: ITelemetryLoggerExt;
+			logger?: TelemetryLoggerExt;
 			/**
 			 * True to run GC sweep phase after the mark phase
 			 */
@@ -605,7 +605,7 @@ export class GarbageCollector implements IGarbageCollector {
 	private async runGC(
 		fullGC: boolean,
 		currentReferenceTimestampMs: number,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): Promise<IGCStats> {
 		// 1. Generate / analyze the runtime's reference graph.
 		// Get the reference graph (gcData) and run GC algorithm to get referenced / unreferenced nodes.
@@ -796,7 +796,7 @@ export class GarbageCollector implements IGarbageCollector {
 	private findAllNodesReferencedBetweenGCs(
 		currentGCData: IGarbageCollectionData,
 		previousGCData: IGarbageCollectionData | undefined,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): string[] | undefined {
 		// If we haven't run GC before there is nothing to do.
 		// No previousGCData, means nothing is unreferenced, and there are no reference state trackers to clear

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -14,7 +14,7 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import type { ReadAndParseBlob } from "@fluidframework/runtime-utils/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	ITelemetryPropertiesExt,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -396,7 +396,7 @@ export interface IGarbageCollector {
 	 */
 	collectGarbage(
 		options: {
-			logger?: ITelemetryLoggerExt;
+			logger?: TelemetryLoggerExt;
 			runSweep?: boolean;
 			fullGC?: boolean;
 		},
@@ -505,7 +505,7 @@ export interface IGarbageCollectorCreateParams {
 	readonly closeFn: (error: ICriticalContainerError) => void;
 
 	readonly gcOptions: IGCRuntimeOptions;
-	readonly baseLogger: ITelemetryLoggerExt;
+	readonly baseLogger: TelemetryLoggerExt;
 	readonly existing: boolean;
 
 	readonly metadata: IContainerRuntimeMetadata | undefined;

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -6,7 +6,7 @@
 import type { Tagged } from "@fluidframework/core-interfaces";
 import type { IGarbageCollectionData } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	type MonitoringContext,
 	generateStack,
 	tagCodeArtifacts,
@@ -350,7 +350,7 @@ export class GCTelemetryTracker {
 		currentGCData: IGarbageCollectionData,
 		previousGCData: IGarbageCollectionData,
 		explicitReferences: Map<string, string[]>,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): void {
 		for (const [nodeId, currentOutboundRoutes] of Object.entries(currentGCData.gcNodes)) {
 			const previousRoutes = previousGCData.gcNodes[nodeId] ?? [];
@@ -395,7 +395,7 @@ export class GCTelemetryTracker {
 	 * Log events that are pending in pendingEventsQueue. This is called after GC runs in the summarizer client
 	 * so that the state of an unreferenced node is updated.
 	 */
-	public async logPendingEvents(logger: ITelemetryLoggerExt): Promise<void> {
+	public async logPendingEvents(logger: TelemetryLoggerExt): Promise<void> {
 		// Events sent come only from the summarizer client. In between summaries, events are pushed to a queue and at
 		// summary time they are then logged.
 		// Events generated:

--- a/packages/runtime/container-runtime/src/inboundBatchAggregator.ts
+++ b/packages/runtime/container-runtime/src/inboundBatchAggregator.ts
@@ -9,7 +9,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	DataCorruptionError,
 	DataProcessingError,
 	extractSafePropertiesFromMessage,
@@ -38,7 +38,7 @@ export class InboundBatchAggregator {
 	constructor(
 		private readonly deltaManager: IDeltaManagerFull,
 		private readonly getClientId: () => string | undefined,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {
 		// Listen for updates and peek at the inbound
 		this.deltaManager.inbound.on("push", this.trackPending);

--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -9,7 +9,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import {
 	DataProcessingError,
 	createChildLogger,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 import { compress } from "lz4js";
 
@@ -25,7 +25,7 @@ import { estimateSocketSize } from "./outbox.js";
  * Use opGroupingManager to group a batch into a singleton batch suitable for compression.
  */
 export class OpCompressor {
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	constructor(logger: ITelemetryBaseLogger) {
 		this.logger = createChildLogger({ logger, namespace: "OpCompressor" });

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -9,7 +9,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	createChildLogger,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 import { decompress } from "lz4js";
 
@@ -40,7 +40,7 @@ export class OpDecompressor {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	private rootMessageContents: any | undefined;
 	private processedCount = 0;
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	constructor(logger: ITelemetryBaseLogger) {
 		this.logger = createChildLogger({ logger, namespace: "OpDecompressor" });

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -8,7 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	createChildLogger,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import type {
@@ -65,7 +65,7 @@ export interface EmptyGroupedBatch {
 
 export class OpGroupingManager {
 	static readonly groupedBatchOp = "groupedBatch";
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	constructor(
 		private readonly config: OpGroupingManagerConfig,

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -11,7 +11,7 @@ import {
 	DataCorruptionError,
 	createChildLogger,
 	extractSafePropertiesFromMessage,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -45,7 +45,7 @@ function isChunkedContents(contents: unknown): contents is IChunkedContents {
 export class OpSplitter {
 	// Local copy of incomplete received chunks.
 	private readonly chunkMap: Map<string, string[]>;
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	constructor(
 		chunks: [string, string[]][],

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -14,7 +14,7 @@ import {
 	UsageError,
 	createChildLogger,
 	type IFluidErrorBase,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import type { ICompressionRuntimeOptions } from "../compressionDefinitions.js";
@@ -194,7 +194,7 @@ export const estimateSocketSize = (batch: OutboundBatch): number => {
  * to support slight variation in semantics for each batch (e.g. support for rebasing or grouping).
  */
 export class Outbox {
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private readonly mainBatch: BatchManager;
 	private readonly blobAttachBatch: BatchManager;
 	private batchRebasesToReport = 5;

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -6,7 +6,7 @@
 import type { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	DataProcessingError,
 	LoggingError,
 	extractSafePropertiesFromMessage,
@@ -366,7 +366,7 @@ export class PendingStateManager implements IDisposable {
 		};
 	}
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	constructor(
 		private readonly stateHandler: IRuntimeStateHandler,

--- a/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
+++ b/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
@@ -5,7 +5,7 @@
 
 import type { ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	TelemetryEventPropertyTypeExt,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -101,7 +101,7 @@ export class SignalTelemetryManager {
 	 */
 	public trackReceivedSignal(
 		envelope: ISignalEnvelope,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		consecutiveReconnects: number,
 	): void {
 		const {

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 import type { SemanticVersion } from "@fluidframework/runtime-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { DataProcessingError } from "@fluidframework/telemetry-utils/internal";
 import { gt, lt, parse } from "semver-ts";
 
@@ -633,7 +633,7 @@ export class DocumentsSchemaController {
 		features: IDocumentSchemaFeatures,
 		private readonly onSchemaChange: (schema: IDocumentSchemaCurrent) => void,
 		info: IDocumentSchemaInfo,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		private readonly disableSchemaUpgrade: boolean,
 	) {
 		// For simplicity, let's only support new schema features for explicit schema control mode

--- a/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
@@ -19,7 +19,7 @@ import type {
 	ISequencedClient,
 } from "@fluidframework/driver-definitions";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	UsageError,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
@@ -135,7 +135,7 @@ export class OrderedClientCollection
 	 * Pointer to end of linked list, for optimized client adds.
 	 */
 	private _youngestClient: LinkNode = this.rootNode;
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 
 	public get count(): number {
 		return this.clientMap.size;
@@ -413,7 +413,7 @@ export class OrderedClientElection
 	}
 
 	constructor(
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly orderedClientCollection: IOrderedClientCollection,
 		/**
 		 * Serialized state from summary or current sequence number at time of load if new.

--- a/packages/runtime/container-runtime/src/summary/summarizerClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerClientElection.ts
@@ -7,7 +7,7 @@ import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
 import type { IClientDetails } from "@fluidframework/driver-definitions";
 import { MessageType } from "@fluidframework/driver-definitions/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type {
 	IOrderedClientElection,
@@ -58,7 +58,7 @@ export class SummarizerClientElection
 	}
 
 	constructor(
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly summaryCollection: IEventProvider<ISummaryCollectionOpEvents>,
 		public readonly clientElection: IOrderedClientElection,
 		private readonly maxOpsSinceLastSummary: number,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -31,7 +31,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import type {
 	ITelemetryErrorEventExt,
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import type {
@@ -90,7 +90,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 	private wipSummarizeCalled: boolean = false;
 	private wipSkipRecursion = false;
 
-	protected readonly logger: ITelemetryLoggerExt;
+	protected readonly logger: TelemetryLoggerExt;
 
 	/**
 	 * Do not call constructor directly.
@@ -664,7 +664,7 @@ export class SummarizerNode implements IRootSummarizerNode {
  * @param config - Configure behavior of summarizer node
  */
 export const createRootSummarizerNode = (
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	summarizeInternalFn: SummarizeInternalFn,
 	changeSequenceNumber: number,
 	referenceSequenceNumber: number | undefined,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
@@ -6,7 +6,7 @@
 import type { SummaryObject } from "@fluidframework/driver-definitions";
 import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	TelemetryDataTag,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -67,7 +67,7 @@ export type ValidateSummaryResult =
 export interface ISummarizerNodeRootContract {
 	startSummary(
 		referenceSequenceNumber: number,
-		summaryLogger: ITelemetryLoggerExt,
+		summaryLogger: TelemetryLoggerExt,
 		latestSummaryRefSeqNum: number,
 	): IStartSummaryResult;
 	validateSummary(): ValidateSummaryResult;

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -24,7 +24,7 @@ import type {
 import type { ISummaryStats } from "@fluidframework/runtime-definitions/internal";
 import type { TelemetryContext } from "@fluidframework/runtime-utils/internal";
 import type {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	ITelemetryLoggerPropertyBag,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -79,7 +79,7 @@ export interface IRefreshSummaryAckOptions {
 	/**
 	 * Telemetry logger to which telemetry events will be forwarded.
 	 */
-	readonly summaryLogger: ITelemetryLoggerExt;
+	readonly summaryLogger: TelemetryLoggerExt;
 }
 
 /**
@@ -157,7 +157,7 @@ export interface ISubmitSummaryOptions extends ISummarizeOptions {
 	/**
 	 * Logger to use for correlated summary events
 	 */
-	readonly summaryLogger: ITelemetryLoggerExt;
+	readonly summaryLogger: TelemetryLoggerExt;
 	/**
 	 * Tells when summary process should be cancelled
 	 */

--- a/packages/runtime/container-runtime/src/summary/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryCollection.ts
@@ -21,7 +21,7 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import {
 	createChildLogger,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 /**
@@ -281,7 +281,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
 		this.deltaManager.off("op", listener);
 	}
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	public constructor(
 		private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
 		logger: ITelemetryBaseLogger,

--- a/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/runningSummarizer.ts
@@ -23,7 +23,7 @@ import {
 	createChildLogger,
 	createChildMonitoringContext,
 	isFluidError,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import { opSize } from "../../opProperties.js";
@@ -432,9 +432,7 @@ export class RunningSummarizer
 	 * but only if they're logging about that same summary.
 	 * @param summaryOpRefSeq - RefSeq number of the summary op, to ensure the log correlation will be correct
 	 */
-	public tryGetCorrelatedLogger = (
-		summaryOpRefSeq: number,
-	): ITelemetryLoggerExt | undefined =>
+	public tryGetCorrelatedLogger = (summaryOpRefSeq: number): TelemetryLoggerExt | undefined =>
 		this.heuristicData.lastAttempt.refSequenceNumber === summaryOpRefSeq
 			? this.mc.logger
 			: undefined;

--- a/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summarizer.ts
@@ -12,7 +12,7 @@ import type { IFluidHandleContext } from "@fluidframework/core-interfaces/intern
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
 import {
 	type IFluidErrorBase,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	LoggingError,
 	UsageError,
 	createChildLogger,
@@ -67,7 +67,7 @@ export class SummarizingWarning
 	static wrap(
 		error: unknown,
 		logged: boolean = false,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 	): SummarizingWarning {
 		const newErrorFn = (errMsg: string): SummarizingWarning =>
 			new SummarizingWarning(errMsg, logged);
@@ -91,7 +91,7 @@ export class Summarizer extends TypedEventEmitter<ISummarizerEvents> implements 
 		return this;
 	}
 
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private runningSummarizer?: RunningSummarizer;
 	private _disposed: boolean = false;
 	private starting: boolean = false;

--- a/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summarizerHeuristics.ts
@@ -4,7 +4,7 @@
  */
 
 import { Timer } from "@fluidframework/core-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type {
 	ISummaryConfigurationHeuristics,
@@ -108,7 +108,7 @@ export class SummarizeHeuristicRunner implements ISummarizeHeuristicRunner {
 		private readonly heuristicData: ISummarizeHeuristicData,
 		private readonly configuration: ISummaryConfigurationHeuristics,
 		trySummarize: (reason: SummarizeReason) => void,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly summarizeStrategies: ISummaryHeuristicStrategy[] = getDefaultSummaryHeuristicStrategies(),
 	) {
 		this.idleTimer = new Timer(this.idleTime, () => this.runSummarize("idle"));

--- a/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryDelayLoadedModule/summaryGenerator.ts
@@ -11,7 +11,7 @@ import { getRetryDelaySecondsFromError } from "@fluidframework/driver-utils/inte
 import { TelemetryContext } from "@fluidframework/runtime-utils/internal";
 import {
 	isFluidError,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 	wrapError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -57,7 +57,7 @@ export class SummaryGenerator extends TypedEventEmitter<ISummarizerEvents> {
 			options: IRefreshSummaryAckOptions,
 		) => Promise<void>,
 		private readonly summaryWatcher: Pick<IClientSummaryWatcher, "watchSummary">,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 	) {
 		super();
 		this.summarizeTimer = new Timer(maxSummarizeTimeoutTime, () =>

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -17,7 +17,7 @@ import type {
 import { assert } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
@@ -96,7 +96,7 @@ export class SummaryManager
 	extends TypedEventEmitter<ISummarizerEvents>
 	implements IDisposable
 {
-	private readonly logger: ITelemetryLoggerExt;
+	private readonly logger: TelemetryLoggerExt;
 	private readonly opsToBypassInitialDelay: number;
 	private readonly initialDelayMs: number;
 	private latestClientId: string | undefined;

--- a/packages/runtime/container-runtime/src/test/fuzz/summarizerFuzzMocks.ts
+++ b/packages/runtime/container-runtime/src/test/fuzz/summarizerFuzzMocks.ts
@@ -16,7 +16,7 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { mergeStats } from "@fluidframework/runtime-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 	raiseConnectedEvent,
 } from "@fluidframework/telemetry-utils/internal";
@@ -286,7 +286,7 @@ class MockConnectedState
 	public connected: boolean = false;
 
 	constructor(
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		public clientId: string,
 	) {
 		super();

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -23,7 +23,7 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import { addBlobToSummary } from "@fluidframework/runtime-utils/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	DataCorruptionError,
 	tagCodeArtifacts,
 } from "@fluidframework/telemetry-utils/internal";
@@ -84,7 +84,7 @@ export function createChannelServiceEndpoints(
 	dirtyFn: () => void,
 	isAttachedAndVisible: () => boolean,
 	storageService: IRuntimeStorageService,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	tree?: ISnapshotTree,
 	extraBlobs?: Map<string, ArrayBufferLike>,
 ): ChannelServiceEndpoints {
@@ -191,7 +191,7 @@ export async function loadChannel(
 	attributes: IChannelAttributes,
 	factory: IChannelFactory,
 	services: ChannelServiceEndpoints,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	channelId: string,
 ): Promise<IChannel> {
 	// Compare snapshot version to collaborative object version

--- a/packages/runtime/datastore/src/channelStorageService.ts
+++ b/packages/runtime/datastore/src/channelStorageService.ts
@@ -8,7 +8,7 @@ import type { IChannelStorageService } from "@fluidframework/datastore-definitio
 import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { getNormalizedObjectStoragePathParts } from "@fluidframework/runtime-utils/internal";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 export class ChannelStorageService implements IChannelStorageService {
 	private static flattenTree(
@@ -30,7 +30,7 @@ export class ChannelStorageService implements IChannelStorageService {
 	constructor(
 		private readonly tree: ISnapshotTree | undefined,
 		private readonly storage: Pick<IRuntimeStorageService, "readBlob">,
-		private readonly logger: ITelemetryLoggerExt,
+		private readonly logger: TelemetryLoggerExt,
 		private readonly extraBlobs?: Map<string, ArrayBufferLike>,
 	) {
 		this.flattenedTree = {};

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -20,7 +20,7 @@ import type {
 	IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	DataProcessingError,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -215,7 +215,7 @@ export class RehydratedLocalChannelContext extends LocalChannelContextBase {
 		runtime: IFluidDataStoreRuntime,
 		dataStoreContext: IFluidDataStoreContext,
 		storageService: IRuntimeStorageService,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		submitFn: (content: unknown, localOpMetadata: unknown) => void,
 		dirtyFn: (address: string) => void,
 		private readonly snapshotTree: ISnapshotTree,
@@ -328,7 +328,7 @@ export class LocalChannelContext extends LocalChannelContextBase {
 		runtime: IFluidDataStoreRuntime,
 		dataStoreContext: IFluidDataStoreContext,
 		storageService: IRuntimeStorageService,
-		logger: ITelemetryLoggerExt,
+		logger: TelemetryLoggerExt,
 		submitFn: (content: unknown, localOpMetadata: unknown) => void,
 		dirtyFn: (address: string) => void,
 	) {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -24,7 +24,7 @@ import type {
 	IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	ThresholdCounter,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
@@ -52,7 +52,7 @@ export class RemoteChannelContext implements IChannelContext {
 	private channel: IChannel | undefined;
 	private readonly services: ChannelServiceEndpoints;
 	private readonly summarizerNode: ISummarizerNodeWithGC;
-	private readonly subLogger: ITelemetryLoggerExt;
+	private readonly subLogger: TelemetryLoggerExt;
 	private readonly thresholdOpsCounter: ThresholdCounter;
 	private static readonly pendingOpsCountThreshold = 1000;
 

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -16,7 +16,7 @@ import {
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ISummarizer } from "@fluidframework/container-runtime/internal";
 import {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
@@ -34,7 +34,7 @@ export interface IDocumentCreatorProps {
 }
 
 export interface IDocumentProps extends IDocumentCreatorProps {
-	logger: ITelemetryLoggerExt | undefined;
+	logger: TelemetryLoggerExt | undefined;
 }
 
 export interface ISummarizeResult {
@@ -45,7 +45,7 @@ export interface ISummarizeResult {
 
 export interface IDocumentLoader {
 	mainContainer: IContainer | undefined;
-	logger: ITelemetryLoggerExt | undefined;
+	logger: TelemetryLoggerExt | undefined;
 	initializeDocument(): Promise<void>;
 	loadDocument(): Promise<IContainer>;
 }

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
@@ -33,7 +33,7 @@ import {
 	SharedMap,
 } from "@fluidframework/map/internal";
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import {
 	ChannelFactoryRegistry,
 	createSummarizerFromFactory,
@@ -127,7 +127,7 @@ export class DocumentMap implements IDocumentLoaderAndSummarizer {
 		return this._dataObjectFactory;
 	}
 	private readonly runtimeFactory: ContainerRuntimeFactoryWithDefaultDataStore;
-	public get logger(): ITelemetryLoggerExt | undefined {
+	public get logger(): TelemetryLoggerExt | undefined {
 		return this.props.logger;
 	}
 	public get mainContainer(): IContainer | undefined {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
@@ -31,7 +31,7 @@ import type { ISharedDirectory } from "@fluidframework/map/internal";
 import { SharedMatrix } from "@fluidframework/matrix/internal";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import {
 	createSummarizerFromFactory,
 	summarizeNow,
@@ -116,7 +116,7 @@ export class DocumentMatrix implements IDocumentLoaderAndSummarizer {
 		return this._mainContainer;
 	}
 
-	public get logger(): ITelemetryLoggerExt | undefined {
+	public get logger(): TelemetryLoggerExt | undefined {
 		return this.props.logger;
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrixPlain.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrixPlain.ts
@@ -32,7 +32,7 @@ import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitio
 import type { ISharedDirectory } from "@fluidframework/map/internal";
 import { SharedMatrix } from "@fluidframework/matrix/internal";
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import {
 	ChannelFactoryRegistry,
 	ITestContainerConfig,
@@ -123,7 +123,7 @@ export class DocumentMatrixPlain implements IDocumentLoaderAndSummarizer {
 		return this._mainContainer;
 	}
 
-	public get logger(): ITelemetryLoggerExt | undefined {
+	public get logger(): TelemetryLoggerExt | undefined {
 		return this.props.logger;
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
@@ -33,7 +33,7 @@ import {
 } from "@fluidframework/map/internal";
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import {
 	createSummarizerFromFactory,
 	summarizeNow,
@@ -114,7 +114,7 @@ export class DocumentMultipleDds implements IDocumentLoaderAndSummarizer {
 		return this._mainContainer;
 	}
 
-	public get logger(): ITelemetryLoggerExt | undefined {
+	public get logger(): TelemetryLoggerExt | undefined {
 		return this.props.logger;
 	}
 

--- a/packages/test/test-service-load/src/FileLogger.ts
+++ b/packages/test/test-service-load/src/FileLogger.ts
@@ -10,7 +10,7 @@ import { type ITelemetryBaseEvent, LogLevel } from "@fluidframework/core-interfa
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	createChildLogger,
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import { pkgName, pkgVersion } from "./packageVersion.js";
@@ -45,7 +45,7 @@ export const createLogger = async (
 		runId: number | undefined;
 	},
 ): Promise<{
-	logger: ITelemetryLoggerExt;
+	logger: TelemetryLoggerExt;
 	flush: () => Promise<void>;
 }> => {
 	const baseLogger = await createInjectedLoggerIfExists();

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -30,7 +30,7 @@ import {
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
 import { toDeltaManagerInternal } from "@fluidframework/runtime-utils/internal";
 import { ITaskManager, TaskManager } from "@fluidframework/task-manager/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { TestConfiguration } from "./testConfigFile.js";
 import { printStatus } from "./utils.js";
@@ -42,7 +42,7 @@ export interface IRunConfig {
 	testConfig: TestConfiguration;
 	verbose: boolean;
 	random: IRandom;
-	logger: ITelemetryLoggerExt;
+	logger: TelemetryLoggerExt;
 	loaderConfig?: ILoaderOptions;
 }
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -21,7 +21,7 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/in
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import { getRetryDelayFromError } from "@fluidframework/driver-utils/internal";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
-import { GenericError, ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { GenericError, TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { getRequiredPendingLocalState } from "@fluidframework/test-utils/internal";
 import commander from "commander";
 
@@ -579,7 +579,7 @@ async function scheduleOffline(
 
 async function setupOpsMetrics(
 	container: IContainer,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	progressIntervalMs: number,
 	testRuntime: IFluidDataStoreRuntime,
 ): Promise<() => void> {

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -7,7 +7,7 @@ import child_process from "child_process";
 
 import { ITestDriver } from "@fluid-internal/test-driver-definitions";
 import {
-	ITelemetryLoggerExt,
+	TelemetryLoggerExt,
 	TelemetryDataTag,
 } from "@fluidframework/telemetry-utils/internal";
 import ps from "ps-node";
@@ -34,7 +34,7 @@ export async function stressTest(
 		createTestId: boolean;
 		testUsers: TestUsers | undefined;
 		profileName: string;
-		logger: ITelemetryLoggerExt;
+		logger: TelemetryLoggerExt;
 		outputDir: string;
 	},
 ): Promise<void> {
@@ -167,7 +167,7 @@ export async function stressTest(
  */
 function setupTelemetry(
 	process: child_process.ChildProcess,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	runId: number,
 	username: string | undefined,
 ): void {
@@ -216,7 +216,7 @@ function setupTelemetry(
 
 function setupDataTelemetry(
 	process: child_process.ChildProcess,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	runId: number,
 	username?: string,
 ): void {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -25,7 +25,7 @@ import {
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { LocalCodeLoader } from "@fluidframework/test-utils/internal";
 import { OdspTokenManager } from "@fluidframework/tool-utils/internal";
 
@@ -55,7 +55,7 @@ export async function initialize(
 	seed: number,
 	testConfig: TestConfiguration,
 	verbose: boolean,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	requestedTestId?: string,
 ): Promise<string> {
 	const random = makeRandom(seed);

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -7,7 +7,7 @@ import type {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import {
 	createContext,
 	type Dispatch,
@@ -24,15 +24,15 @@ import {
  * receives; it should only pass them to the logger provided via {@link DevtoolsPanelProps.usageTelemetryLogger | the
  * usageTelemetryLogger prop for DevtoolsPanel} instead (if any).
  */
-export const LoggerContext = createContext<ITelemetryLoggerExt | undefined>(undefined);
+export const LoggerContext = createContext<TelemetryLoggerExt | undefined>(undefined);
 
 /**
- * Gets the {@link @fluidframework/telemetry-utils#ITelemetryLoggerExt} provided through an {@link LoggerContext}.
+ * Gets the {@link @fluidframework/telemetry-utils#TelemetryLoggerExt} provided through an {@link LoggerContext}.
  *
  * @returns
  * The logger from the context, or undefined is no logger was provided.
  */
-export function useLogger(): ITelemetryLoggerExt | undefined {
+export function useLogger(): TelemetryLoggerExt | undefined {
 	return useContext(LoggerContext);
 }
 

--- a/packages/tools/fluid-runner/src/exportFile.ts
+++ b/packages/tools/fluid-runner/src/exportFile.ts
@@ -13,7 +13,7 @@ import {
 } from "@fluidframework/container-loader/internal";
 import { createLocalOdspDocumentServiceFactory } from "@fluidframework/odsp-driver/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -114,7 +114,7 @@ export async function exportFile(
 export async function createContainerAndExecute(
 	localOdspSnapshot: string | Uint8Array,
 	fluidFileConverter: IFluidFileConverter,
-	logger: ITelemetryLoggerExt,
+	logger: TelemetryLoggerExt,
 	options?: string,
 	timeout?: number,
 	disableNetworkFetch: boolean = false,

--- a/packages/tools/fluid-runner/src/logger/loggerUtils.ts
+++ b/packages/tools/fluid-runner/src/logger/loggerUtils.ts
@@ -6,7 +6,7 @@
 import * as fs from "fs";
 
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -15,7 +15,7 @@ import { type IFileLogger, type ITelemetryOptions, OutputFormat } from "./fileLo
 import { JSONFileLogger } from "./jsonFileLogger.js";
 
 /**
- * Create an {@link @fluidframework/telemetry-utils#ITelemetryLoggerExt} wrapped around provided {@link IFileLogger}.
+ * Create an {@link @fluidframework/telemetry-utils#TelemetryLoggerExt} wrapped around provided {@link IFileLogger}.
  *
  * @remarks
  *
@@ -25,13 +25,13 @@ import { JSONFileLogger } from "./jsonFileLogger.js";
  *
  * Note: if an output format is not supplied, default is JSON.
  *
- * @returns Both the `IFileLogger` implementation and `ITelemetryLoggerExt` wrapper to be called.
+ * @returns Both the `IFileLogger` implementation and `TelemetryLoggerExt` wrapper to be called.
  * @internal
  */
 export function createLogger(
 	filePath: string,
 	options?: ITelemetryOptions,
-): { logger: ITelemetryLoggerExt; fileLogger: IFileLogger } {
+): { logger: TelemetryLoggerExt; fileLogger: IFileLogger } {
 	const fileLogger =
 		options?.outputFormat === OutputFormat.CSV
 			? new CSVFileLogger(filePath, options?.eventsPerFlush, options?.defaultProps)

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -40,7 +40,7 @@ import {
 import { convertToSummaryTreeWithStats } from "@fluidframework/runtime-utils/internal";
 import { FluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
-	type ITelemetryLoggerExt,
+	type TelemetryLoggerExt,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -184,7 +184,7 @@ class Document {
 	private documentSeqNumber = 0;
 	private from: number = -1;
 	private snapshotFileName: string = "";
-	private docLogger: ITelemetryLoggerExt;
+	private docLogger: TelemetryLoggerExt;
 	private originalSummarySeqs: number[];
 
 	public constructor(
@@ -201,7 +201,7 @@ class Document {
 		return this.from;
 	}
 
-	public get logger(): ITelemetryLoggerExt {
+	public get logger(): TelemetryLoggerExt {
 		return this.docLogger;
 	}
 

--- a/packages/utils/telemetry-utils/src/internal.ts
+++ b/packages/utils/telemetry-utils/src/internal.ts
@@ -102,16 +102,3 @@ export type {
 } from "./telemetryTypesUndeprecated.js";
 export { TelemetryEventBatcher } from "./telemetryEventBatcher.js";
 export { allowIncompatibleLayersKey, validateLayerCompatibility } from "./layerCompatError.js";
-
-import type { TelemetryLoggerExt } from "./telemetryTypes.js";
-
-/**
- * Renamed version of TelemetryLoggerExt for convenience of internal use.
- * Where "`ITelemetryLoggerExt`" is exposed in customer API surface, true
- * `ITelemetryLoggerExt` (that is an erased type) must be used. To access
- * use `@fluidframework/telemetry-utils/legacy` import spec. All internal
- * usages should be promoted to `TelemetryLoggerExt` naming.
- *
- * @internal
- */
-export type ITelemetryLoggerExt = TelemetryLoggerExt;

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -13,7 +13,7 @@ import type {
 import { LogLevel } from "@fluidframework/core-interfaces";
 import type { InternalCoreInterfacesUtilityTypes } from "@fluidframework/core-interfaces/internal";
 
-import type { ITelemetryLoggerExt as ITelemetryLoggerExtInternal } from "@fluidframework/telemetry-utils/internal";
+import type { TelemetryLoggerExt as TelemetryLoggerExtInternal } from "@fluidframework/telemetry-utils/internal";
 import type { ITelemetryLoggerExt as ITelemetryLoggerExtExternal } from "@fluidframework/telemetry-utils/legacy";
 
 import { mixinMonitoringContext } from "../config.js";
@@ -35,12 +35,12 @@ function assertIdenticalTypes<T, U>(
 }
 
 /**
- * This is exported but never called - tests that internal and external ITelemetryLoggerExt types are identical.
+ * This is exported but never called - tests that internal TelemetryLoggerExt and external ITelemetryLoggerExt types are identical.
  * At this time the only difference allowed is for the external version to have `@deprecated` tags on it methods.
  * To be removed when external type is erased and the types are permitted to diverge.
  */
 export function checkIdenticalLoggers(
-	internal: ITelemetryLoggerExtInternal,
+	internal: TelemetryLoggerExtInternal,
 	external: ITelemetryLoggerExtExternal,
 ): void {
 	assertIdenticalTypes(internal, external);


### PR DESCRIPTION
## Description

This change is a follow up to #26912 that introduced the new internal `TelemetryLoggerExt` interface. Said interface can be used to replace calls to the internal `ITelemetryLoggerExt`

## Breaking Change

This is a necessary change to enable this PR to be merged: #27476

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The change is just a naming one, no functionality was affected

Fixes: [AB#74860](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74860)
