### PR TITLE
Optimize fetch for a few pipelines

### DIFF
--- a/tools/pipelines/build-performance-observability.yml
+++ b/tools/pipelines/build-performance-observability.yml
@@ -94,6 +94,8 @@ extends:
         steps:
         - checkout: self
           clean: true
+          fetchDepth: 1
+          fetchTags: false
           path: ${{ variables.FluidFrameworkDirectory }}
 
         - template: /tools/pipelines/templates/include-use-node-version.yml@self

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -89,6 +89,8 @@ extends:
               "
         - checkout: self
           path: ${{ variables.FluidFrameworkDirectory }}
+          fetchDepth: 1
+          fetchTags: false
         - template: /tools/pipelines/templates/include-use-node-version.yml@self
         - template: /tools/pipelines/templates/include-install-pnpm.yml@self
           parameters:

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -35,6 +35,8 @@ stages:
     steps:
     - checkout: self
       path: $(FluidFrameworkDirectory)
+      fetchDepth: 1
+      fetchTags: false
     - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
     - template: /tools/pipelines/templates/include-install-pnpm.yml@self

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -119,10 +119,14 @@ stages:
         # Checkout the FluidFramework repo (for workspace scripts and source code)
         - checkout: self
           path: $(FluidFrameworkDirectory)
+          fetchDepth: 1
+          fetchTags: false
 
         # Checkout ff_pipeline_host (provides telemetry-generator and trips-setup/cleanup)
         - checkout: ff_pipeline_host
           path: $(FFPipelineHostDirectory)
+          fetchDepth: 1
+          fetchTags: false
 
         - task: Bash@3
           displayName: Print parameter/variable values for troubleshooting


### PR DESCRIPTION
## Description

Optimize git fetch in a few pipelines. Split out from https://github.com/microsoft/FluidFramework/pull/27342 to reduce reisk and allow more incrementla adoption and review of this pattern.
These pipelines seem low risk (mostly operate always do the same thing as they do in PR CI, and/or are not too high impact) and avoid pipelines which have previously been noted to likley have issues with this change.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
