### PR TITLE
tools: update presence code ownership paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@
 /experimental/dds/tree/src                     @microsoft/fluid-cr-tree
 
 # presence source
-/packages/framework/presence/src               @microsoft/fluid-cr-presence
+/packages/framework/presence*/src               @microsoft/fluid-cr-presence
 
 # Fluid Devtools source
 /packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools


### PR DESCRIPTION
since #26994 refactor split presence logic among several `presence*` named package paths