### PR TITLE
perf(examples): Add devtools toggle button to text example 

### DIFF
--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -107,7 +107,7 @@ interface DualUserViews {
 	 * Properties for (re)initializing Devtools. Held so the UI can toggle Devtools on and off at runtime
 	 * (see {@link DevtoolsToggle}).
 	 */
-	devtoolsProps: DevtoolsProps;
+	devtoolsProps?: DevtoolsProps;
 }
 
 async function createAndAttachNewContainer(client: AzureClient): Promise<{
@@ -430,13 +430,16 @@ const UserPanel: FC<{
  * Button that enables/disables Fluid Devtools at runtime.
  */
 const DevtoolsToggle: FC<{
-	devtoolsProps: DevtoolsProps;
+	devtoolsProps: DevtoolsProps | undefined;
 }> = ({ devtoolsProps }) => {
 	// Devtools defaults to off
 	const [enabled, setEnabled] = useState(false);
 
 	// Handles initialization and cleanup of devtools instance
 	useEffect(() => {
+		if (devtoolsProps === undefined) {
+			return;
+		}
 		if (enabled) {
 			const instance = initializeDevtools(devtoolsProps);
 			return () => {
@@ -454,7 +457,7 @@ const DevtoolsToggle: FC<{
 			onClick={() => setEnabled((value) => !value)}
 			title={
 				enabled
-					? "Disable Fluid Devtools (recommended before capturing a performance trace)"
+					? "Disable Fluid Devtools (recommended before capturing a performance trace. Devtools visualizes every node on every edit)"
 					: "Enable Fluid Devtools"
 			}
 			style={{

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -220,7 +220,7 @@ async function initFluid(): Promise<DualUserViews> {
 	console.log(`User 2 connected to document: ${containerId}`);
 
 	//* Build the Devtools initialization props. Devtools starts disabled and is toggled on/off at runtime
-	// by the React layer 
+	// by the React layer.
 	const devtoolsProps: DevtoolsProps = {
 		logger: devtoolsLogger,
 		initialContainers: [

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -4,7 +4,11 @@
  */
 
 import { AzureClient, type AzureLocalConnectionConfig } from "@fluidframework/azure-client";
-import { createDevtoolsLogger, initializeDevtools } from "@fluidframework/devtools/beta";
+import {
+	createDevtoolsLogger,
+	initializeDevtools,
+	type DevtoolsProps,
+} from "@fluidframework/devtools/beta";
 import {
 	FormattedMainView,
 	QuillMainView as PlainQuillView,
@@ -99,6 +103,11 @@ interface DualUserViews {
 	user1: TreeViewAlpha<typeof TextEditorRoot>;
 	user2: TreeViewAlpha<typeof TextEditorRoot>;
 	containerId: string;
+	/**
+	 * Properties for (re)initializing Devtools. Held so the UI can toggle Devtools on and off at runtime
+	 * (see {@link DevtoolsToggle}).
+	 */
+	devtoolsProps: DevtoolsProps;
 }
 
 async function createAndAttachNewContainer(client: AzureClient): Promise<{
@@ -210,8 +219,9 @@ async function initFluid(): Promise<DualUserViews> {
 
 	console.log(`User 2 connected to document: ${containerId}`);
 
-	// Initialize Devtools
-	initializeDevtools({
+	//* Build the Devtools initialization props. Devtools starts disabled and is toggled on/off at runtime
+	// by the React layer 
+	const devtoolsProps: DevtoolsProps = {
 		logger: devtoolsLogger,
 		initialContainers: [
 			{
@@ -223,12 +233,13 @@ async function initFluid(): Promise<DualUserViews> {
 				containerKey: "User 2 Container",
 			},
 		],
-	});
+	};
 
 	return {
 		user1: user1View,
 		user2: user2View,
 		containerId,
+		devtoolsProps,
 	};
 }
 
@@ -415,6 +426,53 @@ const UserPanel: FC<{
 	);
 };
 
+/**
+ * Button that enables/disables Fluid Devtools at runtime.
+ */
+const DevtoolsToggle: FC<{
+	devtoolsProps: DevtoolsProps;
+}> = ({ devtoolsProps }) => {
+	// Devtools defaults to off
+	const [enabled, setEnabled] = useState(false);
+
+	// Handles initialization and cleanup of devtools instance
+	useEffect(() => {
+		if (enabled) {
+			const instance = initializeDevtools(devtoolsProps);
+			return () => {
+				if (!instance.disposed) {
+					instance.dispose();
+				}
+			};
+		}
+		return undefined;
+	}, [enabled, devtoolsProps]);
+
+	return (
+		<button
+			type="button"
+			onClick={() => setEnabled((value) => !value)}
+			title={
+				enabled
+					? "Disable Fluid Devtools (recommended before capturing a performance trace)"
+					: "Enable Fluid Devtools"
+			}
+			style={{
+				padding: "6px 12px",
+				borderRadius: "4px",
+				border: "1px solid #ccc",
+				background: enabled ? "#e6f4ea" : "#f5f5f5",
+				color: "#333",
+				fontSize: "13px",
+				fontWeight: 600,
+				cursor: "pointer",
+			}}
+		>
+			{`Devtools: ${enabled ? "On" : "Off"}`}
+		</button>
+	);
+};
+
 export const App: FC<{ views: DualUserViews }> = ({ views }) => {
 	return (
 		<div
@@ -426,6 +484,15 @@ export const App: FC<{ views: DualUserViews }> = ({ views }) => {
 				flexDirection: "column",
 			}}
 		>
+			<div
+				style={{
+					marginBottom: "12px",
+					display: "flex",
+					justifyContent: "flex-start",
+				}}
+			>
+				<DevtoolsToggle devtoolsProps={views.devtoolsProps} />
+			</div>
 			<div
 				style={{
 					flex: 1,

--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -219,7 +219,7 @@ async function initFluid(): Promise<DualUserViews> {
 
 	console.log(`User 2 connected to document: ${containerId}`);
 
-	//* Build the Devtools initialization props. Devtools starts disabled and is toggled on/off at runtime
+	// Build the Devtools initialization props. Devtools starts disabled and is toggled on/off at runtime
 	// by the React layer.
 	const devtoolsProps: DevtoolsProps = {
 		logger: devtoolsLogger,
@@ -457,8 +457,8 @@ const DevtoolsToggle: FC<{
 			onClick={() => setEnabled((value) => !value)}
 			title={
 				enabled
-					? "Disable Fluid Devtools (recommended before capturing a performance trace. Devtools visualizes every node on every edit)"
-					: "Enable Fluid Devtools"
+					? "Disable Fluid Devtools (recommended before capturing a performance trace.)"
+					: "Enable Fluid Devtools (Devtools visualizes every node on every edit)"
 			}
 			style={{
 				padding: "6px 12px",

--- a/examples/data-objects/text-editor/src/test/app.test.tsx
+++ b/examples/data-objects/text-editor/src/test/app.test.tsx
@@ -36,6 +36,9 @@ describe("app", () => {
 					user1: createFormattedTreeView("Text A"),
 					user2: createFormattedTreeView("Text B"),
 					containerId: "test",
+					// No containers to register in this render-only test; the Devtools toggle just
+					// initializes/disposes an empty Devtools instance.
+					devtoolsProps: {},
 				}}
 			/>
 		);

--- a/examples/data-objects/text-editor/src/test/app.test.tsx
+++ b/examples/data-objects/text-editor/src/test/app.test.tsx
@@ -36,9 +36,6 @@ describe("app", () => {
 					user1: createFormattedTreeView("Text A"),
 					user2: createFormattedTreeView("Text B"),
 					containerId: "test",
-					// No containers to register in this render-only test; the Devtools toggle just
-					// initializes/disposes an empty Devtools instance.
-					devtoolsProps: {},
 				}}
 			/>
 		);


### PR DESCRIPTION
## Description

The devtools SharedTree visualizer subscribes to each container's SharedTree "op" event and re-serializes the entire tree (exportVerbose → visualizeVerboseNodeFields) on every edit. On a per-character formatted document that work dominates CPU. This was done without eargerly without devtools being called. A button has been added to the top left of the text-editor app that enables/disables devtools (default disabled). 

<img width="356" height="350" alt="Screenshot 2026-06-23 at 9 58 00 AM" src="https://github.com/user-attachments/assets/66ca978d-94ef-413a-804d-25bff0c3bdae" />

Manually tested with trace testing. When disabled exportVerbose is not called and text edits at large doc sizes drop from 500ms+ to 9 ms
## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).