### PR TITLE
Opt text-editor example app into chunkedForest

### DIFF
--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -27,10 +27,14 @@ import {
 // eslint-disable-next-line import-x/no-internal-modules
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 import { SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
-import { asAlpha, type TreeViewAlpha } from "@fluidframework/tree/alpha";
+import {
+	asAlpha,
+	configuredSharedTreeAlpha,
+	ForestTypeOptimized,
+	type TreeViewAlpha,
+} from "@fluidframework/tree/alpha";
 // eslint-disable-next-line import-x/no-internal-modules
 import { FormattedTextAsTree, TextAsTree } from "@fluidframework/tree/internal";
-import { SharedTree } from "@fluidframework/tree/legacy";
 import type { IFluidContainer } from "fluid-framework";
 // eslint-disable-next-line import-x/no-internal-modules, import-x/no-unassigned-import
 import "quill/dist/quill.snow.css";
@@ -57,6 +61,15 @@ function getTinyliciousEndpoint(): string {
 
 	return `http://localhost:${tinyliciousPort}`;
 }
+
+/**
+ * SharedTree configured to use the optimized "chunked" forest.
+ * @remarks
+ * The text domain stores text as long sequences of single-character nodes, which the chunked
+ * forest keeps in compact uniform chunks rather than one allocation per character. This opts the
+ * text editor into that in-memory representation instead of the default reference (object) forest.
+ */
+const SharedTree = configuredSharedTreeAlpha({ forest: ForestTypeOptimized });
 
 const containerSchema = {
 	initialObjects: {

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -64,10 +64,6 @@ function getTinyliciousEndpoint(): string {
 
 /**
  * SharedTree configured to use the optimized "chunked" forest.
- * @remarks
- * The text domain stores text as long sequences of single-character nodes, which the chunked
- * forest keeps in compact uniform chunks rather than one allocation per character. This opts the
- * text editor into that in-memory representation instead of the default reference (object) forest.
  */
 const SharedTree = configuredSharedTreeAlpha({ forest: ForestTypeOptimized });
 


### PR DESCRIPTION
## Summary

The text domain stores text as a sequence of single-character string nodes. Chunked ("optimized") forest packs these nodes into uniform chunks instead of one object allocation per character. This PR opts the text-editor example app into that forest. The app's single `SharedTree` holds both `plainText` and `formattedText`, and forest type is a per-tree option, so both are covered.

## Reviewer Guidance
The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-guidelines#guidelines).