### PR TITLE
feat(build-tools): support TypeScript 6 tsbuildinfo format

### DIFF
--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -65,6 +65,7 @@
 		"type-fest": "^2.19.0",
 		"typescript-5.4": "npm:typescript@~5.4.5",
 		"typescript-5.9": "npm:typescript@~5.9.3",
+		"typescript-6.0": "npm:typescript@~6.0.3",
 		"yaml": "^2.8.1"
 	},
 	"devDependencies": {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -10,18 +10,25 @@ import path from "node:path";
 import isEqual from "lodash.isequal";
 import type * as ts54Types from "typescript-5.4";
 import type * as ts59Types from "typescript-5.9";
+import type * as ts60Types from "typescript-6.0";
 
 import { getTscUtils, type TscUtil } from "../../tscUtils.js";
 import { getInstalledPackageVersion } from "../taskUtils.js";
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask.js";
 
-type tsTypes = typeof ts54Types | typeof ts59Types;
-type tsParsedCommandLine = ts54Types.ParsedCommandLine | ts59Types.ParsedCommandLine;
+type tsTypes = typeof ts54Types | typeof ts59Types | typeof ts60Types;
+type tsParsedCommandLine =
+	| ts54Types.ParsedCommandLine
+	| ts59Types.ParsedCommandLine
+	| ts60Types.ParsedCommandLine;
 
 interface ITsBuildInfo {
 	program: {
 		fileNames: string[];
-		fileInfos: (string | { version: string; affectsGlobalScope: true })[];
+		fileInfos: (
+			| string
+			| { version: string; affectsGlobalScope?: true; impliedFormat?: number }
+		)[];
 		affectedFilesPendingEmit?: any[];
 		emitDiagnosticsPerFile?: any[];
 		semanticDiagnosticsPerFile?: any[];
@@ -29,6 +36,36 @@ interface ITsBuildInfo {
 		options: any;
 	};
 	version: string;
+}
+
+/**
+ * Normalizes a raw tsbuildinfo JSON object into the canonical {@link ITsBuildInfo} shape.
+ *
+ * TypeScript 5.x stores build info under a `program` wrapper, while TypeScript 6+
+ * places the same keys at the top level. This function detects which format is present
+ * and returns a unified structure, or `undefined` if the input is not recognizable.
+ */
+export function normalizeTsBuildInfo(raw: any): ITsBuildInfo | undefined {
+	// TS5 format: { program: { fileNames, fileInfos, options, ... }, version }
+	if (raw.program?.fileNames && raw.program?.fileInfos && raw.program?.options) {
+		return raw as ITsBuildInfo;
+	}
+	// TS6 format: { fileNames, fileInfos, options, ..., version }
+	if (raw.fileNames && raw.fileInfos && raw.options) {
+		return {
+			program: {
+				fileNames: raw.fileNames,
+				fileInfos: raw.fileInfos,
+				options: raw.options,
+				affectedFilesPendingEmit: raw.affectedFilesPendingEmit,
+				emitDiagnosticsPerFile: raw.emitDiagnosticsPerFile,
+				semanticDiagnosticsPerFile: raw.semanticDiagnosticsPerFile,
+				changeFileSet: raw.changeFileSet,
+			},
+			version: raw.version,
+		};
+	}
+	return undefined;
 }
 
 export class TscTask extends LeafTask {
@@ -435,14 +472,10 @@ export class TscTask extends LeafTask {
 			const tsBuildInfoFileFullPath = this.tsBuildInfoFileFullPath;
 			if (tsBuildInfoFileFullPath && existsSync(tsBuildInfoFileFullPath)) {
 				try {
-					const tsBuildInfo = JSON.parse(await readFile(tsBuildInfoFileFullPath, "utf8"));
-					if (
-						tsBuildInfo.program &&
-						tsBuildInfo.program.fileNames &&
-						tsBuildInfo.program.fileInfos &&
-						tsBuildInfo.program.options
-					) {
-						this._tsBuildInfo = tsBuildInfo;
+					const raw = JSON.parse(await readFile(tsBuildInfoFileFullPath, "utf8"));
+					const normalized = normalizeTsBuildInfo(raw);
+					if (normalized) {
+						this._tsBuildInfo = normalized;
 					} else {
 						this.traceError(`Invalid format ${tsBuildInfoFileFullPath}`);
 					}

--- a/build-tools/packages/build-tools/src/fluidBuild/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tsCompile.ts
@@ -6,11 +6,12 @@
 import path from "path";
 import type * as ts54Types from "typescript-5.4";
 import type * as ts59Types from "typescript-5.9";
+import type * as ts60Types from "typescript-6.0";
 import { defaultLogger } from "../common/logging.js";
 import type { UnionToIntersection } from "./tscUtils.js";
 import { getTscUtils, normalizeSlashes } from "./tscUtils.js";
 
-type tsDiagnostic = ts54Types.Diagnostic | ts59Types.Diagnostic;
+type tsDiagnostic = ts54Types.Diagnostic | ts59Types.Diagnostic | ts60Types.Diagnostic;
 
 function castDiagnosticsUnionArrayToIntersection(
 	diagnostics: tsDiagnostic[],

--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -7,9 +7,10 @@ import * as fs from "fs";
 import * as path from "path";
 import type * as ts54Types from "typescript-5.4";
 import type * as ts59Types from "typescript-5.9";
+import type * as ts60Types from "typescript-6.0";
 import { sha256 } from "./hash.js";
 
-type tsTypes = typeof ts54Types | typeof ts59Types;
+type tsTypes = typeof ts54Types | typeof ts59Types | typeof ts60Types;
 
 /**
  * Matches fluid-tsc command start.
@@ -101,7 +102,10 @@ function filterIncrementalOptions(options: any): Record<string, unknown> {
 }
 
 function convertOptionPaths<
-	TCompilerOptions extends ts54Types.CompilerOptions | ts59Types.CompilerOptions,
+	TCompilerOptions extends
+		| ts54Types.CompilerOptions
+		| ts59Types.CompilerOptions
+		| ts60Types.CompilerOptions,
 >(
 	options: TCompilerOptions,
 	base: string,

--- a/build-tools/packages/build-tools/src/test/tscTask.test.ts
+++ b/build-tools/packages/build-tools/src/test/tscTask.test.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert/strict";
+import { describe, it } from "mocha";
+import { normalizeTsBuildInfo } from "../fluidBuild/tasks/leaf/tscTask.js";
+
+describe("normalizeTsBuildInfo", () => {
+	it("parses TS5.x format with program wrapper", () => {
+		const ts5BuildInfo = {
+			program: {
+				fileNames: ["../lib.d.ts", "./src/index.ts"],
+				fileInfos: ["abc123", { version: "def456", affectsGlobalScope: true }],
+				options: {
+					target: 1,
+					module: 1,
+					strict: true,
+				},
+				changeFileSet: [1],
+				affectedFilesPendingEmit: undefined,
+				emitDiagnosticsPerFile: undefined,
+				semanticDiagnosticsPerFile: undefined,
+			},
+			version: "5.4.5",
+		};
+
+		const result = normalizeTsBuildInfo(ts5BuildInfo);
+
+		assert.notEqual(result, undefined, "Expected a defined result");
+		assert.ok(result);
+		assert.deepEqual(result.program.fileNames, ["../lib.d.ts", "./src/index.ts"]);
+		assert.deepEqual(result.program.fileInfos, [
+			"abc123",
+			{ version: "def456", affectsGlobalScope: true },
+		]);
+		assert.deepEqual(result.program.options, { target: 1, module: 1, strict: true });
+		assert.deepEqual(result.program.changeFileSet, [1]);
+		assert.equal(result.version, "5.4.5");
+	});
+
+	it("parses TS6 format with top-level keys (no program wrapper)", () => {
+		const ts6BuildInfo = {
+			fileNames: ["../lib.d.ts", "./src/index.ts"],
+			fileIdsList: [[1, 2]],
+			fileInfos: [
+				{ version: "abc123", affectsGlobalScope: true, impliedFormat: 1 },
+				{ version: "def456", impliedFormat: 99 },
+			],
+			root: [2],
+			options: {
+				composite: true,
+				declaration: true,
+				module: 100,
+				target: 8,
+				tsBuildInfoFile: "./tsconfig.tsbuildinfo",
+			},
+			referencedMap: [],
+			affectedFilesPendingEmit: [2],
+			emitSignatures: [],
+			version: "6.0.3",
+		};
+
+		const result = normalizeTsBuildInfo(ts6BuildInfo);
+
+		assert.notEqual(result, undefined, "Expected a defined result");
+		assert.ok(result);
+		assert.deepEqual(result.program.fileNames, ["../lib.d.ts", "./src/index.ts"]);
+		assert.deepEqual(result.program.fileInfos, [
+			{ version: "abc123", affectsGlobalScope: true, impliedFormat: 1 },
+			{ version: "def456", impliedFormat: 99 },
+		]);
+		assert.deepEqual(result.program.options, {
+			composite: true,
+			declaration: true,
+			module: 100,
+			target: 8,
+			tsBuildInfoFile: "./tsconfig.tsbuildinfo",
+		});
+		assert.deepEqual(result.program.affectedFilesPendingEmit, [2]);
+		assert.equal(result.version, "6.0.3");
+	});
+
+	it("returns undefined for invalid input missing required keys", () => {
+		const invalid = {
+			someRandomKey: true,
+			version: "5.4.5",
+		};
+
+		const result = normalizeTsBuildInfo(invalid);
+		assert.equal(result, undefined);
+	});
+
+	it("returns undefined for partial TS5 format missing fileInfos", () => {
+		const partial = {
+			program: {
+				fileNames: ["./src/index.ts"],
+				options: { strict: true },
+			},
+			version: "5.4.5",
+		};
+
+		const result = normalizeTsBuildInfo(partial);
+		assert.equal(result, undefined);
+	});
+
+	it("returns undefined for partial TS6 format missing options", () => {
+		const partial = {
+			fileNames: ["./src/index.ts"],
+			fileInfos: ["abc123"],
+			version: "6.0.3",
+		};
+
+		const result = normalizeTsBuildInfo(partial);
+		assert.equal(result, undefined);
+	});
+
+	it("handles TS6 format with semanticDiagnosticsPerFile errors", () => {
+		const ts6WithErrors = {
+			fileNames: ["./src/index.ts"],
+			fileInfos: ["abc123"],
+			options: { strict: true },
+			semanticDiagnosticsPerFile: [[1, [{ code: 2322, message: "Type error" }]]],
+			version: "6.0.3",
+		};
+
+		const result = normalizeTsBuildInfo(ts6WithErrors);
+
+		assert.notEqual(result, undefined, "Expected a defined result");
+		assert.ok(result);
+		const diagnostics = result.program.semanticDiagnosticsPerFile;
+		assert.ok(Array.isArray(diagnostics));
+		assert.equal(diagnostics.length, 1);
+		// The entry is an array (indicating errors), which the caller uses to detect issues
+		assert.ok(Array.isArray(diagnostics[0]));
+	});
+});

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       typescript-5.9:
         specifier: npm:typescript@~5.9.3
         version: typescript@5.9.3
+      typescript-6.0:
+        specifier: npm:typescript@~6.0.3
+        version: typescript@6.0.3
       yaml:
         specifier: ^2.8.1
         version: 2.8.1
@@ -5214,6 +5217,11 @@ packages:
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10692,6 +10700,8 @@ snapshots:
   typescript@5.4.5: {}
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   typical@2.6.1: {}
 


### PR DESCRIPTION
TypeScript 6 changed the .tsbuildinfo format by removing the `program` wrapper — all keys (fileNames, fileInfos, options, etc.) are now at the top level. This caused fluid-build to always consider TS6 packages as not up-to-date since it couldn't parse the new format.

Changes:
- Add `normalizeTsBuildInfo()` that detects TS5 (nested) vs TS6 (flat) format and normalizes to a unified shape
- Update `readTsBuildInfo()` to use the new normalization function
- Add `typescript-6.0` (npm:typescript@~6.0.3) as a type-only dependency
- Extend type unions to include TS6 types in tscTask.ts, tscUtils.ts, and tsCompile.ts
- Update `ITsBuildInfo.fileInfos` type to include optional `impliedFormat` field used by TS6
- Add unit tests for normalizeTsBuildInfo covering both formats

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>