### PR TITLE
improvement(client): fix `exactOptionalPropertyTypes` for telemetry-utils

### DIFF
--- a/.changeset/yummy-moons-train.md
+++ b/.changeset/yummy-moons-train.md
@@ -6,5 +6,5 @@
 ITelemetryBaseLogger.minLogLevel may be undefined
 
 Typing for `ITelemetryBaseLogger.minLogLevel` is updated to reflect that in some implementations `minLogLevel` is present but evaluates to `undefined`.
-When building with `excactOptionalPropertyTypes:false` as suggested in compatibility requirements, there is no apparent type change.
+When building with `excactOptionalPropertyTypes:false` as suggested in [compatibility requirements](https://github.com/microsoft/FluidFramework/blob/68732d93a6cc8be2df966b9bb40f58bdd9fad69b/packages/common/core-interfaces/README.md#supported-tools), there is no apparent type change.
 If a type error is experienced, make sure to check for `undefined` or use `?? LogLevel.info` when reading.

--- a/.changeset/yummy-moons-train.md
+++ b/.changeset/yummy-moons-train.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/core-interfaces": minor
+"__section": breaking
+---
+ITelemetryBaseLogger.minLogLevel may be undefined
+
+Typing for `ITelemetryBaseLogger.minLogLevel` is updated to reflect that in some implementations `minLogLevel` is present but evaluates to `undefined`.
+When building with `excactOptionalPropertyTypes:false` as specified in compatibility requirements, there is not apparent type change.
+If a type error is experienced, make sure to check for `undefined` or use `?? LogLevel.info` when reading.

--- a/.changeset/yummy-moons-train.md
+++ b/.changeset/yummy-moons-train.md
@@ -1,9 +1,10 @@
 ---
+"@fluidframework/azure-client": minor
 "@fluidframework/core-interfaces": minor
 "__section": breaking
 ---
 ITelemetryBaseLogger.minLogLevel may be undefined
 
 Typing for `ITelemetryBaseLogger.minLogLevel` is updated to reflect that in some implementations `minLogLevel` is present but evaluates to `undefined`.
-When building with `excactOptionalPropertyTypes:false` as specified in compatibility requirements, there is not apparent type change.
+When building with `excactOptionalPropertyTypes:false` as suggested in compatibility requirements, there is no apparent type change.
 If a type error is experienced, make sure to check for `undefined` or use `?? LogLevel.info` when reading.

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -109,7 +109,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IContainerContext": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -258,6 +258,7 @@ declare type old_as_current_for_Interface_IContainerContext = requireAssignableT
  * typeValidation.broken:
  * "Interface_IContainerContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerContext = requireAssignableTo<TypeOnly<current.IContainerContext>, TypeOnly<old.IContainerContext>>
 
 /*

--- a/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
@@ -305,7 +305,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -448,7 +448,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
@@ -430,7 +430,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.public.api.md
@@ -305,7 +305,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
@@ -305,7 +305,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -160,7 +160,12 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"NOTE": "When these are reset, also remove ./types/validateCoreInterfacesPrevious.generated.ts from src/test/tsconfig.no-exactOptionalPropertyTypes.json exclusion list",
+			"Interface_ITelemetryBaseLogger": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -130,7 +130,7 @@ export interface ITelemetryBaseLogger {
 	 * Minimum log level to be logged.
 	 * @defaultValue {@link LogLevelConst.info | LogLevel.info}.
 	 */
-	minLogLevel?: LogLevel;
+	minLogLevel?: LogLevel | undefined;
 }
 
 /**

--- a/packages/common/core-interfaces/src/test/tsconfig.no-exactOptionalPropertyTypes.json
+++ b/packages/common/core-interfaces/src/test/tsconfig.no-exactOptionalPropertyTypes.json
@@ -8,7 +8,11 @@
 		"exactOptionalPropertyTypes": false,
 		"noEmit": true,
 	},
-	"exclude": ["./jsonSerializable.exactOptionalPropertyTypes.true.spec.ts"],
+	"exclude": [
+		"./jsonSerializable.exactOptionalPropertyTypes.true.spec.ts",
+		// To be removed during next previous version update
+		"./types/validateCoreInterfacesPrevious.generated.ts",
+	],
 	"references": [
 		{
 			"path": "../..",

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -501,6 +501,7 @@ declare type old_as_current_for_Interface_ITelemetryBaseLogger = requireAssignab
  * typeValidation.broken:
  * "Interface_ITelemetryBaseLogger": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ITelemetryBaseLogger = requireAssignableTo<TypeOnly<current.ITelemetryBaseLogger>, TypeOnly<old.ITelemetryBaseLogger>>
 
 /*

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -157,6 +157,9 @@
 		"broken": {
 			"Interface_DataObjectFactoryProps": {
 				"backCompat": false
+			},
+			"Interface_IDataObjectProps": {
+				"backCompat": false
 			}
 		},
 		"entrypoint": "legacy"

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -313,4 +313,5 @@ declare type old_as_current_for_Interface_IDataObjectProps = requireAssignableTo
  * typeValidation.broken:
  * "Interface_IDataObjectProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IDataObjectProps = requireAssignableTo<TypeOnly<current.IDataObjectProps>, TypeOnly<old.IDataObjectProps>>

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -228,7 +228,25 @@
 			"ClassStatics_Loader": {
 				"backCompat": false
 			},
+			"Interface_IContainerHostProps": {
+				"backCompat": false
+			},
+			"Interface_ICreateAndLoadContainerProps": {
+				"backCompat": false
+			},
+			"Interface_ICreateDetachedContainerProps": {
+				"backCompat": false
+			},
+			"Interface_ILoaderProps": {
+				"backCompat": false
+			},
 			"Interface_ILoaderServices": {
+				"backCompat": false
+			},
+			"Interface_ILoadExistingContainerProps": {
+				"backCompat": false
+			},
+			"Interface_IRehydrateDetachedContainerProps": {
 				"backCompat": false
 			}
 		},

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -188,6 +188,7 @@ declare type old_as_current_for_Interface_IContainerHostProps = requireAssignabl
  * typeValidation.broken:
  * "Interface_IContainerHostProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerHostProps = requireAssignableTo<TypeOnly<current.IContainerHostProps>, TypeOnly<old.IContainerHostProps>>
 
 /*
@@ -224,6 +225,7 @@ declare type old_as_current_for_Interface_ICreateAndLoadContainerProps = require
  * typeValidation.broken:
  * "Interface_ICreateAndLoadContainerProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ICreateAndLoadContainerProps = requireAssignableTo<TypeOnly<current.ICreateAndLoadContainerProps>, TypeOnly<old.ICreateAndLoadContainerProps>>
 
 /*
@@ -242,6 +244,7 @@ declare type old_as_current_for_Interface_ICreateDetachedContainerProps = requir
  * typeValidation.broken:
  * "Interface_ICreateDetachedContainerProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ICreateDetachedContainerProps = requireAssignableTo<TypeOnly<current.ICreateDetachedContainerProps>, TypeOnly<old.ICreateDetachedContainerProps>>
 
 /*
@@ -278,6 +281,7 @@ declare type old_as_current_for_Interface_ILoaderProps = requireAssignableTo<Typ
  * typeValidation.broken:
  * "Interface_ILoaderProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ILoaderProps = requireAssignableTo<TypeOnly<current.ILoaderProps>, TypeOnly<old.ILoaderProps>>
 
 /*
@@ -315,6 +319,7 @@ declare type old_as_current_for_Interface_ILoadExistingContainerProps = requireA
  * typeValidation.broken:
  * "Interface_ILoadExistingContainerProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ILoadExistingContainerProps = requireAssignableTo<TypeOnly<current.ILoadExistingContainerProps>, TypeOnly<old.ILoadExistingContainerProps>>
 
 /*
@@ -387,6 +392,7 @@ declare type old_as_current_for_Interface_IRehydrateDetachedContainerProps = req
  * typeValidation.broken:
  * "Interface_IRehydrateDetachedContainerProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IRehydrateDetachedContainerProps = requireAssignableTo<TypeOnly<current.IRehydrateDetachedContainerProps>, TypeOnly<old.IRehydrateDetachedContainerProps>>
 
 /*

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -101,7 +101,17 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IContainerRuntime": {
+				"backCompat": false
+			},
+			"Interface_IContainerRuntimeWithResolveHandle_Deprecated": {
+				"backCompat": false
+			},
+			"TypeAlias_IContainerRuntimeBaseWithCombinedEvents": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
@@ -24,6 +24,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Interface_IContainerRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerRuntime = requireAssignableTo<TypeOnly<current.IContainerRuntime>, TypeOnly<old.IContainerRuntime>>
 
 /*
@@ -51,6 +52,7 @@ declare type old_as_current_for_Interface_IContainerRuntimeWithResolveHandle_Dep
  * typeValidation.broken:
  * "Interface_IContainerRuntimeWithResolveHandle_Deprecated": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerRuntimeWithResolveHandle_Deprecated = requireAssignableTo<TypeOnly<current.IContainerRuntimeWithResolveHandle_Deprecated>, TypeOnly<old.IContainerRuntimeWithResolveHandle_Deprecated>>
 
 /*
@@ -87,6 +89,7 @@ declare type current_as_old_for_Interface_ISummarizerObservabilityProps = requir
  * typeValidation.broken:
  * "TypeAlias_IContainerRuntimeBaseWithCombinedEvents": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IContainerRuntimeBaseWithCombinedEvents = requireAssignableTo<TypeOnly<current.IContainerRuntimeBaseWithCombinedEvents>, TypeOnly<old.IContainerRuntimeBaseWithCombinedEvents>>
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -111,7 +111,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IFluidDataStoreRuntime": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -150,6 +150,7 @@ declare type current_as_old_for_Interface_IDeltaHandler = requireAssignableTo<Ty
  * typeValidation.broken:
  * "Interface_IFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.IFluidDataStoreRuntime>, TypeOnly<old.IFluidDataStoreRuntime>>
 
 /*

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -132,7 +132,20 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IContainerRuntimeBase": {
+				"backCompat": false
+			},
+			"Interface_IFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"Interface_IFluidDataStoreContextDetached": {
+				"backCompat": false
+			},
+			"Interface_IFluidParentContext": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -114,6 +114,7 @@ declare type current_as_old_for_Interface_IAttachMessage = requireAssignableTo<T
  * typeValidation.broken:
  * "Interface_IContainerRuntimeBase": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IContainerRuntimeBase = requireAssignableTo<TypeOnly<current.IContainerRuntimeBase>, TypeOnly<old.IContainerRuntimeBase>>
 
 /*
@@ -204,6 +205,7 @@ declare type current_as_old_for_Interface_IFluidDataStoreChannel = requireAssign
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContext = requireAssignableTo<TypeOnly<current.IFluidDataStoreContext>, TypeOnly<old.IFluidDataStoreContext>>
 
 /*
@@ -213,6 +215,7 @@ declare type current_as_old_for_Interface_IFluidDataStoreContext = requireAssign
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContextDetached": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContextDetached = requireAssignableTo<TypeOnly<current.IFluidDataStoreContextDetached>, TypeOnly<old.IFluidDataStoreContextDetached>>
 
 /*
@@ -276,6 +279,7 @@ declare type current_as_old_for_Interface_IFluidDataStoreRegistry = requireAssig
  * typeValidation.broken:
  * "Interface_IFluidParentContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidParentContext = requireAssignableTo<TypeOnly<current.IFluidParentContext>, TypeOnly<old.IFluidParentContext>>
 
 /*

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -157,7 +157,13 @@
 			"Class_MockFluidDataStoreContext": {
 				"backCompat": false
 			},
+			"Class_MockFluidDataStoreRuntime": {
+				"backCompat": false
+			},
 			"ClassStatics_MockFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"ClassStatics_MockFluidDataStoreRuntime": {
 				"backCompat": false
 			}
 		},

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -187,6 +187,7 @@ declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.MockFluidDataStoreRuntime>, TypeOnly<old.MockFluidDataStoreRuntime>>
 
 /*
@@ -368,6 +369,7 @@ declare type current_as_old_for_ClassStatics_MockFluidDataStoreContext = require
  * typeValidation.broken:
  * "ClassStatics_MockFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<typeof current.MockFluidDataStoreRuntime>, TypeOnly<typeof old.MockFluidDataStoreRuntime>>
 
 /*

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -103,7 +103,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
@@ -103,7 +103,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -103,7 +103,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -103,7 +103,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    minLogLevel?: LogLevel;
+    minLogLevel?: LogLevel | undefined;
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -124,7 +124,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_TinyliciousClientProps": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "beta"
 	}
 }

--- a/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
+++ b/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
@@ -42,6 +42,7 @@ declare type current_as_old_for_ClassStatics_TinyliciousClient = requireAssignab
  * typeValidation.broken:
  * "Interface_TinyliciousClientProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_TinyliciousClientProps = requireAssignableTo<TypeOnly<current.TinyliciousClientProps>, TypeOnly<old.TinyliciousClientProps>>
 
 /*

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -162,7 +162,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IProvideTestFluidObject": {
+				"backCompat": false
+			},
+			"Interface_ITestFluidObject": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -87,6 +87,7 @@ declare type old_as_current_for_Interface_IProvideTestFluidObject = requireAssig
  * typeValidation.broken:
  * "Interface_IProvideTestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IProvideTestFluidObject = requireAssignableTo<TypeOnly<current.IProvideTestFluidObject>, TypeOnly<old.IProvideTestFluidObject>>
 
 /*
@@ -105,4 +106,5 @@ declare type old_as_current_for_Interface_ITestFluidObject = requireAssignableTo
  * typeValidation.broken:
  * "Interface_ITestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ITestFluidObject = requireAssignableTo<TypeOnly<current.ITestFluidObject>, TypeOnly<old.ITestFluidObject>>

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -146,7 +146,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_DevtoolsProps": {
+				"backCompat": false
+			},
+			"Interface_IDevtoolsLogger": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "alpha"
 	}
 }

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -51,6 +51,7 @@ declare type current_as_old_for_Interface_ContainerDevtoolsProps = requireAssign
  * typeValidation.broken:
  * "Interface_DevtoolsProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_DevtoolsProps = requireAssignableTo<TypeOnly<current.DevtoolsProps>, TypeOnly<old.DevtoolsProps>>
 
 /*
@@ -69,6 +70,7 @@ declare type current_as_old_for_Interface_IDevtools = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Interface_IDevtoolsLogger": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IDevtoolsLogger = requireAssignableTo<TypeOnly<current.IDevtoolsLogger>, TypeOnly<old.IDevtoolsLogger>>
 
 /*

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -128,7 +128,7 @@ export function normalizeError(
 	const { message, stack } = extractLogSafeErrorProperties(error, false /* sanitizeStack */);
 	const fluidError: IFluidErrorBase = new NormalizedLoggingError({
 		message,
-		stack,
+		...(stack === undefined ? {} : { stack }),
 	});
 
 	// We need to preserve these properties which are used in a non-typesafe way throughout driver code (see #8743)

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -807,7 +807,7 @@ export class PerformanceEvent {
 
 	private event: ITelemetryGenericEventExt | undefined;
 	private readonly startTime = performanceNow();
-	private startMark?: string;
+	private startMark: string | undefined;
 
 	private constructor(
 		private readonly logger: TelemetryLoggerExt,
@@ -862,7 +862,7 @@ export class PerformanceEvent {
 			const endMark = `${this.event.eventName}-end`;
 			window.performance.mark(endMark);
 			window.performance.measure(`${this.event.eventName}`, this.startMark, endMark);
-			delete this.startMark;
+			this.startMark = undefined;
 		}
 	}
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -805,7 +805,7 @@ export class PerformanceEvent {
 		return performanceNow() - this.startTime;
 	}
 
-	private event?: ITelemetryGenericEventExt;
+	private event: ITelemetryGenericEventExt | undefined;
 	private readonly startTime = performanceNow();
 	private startMark?: string;
 
@@ -846,7 +846,7 @@ export class PerformanceEvent {
 		this.performanceEndMark();
 
 		// To prevent the event from being reported again later
-		delete this.event;
+		this.event = undefined;
 	}
 
 	public end(props?: ITelemetryPropertiesExt): void {
@@ -854,7 +854,7 @@ export class PerformanceEvent {
 		this.performanceEndMark();
 
 		// To prevent the event from being reported again later
-		delete this.event;
+		this.event = undefined;
 	}
 
 	private performanceEndMark(): void {
@@ -872,7 +872,7 @@ export class PerformanceEvent {
 		}
 
 		// To prevent the event from being reported again later
-		delete this.event;
+		this.event = undefined;
 	}
 
 	/**

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -430,7 +430,7 @@ function toEitherTelemetryLoggerExt(
  * exactly an {@link ITelemetryLoggerExt}.
  */
 export function createChildLogger(props?: {
-	logger?: ITelemetryBaseLogger;
+	logger?: ITelemetryBaseLogger | undefined;
 	namespace?: string;
 	properties?: ITelemetryLoggerPropertyBags;
 }): TelemetryLoggerExt & ITelemetryLoggerExt {
@@ -453,8 +453,8 @@ export class ChildLogger extends TelemetryLogger {
 	 * @param properties - Base properties to add to all events
 	 */
 	public static create(
-		baseLogger?: ITelemetryBaseLogger,
-		namespace?: string,
+		baseLogger: ITelemetryBaseLogger | undefined,
+		namespace: string | undefined,
 		properties?: ITelemetryLoggerPropertyBags,
 	): TelemetryLogger {
 		// if we are creating a child of a child, rather than nest, which will increase
@@ -846,7 +846,7 @@ export class PerformanceEvent {
 		this.performanceEndMark();
 
 		// To prevent the event from being reported again later
-		this.event = undefined;
+		delete this.event;
 	}
 
 	public end(props?: ITelemetryPropertiesExt): void {
@@ -854,7 +854,7 @@ export class PerformanceEvent {
 		this.performanceEndMark();
 
 		// To prevent the event from being reported again later
-		this.event = undefined;
+		delete this.event;
 	}
 
 	private performanceEndMark(): void {
@@ -862,7 +862,7 @@ export class PerformanceEvent {
 			const endMark = `${this.event.eventName}-end`;
 			window.performance.mark(endMark);
 			window.performance.measure(`${this.event.eventName}`, this.startMark, endMark);
-			this.startMark = undefined;
+			delete this.startMark;
 		}
 	}
 
@@ -872,7 +872,7 @@ export class PerformanceEvent {
 		}
 
 		// To prevent the event from being reported again later
-		this.event = undefined;
+		delete this.event;
 	}
 
 	/**

--- a/packages/utils/telemetry-utils/tsconfig.json
+++ b/packages/utils/telemetry-utils/tsconfig.json
@@ -4,7 +4,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 	"include": ["src/**/*"],
 }


### PR DESCRIPTION
`ChildLogger` (which is almost always the logger anything accesses) supports `minLogLevel` with a getter that may return `undefined`. Update `ITelemetryBaseLogger` to allow `minLogLevel` to be `undefined`.

This is a type breaking change for anyone not using `exactOptionalPropertyTypes:false` as recommended in package READMEs, but not a runtime breaking change.

`telemetry-utils` corrections:
- use `...(cond ? {} { prop: value })` to only define properties with defined values.
- make optional private properties required allowing `| undefined`.
- in logger helper functions allow explicit `undefined`
  - internal `ChildLogger.create` clarified to expect to arguments though `undefined` is allowed.