### PR TITLE
build(build-tools): enable exactOptionalPropertyTypes

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -40,6 +40,7 @@
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
+		"check:inexactOptionalPropertyTypes": "tsc --project ./tsconfig.inexactOptionalPropertyTypes.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib oclif.manifest.json \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"clean:manifest": "rimraf --glob oclif.manifest.json",
@@ -192,6 +193,9 @@
 				"...",
 				"build:copy",
 				"build:diagrams"
+			],
+			"check:inexactOptionalPropertyTypes": [
+				"^tsc"
 			]
 		}
 	},

--- a/build-tools/packages/build-cli/tsconfig.inexactOptionalPropertyTypes.json
+++ b/build-tools/packages/build-cli/tsconfig.inexactOptionalPropertyTypes.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"exactOptionalPropertyTypes": false,
+		"skipLibCheck": true,
+	},
+}

--- a/build-tools/packages/build-infrastructure/package.json
+++ b/build-tools/packages/build-infrastructure/package.json
@@ -34,6 +34,7 @@
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
+		"check:inexactOptionalPropertyTypes": "tsc --project ./tsconfig.inexactOptionalPropertyTypes.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc _api-extractor-temp",
 		"compile": "fluid-build . --task compile",
 		"eslint": "eslint --quiet --format stylish src",
@@ -92,6 +93,13 @@
 		"ts-node": "^10.9.2",
 		"typedoc": "^0.28.14",
 		"typedoc-plugin-markdown": "^4.9.0"
+	},
+	"fluidBuild": {
+		"tasks": {
+			"check:inexactOptionalPropertyTypes": [
+				"^tsc"
+			]
+		}
 	},
 	"oclif": {
 		"bin": "buildProject",

--- a/build-tools/packages/build-infrastructure/tsconfig.inexactOptionalPropertyTypes.json
+++ b/build-tools/packages/build-infrastructure/tsconfig.inexactOptionalPropertyTypes.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"exactOptionalPropertyTypes": false,
+		"skipLibCheck": true,
+	},
+}

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -24,6 +24,7 @@
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
+		"check:inexactOptionalPropertyTypes": "tsc --project ./tsconfig.inexactOptionalPropertyTypes.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"compile": "fluid-build . --task compile",
 		"eslint": "eslint --quiet --format stylish src",
@@ -86,5 +87,12 @@
 	},
 	"engines": {
 		"node": ">=22.22.2"
+	},
+	"fluidBuild": {
+		"tasks": {
+			"check:inexactOptionalPropertyTypes": [
+				"^tsc"
+			]
+		}
 	}
 }

--- a/build-tools/packages/build-tools/src/common/biomeConfigUtils.ts
+++ b/build-tools/packages/build-tools/src/common/biomeConfigUtils.ts
@@ -54,7 +54,10 @@ export async function getClosestBiomeConfigPath(
 	stopAt?: string,
 ): Promise<string> {
 	return (await findUp)
-		.findUp(["biome.json", "biome.jsonc"], { cwd, stopAt })
+		.findUp(["biome.json", "biome.jsonc"], {
+			cwd,
+			...(stopAt === undefined ? {} : { stopAt }),
+		})
 		.then((config) => {
 			if (config === undefined) {
 				throw new Error(`Can't find biome config file`);

--- a/build-tools/packages/build-tools/src/fluidBuild/commonOptions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/commonOptions.ts
@@ -4,8 +4,8 @@
  */
 
 interface CommonOptions {
-	defaultRoot?: string;
-	root?: string;
+	defaultRoot: string | undefined;
+	root: string | undefined;
 	timer: boolean;
 	logtime: boolean;
 	quiet: boolean;

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepo.ts
@@ -38,13 +38,13 @@ export class FluidRepo {
 			if (typeof item === "string") {
 				return {
 					directory: path.join(resolvedRoot, item),
-					ignoredDirs: undefined,
 				};
 			}
 			const directory = path.join(resolvedRoot, item.directory);
+			const ignoredDirs = item.ignoredDirs?.map((dir) => path.join(directory, dir));
 			return {
 				directory,
-				ignoredDirs: item.ignoredDirs?.map((dir) => path.join(directory, dir)),
+				...(ignoredDirs === undefined ? {} : { ignoredDirs }),
 			};
 		};
 		const loadOneEntry = (item: IFluidBuildDir, group: string): Package[] => {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/apiExtractorWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/apiExtractorWorker.ts
@@ -35,14 +35,14 @@ export async function apiExtractorWorker(message: WorkerMessage): Promise<Worker
 			showVerboseMessages: true,
 			messageCallback: (message) => messages.push(message),
 		});
-	return {
-		code: result.succeeded ? 0 : 1,
-		error: result.succeeded
-			? undefined
-			: // This error does not appear to be used in fluid-build's output,
+	return result.succeeded
+		? { code: 0 }
+		: {
+				code: 1,
+				// This error does not appear to be used in fluid-build's output,
 				// but populate it with useful information anyway.
-				new Error(
+				error: new Error(
 					`Number of Errors: ${result.errorCount}. Messages: ${JSON.stringify(messages.map((m) => m.text))}`,
 				),
-	};
+			};
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tsCompile.ts
@@ -158,7 +158,9 @@ export function tsCompile(
 				tscUtils.convertOptionPaths(commandLine.options, cwd, path.resolve),
 			),
 			host,
-			projectReferences: commandLine.projectReferences,
+			...(commandLine.projectReferences === undefined
+				? {}
+				: { projectReferences: commandLine.projectReferences }),
 		};
 		const program = incremental
 			? baseTs.createIncrementalProgram(param)

--- a/build-tools/packages/build-tools/tsconfig.inexactOptionalPropertyTypes.json
+++ b/build-tools/packages/build-tools/tsconfig.inexactOptionalPropertyTypes.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"exactOptionalPropertyTypes": false,
+		"skipLibCheck": true,
+	},
+}

--- a/build-tools/packages/build-tools/tsconfig.json
+++ b/build-tools/packages/build-tools/tsconfig.json
@@ -15,6 +15,7 @@
 		"module": "node16",
 		"moduleResolution": "node16",
 		"types": ["node"],
+		"exactOptionalPropertyTypes": true,
 	},
 	"include": ["src/**/*.ts", "src/**/*.cts"],
 	"exclude": ["src/test/**/*", "dist", "node_modules"],

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -35,6 +35,7 @@
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
+		"check:inexactOptionalPropertyTypes": "tsc --project ./tsconfig.inexactOptionalPropertyTypes.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib oclif.manifest.json \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"clean:manifest": "rimraf --glob oclif.manifest.json",
@@ -102,6 +103,13 @@
 	},
 	"engines": {
 		"node": ">=22.22.2"
+	},
+	"fluidBuild": {
+		"tasks": {
+			"check:inexactOptionalPropertyTypes": [
+				"^tsc"
+			]
+		}
 	},
 	"oclif": {
 		"bin": "fluv",

--- a/build-tools/packages/version-tools/src/commands/version.ts
+++ b/build-tools/packages/version-tools/src/commands/version.ts
@@ -189,7 +189,7 @@ export default class VersionCommand extends Command {
 			this.error(`The version you provided isn't valid: "${parsedInput}"`);
 		}
 		return {
-			bumpType,
+			...(bumpType === undefined ? {} : { bumpType }),
 			parsedVersion,
 			isFluidInternalFormat: isInternalVersionScheme(parsedVersion) === true,
 		};

--- a/build-tools/packages/version-tools/src/test/tsconfig.json
+++ b/build-tools/packages/version-tools/src/test/tsconfig.json
@@ -8,6 +8,7 @@
 		"outDir": "../../lib/test",
 		"types": ["node", "mocha", "chai"],
 		"skipLibCheck": true,
+		"exactOptionalPropertyTypes": true,
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/build-tools/packages/version-tools/tsconfig.inexactOptionalPropertyTypes.json
+++ b/build-tools/packages/version-tools/tsconfig.inexactOptionalPropertyTypes.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"exactOptionalPropertyTypes": false,
+		"skipLibCheck": true,
+	},
+}

