### PR TITLE
test(tree): Re-enable TableSchema benchmarks

### DIFF
--- a/packages/dds/tree/src/test/tableSchema.bench.ts
+++ b/packages/dds/tree/src/test/tableSchema.bench.ts
@@ -102,10 +102,8 @@ function runBenchmarks(options: BenchmarkConfig): void {
  * Note: These benchmarks are designed to closely match the SharedMatrix benchmarks in the `matrix` package.
  * If you modify or add tests here, consider updating the corresponding SharedMatrix benchmarks as well
  * to ensure consistency and comparability between the two implementations.
- *
- * TODO: AB#71782: Investigate why these tests are so slow / possibly contain cross-test contamination and address those issue, then re-enable these tests.
  */
-describe.skip("TableSchema Benchmarks", () => {
+describe("TableSchema Benchmarks", () => {
 	configureBenchmarkHooks();
 
 	// The value to be set in the cells of the tree.


### PR DESCRIPTION
These benchmarks were disabled due to the memory leak addressed in #27434. Execution of these tests should no longer cause cross-suite memory pollution.

[AB#71782](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/71782)