### PR TITLE
test(tree): speed up createTableTree test setup

### DIFF
--- a/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
+++ b/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
@@ -119,7 +119,7 @@ export function createTableTree({ tableSize, initialCellValue }: TableTreeOption
 	table.insertColumns({ index: 0, columns });
 
 	// Pre populate each row's cells at construction time so the entire dense table is initialized
-	// by a single `insertRows` op. O(n)
+	// by a single `insertRows` op.
 	const columnIds = table.columns.map((column) => column.id);
 	const rows = Array.from({ length: tableSize }, () => {
 		const cells: Record<string, string> = {};

--- a/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
+++ b/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
@@ -118,28 +118,19 @@ export function createTableTree({ tableSize, initialCellValue }: TableTreeOption
 	const columns = Array.from({ length: tableSize }, () => new Column({}));
 	table.insertColumns({ index: 0, columns });
 
-	const rows = Array.from(
-		{ length: tableSize },
-		() =>
-			new Row({
-				cells: {},
-			}),
-	);
-	table.insertRows({ index: 0, rows });
-
-	if (initialCellValue !== undefined) {
-		for (const row of table.rows) {
-			for (const column of table.columns) {
-				table.setCell({
-					key: {
-						column,
-						row,
-					},
-					cell: initialCellValue,
-				});
+	// Pre populate each row's cells at construction time so the entire dense table is initialized
+	// by a single `insertRows` op. O(n)
+	const columnIds = table.columns.map((column) => column.id);
+	const rows = Array.from({ length: tableSize }, () => {
+		const cells: Record<string, string> = {};
+		if (initialCellValue !== undefined) {
+			for (const columnId of columnIds) {
+				cells[columnId] = initialCellValue;
 			}
 		}
-	}
+		return new Row({ cells });
+	});
+	table.insertRows({ index: 0, rows });
 
 	// Configure event listeners
 	const cleanUpEventHandler = Tree.on(table, "treeChanged", () => {});


### PR DESCRIPTION
## Summary
Optimizes dense-table construction in the tableSchema benchmark test utility. Instead of inserting empty rows and then issuing one `setCell` op per cell, each row is now built with its cells pre-populated and the whole table is inserted with a single `insertRows` op.

Tested specifically against tableSchema memory benchmarks which run ~8 minutes faster.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
