### PR TITLE
fix(client-test-version-utils): restore resolveRangeViaManifest behavior

### DIFF
--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -64,8 +64,4 @@ export {
 	SkippedErrorExpectingTestWithDriverType,
 	SkippedErrorExpectingTestWithDriverBaseType,
 } from "./itSkipsOnFailure.js";
-export {
-	getRequestedVersion,
-	type GetRequestedVersionOptions,
-	versionToComparisonNumber,
-} from "./versionUtils.js";
+export { versionToComparisonNumber } from "./versionUtils.js";

--- a/packages/test/test-version-utils/src/test/versionUtils.spec.ts
+++ b/packages/test/test-version-utils/src/test/versionUtils.spec.ts
@@ -12,7 +12,6 @@ import {
 	calculateRequestedRange,
 	getRequestedVersion,
 	readVersionsManifest,
-	resolveRangeViaManifest,
 	versionHasMovedSparsedMatrix,
 } from "../versionUtils.js";
 
@@ -158,28 +157,23 @@ describe("versionUtils", () => {
 		it("error cases for malformed versions", () => {
 			assert.throws(
 				() => getRequestedVersion({ baseVersion: "-1.-2.-1", requested: -1 }),
-				Error,
-				"TypeError: Invalid Version: -1.-2.-1",
+				new TypeError("Invalid Version: -1.-2.-1"),
 			);
 			assert.throws(
 				() => getRequestedVersion({ baseVersion: "1.-2.-1", requested: -1 }),
-				Error,
-				"TypeError: Invalid Version: 1.-2.-1",
+				new TypeError("Invalid Version: 1.-2.-1"),
 			);
 			assert.throws(
 				() => getRequestedVersion({ baseVersion: "1.-2.-1", requested: -1 }),
-				Error,
-				"TypeError: Invalid Version: 1.-2.-1",
+				new TypeError("Invalid Version: 1.-2.-1"),
 			);
 			assert.throws(
 				() => getRequestedVersion({ baseVersion: "badString", requested: -1 }),
-				Error,
-				"TypeError: Invalid Version: badString",
+				new TypeError("Invalid Version: badString"),
 			);
 			assert.throws(
 				() => getRequestedVersion({ baseVersion: "1.0.0", requested: 1 }),
-				Error,
-				"Only negative values are supported for `requested` param.",
+				new Error("Only negative values are supported for `requested` param."),
 			);
 		});
 
@@ -215,31 +209,51 @@ describe("versionUtils", () => {
 	});
 
 	describe("manifest-backed resolution", () => {
-		it("returns exact versions directly when resolving via manifest", () => {
-			const exactVersion = "9.9.9";
-			assert.strictEqual(resolveRangeViaManifest(exactVersion), exactVersion);
-		});
+		/**
+		 * Given a version and prior spec, return latest version satisfying that in manifest.
+		 */
+		function getLatestPriorVersionInManifest(version: string, adjustment: -1 | -2): string {
+			// Get a range for before the given version
+			const range = calculateRequestedRange(version, adjustment, false);
+			const latestPrior = readVersionsManifest()
+				.versions.filter((v) => semverSatisfies(v, range))
+				.sort(rcompare)[0];
 
-		it("returns baseVersion for current-version requests without manifest lookup", () => {
+			assert.ok(latestPrior, `Expected at least one manifest version satisfying ${range}`);
+			return latestPrior;
+		}
+
+		it("returns baseVersion for current-version requests without manifest lookup when nothing different is requested", () => {
 			const baseVersion = "2.110.0-405442";
 			assert.strictEqual(getRequestedVersion({ baseVersion, requested: 0 }), baseVersion);
-			assert.strictEqual(getRequestedVersion({ baseVersion }), baseVersion);
+			assert.strictEqual(
+				getRequestedVersion({ baseVersion, requested: undefined }),
+				baseVersion,
+			);
 		});
 
-		it("returns explicit string requests without manifest lookup", () => {
+		it("throws for explicit string requests when not in manifest", () => {
 			const baseVersion = "2.110.0";
 			const requested = "2.110.0-405442";
+			assert.throws(
+				() => getRequestedVersion({ baseVersion, requested }),
+				/No version in manifest satisfies range/,
+			);
+		});
+
+		it("returns explicit string requests when in manifest", () => {
+			const baseVersion = "2.110.0";
+			// Find something in the manifest.
+			// This requested version is dynamic to allow for the manifest to\
+			// change over time and not require case update.
+			const requested = getLatestPriorVersionInManifest(pkgVersion, -1);
+			// Request it specifically (independent of relationship to baseVersion)
 			assert.strictEqual(getRequestedVersion({ baseVersion, requested }), requested);
 		});
 
 		it("defaults to resolving N-1 using committed manifest versions", () => {
 			const baseVersion = pkgVersion;
-			const range = calculateRequestedRange(baseVersion, -1, false);
-			const expected = readVersionsManifest()
-				.versions.filter((v) => semverSatisfies(v, range))
-				.sort(rcompare)[0];
-
-			assert.ok(expected, `Expected at least one manifest version satisfying ${range}`);
+			const expected = getLatestPriorVersionInManifest(baseVersion, -1);
 			assert.strictEqual(getRequestedVersion({ baseVersion, requested: -1 }), expected);
 		});
 	});

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -93,6 +93,12 @@ function validateRangeSpec(rangeSpec: string): void {
 /**
  * Resolves a semver dependency spec to the single highest version matching that spec which is published in the npm registry.
  * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
+ * @remarks
+ * When rangeSpec is an exact version, registry check is skipped.
+ * @privateRemarks
+ * This function can be costly time-wise and results are trivially cached.
+ * Higher-order caching is handled by `getRequestedVersion` but this is kept to
+ * assist `baseVersion.ts` uses.
  */
 export const resolveRangeViaRegistry = cached((rangeSpec: string): string => {
 	if (semver.valid(rangeSpec)) {
@@ -129,10 +135,6 @@ export const resolveRangeViaRegistry = cached((rangeSpec: string): string => {
  * @param rangeSpec - A valid (as per [semver](https://www.npmjs.com/package/semver)) range specification
  */
 export function resolveRangeViaManifest(rangeSpec: string): string {
-	if (semver.valid(rangeSpec)) {
-		return rangeSpec;
-	}
-
 	validateRangeSpec(rangeSpec);
 	const manifest = readVersionsManifest();
 	const matching = manifest.versions
@@ -289,12 +291,7 @@ export function calculateRequestedRange(
 		return internalSchemeRange;
 	}
 
-	let version: semver.SemVer;
-	try {
-		version = new semver.SemVer(baseVersion);
-	} catch (err: unknown) {
-		throw new Error(err as string);
-	}
+	const version = new semver.SemVer(baseVersion);
 
 	// If the base version is a public version and `adjustPublicMajor` is false, then we need to ensure that we
 	// calculate N-1 as the previous major release, regardless if it is public or internal.
@@ -354,20 +351,20 @@ export function calculateRequestedRange(
 
 /**
  * Options for {@link getRequestedVersion}.
- *
- * @internal
  */
 export interface GetRequestedVersionOptions {
 	/** The base version to move from (eg. "2.60.0"). */
 	baseVersion: string;
 	/**
-	 * If the value is a negative number, the base version will be adjusted down.
-	 * If the value is a string then it will be returned as-is. Throws on positive number.
+	 * If the value is a string, then it will be returned as-is.
+	 * If the value is a negative number, the base version will be adjusted down and returned.
+	 * If the value is 0 or `undefined`, the base version will be returned as-is.
+	 * Otherwise (the value is a positive number), throw.
 	 */
-	requested?: number | string;
+	requested: number | string | undefined;
 	/**
-	 * If `baseVersion` is a Fluid internal version, this controls whether the public or internal
-	 * version is adjusted by `requested`.
+	 * When true, `requested` delta (it must be a negative number) is applied
+	 * to the major version rather than the minor version.
 	 */
 	adjustPublicMajor?: boolean;
 	/**
@@ -406,8 +403,6 @@ export interface GetRequestedVersionOptions {
  *   useOnlineRegistry: true,
  * });
  * ```
- *
- * @internal
  */
 export function getRequestedVersion({
 	baseVersion,
@@ -415,15 +410,10 @@ export function getRequestedVersion({
 	adjustPublicMajor = false,
 	useOnlineRegistry = false,
 }: GetRequestedVersionOptions): string {
-	// Current-version requests should stay pinned to the caller-provided base version.
+	// Base-version requests should stay pinned to the caller-provided base version.
 	// This avoids requiring the current version to exist in the compat manifest/registry.
 	if (requested === undefined || requested === 0) {
 		return baseVersion;
-	}
-
-	// Explicit version strings are already concrete requests, so return them directly.
-	if (typeof requested === "string") {
-		return requested;
 	}
 
 	const calculatedRange = calculateRequestedRange(baseVersion, requested, adjustPublicMajor);
@@ -453,7 +443,7 @@ export function getRequestedVersion({
 			// Here we cache the result so we don't have to enter the try/catch flow again.
 			// Note: This will cache the resolved version range (i.e. >=2.0.0-rc.4.0.0 <2.0.0-rc.5.0.0). Because of this,
 			// it will not cause any conflicts when trying to fetch the current version —
-			// i.e. `getRequestedVersion({ baseVersion: "2.0.0-rc.5.0.0" })` will still return "2.0.0-rc.5.0.0".
+			// i.e. `getRequestedVersion({ baseVersion: "2.0.0-rc.5.0.0", requested: 0 })` will still return "2.0.0-rc.5.0.0".
 			resolutionCache.set(cacheKey, resolvedVersion);
 			return resolvedVersion;
 		}


### PR DESCRIPTION
Cleanup from #27521 CI repair:
- restore behavior of `resolveRangeViaManifest` to only allow version that is within manifest
- update unit tests to check expectations
- remove `getRequestedVersion` from package exports
- require `requested` be specified when calling `getRequestedVersion`
- add/correct various comments

Cleanup from #11082:
- correct `getRequestedVersion` throwing test cases (that weren't checking error message content)
- remove extraneous try-catch and wrap in `calculateRequestedRange`