### PR TITLE
build: migrate base-image mirror to anonymous-pull fluidmirror (eastus2)

### DIFF
--- a/tools/pipelines/README.md
+++ b/tools/pipelines/README.md
@@ -8,9 +8,9 @@ releasing the Fluid Framework.
 The `server-*` pipelines run on a 1ES build pool whose network isolation blocks egress to Docker
 Hub, so each server Dockerfile makes its base-image registry overridable via
 `ARG BASE_IMAGE_REGISTRY` and CI overrides it to a mirrored copy on a public-accessible ACR
-(`fluidpublicmirror-ccbba5fhdscnchft.azurecr.io`; the suffix is ACR's Domain Name Label (DNL)
+(`fluidmirror-a5dqhgefbwhmbtag.azurecr.io`; the suffix is ACR's Domain Name Label (DNL)
 hash, added to the login-server FQDN to prevent subdomain-takeover attacks — `az acr` CLI
-commands still take the bare registry name `fluidpublicmirror`). The same mirror is used by both
+commands still take the bare registry name `fluidmirror`). The same mirror is used by both
 the `internal` and `public` ADO projects. Local builds default to Docker Hub and need no changes.
 
 ```dockerfile
@@ -35,10 +35,10 @@ so no credentials are needed for the base-image pulls.
    ```
 
 2. Import it into the mirror. The command requires permission to perform
-   `Microsoft.ContainerRegistry/registries/importImage/action` on `fluidpublicmirror` (held by the
+   `Microsoft.ContainerRegistry/registries/importImage/action` on `fluidmirror` (held by the
    `Contributor` role, but **not** by `AcrPull`):
    ```bash
-   az acr import --name fluidpublicmirror \
+   az acr import --name fluidmirror \
      --source "docker.io/library/node@<new digest>" \
      --image  "mirror/docker/library/node:<new tag>"
    ```

--- a/tools/pipelines/README.md
+++ b/tools/pipelines/README.md
@@ -23,11 +23,8 @@ build-arg automatically via its `baseImageRegistry` parameter, which defaults to
 FQDN. Callers can override it if they need a different mirror (e.g. for testing).
 
 The mirror namespace `mirror/docker/library/<image>` is byte-identical to Docker Hub's path, so the
-same Dockerfile reference works against either registry. Anonymous pull is disabled on the mirror,
-so credentials for the `Fluid Public Mirror Container Registry` ADO service connection are flowed
-into the docker build step via `templateContext.authenticatedContainerRegistries` in
-[`templates/build-docker-service.yml`](./templates/build-docker-service.yml). Each ADO project has
-its own service connection (same name) backed by its own AcrPull-only service principal.
+same Dockerfile reference works against either registry. Anonymous pull is enabled on the mirror,
+so no credentials are needed for the base-image pulls.
 
 ### Upgrading a pinned base image
 

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -99,7 +99,7 @@ parameters:
   # internal and public 1ES build pools (egress to docker.io is blocked by network isolation policies).
   - name: baseImageRegistry
     type: string
-    default: 'fluidpublicmirror-ccbba5fhdscnchft.azurecr.io/mirror/docker'
+    default: 'fluidmirror-a5dqhgefbwhmbtag.azurecr.io/mirror/docker'
 
   # If the build is running for a test branch
   - name: testBuild

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -600,16 +600,11 @@ extends:
                 pnpm store prune
 
         templateContext:
-          # 'Fluid Public Mirror Container Registry' is required on every run for base-image pulls
-          # (anonymous pull disabled). The push connection $(containerRegistryConnection) is only
-          # added when pushing in the internal project (it's empty in the public project).
+          # The push connection $(containerRegistryConnection) is only added when pushing in the
+          # internal project (it's empty in the public project).
           ${{ if and(eq(parameters.shouldPushDockerImage, true), eq(variables['System.TeamProject'], 'internal')) }}:
             authenticatedContainerRegistries:
             - serviceConnection: $(containerRegistryConnection)
-            - serviceConnection: 'Fluid Public Mirror Container Registry'
-          ${{ else }}:
-            authenticatedContainerRegistries:
-            - serviceConnection: 'Fluid Public Mirror Container Registry'
           outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
           - ${{ if eq(parameters.pack, true) }}:


### PR DESCRIPTION
## Description

Switches the `server-*` base-image mirror from `fluidpublicmirror` (westus2, AcrPull
service connections) to a new ACR `fluidmirror` (eastus2, anonymous pull). This:

- **Restores cross-fork PR support for the `server-*` pipelines.** Cross-fork PRs are
  blocked from accessing service-connection secrets, which silently caused the Docker
  build step to fall back to anonymous pull and 401 against the previously-locked-down
  ACR. PR #27445 (and any future server-* PR from a fork) will pass CI again.
- **Removes per-pipeline `'Fluid Public Mirror Container Registry'` service-connection
  wiring** from `templates/build-docker-service.yml`. The push-side service connection
  (`$(containerRegistryConnection)`) is unchanged.
- **Aligns mirror region with the 1ES build pools** (all in eastus2) so legitimate CI
  egress is free same-region transfer instead of westus2-to-eastus2 cross-region. A
  Cost Management budget on the new resource group provides an abuse tripwire.

Operational details (anonymous-pull approval from OpSec, ACR config, Cost Management
budget) are tracked in [AB#74558](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74558). No Dockerfile changes — base-image digest pins are
preserved byte-for-byte in the new mirror.

The old `fluidpublicmirror` ACR will be torn down in a follow-up after this soaks on
`main`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

End-to-end verification is the `server-*` pipeline runs on this PR — they exercise
the exact same Docker build step that's been failing under network isolation.
