### PR TITLE
Enable bundle-size sticky comments and add notable-changes summary

### DIFF
--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -395,30 +395,53 @@ jobs:
             const fs = require("fs");
             const data = JSON.parse(fs.readFileSync("bundle-comparison.json", "utf8"));
 
-            // Render the happy-path comparison body — per-package sections, or
-            // "No bundle-size changes." if everything is unchanged.
+            // Render the happy-path body: a "Notable changes" summary (added,
+            // removed, or changed-with-parsed-delta ≥ NOTABLE_THRESHOLD) above
+            // the collapsed full per-bundle inventory.
             function renderComparison(comparison) {
+              const NOTABLE_THRESHOLD = 500;
+
               const fmtDelta = d => (d > 0 ? `+${d}` : `${d}`);
 
-              // Render one bundle's diff line — always emitted, even for
-              // unchanged bundles, so the body is a complete inventory.
-              function renderBundleLine(bundle, cmp) {
+              // Indicator emoji and notability for one bundle. ➕/➖ for added/removed,
+              // 🔴/🟢 for changes ≥ NOTABLE_THRESHOLD; smaller/unchanged → none.
+              function getRenderProps(cmp) {
+                if (cmp.base === undefined) return { indicator: "➕", isNotable: true };
+                if (cmp.compare === undefined) return { indicator: "➖", isNotable: true };
+                const delta = cmp.compare.parsedSize - cmp.base.parsedSize;
+                if (Math.abs(delta) >= NOTABLE_THRESHOLD) {
+                  return { indicator: delta > 0 ? "🔴" : "🟢", isNotable: true };
+                }
+                return { indicator: undefined, isNotable: false };
+              }
+
+              // Render one bundle's diff line. Always emitted, including unchanged.
+              // `indicator` (➕/➖/🔴/🟢) is prepended when present.
+              function renderBundleLine(bundle, cmp, indicator) {
+                const prefix = indicator ? `${indicator} ` : "";
                 if (cmp.base === undefined && cmp.compare !== undefined) {
-                  return `- \`${bundle}\`: **added** (parsed ${cmp.compare.parsedSize}, gzip ${cmp.compare.gzipSize})`;
+                  return `- ${prefix}\`${bundle}\`: **added** (parsed ${cmp.compare.parsedSize}, gzip ${cmp.compare.gzipSize})`;
                 }
                 if (cmp.compare === undefined && cmp.base !== undefined) {
-                  return `- \`${bundle}\`: **removed** (was parsed ${cmp.base.parsedSize}, gzip ${cmp.base.gzipSize})`;
+                  return `- ${prefix}\`${bundle}\`: **removed** (was parsed ${cmp.base.parsedSize}, gzip ${cmp.base.gzipSize})`;
                 }
                 const dp = cmp.compare.parsedSize - cmp.base.parsedSize;
                 const dg = cmp.compare.gzipSize - cmp.base.gzipSize;
-                return `- \`${bundle}\`: parsed ${cmp.base.parsedSize} → ${cmp.compare.parsedSize} (${fmtDelta(dp)}), gzip ${cmp.base.gzipSize} → ${cmp.compare.gzipSize} (${fmtDelta(dg)})`;
+                return `- ${prefix}\`${bundle}\`: parsed ${cmp.base.parsedSize} → ${cmp.compare.parsedSize} (${fmtDelta(dp)}), gzip ${cmp.base.gzipSize} → ${cmp.compare.gzipSize} (${fmtDelta(dg)})`;
               }
 
+              const notableLines = [];
               const sections = [];
               for (const [pkg, bundles] of Object.entries(comparison)) {
-                const bundleLines = Object.entries(bundles).map(
-                  ([bundle, cmp]) => renderBundleLine(bundle, cmp),
-                );
+                const bundleLines = [];
+                for (const [bundle, cmp] of Object.entries(bundles)) {
+                  const { indicator, isNotable } = getRenderProps(cmp);
+                  const line = renderBundleLine(bundle, cmp, indicator);
+                  bundleLines.push(line);
+                  if (isNotable) {
+                    notableLines.push(line);
+                  }
+                }
                 if (bundleLines.length > 0) {
                   sections.push(`### \`${pkg}\`\n\n${bundleLines.join("\n")}`);
                 }
@@ -426,9 +449,19 @@ jobs:
               if (sections.length === 0) {
                 return "No bundles found in comparison.";
               }
-              // Per-bundle deltas can be long; wrap them in a collapsed
-              // `<details>` so the top of the comment stays compact.
+
+              const notableSection = [
+                `### Notable changes`,
+                "",
+                notableLines.length > 0
+                  ? notableLines.join("\n")
+                  : `No bundles changed by ≥ ${NOTABLE_THRESHOLD} bytes parsed.`,
+              ].join("\n");
+
+              // Wrap the full inventory in <details> so the top of the comment stays compact.
               return [
+                notableSection,
+                "",
                 "<details>",
                 "<summary>Per-bundle deltas</summary>",
                 "",

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -423,7 +423,19 @@ jobs:
                   sections.push(`### \`${pkg}\`\n\n${bundleLines.join("\n")}`);
                 }
               }
-              return sections.length > 0 ? sections.join("\n\n") : "No bundles found in comparison.";
+              if (sections.length === 0) {
+                return "No bundles found in comparison.";
+              }
+              // Per-bundle deltas can be long; wrap them in a collapsed
+              // `<details>` so the top of the comment stays compact.
+              return [
+                "<details>",
+                "<summary>Per-bundle deltas</summary>",
+                "",
+                sections.join("\n\n"),
+                "",
+                "</details>",
+              ].join("\n");
             }
 
             // Render a failure body for an expected (side, kind) failure.

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -59,9 +59,8 @@ jobs:
       github.event.check_run.name == 'Build - client packages' &&
       contains(github.event.check_run.details_url, '10f9b53e-c7fd-4538-9fff-13cd088a436c')
     runs-on: ubuntu-latest
-    # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
-    # permissions:
-    #   pull-requests: write
+    permissions:
+      pull-requests: write
     steps:
       - name: Resolve PR for check SHA
         id: find_pr
@@ -143,19 +142,18 @@ jobs:
               "",
             ].join("\n");
             fs.writeFileSync("acknowledge.md", body);
