### PR TITLE
Better error handling in assignTestPorts

### DIFF
--- a/tools/test-tools/src/assignTestPorts.ts
+++ b/tools/test-tools/src/assignTestPorts.ts
@@ -28,15 +28,44 @@ export function getPackageInfo(): PackageInfo[] {
 			// shell:true is required for Windows without a resolved path to pnpm.
 			shell: true,
 		});
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const info: PackageInfo[] = JSON.parse(child.stdout);
-		if (!Array.isArray(info)) {
-			// eslint-disable-next-line unicorn/prefer-type-error
+
+		// spawnSync reports a failure to even launch the process (e.g. pnpm not on PATH) via `error`.
+		if (child.error !== undefined) {
+			throw new Error(`Failed to run "pnpm recursive list": ${child.error.message}`);
+		}
+
+		// A non-zero exit (or termination by a signal) means pnpm itself failed. Surface its status and
+		// stderr instead of blindly parsing the (likely empty) stdout, which would otherwise throw an
+		// opaque "Unexpected end of JSON input" that hides the real cause.
+		if (child.status !== 0) {
+			const reason = child.signal === null ? `code ${child.status}` : `signal ${child.signal}`;
+			throw new Error(`"pnpm recursive list" exited with ${reason}.\nstderr:\n${child.stderr}`);
+		}
+
+		const stdout = child.stdout?.trim() ?? "";
+		if (stdout === "") {
 			throw new Error(
-				`stdin input was not package array. Spawn result: ${JSON.stringify(child)}`,
+				`"pnpm recursive list" produced no output on stdout.\nstderr:\n${child.stderr}`,
 			);
 		}
-		return info;
+
+		let info: unknown;
+		try {
+			info = JSON.parse(stdout);
+		} catch (parseError) {
+			throw new Error(
+				`Failed to parse "pnpm recursive list" output as JSON: ${
+					(parseError as Error).message
+				}\nstdout:\n${stdout}\nstderr:\n${child.stderr}`,
+			);
+		}
+
+		if (!Array.isArray(info)) {
+			// eslint-disable-next-line unicorn/prefer-type-error
+			throw new Error(`Expected a package array from "pnpm recursive list", got: ${stdout}`);
+		}
+
+		return info as PackageInfo[];
 	} catch (error) {
 		console.error(error);
 		process.exit(-1);


### PR DESCRIPTION
## Description

This code used to simply try and parse an empty string as JSON and give an unexpected end of JSON syntax error if there was some issue, like those caused by include-install-build-tools overwriting the pnpm version causing pnpm to try and install a different version which failed due to network isolation (Noted in https://github.com/microsoft/FluidFramework/pull/27537 and blocking https://github.com/microsoft/FluidFramework/pull/27509). Now it actually outputs the errors in such cases.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

