### PR TITLE
Polish pr-bundle-size-comments workflow with structured failure stickies

### DIFF
--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -41,13 +41,23 @@ permissions:
   pull-requests: read
 
 jobs:
+  # NOTE on the `contains(... '10f9b53e-c7fd-4538-9fff-13cd088a436c')` check that appears in each of the
+  # triggering jobs below: that GUID is the `public` ADO project under `dev.azure.com/fluidframework`. The
+  # pipelines whose check_runs we react to all live there. We need the scope because both the `public` and
+  # `internal` projects publish check_runs with the same name (e.g. `Build - client packages`); without it
+  # the workflow also fires on `internal`'s check_runs, which we can't process (no anonymous read access)
+  # and don't produce the artifacts we consume. The GUID appears in `check_run.details_url`; there's no
+  # structured `project` field in the event payload, so `contains(details_url, '<guid>')` is the only
+  # stable distinguisher. The project lives at https://dev.azure.com/fluidframework/public.
+
   # Posts the initial "build pending" sticky comment when ADO queues the `Build - client packages` check
   # for a PR commit. We only measure bundle size on client packages today, so PRs that don't trigger that
   # check (server-only, docs-only) receive no sticky.
   acknowledge-build:
     if: >-
       github.event.action == 'created' &&
-      github.event.check_run.name == 'Build - client packages'
+      github.event.check_run.name == 'Build - client packages' &&
+      contains(github.event.check_run.details_url, '10f9b53e-c7fd-4538-9fff-13cd088a436c')
     runs-on: ubuntu-latest
     # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
     # permissions:
@@ -155,7 +165,8 @@ jobs:
   identify-from-pr-build:
     if: >-
       github.event.action == 'completed' &&
-      github.event.check_run.name == 'Build - client packages'
+      github.event.check_run.name == 'Build - client packages' &&
+      contains(github.event.check_run.details_url, '10f9b53e-c7fd-4538-9fff-13cd088a436c')
     runs-on: ubuntu-latest
     outputs:
       prs: ${{ steps.collect.outputs.prs }}
@@ -236,7 +247,8 @@ jobs:
   identify-from-baseline-build:
     if: >-
       github.event.action == 'completed' &&
-      github.event.check_run.name == 'Build - Client bundle size artifacts'
+      github.event.check_run.name == 'Build - Client bundle size artifacts' &&
+      contains(github.event.check_run.details_url, '10f9b53e-c7fd-4538-9fff-13cd088a436c')
     runs-on: ubuntu-latest
     outputs:
       prs: ${{ steps.collect.outputs.prs }}

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -335,9 +335,13 @@ jobs:
           npm link
 
       - name: Compare bundle sizes
-        # Upstream oclif bug (oclif/core#1608): in `--json` mode, thrown errors render as `{"error":{}}` to
-        # stdout and nothing to stderr — the message is lost. On non-zero exit we re-run without `--json` so
-        # the failure reason is visible in the action log.
+        # Expected failure modes (missing/in-progress/failed baseline, no
+        # analyzer.json) come back as a structured `{ kind, side }` payload
+        # under `--json` and a zero exit — the render step dispatches on
+        # `kind` to produce a friendly sticky body. Non-zero exit is reserved
+        # for *unexpected* errors (network, malformed zip, …); upstream oclif
+        # bug oclif/core#1608 swallows their message in `--json` mode, so we
+        # re-run without `--json` to surface it in the action log.
         run: |
           set -uo pipefail
           set +e
@@ -361,56 +365,90 @@ jobs:
       # Format the JSON into the markdown body the sticky comment would post. Done here (not in flub) so
       # the formatting is easy to iterate on without rebuilding build-tools. The body is written to
       # bundle-comparison.md and also echoed to the action log so we can see what the eventual sticky
-      # would contain without actually posting it.
+      # would contain without actually posting it. Dispatches on `data.kind` — happy path renders the
+      # comparison; failure kinds render a friendly per-(kind, side) message.
       - name: Render bundle-size comment body
         # release notes: https://github.com/actions/github-script/releases/tag/v9.0.0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9
         env:
           PR_NUM: ${{ matrix.pr.number }}
+          BASE_SHA: ${{ matrix.pr.mergeBase }}
+          HEAD_SHA: ${{ matrix.pr.head }}
         with:
           script: |
             const fs = require("fs");
             const data = JSON.parse(fs.readFileSync("bundle-comparison.json", "utf8"));
 
