### PR TITLE
build: tag untagged asserts for 2.110.0 release

### DIFF
--- a/packages/dds/claims/src/claims.ts
+++ b/packages/dds/claims/src/claims.ts
@@ -207,7 +207,7 @@ export class Claims<T = unknown> extends SharedObject implements IClaims<T> {
 		if (messageEnvelope.type === MessageType.Operation) {
 			const op = messageContent.contents as IClaimOperation<T>;
 
-			assert(op.type === "claim", "Claims: unexpected op type");
+			assert(op.type === "claim", 0xd02 /* Claims: unexpected op type */);
 
 			const entry = this.claims.get(op.key);
 			// Accept if the key is unclaimed (trySetClaim) or if the caller's
@@ -286,7 +286,7 @@ export class Claims<T = unknown> extends SharedObject implements IClaims<T> {
 	 */
 	protected rollback(content: unknown, _localOpMetadata: unknown): void {
 		const op = content as IClaimOperation<T>;
-		assert(op.type === "claim", "Claims: unexpected op type in rollback");
+		assert(op.type === "claim", 0xd03 /* Claims: unexpected op type in rollback */);
 		const pending = this.pendingClaims.get(op.key);
 		if (pending === undefined) {
 			return;
@@ -297,7 +297,7 @@ export class Claims<T = unknown> extends SharedObject implements IClaims<T> {
 
 	protected applyStashedOp(content: unknown): void {
 		const op = content as IClaimOperation<T>;
-		assert(op.type === "claim", "Claims: only claim ops should be stashed");
+		assert(op.type === "claim", 0xd04 /* Claims: only claim ops should be stashed */);
 		// Track stashed ops as pending so the key is guarded against duplicate
 		// trySetClaim/compareAndSetClaim calls and handles are visited by GC.
 		// No external caller awaits this promise, so resolve is a no-op.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1191,10 +1191,13 @@ export namespace System_TableSchema {
 				const columnCache = this.#getColumnCache();
 				const constraints: TransactionConstraintAlpha[] = [];
 				for (const id of referencedColumnIds) {
-					const column = columnCache.get(id) ?? fail("Column ID not found in cache");
+					const column = columnCache.get(id) ?? fail(0xd05 /* Column ID not found in cache */);
 					constraints.push({ type: "nodeInDocument", node: column });
 				}
-				assert(constraints.length > 0, "No constraints generated for column references.");
+				assert(
+					constraints.length > 0,
+					0xd06 /* No constraints generated for column references. */,
+				);
 				return constraints;
 			}
 

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -315,7 +315,6 @@ export const shortCodeMap = {
 	"0x1e7": "caching was not performed!",
 	"0x1e8": "reentrancy",
 	"0x1e9": "Pending ops",
-	"0x1ec": "No refresh token provided.",
 	"0x1ed": "Share link should be present",
 	"0x1f0": "Unexpected mismatch in readonly",
 	"0x1f5": "Attached state should have storage",
@@ -1440,7 +1439,6 @@ export const shortCodeMap = {
 	"0xaa6": "Cannot submit a commit while a transaction is in progress",
 	"0xaa7": "Checkout has already been locked",
 	"0xaa8": "Checkout has not been locked",
-	"0xaa9": "Forks may only be disposed once",
 	"0xaaa": "All local changes should be applied to the trunk before loading from summary",
 	"0xaab": "must be segment leaf",
 	"0xaac": "must have removedClient ids",
@@ -1941,5 +1939,10 @@ export const shortCodeMap = {
 	"0xcfe": "duplicate field key in base node shape",
 	"0xcff": "duplicate field key in specialized node shape",
 	"0xd00": "expected existing field index",
-	"0xd01": "replayPendingStates must not be called during stashed-op apply window"
+	"0xd01": "replayPendingStates must not be called during stashed-op apply window",
+	"0xd02": "Claims: unexpected op type",
+	"0xd03": "Claims: unexpected op type in rollback",
+	"0xd04": "Claims: only claim ops should be stashed",
+	"0xd05": "Column ID not found in cache",
+	"0xd06": "No constraints generated for column references."
 };


### PR DESCRIPTION
## Description

Tag untagged asserts for the upcoming **2.110.0** minor release.

Generated by `pnpm run policy-check:asserts` per the [minor release prep](.claude/skills/fluid-release/references/minor-release-prep.md) Step 1.

### Changes
- `packages/dds/claims/src/claims.ts` — 3 asserts tagged (`0xd02`–`0xd04`)
- `packages/dds/tree/src/tableSchema.ts` — 2 asserts tagged (`0xd05`, `0xd06`)
- `packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts` — updated short-code map

### Release prep order
This PR is **#1 of 4** for the 2.110.0 release prep. It must merge before the version bump PR (#4).

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>