### PR TITLE
build(client-drivers): enable `exactOptionalPropertyTypes` in most packages

### DIFF
--- a/.changeset/eleven-pugs-learn.md
+++ b/.changeset/eleven-pugs-learn.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/odsp-driver": minor
+"__section": breaking
+---
+OdspFluidDataStoreLocator optional properties may also be explicitly undefined
+
+Typing for `OdspFluidDataStoreLocator` optional properties are updated to reflect that in some implementations those are present but evaluate to `undefined`.
+When building with `excactOptionalPropertyTypes:false` as suggested in [compatibility requirements](https://github.com/microsoft/FluidFramework/blob/68732d93a6cc8be2df966b9bb40f58bdd9fad69b/packages/drivers/odsp-driver/README.md#supported-tools), there is no apparent type change.
+If a type error is experienced, make sure to check for `undefined` when reading.

--- a/examples/utils/example-driver/tsconfig.json
+++ b/examples/utils/example-driver/tsconfig.json
@@ -4,6 +4,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -337,7 +337,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
 
 				this.stepsToPlay = await this.stepsDeferred.promise;
 
-				this.stepsDeferred = undefined;
+				delete this.stepsDeferred;
 				this.ui.disableNextOpButton(true);
 			}
 

--- a/packages/drivers/debugger/src/fluidDebuggerUi.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerUi.ts
@@ -292,7 +292,7 @@ export class DebuggerUI {
 				: `Playing from ${version.id}, seq# ${seqNumber}`;
 
 		this.wasVersionSelected = true;
-		this.selector = undefined;
+		delete this.selector;
 
 		const doc = this.debuggerWindow.document;
 		doc.open();

--- a/packages/drivers/debugger/tsconfig.json
+++ b/packages/drivers/debugger/tsconfig.json
@@ -7,6 +7,5 @@
 		"outDir": "./lib",
 		"lib": ["ES2017", "ES2018.Promise", "ES2018.AsyncIterable", "DOM", "DOM.Iterable"],
 		"types": ["node"],
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -121,7 +121,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_FluidCacheConfig": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/drivers/driver-web-cache/src/test/FluidCacheTimer.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCacheTimer.test.ts
@@ -23,10 +23,11 @@ function getFluidCache(config?: {
 	partitionKey?: string | null;
 	logger?: MockLogger;
 }): FluidCache {
+	const logger = config?.logger;
 	return new FluidCache({
 		partitionKey: config?.partitionKey ?? mockPartitionKey,
 		maxCacheItemAge: config?.maxCacheItemAge ?? 3 * 24 * 60 * 60 * 1000,
-		logger: config?.logger,
+		...(logger === undefined ? {} : { logger }),
 		closeDbAfterMs: 100,
 	});
 }

--- a/packages/drivers/driver-web-cache/src/test/tsconfig.json
+++ b/packages/drivers/driver-web-cache/src/test/tsconfig.json
@@ -4,7 +4,6 @@
 		"rootDir": "./",
 		"outDir": "../../lib/test",
 		"types": ["mocha", "node"],
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 	"include": ["./**/*"],

--- a/packages/drivers/driver-web-cache/src/test/types/validateDriverWebCachePrevious.generated.ts
+++ b/packages/drivers/driver-web-cache/src/test/types/validateDriverWebCachePrevious.generated.ts
@@ -69,4 +69,5 @@ declare type old_as_current_for_Interface_FluidCacheConfig = requireAssignableTo
  * typeValidation.broken:
  * "Interface_FluidCacheConfig": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_FluidCacheConfig = requireAssignableTo<TypeOnly<current.FluidCacheConfig>, TypeOnly<old.FluidCacheConfig>>

--- a/packages/drivers/driver-web-cache/tsconfig.json
+++ b/packages/drivers/driver-web-cache/tsconfig.json
@@ -6,6 +6,5 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"skipLibCheck": true,
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -156,8 +156,8 @@ export const FileSnapshotWriterClassFactory = <TBase extends ReaderConstructor>(
 
 		public reset(): void {
 			this.blobsWriter = new Map<string, ArrayBufferLike>();
-			this.latestWriterTree = undefined;
-			this.docId = undefined;
+			delete this.latestWriterTree;
+			delete this.docId;
 		}
 
 		public onSnapshotHandler(snapshot: IFileSnapshot): void {

--- a/packages/drivers/file-driver/tsconfig.json
+++ b/packages/drivers/file-driver/tsconfig.json
@@ -6,7 +6,6 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"types": ["node"],
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 }

--- a/packages/drivers/local-driver/src/localDocumentStorageService.ts
+++ b/packages/drivers/local-driver/src/localDocumentStorageService.ts
@@ -267,7 +267,11 @@ export class LocalDocumentStorageService implements IDocumentStorageService {
 
 	private stripTree(tree: ISnapshotTreeEx, groupId: string | undefined): void {
 		tree.blobs = {};
-		tree.groupId = groupId;
+		if (groupId === undefined) {
+			delete tree.groupId;
+		} else {
+			tree.groupId = groupId;
+		}
 		tree.trees = {};
 	}
 

--- a/packages/drivers/local-driver/tsconfig.json
+++ b/packages/drivers/local-driver/tsconfig.json
@@ -5,6 +5,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
@@ -186,15 +186,15 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 // @beta @legacy (undocumented)
 export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     // (undocumented)
-    appName?: string;
+    appName?: string | undefined;
     // (undocumented)
-    containerPackageName?: string;
+    containerPackageName?: string | undefined;
     // (undocumented)
-    context?: string;
+    context?: string | undefined;
     // (undocumented)
     dataStorePath: string;
     // (undocumented)
-    fileVersion?: string;
+    fileVersion?: string | undefined;
 }
 
 // @beta @deprecated @legacy

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -152,7 +152,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_OdspFluidDataStoreLocator": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -11,10 +11,10 @@ import type { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/inte
  */
 export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 	dataStorePath: string;
-	appName?: string;
-	containerPackageName?: string;
-	fileVersion?: string;
-	context?: string;
+	appName?: string | undefined;
+	containerPackageName?: string | undefined;
+	fileVersion?: string | undefined;
+	context?: string | undefined;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -159,12 +159,11 @@ export async function fetchSnapshotWithRedeem(
 				// Execute the redeem fallback
 				await redeemSharingLink(odspResolvedUrl, storageTokenFetcher, logger);
 
+				const shareLinkInfo = { ...odspResolvedUrl.shareLinkInfo };
+				delete shareLinkInfo.sharingLinkToRedeem;
 				const odspResolvedUrlWithoutShareLink: IOdspResolvedUrl = {
 					...odspResolvedUrl,
-					shareLinkInfo: {
-						...odspResolvedUrl.shareLinkInfo,
-						sharingLinkToRedeem: undefined,
-					},
+					shareLinkInfo,
 				};
 
 				// Log initial failure only if redeem succeeded - it points out to some bug somewhere

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -576,6 +576,6 @@ export class OdspDelayLoadedDeltaStream {
 	public dispose(error?: unknown): void {
 		this.clearJoinSessionTimer();
 		this.currentConnection?.dispose();
-		this.currentConnection = undefined;
+		delete this.currentConnection;
 	}
 }

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -118,7 +118,6 @@ describe("Create New Utils Tests", () => {
 		fileEntry = {
 			docId: hashedDocumentId,
 			resolvedUrl,
-			fileVersion: undefined,
 		};
 	});
 
@@ -130,7 +129,6 @@ describe("Create New Utils Tests", () => {
 			{
 				docId: hashedDocumentId,
 				resolvedUrl,
-				fileVersion: undefined,
 			},
 			createChildLogger(),
 		);

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -47,7 +47,7 @@ describe("DeltaStorageService", () => {
 		itemId,
 		odspResolvedUrl: true,
 	} as unknown as IOdspResolvedUrl;
-	const fileEntry = { docId: "docId", resolvedUrl, fileVersion: undefined };
+	const fileEntry = { docId: "docId", resolvedUrl };
 
 	it("Should build the correct sharepoint delta url with auth", async () => {
 		const loggerMock = new MockLogger();

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -55,7 +55,6 @@ describe("Tests for Epoch Tracker", () => {
 			{
 				docId: hashedDocumentId,
 				resolvedUrl,
-				fileVersion: undefined,
 			},
 			createChildLogger(),
 		);
@@ -82,7 +81,7 @@ describe("Tests for Epoch Tracker", () => {
 		const cacheEntry1: ICacheEntry = {
 			key: "key1",
 			type: "snapshot",
-			file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+			file: { docId: hashedDocumentId, resolvedUrl },
 		};
 		const cacheEntry2: ICacheEntry = { ...cacheEntry1, key: "key2" };
 		const cacheValue1 = { val: "val1", cacheEntryTime: Date.now() };
@@ -118,7 +117,7 @@ describe("Tests for Epoch Tracker", () => {
 		const cacheEntry1: ICacheEntry = {
 			key: "key1",
 			type: "snapshot",
-			file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+			file: { docId: hashedDocumentId, resolvedUrl },
 		};
 		const cacheEntry2: ICacheEntry = { ...cacheEntry1, key: "key2" };
 		const cacheValue1 = { val: "val1", cacheEntryTime: Date.now() };

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -68,7 +68,6 @@ describe("Tests for Epoch Tracker With Redemption", () => {
 			{
 				docId: hashedDocumentId,
 				resolvedUrl,
-				fileVersion: undefined,
 			},
 			logger.toTelemetryLogger(),
 		);

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -120,7 +120,6 @@ describe("Tests1 for snapshot fetch", () => {
 			{
 				docId: hashedDocumentId,
 				resolvedUrl,
-				fileVersion: undefined,
 			},
 			logger,
 		);
@@ -684,7 +683,7 @@ describe("Tests1 for snapshot fetch", () => {
 
 	it("Location redirection error without shareLink skips redeem", async () => {
 		// No shareLinkInfo set on resolved URL
-		resolved.shareLinkInfo = undefined;
+		delete resolved.shareLinkInfo;
 
 		const newSiteUrl = "https://microsoft.sharepoint.com/siteUrl";
 

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -122,7 +122,7 @@ describe("Tests for snapshot fetch", () => {
 	describe("Tests for caching of different file versions", () => {
 		beforeEach(async () => {
 			localCache = createUtLocalCache();
-			const resolvedUrlWithFileVersion: IOdspResolvedUrl = {
+			const resolvedUrlWithFileVersion = {
 				siteUrl,
 				driveId,
 				itemId,
@@ -141,7 +141,7 @@ describe("Tests for snapshot fetch", () => {
 				fileName: "",
 				summarizer: false,
 				id: "id",
-			};
+			} as const satisfies IOdspResolvedUrl;
 
 			epochTracker = new EpochTracker(
 				localCache,
@@ -196,7 +196,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 
 			await localCache.put(cacheEntry, latestValue);
@@ -226,7 +226,6 @@ describe("Tests for snapshot fetch", () => {
 				{
 					docId: hashedDocumentId,
 					resolvedUrl,
-					fileVersion: undefined,
 				},
 				createChildLogger(),
 			);
@@ -275,7 +274,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 			await localCache.put(cacheEntry, value);
 
@@ -309,7 +308,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 			await localCache.put(cacheEntry, value);
 
@@ -339,7 +338,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 			await localCache.put(cacheEntry, valueWithExpiredCache(maximumCacheDurationMs));
 
@@ -359,7 +358,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 			await localCache.put(cacheEntry, valueWithExpiredCache(maximumCacheDurationMs));
 
@@ -385,7 +384,6 @@ describe("Tests for snapshot fetch", () => {
 				{
 					docId: hashedDocumentId,
 					resolvedUrl,
-					fileVersion: undefined,
 				},
 				createChildLogger(),
 			);
@@ -414,7 +412,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 			await localCache.put(
 				cacheEntry,
@@ -437,7 +435,7 @@ describe("Tests for snapshot fetch", () => {
 			const cacheEntry: ICacheEntry = {
 				key: "",
 				type: "snapshot",
-				file: { docId: hashedDocumentId, resolvedUrl, fileVersion: undefined },
+				file: { docId: hashedDocumentId, resolvedUrl },
 			};
 			await localCache.put(
 				cacheEntry,

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "node:assert";
 
 import type { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions/internal";
-import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest.js";
 import { createOdspUrl } from "../createOdspUrl.js";
@@ -63,7 +62,7 @@ describe("Odsp Driver Resolver", () => {
 
 	it("Should resolve url with a data store", async () => {
 		const resolvedUrl = await resolver.resolve(request);
-		const expected: IOdspResolvedUrl = {
+		const expected = {
 			endpoints: {
 				snapshotStorageUrl: "",
 				attachmentGETStorageUrl: "",

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -125,12 +125,8 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 					...(resolvedUrl1.fileVersion === undefined
 						? {}
 						: { fileVersion: resolvedUrl1.fileVersion }),
-					...(resolvedUrl1.context === undefined
-						? {}
-						: { context: resolvedUrl1.context }),
-					...(resolvedUrl1.appName === undefined
-						? {}
-						: { appName: resolvedUrl1.appName }),
+					...(resolvedUrl1.context === undefined ? {} : { context: resolvedUrl1.context }),
+					...(resolvedUrl1.appName === undefined ? {} : { appName: resolvedUrl1.appName }),
 				});
 				const resolvedUrl2 = await resolver.resolve({ url });
 				assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -117,7 +117,21 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 		it(`resolve - Should resolve odsp driver url correctly, hasVersion: ${urlWithNav.hasVersion}, hasContext: ${urlWithNav.hasContext}`, async () => {
 			const runTest = async (resolver: OdspDriverUrlResolverForShareLink): Promise<void> => {
 				const resolvedUrl1 = await resolver.resolve({ url: urlWithNav.url });
-				const url: string = createOdspUrl({ ...resolvedUrl1, dataStorePath });
+				const url: string = createOdspUrl({
+					siteUrl: resolvedUrl1.siteUrl,
+					driveId: resolvedUrl1.driveId,
+					itemId: resolvedUrl1.itemId,
+					dataStorePath,
+					...(resolvedUrl1.fileVersion === undefined
+						? {}
+						: { fileVersion: resolvedUrl1.fileVersion }),
+					...(resolvedUrl1.context === undefined
+						? {}
+						: { context: resolvedUrl1.context }),
+					...(resolvedUrl1.appName === undefined
+						? {}
+						: { appName: resolvedUrl1.appName }),
+				});
 				const resolvedUrl2 = await resolver.resolve({ url });
 				assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
 				assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -117,17 +117,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 		it(`resolve - Should resolve odsp driver url correctly, hasVersion: ${urlWithNav.hasVersion}, hasContext: ${urlWithNav.hasContext}`, async () => {
 			const runTest = async (resolver: OdspDriverUrlResolverForShareLink): Promise<void> => {
 				const resolvedUrl1 = await resolver.resolve({ url: urlWithNav.url });
-				const url: string = createOdspUrl({
-					siteUrl: resolvedUrl1.siteUrl,
-					driveId: resolvedUrl1.driveId,
-					itemId: resolvedUrl1.itemId,
-					dataStorePath,
-					...(resolvedUrl1.fileVersion === undefined
-						? {}
-						: { fileVersion: resolvedUrl1.fileVersion }),
-					...(resolvedUrl1.context === undefined ? {} : { context: resolvedUrl1.context }),
-					...(resolvedUrl1.appName === undefined ? {} : { appName: resolvedUrl1.appName }),
-				});
+				const url: string = createOdspUrl({ ...resolvedUrl1, dataStorePath });
 				const resolvedUrl2 = await resolver.resolve({ url });
 				assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
 				assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");

--- a/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
@@ -179,7 +179,7 @@ describe("Tests for prefetching snapshot", () => {
 				.removeEntries({
 					docId: hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				})
 				.catch(() => {});
 			snapshotPrefetchResultCache.remove(snapshotPrefetchCacheKey);
@@ -277,7 +277,7 @@ describe("Tests for prefetching snapshot", () => {
 				file: {
 					docId: resolved.hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				},
 			};
 			await localCache.put(cacheEntry, value);
@@ -328,7 +328,7 @@ describe("Tests for prefetching snapshot", () => {
 				file: {
 					docId: hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				},
 			};
 			await localCache.put(cacheEntry, value);
@@ -522,7 +522,7 @@ describe("Tests for prefetching snapshot", () => {
 				.removeEntries({
 					docId: hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				})
 				.catch(() => {});
 			snapshotPrefetchResultCache.remove(snapshotPrefetchCacheKey);
@@ -671,7 +671,7 @@ describe("Tests for prefetching snapshot", () => {
 				.removeEntries({
 					docId: hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				})
 				.catch(() => {});
 			snapshotPrefetchResultCache.remove(snapshotPrefetchCacheKey);
@@ -776,7 +776,7 @@ describe("Tests for prefetching snapshot", () => {
 				file: {
 					docId: resolved.hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				},
 			};
 			await localCache.put(cacheEntry, valueWithGroupId);
@@ -831,7 +831,7 @@ describe("Tests for prefetching snapshot", () => {
 				file: {
 					docId: hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				},
 			};
 			await localCache.put(cacheEntry, valueWithGroupId);
@@ -925,7 +925,7 @@ describe("Tests for prefetching snapshot", () => {
 				.removeEntries({
 					docId: hashedDocumentId,
 					resolvedUrl: resolved,
-					fileVersion: resolved.fileVersion,
+					...(resolved.fileVersion === undefined ? {} : { fileVersion: resolved.fileVersion }),
 				})
 				.catch(() => {});
 			snapshotPrefetchResultCache.remove(snapshotPrefetchCacheKey);

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -184,8 +184,9 @@ describe("Snapshot Format Conversion Tests", () => {
 		assert.deepStrictEqual(result.ops, ops, "Ops should match");
 		assert(result.sequenceNumber === 0, "Seq number should match");
 		assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
-		assert(
-			(result.snapshotTree.id = snapshotContents.snapshotTree.id),
+		assert.equal(
+			result.snapshotTree.id,
+			snapshotContents.snapshotTree.id,
 			"Snapshot id should match",
 		);
 
@@ -220,8 +221,9 @@ describe("Snapshot Format Conversion Tests", () => {
 		assert.deepStrictEqual(result.ops, [], "Ops should match");
 		assert(result.sequenceNumber === 0, "Seq number should match");
 		assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
-		assert(
-			(result.snapshotTree.id = snapshotContents.snapshotTree.id),
+		assert.equal(
+			result.snapshotTree.id,
+			snapshotContents.snapshotTree.id,
 			"Snapshot id should match",
 		);
 		assert(result.telemetryProps.slowBlobStructureCount === 0);
@@ -259,8 +261,9 @@ describe("Snapshot Format Conversion Tests", () => {
 		assert.deepStrictEqual(result.ops, ops, "Ops should match");
 		assert(result.sequenceNumber === 0, "Seq number should match");
 		assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
-		assert(
-			(result.snapshotTree.id = snapshotContents.snapshotTree.id),
+		assert.equal(
+			result.snapshotTree.id,
+			snapshotContents.snapshotTree.id,
 			"Snapshot id should match",
 		);
 		assert(result.telemetryProps.slowBlobStructureCount === 0);

--- a/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
@@ -133,7 +133,6 @@ describe("DeltaConnectionMetadata update tests", () => {
 			{
 				docId: hashedDocumentId,
 				resolvedUrl,
-				fileVersion: undefined,
 			},
 			logger,
 		);

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -70,7 +70,6 @@ describe("OdspDocumentDeltaConnection tests", () => {
 			{
 				docId: hashedDocumentId,
 				resolvedUrl,
-				fileVersion: undefined,
 			},
 			logger,
 		);

--- a/packages/drivers/odsp-driver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-driver/src/test/tsconfig.json
@@ -5,7 +5,6 @@
 		"outDir": "../../lib/test",
 		"types": ["node", "mocha"],
 		"noUncheckedIndexedAccess": false,
-		"exactOptionalPropertyTypes": false,
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
@@ -402,6 +402,7 @@ declare type old_as_current_for_Interface_OdspFluidDataStoreLocator = requireAss
  * typeValidation.broken:
  * "Interface_OdspFluidDataStoreLocator": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_OdspFluidDataStoreLocator = requireAssignableTo<TypeOnly<current.OdspFluidDataStoreLocator>, TypeOnly<old.OdspFluidDataStoreLocator>>
 
 /*

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -128,11 +128,12 @@ export function iteratePairs<T>(it: IterableIterator<T>): IterableIterator<[T, T
 		next: () => {
 			const a = it.next();
 			if (a.done) {
+				// Note: there is no assertion here that b is also done.
 				return { value: undefined, done: true };
 			}
 			const b = it.next();
 			assert(b.done !== true, 0x22b /* "Should be a pair" */);
-			return { value: [a.value, b.value], done: b.done };
+			return { value: [a.value, b.value], done: false };
 		},
 		[Symbol.iterator]: () => {
 			return res;

--- a/packages/drivers/odsp-driver/tsconfig.json
+++ b/packages/drivers/odsp-driver/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		// As of 2026-06-16, there are 50 errors enableing exactOptionalPropertyTypes.
 		"exactOptionalPropertyTypes": false,
 		// TODO: AB#34163 Enable noUncheckedIndexedAccess for packages/drivers/odsp-driver
 		"noUncheckedIndexedAccess": false,

--- a/packages/drivers/odsp-driver/tsconfig.json
+++ b/packages/drivers/odsp-driver/tsconfig.json
@@ -5,7 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		// As of 2026-06-16, there are 50 errors enableing exactOptionalPropertyTypes.
+		// As of 2026-06-18, there are 47 errors enableing exactOptionalPropertyTypes.
 		"exactOptionalPropertyTypes": false,
 		// TODO: AB#34163 Enable noUncheckedIndexedAccess for packages/drivers/odsp-driver
 		"noUncheckedIndexedAccess": false,

--- a/packages/drivers/odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/odsp-urlResolver/src/urlResolver.ts
@@ -41,7 +41,7 @@ export class OdspUrlResolver implements IUrlResolver {
 			const odspDriverUrlResolver: IUrlResolver = new OdspDriverUrlResolver();
 			return odspDriverUrlResolver.resolve({
 				url: urlToBeResolved,
-				headers: request.headers,
+				...(request.headers === undefined ? {} : { headers: request.headers }),
 			});
 		}
 		return undefined;

--- a/packages/drivers/odsp-urlResolver/tsconfig.json
+++ b/packages/drivers/odsp-urlResolver/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 }

--- a/packages/drivers/replay-driver/tsconfig.json
+++ b/packages/drivers/replay-driver/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		// TODO: AB#34164 Enable noUncheckedIndexedAccess for packages/drivers/replay-driver
 		"noUncheckedIndexedAccess": false,
 	},

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -392,16 +392,18 @@ export class DocumentPostCreateError extends Error {
 		/**
 		 * Inner error being wrapped.
 		 */
+		// @ts-expect-error - innerError member is retained for debuggablity, but otherwise unused.
 		private readonly innerError: Error,
 	) {
 		super(innerError.message);
+		if (innerError.stack) {
+			this.stack = innerError.stack;
+		}
 	}
 
 	public readonly name = "DocumentPostCreateError";
 
-	public get stack(): string | undefined {
-		return this.innerError.stack;
-	}
+	public readonly stack?: string;
 }
 
 /**

--- a/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
@@ -43,8 +43,8 @@ function buildHierarchy(
 			const newTree: ISnapshotTree = {
 				blobs: {},
 				trees: {},
-				unreferenced: entry.unreferenced,
-				groupId: entry.groupId,
+				...(entry.unreferenced === undefined ? {} : { unreferenced: entry.unreferenced }),
+				...(entry.groupId === undefined ? {} : { groupId: entry.groupId }),
 			};
 			node.trees[decodeURIComponent(entryPathBase)] = newTree;
 			lookup[entryPath] = newTree;

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -39,7 +39,7 @@ const buildRequestUrl = (requestConfig: RequestConfig): string =>
 
 const buildRequestInitConfig = (requestConfig: RequestConfig): RequestInit => {
 	const requestInit: RequestInit = {
-		method: requestConfig.method,
+		...(requestConfig.method === undefined ? {} : { method: requestConfig.method }),
 		// NOTE: Although the RequestHeaders type permits non-string values in the header, here we are
 		// guaranteed the requestConfig only has string values in its header.
 		headers: requestConfig.headers as Record<string, string>,

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -36,8 +36,8 @@ export abstract class RestWrapper {
 	): Promise<IR11sResponse<T>> {
 		const options: RequestConfig = {
 			...additionalOptions,
-			baseURL: this.baseurl,
-			headers,
+			...(this.baseurl === undefined ? {} : { baseURL: this.baseurl }),
+			...(headers === undefined ? {} : { headers }),
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "GET",
@@ -70,9 +70,9 @@ export abstract class RestWrapper {
 	): Promise<IR11sResponse<T>> {
 		const options: RequestConfig = {
 			...additionalOptions,
-			baseURL: this.baseurl,
+			...(this.baseurl === undefined ? {} : { baseURL: this.baseurl }),
 			data: requestBody,
-			headers,
+			...(headers === undefined ? {} : { headers }),
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "POST",
@@ -103,8 +103,8 @@ export abstract class RestWrapper {
 	): Promise<IR11sResponse<T>> {
 		const options: RequestConfig = {
 			...additionalOptions,
-			baseURL: this.baseurl,
-			headers,
+			...(this.baseurl === undefined ? {} : { baseURL: this.baseurl }),
+			...(headers === undefined ? {} : { headers }),
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "DELETE",
@@ -137,9 +137,9 @@ export abstract class RestWrapper {
 	): Promise<IR11sResponse<T>> {
 		const options: RequestConfig = {
 			...additionalOptions,
-			baseURL: this.baseurl,
+			...(this.baseurl === undefined ? {} : { baseURL: this.baseurl }),
 			data: requestBody,
-			headers,
+			...(headers === undefined ? {} : { headers }),
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "PATCH",

--- a/packages/drivers/routerlicious-driver/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/src/test/tsconfig.json
@@ -4,7 +4,6 @@
 		"rootDir": "./",
 		"outDir": "../../lib/test",
 		"types": ["mocha", "node"],
-		"exactOptionalPropertyTypes": false,
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/drivers/routerlicious-driver/src/test/wholeSummaryDocumentStorageService.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/wholeSummaryDocumentStorageService.spec.ts
@@ -98,13 +98,9 @@ const expectedSummary: ISummaryTree = {
 						rootDOId: {
 							tree: {},
 							type: 1,
-							unreferenced: undefined,
-							groupId: undefined,
 						},
 					},
 					type: 1,
-					unreferenced: undefined,
-					groupId: undefined,
 				},
 				".metadata": {
 					content:
@@ -113,8 +109,6 @@ const expectedSummary: ISummaryTree = {
 				},
 			},
 			type: 1,
-			unreferenced: undefined,
-			groupId: undefined,
 		},
 		".protocol": {
 			tree: {
@@ -129,13 +123,9 @@ const expectedSummary: ISummaryTree = {
 				},
 			},
 			type: 1,
-			unreferenced: undefined,
-			groupId: undefined,
 		},
 	},
 	type: 1,
-	unreferenced: undefined,
-	groupId: undefined,
 };
 
 class MockGitManager {

--- a/packages/drivers/routerlicious-driver/src/treeUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/treeUtils.ts
@@ -38,8 +38,10 @@ export class SummaryTreeAssembler {
 		return {
 			type: SummaryType.Tree,
 			tree: { ...this.summaryTree },
-			unreferenced: this.props?.unreferenced,
-			groupId: this.props?.groupId,
+			...(this.props?.unreferenced === undefined
+				? {}
+				: { unreferenced: this.props.unreferenced }),
+			...(this.props?.groupId === undefined ? {} : { groupId: this.props.groupId }),
 		};
 	}
 
@@ -94,8 +96,8 @@ export function convertSnapshotAndBlobsToSummaryTree(
 	blobs: Map<string, ArrayBuffer>,
 ): ISummaryTree {
 	const assembler = new SummaryTreeAssembler({
-		unreferenced: snapshot.unreferenced,
-		groupId: snapshot.groupId,
+		...(snapshot.unreferenced === undefined ? {} : { unreferenced: snapshot.unreferenced }),
+		...(snapshot.groupId === undefined ? {} : { groupId: snapshot.groupId }),
 	});
 	for (const [path, id] of Object.entries(snapshot.blobs)) {
 		const blob = blobs.get(id);

--- a/packages/drivers/routerlicious-driver/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		// TODO: AB#34165 Enable noUncheckedIndexedAccess for packages/drivers/routerlicious-driver
 		"noUncheckedIndexedAccess": false,
 	},

--- a/packages/drivers/tinylicious-driver/tsconfig.json
+++ b/packages/drivers/tinylicious-driver/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 }

--- a/packages/runtime/test-runtime-utils/tsconfig.json
+++ b/packages/runtime/test-runtime-utils/tsconfig.json
@@ -8,7 +8,5 @@
 		"noImplicitOverride": true,
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": true,
-		// Skip lib check to avoid exactOptionalPropertyTypes errors in dependencies (routerlicious-driver)
-		"skipLibCheck": true,
 	},
 }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -341,6 +341,9 @@ export class OdspTestDriver implements ITestDriver {
 	}
 
 	public readonly type = "odsp";
+	public readonly endpointName?: string;
+	public readonly tenantName?: string;
+	public readonly userIndex?: number;
 	public get version(): string {
 		return this.api.version;
 	}
@@ -349,11 +352,21 @@ export class OdspTestDriver implements ITestDriver {
 	private constructor(
 		private readonly config: Readonly<IOdspTestDriverConfig>,
 		private readonly api = OdspDriverApi,
-		public readonly tenantName?: string,
-		public readonly userIndex?: number,
-		public readonly endpointName?: string,
+		tenantName?: string,
+		userIndex?: number,
+		endpointName?: string,
 		private readonly tokenManager: OdspTokenManager = defaultTokenManager,
-	) {}
+	) {
+		if (endpointName !== undefined) {
+			this.endpointName = endpointName;
+		}
+		if (tenantName !== undefined) {
+			this.tenantName = tenantName;
+		}
+		if (userIndex !== undefined) {
+			this.userIndex = userIndex;
+		}
+	}
 
 	/**
 	 * Returns the url to container which can be used to load the container through loader.
@@ -400,7 +413,7 @@ export class OdspTestDriver implements ITestDriver {
 			this.config.options,
 		);
 		// Automatically reset the cache after creating the factory
-		this.cache = undefined;
+		delete this.cache;
 		return documentServiceFactory;
 	}
 

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -44,7 +44,7 @@ const dockerConfig = (driverPolicies?: IRouterliciousDriverPolicies): IConfig =>
 	},
 	tenantId: "fluid",
 	tenantSecret: "create-new-tenants-if-going-to-production",
-	driverPolicies,
+	...(driverPolicies === undefined ? {} : { driverPolicies }),
 });
 
 function getConfig(
@@ -68,7 +68,7 @@ function getConfig(
 			},
 			tenantId,
 			tenantSecret,
-			driverPolicies,
+			...(driverPolicies !== undefined ? { driverPolicies } : {}),
 		};
 	}
 	assert(fluidHost !== undefined, "Missing Fluid host");
@@ -81,7 +81,7 @@ function getConfig(
 		},
 		tenantId,
 		tenantSecret,
-		driverPolicies,
+		...(driverPolicies !== undefined ? { driverPolicies } : {}),
 	};
 }
 
@@ -169,6 +169,7 @@ export class RouterliciousTestDriver implements ITestDriver {
 	}
 
 	public readonly type = "routerlicious";
+	public readonly endpointName?: string;
 	public get version(): string {
 		return this.api.version;
 	}
@@ -178,8 +179,12 @@ export class RouterliciousTestDriver implements ITestDriver {
 		private readonly serviceEndpoints: IServiceEndpoint,
 		private readonly api: RouterliciousDriverApiType = RouterliciousDriverApi,
 		private readonly driverPolicies: IRouterliciousDriverPolicies | undefined,
-		public readonly endpointName?: string,
-	) {}
+		endpointName?: string,
+	) {
+		if (endpointName !== undefined) {
+			this.endpointName = endpointName;
+		}
+	}
 
 	async createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string> {
 		const containerId = containerUrl && "id" in containerUrl ? containerUrl.id : testId;

--- a/packages/test/test-drivers/tsconfig.json
+++ b/packages/test/test-drivers/tsconfig.json
@@ -6,6 +6,5 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"types": ["node"],
-		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
`odsp-driver` is notably left with `exactOptionalPropertyTypes` disabled as 50 errors are flagged when enabled.

common corrections:
- use `...(cond ? {} { prop: value })` to only define properties with defined values.
- delete optional properties instead of setting to `undefined`.

special cases:
- `packages/drivers/driver-web-cache`: disable back compat for `FluidCacheConfig` as `ITelemetryBaseLogger.minLogLevel` recently changed and that change is not detecatble via `exactOptionalPropertyTypes` enablement.
- `packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts`: explicit `false` instead of possibly `undefined`.
- `packages/drivers/odsp-driver/src/contractsPublic.ts`: updated to explicitly allow `undefined` for optional properties as is done by `decodeOdspFluidDataStoreLocator`.
- `packages/drivers/routerlicious-driver/src/documentServiceFactory.ts`: capture optional property instead of getter that might have to evaluate to `undefined`.
- `packages/test/test-drivers`: only set optional members when defined by caller