### PR TITLE
fix(client-odsp-driver): remove `@deprecation` from non-deprecated API

### DIFF
--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
@@ -197,8 +197,8 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     fileVersion?: string | undefined;
 }
 
-// @beta @deprecated @legacy
-export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean, snapshotFormatFetchType?: SnapshotFormatSupportType, odspDocumentServiceFactory?: OdspDocumentServiceFactory): Promise<boolean>;
+// @beta @legacy
+export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, _forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, _fetchBinarySnapshotFormat?: boolean, _snapshotFormatFetchType?: SnapshotFormatSupportType, odspDocumentServiceFactory?: OdspDocumentServiceFactory): Promise<boolean>;
 
 // @beta @legacy
 export interface ShareLinkFetcherProps {

--- a/packages/drivers/odsp-driver/src/WriteBufferUtils.ts
+++ b/packages/drivers/odsp-driver/src/WriteBufferUtils.ts
@@ -188,11 +188,7 @@ function serializeDictionaryString(
 	buffer.write(id, idLength);
 }
 
-function serializeString(
-	buffer: WriteBuffer,
-	content: string,
-	codeMap = binaryBytesToCodeMap,
-): void {
+function serializeString(buffer: WriteBuffer, content: string): void {
 	serializeBlob(buffer, IsoBuffer.from(content, "utf8"), utf8StringBytesToCodeMap);
 }
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -85,7 +85,6 @@ export enum SnapshotFormatSupportType {
  * @param snapshotUrl - snapshot url from where the odsp snapshot will be fetched
  * @param versionId - id of specific snapshot to be fetched
  * @param fetchFullSnapshot - whether we want to fetch full snapshot(with blobs)
- * @param forceAccessTokenViaAuthorizationHeader - Deprecated and not used, true value always used instead. Whether to force passing given token via authorization header
  * @param snapshotDownloader - Implementation of the get/post methods used to fetch the snapshot. snapshotDownloader is responsible for generating the appropriate headers (including Authorization header) as well as handling any token refreshes before retrying.
  * @returns A promise of the snapshot and the status code of the response
  */
@@ -93,7 +92,6 @@ export async function fetchSnapshot(
 	snapshotUrl: string,
 	versionId: string,
 	fetchFullSnapshot: boolean,
-	forceAccessTokenViaAuthorizationHeader: boolean,
 	logger: TelemetryLoggerExt,
 	snapshotDownloader: (url: string) => Promise<IOdspResponse<unknown>>,
 ): Promise<ISnapshot> {
@@ -120,7 +118,6 @@ export async function fetchSnapshotWithRedeem(
 	odspResolvedUrl: IOdspResolvedUrl,
 	storageTokenFetcher: InstrumentedStorageTokenFetcher,
 	snapshotOptions: ISnapshotOptions | undefined,
-	forceAccessTokenViaAuthorizationHeader: boolean,
 	logger: TelemetryLoggerExt,
 	snapshotDownloader: (
 		finalOdspResolvedUrl: IOdspResolvedUrl,
@@ -411,7 +408,7 @@ async function fetchLatestSnapshotCore(
 									}
 									return res;
 								})
-								.catch((error) =>
+								.catch((_error) =>
 									// Parsing can fail and message could contain full request URI, including
 									// tokens, etc. So do not log error object itself.
 									throwOdspNetworkError(
@@ -455,7 +452,7 @@ async function fetchLatestSnapshotCore(
 									}
 									return res;
 								})
-								.catch((error) =>
+								.catch((_error) =>
 									// Parsing can fail and message could contain full request URI, including
 									// tokens, etc. So do not log error object itself.
 									throwOdspNetworkError(

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -72,7 +72,7 @@ export const getFileLink = mockify(
 					{
 						// TODO: use a stronger type
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						onRetry(delayInMs: number, error: any) {
+						onRetry(_delayInMs: number, error: any) {
 							retryCount++;
 							if (retryCount === 5) {
 								if (error !== undefined && typeof error === "object") {

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentService.ts
@@ -58,7 +58,7 @@ export class LocalOdspDocumentService
 		throw toThrow;
 	}
 
-	public dispose(error?: unknown): void {
+	public dispose(): void {
 		// Do nothing
 	}
 }

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentServiceFactory.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import type {
 	IDocumentService,
 	IResolvedUrl,
@@ -42,12 +40,7 @@ export class LocalOdspDocumentServiceFactory extends OdspDocumentServiceFactoryC
 		throw toThrow;
 	}
 
-	public createContainer(
-		_createNewSummary: ISummaryTree | undefined,
-		_createNewResolvedUrl: IResolvedUrl,
-		logger?: ITelemetryBaseLogger,
-		_clientIsSummarizer?: boolean,
-	): never {
+	public createContainer(): never {
 		const toThrow = new UsageError(
 			'"createContainer" is not supported by LocalOdspDocumentServiceFactory',
 		);

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
@@ -7,7 +7,6 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import type {
 	ISnapshot,
-	ISnapshotFetchOptions,
 	ISummaryContext,
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
@@ -66,7 +65,7 @@ export class LocalOdspDocumentStorageService extends OdspDocumentStorageServiceB
 		return this.getSnapshotVersion();
 	}
 
-	public async getSnapshot(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot> {
+	public async getSnapshot(): Promise<ISnapshot> {
 		this.throwUsageError("getSnapshot");
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -214,7 +214,7 @@ export class OdspDelayLoadedDeltaStream {
 					websocketEndpoint.deltaStreamSocketUrl,
 					connectionId,
 				);
-				connection.on("op", (documentId, ops: ISequencedDocumentMessage[]) => {
+				connection.on("op", (_documentId, ops: ISequencedDocumentMessage[]) => {
 					this.opsReceived(ops);
 				});
 				connection.on("signal", this.signalHandler);
@@ -573,7 +573,7 @@ export class OdspDelayLoadedDeltaStream {
 		return connection;
 	}
 
-	public dispose(error?: unknown): void {
+	public dispose(): void {
 		this.clearJoinSessionTimer();
 		this.currentConnection?.dispose();
 		delete this.currentConnection;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -67,7 +67,7 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
 	// Map of all existing socket io sockets. [url, tenantId, documentId] -> socket
 	private static readonly socketIoSockets: Map<string, SocketReference> = new Map();
 
-	public static find(key: string, logger: TelemetryLoggerExt): SocketReference | undefined {
+	public static find(key: string): SocketReference | undefined {
 		const socketReference = SocketReference.socketIoSockets.get(key);
 
 		// Verify the socket is healthy before reusing it
@@ -279,7 +279,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			enableMultiplexing,
 			tenantId,
 			documentId,
-			telemetryLogger,
 		);
 
 		const socket = socketReference.socket;
@@ -389,10 +388,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		enableMultiplexing: boolean,
 		tenantId: string,
 		documentId: string,
-		logger: TelemetryLoggerExt,
 	): SocketReference {
 		// eslint-disable-next-line unicorn/no-array-method-this-argument
-		const existingSocketReference = SocketReference.find(key, logger);
+		const existingSocketReference = SocketReference.find(key);
 		if (existingSocketReference) {
 			return existingSocketReference;
 		}

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -662,7 +662,6 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 				this.odspResolvedUrl,
 				this.getAuthHeader,
 				snapshotOptions,
-				!!this.hostPolicy.sessionOptions?.forceAccessTokenViaAuthorizationHeader,
 				this.logger,
 				snapshotDownloader,
 				putInCache,
@@ -704,7 +703,6 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 					this.odspResolvedUrl,
 					this.getAuthHeader,
 					snapshotOptionsWithoutBlobs,
-					!!this.hostPolicy.sessionOptions?.forceAccessTokenViaAuthorizationHeader,
 					this.logger,
 					snapshotDownloader,
 					putInCache,
@@ -886,7 +884,6 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 				this.snapshotUrl!,
 				id,
 				this.fetchFullSnapshot,
-				!!this.hostPolicy.sessionOptions?.forceAccessTokenViaAuthorizationHeader,
 				this.logger,
 				snapshotDownloader,
 			);

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import {
 	type FetchSource,
 	type FiveDaysMs,
@@ -227,7 +227,7 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 		context: ISummaryContext,
 	): Promise<string>;
 
-	public async downloadSummary(commit: ISummaryHandle): Promise<ISummaryTree> {
+	public async downloadSummary(): Promise<ISummaryTree> {
 		throw new Error("Not implemented yet");
 	}
 

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -43,22 +43,22 @@ import {
 } from "./odspUtils.js";
 
 /**
- * Function to prefetch the snapshot and cached it in the persistant cache, so that when the container is loaded
+ * Function to prefetch the snapshot and cached it in the persistent cache, so that when the container is loaded
  * the cached latest snapshot could be used and removes the network call from the critical path.
  *
  * @param resolvedUrl - Resolved url to fetch the snapshot.
  * @param getStorageToken - function that can provide the storage token for a given site. This is
  * is also referred to as the "VROOM" token in SPO.
  * @param persistedCache - Cache to store the fetched snapshot.
- * @param forceAccessTokenViaAuthorizationHeader - @deprecated Not used, true value always used instead. Whether to force passing given token via authorization header.
+ * @param _forceAccessTokenViaAuthorizationHeader - Deprecated and not used.
  * @param logger - Logger to have telemetry events.
  * @param hostSnapshotFetchOptions - Options to fetch the snapshot if any. Otherwise default will be used.
  * @param enableRedeemFallback - True to have the sharing link redeem fallback in case the Trees Latest/Redeem
  * 1RT call fails with redeem error. During fallback it will first redeem the sharing link and then make
  * the Trees latest call.
  * Note: this can be considered deprecated - it will be replaced with `snapshotFormatFetchType`.
- * @param fetchBinarySnapshotFormat - Control if we want to fetch binary format snapshot.
- * @param snapshotFormatFetchType - Snapshot format to fetch.
+ * @param _fetchBinarySnapshotFormat - Deprecated and not used.
+ * @param _snapshotFormatFetchType - Deprecated and not used.
  * @param odspDocumentServiceFactory - factory to access the non persistent cache and store the prefetch promise.
  *
  * @returns `true` if the snapshot is cached, `false` otherwise.
@@ -69,12 +69,12 @@ export async function prefetchLatestSnapshot(
 	resolvedUrl: IResolvedUrl,
 	getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
 	persistedCache: IPersistedCache,
-	forceAccessTokenViaAuthorizationHeader: boolean,
+	_forceAccessTokenViaAuthorizationHeader: boolean,
 	logger: ITelemetryBaseLogger,
 	hostSnapshotFetchOptions: ISnapshotOptions | undefined,
 	enableRedeemFallback: boolean = true,
-	fetchBinarySnapshotFormat?: boolean,
-	snapshotFormatFetchType?: SnapshotFormatSupportType,
+	_fetchBinarySnapshotFormat?: boolean,
+	_snapshotFormatFetchType?: SnapshotFormatSupportType,
 	odspDocumentServiceFactory?: OdspDocumentServiceFactory,
 ): Promise<boolean> {
 	const mc = createChildMonitoringContext({ logger, namespace: "PrefetchSnapshot" });
@@ -144,7 +144,6 @@ export async function prefetchLatestSnapshot(
 				odspResolvedUrl,
 				getAuthHeader,
 				hostSnapshotFetchOptions,
-				forceAccessTokenViaAuthorizationHeader,
 				odspLogger,
 				snapshotDownloader,
 				putInCache,

--- a/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
@@ -67,10 +67,7 @@ describe("Local Odsp driver", () => {
 
 		it("createContainer throws error", async () => {
 			await assertThrowsUsageError(async () =>
-				new LocalOdspDocumentServiceFactory("sample data").createContainer(
-					undefined,
-					fakeOdspResolvedUrl,
-				),
+				new LocalOdspDocumentServiceFactory("sample data").createContainer(),
 			);
 		});
 
@@ -199,9 +196,6 @@ describe("Local Odsp driver", () => {
 				localSnapshot,
 			);
 			assert.doesNotThrow(() => service.dispose());
-			assert.doesNotThrow(() => service.dispose(null));
-			assert.doesNotThrow(() => service.dispose(undefined));
-			assert.doesNotThrow(() => service.dispose(new Error("I am an error")));
 		});
 	});
 

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -414,9 +414,7 @@ export class NodeCore {
 		durationStructure: number;
 		durationStrings: number;
 	} {
-		const [stringsToResolve, durationStructure] = measure(() =>
-			this.loadStructure(buffer, logger),
-		);
+		const [stringsToResolve, durationStructure] = measure(() => this.loadStructure(buffer));
 		const [, durationStrings] = measure(() =>
 			this.loadStrings(buffer, stringsToResolve, logger),
 		);
@@ -427,10 +425,7 @@ export class NodeCore {
 	 * Load and parse the buffer into a tree.
 	 * @param buffer - buffer to read from.
 	 */
-	protected loadStructure(
-		buffer: ReadBuffer,
-		logger: TelemetryLoggerExt,
-	): IStringElementInternal[] {
+	protected loadStructure(buffer: ReadBuffer): IStringElementInternal[] {
 		const stack: NodeTypes[][] = [];
 		const stringsToResolve: IStringElementInternal[] = [];
 		const dictionary: IStringElement[] = [];

--- a/packages/drivers/odsp-driver/tsconfig.json
+++ b/packages/drivers/odsp-driver/tsconfig.json
@@ -5,7 +5,8 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		// As of 2026-06-18, there are 47 errors enableing exactOptionalPropertyTypes.
+		"noUnusedParameters": true,
+		// As of 2026-06-18, there are 47 errors enabling exactOptionalPropertyTypes.
 		"exactOptionalPropertyTypes": false,
 		// TODO: AB#34163 Enable noUncheckedIndexedAccess for packages/drivers/odsp-driver
 		"noUncheckedIndexedAccess": false,


### PR DESCRIPTION
`prefetchLatestSnapshot` is not deprecated but that tag was picked up for function when it was erroneously applied to a parameter in #21601.

Additionally, enable noUnusedParameters for odsp-driver and cleanup resulting errors. Cleans up some deprecated code and slightly reduces bundle size.