### PR TITLE
Fix FrozenDocumentStorageService for es2022

### DIFF
--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -200,10 +200,7 @@ class FrozenDocumentStorageService implements IDocumentStorageService, IDisposab
 		return this._disposed;
 	}
 
-	constructor(
-		readOnly: boolean,
-		private readonly documentStorageService?: IDocumentStorageService,
-	) {
+	constructor(readOnly: boolean, documentStorageService?: IDocumentStorageService) {
 		let rejectFn!: (error: Error) => void;
 		const promise = new Promise<never>((_, reject) => {
 			rejectFn = reject;
@@ -225,15 +222,16 @@ class FrozenDocumentStorageService implements IDocumentStorageService, IDisposab
 		this.createBlob = readOnly
 			? frozenDocumentStorageServiceHandler
 			: async () => this.disposalDeferred.promise;
+		this.readBlob =
+			documentStorageService?.readBlob.bind(documentStorageService) ??
+			frozenReadBlobOfflineHandler;
 	}
 
 	getSnapshotTree = frozenDocumentStorageServiceHandler;
 	getSnapshot = frozenDocumentStorageServiceHandler;
 	getVersions = frozenDocumentStorageServiceHandler;
 	createBlob: IDocumentStorageService["createBlob"];
-	readBlob =
-		this.documentStorageService?.readBlob.bind(this.documentStorageService) ??
-		frozenReadBlobOfflineHandler;
+	readBlob: IDocumentStorageService["readBlob"];
 	uploadSummaryWithContext = frozenDocumentStorageServiceHandler;
 	downloadSummary = frozenDocumentStorageServiceHandler;
 


### PR DESCRIPTION
## Description

Due to changes in property initialization (inline initializers actually compiled to inline initializers which run before the constructor), this code would not work or compile with es2022, and needed a tweak.

ES2021 (TypeScript downcompilation): TypeScript emits class fields as constructor body assignments, placing parameter property assignments first, then field initializers. So this.documentStorageService = documentStorageService runs before readBlob = this.documentStorageService?.readBlob.bind(...).

ES2022 (native class fields): Field initializers run before the constructor body. Constructor parameter properties (private readonly documentStorageService) are assigned inside the constructor body. So when readBlob's initializer runs, this.documentStorageService is always undefined.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
