### PR TITLE
feat(driver): validate Loader compatibility with Driver across the boundary

### DIFF
--- a/.changeset/few-nights-juggle.md
+++ b/.changeset/few-nights-juggle.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/local-driver": minor
+"@fluidframework/odsp-driver": minor
+"__section": feature
+---
+New ILayerCompatSupportRequirements property on LocalDocumentServiceFactory and OdspDocumentServiceFactoryCore
+
+A new optional property, `ILayerCompatSupportRequirements`, has been added to `LocalDocumentServiceFactory` and `OdspDocumentServiceFactoryCore`.
+
+The Driver layer uses this property to publish the requirements that the Loader layer must meet to be compatible with it. Because the Driver has no reference to the Loader, it cannot validate the Loader directly; instead the Loader reads these requirements and validates itself against them on the Driver's behalf. This enables the Loader / Driver compatibility check to run in both directions.

--- a/.changeset/few-nights-juggle.md
+++ b/.changeset/few-nights-juggle.md
@@ -5,6 +5,6 @@
 ---
 New ILayerCompatSupportRequirements property on LocalDocumentServiceFactory and OdspDocumentServiceFactoryCore
 
-A new optional property, `ILayerCompatSupportRequirements`, has been added to `LocalDocumentServiceFactory` and `OdspDocumentServiceFactoryCore`.
+A new optional property, `ILayerCompatSupportRequirements`, has been added to [`LocalDocumentServiceFactory`](https://fluidframework.com/docs/api/local-driver/localdocumentservicefactory-class) and [`OdspDocumentServiceFactoryCore`](https://fluidframework.com/docs/api/odsp-driver/odspdocumentservicefactorycore-class).
 
 The Driver layer uses this property to publish the requirements that the Loader layer must meet to be compatible with it. Because the Driver has no reference to the Loader, it cannot validate the Loader directly; instead the Loader reads these requirements and validates itself against them on the Driver's behalf. This enables the Loader / Driver compatibility check to run in both directions.

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -43,6 +43,7 @@ flowchart
 
     %% Validation relationships
     Loader -.->|validates| Driver
+    Driver -.->|validates| Loader
     Loader -.->|validates| Runtime
     Runtime -.->|validates| Loader
     Runtime -.->|validates| DataStore
@@ -58,9 +59,11 @@ flowchart
 
 ### Loader ↔ Driver Boundary
 
-- **Validator:** Loader validates Driver
+- **Validator:** Both directions
+    - Loader validates Driver during container creation
+    - Driver validates Loader during container creation
 - **When:** During container creation (before connection established)
-> Note: Driver doesn't validate Loader because there are no interacts from Driver to Loader. So, there isn't a need to maintain compatibility in that direction.
+> Note: Unlike the other boundaries, both validations are performed by the Loader. The Driver has no reference to the Loader, so it cannot run the validation itself. Instead, the Driver publishes the requirements the Loader must meet (via `ILayerCompatSupportRequirements`, exposed on its `IDocumentServiceFactory`), and the Loader validates itself against them on the Driver's behalf.
 
 ### Loader ↔ Runtime Boundary
 
@@ -87,6 +90,8 @@ The incompatibilities between the layers are detected as follows:
 - **Loader ↔ Driver** and **Loader ↔ Runtime**: Incompatibility is detected during container create / load. If incompatibility is detected, a `FluidErrorTypes.layerIncompatibilityError` error is thrown, failing the container creation / load.
 - **Runtime ↔ DataStore**: Incompatibility is detected during data store create / load. If incompatibility is detected, a `FluidErrorTypes.layerIncompatibilityError` error is thrown, failing the data store creation / load.
   If the data store is being created / loaded during container create / load, that will also throw a `FluidErrorTypes.layerIncompatibilityError` error, failing the container creation / load.
+
+> Note: Even with these compatibility policies and windows in place, there may be clients running layers older than the versions in which compatibility validation was introduced. Such a layer does not provide compatibility details, so validation treats it leniently and does not fail it on that basis, preserving backward compatibility. If that old layer is paired with a newer layer in a combination that is in fact incompatible — for example, where a layer compat feature has since been enabled by default and the corresponding back-compat code removed — the interaction may still fail. In that case it does not surface as a `FluidErrorTypes.layerIncompatibilityError`; instead it fails in that feature's own failure mode (whatever error the specific feature surfaces).
 
 #### Telemetry
 
@@ -139,6 +144,7 @@ These support windows are enforced through the compatibility validation system d
 - Stream ops from ordering service
 - Implement service-specific protocols
 
+**Validates:** Loader layer (performed by the Loader on the Driver's behalf)
 **Validated By:** Loader layer
 
 ### 2. Loader Layer
@@ -158,7 +164,7 @@ These support windows are enforced through the compatibility validation system d
 - Coordinate between Driver and Runtime layers
 
 **Validates:** Driver and Runtime layers
-**Validated By:** Runtime layer
+**Validated By:** Runtime and Driver layers
 
 ### 3. Runtime Layer
 

--- a/LayerCompatibility.md
+++ b/LayerCompatibility.md
@@ -63,7 +63,10 @@ flowchart
     - Loader validates Driver during container creation
     - Driver validates Loader during container creation
 - **When:** During container creation (before connection established)
-> Note: Unlike the other boundaries, both validations are performed by the Loader. The Driver has no reference to the Loader, so it cannot run the validation itself. Instead, the Driver publishes the requirements the Loader must meet (via `ILayerCompatSupportRequirements`, exposed on its `IDocumentServiceFactory`), and the Loader validates itself against them on the Driver's behalf.
+
+> Note: Unlike the other boundaries, both validations are performed by the Loader.
+> The Driver has no reference to the Loader, so it cannot run the validation itself.
+> Instead, the Driver publishes the requirements the Loader must meet (via `ILayerCompatSupportRequirements`, exposed on its `IDocumentServiceFactory`), and the Loader validates itself against them on the Driver's behalf.
 
 ### Loader ↔ Runtime Boundary
 
@@ -91,7 +94,10 @@ The incompatibilities between the layers are detected as follows:
 - **Runtime ↔ DataStore**: Incompatibility is detected during data store create / load. If incompatibility is detected, a `FluidErrorTypes.layerIncompatibilityError` error is thrown, failing the data store creation / load.
   If the data store is being created / loaded during container create / load, that will also throw a `FluidErrorTypes.layerIncompatibilityError` error, failing the container creation / load.
 
-> Note: Even with these compatibility policies and windows in place, there may be clients running layers older than the versions in which compatibility validation was introduced. Such a layer does not provide compatibility details, so validation treats it leniently and does not fail it on that basis, preserving backward compatibility. If that old layer is paired with a newer layer in a combination that is in fact incompatible — for example, where a layer compat feature has since been enabled by default and the corresponding back-compat code removed — the interaction may still fail. In that case it does not surface as a `FluidErrorTypes.layerIncompatibilityError`; instead it fails in that feature's own failure mode (whatever error the specific feature surfaces).
+> Note: Even with these compatibility policies and windows in place, there may be clients running layers older than the versions in which compatibility validation was introduced.
+> Such a layer does not provide compatibility details, so validation treats it leniently and does not fail it on that basis, preserving backward compatibility.
+> If that old layer is paired with a newer layer in a combination that is in fact incompatible — for example, where a layer compat feature has since been enabled by default and the corresponding back-compat code removed — the interaction may still fail.
+> In that case it does not surface as a `FluidErrorTypes.layerIncompatibilityError`; instead it fails in that feature's own failure mode (whatever error the specific feature surfaces).
 
 #### Telemetry
 

--- a/packages/common/client-utils/src/indexBrowser.ts
+++ b/packages/common/client-utils/src/indexBrowser.ts
@@ -39,6 +39,8 @@ export {
 	type ILayerCompatDetails,
 	type IProvideLayerCompatDetails,
 	type ILayerCompatSupportRequirements,
+	type IProvideLayerCompatSupportRequirements,
+	defaultLayerCompatDetails,
 	LayerCompatibilityPolicyWindowMonths,
 } from "./layerCompat.js";
 export { generation } from "./layerGenerationState.js";

--- a/packages/common/client-utils/src/indexNode.ts
+++ b/packages/common/client-utils/src/indexNode.ts
@@ -39,6 +39,8 @@ export {
 	type ILayerCompatDetails,
 	type IProvideLayerCompatDetails,
 	type ILayerCompatSupportRequirements,
+	type IProvideLayerCompatSupportRequirements,
+	defaultLayerCompatDetails,
 	LayerCompatibilityPolicyWindowMonths,
 } from "./layerCompat.js";
 export { generation } from "./layerGenerationState.js";

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -120,10 +120,34 @@ export const defaultLayerCompatDetails: ILayerCompatDetails = {
 };
 
 /**
- * The requirements that a layer needs another layer to support for them to be compatible.
  * @internal
  */
-export interface ILayerCompatSupportRequirements {
+export const ILayerCompatSupportRequirements: keyof IProvideLayerCompatSupportRequirements =
+	"ILayerCompatSupportRequirements";
+
+/**
+ * @internal
+ */
+export interface IProvideLayerCompatSupportRequirements {
+	readonly ILayerCompatSupportRequirements: ILayerCompatSupportRequirements;
+}
+
+/**
+ * The requirements that a layer needs another layer to support for them to be compatible.
+ *
+ * @remarks
+ * A layer can also publish its requirements across a boundary as a `FluidObject` (via
+ * {@link IProvideLayerCompatSupportRequirements}) for the case where the layer on the other side of the boundary
+ * cannot run the compatibility validation itself. Most boundaries are validated by both layers because each holds
+ * a reference to the other (e.g. the Loader and the Runtime). The Driver / Loader boundary is asymmetric: the
+ * Loader holds a reference to the Driver, but the Driver has no reference to the Loader and so cannot validate it.
+ * To still validate in both directions, the Driver publishes its requirements for the Loader and the Loader
+ * validates itself against them on the Driver's behalf.
+ *
+ * @internal
+ */
+export interface ILayerCompatSupportRequirements
+	extends Partial<IProvideLayerCompatSupportRequirements> {
 	/**
 	 * The minimum supported generation the other layer needs to be at.
 	 */

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -120,12 +120,15 @@ export const defaultLayerCompatDetails: ILayerCompatDetails = {
 };
 
 /**
+ * Key used to look up {@link (ILayerCompatSupportRequirements:interface)} on a `FluidObject`.
  * @internal
  */
 export const ILayerCompatSupportRequirements: keyof IProvideLayerCompatSupportRequirements =
 	"ILayerCompatSupportRequirements";
 
 /**
+ * Provides {@link (ILayerCompatSupportRequirements:interface)} so that a layer can publish, as a `FluidObject`, the
+ * requirements another layer must meet to be compatible with it.
  * @internal
  */
 export interface IProvideLayerCompatSupportRequirements {

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -137,8 +137,9 @@ export interface IProvideLayerCompatSupportRequirements {
  *
  * @remarks
  * A layer can also publish its requirements across a boundary as a `FluidObject` (via
- * {@link IProvideLayerCompatSupportRequirements}) for the case where the layer on the other side of the boundary
- * cannot run the compatibility validation itself. Most boundaries are validated by both layers because each holds
+ * {@link IProvideLayerCompatSupportRequirements}) for the case where this layer cannot run the compatibility
+ * validation itself and instead needs the layer on the other side of the boundary to check itself against the
+ * published requirements. Most boundaries are validated by both layers because each holds
  * a reference to the other (e.g. the Loader and the Runtime). The Driver / Loader boundary is asymmetric: the
  * Loader holds a reference to the Driver, but the Driver has no reference to the Loader and so cannot validate it.
  * To still validate in both directions, the Driver publishes its requirements for the Loader and the Loader

--- a/packages/drivers/local-driver/api-report/local-driver.legacy.beta.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.legacy.beta.api.md
@@ -15,6 +15,7 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     disconnectClient(clientId: string, disconnectReason: string): void;
     readonly ILayerCompatDetails?: unknown;
+    readonly ILayerCompatSupportRequirements?: unknown;
     nackClient(clientId: string, code?: number, type?: NackErrorType, message?: any): void;
 }
 

--- a/packages/drivers/local-driver/src/index.ts
+++ b/packages/drivers/local-driver/src/index.ts
@@ -9,7 +9,10 @@ export { createLocalDocumentService, LocalDocumentService } from "./localDocumen
 export { LocalDocumentServiceFactory } from "./localDocumentServiceFactory.js";
 export { LocalDocumentStorageService } from "./localDocumentStorageService.js";
 export { createLocalResolverCreateNewRequest, LocalResolver } from "./localResolver.js";
-export { localDriverCompatDetailsForLoader } from "./localLayerCompatState.js";
+export {
+	localDriverCompatDetailsForLoader,
+	localDriverCompatRequirementsForLoader,
+} from "./localLayerCompatState.js";
 export { LocalSessionStorageDbFactory } from "./localSessionStorageDb.js";
 export type {
 	EphemeralService,

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -18,7 +18,10 @@ import type { ILocalDeltaConnectionServer } from "@fluidframework/server-local-s
 import { createDocument } from "./localCreateDocument.js";
 import type { LocalDocumentDeltaConnection } from "./localDocumentDeltaConnection.js";
 import { createLocalDocumentService } from "./localDocumentService.js";
-import { localDriverCompatDetailsForLoader } from "./localLayerCompatState.js";
+import {
+	localDriverCompatDetailsForLoader,
+	localDriverCompatRequirementsForLoader,
+} from "./localLayerCompatState.js";
 
 /**
  * Implementation of document service factory for local use.
@@ -46,6 +49,17 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
 	 * is currently marked as legacy alpha. So, using unknown here.
 	 */
 	public readonly ILayerCompatDetails?: unknown = localDriverCompatDetailsForLoader;
+
+	/**
+	 * The requirements that the Loader layer must meet to be compatible with this Local Driver. This is exposed to
+	 * the Loader layer so that it can validate Loader / Driver compatibility on this Driver's behalf (the Driver has
+	 * no reference to the Loader to validate it directly).
+	 * @remarks This is for internal use only.
+	 * The type of this should be ILayerCompatSupportRequirements. However, ILayerCompatSupportRequirements is
+	 * internal and this class is currently marked as legacy alpha. So, using unknown here.
+	 */
+	public readonly ILayerCompatSupportRequirements?: unknown =
+		localDriverCompatRequirementsForLoader;
 
 	public async createContainer(
 		createNewSummary: ISummaryTree | undefined,

--- a/packages/drivers/local-driver/src/localLayerCompatState.ts
+++ b/packages/drivers/local-driver/src/localLayerCompatState.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { generation, type ILayerCompatDetails } from "@fluid-internal/client-utils";
+import {
+	generation,
+	LayerCompatibilityPolicyWindowMonths,
+	type ILayerCompatDetails,
+	type ILayerCompatSupportRequirements,
+} from "@fluid-internal/client-utils";
 
 import { pkgVersion } from "./packageVersion.js";
 
@@ -24,4 +29,27 @@ export const localDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	 * The features supported by the Local Driver layer across the Driver / Loader boundary.
 	 */
 	supportedFeatures: new Set<string>(),
+};
+
+/**
+ * The requirements that the Loader layer must meet to be compatible with this Local Driver. This is published to
+ * the Loader layer (which holds the reference to this Driver) so that it can validate Loader / Driver compatibility
+ * on this Driver's behalf.
+ * @internal
+ */
+export const localDriverCompatRequirementsForLoader: ILayerCompatSupportRequirements = {
+	/**
+	 * Minimum generation that Loader must be at to be compatible with this Driver. This is calculated based on the
+	 * LayerCompatibilityPolicyWindowMonths.DriverLoader value which defines how many months old can the Loader layer
+	 * be compared to the Driver layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
+	 */
+	minSupportedGeneration: Math.max(
+		0,
+		generation - LayerCompatibilityPolicyWindowMonths.DriverLoader,
+	),
+	/**
+	 * The features that the Loader must support to be compatible with this Driver.
+	 */
+	requiredFeatures: [],
 };

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.alpha.api.md
@@ -167,6 +167,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory, 
     readonly createPointInTimeDocumentService?: IPointInTimeDocumentServiceFactory["createPointInTimeDocumentService"];
     getRelayServiceSessionInfo(resolvedUrl: IResolvedUrl): Promise<ISocketStorageDiscovery | undefined>;
     readonly ILayerCompatDetails?: unknown;
+    readonly ILayerCompatSupportRequirements?: unknown;
     // (undocumented)
     get IRelaySessionAwareDriverFactory(): this;
     // (undocumented)

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
@@ -167,6 +167,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory, 
     readonly createPointInTimeDocumentService?: IPointInTimeDocumentServiceFactory["createPointInTimeDocumentService"];
     getRelayServiceSessionInfo(resolvedUrl: IResolvedUrl): Promise<ISocketStorageDiscovery | undefined>;
     readonly ILayerCompatDetails?: unknown;
+    readonly ILayerCompatSupportRequirements?: unknown;
     // (undocumented)
     get IRelaySessionAwareDriverFactory(): this;
     // (undocumented)

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -73,4 +73,7 @@ export {
 } from "./compactSnapshotParser.js";
 
 // Layer Compat details
-export { odspDriverCompatDetailsForLoader } from "./odspLayerCompatState.js";
+export {
+	odspDriverCompatDetailsForLoader,
+	odspDriverCompatRequirementsForLoader,
+} from "./odspLayerCompatState.js";

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -52,7 +52,10 @@ import {
 } from "./odspCache.js";
 import { OdspDocumentService } from "./odspDocumentService.js";
 import { OdspDriverUrlResolver } from "./odspDriverUrlResolver.js";
-import { odspDriverCompatDetailsForLoader } from "./odspLayerCompatState.js";
+import {
+	odspDriverCompatDetailsForLoader,
+	odspDriverCompatRequirementsForLoader,
+} from "./odspLayerCompatState.js";
 import {
 	type IExistingFileInfo,
 	type INewFileInfo,
@@ -297,6 +300,17 @@ export class OdspDocumentServiceFactoryCore
 	 * is currently marked as legacy alpha. So, using unknown here.
 	 */
 	public readonly ILayerCompatDetails?: unknown = odspDriverCompatDetailsForLoader;
+
+	/**
+	 * The requirements that the Loader layer must meet to be compatible with this ODSP Driver. This is exposed to
+	 * the Loader layer so that it can validate Loader / Driver compatibility on this Driver's behalf (the Driver has
+	 * no reference to the Loader to validate it directly).
+	 * @remarks This is for internal use only.
+	 * The type of this should be ILayerCompatSupportRequirements. However, ILayerCompatSupportRequirements is
+	 * internal and this class is currently marked as legacy alpha. So, using unknown here.
+	 */
+	public readonly ILayerCompatSupportRequirements?: unknown =
+		odspDriverCompatRequirementsForLoader;
 
 	public async createDocumentService(
 		resolvedUrl: IResolvedUrl,

--- a/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
+++ b/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { generation, type ILayerCompatDetails } from "@fluid-internal/client-utils";
+import {
+	generation,
+	LayerCompatibilityPolicyWindowMonths,
+	type ILayerCompatDetails,
+	type ILayerCompatSupportRequirements,
+} from "@fluid-internal/client-utils";
 
 import { pkgVersion } from "./packageVersion.js";
 
@@ -24,4 +29,27 @@ export const odspDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	 * The features supported by the ODSP Driver layer across the Driver / Loader boundary.
 	 */
 	supportedFeatures: new Set<string>(),
+};
+
+/**
+ * The requirements that the Loader layer must meet to be compatible with this ODSP Driver. This is published to
+ * the Loader layer (which holds the reference to this Driver) so that it can validate Loader / Driver compatibility
+ * on this Driver's behalf.
+ * @internal
+ */
+export const odspDriverCompatRequirementsForLoader: ILayerCompatSupportRequirements = {
+	/**
+	 * Minimum generation that Loader must be at to be compatible with this Driver. This is calculated based on the
+	 * LayerCompatibilityPolicyWindowMonths.DriverLoader value which defines how many months old can the Loader layer
+	 * be compared to the Driver layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
+	 */
+	minSupportedGeneration: Math.max(
+		0,
+		generation - LayerCompatibilityPolicyWindowMonths.DriverLoader,
+	),
+	/**
+	 * The features that the Loader must support to be compatible with this Driver.
+	 */
+	requiredFeatures: [],
 };

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -95,7 +95,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_ReplayDocumentServiceFactory": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "internal"
 	}
 }

--- a/packages/drivers/replay-driver/src/replayDocumentServiceFactory.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentServiceFactory.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
+import type {
+	ILayerCompatDetails,
+	ILayerCompatSupportRequirements,
+} from "@fluid-internal/client-utils";
 import type { FluidObject, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import type {
@@ -39,6 +42,16 @@ export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
 	public get ILayerCompatDetails(): ILayerCompatDetails | undefined {
 		return (this.documentServiceFactory as FluidObject<ILayerCompatDetails>)
 			.ILayerCompatDetails;
+	}
+
+	/**
+	 * The requirements that the Loader layer must meet to be compatible with this Driver. This is exposed to
+	 * the Loader layer so that it can validate Loader / Driver compatibility on this Driver's behalf (the Driver has
+	 * no reference to the Loader to validate it directly).
+	 */
+	public get ILayerCompatSupportRequirements(): ILayerCompatSupportRequirements | undefined {
+		return (this.documentServiceFactory as FluidObject<ILayerCompatSupportRequirements>)
+			.ILayerCompatSupportRequirements;
 	}
 
 	public constructor(

--- a/packages/drivers/replay-driver/src/test/types/validateReplayDriverPrevious.generated.ts
+++ b/packages/drivers/replay-driver/src/test/types/validateReplayDriverPrevious.generated.ts
@@ -96,6 +96,7 @@ declare type current_as_old_for_Class_ReplayDocumentService = requireAssignableT
  * typeValidation.broken:
  * "Class_ReplayDocumentServiceFactory": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_ReplayDocumentServiceFactory = requireAssignableTo<TypeOnly<old.ReplayDocumentServiceFactory>, TypeOnly<current.ReplayDocumentServiceFactory>>
 
 /*

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -6,6 +6,8 @@
 import type {
 	ILayerCompatDetails,
 	IProvideLayerCompatDetails,
+	ILayerCompatSupportRequirements,
+	IProvideLayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
@@ -35,7 +37,10 @@ import type { ISnapshotTreeVersion } from "./definitions.js";
 import { DocumentService } from "./documentService.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 import type { IRouterliciousDriverPolicies } from "./policies.js";
-import { r11sDriverCompatDetailsForLoader } from "./r11sLayerCompatState.js";
+import {
+	r11sDriverCompatDetailsForLoader,
+	r11sDriverCompatRequirementsForLoader,
+} from "./r11sLayerCompatState.js";
 import {
 	RouterliciousOrdererRestWrapper,
 	RouterliciousStorageRestWrapper,
@@ -66,7 +71,10 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
  * @internal
  */
 export class RouterliciousDocumentServiceFactory
-	implements IDocumentServiceFactory, IProvideLayerCompatDetails
+	implements
+		IDocumentServiceFactory,
+		IProvideLayerCompatDetails,
+		IProvideLayerCompatSupportRequirements
 {
 	private readonly driverPolicies: IRouterliciousDriverPolicies;
 	private readonly blobCache: ICache<ArrayBufferLike>;
@@ -106,6 +114,15 @@ export class RouterliciousDocumentServiceFactory
 	 */
 	public get ILayerCompatDetails(): ILayerCompatDetails {
 		return r11sDriverCompatDetailsForLoader;
+	}
+
+	/**
+	 * The requirements that the Loader layer must meet to be compatible with this Routerlicious Driver. This is
+	 * exposed to the Loader layer so that it can validate Loader / Driver compatibility on this Driver's behalf
+	 * (the Driver has no reference to the Loader to validate it directly).
+	 */
+	public get ILayerCompatSupportRequirements(): ILayerCompatSupportRequirements {
+		return r11sDriverCompatRequirementsForLoader;
 	}
 
 	/**

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -24,4 +24,7 @@ export {
 export type { IRouterliciousDriverPolicies } from "./policies.js";
 
 // Layer Compat details
-export { r11sDriverCompatDetailsForLoader } from "./r11sLayerCompatState.js";
+export {
+	r11sDriverCompatDetailsForLoader,
+	r11sDriverCompatRequirementsForLoader,
+} from "./r11sLayerCompatState.js";

--- a/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { generation, type ILayerCompatDetails } from "@fluid-internal/client-utils";
+import {
+	generation,
+	LayerCompatibilityPolicyWindowMonths,
+	type ILayerCompatDetails,
+	type ILayerCompatSupportRequirements,
+} from "@fluid-internal/client-utils";
 
 import { pkgVersion } from "./packageVersion.js";
 
@@ -24,4 +29,27 @@ export const r11sDriverCompatDetailsForLoader: ILayerCompatDetails = {
 	 * The features supported by the Routerlicious Driver layer across the Driver / Loader boundary.
 	 */
 	supportedFeatures: new Set<string>(),
+};
+
+/**
+ * The requirements that the Loader layer must meet to be compatible with this Routerlicious Driver. This is published
+ * to the Loader layer (which holds the reference to this Driver) so that it can validate Loader / Driver compatibility
+ * on this Driver's behalf.
+ * @internal
+ */
+export const r11sDriverCompatRequirementsForLoader: ILayerCompatSupportRequirements = {
+	/**
+	 * Minimum generation that Loader must be at to be compatible with this Driver. This is calculated based on the
+	 * LayerCompatibilityPolicyWindowMonths.DriverLoader value which defines how many months old can the Loader layer
+	 * be compared to the Driver layer for them to still be considered compatible.
+	 * The minimum valid generation value is 0.
+	 */
+	minSupportedGeneration: Math.max(
+		0,
+		generation - LayerCompatibilityPolicyWindowMonths.DriverLoader,
+	),
+	/**
+	 * The features that the Loader must support to be compatible with this Driver.
+	 */
+	requiredFeatures: [],
 };

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -9,6 +9,7 @@ import {
 	TypedEventEmitter,
 	performanceNow,
 	type ILayerCompatDetails,
+	type ILayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
 import {
 	AttachState,
@@ -131,6 +132,7 @@ import type { ILoaderServices } from "./loader.js";
 import { RelativeLoader } from "./loader.js";
 import {
 	validateDriverCompatibility,
+	validateLoaderCompatibilityWithDriver,
 	validateRuntimeCompatibility,
 } from "./loaderLayerCompatState.js";
 import {
@@ -757,13 +759,30 @@ export class Container
 			protocolHandlerBuilder,
 		} = createProps;
 
-		// Validate that the Driver is compatible with this Loader.
-		const maybeDriverCompatDetails =
-			documentServiceFactory as FluidObject<ILayerCompatDetails>;
+		const maybeDriverCompat = documentServiceFactory as FluidObject<ILayerCompatDetails> &
+			FluidObject<ILayerCompatSupportRequirements>;
+		const driverCompatMonitoringContext = createChildMonitoringContext({
+			logger: subLogger,
+			namespace: "Container",
+		});
+
+		// Validate that the Driver is compatible with this Loader. This is the standard direction: the Loader holds
+		// a reference to the Driver and validates it.
 		validateDriverCompatibility(
-			maybeDriverCompatDetails.ILayerCompatDetails,
+			maybeDriverCompat.ILayerCompatDetails,
 			(error) => {} /* disposeFn */, // There is nothing to dispose here, so just ignore the error.
-			createChildMonitoringContext({ logger: subLogger, namespace: "Container" }),
+			driverCompatMonitoringContext,
+		);
+
+		// Validate that this Loader is compatible with the Driver. This is the reverse, non-standard direction: a
+		// layer normally validates the layer it holds a reference to, but the Driver has no reference to the Loader
+		// and so cannot validate it itself. The Driver instead publishes the requirements it has for the Loader (via
+		// ILayerCompatSupportRequirements), and the Loader validates itself against them here, on the Driver's behalf.
+		validateLoaderCompatibilityWithDriver(
+			maybeDriverCompat.ILayerCompatDetails,
+			maybeDriverCompat.ILayerCompatSupportRequirements,
+			(error) => {} /* disposeFn */, // There is nothing to dispose here, so just ignore the error.
+			driverCompatMonitoringContext,
 		);
 
 		this.connectionTransitionTimes[ConnectionState.Disconnected] = performanceNow();

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -41,6 +41,7 @@ export {
 	loaderCoreCompatDetails,
 	runtimeSupportRequirementsForLoader,
 	loaderCompatDetailsForRuntime,
+	loaderCompatDetailsForDriver,
 } from "./loaderLayerCompatState.js";
 export { loadContainerPaused } from "./loadPaused.js";
 export {

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -5,6 +5,7 @@
 
 import {
 	generation,
+	defaultLayerCompatDetails,
 	LayerCompatibilityPolicyWindowMonths,
 	type ILayerCompatDetails,
 	type ILayerCompatSupportRequirements,
@@ -40,6 +41,18 @@ export const loaderCompatDetailsForRuntime: ILayerCompatDetails = {
 	...loaderCoreCompatDetails,
 	/**
 	 * The features supported by the Loader layer across the Loader / Runtime boundary.
+	 */
+	supportedFeatures: new Set<string>(),
+};
+
+/**
+ * Loader's compatibility details that is validated against the Driver layer's requirements.
+ * @internal
+ */
+export const loaderCompatDetailsForDriver: ILayerCompatDetails = {
+	...loaderCoreCompatDetails,
+	/**
+	 * The features supported by the Loader layer across the Loader / Driver boundary.
 	 */
 	supportedFeatures: new Set<string>(),
 };
@@ -117,9 +130,47 @@ export function validateDriverCompatibility(
 	validateLayerCompatibility(
 		"loader",
 		"driver",
-		loaderCompatDetailsForRuntime,
+		loaderCompatDetailsForDriver,
 		driverSupportRequirementsForLoader,
 		maybeDriverCompatDetails,
+		disposeFn,
+		mc,
+	);
+}
+
+/**
+ * Validates that the Loader layer is compatible with the Driver.
+ *
+ * @remarks
+ * This is the reverse of {@link validateDriverCompatibility} and is intentionally a separate function because it
+ * does not follow the standard layer-validation pattern. Normally each layer validates the layer it holds a
+ * reference to - the Loader validates the Driver, the Runtime validates the Loader, and so on. The Driver, however,
+ * has no reference to the Loader and therefore cannot run this validation itself. To still enforce compatibility in
+ * both directions across the Driver / Loader boundary, the Driver publishes the requirements it has for the Loader
+ * (via ILayerCompatSupportRequirements) and the Loader validates itself against them here, on the Driver's behalf.
+ *
+ * @param maybeDriverCompatDetails - The Driver's compatibility details, used only to attribute the version /
+ * generation of the Driver in telemetry if the Loader is found to be incompatible.
+ * @param maybeDriverCompatRequirements - The requirements the Driver has for the Loader. Older Drivers may not
+ * publish these, in which case there is nothing to validate in this direction.
+ *
+ * @internal
+ */
+export function validateLoaderCompatibilityWithDriver(
+	maybeDriverCompatDetails: ILayerCompatDetails | undefined,
+	maybeDriverCompatRequirements: ILayerCompatSupportRequirements | undefined,
+	disposeFn: (error?: ICriticalContainerError) => void,
+	mc: MonitoringContext,
+): void {
+	if (maybeDriverCompatRequirements === undefined) {
+		return;
+	}
+	validateLayerCompatibility(
+		"driver",
+		"loader",
+		maybeDriverCompatDetails ?? defaultLayerCompatDetails,
+		maybeDriverCompatRequirements,
+		loaderCompatDetailsForDriver,
 		disposeFn,
 		mc,
 	);

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -108,13 +108,19 @@ export function validateRuntimeCompatibility(
 	mc: MonitoringContext,
 ): void {
 	validateLayerCompatibility(
-		"loader",
-		"runtime",
-		loaderCompatDetailsForRuntime,
-		runtimeSupportRequirementsForLoader,
-		maybeRuntimeCompatDetails,
-		() => {} /* disposeFn - no op. This will be handled by the caller */,
-		mc,
+		/* validatingLayer */ {
+			layer: "loader",
+			compatDetails: loaderCompatDetailsForRuntime,
+			compatSupportRequirements: runtimeSupportRequirementsForLoader,
+		},
+		/* targetLayer */ {
+			layer: "runtime",
+			compatDetails: maybeRuntimeCompatDetails,
+		},
+		{
+			disposeFn: () => {} /* no op. This will be handled by the caller */,
+			mc,
+		},
 	);
 }
 
@@ -128,13 +134,16 @@ export function validateDriverCompatibility(
 	mc: MonitoringContext,
 ): void {
 	validateLayerCompatibility(
-		"loader",
-		"driver",
-		loaderCompatDetailsForDriver,
-		driverSupportRequirementsForLoader,
-		maybeDriverCompatDetails,
-		disposeFn,
-		mc,
+		/* validatingLayer */ {
+			layer: "loader",
+			compatDetails: loaderCompatDetailsForDriver,
+			compatSupportRequirements: driverSupportRequirementsForLoader,
+		},
+		/* targetLayer */ {
+			layer: "driver",
+			compatDetails: maybeDriverCompatDetails,
+		},
+		{ disposeFn, mc },
 	);
 }
 
@@ -166,12 +175,15 @@ export function validateLoaderCompatibilityWithDriver(
 		return;
 	}
 	validateLayerCompatibility(
-		"driver",
-		"loader",
-		maybeDriverCompatDetails ?? defaultLayerCompatDetails,
-		maybeDriverCompatRequirements,
-		loaderCompatDetailsForDriver,
-		disposeFn,
-		mc,
+		/* validatingLayer */ {
+			layer: "driver",
+			compatDetails: maybeDriverCompatDetails ?? defaultLayerCompatDetails,
+			compatSupportRequirements: maybeDriverCompatRequirements,
+		},
+		/* targetLayer */ {
+			layer: "loader",
+			compatDetails: loaderCompatDetailsForDriver,
+		},
+		{ disposeFn, mc },
 	);
 }

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -110,7 +110,7 @@ export function validateRuntimeCompatibility(
 	validateLayerCompatibility(
 		/* validatingLayer */ {
 			layer: "loader",
-			compatDetails: loaderCompatDetailsForRuntime,
+			packageInfo: loaderCoreCompatDetails,
 			compatSupportRequirements: runtimeSupportRequirementsForLoader,
 		},
 		/* targetLayer */ {
@@ -136,7 +136,7 @@ export function validateDriverCompatibility(
 	validateLayerCompatibility(
 		/* validatingLayer */ {
 			layer: "loader",
-			compatDetails: loaderCompatDetailsForDriver,
+			packageInfo: loaderCoreCompatDetails,
 			compatSupportRequirements: driverSupportRequirementsForLoader,
 		},
 		/* targetLayer */ {
@@ -177,7 +177,7 @@ export function validateLoaderCompatibilityWithDriver(
 	validateLayerCompatibility(
 		/* validatingLayer */ {
 			layer: "driver",
-			compatDetails: maybeDriverCompatDetails ?? defaultLayerCompatDetails,
+			packageInfo: maybeDriverCompatDetails ?? defaultLayerCompatDetails,
 			compatSupportRequirements: maybeDriverCompatRequirements,
 		},
 		/* targetLayer */ {

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -8,6 +8,7 @@ import { strict as assert } from "node:assert";
 import {
 	TypedEventEmitter,
 	type IProvideLayerCompatDetails,
+	type IProvideLayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
 import type { IAudience } from "@fluidframework/container-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
@@ -81,9 +82,10 @@ class MockContainer
 }
 
 const documentServiceFactoryProxy = failSometimeProxy<
-	IDocumentServiceFactory & IProvideLayerCompatDetails
+	IDocumentServiceFactory & IProvideLayerCompatDetails & IProvideLayerCompatSupportRequirements
 >({
 	ILayerCompatDetails: AbsentProperty,
+	ILayerCompatSupportRequirements: AbsentProperty,
 });
 
 function createTestContainer(mockLogger: MockLogger): Container {

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -5,7 +5,10 @@
 
 import { strict as assert } from "node:assert";
 
-import type { IProvideLayerCompatDetails } from "@fluid-internal/client-utils";
+import type {
+	IProvideLayerCompatDetails,
+	IProvideLayerCompatSupportRequirements,
+} from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { FluidErrorTypes, type ConfigTypes } from "@fluidframework/core-interfaces/internal";
 import type {
@@ -35,9 +38,10 @@ import {
 } from "./testProxies.js";
 
 const documentServiceFactoryFailProxy = failSometimeProxy<
-	IDocumentServiceFactory & IProvideLayerCompatDetails
+	IDocumentServiceFactory & IProvideLayerCompatDetails & IProvideLayerCompatSupportRequirements
 >({
 	ILayerCompatDetails: AbsentProperty,
+	ILayerCompatSupportRequirements: AbsentProperty,
 });
 
 describe("loader unit test", () => {
@@ -235,7 +239,9 @@ describe("DisableLoadConnectionRetries", () => {
 
 	it("load rejects when connectToStorage fails with retryable error and flag is enabled", async () => {
 		const documentServiceFactory = failSometimeProxy<
-			IDocumentServiceFactory & IProvideLayerCompatDetails
+			IDocumentServiceFactory &
+				IProvideLayerCompatDetails &
+				IProvideLayerCompatSupportRequirements
 		>({
 			createDocumentService: async () =>
 				failSometimeProxy<IDocumentService>({
@@ -250,6 +256,7 @@ describe("DisableLoadConnectionRetries", () => {
 					dispose: () => {},
 				}),
 			ILayerCompatDetails: AbsentProperty,
+			ILayerCompatSupportRequirements: AbsentProperty,
 		});
 
 		const loader = new Loader({
@@ -271,7 +278,9 @@ describe("DisableLoadConnectionRetries", () => {
 
 	it("load rejects when connectToDeltaStream fails with retryable error and flag is enabled", async () => {
 		const documentServiceFactory = failSometimeProxy<
-			IDocumentServiceFactory & IProvideLayerCompatDetails
+			IDocumentServiceFactory &
+				IProvideLayerCompatDetails &
+				IProvideLayerCompatSupportRequirements
 		>({
 			createDocumentService: async () =>
 				failSometimeProxy<IDocumentService>({
@@ -286,6 +295,7 @@ describe("DisableLoadConnectionRetries", () => {
 					dispose: () => {},
 				}),
 			ILayerCompatDetails: AbsentProperty,
+			ILayerCompatSupportRequirements: AbsentProperty,
 		});
 
 		const loader = new Loader({

--- a/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
+++ b/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
@@ -5,10 +5,11 @@
 
 import { strict as assert } from "node:assert";
 
-import type {
-	FluidLayer,
-	ILayerCompatDetails,
-	ILayerCompatSupportRequirements,
+import {
+	type FluidLayer,
+	type ILayerCompatDetails,
+	type ILayerCompatSupportRequirements,
+	generation as currentGeneration,
 } from "@fluid-internal/client-utils";
 import type { ICriticalContainerError } from "@fluidframework/container-definitions/internal";
 import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces/internal";
@@ -26,6 +27,7 @@ import {
 	loaderCoreCompatDetails,
 	runtimeSupportRequirementsForLoader,
 	validateDriverCompatibility,
+	validateLoaderCompatibilityWithDriver,
 	validateRuntimeCompatibility,
 } from "../loaderLayerCompatState.js";
 import { pkgVersion } from "../packageVersion.js";
@@ -43,12 +45,23 @@ type ILayerCompatSupportRequirementsOverride = Omit<
 	requiredFeatures: string[];
 };
 
+/**
+ * Validates the properties of a layer incompatibility error.
+ *
+ * @remarks
+ * The Driver / Loader boundary is validated in both directions (see validateDriverCompatibility and
+ * validateLoaderCompatibilityWithDriver), so the error's `layer` is not always the Loader. The `layer` /
+ * `layerGeneration` parameters default to the Loader for the common forward-direction case, but can be overridden
+ * for the reverse direction where the Driver is the validating `layer`.
+ */
 function validateFailureProperties(
 	error: Error,
 	isGenerationCompatible: boolean,
 	incompatibleLayerGeneration: number,
 	incompatibleLayer: FluidLayer,
 	unsupportedFeatures?: string[],
+	layer: FluidLayer = "loader",
+	layerGeneration: number = loaderCoreCompatDetails.generation,
 ): boolean {
 	assert(isLayerIncompatibilityError(error), "Error should be a layerIncompatibilityError");
 	assert(typeof error.details === "string", "Error details should be present");
@@ -59,18 +72,18 @@ function validateFailureProperties(
 		"Generation compatibility not as expected",
 	);
 
-	assert.strictEqual(error.layer, "loader", "Layer type not as expected");
+	assert.strictEqual(error.layer, layer, "Layer type not as expected");
 	assert.strictEqual(
 		error.incompatibleLayer,
 		incompatibleLayer,
 		"Incompatible layer type not as expected",
 	);
 
-	assert.strictEqual(error.layerVersion, pkgVersion, "Loader version not as expected");
+	assert.strictEqual(error.layerVersion, pkgVersion, `${layer} version not as expected`);
 	assert.strictEqual(
 		detailedProperties.layerGeneration,
-		loaderCoreCompatDetails.generation,
-		"Loader generation not as expected",
+		layerGeneration,
+		`${layer} generation not as expected`,
 	);
 	assert.deepStrictEqual(
 		detailedProperties.unsupportedFeatures,
@@ -255,6 +268,149 @@ describe("Loader Layer compatibility", () => {
 	});
 
 	/**
+	 * These tests cover the reverse direction of the Driver / Loader boundary: the Loader validating itself
+	 * against the requirements published by the Driver (on the Driver's behalf, since the Driver has no
+	 * reference to the Loader).
+	 */
+	describe("Validation of Loader against Driver's requirements", () => {
+		const mc = createChildMonitoringContext({ logger: createChildLogger() });
+		// Only the pkgVersion and generation of these details are used (for telemetry); the requirements drive
+		// the actual compatibility check in this direction.
+		const driverCompatDetails: ILayerCompatDetails = {
+			pkgVersion,
+			generation: currentGeneration,
+			supportedFeatures: new Set(),
+		};
+
+		it("Loader is compatible when it meets the Driver's requirements", () => {
+			// Note: unlike the loader / driver direction validation, a "required features are satisfied" case is not
+			// exercised here because the Loader's details validated in this direction (loaderCompatDetailsForDriver)
+			// is not passed in by the Driver layer. It is a const and modifying it would be an anti-pattern and doesn't
+			// validate anything meaningful.
+			const driverRequirements: ILayerCompatSupportRequirements = {
+				minSupportedGeneration: loaderCoreCompatDetails.generation,
+				requiredFeatures: [],
+			};
+			assert.doesNotThrow(
+				() =>
+					validateLoaderCompatibilityWithDriver(
+						driverCompatDetails,
+						driverRequirements,
+						() => {
+							throw new Error("should not dispose");
+						},
+						mc,
+					),
+				"Loader should be compatible with the Driver's requirements",
+			);
+		});
+
+		it("Loader is compatible when the Driver publishes no requirements", () => {
+			assert.doesNotThrow(
+				() =>
+					validateLoaderCompatibilityWithDriver(
+						driverCompatDetails,
+						undefined /* maybeDriverCompatRequirements */,
+						() => {
+							throw new Error("should not dispose");
+						},
+						mc,
+					),
+				"Loader should be compatible when the Driver publishes no requirements",
+			);
+		});
+
+		it("Loader generation is incompatible with the Driver's requirements", () => {
+			const disposeFn = Sinon.fake();
+			const driverRequirements: ILayerCompatSupportRequirements = {
+				minSupportedGeneration: loaderCoreCompatDetails.generation + 1,
+				requiredFeatures: [],
+			};
+			assert.throws(
+				() =>
+					validateLoaderCompatibilityWithDriver(
+						driverCompatDetails,
+						driverRequirements,
+						disposeFn,
+						mc,
+					),
+				(e: Error) =>
+					validateFailureProperties(
+						e,
+						false /* isGenerationCompatible */,
+						loaderCoreCompatDetails.generation /* incompatibleLayerGeneration (Loader) */,
+						"loader" /* incompatibleLayer */,
+						undefined /* unsupportedFeatures */,
+						"driver" /* layer */,
+						driverCompatDetails.generation /* layerGeneration */,
+					),
+				"Loader should be incompatible with the Driver's requirements",
+			);
+			assert(disposeFn.calledOnce, "Dispose should be called");
+		});
+
+		it("Loader features are incompatible with the Driver's requirements", () => {
+			const disposeFn = Sinon.fake();
+			const requiredFeatures = ["feature1", "feature2"];
+			const driverRequirements: ILayerCompatSupportRequirements = {
+				minSupportedGeneration: loaderCoreCompatDetails.generation,
+				requiredFeatures,
+			};
+			assert.throws(
+				() =>
+					validateLoaderCompatibilityWithDriver(
+						driverCompatDetails,
+						driverRequirements,
+						disposeFn,
+						mc,
+					),
+				(e: Error) =>
+					validateFailureProperties(
+						e,
+						true /* isGenerationCompatible */,
+						loaderCoreCompatDetails.generation /* incompatibleLayerGeneration (Loader) */,
+						"loader" /* incompatibleLayer */,
+						requiredFeatures,
+						"driver" /* layer */,
+						driverCompatDetails.generation /* layerGeneration */,
+					),
+				"Loader should be incompatible with the Driver's requirements",
+			);
+			assert(disposeFn.calledOnce, "Dispose should be called");
+		});
+
+		it("Loader generation and features are both incompatible with the Driver's requirements", () => {
+			const disposeFn = Sinon.fake();
+			const requiredFeatures = ["feature1", "feature2"];
+			const driverRequirements: ILayerCompatSupportRequirements = {
+				minSupportedGeneration: loaderCoreCompatDetails.generation + 1,
+				requiredFeatures,
+			};
+			assert.throws(
+				() =>
+					validateLoaderCompatibilityWithDriver(
+						driverCompatDetails,
+						driverRequirements,
+						disposeFn,
+						mc,
+					),
+				(e: Error) =>
+					validateFailureProperties(
+						e,
+						false /* isGenerationCompatible */,
+						loaderCoreCompatDetails.generation /* incompatibleLayerGeneration (Loader) */,
+						"loader" /* incompatibleLayer */,
+						requiredFeatures,
+						"driver" /* layer */,
+						driverCompatDetails.generation /* layerGeneration */,
+					),
+				"Loader should be incompatible with the Driver's requirements",
+			);
+			assert(disposeFn.calledOnce, "Dispose should be called");
+		});
+	});
+
+	/**
 	 * These tests validates that the Loader layer compatibility is correctly enforced during load / initialization.
 	 */
 	describe("Validation during load / initialization", () => {
@@ -359,5 +515,43 @@ describe("Loader Layer compatibility", () => {
 				});
 			});
 		}
+
+		it("Loader is incompatible with a Driver that requires a newer Loader", async () => {
+			const driverCompatDetails: ILayerCompatDetails = {
+				pkgVersion,
+				generation: driverSupportRequirementsForLoader.minSupportedGeneration,
+				supportedFeatures: new Set(),
+			};
+			// The Driver requires a Loader generation newer than this Loader, so validation should fail in the
+			// reverse direction.
+			const driverCompatRequirements: ILayerCompatSupportRequirements = {
+				minSupportedGeneration: loaderCoreCompatDetails.generation + 1,
+				requiredFeatures: [],
+			};
+			const loader = new Loader({
+				codeLoader: createTestCodeLoaderProxy(),
+				documentServiceFactory: createTestDocumentServiceFactoryProxy(
+					resolvedUrl,
+					driverCompatDetails,
+					driverCompatRequirements,
+				),
+				urlResolver,
+			});
+
+			await assert.rejects(
+				async () => createAndAttachContainer(loader),
+				(error: Error) =>
+					validateFailureProperties(
+						error,
+						false /* isGenerationCompatible */,
+						loaderCoreCompatDetails.generation /* incompatibleLayerGeneration (Loader) */,
+						"loader" /* incompatibleLayer */,
+						undefined /* unsupportedFeatures */,
+						"driver" /* layer */,
+						driverCompatDetails.generation /* layerGeneration */,
+					),
+				"Loader should be incompatible with a Driver that requires a newer Loader",
+			);
+		});
 	});
 });

--- a/packages/loader/container-loader/src/test/testProxies.ts
+++ b/packages/loader/container-loader/src/test/testProxies.ts
@@ -6,7 +6,9 @@
 import {
 	stringToBuffer,
 	type ILayerCompatDetails,
+	type ILayerCompatSupportRequirements,
 	type IProvideLayerCompatDetails,
+	type IProvideLayerCompatSupportRequirements,
 } from "@fluid-internal/client-utils";
 import type {
 	ICodeDetailsLoader,
@@ -27,8 +29,13 @@ import { AbsentProperty, failSometimeProxy } from "./failProxy.js";
 export function createTestDocumentServiceFactoryProxy(
 	resolvedUrl: IResolvedUrl,
 	compatibilityDetails?: ILayerCompatDetails,
+	compatibilityRequirements?: ILayerCompatSupportRequirements,
 ): IDocumentServiceFactory {
-	return failSometimeProxy<IDocumentServiceFactory & IProvideLayerCompatDetails>({
+	return failSometimeProxy<
+		IDocumentServiceFactory &
+			IProvideLayerCompatDetails &
+			IProvideLayerCompatSupportRequirements
+	>({
 		createContainer: async () =>
 			failSometimeProxy<IDocumentService>({
 				policies: {},
@@ -39,6 +46,7 @@ export function createTestDocumentServiceFactoryProxy(
 					}),
 			}),
 		ILayerCompatDetails: compatibilityDetails ?? AbsentProperty,
+		ILayerCompatSupportRequirements: compatibilityRequirements ?? AbsentProperty,
 	});
 }
 

--- a/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
+++ b/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
@@ -127,14 +127,17 @@ export function validateLoaderCompatibility(
 	);
 
 	validateLayerCompatibility(
-		"runtime",
-		"loader",
-		runtimeCompatDetailsForLoader,
-		loaderSupportRequirementsForRuntime,
-		maybeLoaderCompatDetailsForRuntime,
-		disposeFn,
-		mc,
-		disableStrictLoaderLayerCompatibilityCheck !== true /* strictCompatibilityCheck */,
+		/* validatingLayer */ {
+			layer: "runtime",
+			compatDetails: runtimeCompatDetailsForLoader,
+			compatSupportRequirements: loaderSupportRequirementsForRuntime,
+		},
+		/* targetLayer */ {
+			layer: "loader",
+			compatDetails: maybeLoaderCompatDetailsForRuntime,
+			strictCompatibilityCheck: disableStrictLoaderLayerCompatibilityCheck !== true,
+		},
+		{ disposeFn, mc },
 	);
 }
 
@@ -148,12 +151,15 @@ export function validateDatastoreCompatibility(
 	mc: MonitoringContext,
 ): void {
 	validateLayerCompatibility(
-		"runtime",
-		"dataStore",
-		runtimeCompatDetailsForDataStore,
-		dataStoreSupportRequirementsForRuntime,
-		maybeDataStoreCompatDetailsForRuntime,
-		disposeFn,
-		mc,
+		/* validatingLayer */ {
+			layer: "runtime",
+			compatDetails: runtimeCompatDetailsForDataStore,
+			compatSupportRequirements: dataStoreSupportRequirementsForRuntime,
+		},
+		/* targetLayer */ {
+			layer: "dataStore",
+			compatDetails: maybeDataStoreCompatDetailsForRuntime,
+		},
+		{ disposeFn, mc },
 	);
 }

--- a/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
+++ b/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
@@ -129,7 +129,7 @@ export function validateLoaderCompatibility(
 	validateLayerCompatibility(
 		/* validatingLayer */ {
 			layer: "runtime",
-			compatDetails: runtimeCompatDetailsForLoader,
+			packageInfo: runtimeCoreCompatDetails,
 			compatSupportRequirements: loaderSupportRequirementsForRuntime,
 		},
 		/* targetLayer */ {
@@ -153,7 +153,7 @@ export function validateDatastoreCompatibility(
 	validateLayerCompatibility(
 		/* validatingLayer */ {
 			layer: "runtime",
-			compatDetails: runtimeCompatDetailsForDataStore,
+			packageInfo: runtimeCoreCompatDetails,
 			compatSupportRequirements: dataStoreSupportRequirementsForRuntime,
 		},
 		/* targetLayer */ {

--- a/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
+++ b/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
@@ -75,12 +75,15 @@ export function validateRuntimeCompatibility(
 	mc: MonitoringContext,
 ): void {
 	validateLayerCompatibility(
-		"dataStore",
-		"runtime",
-		dataStoreCompatDetailsForRuntime,
-		runtimeSupportRequirementsForDataStore,
-		maybeRuntimeCompatDetails,
-		disposeFn,
-		mc,
+		/* validatingLayer */ {
+			layer: "dataStore",
+			compatDetails: dataStoreCompatDetailsForRuntime,
+			compatSupportRequirements: runtimeSupportRequirementsForDataStore,
+		},
+		/* targetLayer */ {
+			layer: "runtime",
+			compatDetails: maybeRuntimeCompatDetails,
+		},
+		{ disposeFn, mc },
 	);
 }

--- a/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
+++ b/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
@@ -77,7 +77,7 @@ export function validateRuntimeCompatibility(
 	validateLayerCompatibility(
 		/* validatingLayer */ {
 			layer: "dataStore",
-			compatDetails: dataStoreCompatDetailsForRuntime,
+			packageInfo: dataStoreCoreCompatDetails,
 			compatSupportRequirements: runtimeSupportRequirementsForDataStore,
 		},
 		/* targetLayer */ {

--- a/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
@@ -19,6 +19,7 @@ import {
 import type { IContainer } from "@fluidframework/container-definitions/internal";
 import {
 	driverSupportRequirementsForLoader,
+	loaderCompatDetailsForDriver,
 	loaderCompatDetailsForRuntime,
 	loaderCoreCompatDetails,
 	runtimeSupportRequirementsForLoader,
@@ -42,9 +43,18 @@ import {
 	dataStoreCoreCompatDetails,
 	runtimeSupportRequirementsForDataStore,
 } from "@fluidframework/datastore/internal";
-import { localDriverCompatDetailsForLoader } from "@fluidframework/local-driver/internal";
-import { odspDriverCompatDetailsForLoader } from "@fluidframework/odsp-driver/internal";
-import { r11sDriverCompatDetailsForLoader } from "@fluidframework/routerlicious-driver/internal";
+import {
+	localDriverCompatDetailsForLoader,
+	localDriverCompatRequirementsForLoader,
+} from "@fluidframework/local-driver/internal";
+import {
+	odspDriverCompatDetailsForLoader,
+	odspDriverCompatRequirementsForLoader,
+} from "@fluidframework/odsp-driver/internal";
+import {
+	r11sDriverCompatDetailsForLoader,
+	r11sDriverCompatRequirementsForLoader,
+} from "@fluidframework/routerlicious-driver/internal";
 import {
 	allowIncompatibleLayersKey,
 	isLayerIncompatibilityError,
@@ -155,6 +165,31 @@ function getDriverCompatDetailsForLoader(driverType: TestDriverTypes): ILayerCom
 }
 
 /**
+ * Returns the requirements the driver layer imposes on the loader based on the provided driver type. These are
+ * the requirements the driver publishes for the loader to validate itself against (the reverse direction of the
+ * Driver / Loader boundary).
+ * @param driverType - The type of driver for which the requirements are needed.
+ * @returns The support requirements for the loader from the specified driver type.
+ */
+function getDriverCompatRequirementsForLoader(
+	driverType: TestDriverTypes,
+): ILayerCompatSupportRequirements {
+	switch (driverType) {
+		case "tinylicious":
+		case "t9s":
+		case "routerlicious":
+		case "r11s":
+			return r11sDriverCompatRequirementsForLoader;
+		case "odsp":
+			return odspDriverCompatRequirementsForLoader;
+		case "local":
+			return localDriverCompatRequirementsForLoader;
+		default:
+			assert.fail(`Unexpected driver type: ${driverType}`);
+	}
+}
+
+/**
  * Returns the parameters required for testing that layer2 is compatible with layer1.
  * @param layer1 - The layer that is validating compatibility.
  * @param layer2 - The layer that is being validated for compatibility.
@@ -185,6 +220,23 @@ function getLayerTestParams(
 				layer1Generation: loaderCoreCompatDetails.generation,
 				layer2CompatDetails: getDriverCompatDetailsForLoader(driverType),
 			};
+		case "driver-loader": {
+			assert(
+				driverType !== undefined,
+				"Driver type must be provided for driver-loader combination",
+			);
+			// In this (reverse) direction the driver is layer1: it publishes the requirements the loader must
+			// meet, and the loader (layer2) validates itself against them on the driver's behalf.
+			const driverCompatDetails = getDriverCompatDetailsForLoader(driverType);
+			return {
+				layer1SupportRequirements: getDriverCompatRequirementsForLoader(
+					driverType,
+				) as ILayerCompatSupportRequirementsOverride,
+				layer1Version: driverCompatDetails.pkgVersion,
+				layer1Generation: driverCompatDetails.generation,
+				layer2CompatDetails: loaderCompatDetailsForDriver,
+			};
+		}
 		case "loader-runtime":
 			return {
 				layer1SupportRequirements:
@@ -240,9 +292,12 @@ function getExpectedErrorEvents(
 		},
 	];
 
-	// Loader layer validates Driver compatibility during container creation, so if it fails,
-	// there is no container to dispose of and we won't get the dispose event.
-	if (layer1 === "loader" && layer2 === "driver") {
+	// The Driver / Loader boundary is validated in the Container constructor (in both directions), so if it
+	// fails, there is no container to dispose of and we won't get the dispose event.
+	if (
+		(layer1 === "loader" && layer2 === "driver") ||
+		(layer1 === "driver" && layer2 === "loader")
+	) {
 		expectedErrorEvents.pop();
 	}
 
@@ -269,6 +324,11 @@ function getExpectedErrorEvents(
 	let telemetryNamespace: string = ":";
 	switch (layer1) {
 		case "loader":
+			telemetryNamespace = ":Container:";
+			break;
+		case "driver":
+			// The driver does not run the validation itself; the loader validates on its behalf and logs the
+			// error in the Container's telemetry namespace.
 			telemetryNamespace = ":Container:";
 			break;
 		case "runtime":
@@ -301,6 +361,10 @@ describeCompat("Layer compatibility validation", "NoCompat", (getTestObjectProvi
 		{
 			layer1: "loader",
 			layer2: "driver",
+		},
+		{
+			layer1: "driver",
+			layer2: "loader",
 		},
 		{
 			layer1: "loader",

--- a/packages/utils/telemetry-utils/src/layerCompatError.ts
+++ b/packages/utils/telemetry-utils/src/layerCompatError.ts
@@ -41,7 +41,7 @@ const strictCheckBypassLoggedForPair: Set<string> = new Set<string>();
  * @param validatingLayer - The layer whose support requirements define compatibility. The `targetLayer` must meet
  * these requirements to be considered compatible.
  * - `layer`: The name of this layer.
- * - `compatDetails`: The compatibility details (version / generation) of this layer, used for telemetry attribution.
+ * - `packageInfo`: The package version / generation of this layer, used for telemetry attribution.
  * - `compatSupportRequirements`: The requirements the `targetLayer` must satisfy to be compatible with this layer.
  * @param targetLayer - The layer being validated against the `validatingLayer`'s requirements.
  * - `layer`: The name of this layer.
@@ -56,7 +56,7 @@ const strictCheckBypassLoggedForPair: Set<string> = new Set<string>();
 export function validateLayerCompatibility(
 	validatingLayer: {
 		layer: FluidLayer;
-		compatDetails: Pick<ILayerCompatDetails, "pkgVersion" | "generation">;
+		packageInfo: Pick<ILayerCompatDetails, "pkgVersion" | "generation">;
 		compatSupportRequirements: ILayerCompatSupportRequirements;
 	},
 	targetLayer: {
@@ -71,7 +71,7 @@ export function validateLayerCompatibility(
 ): void {
 	const {
 		layer: validatingLayerName,
-		compatDetails: validatingLayerCompatDetails,
+		packageInfo: validatingLayerPackageInfo,
 		compatSupportRequirements: validatingLayerSupportRequirements,
 	} = validatingLayer;
 	const {
@@ -89,17 +89,17 @@ export function validateLayerCompatibility(
 		const coreProperties = {
 			layer: validatingLayerName,
 			incompatibleLayer: targetLayerName,
-			layerVersion: validatingLayerCompatDetails.pkgVersion,
+			layerVersion: validatingLayerPackageInfo.pkgVersion,
 			incompatibleLayerVersion: maybeTargetLayerCompatDetails?.pkgVersion ?? "unknown",
 			compatibilityRequirementsInMonths:
-				validatingLayerCompatDetails.generation -
+				validatingLayerPackageInfo.generation -
 				validatingLayerSupportRequirements.minSupportedGeneration,
 			actualDifferenceInMonths:
-				validatingLayerCompatDetails.generation -
+				validatingLayerPackageInfo.generation -
 				(maybeTargetLayerCompatDetails?.generation ?? 0),
 		};
 		const detailedProperties = {
-			layerGeneration: validatingLayerCompatDetails.generation,
+			layerGeneration: validatingLayerPackageInfo.generation,
 			incompatibleLayerGeneration: maybeTargetLayerCompatDetails?.generation,
 			minSupportedGeneration: validatingLayerSupportRequirements.minSupportedGeneration,
 			isGenerationCompatible: layerCheckResult.isGenerationCompatible,

--- a/packages/utils/telemetry-utils/src/layerCompatError.ts
+++ b/packages/utils/telemetry-utils/src/layerCompatError.ts
@@ -37,58 +37,77 @@ const strictCheckBypassLoggedForPair: Set<string> = new Set<string>();
  * Validates the compatibility between two layers using their compatibility details and support requirements.
  * If the layers are incompatible, it logs a "LayerIncompatibilityError" error event. It will also call the dispose
  * function with the error and throw the error.
- * @param layer1 - The name of the first layer.
- * @param layer2 - The name of the second layer.
- * @param compatDetailsLayer1 - The compatibility details of the first layer.
- * @param compatSupportRequirementsLayer1 - The support requirements that the second layer must meet to be compatible
- * with the first layer.
- * @param maybeCompatDetailsLayer2 - The compatibility details of the second layer. This can be undefined if the
- * second layer does not provide compatibility details.
- * @param disposeFn - A function that will be called with the error if the layers are incompatible.
- * @param mc - The monitoring context for logging and reading configuration.
- * @param strictCompatibilityCheck - If true, the function will use default compatibility details for the second layer if
- * they are missing and use it for validation.
- * If false, it will skip the compatibility check if the details are missing and just log an error.
- * Defaults to false.
+ *
+ * @param validatingLayer - The layer whose support requirements define compatibility. The `targetLayer` must meet
+ * these requirements to be considered compatible.
+ * - `layer`: The name of this layer.
+ * - `compatDetails`: The compatibility details (version / generation) of this layer, used for telemetry attribution.
+ * - `compatSupportRequirements`: The requirements the `targetLayer` must satisfy to be compatible with this layer.
+ * @param targetLayer - The layer being validated against the `validatingLayer`'s requirements.
+ * - `layer`: The name of this layer.
+ * - `compatDetails`: The compatibility details of this layer. Can be undefined if this layer does not provide them.
+ * - `strictCompatibilityCheck`: If true, default compatibility details are used for this layer when its details are missing, and validation proceeds. If false (default), the compatibility check is skipped when details are missing and an error is logged instead.
+ * @param context - Ambient dependencies for the validation.
+ * - `disposeFn`: A function that will be called with the error if the layers are incompatible.
+ * - `mc`: The monitoring context for logging and reading configuration.
  *
  * @internal
  */
 export function validateLayerCompatibility(
-	layer1: FluidLayer,
-	layer2: FluidLayer,
-	compatDetailsLayer1: Pick<ILayerCompatDetails, "pkgVersion" | "generation">,
-	compatSupportRequirementsLayer1: ILayerCompatSupportRequirements,
-	maybeCompatDetailsLayer2: ILayerCompatDetails | undefined,
-	disposeFn: (error?: IErrorBase) => void,
-	mc: MonitoringContext,
-	strictCompatibilityCheck: boolean = false,
+	validatingLayer: {
+		layer: FluidLayer;
+		compatDetails: Pick<ILayerCompatDetails, "pkgVersion" | "generation">;
+		compatSupportRequirements: ILayerCompatSupportRequirements;
+	},
+	targetLayer: {
+		layer: FluidLayer;
+		compatDetails: ILayerCompatDetails | undefined;
+		strictCompatibilityCheck?: boolean;
+	},
+	context: {
+		disposeFn: (error?: IErrorBase) => void;
+		mc: MonitoringContext;
+	},
 ): void {
+	const {
+		layer: validatingLayerName,
+		compatDetails: validatingLayerCompatDetails,
+		compatSupportRequirements: validatingLayerSupportRequirements,
+	} = validatingLayer;
+	const {
+		layer: targetLayerName,
+		compatDetails: maybeTargetLayerCompatDetails,
+		strictCompatibilityCheck = false,
+	} = targetLayer;
+	const { disposeFn, mc } = context;
+
 	const layerCheckResult = checkLayerCompatibility(
-		compatSupportRequirementsLayer1,
-		maybeCompatDetailsLayer2,
+		validatingLayerSupportRequirements,
+		maybeTargetLayerCompatDetails,
 	);
 	if (!layerCheckResult.isCompatible) {
 		const coreProperties = {
-			layer: layer1,
-			incompatibleLayer: layer2,
-			layerVersion: compatDetailsLayer1.pkgVersion,
-			incompatibleLayerVersion: maybeCompatDetailsLayer2?.pkgVersion ?? "unknown",
+			layer: validatingLayerName,
+			incompatibleLayer: targetLayerName,
+			layerVersion: validatingLayerCompatDetails.pkgVersion,
+			incompatibleLayerVersion: maybeTargetLayerCompatDetails?.pkgVersion ?? "unknown",
 			compatibilityRequirementsInMonths:
-				compatDetailsLayer1.generation -
-				compatSupportRequirementsLayer1.minSupportedGeneration,
+				validatingLayerCompatDetails.generation -
+				validatingLayerSupportRequirements.minSupportedGeneration,
 			actualDifferenceInMonths:
-				compatDetailsLayer1.generation - (maybeCompatDetailsLayer2?.generation ?? 0),
+				validatingLayerCompatDetails.generation -
+				(maybeTargetLayerCompatDetails?.generation ?? 0),
 		};
 		const detailedProperties = {
-			layerGeneration: compatDetailsLayer1.generation,
-			incompatibleLayerGeneration: maybeCompatDetailsLayer2?.generation,
-			minSupportedGeneration: compatSupportRequirementsLayer1.minSupportedGeneration,
+			layerGeneration: validatingLayerCompatDetails.generation,
+			incompatibleLayerGeneration: maybeTargetLayerCompatDetails?.generation,
+			minSupportedGeneration: validatingLayerSupportRequirements.minSupportedGeneration,
 			isGenerationCompatible: layerCheckResult.isGenerationCompatible,
 			unsupportedFeatures: layerCheckResult.unsupportedFeatures,
 		};
 
 		const error = new LayerIncompatibilityError(
-			`The versions of the ${layer1} and ${layer2} are not compatible`,
+			`The versions of the ${validatingLayerName} and ${targetLayerName} are not compatible`,
 			{
 				...coreProperties,
 				details: JSON.stringify(detailedProperties),
@@ -112,21 +131,21 @@ export function validateLayerCompatibility(
 			return;
 		}
 
-		if (maybeCompatDetailsLayer2 === undefined && !strictCompatibilityCheck) {
-			// If there is no compatibility details for layer2 and strictCompatibilityCheck is false, do not fail.
-			// There can be a couple of scenarios where this can happen:
-			// 1. layer2's version is older than the version where compatibility enforcement was introduced. In this
-			//    case, the behavior is the same as before compatibility enforcement was introduced.
-			// 2. layer2 has a custom implementation which doesn't provide compatibility details. In this case,
-			//    we don't know for sure that it is incompatible. It may fail at a later point when it tries to use
-			//    some feature that the Runtime doesn't support.
-			if (!strictCheckBypassLoggedForPair.has(`${layer1}-${layer2}`)) {
+		if (maybeTargetLayerCompatDetails === undefined && !strictCompatibilityCheck) {
+			// If there is no compatibility details for the target layer and strictCompatibilityCheck is false, do not
+			// fail. There can be a couple of scenarios where this can happen:
+			// 1. The target layer's version is older than the version where compatibility enforcement was introduced.
+			//    In this case, the behavior is the same as before compatibility enforcement was introduced.
+			// 2. The target layer has a custom implementation which doesn't provide compatibility details. In this
+			//    case, we don't know for sure that it is incompatible. It may fail at a later point when it tries to
+			//    use some feature that the Runtime doesn't support.
+			if (!strictCheckBypassLoggedForPair.has(`${validatingLayerName}-${targetLayerName}`)) {
 				// This event is only logged once per session per layer combination to avoid flooding telemetry.
-				strictCheckBypassLoggedForPair.add(`${layer1}-${layer2}`);
+				strictCheckBypassLoggedForPair.add(`${validatingLayerName}-${targetLayerName}`);
 				mc.logger.sendTelemetryEvent(
 					{
 						eventName: "LayerIncompatibilityDetectedButBypassed",
-						reason: `No compatibility details provided for ${layer2} and strictCompatibilityCheck is false`,
+						reason: `No compatibility details provided for ${targetLayerName} and strictCompatibilityCheck is false`,
 					},
 					error,
 				);


### PR DESCRIPTION
## Description

This adds **bidirectional** layer-compatibility validation across the Driver / Loader boundary.

Previously the Loader only validated that the Driver was compatible with it (`validateDriverCompatibility`). The reverse — that the Loader is compatible with the Driver — was never checked, because the Driver holds no reference to the Loader and so cannot validate it.

To close that gap without inverting the layer hierarchy, the Driver now **publishes the requirements the Loader must meet** via a new `ILayerCompatSupportRequirements` `FluidObject` exposed on each driver's `IDocumentServiceFactory`. The Loader reads those requirements and validates itself against them **on the Driver's behalf**, via the new `validateLoaderCompatibilityWithDriver` function. Both directions now run from the `Container` constructor.

## The gap this addresses

The Driver does not hold reference to Loader and hence cannot check what features it supports or what it's generation is. So, if it wants to make a breaking change (say change in behavior of one of the APIs), it cannot make that change conditionally based on whether the Loader is compatible with the new behavior. Instead, it must ship the change dark, wait for saturation and then enable the new behavior. Say it does this in version N.

The gap this leaves is that if there is a combination of new Driver (post enabling new behavior) and old Loader (pre version N), the Loader will crash at the failure point of the new behavior which can be misleading and is exactly the kind of problems the layer compat checks are supposed to solve.

With this change, in the above scenario, with new Driver (post enabling new behavior) and old Loader (pre version N), the old Loader will fail the compatibility check with a clear error.

> Note that we still cannot conditionaly turn the new behavior in the Driver on based on Loader version. That gap cannot be closed until we pass in a Loader object to the Driver.

### Loaders before this change

In the above scenarios, if the old Loader is pre this change, it will crash at the failure point of the new behavior. This is not ideal but there is not much we can do about this. Moreover, this is fine because the new policy has been documented and communicated to customer way in advance.

## Also included in this change

- **Bug fix:** the Driver-boundary check was reusing `loaderCompatDetailsForRuntime`; it now uses a dedicated `loaderCompatDetailsForDriver`.
- A separate `IProvideLayerCompatSupportRequirements` provider (rather than embedding requirements in `ILayerCompatDetails`), keeping "what I am" and "what I require of you" distinct.
- Reverse-direction unit tests in `container-loader`, and the reverse (`driver -> loader`) direction added to the end-to-end `layerCompat` suite (runs per driver type across both create and load flows).

The new `ILayerCompatSupportRequirements` property on `LocalDocumentServiceFactory` and `OdspDocumentServiceFactoryCore` mirrors the existing `ILayerCompatDetails` property (added in #25120). A changeset is included.

[AB#58900](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/58900)