### PR TITLE
docs(fluid-release-skill): add 2.110.0 to release schedule

### DIFF
--- a/.claude/skills/fluid-release/references/release-schedule.md
+++ b/.claude/skills/fluid-release/references/release-schedule.md
@@ -4,6 +4,7 @@ Dates are in MM/DD/YY format. The schedule is ordered newest-first.
 
 | Proposed Date | Released Date | Release Type | Release Ver | "main" Ver | Release Notes |
 |---------------|---------------|--------------|-------------|------------|---------------|
+| 06/22/26 | | minor+beta/legacy breaks | 2.110.0 | 2.111.0 | |
 | 06/06/26 | | minor | 2.103.0 | 2.110.0 | |
 | 05/26/26 | | minor | 2.102.0 | 2.103.0 | |
 | 05/11/26 | | minor | 2.101.0 | 2.102.0 | |


### PR DESCRIPTION
## Description

Adds the **2.110.0** `minor+beta/legacy breaks` release to `.claude/skills/fluid-release/references/release-schedule.md`.

### Details
| Field | Value |
|---|---|
| Proposed date | 06/22/26 (biweekly Monday cadence) |
| Actual release | 06/23/26 (`client_v2.110.0` tag) |
| Release type | `minor+beta/legacy breaks` |
| Release version | 2.110.0 |
| `main` Ver after branch cut | 2.111.0 |
| Release branch | [release/client/2.110](https://github.com/microsoft/FluidFramework/tree/release/client/2.110) |
| Release notes | [RELEASE_NOTES/2.110.0.md](https://github.com/microsoft/FluidFramework/blob/main/RELEASE_NOTES/2.110.0.md) |

### Classification rationale
- Matches the X.X0.0 pattern historically used for `@beta`/`@legacy` breaking releases (2.90.0, 2.100.0, 2.110.0).
- `RELEASE_NOTES/2.110.0.md` contains breaking changes to `@beta` and `@legacy` APIs.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>