### PR TITLE
Bump eslint-config-fluid version to 13.0

### DIFF
--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "12.0.0",
+	"version": "13.0.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
This is a version bump for the changes in #27482 which add TypeBox import pattern syntax exclusions.