### PR TITLE
Feat(tree) `TreeBranchAlpha.isMissingEditsFrom`

### DIFF
--- a/.changeset/jolly-owls-grow.md
+++ b/.changeset/jolly-owls-grow.md
@@ -1,0 +1,9 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+TreeBranchAlpha.isMissingEditsFrom
+
+Adds a new method (`isMissingEditsFrom(branch: TreeBranch): boolean`)  to `TreeBranchAlpha`.
+`isMissingEditsFrom` can be used to determine whether there are edits on the given `branch` that have not yet been merged into this branch.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1768,6 +1768,7 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
     // (undocumented)
     fork(): TreeBranchAlpha;
     hasRootSchema<TSchema extends ImplicitFieldSchema>(schema: TSchema): this is TreeViewAlpha<TSchema>;
+    isMissingEditsFrom(branch: TreeBranch): boolean;
     runTransaction<TSuccessValue, TFailureValue>(transaction: () => TransactionCallbackStatus<TSuccessValue, TFailureValue>, params?: RunTransactionParams): TransactionResultExt<TSuccessValue, TFailureValue>;
     runTransaction(transaction: () => VoidTransactionCallbackStatus | void, params?: RunTransactionParams): TransactionResult;
     runTransactionAsync<TSuccessValue, TFailureValue>(transaction: () => Promise<TransactionCallbackStatus<TSuccessValue, TFailureValue>>, params?: RunTransactionParams): Promise<TransactionResultExt<TSuccessValue, TFailureValue>>;

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -529,5 +529,9 @@ export class SchematizingSimpleTreeView<
 		this.checkout.rebaseOnto(context);
 	}
 
