### PR TITLE
BREAKING CHANGE(client-presence): remove deprecated `getPresence`

### DIFF
--- a/.changeset/tough-schools-punch.md
+++ b/.changeset/tough-schools-punch.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/presence": minor
+"__section": breaking
+---
+getPresence export removed
+
+Import from `fluid-framework` instead.
+See [#26397](https://github.com/microsoft/FluidFramework/issues/26397).

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -49,9 +49,6 @@ export interface BroadcastControlSettings {
 // @public
 export type ClientConnectionId = string;
 
-// @beta @deprecated
-export const getPresence: (fluidContainer: IFluidContainer) => Presence;
-
 // @public @system
 export namespace InternalPresenceTypes {
     // @system

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -49,9 +49,6 @@ export interface BroadcastControlSettings {
 // @public
 export type ClientConnectionId = string;
 
-// @beta @deprecated
-export const getPresence: (fluidContainer: IFluidContainer) => Presence;
-
 // @public @system
 export namespace InternalPresenceTypes {
     // @system

--- a/packages/framework/presence/api-report/presence.legacy.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.legacy.alpha.api.md
@@ -49,9 +49,6 @@ export interface BroadcastControlSettings {
 // @public
 export type ClientConnectionId = string;
 
-// @beta @deprecated
-export const getPresence: (fluidContainer: IFluidContainer) => Presence;
-
 // @alpha @legacy
 export function getPresenceFromDataStoreContext(context: IFluidDataStoreContext): Presence;
 

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -102,7 +102,6 @@
 		"@fluid-internal/presence-definitions": "workspace:~",
 		"@fluid-internal/presence-runtime": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
-		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~"
 	},
 	"devDependencies": {

--- a/packages/framework/presence/src/getPresence.ts
+++ b/packages/framework/presence/src/getPresence.ts
@@ -9,24 +9,10 @@ import {
 	extensionId,
 } from "@fluid-internal/presence-runtime/extension";
 import { assert } from "@fluidframework/core-utils/internal";
-import type { IFluidContainer } from "@fluidframework/fluid-static";
-import { getPresenceAlpha } from "@fluidframework/fluid-static/internal";
 import type {
 	FluidDataStoreContextInternal,
 	IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions/internal";
-
-/**
- * Acquire a {@link Presence} from a Fluid Container
- * @param fluidContainer - Fluid Container to acquire the map from
- * @returns the {@link Presence}
- *
- * @beta
- *
- * @deprecated Import from `fluid-framework` instead. This export will be removed in the 2.110.0 release.
- * See {@link https://github.com/microsoft/FluidFramework/issues/26397}
- */
-export const getPresence: (fluidContainer: IFluidContainer) => Presence = getPresenceAlpha;
 
 function assertContextHasExtensionProvider(
 	context: IFluidDataStoreContext,

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -79,7 +79,4 @@ export {
 } from "@fluid-internal/presence-runtime/states";
 
 // Local exports
-export {
-	getPresence,
-	getPresenceFromDataStoreContext,
-} from "./getPresence.js";
+export { getPresenceFromDataStoreContext } from "./getPresence.js";

--- a/packages/framework/presence/tsconfig.json
+++ b/packages/framework/presence/tsconfig.json
@@ -7,11 +7,5 @@
 		"outDir": "./lib",
 		"noImplicitAny": true,
 		"noImplicitOverride": true,
-		// `skipLibCheck` set to handle improper handling of exactOptionalPropertyTypes
-		// in upstream packages (mainly merge-tree and container-runtime) required via
-		// fluid-static (for isInternalFluidContainer).
-		// Could alternatively build with exactOptionalPropertyTypes: false.
-		// This can go away once getPresence.ts is removed from the package.
-		"skipLibCheck": true,
 	},
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11622,9 +11622,6 @@ importers:
       '@fluidframework/core-utils':
         specifier: workspace:~
         version: link:../../common/core-utils
-      '@fluidframework/fluid-static':
-        specifier: workspace:~
-        version: link:../fluid-static
       '@fluidframework/runtime-definitions':
         specifier: workspace:~
         version: link:../../runtime/runtime-definitions


### PR DESCRIPTION
`getPresence` is accessible from `fluid-framework`. `@fluidframework/presence` no longer depends on `@fluidframework/fluid-static` making it more palatable to encapsulate API set use.

[AB#70394](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/70394)