-            core.info(`PR #${process.env.PR_NUM}: would post the following body as a sticky comment.`);
+            core.info(`PR #${process.env.PR_NUM}: rendered the following body for the sticky comment.`);
             core.startGroup("acknowledge.md");
             core.info(body);
             core.endGroup();
 
-      # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
-      # - if: steps.render.outcome == 'success'
-      #   # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
-      #   uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
-      #   with:
-      #     header: bundle-size-report
-      #     number: ${{ steps.find_pr.outputs.pr_num }}
-      #     path: ${{ github.workspace }}/acknowledge.md
+      - if: steps.render.outcome == 'success'
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
+        with:
+          header: bundle-size-report
+          number: ${{ steps.find_pr.outputs.pr_num }}
+          path: ${{ github.workspace }}/acknowledge.md
 
   # Reacts to a PR's own `Build - client packages` build completing. The check SHA is a PR head SHA, so we
   # produce at most one matrix entry — the PR whose head matches. Fires on *any* completion (not just
@@ -317,9 +315,8 @@ jobs:
         pr: ${{ fromJSON(needs.identify-from-pr-build.outputs.prs || needs.identify-from-baseline-build.outputs.prs || '[]') }}
       fail-fast: false
     runs-on: ubuntu-latest
-    # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
-    # permissions:
-    #   pull-requests: write
+    permissions:
+      pull-requests: write
     steps:
       # Check out the PR's base branch (never PR HEAD — PR-authored code isn't trusted) just to get build-tools
       # source so we can build flub. The comparison itself reads only ADO artifacts identified by SHA — no local
@@ -378,11 +375,11 @@ jobs:
             exit "$EC"
           fi
 
-      # Format the JSON into the markdown body the sticky comment would post. Done here (not in flub) so
+      # Format the JSON into the markdown body the sticky comment posts. Done here (not in flub) so
       # the formatting is easy to iterate on without rebuilding build-tools. The body is written to
