### PR TITLE
fix(build-tools): Allow safe tsc project reuse in tsc-project-single-use policy

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -865,20 +865,20 @@ export const handlers: Handler[] = [
 	},
 	{
 		/**
-		 * Checks that all tsc project files (tsconfig.json), are only used once as the main
-		 * configuration among scripts.
-		 * Multiple uses may indicate a collision during build.
+		 * Checks that tsc project files (tsconfig.json) used by multiple scripts do not collide
+		 * during build. A project file may be reused with different command line options, as long
+		 * as each use writes to a distinct incremental build info (`*.tsbuildinfo`) file. Sharing
+		 * the incremental build info file would cause the parallel builds to corrupt each other.
 		 */
 		name: "tsc-project-single-use",
 		match,
 		handler: async (file: string, root: string): Promise<string | undefined> => {
-			const projectMap = new Map<string, string>();
+			const tsBuildInfoMap = new Map<string, string>();
 			return buildDepsHandler(
 				file,
 				root,
 				({ packageDir, script, command }: BuildDepsCallbackContext) => {
 					const tscUtils = TscUtils.getTscUtils(packageDir);
-					// If the project has a referenced project, depend on that instead of the default
 					const parsedCommand = tscUtils.parseCommandLine(command);
 					if (!parsedCommand) {
 						throw new Error(`Error parsing tsc command for script '${script}': ${command}`);
@@ -889,11 +889,32 @@ export const handlers: Handler[] = [
 							`Could not find config file for script '${script}' in ${packageDir}`,
 						);
 					}
-					const previousUse = projectMap.get(configFile);
-					if (previousUse !== undefined) {
-						return `'${previousUse}' and '${script}' tasks share use of ${configFile}`;
+					const options = TscUtils.getResolvedTsConfig(
+						tscUtils,
+						packageDir,
+						parsedCommand,
+						configFile,
+					);
+					if (options === undefined) {
+						throw new Error(
+							`Failed to resolve tsc config for script '${script}' (project ${configFile})`,
+						);
 					}
-					projectMap.set(configFile, script);
+
+					// The incremental build info file must be unique, even when no output is
+					// emitted, since concurrent uses would otherwise corrupt each other's state.
+					const tsBuildInfoPath = TscUtils.getTsBuildInfoFullPath(
+						options,
+						packageDir,
+						configFile,
+					);
+					if (tsBuildInfoPath !== undefined) {
+						const previousUse = tsBuildInfoMap.get(tsBuildInfoPath);
+						if (previousUse !== undefined) {
+							return `'${previousUse}' and '${script}' tasks share use of incremental build info file ${tsBuildInfoPath}`;
+						}
+						tsBuildInfoMap.set(tsBuildInfoPath, script);
+					}
 				},
 			);
 		},

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -12,11 +12,16 @@ import type * as ts54Types from "typescript-5.4";
 import type * as ts59Types from "typescript-5.9";
 import type * as ts60Types from "typescript-6.0";
 
-import { getTscUtils, type TscUtil } from "../../tscUtils.js";
+import type { TscUtil } from "../../tscUtils.js";
+import {
+	getResolvedTsConfig,
+	getTsBuildInfoFullPath,
+	getTscUtils,
+	remapOutFile,
+} from "../../tscUtils.js";
 import { getInstalledPackageVersion } from "../taskUtils.js";
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask.js";
 
-type tsTypes = typeof ts54Types | typeof ts59Types | typeof ts60Types;
 type tsParsedCommandLine =
 	| ts54Types.ParsedCommandLine
 	| ts59Types.ParsedCommandLine
@@ -272,7 +277,7 @@ export class TscTask extends LeafTask {
 		if (this._sourceStats.some((value) => isEqual(value, stat))) {
 			const parsed = path.parse(fullPath);
 			const directory = parsed.dir;
-			return this.remapOutFile(config, directory, `${parsed.name}.d.ts`);
+			return remapOutFile(config, directory, `${parsed.name}.d.ts`);
 		}
 		return fullPath;
 	}
@@ -325,33 +330,14 @@ export class TscTask extends LeafTask {
 				return undefined;
 			}
 
-			const tscUtils = this.getTscUtils();
-			const config = tscUtils.readConfigFile(configFileFullPath);
-			if (!config) {
-				this.traceError(`ts fail to parse ${configFileFullPath}`);
-				return undefined;
-			}
-
-			// Fix up relative path from the command line based on the package directory
-			const commandOptions = tscUtils.convertOptionPaths(
-				parsedCommand.options,
+			const options = getResolvedTsConfig(
+				this.getTscUtils(),
 				this.node.pkg.directory,
-				path.resolve,
-			);
-
-			// Parse the config file relative to the config file directory
-			const configDir = path.parse(configFileFullPath).dir;
-			const ts = tscUtils.tsLib;
-			const options = ts.parseJsonConfigFileContent(
-				config,
-				ts.sys,
-				configDir,
-				tscUtils.castOptionsUnionToIntersection(commandOptions),
+				parsedCommand,
 				configFileFullPath,
 			);
-
-			if (options.errors.length) {
-				this.traceError(`ts fail to parse file content ${configFileFullPath}`);
+			if (options === undefined) {
+				this.traceError(`ts fail to parse ${configFileFullPath}`);
 				return undefined;
 			}
 			this._tsConfig = options;
@@ -386,71 +372,16 @@ export class TscTask extends LeafTask {
 		return parsedCommand;
 	}
 
-	private get tsBuildInfoFileName(): string | undefined {
-		const configFileFullPath = this.configFileFullPath;
-		if (!configFileFullPath) {
-			return undefined;
-		}
-
-		const configFileParsed = path.parse(configFileFullPath);
-		if (configFileParsed.ext === ".json") {
-			return `${configFileParsed.name}.tsbuildinfo`;
-		}
-		return `${configFileParsed.name}${configFileParsed.ext}.tsbuildinfo`;
-	}
-
-	private getTsBuildInfoFileFromConfig(): string | undefined {
-		const options = this.readTsConfig();
-		if (!options || !options.options.incremental) {
-			return undefined;
-		}
-
-		if (options.options.tsBuildInfoFile) {
-			return options.options.tsBuildInfoFile;
-		}
-
-		const outFile = options.options.out ? options.options.out : options.options.outFile;
-		if (outFile) {
-			return `${outFile}.tsbuildinfo`;
-		}
-
-		const configFileFullPath = this.configFileFullPath;
-		if (!configFileFullPath) {
-			return undefined;
-		}
-
-		const tsBuildInfoFileName = this.tsBuildInfoFileName;
-		if (!tsBuildInfoFileName) {
-			return undefined;
-		}
-
-		return this.remapOutFile(options, path.parse(configFileFullPath).dir, tsBuildInfoFileName);
-	}
-
-	private remapOutFile(
-		options: tsParsedCommandLine,
-		directory: string,
-		fileName: string,
-	): string {
-		if (options.options.outDir) {
-			if (options.options.rootDir) {
-				const relative = path.relative(options.options.rootDir, directory);
-				return path.join(options.options.outDir, relative, fileName);
-			}
-			return path.join(options.options.outDir, fileName);
-		}
-		return path.join(directory, fileName);
-	}
-
 	private get tsBuildInfoFileFullPath(): string | undefined {
 		if (this._tsBuildInfoFullPath === undefined) {
-			const infoFile = this.getTsBuildInfoFileFromConfig();
-			if (infoFile) {
-				if (path.isAbsolute(infoFile)) {
-					this._tsBuildInfoFullPath = infoFile;
-				} else {
-					this._tsBuildInfoFullPath = this.getPackageFileFullPath(infoFile);
-				}
+			const options = this.readTsConfig();
+			const configFileFullPath = this.configFileFullPath;
+			if (options && configFileFullPath) {
+				this._tsBuildInfoFullPath = getTsBuildInfoFullPath(
+					options,
+					this.node.pkg.directory,
+					configFileFullPath,
+				);
 			}
 		}
 		return this._tsBuildInfoFullPath;

--- a/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tscUtils.ts
@@ -390,3 +390,139 @@ export function getTscUtils(path: string): TscUtil {
 export function normalizeSlashes(path: string): string {
 	return path.replace(/\\/g, "/");
 }
+
+/**
+ * A parsed tsc config, as returned by {@link getResolvedTsConfig}. This is the union of the
+ * supported TypeScript versions' `ParsedCommandLine` types.
+ */
+export type ResolvedTsConfig =
+	| ts54Types.ParsedCommandLine
+	| ts59Types.ParsedCommandLine
+	| ts60Types.ParsedCommandLine;
+
+/**
+ * Resolves the effective tsc compiler options for a project by parsing its config file
+ * (including any `extends`) and merging in the option overrides from the parsed command line.
+ * Command line options take precedence. Relative paths from the command line are resolved
+ * relative to {@link packageDir}; the config file is parsed relative to its own directory.
+ *
+ * @param tscUtils - Utilities bound to the TypeScript version used by the package.
+ * @param packageDir - The package directory, used to resolve relative command line paths.
+ * @param parsedCommand - The parsed tsc command line (see {@link TscUtil.parseCommandLine}).
+ * @param configFileFullPath - The absolute path to the project's config file.
+ * @returns The resolved config, or `undefined` if the config could not be read or parsed.
+ */
+export function getResolvedTsConfig(
+	tscUtils: TscUtil,
+	packageDir: string,
+	parsedCommand: ResolvedTsConfig,
+	configFileFullPath: string,
+): ResolvedTsConfig | undefined {
+	const config = tscUtils.readConfigFile(configFileFullPath);
+	if (!config) {
+		return undefined;
+	}
+
+	// Fix up relative paths from the command line based on the package directory.
+	const commandOptions = tscUtils.convertOptionPaths(
+		parsedCommand.options,
+		packageDir,
+		path.resolve,
+	);
+
+	// Parse the config file relative to the config file directory, with command line options
+	// taking precedence.
+	const ts = tscUtils.tsLib;
+	const options = ts.parseJsonConfigFileContent(
+		config,
+		ts.sys,
+		path.dirname(configFileFullPath),
+		tscUtils.castOptionsUnionToIntersection(commandOptions),
+		configFileFullPath,
+	);
+
+	if (options.errors.length) {
+		return undefined;
+	}
+	return options;
+}
+
+/**
+ * Computes the default incremental build info file name (`*.tsbuildinfo`) for a config file,
+ * matching how tsc derives it from the config file name.
+ */
+function getTsBuildInfoFileName(configFileFullPath: string): string {
+	const configFileParsed = path.parse(configFileFullPath);
+	if (configFileParsed.ext === ".json") {
+		return `${configFileParsed.name}.tsbuildinfo`;
+	}
+	return `${configFileParsed.name}${configFileParsed.ext}.tsbuildinfo`;
+}
+
+/**
+ * Remaps a file that would be emitted next to the config/source into the configured output
+ * directory, matching how tsc places emitted files (and the incremental build info file).
+ */
+export function remapOutFile(
+	options: ResolvedTsConfig,
+	directory: string,
+	fileName: string,
+): string {
+	if (options.options.outDir) {
+		if (options.options.rootDir) {
+			const relative = path.relative(options.options.rootDir, directory);
+			return path.join(options.options.outDir, relative, fileName);
+		}
+		return path.join(options.options.outDir, fileName);
+	}
+	return path.join(directory, fileName);
+}
+
+/**
+ * Computes the incremental build info (`*.tsbuildinfo`) file that a tsc invocation would write,
+ * relative to the package as configured, or `undefined` if the invocation is not incremental
+ * (and therefore does not write one).
+ *
+ * @param options - The resolved config (see {@link getResolvedTsConfig}).
+ * @param configFileFullPath - The absolute path to the project's config file.
+ */
+export function getTsBuildInfoFileFromConfig(
+	options: ResolvedTsConfig,
+	configFileFullPath: string,
+): string | undefined {
+	if (!options.options.incremental) {
+		return undefined;
+	}
+
+	if (options.options.tsBuildInfoFile) {
+		return options.options.tsBuildInfoFile;
+	}
+
+	const outFile = options.options.out ? options.options.out : options.options.outFile;
+	if (outFile) {
+		return `${outFile}.tsbuildinfo`;
+	}
+
+	const tsBuildInfoFileName = getTsBuildInfoFileName(configFileFullPath);
+	return remapOutFile(options, path.parse(configFileFullPath).dir, tsBuildInfoFileName);
+}
+
+/**
+ * Computes the absolute path of the incremental build info (`*.tsbuildinfo`) file that a tsc
+ * invocation would write, or `undefined` if the invocation is not incremental.
+ *
+ * @param options - The resolved config (see {@link getResolvedTsConfig}).
+ * @param packageDir - The package directory, used to resolve a relative build info path.
+ * @param configFileFullPath - The absolute path to the project's config file.
+ */
+export function getTsBuildInfoFullPath(
+	options: ResolvedTsConfig,
+	packageDir: string,
+	configFileFullPath: string,
+): string | undefined {
+	const infoFile = getTsBuildInfoFileFromConfig(options, configFileFullPath);
+	if (infoFile === undefined) {
+		return undefined;
+	}
+	return path.isAbsolute(infoFile) ? infoFile : path.join(packageDir, infoFile);
+}

--- a/build-tools/packages/build-tools/src/test/data/tsc/src/index.ts
+++ b/build-tools/packages/build-tools/src/test/data/tsc/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/build-tools/packages/build-tools/src/test/data/tsc/src/index.ts
+++ b/build-tools/packages/build-tools/src/test/data/tsc/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export const value = 1;

--- a/build-tools/packages/build-tools/src/test/data/tsc/tsconfig.base.json
+++ b/build-tools/packages/build-tools/src/test/data/tsc/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"incremental": true,
+		"outDir": "./lib",
+		"strict": true,
+	},
+}

--- a/build-tools/packages/build-tools/src/test/data/tsc/tsconfig.json
+++ b/build-tools/packages/build-tools/src/test/data/tsc/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+	},
+	"include": ["src/**/*"],
+}

--- a/build-tools/packages/build-tools/src/test/tscUtils.test.ts
+++ b/build-tools/packages/build-tools/src/test/tscUtils.test.ts
@@ -1,0 +1,197 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "mocha";
+
+import {
+	getResolvedTsConfig,
+	getTsBuildInfoFileFromConfig,
+	getTsBuildInfoFullPath,
+	getTscUtils,
+	type ResolvedTsConfig,
+	remapOutFile,
+} from "../fluidBuild/tscUtils.js";
+import { testDataPath } from "./init.js";
+
+/**
+ * The functions under test only read the `options` bag (and, for build info, the config file
+ * path). This helper builds a minimal {@link ResolvedTsConfig} for the pure-function tests
+ * without needing to invoke the TypeScript compiler.
+ */
+function makeConfig(options: Record<string, unknown>): ResolvedTsConfig {
+	return { options, fileNames: [], errors: [] } as unknown as ResolvedTsConfig;
+}
+
+describe("tscUtils", () => {
+	describe("remapOutFile", () => {
+		it("emits next to the source when no outDir is set", () => {
+			const result = remapOutFile(makeConfig({}), "/pkg/src", "index.tsbuildinfo");
+			assert.equal(result, path.join("/pkg/src", "index.tsbuildinfo"));
+		});
+
+		it("emits into outDir when rootDir is not set", () => {
+			const result = remapOutFile(
+				makeConfig({ outDir: "/pkg/lib" }),
+				"/pkg/src",
+				"index.tsbuildinfo",
+			);
+			assert.equal(result, path.join("/pkg/lib", "index.tsbuildinfo"));
+		});
+
+		it("preserves the rootDir-relative path under outDir", () => {
+			const result = remapOutFile(
+				makeConfig({ outDir: "/pkg/lib", rootDir: "/pkg/src" }),
+				"/pkg/src/sub",
+				"index.tsbuildinfo",
+			);
+			assert.equal(result, path.join("/pkg/lib", "sub", "index.tsbuildinfo"));
+		});
+	});
+
+	describe("getTsBuildInfoFileFromConfig", () => {
+		const configFile = "/pkg/tsconfig.json";
+
+		it("returns undefined when the build is not incremental", () => {
+			assert.equal(getTsBuildInfoFileFromConfig(makeConfig({}), configFile), undefined);
+		});
+
+		it("uses an explicit tsBuildInfoFile when configured", () => {
+			const result = getTsBuildInfoFileFromConfig(
+				makeConfig({ incremental: true, tsBuildInfoFile: "./custom.tsbuildinfo" }),
+				configFile,
+			);
+			assert.equal(result, "./custom.tsbuildinfo");
+		});
+
+		it("derives the build info file from outFile", () => {
+			const result = getTsBuildInfoFileFromConfig(
+				makeConfig({ incremental: true, outFile: "/pkg/out/bundle.js" }),
+				configFile,
+			);
+			assert.equal(result, "/pkg/out/bundle.js.tsbuildinfo");
+		});
+
+		it("derives the build info file from the legacy out option", () => {
+			const result = getTsBuildInfoFileFromConfig(
+				makeConfig({ incremental: true, out: "/pkg/out/bundle.js" }),
+				configFile,
+			);
+			assert.equal(result, "/pkg/out/bundle.js.tsbuildinfo");
+		});
+
+		it("defaults to the config file name beside the config (.json extension)", () => {
+			const result = getTsBuildInfoFileFromConfig(
+				makeConfig({ incremental: true }),
+				configFile,
+			);
+			assert.equal(result, path.join("/pkg", "tsconfig.tsbuildinfo"));
+		});
+
+		it("keeps a non-.json config extension in the default name", () => {
+			const result = getTsBuildInfoFileFromConfig(
+				makeConfig({ incremental: true }),
+				"/pkg/tsconfig.cjs",
+			);
+			assert.equal(result, path.join("/pkg", "tsconfig.cjs.tsbuildinfo"));
+		});
+
+		it("remaps the default build info file into outDir", () => {
+			const result = getTsBuildInfoFileFromConfig(
+				makeConfig({ incremental: true, outDir: "/pkg/lib" }),
+				configFile,
+			);
+			assert.equal(result, path.join("/pkg/lib", "tsconfig.tsbuildinfo"));
+		});
+	});
+
+	describe("getTsBuildInfoFullPath", () => {
+		const packageDir = "/pkg";
+		const configFile = "/pkg/tsconfig.json";
+
+		it("returns undefined when the build is not incremental", () => {
+			assert.equal(getTsBuildInfoFullPath(makeConfig({}), packageDir, configFile), undefined);
+		});
+
+		it("returns an absolute tsBuildInfoFile unchanged", () => {
+			const result = getTsBuildInfoFullPath(
+				makeConfig({ incremental: true, tsBuildInfoFile: "/elsewhere/build.tsbuildinfo" }),
+				packageDir,
+				configFile,
+			);
+			assert.equal(result, "/elsewhere/build.tsbuildinfo");
+		});
+
+		it("resolves a relative tsBuildInfoFile against the package directory", () => {
+			const result = getTsBuildInfoFullPath(
+				makeConfig({ incremental: true, tsBuildInfoFile: "./custom.tsbuildinfo" }),
+				packageDir,
+				configFile,
+			);
+			assert.equal(result, path.join(packageDir, "custom.tsbuildinfo"));
+		});
+	});
+
+	describe("getResolvedTsConfig", () => {
+		const projectDir = path.resolve(testDataPath, "tsc");
+		const tscUtils = getTscUtils(projectDir);
+
+		function resolveProject(command: string): ResolvedTsConfig | undefined {
+			const parsedCommand = tscUtils.parseCommandLine(command);
+			assert.ok(parsedCommand, "expected the command line to parse");
+			const configFile = tscUtils.findConfigFile(projectDir, parsedCommand);
+			assert.ok(configFile, "expected to find the config file");
+			return getResolvedTsConfig(tscUtils, projectDir, parsedCommand, configFile);
+		}
+
+		it("merges options inherited via extends", () => {
+			const resolved = resolveProject("tsc --project ./tsconfig.json");
+			assert.ok(resolved, "expected the config to resolve");
+			// incremental and strict come from tsconfig.base.json via extends.
+			assert.equal(resolved.options.incremental, true);
+			assert.equal(resolved.options.strict, true);
+			// outDir (from base) and rootDir (from the child) are resolved to absolute paths.
+			assert.equal(resolved.options.outDir, path.join(projectDir, "lib"));
+			assert.equal(resolved.options.rootDir, path.join(projectDir, "src"));
+		});
+
+		it("applies command line option overrides", () => {
+			const resolved = resolveProject(
+				"tsc --project ./tsconfig.json --tsBuildInfoFile ./override.tsbuildinfo",
+			);
+			assert.ok(resolved, "expected the config to resolve");
+			assert.equal(
+				resolved.options.tsBuildInfoFile,
+				path.join(projectDir, "override.tsbuildinfo"),
+			);
+		});
+
+		it("computes the build info path from the resolved config", () => {
+			const resolved = resolveProject("tsc --project ./tsconfig.json");
+			assert.ok(resolved, "expected the config to resolve");
+			// outDir=lib, rootDir=src, config dir = projectDir: the default name remaps to the
+			// package root (lib/.. relative to src).
+			const result = getTsBuildInfoFullPath(
+				resolved,
+				projectDir,
+				path.join(projectDir, "tsconfig.json"),
+			);
+			assert.equal(result, path.join(projectDir, "tsconfig.tsbuildinfo"));
+		});
+
+		it("returns undefined when the config file cannot be read", () => {
+			const parsedCommand = tscUtils.parseCommandLine("tsc --project ./tsconfig.json");
+			assert.ok(parsedCommand);
+			const result = getResolvedTsConfig(
+				tscUtils,
+				projectDir,
+				parsedCommand,
+				path.join(projectDir, "does-not-exist.json"),
+			);
+			assert.equal(result, undefined);
+		});
+	});
+});


### PR DESCRIPTION
Previously the tsc-project-single-use policy failed whenever a tsconfig project file was referenced by more than one script, even when the uses could not collide. This blocked valid patterns such as reusing a project with different command line options (e.g. a noEmit type-check that writes a distinct tsbuildinfo file).

The policy now resolves each tsc invocation's effective options and only fails when two scripts would write the same incremental build info (tsbuildinfo) file, which is the actual collision that corrupts parallel builds.

The build info and tsconfig resolution logic was extracted from the fluid-build tsc task into shared, exported functions in tscUtils (getResolvedTsConfig, getTsBuildInfoFileFromConfig, getTsBuildInfoFullPath, remapOutFile) so the policy check and the build task share a single implementation. Unit tests cover the extracted functions, including extends-based option merging and command line overrides.

This policy change will allow secondary tsconfig project file use for alternate checks, like verifying that both exactOptionalPropertyType true and false settings work for production code, without authoring a host of additional files. And example build entry could be:
```json
"check:inexactOptionalPropertyTypes": "tsc --project ./tsconfig.json --noEmit --exactOptionalPropertyTypes false --skipLibCheck --emitDeclarationOnly false --tsBuildInfoFile ./tsconfig.inexactOptionalPropertyTypes.tsbuildinfo",
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>