### PR TITLE
feat(website): disable cookies being imported from libraries

### DIFF
--- a/website/src/appInsights.ts
+++ b/website/src/appInsights.ts
@@ -21,6 +21,7 @@ if (typeof window !== "undefined" && window.location.hostname !== "localhost") {
 		appInsights = new ApplicationInsights({
 			config: {
 				connectionString: `InstrumentationKey=${instrumentationKey}`,
+				disableCookieUsage: true,
 				enableAutoRouteTracking: true,
 				enableDebug: true,
 				extensions: [reactPlugin],


### PR DESCRIPTION
## Description

There is an ongoing effort to remove non-essential cookies from the Fluid Framework website.

There were some cookies being created from libraries used for the application insights. This change ensures that we only create cookies that we actually need.

The cookies that are being disabled are `ai_session` and `ai_user`. The existing `userId` cookie used for analytics will remain unaffected.

Fixes [AB#73908](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/73908)

## Reviewer Guidance

As far as I'm aware we don't actively use the cookies that are being removed, but if they are actually necessary, please let me know.