+	public isMissingEditsFrom(context: TreeBranchAlpha): boolean {
+		return this.checkout.isMissingEditsFrom(context);
+	}
+
 	// #endregion Branching
 }

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -57,6 +57,7 @@ import {
 	makeAnonChange,
 	type TaggedChange,
 	deltaFieldMapHasVisibleChanges,
+	findCommonAncestor,
 } from "../core/index.js";
 import {
 	type FieldBatchCodec,
@@ -1285,6 +1286,19 @@ export class TreeCheckout implements ITreeCheckout {
 
 	public rebaseOnto(branch: TreeBranch): void {
 		getCheckout(branch).rebase(this);
+	}
+
+	public isMissingEditsFrom(branch: TreeBranch): boolean {
+		const branchCheckout = getCheckout(branch);
+		const targetPath: GraphCommit<unknown>[] = [];
+		const ancestor = findCommonAncestor(this.mainBranch.getHead(), [
+			branchCheckout.mainBranch.getHead(),
+			targetPath,
+		]);
+		if (ancestor === undefined) {
+			throw new UsageError("Branches do not share a common ancestor.");
+		}
+		return targetPath.length > 0;
 	}
 
 	public merge(branch: TreeBranch): void;

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -342,6 +342,15 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
 	 * Update the tests and docs to match when that is done.
 	 */
 	applyChange(change: JsonCompatibleReadOnly): void;
+
+	/**
+	 * Returns true iff there are changes on the given branch that are not present on this branch.
+	 * @param branch - The branch to compare to.
+	 *
+	 * The new edits, if any, can be applied to this branch by {@link TreeBranch.rebaseOnto | rebasing this branch onto the given branch}
+	 * or by {@link TreeBranch.merge | merging the given branch into this branch}.
+	 */
+	isMissingEditsFrom(branch: TreeBranch): boolean;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -344,11 +344,13 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
 	applyChange(change: JsonCompatibleReadOnly): void;
 
 	/**
-	 * Returns true iff there are changes on the given branch that are not present on this branch.
+	 * Determines if there are changes on the given branch that are not present on this branch.
 	 * @param branch - The branch to compare to.
 	 *
 	 * The new edits, if any, can be applied to this branch by {@link TreeBranch.rebaseOnto | rebasing this branch onto the given branch}
 	 * or by {@link TreeBranch.merge | merging the given branch into this branch}.
+	 *
+	 * @throws UsageError if the branches are unrelated.
 	 */
 	isMissingEditsFrom(branch: TreeBranch): boolean;
 }

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -204,6 +204,9 @@ describe("schematizeTree", () => {
 			rebaseOnto(): void {
 				throw new Error("Function not implemented.");
 			},
+			isMissingEditsFrom(branch: unknown): never {
+				throw new Error("Function not implemented.");
+			},
 			dispose(): void {
 				throw new Error("Function not implemented.");
 			},

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -407,4 +407,48 @@ describe("simple-tree tree", () => {
 			assert.equal(viewA.root, 5);
 		});
 	});
+
+	describe("isMissingEditsFrom", () => {
+		it("returns false when the branches are equivalent", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			assert.equal(viewA.isMissingEditsFrom(viewB), false);
+			assert.equal(viewB.isMissingEditsFrom(viewA), false);
+		});
+
+		it("returns false when only 'this' branch is ahead", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			viewB.root = 4;
+			assert.equal(viewB.isMissingEditsFrom(viewA), false);
+		});
+
+		it("returns true when only the other branch is ahead", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			viewB.root = 4;
+			assert.equal(viewA.isMissingEditsFrom(viewB), true);
+		});
+
+		it("returns true when both branches are diverged", () => {
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			viewA.root = 4;
+			viewB.root = 4;
+			assert.equal(viewA.isMissingEditsFrom(viewB), true);
+			assert.equal(viewB.isMissingEditsFrom(viewA), true);
+		});
+	});
 });

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1490,6 +1490,9 @@ export class MockTreeCheckout implements ITreeCheckout {
 	public rebaseOnto(branch: unknown): void {
 		throw new Error("Method 'rebaseOnto' not implemented in MockTreeCheckout.");
 	}
+	public isMissingEditsFrom(branch: unknown): never {
+		throw new Error("Method 'hasNewEdits' not implemented in MockTreeCheckout.");
+	}
 	public dispose(): void {
 		throw new Error("Method 'dispose' not implemented in MockTreeCheckout.");
 	}

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1491,7 +1491,7 @@ export class MockTreeCheckout implements ITreeCheckout {
 		throw new Error("Method 'rebaseOnto' not implemented in MockTreeCheckout.");
 	}
 	public isMissingEditsFrom(branch: unknown): never {
-		throw new Error("Method 'hasNewEdits' not implemented in MockTreeCheckout.");
+		throw new Error("Method 'isMissingEditsFrom' not implemented in MockTreeCheckout.");
 	}
 	public dispose(): void {
 		throw new Error("Method 'dispose' not implemented in MockTreeCheckout.");

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2202,6 +2202,7 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
     // (undocumented)
     fork(): TreeBranchAlpha;
     hasRootSchema<TSchema extends ImplicitFieldSchema>(schema: TSchema): this is TreeViewAlpha<TSchema>;
+    isMissingEditsFrom(branch: TreeBranch): boolean;
     runTransaction<TSuccessValue, TFailureValue>(transaction: () => TransactionCallbackStatus<TSuccessValue, TFailureValue>, params?: RunTransactionParams): TransactionResultExt<TSuccessValue, TFailureValue>;
     runTransaction(transaction: () => VoidTransactionCallbackStatus | void, params?: RunTransactionParams): TransactionResult;
     runTransactionAsync<TSuccessValue, TFailureValue>(transaction: () => Promise<TransactionCallbackStatus<TSuccessValue, TFailureValue>>, params?: RunTransactionParams): Promise<TransactionResultExt<TSuccessValue, TFailureValue>>;


### PR DESCRIPTION
## Description

Adds a new method (`isMissingEditsFrom(branch: TreeBranch): boolean`)  to `TreeBranchAlpha`.
`isMissingEditsFrom` can be used to determine whether there are edits on the given `branch` that have not yet been merged into this branch.

## Breaking Changes

None