-      # bundle-comparison.md and also echoed to the action log so we can see what the eventual sticky
-      # would contain without actually posting it. Dispatches on `data.kind` — happy path renders the
-      # comparison; failure kinds render a friendly per-(kind, side) message.
+      # bundle-comparison.md and also echoed to the action log so we can see what got posted.
+      # Dispatches on `data.kind` — happy path renders the comparison; failure kinds render a
+      # friendly per-(kind, side) message.
       - name: Render bundle-size comment body
         # release notes: https://github.com/actions/github-script/releases/tag/v9.0.0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9
@@ -511,15 +508,14 @@ jobs:
             ].join("\n") + "\n";
 
             fs.writeFileSync("bundle-comparison.md", body);
-            core.info(`PR #${process.env.PR_NUM}: would post the following body as a sticky comment.`);
+            core.info(`PR #${process.env.PR_NUM}: rendered the following body for the sticky comment.`);
             core.startGroup("bundle-comparison.md");
             core.info(body);
             core.endGroup();
 
-      # Uncomment to enable comment posting after bake-in (tracked: AB#75349).
       # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
-      # - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
-      #   with:
-      #     header: bundle-size-report
-      #     number: ${{ matrix.pr.number }}
-      #     path: ${{ github.workspace }}/bundle-comparison.md
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # ratchet:marocchino/sticky-pull-request-comment@v3
+        with:
+          header: bundle-size-report
+          number: ${{ matrix.pr.number }}
+          path: ${{ github.workspace }}/bundle-comparison.md

--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -311,7 +311,7 @@ jobs:
         (needs.identify-from-pr-build.result == 'success' && needs.identify-from-pr-build.outputs.prs != '[]') ||
         (needs.identify-from-baseline-build.result == 'success' && needs.identify-from-baseline-build.outputs.prs != '[]')
       )
-    name: compare (PR #${{ matrix.pr.number }})
+    name: "${{ matrix.pr.number && format('compare (PR #{0})', matrix.pr.number) || 'compare' }}"
     strategy:
       matrix:
         pr: ${{ fromJSON(needs.identify-from-pr-build.outputs.prs || needs.identify-from-baseline-build.outputs.prs || '[]') }}


### PR DESCRIPTION
## Description

Flips the `pr-bundle-size-comments` workflow out of bake-in mode and enriches the rendered sticky body. After #27549 the workflow had been logging would-be sticky content into the action log for observation; this PR enables the actual posting (`marocchino/sticky-pull-request-comment`) on both `acknowledge-build` (the "Pending — …" body) and `compare` (the results / failure body). Resolves [AB#75349](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/75349) and [AB#56981](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/56981).

### Notable changes summary

Above the per-bundle inventory, the comment now leads with a "Notable changes" section that lifts only the bundles a reviewer would actually want to see at a glance:

- ➕ for added bundles
- ➖ for removed bundles
- 🔴 for changed bundles whose parsed delta is ≥ 500 bytes
- 🟢 for changed bundles whose parsed delta is ≤ −500 bytes

Each bundle's full line is rendered once and reused in both the notable summary and the full inventory, so the two never diverge. When nothing qualifies, the section reads "No bundles changed by ≥ 500 bytes parsed." (kept so reviewers know the analysis ran successfully, just had nothing dramatic to lift).

### Collapsible per-bundle inventory

The full per-package inventory (every bundle, including 0-delta lines) is wrapped in a `<details>`/`<summary>` block. The top of the sticky stays compact (just the header, base/head SHAs, and the notable summary); reviewers click "Per-bundle deltas" to expand the rest.

### Display-name fix on the `compare` job

The previous `name: compare (PR #${{ matrix.pr.number }})` was unquoted, so YAML treated the space-then-`#` as a comment and the stored job name was the truncated `compare (PR`. Quote the value and wrap in a conditional so the matrix-expanded case renders `compare (PR #27548)` and the empty-matrix case (acknowledge-build no-op) falls back to plain `compare`. Bug was visible in pre-merge runs of #27549.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The shape of the sticky body is defined by `renderComparison` / `renderFailure` in `.github/workflows/pr-bundle-size-comments.yml`. The structured failure-mode dispatch from #27549 means flipping comment posting on is fully wired up — the failure-mode sticky bodies are now what real users will see, not just lines in the action log. End-to-end failure-rendering was validated on the canary PR (#27548): the deliberate-build-break commit there produced the all-failed body via the workflow's render path, observable in run 27657241881.