-            const fmtDelta = d => (d > 0 ? `+${d}` : `${d}`);
+            // Render the happy-path comparison body — per-package sections, or
+            // "No bundle-size changes." if everything is unchanged.
+            function renderComparison(comparison) {
+              const fmtDelta = d => (d > 0 ? `+${d}` : `${d}`);
 
-            const lines = [
-              "## Bundle size comparison",
-              "",
-              `Base commit: \`${data.baseCommit}\``,
-              `Head commit: \`${data.headCommit}\``,
-              "",
-            ];
-
-            const packageSections = [];
-            for (const [pkg, bundles] of Object.entries(data.comparison)) {
-              const bundleLines = [];
-              for (const [bundle, cmp] of Object.entries(bundles)) {
+              // Render one bundle's diff line — always emitted, even for
+              // unchanged bundles, so the body is a complete inventory.
+              function renderBundleLine(bundle, cmp) {
                 if (cmp.base === undefined && cmp.compare !== undefined) {
-                  bundleLines.push(`- \`${bundle}\`: **added** (parsed ${cmp.compare.parsedSize}, gzip ${cmp.compare.gzipSize})`);
-                } else if (cmp.compare === undefined && cmp.base !== undefined) {
-                  bundleLines.push(`- \`${bundle}\`: **removed** (was parsed ${cmp.base.parsedSize}, gzip ${cmp.base.gzipSize})`);
-                } else if (
-                  cmp.base.parsedSize !== cmp.compare.parsedSize ||
-                  cmp.base.gzipSize !== cmp.compare.gzipSize
-                ) {
-                  const dp = cmp.compare.parsedSize - cmp.base.parsedSize;
-                  const dg = cmp.compare.gzipSize - cmp.base.gzipSize;
-                  bundleLines.push(`- \`${bundle}\`: parsed ${cmp.base.parsedSize} → ${cmp.compare.parsedSize} (${fmtDelta(dp)}), gzip ${cmp.base.gzipSize} → ${cmp.compare.gzipSize} (${fmtDelta(dg)})`);
+                  return `- \`${bundle}\`: **added** (parsed ${cmp.compare.parsedSize}, gzip ${cmp.compare.gzipSize})`;
+                }
+                if (cmp.compare === undefined && cmp.base !== undefined) {
+                  return `- \`${bundle}\`: **removed** (was parsed ${cmp.base.parsedSize}, gzip ${cmp.base.gzipSize})`;
+                }
+                const dp = cmp.compare.parsedSize - cmp.base.parsedSize;
+                const dg = cmp.compare.gzipSize - cmp.base.gzipSize;
+                return `- \`${bundle}\`: parsed ${cmp.base.parsedSize} → ${cmp.compare.parsedSize} (${fmtDelta(dp)}), gzip ${cmp.base.gzipSize} → ${cmp.compare.gzipSize} (${fmtDelta(dg)})`;
+              }
+
+              const sections = [];
+              for (const [pkg, bundles] of Object.entries(comparison)) {
+                const bundleLines = Object.entries(bundles).map(
+                  ([bundle, cmp]) => renderBundleLine(bundle, cmp),
+                );
+                if (bundleLines.length > 0) {
+                  sections.push(`### \`${pkg}\`\n\n${bundleLines.join("\n")}`);
                 }
               }
-              if (bundleLines.length > 0) {
-                packageSections.push(`### \`${pkg}\``, "", ...bundleLines, "");
-              }
+              return sections.length > 0 ? sections.join("\n\n") : "No bundles found in comparison.";
             }
 
-            if (packageSections.length > 0) {
-              lines.push(...packageSections);
-            } else {
-              lines.push("No bundle-size changes.");
+            // Render a failure body for an expected (side, kind) failure.
+            // `in-progress` is the normal "wait for the build" path and reads
+            // like acknowledge-build's pending sticky — no warning framing.
+            // Everything else is an actual error and gets the "Comparison
+            // unavailable" header.
+            function renderFailure(side, kind) {
+              // Friendly per-(side, kind) sticky body for expected failure modes.
+              const failureMessages = {
+                base: {
+                  "no-build": "No baseline CI build was found for the merge-base commit. It may be older than the workflow's search horizon, or the baseline pipeline may not have run on it. Try merging a recent main commit into this PR.",
+                  "in-progress": "Pending — the baseline CI build for the merge-base commit hasn't completed yet. Results will appear here when the build finishes.",
+                  "all-failed": "The baseline CI build for the merge-base commit failed — likely a flaky producer build. Try merging a recent main commit into this PR, or re-queue the baseline pipeline manually.",
+                  "no-id": "An ADO state anomaly prevented looking up the baseline build (no usable build id). This shouldn't happen in practice — please report.",
+                  "no-analyzer-jsons": "The baseline build completed but didn't publish a bundle-size artifact for the merge-base commit. Try merging a recent main commit into this PR.",
+                },
+                head: {
+                  "no-build": "No CI build was found for the PR HEAD commit. This shouldn't happen — the workflow only runs after the PR's `Build - client packages` check completes. Please report.",
+                  "in-progress": "Pending — the PR's CI build hasn't completed yet. Results will appear here when the build finishes.",
+                  "all-failed": "The PR's CI build failed — fix the build and the comment will update once the next run succeeds.",
+                  "no-id": "An ADO state anomaly prevented looking up the PR's build (no usable build id). This shouldn't happen in practice — please report.",
+                  "no-analyzer-jsons": "The PR's CI build completed but didn't publish a bundle-size artifact. Check whether your changes affect the bundle-publishing client packages.",
+                },
+              };
+              const message = failureMessages[side]?.[kind]
+                ?? `Comparison failed with kind \`${kind}\` on the \`${side}\` side. Please report.`;
+              return kind === "in-progress" ? message : `⚠️ Comparison unavailable.\n\n${message}`;
             }
 
-            const body = lines.join("\n") + "\n";
+            const body = [
+              "## Bundle size comparison",
+              "",
+              `Base commit: \`${process.env.BASE_SHA}\``,
+              `Head commit: \`${process.env.HEAD_SHA}\``,
+              "",
+              data.kind === "completed"
+                ? renderComparison(data.comparison)
+                : renderFailure(data.side, data.kind),
+            ].join("\n") + "\n";
+
             fs.writeFileSync("bundle-comparison.md", body);
             core.info(`PR #${process.env.PR_NUM}: would post the following body as a sticky comment.`);
             core.startGroup("bundle-comparison.md");

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -106,6 +106,7 @@ jobs:
               return;
             }
 
+            core.info(`Matched PR #${pr.number} head=${pr.headRefOid} base=${pr.baseRefName} mergeBase=${mb}`);
             core.setOutput("pr_num", pr.number);
             core.setOutput("head_sha", pr.headRefOid);
             core.setOutput("merge_base", mb);
@@ -133,10 +134,9 @@ jobs:
             ].join("\n");
             fs.writeFileSync("acknowledge.md", body);
             core.info(`PR #${process.env.PR_NUM}: would post the following body as a sticky comment.`);
-            core.info("");
-            core.info("--- acknowledge.md ---");
+            core.startGroup("acknowledge.md");
             core.info(body);
-            core.info("--- end ---");
+            core.endGroup();
 
       # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
       # - if: steps.render.outcome == 'success'

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -148,12 +148,14 @@ jobs:
       #     path: ${{ github.workspace }}/acknowledge.md
 
   # Reacts to a PR's own `Build - client packages` build completing. The check SHA is a PR head SHA, so we
-  # produce at most one matrix entry — the PR whose head matches.
+  # produce at most one matrix entry — the PR whose head matches. Fires on *any* completion (not just
+  # success) so a failed PR build also updates the sticky: the compare job's flub call returns the
+  # appropriate failure kind (`all-failed`, etc.) and the sticky moves off the acknowledge-build "Pending
+  # — …" placeholder instead of staying stale.
   identify-from-pr-build:
     if: >-
       github.event.action == 'completed' &&
-      github.event.check_run.name == 'Build - client packages' &&
-      github.event.check_run.conclusion == 'success'
+      github.event.check_run.name == 'Build - client packages'
     runs-on: ubuntu-latest
     outputs:
       prs: ${{ steps.collect.outputs.prs }}
@@ -227,12 +229,14 @@ jobs:
 
   # Reacts to the baseline pipeline (`Build - Client bundle size artifacts`) completing on a main/release
   # commit. The check SHA is on the base branch, so we produce a matrix entry per open PR whose merge-base
-  # equals this SHA — typically 0–few PRs.
+  # equals this SHA — typically 0–few PRs. Fires on *any* completion (not just success) so a baseline
+  # failure also re-triggers affected PRs: the compare job's flub call returns the appropriate failure
+  # kind (`all-failed`, etc.) and the sticky updates from "Pending — …" to a per-kind body instead of
+  # staying stale forever.
   identify-from-baseline-build:
     if: >-
       github.event.action == 'completed' &&
-      github.event.check_run.name == 'Build - Client bundle size artifacts' &&
-      github.event.check_run.conclusion == 'success'
+      github.event.check_run.name == 'Build - Client bundle size artifacts'
     runs-on: ubuntu-latest
     outputs:
       prs: ${{ steps.collect.outputs.prs }}

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -292,6 +292,7 @@ jobs:
         (needs.identify-from-pr-build.result == 'success' && needs.identify-from-pr-build.outputs.prs != '[]') ||
         (needs.identify-from-baseline-build.result == 'success' && needs.identify-from-baseline-build.outputs.prs != '[]')
       )
