### PR TITLE
Safer typing in translateRequestFields

### DIFF
--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -121,9 +121,7 @@ export class RestLessServer {
 		(request as any)._body = true;
 		const body: string | undefined = bodyField instanceof Array ? bodyField[0] : bodyField;
 		request.body = body;
-		request.headers["content-length"] = body
-			? `${body.length}`
-			: undefined;
+		request.headers["content-length"] = body ? `${body.length}` : undefined;
 	}
 
 	private parseRequestBody(request: IncomingMessageEx): void {

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -119,9 +119,10 @@ export class RestLessServer {
 		const bodyField: RequestField = fields[RestLessFieldNames.Body];
 		// Tell body-parser middleware not to parse the body
 		(request as any)._body = true;
-		request.body = bodyField instanceof Array ? bodyField[0] : bodyField;
-		request.headers["content-length"] = request.body
-			? `${(request.body as string).length}`
+		const body: string | undefined = bodyField instanceof Array ? bodyField[0] : bodyField;
+		request.body = body;
+		request.headers["content-length"] = body
+			? `${body.length}`
 			: undefined;
 	}
 


### PR DESCRIPTION
## Description

Our code scanner has flagged this as a Critical issue for over 3 years. It seems to be a false positive. This change adjusts the code so it can have more robust typing, avoid the need for a cast, and hopefully make it clear to the scanner that this is actuall safe.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
