### PR TITLE
Override shell-quote to ^1.8.4

### DIFF
--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -4799,8 +4799,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -7600,7 +7600,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -10263,7 +10263,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/build-tools/pnpm-workspace.yaml
+++ b/build-tools/pnpm-workspace.yaml
@@ -47,3 +47,8 @@ trustPolicyExclude:
   # repo); provenance attestation was lost on a subsequent 6.x release.
   - "undici-types@6.21.0"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/common/build/eslint-config-fluid/pnpm-lock.yaml
+++ b/common/build/eslint-config-fluid/pnpm-lock.yaml
@@ -1751,8 +1751,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
@@ -2809,7 +2809,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -3682,7 +3682,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   signal-exit@4.1.0: {}
 

--- a/common/build/eslint-config-fluid/pnpm-workspace.yaml
+++ b/common/build/eslint-config-fluid/pnpm-workspace.yaml
@@ -18,3 +18,8 @@ trustPolicy: no-downgrade
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.
 trustPolicyExclude: []
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -4972,8 +4972,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -8561,7 +8561,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -11917,7 +11917,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/common/lib/common-utils/pnpm-workspace.yaml
+++ b/common/lib/common-utils/pnpm-workspace.yaml
@@ -40,3 +40,8 @@ trustPolicyExclude:
   # used legacy tooling that pins ^5 / ^6.
   - "semver@5.7.2 || 6.3.1"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -2988,8 +2988,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -5132,7 +5132,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -6920,7 +6920,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/common/lib/protocol-definitions/pnpm-workspace.yaml
+++ b/common/lib/protocol-definitions/pnpm-workspace.yaml
@@ -44,3 +44,8 @@ trustPolicyExclude:
   # repo); provenance attestation was lost on a subsequent 6.x release.
   - "undici-types@6.19.8"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ overrides:
   picomatch@>=4 <5: ^4.0.4
   qs: ^6.15.0
   serialize-javascript@>=6 <7: ^7.0.4
+  shell-quote: ^1.8.4
   simple-git: ^3.32.3
   simplemde>codemirror: ^5.65.11
   simplemde>marked: ^4.3.0
@@ -26504,8 +26505,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shimmer@1.2.1:
@@ -35042,7 +35043,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -38251,7 +38252,7 @@ snapshots:
   launch-editor@2.9.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   lazy-ass@1.6.0: {}
 
@@ -39331,7 +39332,7 @@ snapshots:
       minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string.prototype.padend: 3.1.6
 
   npm-run-path@4.0.1:
@@ -40891,7 +40892,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shimmer@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,6 +119,9 @@ overrides:
   # No 6.x fix exists; 7.x is API-compatible (only drops Node <20 support).
   serialize-javascript@>=6 <7: ^7.0.4
 
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4
+
   # Resolve a CG alert.
   simple-git: ^3.32.3
 

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -4665,8 +4665,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -7771,7 +7771,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -10635,7 +10635,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/server/gitrest/pnpm-workspace.yaml
+++ b/server/gitrest/pnpm-workspace.yaml
@@ -53,3 +53,8 @@ trustPolicyExclude:
   # repo); provenance attestation was lost on a subsequent 6.x release.
   - "undici-types@6.21.0"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -4930,8 +4930,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.10.0:
@@ -8302,7 +8302,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -11390,7 +11390,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shelljs@0.10.0:
     dependencies:

--- a/server/historian/pnpm-workspace.yaml
+++ b/server/historian/pnpm-workspace.yaml
@@ -56,3 +56,8 @@ trustPolicyExclude:
   # repo); provenance attestation was lost on a subsequent 6.x release.
   - "undici-types@6.21.0"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -7475,8 +7475,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.10.0:
@@ -11552,7 +11552,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -15150,7 +15150,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shelljs@0.10.0:
     dependencies:

--- a/server/routerlicious/pnpm-workspace.yaml
+++ b/server/routerlicious/pnpm-workspace.yaml
@@ -55,3 +55,8 @@ trustPolicyExclude:
   # repo); provenance attestation was lost on a subsequent 6.x release.
   - "undici-types@6.21.0"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -3203,8 +3203,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -5287,7 +5287,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -7534,7 +7534,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/tools/api-markdown-documenter/pnpm-workspace.yaml
+++ b/tools/api-markdown-documenter/pnpm-workspace.yaml
@@ -46,3 +46,8 @@ trustPolicyExclude:
   # repo); provenance attestation was lost on a subsequent 6.x release.
   - "undici-types@6.21.0"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -1313,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
@@ -2063,7 +2063,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -2802,7 +2802,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   signal-exit@4.1.0: {}
 

--- a/tools/benchmark/pnpm-workspace.yaml
+++ b/tools/benchmark/pnpm-workspace.yaml
@@ -41,3 +41,8 @@ trustPolicyExclude:
   # and also used by other workspaces in this repo, so allowing it seems like a minimal risk.
   - "semver@5.7.2"
 strictDepBuilds: true
+
+# Security overrides.
+overrides:
+  # Resolve CVE-2026-9277.
+  shell-quote: ^1.8.4

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   mdast-util-to-hast: ^13.2.1
   node-forge: ^1.4.0
   qs: ^6.15.0
+  shell-quote: ^1.8.4
   simple-git: ^3.32.3
   validator: ^13.15.0
   minimatch@>=3 <4: ^3.1.5
@@ -1643,6 +1644,7 @@ packages:
 
   '@nevware21/ts-utils@0.11.6':
     resolution: {integrity: sha512-OUUJTh3fnaUSzg9DEHgv3d7jC+DnPL65mIO7RaR+jWve7+MmcgIvF79gY97DPQ4frH+IpNR78YAYd/dW4gK3kg==}
+    deprecated: Critical CVE-2026-46681 fixed in v0.14.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2439,6 +2441,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -7597,8 +7600,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -8320,6 +8323,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -13095,7 +13099,7 @@ snapshots:
       date-fns: 2.30.0
       lodash: 4.18.1
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       spawn-command: 0.0.2
       supports-color: 8.1.1
       tree-kill: 1.2.2
@@ -13105,7 +13109,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -15871,7 +15875,7 @@ snapshots:
   launch-editor@2.9.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   layout-base@1.0.2: {}
 
@@ -17848,7 +17852,7 @@ snapshots:
       prompts: 2.4.2
       react-error-overlay: 6.0.11
       recursive-readdir: 2.2.3
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
       webpack: 5.96.1
@@ -18495,7 +18499,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shelljs@0.8.5:
     dependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -87,6 +87,8 @@ overrides:
   node-forge: ^1.4.0
   # qs: overridden to ^6.15.0 to resolve a known vulnerability in older versions.
   qs: ^6.15.0
+  # shell-quote: overridden to ^1.8.4 to resolve CVE-2026-9277.
+  shell-quote: ^1.8.4
   # simple-git: overridden to ^3.32.3 to resolve a CG alert.
   simple-git: ^3.32.3
   # validator: overridden to ^13.15.0 to resolve a known vulnerability in older


### PR DESCRIPTION
## Summary

Adds pnpm overrides across all 11 workspace roots to bump `shell-quote` from 1.8.3 → 1.8.4, resolving [CG alert 14301083](https://dev.azure.com/fluidframework/internal/_componentGovernance/17385/alert/14301083?typeId=19241591&pipelinesTrackingFilter=0).

## Changes

- Added `shell-quote: ^1.8.4` override to all workspace `pnpm-workspace.yaml` files
- Updated all `pnpm-lock.yaml` files (1.8.3 → 1.8.4)

Affected workspaces:
- root (client release group)
- build-tools
- common/build/eslint-config-fluid
- common/lib/common-utils
- common/lib/protocol-definitions
- server/gitrest
- server/historian
- server/routerlicious
- tools/api-markdown-documenter
- tools/benchmark
- website