+    name: compare (PR #${{ matrix.pr.number }})
     strategy:
       matrix:
         pr: ${{ fromJSON(needs.identify-from-pr-build.outputs.prs || needs.identify-from-baseline-build.outputs.prs || '[]') }}

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -343,7 +343,9 @@ jobs:
             --head ${{ matrix.pr.head }} \
             --json > bundle-comparison.json
           EC=$?
+          echo "::group::bundle-comparison.json"
           cat bundle-comparison.json
+          echo "::endgroup::"
           if [ "$EC" -ne 0 ]; then
             echo
             echo "flub --json exited $EC; re-running without --json so the error message is visible:"
@@ -408,10 +410,9 @@ jobs:
             const body = lines.join("\n") + "\n";
             fs.writeFileSync("bundle-comparison.md", body);
             core.info(`PR #${process.env.PR_NUM}: would post the following body as a sticky comment.`);
-            core.info("");
-            core.info("--- bundle-comparison.md ---");
+            core.startGroup("bundle-comparison.md");
             core.info(body);
-            core.info("--- end ---");
+            core.endGroup();
 
       # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
       # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -188,6 +188,7 @@ jobs:
             );
             const pr = search.nodes[0];
             if (!pr) {
+              core.info(`Affected PRs (0): no open PR matches head SHA ${sha}`);
               core.setOutput("prs", "[]");
               return;
             }
@@ -207,17 +208,19 @@ jobs:
               throw err;
             }
             if (!mb) {
-              core.info(`PR #${pr.number} has no shared history with ${pr.baseRefName}; nothing to compare.`);
+              core.info(`Affected PRs (0): PR #${pr.number} has no shared history with ${pr.baseRefName}`);
               core.setOutput("prs", "[]");
               return;
             }
 
-            core.setOutput("prs", JSON.stringify([{
+            const affected = [{
               number: pr.number,
               head: pr.headRefOid,
               baseRef: pr.baseRefName,
               mergeBase: mb,
-            }]));
+            }];
+            core.info(`Affected PRs (1): #${pr.number} head=${pr.headRefOid} base=${pr.baseRefName} mergeBase=${mb}`);
+            core.setOutput("prs", JSON.stringify(affected));
 
   # Reacts to the baseline pipeline (`Build - Client bundle size artifacts`) completing on a main/release
   # commit. The check SHA is on the base branch, so we produce a matrix entry per open PR whose merge-base
