### PR TITLE
Cleanup pack-packages for better error propagation and pnpm 11 support

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -50,7 +50,6 @@
 		"format:biome": "biome check --write .",
 		"lint": "npm run eslint",
 		"lint:fix": "npm run eslint:fix",
-		"postpack": "npm run clean:manifest",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm run test",
 		"test:mocha": "mocha --forbid-only",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -45,7 +45,6 @@
 		"format:biome": "biome check --write .",
 		"lint": "npm run eslint",
 		"lint:fix": "npm run eslint:fix",
-		"postpack": "npm run clean:manifest",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm run test",
 		"test:mocha": "mocha --forbid-only \"lib/test/**/*.test.js\"",

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -19,15 +19,23 @@ if [ -f ".releaseGroup" ]; then
   if [ "$PACKAGE_MANAGER" == "pnpm" ]; then
     flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "pnpm --if-present pack:tests"
   fi
-  flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "$PACKAGE_MANAGER pack" && \
-  flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz" && \
+  flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "$PACKAGE_MANAGER pack"
+  flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz"
   flub exec --no-private --releaseGroup $RELEASE_GROUP -- "[ ! -f ./*test-files.tar ] || (echo 'test files found' && mv -t $STAGING_PATH/test-files/ ./*test-files.tar)"
+
+  # Clean up generated files that are listed in a package's "files" array (e.g. oclif.manifest.json) after packing.
+  # These are produced during build and intentionally shipped in the published tarball, but should not linger in
+  # the working tree. This cleanup deliberately runs here rather than in a package "postpack" script: under
+  # pnpm >=11, `pnpm pack` re-stats every "files" entry after postpack runs and fails with ENOENT if postpack
+  # deleted one. Running it here, after all packs complete, avoids that while still cleaning the working tree.
+  flub exec --no-private --releaseGroup $RELEASE_GROUP -- "pnpm run --if-present clean:manifest"
 
 else
   if [ "$PACKAGE_MANAGER" == "pnpm" ]; then
     pnpm --if-present pack:tests
   fi
-  $PACKAGE_MANAGER pack && mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz
+  $PACKAGE_MANAGER pack
+  mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz
 fi
 
 # This saves a list of the packages in the working directory in topological order to a temporary file.


### PR DESCRIPTION
## Description

Prevent swallowing of errors, and fix pnpm 11 support.

This use of && seemed harmful to me, as it obscured the error (this script did not fail). Claude agreed:

> These are separate statements (not chained with `&&`) so that `set -e` aborts the script on the first
> failure. Under `set -e`, a failing command that is not the last link of an `&&` chain is exempt from
> exit-on-error, so chaining would silently swallow a failed `pnpm pack` and let the script continue.

The && below is also removed for the same reason.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
