### PR TITLE
Add some notes to include-install-build-tools

### DIFF
--- a/tools/pipelines/templates/include-install-build-tools.yml
+++ b/tools/pipelines/templates/include-install-build-tools.yml
@@ -15,7 +15,10 @@ parameters:
   type: string
 
 # The version of the build tools to install, or "repo" to install the one from the repository.
-# If "repo" is selected, this includes a global install of what ever version of pnpm build-tools uses.
+# If "repo" is selected, this includes a global install of what ever version of pnpm build-tools uses
+# overwriting the already installed version.
+# If anything except "repo" is selected, this results in a lock-less install, which could pull in untested
+# and un-audited versions of the many dependencies of build-tools.
 - name: buildToolsVersionToInstall
   type: string
   default: repo

--- a/tools/pipelines/templates/include-install-build-tools.yml
+++ b/tools/pipelines/templates/include-install-build-tools.yml
@@ -3,13 +3,19 @@
 
 # include-install-build-tools
 #
-# This template can be included in pipelines to install the Fluid build-tools locally so flub can be used in the
+# This template can be included in pipelines to install the Fluid build-tools globally so flub can be used in the
 # pipeline.
+# Note that the preferred pattern for using the build tools is to dev a dev dependency on them, and just use that version.
+# Using this template is discouraged as it is introducing another dependency mechanism into the pipeline,
+# Can cause complications with the global pnpm installs overriding each other, and in slower than simply using a pre-build dev dependency.
+# Additionally, using this template requires triggering the pipeline for any changes to build tools or we risk breaking the pipeline.
 
 parameters:
 - name: buildDirectory
   type: string
 
+# The version of the build tools to install, or "repo" to install the one from the repository.
+# If "repo" is selected, this includes a global install of what ever version of pnpm build-tools uses.
 - name: buildToolsVersionToInstall
   type: string
   default: repo

--- a/tools/pipelines/templates/include-install-build-tools.yml
+++ b/tools/pipelines/templates/include-install-build-tools.yml
@@ -5,7 +5,7 @@
 #
 # This template can be included in pipelines to install the Fluid build-tools globally so flub can be used in the
 # pipeline.
-# Note that the preferred pattern for using the build tools is to dev a dev dependency on them, and just use that version.
+# Note that the preferred pattern for using the build tools is to declare a dev dependency on them, and just use that version.
 # Using this template is discouraged as it is introducing another dependency mechanism into the pipeline,
 # Can cause complications with the global pnpm installs overriding each other, and in slower than simply using a pre-build dev dependency.
 # Additionally, using this template requires triggering the pipeline for any changes to build tools or we risk breaking the pipeline.
@@ -15,8 +15,8 @@ parameters:
   type: string
 
 # The version of the build tools to install, or "repo" to install the one from the repository.
-# If "repo" is selected, this includes a global install of what ever version of pnpm build-tools uses
-# overwriting the already installed version.
+# If "repo" is selected, this includes a global install of whatever version of pnpm build-tools uses,
+# which can overwrite an already installed version (like the one used by the package/release-group being built).
 # If anything except "repo" is selected, this results in a lock-less install, which could pull in untested
 # and un-audited versions of the many dependencies of build-tools.
 - name: buildToolsVersionToInstall


### PR DESCRIPTION
## Description

This pipeline template is problematic, and introduces an additional way to depend on build tools which we could probably do without. This clarifies the issues with it a bit.

These issues turned up when trying (and failing) to update build-tools to pnpm 11 which caused hard to root cause problems for users of this pipeline with the default "repo" mode.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

