### PR TITLE
docs: add Concepts documentation tree (testing + summarization branches)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,171 @@
+# Fluid Framework — Concepts
+
+This is the **root of the engineering documentation tree**. It gives a high‑level,
+conceptual tour of how the Fluid Framework is put together and links out to deeper
+documents that live next to the code they describe.
+
+The goal is a single, navigable starting point: read a short overview of a concept here,
+then follow the link into the package/folder where that concept lives for the full detail.
+
+> **How this tree works**
+> Each top‑level concept below has a short "what & why" summary and a **Learn more** list of
+> links. Overview docs live here at the root; detailed docs live in the relevant sub‑folder
+> (e.g. summarization lives in `container-runtime`, end‑to‑end testing lives in `packages/test`).
+> When you add a new doc deep in the repo, link it back up into the right section here so it
+> stays reachable.
+
+---
+
+## Table of contents
+
+- [Programming models](#programming-models) — encapsulated vs. declarative
+- [Layers](#layers) — the four layers: Driver / Loader / Runtime / Datastore
+- [Compatibility](#compatibility) — API, layer, cross‑client, and data‑at‑rest
+- [Op processing](#op-processing) — batching, compression, chunking
+- [Summarization](#summarization) — snapshots, the summarizer client, incremental summaries
+- [Garbage collection](#garbage-collection) — mark / sweep of unreferenced objects
+- [Testing](#testing) — unit, end‑to‑end, cross‑version, fuzz, and load testing
+
+---
+
+## Programming models
+
+Fluid exposes two ways to build an application on top of the same runtime:
+
+- **Encapsulated model** — your code packages data and logic into `DataObject`s that the
+  container loads by code. Maximum flexibility and dynamic loading; more boilerplate.
+- **Declarative model** — you describe a fixed schema of shared objects up front (e.g. via
+  `SharedTree` / the `fluid-framework` container schema) and the framework wires it up. Simpler
+  to consume; the shape is known at build time.
+
+Understanding which model an application uses drives a lot of downstream behavior, including how
+cross‑client compatibility is reasoned about.
+
+**Learn more**
+
+- [Application models](./ApplicationModels.md) — encapsulated vs. declarative, in depth
+
+---
+
+## Layers
+
+A Fluid client is a stack of **four layers**, each with a defined contract to the layer above
+and below:
+
+| Layer | Responsibility | Made up of |
+| ----- | -------------- | ---------- |
+| **Driver** | Talks to a specific service (ODSP, Routerlicious/AFR, local). Sends/receives ops & snapshots. | the service drivers |
+| **Loader** | Resolves and loads a container, manages the connection lifecycle. | the container loader |
+| **Runtime** | Orchestrates data stores, op processing, summarization, and GC. | the **container runtime** |
+| **Datastore** | The code+data units within a container and the shared data types that hold user data. | the **data store runtime** and the **DDSes** (SharedTree, SharedMap, sequences, …) |
+
+Note the nesting: the **container runtime** belongs to the **Runtime** layer, while both the
+**data store runtime** and the **DDSes** belong to the **Datastore** layer.
+
+Layers are versioned and shipped independently, which is why **layer compatibility** is a
+first‑class concern (see [Compatibility](#compatibility)).
+
+**Learn more**
+
+- [Layer compatibility](./LayerCompatibility.md) — how layer boundaries are validated
+- [Layer compatibility dev guide](./LayerCompatibilityDevGuide.md)
+- [`PACKAGES.md`](./PACKAGES.md) — the full package/layer listing enforced by `layer-check`
+
+---
+
+## Compatibility
+
+Fluid ships many independently‑versioned packages and must keep documents and clients working
+across versions. There are four distinct dimensions:
+
+1. **API compatibility** — source/runtime compatibility of public APIs across releases.
+2. **Layer compatibility** — a loader/driver/runtime of one version working with another.
+3. **Cross‑client compatibility** — clients on different releases collaborating on the same
+   document (an 18‑month window enforced via `minVersionForCollab`).
+4. **Data‑at‑rest compatibility** — newer code reading summaries/snapshots written by older code.
+
+**Learn more**
+
+- [Compatibility considerations](./FluidCompatibilityConsiderations.md) — overview of all four dimensions
+- [Layer compatibility](./LayerCompatibility.md) and its [dev guide](./LayerCompatibilityDevGuide.md)
+- [Cross‑client compatibility](./CrossClientCompatibility.md) and its
+  [dev guide](./CrossClientCompatibilityDevGuide.md)
+- [Compatibility checkpoints](./CompatibilityCheckpoints.md) — the checkpoint schedule & version ranges
+
+---
+
+## Op processing
+
+Every change in a Fluid document is an **operation** ("op"). The container runtime owns the
+pipeline that gets ops to and from the ordering service efficiently:
+
+- **Outbound:** ops are accumulated in an outbox, **grouped** into batches, optionally
+  **compressed** (lz4), and **chunked** if they exceed the service's max message size.
+- **Inbound:** received messages are de‑chunked, decompressed, and ungrouped before the runtime
+  applies them, preserving batch and ordering guarantees.
+
+This pipeline is what makes high‑frequency collaboration affordable.
+
+**Learn more**
+
+- [Op lifecycle & batching](./packages/runtime/container-runtime/src/opLifecycle/README.md) —
+  grouping, compression, chunking, with end‑to‑end flow diagrams
+
+---
+
+## Summarization
+
+The op log grows forever, but new clients shouldn't have to replay all of history. A
+**summary** captures the state of a container at a sequence number so future clients can start
+from there. Summaries are produced by a dedicated, non‑interactive **summarizer client** (elected
+among connected write clients), generated on heuristics, and uploaded to storage and acked via
+the ordering service. Summaries are **incremental** — unchanged subtrees are referenced by handle
+rather than re‑uploaded.
+
+**Learn more**
+
+- [Summarization overview](./packages/runtime/container-runtime/src/summary/README.md) —
+  what/why/who/when/how, the summary lifecycle, incremental summaries, resiliency
+- [Summary & snapshot formats](./packages/runtime/container-runtime/src/summary/summaryFormats.md) —
+  the on‑the‑wire tree formats
+- [Writing tests that take summaries](./packages/test/test-end-to-end-tests/WritingTestsThatTakeSummaries.md) —
+  how to test summarization deterministically
+
+---
+
+## Garbage collection
+
+As a document evolves, objects (data stores, DDSes, blobs) can become **unreferenced**. Garbage
+collection reclaims them in two phases: a continuous **mark** phase that walks the reference graph
+to find unreferenced objects, and a **sweep** phase (integrated into the summary cycle) that
+eventually deletes them. A **tombstone** mode sits in between to catch incorrect references safely
+before deletion is enabled.
+
+GC state travels inside the summary, so GC and summarization are tightly coupled.
+
+**Learn more**
+
+- [Garbage collection overview](./packages/runtime/container-runtime/src/gc/README.md) —
+  mark/sweep, tombstones, session expiry, and configuration
+
+---
+
+## Testing
+
+Fluid's correctness across services, versions, and time relies on several complementary test
+styles: fast unit tests, **end‑to‑end** tests parameterized over drivers and version
+combinations, **cross‑version/compat** testing, **fuzz/stochastic** testing for DDSes, **snapshot**
+format compatibility tests, and **load** testing.
+
+Tests are **not confined to one directory**: every package has its own unit tests (and optionally
+fuzz tests) under `src/test`, while the cross‑cutting suites and shared infrastructure live in
+[`packages/test`](./packages/test/README.md).
+
+**Learn more**
+
+- [Testing overview](./TESTING.md) — where each kind of test lives and how the pieces fit together
+
+---
+
+_This tree is a work in progress. Testing and Summarization are the first fully wired‑in
+branches; other branches link to existing docs and will be expanded over time._

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 The Fluid Framework is a library for building distributed, real-time collaborative web
 applications using JavaScript or TypeScript.
 
+> 📚 **New to the internals?** Start with [**CONCEPTS.md**](./CONCEPTS.md) — a high‑level,
+> navigable tour of how the framework works (layers, compatibility, op processing, summarization,
+> garbage collection, testing) with links into the relevant code.
+
 ## Getting started using the Fluid Framework
 
 You may be here because you want to...

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,74 @@
+# Testing
+
+> Part of the [Fluid Framework documentation tree](./CONCEPTS.md#testing). This is the cross‑cutting
+> overview of how the framework is tested. It spans the **whole repo** — tests are not confined to
+> any single directory.
+
+Fluid has to stay correct across **many services**, **many versions**, and **a lot of elapsed
+time**. No single kind of test covers all of that, so the repo layers several complementary
+styles. Crucially, **tests live in two places**:
+
+- **In each package** — every package has its own unit tests (and, where it makes sense, fuzz
+  tests) alongside the code they exercise.
+- **In [`packages/test`](./packages/test/README.md)** — the cross‑cutting suites and shared
+  infrastructure that don't belong to any one package (end‑to‑end, cross‑version/compat, drivers,
+  snapshots, load).
+
+## Test styles at a glance
+
+| Style | What it covers | Where it lives |
+| ----- | -------------- | -------------- |
+| **Unit tests** | Logic inside a single package, in isolation. | `src/test` in **every** package |
+| **Fuzz / stochastic** | Randomized op sequences against a DDS to find convergence/edge‑case bugs. | `src/test` of the relevant package, built on [`stochastic-test-utils`](./packages/test/stochastic-test-utils/README.md) |
+| **End‑to‑end (e2e)** | A real container loop (create → change → summarize → load) run against each driver. | [`packages/test/test-end-to-end-tests`](./packages/test/test-end-to-end-tests/README.md) |
+| **Cross‑version / compat** | The same e2e scenarios with mixed‑version layers, to validate [compatibility](./CONCEPTS.md#compatibility). | [`packages/test/test-version-utils`](./packages/test/test-version-utils/README.md) |
+| **Snapshot compatibility** | New code can still load summaries/snapshots written by old code. | [`packages/test/snapshots`](./packages/test/snapshots/README.md) |
+| **Load / stress** | Behavior under many clients and high op rates. | [`packages/test/test-service-load`](./packages/test/test-service-load/README.md), [`local-server-stress-tests`](./packages/test/local-server-stress-tests/) |
+
+## Tests that live in each package
+
+The majority of tests are **unit tests** in the package they cover, under `src/test`. They are
+fast, run in isolation, and are the first line of defense. Run them with `pnpm test` from inside
+the package (see [Running tests](#running-tests)).
+
+Many packages — especially those that implement a **DDS** — also have **fuzz (stochastic) tests**
+in their own `src/test`. These drive randomized, interleaved op sequences through a model and
+reducer to verify that clients **converge** (any two clients that have seen the same ops end in the
+same state) and to surface edge cases hand‑written tests miss. The shared machinery
+(`describeFuzz`, `performFuzzActions`, the `FUZZ_TEST_COUNT` / `FUZZ_STRESS_RUN` controls) lives in
+[`stochastic-test-utils`](./packages/test/stochastic-test-utils/README.md), but the tests
+themselves live next to each DDS.
+
+## Cross‑cutting tests in `packages/test`
+
+Some tests can't belong to a single package because they exercise the whole stack or many versions
+at once. These live in [`packages/test`](./packages/test/README.md):
+
+- **End‑to‑end** — written once, then parameterized **over drivers** (local, Tinylicious,
+  Routerlicious/AFR, ODSP) and **over version combinations**. See
+  [`test-end-to-end-tests`](./packages/test/test-end-to-end-tests/README.md).
+- **Cross‑version / compat** — `describeCompat(...)` from
+  [`test-version-utils`](./packages/test/test-version-utils/README.md) generates a matrix of
+  mixed‑version layer combinations (e.g. *new loader + old runtime*) and installs the legacy
+  versions to do it. This is the testing counterpart to the
+  [compatibility policy docs](./CONCEPTS.md#compatibility).
+- **Snapshot compatibility** — [`snapshots`](./packages/test/snapshots/README.md) checks that
+  current code loads a corpus of older snapshots.
+- **Load / stress** — [`test-service-load`](./packages/test/test-service-load/README.md) simulates
+  many clients and high throughput.
+
+For the full directory listing and the shared utilities (drivers, `TestFluidObject`, Mocha setup),
+see the [`packages/test` README](./packages/test/README.md).
+
+## Running tests
+
+See the [root README](./README.md#testing) for the canonical commands:
+
+- `pnpm test` — all tests from the repo root, or a scoped set when run inside a package.
+- `pnpm build-and-test <name-regex>` — incremental build + test.
+- `ci:test` / `ci:test:coverage` — mirror the CI pipeline.
+- Add `.only` / `.skip` to focus or exclude individual tests; some tests need the Git LFS
+  submodule (`FluidFrameworkTestData`) fetched.
+
+The public‑facing testing guide (Mocha, Jest, Puppeteer, Tinylicious, AFR automation) is at
+[`docs/docs/testing/testing.mdx`](./docs/docs/testing/testing.mdx).

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -1,0 +1,43 @@
+# `packages/test` — shared & cross‑cutting test infrastructure
+
+> Part of the [Fluid Framework documentation tree](../../CONCEPTS.md#testing). For the big‑picture
+> testing guide that spans the **whole repo** (including the unit and fuzz tests that live inside
+> each package), start at [`/TESTING.md`](../../TESTING.md). This page describes only what lives in
+> **this directory**.
+
+`packages/test` holds the tests and utilities that **don't belong to any single package** —
+because they exercise the whole client stack, run against real services, or run across multiple
+versions. Per‑package unit and fuzz tests live next to their own code, not here.
+
+## Suites
+
+| Package | What it is |
+| ------- | ---------- |
+| [`test-end-to-end-tests`](./test-end-to-end-tests/README.md) | The main e2e suite: a real container loop, parameterized over drivers and version combinations. |
+| [`snapshots`](./snapshots/README.md) | Validates that current code can load older snapshots/summaries (corpus partly in the `FluidFrameworkTestData` submodule). |
+| [`test-service-load`](./test-service-load/README.md) | Load/stress tool: many simulated clients and high op rates against a real or local service. |
+| [`local-server-tests`](./local-server-tests/) | Scenarios that need direct local‑server control (disconnect/nack). |
+| [`local-server-stress-tests`](./local-server-stress-tests/) | Stress testing against the local server. |
+| [`functional-tests`](./functional-tests/) | Functional test suite. |
+
+## Shared infrastructure
+
+| Package | What it provides |
+| ------- | ---------------- |
+| [`test-version-utils`](./test-version-utils/README.md) | `describeCompat(...)` — generates the mixed‑version (compat) test matrix and installs legacy versions. The engine behind [cross‑version testing](../../CONCEPTS.md#compatibility). |
+| [`test-drivers`](./test-drivers/README.md) | The driver abstraction that lets one e2e test run against local, Tinylicious, Routerlicious/AFR, and ODSP. |
+| [`test-driver-definitions`](./test-driver-definitions/) | The driver interface the drivers implement. |
+| [`test-utils`](./test-utils/README.md) | Core e2e helpers: loaders, `TestFluidObject`, op‑processing controllers. |
+| [`stochastic-test-utils`](./stochastic-test-utils/README.md) | The fuzz/stochastic engine (`describeFuzz`, `performFuzzActions`) used by per‑package DDS fuzz tests. |
+| [`mocha-test-setup`](./mocha-test-setup/README.md) | Central Mocha config and the `FLUID_TEST_*` environment variables. |
+| [`test-pairwise-generator`](./test-pairwise-generator/) | Pairwise test‑case generation. |
+| [`types_jest-environment-puppeteer`](./types_jest-environment-puppeteer/) | Types for browser (Jest + Puppeteer) tests. |
+
+## Writing these tests
+
+- [Writing compat‑correct tests](./test-end-to-end-tests/WritingCompatCorrectTests.md) — using the
+  `apis` argument so a test exercises the right versioned types.
+- [Writing tests that take summaries](./test-end-to-end-tests/WritingTestsThatTakeSummaries.md) —
+  deterministic summarization testing (dedicated summarizer, auto‑summary disabled, synchronization).
+
+For how to run any of this, see [`/TESTING.md` → Running tests](../../TESTING.md#running-tests).


### PR DESCRIPTION
## Description

Introduces a tree-style engineering documentation structure for the repo. A new root-level `CONCEPTS.md` acts as a single, navigable entry point that gives a high-level tour of how the framework works and links out to deeper docs that live next to the code they describe.

Each package can in turn have its own CONCEPTS.md doc if it chooses to do so. For example, tree DDS has a lot of interesting concepts some with docs and some without - it can tie it all with this style.

Another advantage of this is it helps agents find information easily.

`CONCEPTS.md` covers, at a glance. These are just the initial set of concepts to show as examples - More will be added in the future.

- **Programming models** — encapsulated vs. declarative
- **Layers** — the four layers (Driver / Loader / Runtime / Datastore) and how the container runtime, data store runtime, and DDSes nest within them
- **Compatibility** — API, layer, cross-client, and data-at-rest
- **Op processing**, **Summarization**, and **Garbage collection** — linking to the existing module READMEs under `container-runtime`
- **Testing**

This PR fully wires in the first two branches as worked examples:

- **Testing** — new `TESTING.md` is the cross-cutting hub. It makes explicit that tests live in two places: per-package unit/fuzz tests under each package's `src/test`, and the cross-cutting suites (e2e, compat, snapshot, load) under `packages/test`. A new `packages/test/README.md` describes that directory's shared/cross-cutting test infrastructure.
- **Summarization** — wired through the existing, high-quality `container-runtime/src/summary/README.md` rather than duplicating it.

The root `README.md` gets a callout near the top linking to `CONCEPTS.md` so the tree is discoverable from the repo landing page.

Docs-only change: no code, public API, or package behavior is affected.

This is an initial proposal for the documentation style — feedback welcome on:

- The overall tree shape and section ordering in `CONCEPTS.md`.
- The split between root-level overview docs vs. docs that live next to code.
- Which branches to flesh out next (op processing and GC already have module READMEs ready to wire deeper; Layers could use a dedicated overview doc).

Marking as draft while the style is being discussed.