@@ -268,6 +271,14 @@ jobs:
                   baseRef: pr.base.ref,
                   mergeBase: mb,
                 });
+              }
+            }
+            if (affected.length === 0) {
+              core.info("Affected PRs (0): none");
+            } else {
+              core.info(`Affected PRs (${affected.length}):`);
+              for (const a of affected) {
+                core.info(`  - #${a.number} head=${a.head} base=${a.baseRef} mergeBase=${a.mergeBase}`);
               }
             }
             core.setOutput("prs", JSON.stringify(affected));

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -24,13 +24,16 @@ on:
   check_run:
     types: [created, completed]
 
-# Use concurrency to ensure the completed event wins over the created event for a given SHA — so the
-# results sticky is never clobbered by a still-running "pending" handler. Cross-SHA staleness on the PR
-# path (push A then B, then A's build completes anyway) is handled in identify-from-pr-build: it searches
-# for an open PR whose current head SHA matches the just-completed build, so an event for a stale SHA
-# finds no PR and can't write anything.
+# Use concurrency to ensure the completed event wins over the created event for a given (SHA, check
+# name) — so the results sticky is never clobbered by a still-running "pending" handler. The check name
+# is part of the group key because each ADO sub-check fires its own check_run event on the same SHA
+# (e.g. `Build - client packages (🔒 SDLSources ...)`, `Build - client packages (Build Stage Build)`)
+# and we don't want those to cancel an in-flight acknowledge-build / identify-* run that's processing a
+# matching event. Cross-SHA staleness on the PR path (push A then B, then A's build completes anyway)
+# is handled in identify-from-pr-build: it searches for an open PR whose current head SHA matches the
+# just-completed build, so an event for a stale SHA finds no PR and can't write anything.
 concurrency:
-  group: pr-bundle-size-${{ github.event.check_run.head_sha }}
+  group: pr-bundle-size-${{ github.event.check_run.head_sha }}-${{ github.event.check_run.name }}
   cancel-in-progress: true
 
 permissions:

--- a/build-tools/packages/build-cli/src/commands/check/bundleSize.ts
+++ b/build-tools/packages/build-cli/src/commands/check/bundleSize.ts
@@ -7,7 +7,10 @@ import { execFileSync } from "node:child_process";
 import { Flags } from "@oclif/core";
 
 import { fluidframeworkAdoOrgUrl } from "../../library/azureDevops/constants.js";
