### PR TITLE
build(client-drivers): enable  `exactOptionalPropertyTypes` in base packages

### DIFF
--- a/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
@@ -267,7 +267,7 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
     connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
     connectToStorage(): Promise<IDocumentStorageService>;
     dispose(error?: any): void;
-    policies?: IDocumentServicePolicies;
+    policies?: IDocumentServicePolicies | undefined;
     // (undocumented)
     resolvedUrl: IResolvedUrl;
 }

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -375,7 +375,7 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	/**
 	 * Policies implemented/instructed by driver.
 	 */
-	policies?: IDocumentServicePolicies;
+	policies?: IDocumentServicePolicies | undefined;
 
 	/**
 	 * Access to storage associated with the document

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -128,7 +128,15 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_DocumentDeltaConnection": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"ClassStatics_DocumentDeltaConnection": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "internal"
 	}
 }

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -73,7 +73,7 @@ export class DocumentDeltaConnection
 	 * for "read" connections. "write" connections may use own "join" op to similar information,
 	 * that is likely to be more up-to-date.
 	 */
-	public checkpointSequenceNumber: number | undefined;
+	public checkpointSequenceNumber?: number;
 
 	// Listen for ops sent before we receive a response to connect_document
 	protected readonly queuedMessages: ISequencedDocumentMessage[] = [];
@@ -645,7 +645,11 @@ export class DocumentDeltaConnection
 					LogLevel.verbose,
 				);
 
-				this.checkpointSequenceNumber = response.checkpointSequenceNumber;
+				if (response.checkpointSequenceNumber === undefined) {
+					delete response.checkpointSequenceNumber;
+				} else {
+					this.checkpointSequenceNumber = response.checkpointSequenceNumber;
+				}
 
 				this.removeConnectionListeners();
 				resolve(response);

--- a/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
+++ b/packages/drivers/driver-base/src/test/types/validateDriverBasePrevious.generated.ts
@@ -24,6 +24,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_DocumentDeltaConnection": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_DocumentDeltaConnection = requireAssignableTo<TypeOnly<old.DocumentDeltaConnection>, TypeOnly<current.DocumentDeltaConnection>>
 
 /*
@@ -33,6 +34,7 @@ declare type old_as_current_for_Class_DocumentDeltaConnection = requireAssignabl
  * typeValidation.broken:
  * "Class_DocumentDeltaConnection": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_DocumentDeltaConnection = requireAssignableTo<TypeOnly<current.DocumentDeltaConnection>, TypeOnly<old.DocumentDeltaConnection>>
 
 /*
@@ -42,6 +44,7 @@ declare type current_as_old_for_Class_DocumentDeltaConnection = requireAssignabl
  * typeValidation.broken:
  * "ClassStatics_DocumentDeltaConnection": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_DocumentDeltaConnection = requireAssignableTo<TypeOnly<typeof current.DocumentDeltaConnection>, TypeOnly<typeof old.DocumentDeltaConnection>>
 
 /*

--- a/packages/drivers/driver-base/tsconfig.json
+++ b/packages/drivers/driver-base/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 }

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -243,7 +243,7 @@ export const createWriteError = (
  */
 export function createGenericNetworkError(
 	message: string,
-	retryInfo: { canRetry: boolean; retryAfterMs?: number },
+	retryInfo: { canRetry: boolean; retryAfterMs?: number | undefined },
 	props: DriverErrorTelemetryProps,
 ): ThrottlingError | GenericNetworkError {
 	if (retryInfo.retryAfterMs !== undefined && retryInfo.canRetry) {

--- a/packages/loader/driver-utils/src/test/getKeyForCacheEntry.spec.ts
+++ b/packages/loader/driver-utils/src/test/getKeyForCacheEntry.spec.ts
@@ -16,7 +16,7 @@ function createMockCacheEntry(type: string, key: string, fileVersion?: string): 
 		tokens: {},
 		type: "fluid",
 		url: "fluid://resolved-url",
-		fileVersion,
+		...(fileVersion === undefined ? {} : { fileVersion }),
 	} satisfies IResolvedUrl & { fileVersion?: string };
 	return {
 		type,
@@ -24,7 +24,7 @@ function createMockCacheEntry(type: string, key: string, fileVersion?: string): 
 		file: {
 			resolvedUrl,
 			docId: resolvedUrl.id,
-			fileVersion: resolvedUrl.fileVersion,
+			...(fileVersion === undefined ? {} : { fileVersion }),
 		},
 	};
 }

--- a/packages/loader/driver-utils/src/test/summaryCompresssionTester.spec.ts
+++ b/packages/loader/driver-utils/src/test/summaryCompresssionTester.spec.ts
@@ -150,7 +150,7 @@ class InternalTestStorage implements IDocumentStorageService {
 	async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
 		return this._uploadedSummary!;
 	}
-	disposed?: boolean | undefined;
+	disposed?: boolean;
 	dispose?(error?: Error | undefined): void {
 		throw new Error("Method not implemented.");
 	}

--- a/packages/loader/driver-utils/src/test/tsconfig.json
+++ b/packages/loader/driver-utils/src/test/tsconfig.json
@@ -4,7 +4,6 @@
 		"rootDir": "./",
 		"outDir": "../../lib/test",
 		"types": ["mocha", "node"],
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 	"include": ["./**/*"],

--- a/packages/loader/driver-utils/src/treeConversions.ts
+++ b/packages/loader/driver-utils/src/treeConversions.ts
@@ -64,7 +64,9 @@ export function convertSummaryTreeToSnapshotITree(summaryTree: ISummaryTree): IT
 	}
 	return {
 		entries,
-		unreferenced: summaryTree.unreferenced,
-		groupId: summaryTree.groupId,
+		...(summaryTree.unreferenced === undefined
+			? {}
+			: { unreferenced: summaryTree.unreferenced }),
+		...(summaryTree.groupId === undefined ? {} : { groupId: summaryTree.groupId }),
 	};
 }

--- a/packages/loader/driver-utils/tsconfig.json
+++ b/packages/loader/driver-utils/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		// TODO: AB#34167 Enable noUncheckedIndexedAccess for packages/loader/driver-utils
 		"noUncheckedIndexedAccess": false,
 	},


### PR DESCRIPTION
`driver-definitions`:
 - `IDocumentService.policies` is expanded to allow `undefined` as this is already a common runtime occurence. With customers continuing to use `exactOptionalPropertyTypes:false` as documented there is no change despite the explicit `| undefined` change.

`driver-base`:
 - `DocumentDeltaConnection.checkpointSequenceNumber` now respects `IDocumentDeltaConnection` specification

`driver-utils`:
 - use `...(cond ? {} { prop: value })` to only define properties with defined values.