### PR TITLE
Add same oclif->aws-sdk overrides in build-tools publish install as in the root workspace

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -80,7 +80,14 @@ jobs:
                 echo "Creating package.json with npm overrides"
 
                 # Manual overrides - add new entries here as needed, using same syntax supported by the pnpm overrides field
-                manual_overrides='{}'
+                # oclif includes some AWS-related features, but we don't use them, so we drop those transitive
+                # @aws-sdk dependencies. These deps release very frequently and a new release can break the
+                # lockfile-less install here (e.g. a new @aws-sdk/* version that can't be resolved from the feed).
+                # Keep in sync with the same overrides in the root pnpm-workspace.yaml / build-tools package.json.
+                manual_overrides='{
+                  "oclif>@aws-sdk/client-cloudfront": "-",
+                  "oclif>@aws-sdk/client-s3": "-"
+                }'
                 # Build overrides for local tarballs so interdependencies resolve correctly
                 tarball_overrides='{}'
                 for tgz in *.tgz; do


### PR DESCRIPTION
## Description

Client CI recently started failing at build-tools install time due to some aws-sdk dependencies publishing a new package version that was not available in our internal feeds due to known quarantining policies.

[AB#73628](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73628) tracks converting the installation touched in this PR to use a proper lockfile, but in the meantime we already have longstanding overrides in the root workspace to slim down the install tree of transitive dependencies of oclif, and it makes sense to replicate those overrides here to minimize impact for problems like this in the future.