-import { getArtifactForCommit } from "../../library/azureDevops/getArtifactForCommit.js";
+import {
+	describeArtifactFailure,
+	getArtifactForCommit,
+} from "../../library/azureDevops/getArtifactForCommit.js";
 import { getAzureDevopsApi } from "../../library/azureDevops/getAzureDevopsApi.js";
 import {
 	bundleSizeArtifactsBaselinePipeline,
@@ -132,15 +135,19 @@ export default class CheckBundleSize extends BaseCommand<typeof CheckBundleSize>
 
 		// Public ADO project — anonymous reads are fine at this command's scale.
 		const adoApi = getAzureDevopsApi(undefined, fluidframeworkAdoOrgUrl);
-		const artifactContents = await getArtifactForCommit({
+		const baselineMatch = { kind: "commit", sha: baselineCommit } as const;
+		const baselineArtifact = await getArtifactForCommit({
 			adoApi,
 			artifactName: bundleSizeArtifactsBaselinePipeline.bundleAnalyzerJsonArtifactName,
-			match: { kind: "commit", sha: baselineCommit },
+			match: baselineMatch,
 			definitionId: bundleSizeArtifactsBaselinePipeline.definitionId,
 			project: bundleSizeArtifactsBaselinePipeline.project,
 		});
+		if (baselineArtifact.kind !== "completed") {
+			this.error(describeArtifactFailure(baselineMatch, baselineArtifact));
+		}
 
-		const baselineJsons = extractAnalyzerJsonsFromArtifact(artifactContents);
+		const baselineJsons = extractAnalyzerJsonsFromArtifact(baselineArtifact.contents);
 		if (baselineJsons.size === 0) {
 			this.error(
 				`Baseline artifact contains no analyzer.json files for commit ${baselineCommit}.`,

--- a/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
+++ b/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
@@ -7,11 +7,14 @@ import { Flags } from "@oclif/core";
 
 import { fluidframeworkAdoOrgUrl } from "../../library/azureDevops/constants.js";
 import {
+	type ArtifactLookupFailure,
+	type BuildMatch,
 	describeArtifactFailure,
 	getArtifactForCommit,
 } from "../../library/azureDevops/getArtifactForCommit.js";
 import { getAzureDevopsApi } from "../../library/azureDevops/getAzureDevopsApi.js";
 import {
+	type AnalyzerJsonByPackage,
 	bundleSizeArtifactsBaselinePipeline,
 	bundleSizeArtifactsPrPipeline,
 	compareJsonReportsByPackage,
@@ -21,13 +24,33 @@ import {
 import { BaseCommand } from "../../library/commands/base.js";
 
 /**
- * Result serialized to stdout by `--json`.
+ * Which side of a comparison we're operating on.
  */
-interface ComparePipelineBundleArtifactsResult {
-	baseCommit: string;
-	headCommit: string;
-	comparison: PackageComparison;
-}
+type ComparisonSide = "base" | "head";
+
+/**
+ * Failure variants a {@link ComparePipelineBundleArtifactsResult} can surface.
+ * Reuses the library's {@link ArtifactLookupFailure} kinds and adds a
+ * command-level case for artifacts that downloaded but contain no
+ * `analyzer.json` files.
+ */
+type ComparePipelineSideFailure = ArtifactLookupFailure | { kind: "no-analyzer-jsons" };
+
+/**
+ * Result serialized to stdout by `--json`. Discriminated by `kind`:
+ *
+ * - `completed`: happy path with the structured per-package comparison.
+ * - any other kind: failure, scoped to one `side` of the comparison so the
+ *   consuming workflow can render an actionable sticky comment.
+ */
+type ComparePipelineBundleArtifactsResult =
+	| {
+			kind: "completed";
+			baseCommit: string;
+			headCommit: string;
+			comparison: PackageComparison;
+	  }
+	| (ComparePipelineSideFailure & { side: ComparisonSide });
 
 export default class ComparePipelineBundleArtifacts extends BaseCommand<
 	typeof ComparePipelineBundleArtifacts
@@ -57,40 +80,71 @@ export default class ComparePipelineBundleArtifacts extends BaseCommand<
 		// Public ADO project — anonymous reads are fine at this command's scale.
 		const adoApi = getAzureDevopsApi(undefined, fluidframeworkAdoOrgUrl);
 
-		const baseMatch = { kind: "commit", sha: base } as const;
-		const baseArtifact = await getArtifactForCommit({
-			adoApi,
-			artifactName: bundleSizeArtifactsBaselinePipeline.bundleAnalyzerJsonArtifactName,
-			match: baseMatch,
-			definitionId: bundleSizeArtifactsBaselinePipeline.definitionId,
-			project: bundleSizeArtifactsBaselinePipeline.project,
-		});
-		if (baseArtifact.kind !== "completed") {
-			this.error(describeArtifactFailure(baseMatch, baseArtifact));
-		}
-		const baseJsons = extractAnalyzerJsonsFromArtifact(baseArtifact.contents);
-		if (baseJsons.size === 0) {
-			this.error(`Base artifact contains no analyzer.json files for commit ${base}.`);
+		// Fetch and validate one side. Returns the parsed analyzer.json map on
+		// success, or a structured failure kind. The caller decides whether to
+		// emit a printed error and exit non-zero.
+		const fetchSide = async (
+			match: BuildMatch,
+			pipeline: {
+				project: string;
+				definitionId: number;
+				bundleAnalyzerJsonArtifactName: string;
+			},
+		): Promise<
+			{ kind: "completed"; jsons: AnalyzerJsonByPackage } | ComparePipelineSideFailure
+		> => {
+			const artifact = await getArtifactForCommit({
+				adoApi,
+				artifactName: pipeline.bundleAnalyzerJsonArtifactName,
+				match,
+				definitionId: pipeline.definitionId,
+				project: pipeline.project,
+			});
+			if (artifact.kind !== "completed") {
+				return { kind: artifact.kind };
+			}
+			const jsons = extractAnalyzerJsonsFromArtifact(artifact.contents);
+			if (jsons.size === 0) {
+				return { kind: "no-analyzer-jsons" };
+			}
+			return { kind: "completed", jsons };
+		};
+
+		// Emit a per-side failure: outside `--json` mode print + non-zero exit
+		// via `this.error()`; inside `--json` return the structured kind so
+		// oclif emits it as the result payload (instead of going through the
+		// oclif/core#1608 error path).
+		const handleFailure = (
+			match: BuildMatch,
+			side: ComparisonSide,
+			failure: ComparePipelineSideFailure,
+		): ComparePipelineBundleArtifactsResult => {
+			if (!this.jsonEnabled()) {
+				const subject =
+					match.kind === "commit" ? `commit ${match.sha}` : `PR HEAD ${match.sha}`;
+				const message =
+					failure.kind === "no-analyzer-jsons"
+						? `${side === "base" ? "Base" : "Head"} artifact contains no analyzer.json files for ${subject}.`
+						: describeArtifactFailure(match, failure);
+				this.error(message);
+			}
+			return { ...failure, side };
+		};
+
+		const baseMatch: BuildMatch = { kind: "commit", sha: base };
+		const baseResult = await fetchSide(baseMatch, bundleSizeArtifactsBaselinePipeline);
+		if (baseResult.kind !== "completed") {
+			return handleFailure(baseMatch, "base", baseResult);
 		}
 
-		const headMatch = { kind: "prHead", sha: head } as const;
-		const headArtifact = await getArtifactForCommit({
-			adoApi,
-			artifactName: bundleSizeArtifactsPrPipeline.bundleAnalyzerJsonArtifactName,
-			match: headMatch,
-			definitionId: bundleSizeArtifactsPrPipeline.definitionId,
-			project: bundleSizeArtifactsPrPipeline.project,
-		});
-		if (headArtifact.kind !== "completed") {
-			this.error(describeArtifactFailure(headMatch, headArtifact));
-		}
-		const headJsons = extractAnalyzerJsonsFromArtifact(headArtifact.contents);
-		if (headJsons.size === 0) {
-			this.error(`Head artifact contains no analyzer.json files for commit ${head}.`);
+		const headMatch: BuildMatch = { kind: "prHead", sha: head };
+		const headResult = await fetchSide(headMatch, bundleSizeArtifactsPrPipeline);
+		if (headResult.kind !== "completed") {
+			return handleFailure(headMatch, "head", headResult);
 		}
 
-		const comparison = compareJsonReportsByPackage(baseJsons, headJsons);
+		const comparison = compareJsonReportsByPackage(baseResult.jsons, headResult.jsons);
 
-		return { baseCommit: base, headCommit: head, comparison };
+		return { kind: "completed", baseCommit: base, headCommit: head, comparison };
 	}
 }

--- a/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
+++ b/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
@@ -40,8 +40,7 @@ type ComparePipelineSideFailure = ArtifactLookupFailure | { kind: "no-analyzer-j
  * Result serialized to stdout by `--json`. Discriminated by `kind`:
  *
  * - `completed`: happy path with the structured per-package comparison.
- * - any other kind: failure, scoped to one `side` of the comparison so the
- *   consuming workflow can render an actionable sticky comment.
+ * - any other kind: failure, scoped to one `side` of the comparison so the consuming workflow can render an actionable sticky comment.
  */
 type ComparePipelineBundleArtifactsResult =
 	| {

--- a/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
+++ b/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
@@ -6,7 +6,10 @@
 import { Flags } from "@oclif/core";
 
 import { fluidframeworkAdoOrgUrl } from "../../library/azureDevops/constants.js";
-import { getArtifactForCommit } from "../../library/azureDevops/getArtifactForCommit.js";
+import {
+	describeArtifactFailure,
+	getArtifactForCommit,
+} from "../../library/azureDevops/getArtifactForCommit.js";
 import { getAzureDevopsApi } from "../../library/azureDevops/getAzureDevopsApi.js";
 import {
 	bundleSizeArtifactsBaselinePipeline,
@@ -54,26 +57,34 @@ export default class ComparePipelineBundleArtifacts extends BaseCommand<
 		// Public ADO project — anonymous reads are fine at this command's scale.
 		const adoApi = getAzureDevopsApi(undefined, fluidframeworkAdoOrgUrl);
 
+		const baseMatch = { kind: "commit", sha: base } as const;
 		const baseArtifact = await getArtifactForCommit({
 			adoApi,
 			artifactName: bundleSizeArtifactsBaselinePipeline.bundleAnalyzerJsonArtifactName,
-			match: { kind: "commit", sha: base },
+			match: baseMatch,
 			definitionId: bundleSizeArtifactsBaselinePipeline.definitionId,
 			project: bundleSizeArtifactsBaselinePipeline.project,
 		});
-		const baseJsons = extractAnalyzerJsonsFromArtifact(baseArtifact);
+		if (baseArtifact.kind !== "completed") {
+			this.error(describeArtifactFailure(baseMatch, baseArtifact));
+		}
+		const baseJsons = extractAnalyzerJsonsFromArtifact(baseArtifact.contents);
 		if (baseJsons.size === 0) {
 			this.error(`Base artifact contains no analyzer.json files for commit ${base}.`);
 		}
 
+		const headMatch = { kind: "prHead", sha: head } as const;
 		const headArtifact = await getArtifactForCommit({
 			adoApi,
 			artifactName: bundleSizeArtifactsPrPipeline.bundleAnalyzerJsonArtifactName,
-			match: { kind: "prHead", sha: head },
+			match: headMatch,
 			definitionId: bundleSizeArtifactsPrPipeline.definitionId,
 			project: bundleSizeArtifactsPrPipeline.project,
 		});
-		const headJsons = extractAnalyzerJsonsFromArtifact(headArtifact);
+		if (headArtifact.kind !== "completed") {
+			this.error(describeArtifactFailure(headMatch, headArtifact));
+		}
+		const headJsons = extractAnalyzerJsonsFromArtifact(headArtifact.contents);
 		if (headJsons.size === 0) {
 			this.error(`Head artifact contains no analyzer.json files for commit ${head}.`);
 		}

--- a/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
+++ b/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
@@ -14,8 +14,10 @@ import { type ArtifactContents, downloadArtifact } from "./downloadArtifact.js";
 import { getBuilds } from "./utils.js";
 
 // Search window — ADO has no query-by-SHA API, so we fetch this many recent
-// builds and filter client-side. Caps how stale a target SHA can be.
-const recentBuildsToFetch = 100;
+// builds and filter client-side. Caps how stale a target SHA can be. At the
+// observed CI rate in this repo (~5 main-branch builds/day per pipeline),
+// 500 builds covers roughly the last 3 months.
+const recentBuildsToFetch = 500;
 
 /**
  * How to identify the ADO build for a SHA.

--- a/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
+++ b/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
@@ -46,15 +46,12 @@ function buildMatches(b: Build, match: BuildMatch): boolean {
 }
 
 /**
- * Failure variants shared by {@link FindBuildIdResult} and
- * {@link GetArtifactForCommitResult}.
+ * Failure variants shared by {@link FindBuildIdResult} and {@link GetArtifactForCommitResult}.
  *
  * - `no-build`: no candidate builds matched the SHA — too stale, or never queued.
- * - `in-progress`: at least one candidate is actively running (NotStarted /
- *   InProgress / Postponed) and none have succeeded yet. Retrying later may help.
+ * - `in-progress`: at least one candidate is actively running (NotStarted / InProgress / Postponed) and none have succeeded yet. Retrying later may help.
  * - `all-failed`: every candidate completed but none succeeded.
- * - `no-id`: at least one candidate Succeeded but is missing an `id` — an ADO
- *   state anomaly that shouldn't happen in practice.
+ * - `no-id`: at least one candidate Succeeded but is missing an `id` — an ADO state anomaly that shouldn't happen in practice.
  */
 export type ArtifactLookupFailure =
 	| { kind: "no-build" }
@@ -177,5 +174,9 @@ export function describeArtifactFailure(
 			return `All builds for ${subject} have completed but none succeeded.`;
 		case "no-id":
 			return `No build for ${subject} has a usable build id.`;
+		default:
+			throw new Error(
+				`Unhandled ArtifactLookupFailure kind: ${(failure as { kind: string }).kind}`,
+			);
 	}
 }

--- a/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
+++ b/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
@@ -46,19 +46,39 @@ function buildMatches(b: Build, match: BuildMatch): boolean {
 }
 
 /**
+ * Failure variants shared by {@link FindBuildIdResult} and
+ * {@link GetArtifactForCommitResult}.
+ *
+ * - `no-build`: no candidate builds matched the SHA — too stale, or never queued.
+ * - `in-progress`: at least one candidate is actively running (NotStarted /
+ *   InProgress / Postponed) and none have succeeded yet. Retrying later may help.
+ * - `all-failed`: every candidate completed but none succeeded.
+ * - `no-id`: at least one candidate Succeeded but is missing an `id` — an ADO
+ *   state anomaly that shouldn't happen in practice.
+ */
+export type ArtifactLookupFailure =
+	| { kind: "no-build" }
+	| { kind: "in-progress" }
+	| { kind: "all-failed" }
+	| { kind: "no-id" };
+
+/**
+ * Outcome of looking up a build for a {@link BuildMatch}. `completed` carries
+ * the usable build's id; the failure variants are {@link ArtifactLookupFailure}.
+ */
+export type FindBuildIdResult = { kind: "completed"; buildId: number } | ArtifactLookupFailure;
+
+/**
  * Find a usable build matching `match` — one with an id, status Completed,
  * and result Succeeded. Scans all matches (a SHA can map to multiple builds
- * via re-runs/retries), not just the first.
- *
- * @returns The build id. Throws with a human-readable message when no usable
- * build is found, prioritizing "still running" over "all failed".
+ * via re-runs/retries), not just the first. Prioritizes "still running" over
+ * "all failed" in the failure cases since retrying later may help.
  */
-function findBuildId(builds: Build[], match: BuildMatch): number {
+function findBuildId(builds: Build[], match: BuildMatch): FindBuildIdResult {
 	const candidates = builds.filter((b) => buildMatches(b, match));
-	const subject = describeMatch(match);
 
 	if (candidates.length === 0) {
-		throw new Error(`No build found for ${subject}`);
+		return { kind: "no-build" };
 	}
 
 	const usable = candidates.find(
@@ -68,7 +88,7 @@ function findBuildId(builds: Build[], match: BuildMatch): number {
 			b.result === BuildResult.Succeeded,
 	);
 	if (usable !== undefined) {
-		return usable.id;
+		return { kind: "completed", buildId: usable.id };
 	}
 
 	// Report the most actionable failure state. Actively-running gets priority
@@ -79,14 +99,14 @@ function findBuildId(builds: Build[], match: BuildMatch): number {
 		b.status === BuildStatus.InProgress ||
 		b.status === BuildStatus.Postponed;
 	if (candidates.some(isActivelyRunning)) {
-		throw new Error(`Found an in-progress build for ${subject}; none have succeeded yet.`);
+		return { kind: "in-progress" };
 	}
 	if (candidates.every((b) => b.result !== BuildResult.Succeeded)) {
-		throw new Error(`All builds for ${subject} have completed but none succeeded.`);
+		return { kind: "all-failed" };
 	}
 	// At least one candidate Succeeded but is missing an `id` — an ADO state
 	// anomaly that shouldn't happen, but `id` is typed `number | undefined`.
-	throw new Error(`No build for ${subject} has a usable build id.`);
+	return { kind: "no-id" };
 }
 
 export interface GetArtifactForCommitArgs {
@@ -103,15 +123,26 @@ export interface GetArtifactForCommitArgs {
 }
 
 /**
+ * Outcome of fetching an artifact for a {@link BuildMatch}. `completed` carries
+ * the downloaded artifact contents; the failure variants are
+ * {@link ArtifactLookupFailure}. Download failures (network, malformed zip,
+ * etc.) still propagate as thrown exceptions.
+ */
+export type GetArtifactForCommitResult =
+	| { kind: "completed"; contents: ArtifactContents }
+	| ArtifactLookupFailure;
+
+/**
  * Fetch one artifact from the ADO build that `match` identifies.
  *
- * @returns The artifact's {@link ArtifactContents}. Throws when no usable
- * build is found (see {@link BuildMatch}); download failures propagate from
- * `downloadArtifact`.
+ * @returns A {@link GetArtifactForCommitResult}: `completed` with the
+ * artifact contents on the happy path, or one of the failure kinds when no
+ * usable build is found. Download failures still throw (unexpected and
+ * propagate from `downloadArtifact`).
  */
 export async function getArtifactForCommit(
 	args: GetArtifactForCommitArgs,
-): Promise<ArtifactContents> {
+): Promise<GetArtifactForCommitResult> {
 	const { adoApi, artifactName, match, definitionId, project } = args;
 
 	const builds = await getBuilds(adoApi, {
@@ -119,7 +150,32 @@ export async function getArtifactForCommit(
 		definitions: [definitionId],
 		maxBuildsPerDefinition: recentBuildsToFetch,
 	});
-	const buildId = findBuildId(builds, match);
+	const lookup = findBuildId(builds, match);
+	if (lookup.kind !== "completed") {
+		return lookup;
+	}
 
-	return downloadArtifact(adoApi, project, buildId, artifactName);
+	const contents = await downloadArtifact(adoApi, project, lookup.buildId, artifactName);
+	return { kind: "completed", contents };
+}
+
+/**
+ * Human-readable message for an {@link ArtifactLookupFailure}, given the
+ * originating {@link BuildMatch} that produced it.
+ */
+export function describeArtifactFailure(
+	match: BuildMatch,
+	failure: ArtifactLookupFailure,
+): string {
+	const subject = describeMatch(match);
+	switch (failure.kind) {
+		case "no-build":
+			return `No build found for ${subject}.`;
+		case "in-progress":
+			return `Found an in-progress build for ${subject}; none have succeeded yet.`;
+		case "all-failed":
+			return `All builds for ${subject} have completed but none succeeded.`;
+		case "no-id":
+			return `No build for ${subject} has a usable build id.`;
+	}
 }


### PR DESCRIPTION
[AB#75772](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/75772)

## Description

Adds structured failure-mode dispatch to the `pr-bundle-size-comments` workflow that landed in #27527, and fixes several issues observed in production: a concurrency-cancellation bug that prevented `acknowledge-build` from ever running to completion, a 100-build search horizon that lost old PRs' merge-base baselines, stickies left stale forever when a build subsequently failed or was cancelled, and the workflow firing for `internal` ADO project check_runs we can't process. Plus diagnostic polish.

### Concurrency fix

The concurrency group key was just the check_run head SHA, so every ADO sub-check that fires on the same commit (`Build - client packages (Build Stage Build)`, `Build - client packages (🔒 SDLSources ...)`, etc.) was cancelling any in-flight workflow run for that SHA via `cancel-in-progress` — even though those events are noise we filter out at the job `if:`. Net effect: `acknowledge-build` never ran to completion in practice. Including the check name in the group key isolates each event stream while preserving the intended completed-cancels-pending semantics for matching events.

### Search horizon bumped

`recentBuildsToFetch` 100 → 500. ADO has no query-by-SHA API; bumped the client-side filter window from ~3 weeks to ~3 months of main-branch CI at the observed ~5 builds/day.

### Structured failure-mode dispatch

`findBuildId` and `getArtifactForCommit` now return discriminated unions — `{ kind: "completed" | "no-build" | "in-progress" | "all-failed" | "no-id" }` — instead of throwing string-formatted Errors that downstream consumers would have to grep. `flub report comparePipelineBundleArtifacts --json` emits a matching `{ kind, side: "base" | "head" }` payload for failures (with `no-analyzer-jsons` added at the command level on top of the library kinds).

The workflow's render step dispatches on `kind`:
- `completed` → the per-package comparison body, including 0-delta lines for full inventory.
- `in-progress` → a matter-of-fact "Pending — …" line that mirrors `acknowledge-build`'s pending sticky. Normal "wait for the build" path, not an error.
- everything else → "⚠️ Comparison unavailable." plus a friendly per-(side, kind) paragraph telling the user what's happening and whether they need to act (merge a recent main commit, fix the PR build, …).

### Deferred-baseline / failed-build auto-resolution

Both `identify-*` jobs no longer gate on `conclusion == 'success'`. Any completion re-triggers the appropriate path: flub's structured kind dispatches the right body and the sticky updates from "Pending — …" to (e.g.) "The baseline CI build for the merge-base commit failed — likely a flaky producer build. Try merging a recent main commit into this PR, or re-queue the baseline pipeline manually."

### Project scoping

Both the `public` and `internal` ADO projects publish check_runs with the same names (e.g. `Build - client packages`). The original `if:` filters matched on name only, so the workflow was also firing for internal-project events — which we can't process (no anonymous read access in the workflow context) and which don't produce the artifacts we consume. Add `contains(check_run.details_url, '<public-project-guid>')` to all three triggering jobs so we only react to public-project check_runs. There's no structured `project` field in the check_run payload, so a details_url GUID match is the only stable distinguisher.

### Diagnostic improvements

- **`Affected PRs (N):` summary at the end of both identify-* jobs** so the action log says at a glance whether the matrix was empty or which PRs it pointed at.
- **`Matched PR #X head=... base=... mergeBase=...` summary in `acknowledge-build`'s find_pr step** for symmetry — the happy path was previously silent.
- **Cleaner matrix display name on the `compare` job**: `compare (PR #27546)` instead of the auto-generated `compare (27546, 0412ca768f..., main, fb992c35c4...)`.
- **Collapsible log groups for the JSON output and rendered markdown bodies** — the bulk content is folded by default; the "would post" header line stays visible above the fold so it's still clear what's there.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The structured-failure refactor is the main load-bearing piece — start at `library/azureDevops/getArtifactForCommit.ts` (where the discriminated union and `describeArtifactFailure` helper live) and follow it through `commands/report/comparePipelineBundleArtifacts.ts` (the `fetchSide`/`handleFailure` dispatch) and `.github/workflows/pr-bundle-size-comments.yml` (the `renderComparison`/`renderFailure` split + the `identify-*` filter widening).