--- a/build-tools/packages/version-tools/tsconfig.json
+++ b/build-tools/packages/version-tools/tsconfig.json
@@ -6,6 +6,7 @@
 		"outDir": "./lib",
 		"types": ["node"],
 		"noImplicitAny": true,
+		"exactOptionalPropertyTypes": true,
 	},
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -80,7 +80,14 @@ module.exports = {
 			script: false,
 		},
 		"lint": {
-			dependsOn: ["eslint", "good-fences", "depcruise", "check:exports", "check:release-tags"],
+			dependsOn: [
+				"check:inexactOptionalPropertyTypes",
+				"eslint",
+				"good-fences",
+				"depcruise",
+				"check:exports",
+				"check:release-tags",
+			],
 			script: false,
 		},
 		"checks": {
@@ -165,6 +172,7 @@ module.exports = {
 		// therefore we need to require both before running api-extractor.
 		"check:release-tags": ["tsc", "build:esnext"],
 		"check:are-the-types-wrong": ["tsc", "build:esnext", "api"],
+		"check:inexactOptionalPropertyTypes": ["^build:esnext", "^api-extractor:esnext"],
 		"check:format": {
 			dependencies: [],
 			script: true,


### PR DESCRIPTION
Update build-tools packages to use exactOptionalPropertyTypes:true in normal build as well as check exactOptionalPropertyTypes:false successfully type checks (no emit, skipLibCheck).

### Fixes
build-tools:
 - **`common/biomeConfigUtils.ts`** — Conditionally spread `stopAt` only when defined, avoiding passing `undefined` to the `find-up` library's `Options.stopAt` which expects `string`.
 - **`fluidBuild/commonOptions.ts`** — Changed `defaultRoot` and `root` from optional properties (`?: string`) to required properties with explicit `undefined` in the union (`string | undefined`), allowing direct assignment from `process.env`.
 - **`fluidBuild/fluidRepo.ts`** — Removed explicit `ignoredDirs: undefined` assignment; conditionally spread `ignoredDirs` only when the mapped value is defined.
 - **`fluidBuild/tasks/workers/apiExtractorWorker.ts`** — Split return into two distinct object literals (success without `error`, failure with `error`) instead of assigning `undefined` to  the optional `error` property.
 - **`fluidBuild/tsCompile.ts`** — Conditionally spread `projectReferences` only when `commandLine.projectReferences` is defined, avoiding passing `undefined` to TypeScript API's  `CreateProgramOptions`.

version-tools:
 - **`commands/version.ts`** — Conditionally spread `bumpType` only when defined, avoiding `undefined` assignment to an optional property.