### PR TITLE
docs(fluid-release-skill): document update-compat-versions in release steps

### DIFF
--- a/.claude/skills/fluid-release/references/minor-release-prep.md
+++ b/.claude/skills/fluid-release/references/minor-release-prep.md
@@ -132,6 +132,22 @@ pnpm -r run build:genver
 pnpm install --no-frozen-lockfile
 ```
 
+### Update compat workspace versions
+
+The compat-test workspaces under `packages/test/test-version-utils/compat-workspaces/` are pinned to specific prior versions and must be refreshed after every version bump (per the docstring in `packages/test/test-version-utils/scripts/updateCompatVersions.ts`):
+
+```bash
+pnpm run --filter=@fluid-private/test-version-utils update-compat-versions
+```
+
+This regenerates:
+- `compat-workspaces/generated-versions.cjs`
+- `compat-workspaces/full/<version>/package.json` files (adds/removes as needed)
+- `compat-workspaces/full/pnpm-lock.yaml`
+- The auto-generated table in `CompatibilityCheckpoints.md`
+
+If the bump doesn't cross a compatibility checkpoint and the newly released version isn't yet on npm, this is often a no-op — but **always run it** so the next release doesn't conflate changes. The script will be re-run during [type test updates](type-test-updates.md) Step 8 to pick up the freshly published version as N-1.
+
 Create branch `release-prep/<VERSION>/4-bump-<NEXT_VERSION>`, commit, push to upstream, and create a PR. **This PR must merge LAST.**
 
 ## Step 5: Create the Release Branch

--- a/.claude/skills/fluid-release/references/type-test-updates.md
+++ b/.claude/skills/fluid-release/references/type-test-updates.md
@@ -39,6 +39,16 @@ pnpm run build
 pnpm run typetests:gen
 ```
 
+### Refresh compat workspace versions
+
+Re-run `update-compat-versions` now that the newly released version is published to npm. This typically shifts N-1 to the just-released version and slides the back-compat window accordingly:
+
+```bash
+pnpm run --filter=@fluid-private/test-version-utils update-compat-versions
+```
+
+Include any changes (in `compat-workspaces/` and `CompatibilityCheckpoints.md`) in the same PR as the type test baseline updates.
+
 Commit and create a PR targeting `main`.
 
 - **Interactive:** Pause and confirm before creating the PR.


### PR DESCRIPTION
## Description

The compat-test workspaces under `packages/test/test-version-utils/compat-workspaces/` must be regenerated after every version bump and again after the release publishes to npm, per the docstring in `packages/test/test-version-utils/scripts/updateCompatVersions.ts`:

> Run this script after:
> - A Fluid Framework version bump as part of the release process
> - A new compatibility checkpoint is designated

Previously the fluid-release skill's `minor-release-prep.md` and `type-test-updates.md` references omitted this command, so it was easy to miss during release prep (it was missed during 2.110.0 prep, where it happened to be a no-op).

## Changes

- **`minor-release-prep.md` Step 4** — Add an 'Update compat workspace versions' section after `build:genver`, with explanation of regenerated files and a forward-reference to Step 8.
- **`type-test-updates.md` Step 8** — Add a 'Refresh compat workspace versions' section. Run the same command after the freshly released version is on npm and include the changes in the type-test baseline PR.

## Why Step 9 is intentionally not touched

The release branch's compat workspace is frozen at release time; any post-release shifts in N-1 only matter on `main`.

## Validation

- Verified the script is a no-op locally when run on `microsoft/main` (currently at 2.111.0, where 2.110.0 isn't yet on npm and we're still inside CC-4).
- Reviewed all repo references to `update-compat-versions` to confirm the timing guidance.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>