### PR TITLE
BREAKING CHANGE(client-fluid-static): remove deprecated `minVersionForCollabOverride` from `createTreeContainerRuntimeFactory`

### DIFF
--- a/.changeset/dry-jokes-pay.md
+++ b/.changeset/dry-jokes-pay.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/fluid-static": minor
+"__section": breaking
+---
+minVersionForCollabOverride removed from createTreeContainerRuntimeFactory props argument
+
+Instead specify `minVersionForCollaboration` property directly.
+(Deprecated `compatibilityMode` property should also be removed.)
+See [#27356](https://github.com/microsoft/FluidFramework/issues/27356) and [#23289](https://github.com/microsoft/FluidFramework/issues/23289).

--- a/examples/service-clients/azure-client/todo-list/test/index.tsx
+++ b/examples/service-clients/azure-client/todo-list/test/index.tsx
@@ -105,7 +105,7 @@ async function createContainerAndRenderInElement(
 		containerId,
 		createTreeContainerRuntimeFactory({
 			schema: todoListContainerSchema,
-			compatibilityMode: "2.0.0",
+			minVersionForCollaboration: "2.0.0",
 		}),
 		createNewFlag,
 	);

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
@@ -30,7 +30,6 @@ export function createTreeContainerRuntimeFactory(props: {
     readonly compatibilityMode: CompatibilityMode;
     readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
     readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-    readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory;
 
 // @public

--- a/packages/framework/fluid-static/src/treeRootDataObject.ts
+++ b/packages/framework/fluid-static/src/treeRootDataObject.ts
@@ -247,7 +247,7 @@ export function createTreeContainerRuntimeFactory(props: {
 	/**
 	 * Legacy compatibility mode for the container.
 	 */
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- specify minVersionForCollaboration instead; see #23289
 	readonly compatibilityMode: CompatibilityMode;
 	/**
 	 * Optional registry of data stores to pass to the DataObject factory.
@@ -259,29 +259,20 @@ export function createTreeContainerRuntimeFactory(props: {
 	 * If not provided, only the default options for the given compatibilityMode will be used.
 	 */
 	readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-	/**
-	 * Optional override for minimum version for collaboration.
-	 * @remarks
-	 * If not provided, the default for the given compatibilityMode will be used.
-	 * Rather than defining this, omit `compatibilityMode` and pass `minVersionForCollaboration` directly.
-	 */
-	readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory;
 
 // Implementation
 export function createTreeContainerRuntimeFactory(props: {
 	readonly schema: TreeContainerSchema;
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- specify minVersionForCollaboration instead; see #23289
 	readonly compatibilityMode?: CompatibilityMode;
 	readonly minVersionForCollaboration?: MinimumVersionForCollab;
 	readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
 	readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
-	readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory {
 	const {
 		compatibilityMode,
 		minVersionForCollaboration,
-		minVersionForCollabOverride,
 		rootDataStoreRegistry,
 		runtimeOptionOverrides,
 		schema,
@@ -295,9 +286,7 @@ export function createTreeContainerRuntimeFactory(props: {
 			"Either minVersionForCollaboration or compatibilityMode (deprecated) must be provided.",
 		);
 	} else {
-		minVersionForCollab =
-			minVersionForCollabOverride ??
-			resolveCompatibilityModeToMinVersionForCollab(compatibilityMode);
+		minVersionForCollab = resolveCompatibilityModeToMinVersionForCollab(compatibilityMode);
 	}
 
 	const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(schema);


### PR DESCRIPTION
Additionally fix invalid test example code (that is not built under CI).

[AB#75624](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/75624)