### PR TITLE
fix(matrix): update consensus value when acking first of multiple pending setCells

### DIFF
--- a/.changeset/matrix-lww-consensus-rollback.md
+++ b/.changeset/matrix-lww-consensus-rollback.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/matrix": minor
+"__section": fix
+---
+Fix incorrect rollback of pending `setCell` operations in LWW mode
+
+When multiple local `setCell` operations were pending for the same cell and the first was acknowledged, `SharedMatrix` did not update its tracked consensus value to the acknowledged value. On reconnect, rolling back the remaining pending operations could restore a stale value, causing the matrix to diverge between clients. The consensus value is now updated when acking the first of multiple pending writes in last-writer-wins mode.

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -1079,6 +1079,11 @@ export class SharedMatrix<T = any>
 					assert(ackedChange?.localSeq === localSeq, 0xbab /* must match */);
 					if (pendingCell?.local.length === 0) {
 						this.pending.setCell(rowHandle, colHandle, undefined);
+					} else if (pendingCell !== undefined && this.fwwPolicy.state !== "on") {
+						// In LWW mode, update consensus to the acked value so that
+						// rollback of any remaining local changes restores the correct
+						// server state. FWW mode is handled below via shouldSetCellBasedOnFWW.
+						pendingCell.consensus = ackedChange.value;
 					}
 
 					// If policy is switched and cell should be modified too based on policy, then update the tracker.

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -958,6 +958,49 @@ describe("Matrix1", () => {
 						[undefined, 0],
 					]);
 				});
+
+				// Regression test: when multiple local setCells are pending for the same cell
+				// and the first is acked, the consensus value must be updated to the acked value.
+				// Without this update, reconnection rolls back remaining pending ops to the wrong
+				// (stale) server state, which can cause divergence in complex multi-client
+				// scenarios (e.g., stress test seed 92).
+				it("updates consensus when acking first of multiple pending setCells in LWW mode", async () => {
+					if (isSetCellPolicyFWW) {
+						// This test is specific to LWW mode; FWW has separate handling.
+						return;
+					}
+
+					matrix1.insertRows(0, 1);
+					matrix1.insertCols(0, 1);
+					containerRuntimeFactory.processAllMessages();
+
+					// Client 1 sets cell (0,0) twice (both pending).
+					matrix1.setCell(0, 0, "A");
+					matrix1.setCell(0, 0, "B");
+
+					// Ack client 1's first op ("A").
+					containerRuntimeFactory.processOneMessage();
+
+					// Access internal pending state to verify consensus was updated.
+					// After acking "A" with "B" still pending, consensus should be "A".
+					const matrixInternal = matrix1 as unknown as {
+						pending: { getCell(r: number, c: number): { consensus: unknown } };
+						rows: { getAllocatedHandle(r: number): number };
+						cols: { getAllocatedHandle(c: number): number };
+					};
+					const rowHandle = matrixInternal.rows.getAllocatedHandle(0);
+					const colHandle = matrixInternal.cols.getAllocatedHandle(0);
+					const pendingCell = matrixInternal.pending.getCell(rowHandle, colHandle);
+					assert.strictEqual(
+						pendingCell.consensus,
+						"A",
+						"after acking first of two pending setCells, consensus should be the acked value ('A'), not the stale pre-first-op value (undefined)",
+					);
+
+					containerRuntime1.connected = false;
+					containerRuntime1.connected = true;
+					await expect();
+				});
 			});
 
 			describe("Doesn't leave dangling row/col reference positions", () => {

--- a/packages/dds/ordered-collection/src/test/fuzzUtils.ts
+++ b/packages/dds/ordered-collection/src/test/fuzzUtils.ts
@@ -155,7 +155,7 @@ function assertEqualConsensusOrderedCollections(
 	const aData = (a as any).data as IOrderedCollection<string>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 	const bData = (b as any).data as IOrderedCollection<string>;
-	assert.equal(aData.size, bData.size, "Data sizes should be equal");
+	assert.equal(aData.size(), bData.size(), "Data sizes should be equal");
 	assert.deepEqual(aData.asArray(), bData.asArray(), "Data contents should be equal");
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -40,8 +40,8 @@ describe("Local Server Stress", () => {
 		},
 		// Minimization is slow with many seeds; use only to minimize specific failing seeds.
 		skipMinimization: true,
-		// Pre-existing DDS bugs: seeds 0 and 54 (ConsensusOrderedCollection), seed 92 (Matrix).
-		skip: [0, 54, 92],
+		// Pre-existing DDS bug: seed 0 (ConsensusOrderedCollection).
+		skip: [0],
 		// Use skip, replay, and only properties to control which seeds run.
 	});
 });


### PR DESCRIPTION
## Description

In last-writer-wins (LWW) mode, `SharedMatrix` did not update its tracked
consensus value when the first of multiple pending `setCell` operations for the
same cell was acknowledged. On reconnect, rolling back the remaining pending
operations could restore a stale value, causing the matrix to diverge between
clients.

This was surfaced by the `local-server-stress` suite (seed 92). The fix updates
`pendingCell.consensus` to the acked value when acking the first of multiple
pending writes in LWW mode (FWW mode is already handled separately via
`shouldSetCellBasedOnFWW`).

**Reproduction / verification:** Added a regression test in `matrix.spec.ts`
that issues two pending `setCell`s, acks the first, and asserts the consensus
value is updated to the acked value before verifying client convergence after a
reconnect. With the fix, stress seed 92 passes; previously it diverged.

### Additional changes

- **ordered-collection:** Fixed the fuzz consistency util to call `size()` as a
  method (it was comparing the function reference, not the size).
- **local-server-stress:** Re-skipped seed 0, which exercises a separate,
  pre-existing `ConsensusOrderedCollection` job-tracking reconciliation bug (not
  addressed here). All other 199 seeds pass.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Opening as a draft: the ConsensusOrderedCollection bug behind seed 0 is left
skipped rather than fixed in this PR — confirm that's the desired scope.