### PR TITLE
Make FormattedTextAsTree generic, moving special case to FormattedTextAsTreeDefault

### DIFF
--- a/examples/data-objects/text-editor/src/app.tsx
+++ b/examples/data-objects/text-editor/src/app.tsx
@@ -38,7 +38,7 @@ import {
 	type TreeViewAlpha,
 } from "@fluidframework/tree/alpha";
 // eslint-disable-next-line import-x/no-internal-modules
-import { FormattedTextAsTree, TextAsTree } from "@fluidframework/tree/internal";
+import { FormattedTextAsTreeDefault, TextAsTree } from "@fluidframework/tree/internal";
 import type { IFluidContainer } from "fluid-framework";
 // eslint-disable-next-line import-x/no-internal-modules, import-x/no-unassigned-import
 import "quill/dist/quill.snow.css";
@@ -81,7 +81,7 @@ const sf = new SchemaFactory("com.fluidframework.example.text-editor");
 
 export class TextEditorRoot extends sf.object("TextEditorRoot", {
 	plainText: TextAsTree.Tree,
-	formattedText: FormattedTextAsTree.Tree,
+	formattedText: FormattedTextAsTreeDefault.Tree,
 }) {}
 
 export const treeConfig = new TreeViewConfiguration({ schema: TextEditorRoot });
@@ -125,7 +125,7 @@ async function createAndAttachNewContainer(client: AzureClient): Promise<{
 	treeView.initialize(
 		new TextEditorRoot({
 			plainText: TextAsTree.Tree.fromString(""),
-			formattedText: FormattedTextAsTree.Tree.fromString(""),
+			formattedText: FormattedTextAsTreeDefault.Tree.fromString(""),
 		}),
 	);
 

--- a/examples/data-objects/text-editor/src/test/app.test.tsx
+++ b/examples/data-objects/text-editor/src/test/app.test.tsx
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 // eslint-disable-next-line import-x/no-internal-modules
-import { FormattedTextAsTree, type TreeViewAlpha } from "@fluidframework/tree/internal";
+import { FormattedTextAsTreeDefault, type TreeViewAlpha } from "@fluidframework/tree/internal";
 import { render } from "@testing-library/react";
 import { TextAsTree, independentView } from "fluid-framework/alpha";
 
@@ -20,7 +20,7 @@ function createFormattedTreeView(initialValue = ""): TreeViewAlpha<typeof TextEd
 	treeView.initialize(
 		new TextEditorRoot({
 			plainText: TextAsTree.Tree.fromString(initialValue),
-			formattedText: FormattedTextAsTree.Tree.fromString(initialValue),
+			formattedText: FormattedTextAsTreeDefault.Tree.fromString(initialValue),
 		}),
 	);
 	return treeView;

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -406,6 +406,7 @@ export { asAlpha, asBeta } from "./api.js";
 export {
 	TextAsTree,
 	FormattedTextAsTree,
+	FormattedTextAsTreeDefault,
 	codePointCount,
 	utf16LengthForCodePoints,
 } from "./text/index.js";

--- a/packages/dds/tree/src/test/domain-schema-compatibility-snapshots/formattedText/2.111.0.json
+++ b/packages/dds/tree/src/test/domain-schema-compatibility-snapshots/formattedText/2.111.0.json
@@ -32,77 +32,77 @@
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.h1": {
+		"com.fluidframework.text.formatted.default.lineTag.h1": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.h2": {
+		"com.fluidframework.text.formatted.default.lineTag.h2": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.h3": {
+		"com.fluidframework.text.formatted.default.lineTag.h3": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.h4": {
+		"com.fluidframework.text.formatted.default.lineTag.h4": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.h5": {
+		"com.fluidframework.text.formatted.default.lineTag.h5": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.li": {
+		"com.fluidframework.text.formatted.default.lineTag.li": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.ol": {
+		"com.fluidframework.text.formatted.default.lineTag.ol": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.checked": {
+		"com.fluidframework.text.formatted.default.lineTag.checked": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.unchecked": {
+		"com.fluidframework.text.formatted.default.lineTag.unchecked": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.blockquote": {
+		"com.fluidframework.text.formatted.default.lineTag.blockquote": {
 			"object": {
 				"kind": 2,
 				"fields": {},
 				"allowUnknownOptionalFields": false
 			}
 		},
-		"com.fluidframework.text.formatted.lineTag.codeBlock": {
+		"com.fluidframework.text.formatted.default.lineTag.codeBlock": {
 			"object": {
 				"kind": 2,
 				"fields": {},
@@ -115,44 +115,44 @@
 				"leafKind": 0
 			}
 		},
-		"com.fluidframework.text.formatted.StringLineAtom": {
+		"com.fluidframework.text.formatted.default.StringLineAtom": {
 			"object": {
 				"kind": 2,
 				"fields": {
 					"tag": {
 						"kind": 1,
 						"simpleAllowedTypes": {
-							"com.fluidframework.text.formatted.lineTag.h1": {
+							"com.fluidframework.text.formatted.default.lineTag.h1": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.h2": {
+							"com.fluidframework.text.formatted.default.lineTag.h2": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.h3": {
+							"com.fluidframework.text.formatted.default.lineTag.h3": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.h4": {
+							"com.fluidframework.text.formatted.default.lineTag.h4": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.h5": {
+							"com.fluidframework.text.formatted.default.lineTag.h5": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.li": {
+							"com.fluidframework.text.formatted.default.lineTag.li": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.ol": {
+							"com.fluidframework.text.formatted.default.lineTag.ol": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.checked": {
+							"com.fluidframework.text.formatted.default.lineTag.checked": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.unchecked": {
+							"com.fluidframework.text.formatted.default.lineTag.unchecked": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.blockquote": {
+							"com.fluidframework.text.formatted.default.lineTag.blockquote": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.lineTag.codeBlock": {
+							"com.fluidframework.text.formatted.default.lineTag.codeBlock": {
 								"isStaged": false
 							}
 						},
@@ -177,7 +177,7 @@
 				"leafKind": 2
 			}
 		},
-		"com.fluidframework.text.formatted.CharacterFormat": {
+		"com.fluidframework.text.formatted.default.CharacterFormat": {
 			"object": {
 				"kind": 2,
 				"fields": {
@@ -240,7 +240,7 @@
 							"com.fluidframework.text.formatted.StringTextAtom": {
 								"isStaged": false
 							},
-							"com.fluidframework.text.formatted.StringLineAtom": {
+							"com.fluidframework.text.formatted.default.StringLineAtom": {
 								"isStaged": false
 							}
 						},
@@ -249,7 +249,7 @@
 					"format": {
 						"kind": 1,
 						"simpleAllowedTypes": {
-							"com.fluidframework.text.formatted.CharacterFormat": {
+							"com.fluidframework.text.formatted.default.CharacterFormat": {
 								"isStaged": false
 							}
 						},

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -17,15 +17,18 @@ import { FormattedTextAsTree } from "../../text/textDomainFormatted.js";
 import { describeHydration, hydrateNode } from "../simple-tree/index.js";
 import { testSchemaCompatibilitySnapshots } from "../snapshots/index.js";
 import { suitesWithAndWithoutProduction } from "../utils.js";
+import { FormattedTextAsTreeDefault } from "../../text/index.js";
 
 describe("textDomainFormatted", () => {
 	it("compatibility", () => {
-		const currentViewSchema = new TreeViewConfiguration({ schema: FormattedTextAsTree.Tree });
+		const currentViewSchema = new TreeViewConfiguration({
+			schema: FormattedTextAsTreeDefault.Tree,
+		});
 		testSchemaCompatibilitySnapshots(currentViewSchema, "2.111.0", "formattedText");
 	});
 
 	it("basic unformatted use", () => {
-		const text = FormattedTextAsTree.Tree.fromString("hello");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
 		assert.equal(text.fullString(), "hello");
 		assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);
 		text.insertAt(5, " world");
@@ -35,7 +38,7 @@ describe("textDomainFormatted", () => {
 	});
 
 	it("formatting", () => {
-		const text = FormattedTextAsTree.Tree.fromString("hello");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
 		text.formatRange(1, 4, { bold: true });
 		assert.equal(text.fullString(), "hello");
 		assert.deepEqual(
@@ -54,7 +57,7 @@ describe("textDomainFormatted", () => {
 	});
 
 	it("insertWithFormattingAt", () => {
-		const text = FormattedTextAsTree.Tree.fromString("ab");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
 		text.insertWithFormattingAt(1, [
 			{ content: { content: "c" }, format: { ...text.defaultFormat, italic: true } },
 		]);
@@ -73,7 +76,7 @@ describe("textDomainFormatted", () => {
 	});
 
 	it("defaultFormat", () => {
-		const text = FormattedTextAsTree.Tree.fromString("ab");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
 		text.defaultFormat.underline = true;
 		text.insertAt(2, "cd");
 		assert.deepEqual(
@@ -91,7 +94,7 @@ describe("textDomainFormatted", () => {
 	});
 
 	it("getUniformRun", () => {
-		const text = FormattedTextAsTree.Tree.fromString("abc");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 		text.defaultFormat.underline = true;
 		text.insertAt(3, "de");
 		text.defaultFormat.italic = true;
@@ -105,7 +108,7 @@ describe("textDomainFormatted", () => {
 	});
 
 	it("getString with getUniformRun", () => {
-		const text = FormattedTextAsTree.Tree.fromString("abc");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 		text.defaultFormat.underline = true;
 		text.insertAt(3, "de");
 		text.defaultFormat.italic = true;
@@ -122,15 +125,15 @@ describe("textDomainFormatted", () => {
 		assert.equal(text.getUniformRun(0), 3);
 	});
 	it("getString with getUniformRun on line atoms", () => {
-		const text = FormattedTextAsTree.Tree.fromString("abcde");
+		const text = FormattedTextAsTreeDefault.Tree.fromString("abcde");
 
 		text.insertWithFormattingAt(3, [
 			{
-				content: new FormattedTextAsTree.StringLineAtom({
-					tag: FormattedTextAsTree.LineTag("h5"),
+				content: new FormattedTextAsTreeDefault.StringLineAtom({
+					tag: FormattedTextAsTreeDefault.LineTag("h5"),
 					indent: 0,
 				}),
-				format: new FormattedTextAsTree.CharacterFormat({
+				format: new FormattedTextAsTreeDefault.CharacterFormat({
 					bold: false,
 					italic: false,
 					underline: false,
@@ -153,7 +156,7 @@ describe("textDomainFormatted", () => {
 
 	describeHydration("onContentChanged", (_init, hydrated) => {
 		it("fires with insert ops when characters are added", () => {
-			const text = FormattedTextAsTree.Tree.fromString("ab");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -171,7 +174,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("fires for insert at start", () => {
-			const text = FormattedTextAsTree.Tree.fromString("abc");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -186,7 +189,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("fires for insert at end", () => {
-			const text = FormattedTextAsTree.Tree.fromString("abc");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -204,7 +207,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("fires with remove ops when characters are deleted", () => {
-			const text = FormattedTextAsTree.Tree.fromString("abcde");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abcde");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -222,7 +225,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("fires for remove all", () => {
-			const text = FormattedTextAsTree.Tree.fromString("abc");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -237,7 +240,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("fires with insert and remove ops for a replace", () => {
-			const text = FormattedTextAsTree.Tree.fromString("abcde");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abcde");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -261,7 +264,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("fires with formattingChanged on retain when formatting changes", () => {
-			const text = FormattedTextAsTree.Tree.fromString("abcde");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abcde");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -291,7 +294,7 @@ describe("textDomainFormatted", () => {
 		// the unhydrated event path), so we only assert the hydrated behavior here.
 		it("does not fire for an empty insert (hydrated)", () => {
 			if (!hydrated) return;
-			const text = FormattedTextAsTree.Tree.fromString("abc");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 			hydrateNode(text);
 			let callCount = 0;
 			text.onContentChanged(() => {
@@ -303,7 +306,7 @@ describe("textDomainFormatted", () => {
 
 		it("does not fire for an empty remove (hydrated)", () => {
 			if (!hydrated) return;
-			const text = FormattedTextAsTree.Tree.fromString("abc");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
 			hydrateNode(text);
 			let callCount = 0;
 			text.onContentChanged(() => {
@@ -314,7 +317,7 @@ describe("textDomainFormatted", () => {
 		});
 
 		it("cleanup function unsubscribes the callback", () => {
-			const text = FormattedTextAsTree.Tree.fromString("ab");
+			const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
 			if (hydrated) {
 				hydrateNode(text);
 			}
@@ -335,8 +338,8 @@ describe("textDomainFormatted", () => {
 	describeHydration("observation tracking", (init, hydrated) => {
 		// Text has debug asserts which can add observations, so ensure tracking works with and without production build emulation.
 		suitesWithAndWithoutProduction((emulateProduction) => {
-			function setupObservations(): [FormattedTextAsTree.Tree, string[]] {
-				const text = FormattedTextAsTree.Tree.fromString("hello");
+			function setupObservations(): [FormattedTextAsTreeDefault.Tree, string[]] {
+				const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
 				if (hydrated) {
 					hydrateNode(text);
 				}

--- a/packages/dds/tree/src/text/index.ts
+++ b/packages/dds/tree/src/text/index.ts
@@ -5,4 +5,5 @@
 
 export { TextAsTree } from "./textDomain.js";
 export { FormattedTextAsTree } from "./textDomainFormatted.js";
+export { FormattedTextAsTreeDefault } from "./textDomainFormattedDefault.js";
 export { codePointCount, utf16LengthForCodePoints } from "./codePointUtils.js";

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -522,7 +522,7 @@ export namespace FormattedTextAsTree {
 	 */
 	export interface Statics<TTree> {
 		/**
-		 * Construct a a node of `this` schema from a string, where each character (as defined by iterating over the string) becomes a single character in the text node.
+		 * Construct a node of `this` schema from a string, where each character (as defined by iterating over the string) becomes a single character in the text node.
 		 * @remarks This combines pairs of utf-16 surrogate code units into single characters as appropriate.
 		 */
 		fromString(value: string): TTree;
@@ -542,7 +542,7 @@ export namespace FormattedTextAsTree {
 	 * and navigation/selection (which typically uses grapheme clusters).
 	 *
 	 * @see {@link FormattedTextAsTree.Statics.fromString} for construction.
-	 * @see {@link FormattedTextAsTree.createSchema} for creating whose nodes implement this.
+	 * @see {@link FormattedTextAsTree.createSchema} for creating schemas whose nodes implement this.
 	 * @internal
 	 */
 	export interface Members<TFormatTree, TPartialFormat, TFormattedAtom, TFormattedInsert>

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -16,14 +16,12 @@ import {
 import { currentObserver, buildNodeComparator } from "../feature-libraries/index.js";
 import { TreeAlpha, Tree as TreeStatic } from "../shared-tree/index.js";
 import {
-	enumFromStrings,
 	getInnerNode,
 	SchemaFactory,
 	SchemaFactoryAlpha,
 	TreeArrayNode,
 	TreeBeta,
 	createCustomizedFluidFrameworkScopedFactory,
-	SchemaFactoryBeta,
 	isObjectNodeSchema,
 	eraseSchemaDetailsSubclassable,
 } from "../simple-tree/index.js";
@@ -41,6 +39,7 @@ import type {
 	ScopedSchemaName,
 	ErasedSchemaSubclassable,
 	ErasedNode,
+	SchemaFactoryBeta,
 } from "../simple-tree/index.js";
 import { brand, mapIterable, validateIndex, validateIndexRange } from "../util/index.js";
 
@@ -66,417 +65,421 @@ function createFormattedScopedFactory<TUserScope extends string>(
  */
 const sfStatic = new SchemaFactoryAlpha("com.fluidframework.text.formatted");
 
-/**
- * Factory for formatted text schema as a function of the formatting and the embedded object (atom) types.
- *
- * TODO: This will eventually be exposed as the user facing API.
- */
-function createSchema<
-	const TUserScope extends string,
-	const FormatSchema extends ImplicitAllowedTypes,
-	const ExtraAtomsSchema extends readonly LazyItem<
-		TreeNodeSchema<string, NodeKind, FormattedTextAsTree.TextAtom & TreeNode>
-	>[],
->(
-	inputSchemaFactory: SchemaFactoryBeta<TUserScope>,
-	formatSchema: FormatSchema,
-	extraAtoms: ExtraAtomsSchema,
-	defaultFormatInsertable: InsertableTreeFieldFromImplicitField<FormatSchema>,
-): FormattedTextAsTree.FormattedTextSchema<TUserScope, FormatSchema, ExtraAtomsSchema> {
-	const atoms = [FormattedTextAsTree.StringTextAtom, ...extraAtoms] as const;
-
-	const sf = createFormattedScopedFactory(inputSchemaFactory);
-
-	type Members = FormattedTextAsTree.FormattedTextMembers<FormatSchema, ExtraAtomsSchema>;
-
-	class TextNode
-		extends sf.object("Text", {
-			content: SchemaFactory.required([() => StringArray], { key: EmptyKey }),
-		})
-		implements Members
-	{
-		public defaultFormat: TreeFieldFromImplicitField<FormatSchema> =
-			TreeBeta.create<FormatSchema>(formatSchema, defaultFormatInsertable);
-
-		public insertAt(index: number, additionalCharacters: string): void {
-			this.content.insertAt(
-				index,
-				TreeArrayNode.spread(textAtomsFromString(additionalCharacters, this.defaultFormat)),
-			);
-		}
-
-		public removeRange(index: number | undefined, end: number | undefined): void {
-			this.content.removeRange(index, end);
-		}
-
-		public characters(): Iterable<string> {
-			return mapIterable(this.content, (atom) => atom.content.content);
-		}
-
-		public charactersCopy(): string[] {
-			const result = this.content.charactersCopy();
-			debugAssert(
-				() =>
-					compareArrays(result, this.charactersCopy_reference()) ||
-					"invalid charactersCopy optimizations",
-			);
-			return result;
-		}
-
-		public characterCount(): number {
-			return this.content.length;
-		}
-
-		public fullString(): string {
-			const result = this.content.fullString();
-			debugAssert(
-				() => result === this.fullString_reference() || "invalid fullString optimizations",
-			);
-			return result;
-		}
-
-		/**
-		 * A non-optimized reference implementation of fullString.
-		 */
-		public fullString_reference(): string {
-			return [...this.characters()].join("");
-		}
-
-		/**
-		 * Unoptimized trivially correct implementation of charactersCopy.
-		 */
-		public charactersCopy_reference(): string[] {
-			return [...this.characters()];
-		}
-
-		public static fromString(
-			value: string,
-			format?: TreeFieldFromImplicitField<FormatSchema>,
-		): TextNode {
-			// Use `this` rather than `TextNode` so the more derived schema class is constructed when using this as a static on a subclass.
-			return new this({
-				content: [
-					// Constructing an ArrayNode from an iterator is supported, so creating an array from the iterable of characters seems like it's not necessary here,
-					// but to reduce the risk of incorrect data interpretation, we actually ban this in the special case where the iterable is a string directly, which is the case here.
-					// Thus the array construction here is necessary to avoid a runtime error.
-					...textAtomsFromString(
-						value,
-						format ?? TreeBeta.create<FormatSchema>(formatSchema, defaultFormatInsertable),
-					),
-				],
-			});
-		}
-
-		public charactersWithFormatting(): readonly StringAtom[] {
-			return this.content;
-		}
-		public insertWithFormattingAt(
-			index: number,
-			additionalCharacters: Iterable<InsertableTypedNode<typeof StringAtom>>,
-		): void {
-			this.content.insertAt(index, TreeArrayNode.spread(additionalCharacters));
-		}
-
-		public formatRange(
-			start: number | undefined,
-			end: number | undefined,
-			format: Partial<TreeNodeFromImplicitAllowedTypes<FormatSchema>>,
-		): void {
-			const formatStart = start ?? 0;
-			validateIndex(formatStart, this.content, "FormattedTextAsTree.formatRange", true);
-
-			const formatEnd = Math.min(this.content.length, end ?? this.content.length);
-			validateIndexRange(
-				formatStart,
-				formatEnd,
-				this.content,
-				"FormattedTextAsTree.formatRange",
-			);
-
-			const fieldFormats = Object.entries(format) as [
-				keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
-				unknown,
-			][];
-
-			TreeAlpha.context(this).runTransaction(() => {
-				for (let i = formatStart; i < formatEnd; i++) {
-					const atom = this.content[i];
-					// Range validated above, so this should never fail.
-					assert(atom !== undefined, "Index out of bounds while formatting text range.");
-					const formatNode: TreeNode | TreeValue = atom.format;
-					const atomFormatSchema = TreeStatic.schema(formatNode);
-					if (!isObjectNodeSchema(atomFormatSchema)) {
-						// TODO: redesign this API to work with all allowed FormatSchema types.
-						throw new UsageError(
-							"formatRange currently only supports object nodes for the format.",
-						);
-					}
-					for (const [key, value] of fieldFormats) {
-						// Object.entries should only return string keyed enumerable own properties.
-						// The TypeScript typing does not account for this, and thus this assertion is necessary for this code to compile.
-						assert(
-							typeof key === "string",
-							0xcc8 /* Object.entries returned a non-string key. */,
-						);
-
-						const field = atomFormatSchema.fields.get(key);
-						if (field === undefined) {
-							throw new UsageError(`Unknown format key: ${key}`);
-						}
-
-						// Ensures that if the input is a node, it is cloned before being inserted into the tree.
-						const clonedValue = TreeBeta.clone(TreeBeta.create(field, value as never)) as
-							| TreeNode
-							| TreeValue;
-
-						(
-							formatNode as unknown as Record<
-								keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
-								TreeNode | TreeValue
-							>
-						)[key] = clonedValue;
-					}
-				}
-			});
-		}
-
-		/**
-		 * Returns the {@link  FormattedTextAsTree.TextAtom.content} at the given atom index, or `undefined` if out of bounds.
-		 */
-		private getAtomCharacterAt(index: number): string | undefined {
-			const atom = this.content[index];
-			if (atom === undefined) return undefined;
-			return atom.content.content;
-		}
-
-		public onCharactersChanged(
-			callback: (ops: readonly TextAsTree.TextOp[] | undefined) => void,
-		): () => void {
-			return TreeAlpha.on(this.content, "nodeChanged", ({ delta }) =>
-				processCharactersChangedDelta(
-					delta,
-					(index) => this.getAtomCharacterAt(index),
-					callback,
-				),
-			);
-		}
-
-		public onContentChanged(
-			callback: (ops: readonly TextAsTree.TextOp[] | undefined) => void,
-		): () => void {
-			return TreeAlpha.on(this.content, "treeChanged", ({ delta }) =>
-				processCharactersChangedDelta(
-					delta,
-					(index) => this.getAtomCharacterAt(index),
-					callback,
-				),
-			);
-		}
-
-		public getUniformRun(startIndex: number, endIndex?: number): number {
-			return this.content.getUniformRun(startIndex, endIndex);
-		}
-
-		public getString(startIndex: number, endIndex?: number): string {
-			return this.content.getString(startIndex, endIndex);
-		}
-	}
-
-	function textAtomsFromString(
-		value: string,
-		format: TreeFieldFromImplicitField<FormatSchema>,
-	): Iterable<StringAtom> {
-		const result = mapIterable(charactersFromString(value), (char) => {
-			const textAtom = new FormattedTextAsTree.StringTextAtom({ content: char });
-			const data = {
-				content: textAtom,
-				format: TreeBeta.clone<FormatSchema>(format),
-			};
-			return new StringAtom(data as never); // Generic break type safety here. TODO: try and make safer.
-		});
-		return result;
-	}
-
-	class StringArray extends sf.array("StringArray", [() => StringAtom]) {
-		public withBorrowedSequenceCursor<T>(f: (cursor: ITreeCursorSynchronous) => T): T {
-			const innerNode = getInnerNode(this);
-			// Since the cursor will be used to read content from the tree and won't track observations,
-			// treat it as if it observed the whole subtree.
-			currentObserver?.observeNodeDeep(innerNode);
-			const cursor = innerNode.borrowCursor();
-			cursor.enterField(EmptyKey);
-			const result = f(cursor);
-			cursor.exitField();
-			return result;
-		}
-
-		private getCharactersSubarray(startIndex: number, endIndex: number): string[] {
-			return this.withBorrowedSequenceCursor((cursor) => {
-				const result: string[] = [];
-				forEachNodeSubsequence(cursor, startIndex, endIndex, () => {
-					debugAssert(
-						() =>
-							(cursor.type as string) === StringAtom.identifier ||
-							"invalid fullString type optimizations",
-					);
-					cursor.enterField(EmptyKey);
-					cursor.enterNode(0);
-					let content: string;
-					switch (cursor.type) {
-						case FormattedTextAsTree.StringTextAtom.identifier: {
-							cursor.enterField(EmptyKey);
-							cursor.enterNode(0);
-							content = cursor.value as string;
-							debugAssert(
-								() => typeof content === "string" || "invalid fullString type optimizations",
-							);
-							cursor.exitNode();
-							cursor.exitField();
-							break;
-						}
-						case FormattedTextAsTree.StringLineAtom.identifier: {
-							content = "\n";
-							break;
-						}
-						default: {
-							fail(0xcde /* Unsupported node type in text array */, () => `${cursor.type}`);
-						}
-					}
-					cursor.exitNode();
-					cursor.exitField();
-					result.push(content);
-				});
-				return result;
-			});
-		}
-
-		public charactersCopy(): string[] {
-			return this.getCharactersSubarray(0, this.length);
-		}
-
-		public fullString(): string {
-			return this.charactersCopy().join("");
-		}
-
-		public getString(startIndex: number, endIndex: number = this.length): string {
-			validateIndexRange(startIndex, endIndex, this, "FormattedTextAsTree.getString");
-			return this.getCharactersSubarray(startIndex, endIndex).join("");
-		}
-
-		public getUniformRun(startIndex: number, endIndex: number = this.length): number {
-			validateIndexRange(startIndex, endIndex, this, "FormattedTextAsTree.getUniformRun");
-			if (endIndex === startIndex) {
-				throw new UsageError("endIndex must be greater than startIndex for getUniformRun.");
-			}
-			const arrayLength = this.length;
-			return this.withBorrowedSequenceCursor((cursor) => {
-				cursor.enterNode(startIndex);
-
-				// Capture the content type of the first atom
-				cursor.enterField(EmptyKey);
-				cursor.enterNode(0);
-				const contentType = cursor.type;
-				cursor.exitNode();
-				cursor.exitField();
-
-				// Build a comparator from the format subtree of the first atom
-				// This compares by field key
-				cursor.enterField(formatKey);
-				cursor.enterNode(0);
-				const formatComparator = buildNodeComparator(cursor);
-				cursor.exitNode();
-				cursor.exitField();
-
-				let runLength = 1;
-				const limit = Math.min(endIndex, arrayLength) - startIndex;
-
-				while (runLength < limit && cursor.nextNode()) {
-					// Compare atom type
-					cursor.enterField(EmptyKey);
-					cursor.enterNode(0);
-					const typeMatches = cursor.type === contentType;
-					cursor.exitNode();
-					cursor.exitField();
-					if (!typeMatches) {
-						break;
-					}
-
-					// Compare format subtree using the compiled comparator
-					cursor.enterField(formatKey);
-					cursor.enterNode(0);
-					const formatMatches = formatComparator(cursor);
-					cursor.exitNode();
-					cursor.exitField();
-
-					if (formatMatches !== true) {
-						break;
-					}
-
-					runLength++;
-				}
-				cursor.exitNode();
-				return runLength;
-			});
-		}
-	}
-
-	/**
-	 * A unit of the text, with formatting.
-	 */
-	class StringAtom
-		extends sf.object("StringAtom", {
-			content: SchemaFactory.required(atoms, { key: EmptyKey }),
-			format: SchemaFactory.required(formatSchema),
-		})
-		implements
-			FormattedTextAsTree.FormattedAtom<
-				TreeNodeFromImplicitAllowedTypes<FormatSchema>,
-				TreeNodeFromImplicitAllowedTypes<typeof atoms>
-			> {}
-
-	/**
-	 * Schema for a text node.
-	 * @remarks
-	 * See {@link FormattedTextAsTree.Members} for the API.
-	 * See {@link FormattedTextAsTree.Statics} for static APIs on this Schema, including construction.
-	 */
-	const Tree = eraseSchemaDetailsSubclassable<Members, FormattedTextAsTree.Statics<Tree>>()(
-		TextNode,
-	);
-	type Tree = ErasedNode<
-		Members,
-		FormattedTextAsTree.FormattedTextSchemaIdentifier<TUserScope>
-	>;
-
-	return Tree;
-}
-
-const defaultFormat = {
-	bold: false,
-	italic: false,
-	underline: false,
-	size: 12,
-	font: "Arial",
-} as const;
-
 const formatKey: FieldKey = brand("format");
 
 /**
  * A collection of text related types, schema and utilities for working with text beyond the basic {@link SchemaStatics.string}.
+ * @remarks
+ * This is generic over formatting an embedded object/atom types.
+ * See {@link FormattedTextAsTreeDefault} for a default parameterization.
  * @privateRemarks
- * This has hard-coded assumptions about what kind of embedded content and what kind of formatting is supported.
- * We will want to generalize this with a more generic schema factory function like with table.
- * Then either that and/or the output from it can be package exported.
- * This version is just an initial prototype.
+ * TODO:
+ * - Add more comprehensive tests for generic parameterizations other than default.
+ * - Sort out API around overwriting subsets of formatting information.
  * @internal
  */
 export namespace FormattedTextAsTree {
+	/**
+	 * Factory for formatted text schema as a function of the formatting and the embedded object (atom) types.
+	 */
+	export function createSchema<
+		const TUserScope extends string,
+		const FormatSchema extends ImplicitAllowedTypes,
+		const ExtraAtomsSchema extends readonly LazyItem<
+			TreeNodeSchema<string, NodeKind, TextAtom & TreeNode>
+		>[],
+	>(
+		inputSchemaFactory: SchemaFactoryBeta<TUserScope>,
+		formatSchema: FormatSchema,
+		extraAtoms: ExtraAtomsSchema,
+		defaultFormatInsertable: InsertableTreeFieldFromImplicitField<FormatSchema>,
+	): FormattedTextSchema<TUserScope, FormatSchema, ExtraAtomsSchema> {
+		const atoms = [StringTextAtom, ...extraAtoms] as const;
+
+		const sf = createFormattedScopedFactory(inputSchemaFactory);
+		class TextNode
+			extends sf.object("Text", {
+				content: SchemaFactory.required([() => StringArray], { key: EmptyKey }),
+			})
+			implements FormattedTextMembers<FormatSchema, ExtraAtomsSchema>
+		{
+			public defaultFormat: TreeFieldFromImplicitField<FormatSchema> =
+				TreeBeta.create<FormatSchema>(formatSchema, defaultFormatInsertable);
+
+			public insertAt(index: number, additionalCharacters: string): void {
+				this.content.insertAt(
+					index,
+					TreeArrayNode.spread(textAtomsFromString(additionalCharacters, this.defaultFormat)),
+				);
+			}
+
+			public removeRange(index: number | undefined, end: number | undefined): void {
+				this.content.removeRange(index, end);
+			}
+
+			public characters(): Iterable<string> {
+				return mapIterable(this.content, (atom) => atom.content.content);
+			}
+
+			public charactersCopy(): string[] {
+				const result = this.content.charactersCopy();
+				debugAssert(
+					() =>
+						compareArrays(result, this.charactersCopy_reference()) ||
+						"invalid charactersCopy optimizations",
+				);
+				return result;
+			}
+
+			public characterCount(): number {
+				return this.content.length;
+			}
+
+			public fullString(): string {
+				const result = this.content.fullString();
+				debugAssert(
+					() => result === this.fullString_reference() || "invalid fullString optimizations",
+				);
+				return result;
+			}
+
+			/**
+			 * A non-optimized reference implementation of fullString.
+			 */
+			public fullString_reference(): string {
+				return [...this.characters()].join("");
+			}
+
+			/**
+			 * Unoptimized trivially correct implementation of charactersCopy.
+			 */
+			public charactersCopy_reference(): string[] {
+				return [...this.characters()];
+			}
+
+			public static fromString(
+				value: string,
+				format?: TreeFieldFromImplicitField<FormatSchema>,
+			): TextNode {
+				// Use `this` rather than `TextNode` so the more derived schema class is constructed when using this as a static on a subclass.
+				return new this({
+					content: [
+						// Constructing an ArrayNode from an iterator is supported, so creating an array from the iterable of characters seems like it's not necessary here,
+						// but to reduce the risk of incorrect data interpretation, we actually ban this in the special case where the iterable is a string directly, which is the case here.
+						// Thus the array construction here is necessary to avoid a runtime error.
+						...textAtomsFromString(
+							value,
+							format ?? TreeBeta.create<FormatSchema>(formatSchema, defaultFormatInsertable),
+						),
+					],
+				});
+			}
+
+			public charactersWithFormatting(): readonly StringAtom[] {
+				return this.content;
+			}
+			public insertWithFormattingAt(
+				index: number,
+				additionalCharacters: Iterable<InsertableTypedNode<typeof StringAtom>>,
+			): void {
+				this.content.insertAt(index, TreeArrayNode.spread(additionalCharacters));
+			}
+
+			public formatRange(
+				start: number | undefined,
+				end: number | undefined,
+				format: Partial<TreeNodeFromImplicitAllowedTypes<FormatSchema>>,
+			): void {
+				const formatStart = start ?? 0;
+				validateIndex(formatStart, this.content, "FormattedTextAsTree.formatRange", true);
+
+				const formatEnd = Math.min(this.content.length, end ?? this.content.length);
+				validateIndexRange(
+					formatStart,
+					formatEnd,
+					this.content,
+					"FormattedTextAsTree.formatRange",
+				);
+
+				const fieldFormats = Object.entries(format) as [
+					keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
+					unknown,
+				][];
+
+				TreeAlpha.context(this).runTransaction(() => {
+					for (let i = formatStart; i < formatEnd; i++) {
+						const atom = this.content[i];
+						// Range validated above, so this should never fail.
+						assert(atom !== undefined, "Index out of bounds while formatting text range.");
+						const formatNode: TreeNode | TreeValue = atom.format;
+						const atomFormatSchema = TreeStatic.schema(formatNode);
+						if (!isObjectNodeSchema(atomFormatSchema)) {
+							// TODO: redesign this API to work with all allowed FormatSchema types.
+							throw new UsageError(
+								"formatRange currently only supports object nodes for the format.",
+							);
+						}
+						for (const [key, value] of fieldFormats) {
+							// Object.entries should only return string keyed enumerable own properties.
+							// The TypeScript typing does not account for this, and thus this assertion is necessary for this code to compile.
+							assert(
+								typeof key === "string",
+								0xcc8 /* Object.entries returned a non-string key. */,
+							);
+
+							const field = atomFormatSchema.fields.get(key);
+							if (field === undefined) {
+								throw new UsageError(`Unknown format key: ${key}`);
+							}
+
+							// Ensures that if the input is a node, it is cloned before being inserted into the tree.
+							const clonedValue = TreeBeta.clone(TreeBeta.create(field, value as never)) as
+								| TreeNode
+								| TreeValue;
+
+							(
+								formatNode as unknown as Record<
+									keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
+									TreeNode | TreeValue
+								>
+							)[key] = clonedValue;
+						}
+					}
+				});
+			}
+
+			/**
+			 * Returns the {@link  FormattedTextAsTree.TextAtom.content} at the given atom index, or `undefined` if out of bounds.
+			 */
+			private getAtomCharacterAt(index: number): string | undefined {
+				const atom = this.content[index];
+				if (atom === undefined) return undefined;
+				return atom.content.content;
+			}
+
+			public onCharactersChanged(
+				callback: (ops: readonly TextAsTree.TextOp[] | undefined) => void,
+			): () => void {
+				return TreeAlpha.on(this.content, "nodeChanged", ({ delta }) =>
+					processCharactersChangedDelta(
+						delta,
+						(index) => this.getAtomCharacterAt(index),
+						callback,
+					),
+				);
+			}
+
+			public onContentChanged(
+				callback: (ops: readonly TextAsTree.TextOp[] | undefined) => void,
+			): () => void {
+				return TreeAlpha.on(this.content, "treeChanged", ({ delta }) =>
+					processCharactersChangedDelta(
+						delta,
+						(index) => this.getAtomCharacterAt(index),
+						callback,
+					),
+				);
+			}
+
+			public getUniformRun(startIndex: number, endIndex?: number): number {
+				return this.content.getUniformRun(startIndex, endIndex);
+			}
+
+			public getString(startIndex: number, endIndex?: number): string {
+				return this.content.getString(startIndex, endIndex);
+			}
+		}
+
+		function textAtomsFromString(
+			value: string,
+			format: TreeFieldFromImplicitField<FormatSchema>,
+		): Iterable<StringAtom> {
+			const result = mapIterable(charactersFromString(value), (char) => {
+				const textAtom = new StringTextAtom({ content: char });
+				const data = {
+					content: textAtom,
+					format: TreeBeta.clone<FormatSchema>(format),
+				};
+				return new StringAtom(data as never); // Generic break type safety here. TODO: try and make safer.
+			});
+			return result;
+		}
+
+		class StringArray extends sf.array("StringArray", [() => StringAtom]) {
+			public withBorrowedSequenceCursor<T>(f: (cursor: ITreeCursorSynchronous) => T): T {
+				const innerNode = getInnerNode(this);
+				// Since the cursor will be used to read content from the tree and won't track observations,
+				// treat it as if it observed the whole subtree.
+				currentObserver?.observeNodeDeep(innerNode);
+				const cursor = innerNode.borrowCursor();
+				cursor.enterField(EmptyKey);
+				const result = f(cursor);
+				cursor.exitField();
+				return result;
+			}
+
+			private getCharactersSubarray(startIndex: number, endIndex: number): string[] {
+				const slowPathIndexes: number[] = [];
+				const result: string[] = [];
+				this.withBorrowedSequenceCursor((cursor) => {
+					forEachNodeSubsequence(cursor, startIndex, endIndex, () => {
+						debugAssert(
+							() =>
+								(cursor.type as string) === StringAtom.identifier ||
+								"invalid fullString type optimizations",
+						);
+						cursor.enterField(EmptyKey);
+						cursor.enterNode(0);
+						let content: string;
+						switch (cursor.type) {
+							case StringTextAtom.identifier: {
+								cursor.enterField(EmptyKey);
+								cursor.enterNode(0);
+								content = cursor.value as string;
+								debugAssert(
+									() => typeof content === "string" || "invalid fullString type optimizations",
+								);
+								cursor.exitNode();
+								cursor.exitField();
+								break;
+							}
+							// TODO: we could optimize this for constant cases via an optional symbol on the atom schema holding the constant.
+							// A less general optimization could just include cases for build in types with constant values
+							// (like below commented code: currently this would cause a cyclical dependency but could be refactored).
+							// case FormattedTextAsTree.StringLineAtom.identifier: {
+							// 	content = "\n";
+							// 	break;
+							// }
+							default: {
+								slowPathIndexes.push(result.length);
+								content = ""; // Placeholder for slow path content
+							}
+						}
+						cursor.exitNode();
+						cursor.exitField();
+						result.push(content);
+					});
+				});
+
+				// Fill in slow path cases not optimized above.
+				for (const index of slowPathIndexes) {
+					const node =
+						this[index + startIndex] ??
+						fail("getCharactersSubarray failed to find index after index range was checked");
+					result[index] = node.content.content;
+				}
+
+				return result;
+			}
+
+			public charactersCopy(): string[] {
+				return this.getCharactersSubarray(0, this.length);
+			}
+
+			public fullString(): string {
+				return this.charactersCopy().join("");
+			}
+
+			public getString(startIndex: number, endIndex: number = this.length): string {
+				validateIndexRange(startIndex, endIndex, this, "FormattedTextAsTree.getString");
+				return this.getCharactersSubarray(startIndex, endIndex).join("");
+			}
+
+			public getUniformRun(startIndex: number, endIndex: number = this.length): number {
+				validateIndexRange(startIndex, endIndex, this, "FormattedTextAsTree.getUniformRun");
+				if (endIndex === startIndex) {
+					throw new UsageError("endIndex must be greater than startIndex for getUniformRun.");
+				}
+				const arrayLength = this.length;
+				return this.withBorrowedSequenceCursor((cursor) => {
+					cursor.enterNode(startIndex);
+
+					// Capture the content type of the first atom
+					cursor.enterField(EmptyKey);
+					cursor.enterNode(0);
+					const contentType = cursor.type;
+					cursor.exitNode();
+					cursor.exitField();
+
+					// Build a comparator from the format subtree of the first atom
+					// This compares by field key
+					cursor.enterField(formatKey);
+					cursor.enterNode(0);
+					const formatComparator = buildNodeComparator(cursor);
+					cursor.exitNode();
+					cursor.exitField();
+
+					let runLength = 1;
+					const limit = Math.min(endIndex, arrayLength) - startIndex;
+
+					while (runLength < limit && cursor.nextNode()) {
+						// Compare atom type
+						cursor.enterField(EmptyKey);
+						cursor.enterNode(0);
+						const typeMatches = cursor.type === contentType;
+						cursor.exitNode();
+						cursor.exitField();
+						if (!typeMatches) {
+							break;
+						}
+
+						// Compare format subtree using the compiled comparator
+						cursor.enterField(formatKey);
+						cursor.enterNode(0);
+						const formatMatches = formatComparator(cursor);
+						cursor.exitNode();
+						cursor.exitField();
+
+						if (formatMatches !== true) {
+							break;
+						}
+
+						runLength++;
+					}
+					cursor.exitNode();
+					return runLength;
+				});
+			}
+		}
+
+		/**
+		 * A unit of the text, with formatting.
+		 */
+		class StringAtom
+			extends sf.object("StringAtom", {
+				content: SchemaFactory.required(atoms, { key: EmptyKey }),
+				format: SchemaFactory.required(formatSchema),
+			})
+			implements
+				FormattedAtom<
+					TreeNodeFromImplicitAllowedTypes<FormatSchema>,
+					TreeNodeFromImplicitAllowedTypes<typeof atoms>
+				> {}
+
+		/**
+		 * Schema for a text node.
+		 * @remarks
+		 * See {@link FormattedTextAsTree.Members} for the API.
+		 * See {@link FormattedTextAsTree.Statics} for static APIs on this Schema, including construction.
+		 */
+		const Tree = eraseSchemaDetailsSubclassable<
+			FormattedTextMembers<FormatSchema, ExtraAtomsSchema>,
+			Statics<Tree>
+		>()(TextNode);
+		type Tree = ErasedNode<
+			FormattedTextMembers<FormatSchema, ExtraAtomsSchema>,
+			FormattedTextSchemaIdentifier<TUserScope>
+		>;
+
+		return Tree;
+	}
+
 	/**
 	 * Portion of a string with formatting.
 	 * @sealed
 	 * @internal
 	 */
-	export interface FormattedAtom<TFormat = CharacterFormat, TText = StringAtomContent> {
+	export interface FormattedAtom<TFormat, TText> {
 		readonly content: TText;
 		format: TFormat;
 	}
@@ -490,20 +493,6 @@ export namespace FormattedTextAsTree {
 		 * The content of the text atom, viewed as a string.
 		 */
 		readonly content: string;
-	}
-
-	/**
-	 * Formatting options for characters.
-	 * @internal
-	 */
-	export class CharacterFormat extends sfStatic.objectAlpha("CharacterFormat", {
-		bold: SchemaFactory.boolean,
-		italic: SchemaFactory.boolean,
-		underline: SchemaFactory.boolean,
-		size: SchemaFactory.number,
-		font: SchemaFactory.string,
-	}) {
-		public static readonly defaultFormat = new CharacterFormat(defaultFormat);
 	}
 
 	/**
@@ -528,64 +517,12 @@ export namespace FormattedTextAsTree {
 		implements TextAtom {}
 
 	/**
-	 * Tag with which a line in text can be formatted from HTML.
-	 * @internal
-	 */
-	export const LineTag = enumFromStrings(sfStatic.scopedFactory("lineTag"), [
-		"h1",
-		"h2",
-		"h3",
-		"h4",
-		"h5",
-		"li",
-		"ol",
-		"checked",
-		"unchecked",
-		"blockquote",
-		"codeBlock",
-	]);
-	/**
-	 * {@inheritdoc FormattedTextAsTree.(LineTag:variable)}
-	 * @internal
-	 */
-	export type LineTag = TreeNodeFromImplicitAllowedTypes<typeof LineTag.schema>;
-
-	/**
-	 * Unit in the string representing a new line character with line formatting.
-	 * @remarks
-	 * This aligns with how Quill represents line formatting.
-	 * Quill formats line attributes (headers, list, blockquote, etc... ) on the newline character
-	 * and only lines using this atom can have line-specific formatting.
-	 * The optional indent level mirrors Quill's indent attribute,
-	 * which is applies to the line before the line break.
-	 * Any tagged line can be indented independently.
-	 * @internal
-	 */
-	export class StringLineAtom extends sfStatic.object("StringLineAtom", {
-		tag: LineTag.schema,
-		indent: SchemaFactory.number,
-	}) {
-		public readonly content = "\n";
-	}
-
-	/**
-	 * Types of "atoms" that make up the text.
-	 * @internal
-	 */
-	export const StringAtomContent = [StringTextAtom, StringLineAtom] as const;
-	/**
-	 * {@inheritdoc FormattedTextAsTree.(StringAtomContent:variable)}
-	 * @internal
-	 */
-	export type StringAtomContent = TreeNodeFromImplicitAllowedTypes<typeof StringAtomContent>;
-
-	/**
 	 * Statics for text nodes.
 	 * @internal
 	 */
-	export interface Statics<TTree = Tree> {
+	export interface Statics<TTree> {
 		/**
-		 * Construct a {@link FormattedTextAsTree.(Tree:class)} from a string, where each character (as defined by iterating over the string) becomes a single character in the text node.
+		 * Construct a a node of `this` schema from a string, where each character (as defined by iterating over the string) becomes a single character in the text node.
 		 * @remarks This combines pairs of utf-16 surrogate code units into single characters as appropriate.
 		 */
 		fromString(value: string): TTree;
@@ -605,7 +542,7 @@ export namespace FormattedTextAsTree {
 	 * and navigation/selection (which typically uses grapheme clusters).
 	 *
 	 * @see {@link FormattedTextAsTree.Statics.fromString} for construction.
-	 * @see {@link FormattedTextAsTree.(Tree:class)} for schema.
+	 * @see {@link FormattedTextAsTree.createSchema} for creating whose nodes implement this.
 	 * @internal
 	 */
 	export interface Members<TFormatTree, TPartialFormat, TFormattedAtom, TFormattedInsert>
@@ -774,11 +711,4 @@ export namespace FormattedTextAsTree {
 			FormattedTextMembers<FormatSchema, ExtraAtomsSchema>,
 			FormattedTextSchemaIdentifier<TUserScope>
 		>;
-
-	export class Tree extends createSchema(
-		new SchemaFactoryBeta("default"),
-		CharacterFormat,
-		[StringLineAtom],
-		defaultFormat,
-	) {}
 }

--- a/packages/dds/tree/src/text/textDomainFormattedDefault.ts
+++ b/packages/dds/tree/src/text/textDomainFormattedDefault.ts
@@ -33,7 +33,7 @@ const defaultFormat = {
  * A collection of text related types, schema and utilities for working with text beyond the basic {@link SchemaStatics.string}.
  * @remarks
  * This is a default parameterization of the generic {@link FormattedTextAsTree} with hard-coded assumptions about what kind of embedded content and what kind of formatting is supported.
- * It is unlikely this meeds the needs of most users, but it can serve as an unstable example of how to use the generic {@link FormattedTextAsTree}.
+ * It is unlikely this meets the needs of most users, but it can serve as an unstable example of how to use the generic {@link FormattedTextAsTree}.
  * @internal
  */
 export namespace FormattedTextAsTreeDefault {

--- a/packages/dds/tree/src/text/textDomainFormattedDefault.ts
+++ b/packages/dds/tree/src/text/textDomainFormattedDefault.ts
@@ -1,0 +1,150 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	enumFromStrings,
+	SchemaFactory,
+	SchemaFactoryAlpha,
+	SchemaFactoryBeta,
+} from "../simple-tree/index.js";
+import type {
+	TreeNodeFromImplicitAllowedTypes,
+	InsertableTreeNodeFromImplicitAllowedTypes,
+} from "../simple-tree/index.js";
+
+import { FormattedTextAsTree } from "./textDomainFormatted.js";
+
+/**
+ * Schema factory for default formatted text types which are not generic.
+ */
+const sf = new SchemaFactoryAlpha("com.fluidframework.text.formatted.default");
+
+const defaultFormat = {
+	bold: false,
+	italic: false,
+	underline: false,
+	size: 12,
+	font: "Arial",
+} as const;
+
+/**
+ * A collection of text related types, schema and utilities for working with text beyond the basic {@link SchemaStatics.string}.
+ * @remarks
+ * This is a default parameterization of the generic {@link FormattedTextAsTree} with hard-coded assumptions about what kind of embedded content and what kind of formatting is supported.
+ * It is unlikely this meeds the needs of most users, but it can serve as an unstable example of how to use the generic {@link FormattedTextAsTree}.
+ * @internal
+ */
+export namespace FormattedTextAsTreeDefault {
+	/**
+	 * Portion of a string with formatting.
+	 * @sealed
+	 * @internal
+	 */
+	export type FormattedAtom = FormattedTextAsTree.FormattedAtom<
+		CharacterFormat,
+		StringAtomContent
+	>;
+
+	/**
+	 * Formatting options for characters.
+	 * @internal
+	 */
+	export class CharacterFormat extends sf.objectAlpha("CharacterFormat", {
+		bold: SchemaFactory.boolean,
+		italic: SchemaFactory.boolean,
+		underline: SchemaFactory.boolean,
+		size: SchemaFactory.number,
+		font: SchemaFactory.string,
+	}) {
+		public static readonly defaultFormat = new CharacterFormat(defaultFormat);
+	}
+
+	/**
+	 * Tag with which a line in text can be formatted from HTML.
+	 * @internal
+	 */
+	export const LineTag = enumFromStrings(sf.scopedFactory("lineTag"), [
+		"h1",
+		"h2",
+		"h3",
+		"h4",
+		"h5",
+		"li",
+		"ol",
+		"checked",
+		"unchecked",
+		"blockquote",
+		"codeBlock",
+	]);
+	/**
+	 * {@inheritdoc FormattedTextAsTreeDefault.(LineTag:variable)}
+	 * @internal
+	 */
+	export type LineTag = TreeNodeFromImplicitAllowedTypes<typeof LineTag.schema>;
+
+	/**
+	 * Unit in the string representing a new line character with line formatting.
+	 * @remarks
+	 * This aligns with how Quill represents line formatting.
+	 * Quill formats line attributes (headers, list, blockquote, etc... ) on the newline character
+	 * and only lines using this atom can have line-specific formatting.
+	 * The optional indent level mirrors Quill's indent attribute,
+	 * which is applies to the line before the line break.
+	 * Any tagged line can be indented independently.
+	 * @internal
+	 */
+	export class StringLineAtom extends sf.object("StringLineAtom", {
+		tag: LineTag.schema,
+		indent: SchemaFactory.number,
+	}) {
+		public readonly content = "\n";
+	}
+
+	/**
+	 * Types of "atoms" that make up the text.
+	 * @internal
+	 */
+	export const StringAtomContent = [
+		FormattedTextAsTree.StringTextAtom,
+		StringLineAtom,
+	] as const;
+	/**
+	 * {@inheritdoc FormattedTextAsTreeDefault.(StringAtomContent:variable)}
+	 * @internal
+	 */
+	export type StringAtomContent = TreeNodeFromImplicitAllowedTypes<typeof StringAtomContent>;
+
+	/**
+	 * Statics for text nodes.
+	 * @internal
+	 */
+	export type Statics<TTree = Tree> = FormattedTextAsTree.Statics<TTree>;
+
+	/**
+	 * Insertable shape for a formatted text atom used by {@link FormattedTextAsTree.Members.insertWithFormattingAt}.
+	 * @internal
+	 */
+	export type FormattedAtomInsertable = FormattedTextAsTree.FormattedAtom<
+		InsertableTreeNodeFromImplicitAllowedTypes<typeof CharacterFormat>,
+		InsertableTreeNodeFromImplicitAllowedTypes<FormattedTextAtoms>
+	>;
+
+	/**
+	 * Helper for expressing the full set of formatted text atoms for a given schema.
+	 * @privateRemarks
+	 * Eventually this should probably be given a better name and/or made a system type in a system namespace.
+	 * @internal
+	 */
+	export type FormattedTextAtoms = FormattedTextAsTree.FormattedTextAtoms<
+		[typeof StringLineAtom]
+	>;
+
+	export class Tree extends FormattedTextAsTree.createSchema(
+		new SchemaFactoryBeta("default"),
+		CharacterFormat,
+		[StringLineAtom],
+		defaultFormat,
+	) {}
+}

--- a/packages/framework/quill-react/src/formatted/quillAttributeUtils.ts
+++ b/packages/framework/quill-react/src/formatted/quillAttributeUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { FormattedTextAsTree } from "@fluidframework/tree/internal";
+import { FormattedTextAsTreeDefault } from "@fluidframework/tree/internal";
 import DeltaPackage from "quill-delta";
 
 // Workaround for quill-delta's export style not working well with node16 module resolution.
@@ -30,7 +30,7 @@ export const defaultFont = "Arial";
 const defaultHeading = "h5";
 
 /** The string literal values accepted by LineTag. */
-type LineTagValue = Parameters<typeof FormattedTextAsTree.LineTag>[0];
+type LineTagValue = Parameters<typeof FormattedTextAsTreeDefault.LineTag>[0];
 
 /** Quill header numbers → LineTag values. */
 const headerToLineTag = {
@@ -170,7 +170,7 @@ export function parseSize(size: unknown): number {
  */
 export function parseLineTag(
 	attributes?: Record<string, unknown>,
-): FormattedTextAsTree.LineTag | undefined {
+): FormattedTextAsTreeDefault.LineTag | undefined {
 	if (!attributes) return undefined;
 	// Quill should never send both header and list attributes simultaneously.
 	assert(
@@ -188,19 +188,19 @@ export function parseLineTag(
 	if (typeof attributes.header === "number") {
 		const tag: LineTagValue =
 			headerToLineTag[attributes.header as keyof typeof headerToLineTag] ?? defaultHeading;
-		return FormattedTextAsTree.LineTag(tag);
+		return FormattedTextAsTreeDefault.LineTag(tag);
 	}
 	if (typeof attributes.list === "string") {
 		const tag = listToLineTag[attributes.list as keyof typeof listToLineTag];
 		if (tag !== undefined) {
-			return FormattedTextAsTree.LineTag(tag);
+			return FormattedTextAsTreeDefault.LineTag(tag);
 		}
 	}
 	if (attributes.blockquote === true) {
-		return FormattedTextAsTree.LineTag("blockquote");
+		return FormattedTextAsTreeDefault.LineTag("blockquote");
 	}
 	if (typeof attributes["code-block"] === "string") {
-		return FormattedTextAsTree.LineTag("codeBlock");
+		return FormattedTextAsTreeDefault.LineTag("codeBlock");
 	}
 	return undefined;
 }
@@ -236,9 +236,9 @@ export function quillAttributesToFormat(attributes?: Record<string, unknown>): {
  */
 export function quillAttributesToPartial(
 	attributes?: Record<string, unknown>,
-): Partial<FormattedTextAsTree.CharacterFormat> {
+): Partial<FormattedTextAsTreeDefault.CharacterFormat> {
 	if (!attributes) return {};
-	const format: Partial<FormattedTextAsTree.CharacterFormat> = {};
+	const format: Partial<FormattedTextAsTreeDefault.CharacterFormat> = {};
 	// Only include attributes that are explicitly present in the Quill delta
 	if ("bold" in attributes) format.bold = attributes.bold === true;
 	if ("italic" in attributes) format.italic = attributes.italic === true;
@@ -265,7 +265,7 @@ export function sizeToQuillAttribute(size: number): string {
  * Only includes non-default values to keep deltas minimal.
  */
 export function formatToQuillAttributes(
-	format: FormattedTextAsTree.CharacterFormat,
+	format: FormattedTextAsTreeDefault.CharacterFormat,
 ): QuillAttributeMap {
 	const attributes: QuillAttributeMap = {};
 	// Only include non-default formatting to keep Quill deltas minimal
@@ -287,7 +287,7 @@ export function formatToQuillAttributes(
  * to retained (already-present) content via `updateContents`.
  */
 export function formatToFullQuillAttributes(
-	format: FormattedTextAsTree.CharacterFormat,
+	format: FormattedTextAsTreeDefault.CharacterFormat,
 ): QuillAttributeMap {
 	// Quill uses `null` (not `undefined`) to clear attributes, so we must use null
 	// for default-valued properties rather than omitting them.

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -13,6 +13,7 @@ import {
 import {
 	codePointCount,
 	FormattedTextAsTree,
+	FormattedTextAsTreeDefault,
 	type TextAsTree,
 	TreeAlpha,
 	utf16LengthForCodePoints,
@@ -61,7 +62,7 @@ const Delta = DeltaPackage.default;
  */
 export interface FormattedMainViewProps extends TextEditorProps {
 	/** The formatted text tree to edit. */
-	readonly root: PropTreeNode<FormattedTextAsTree.Tree>;
+	readonly root: PropTreeNode<FormattedTextAsTreeDefault.Tree>;
 }
 
 /**
@@ -92,18 +93,15 @@ FormattedMainView.displayName = "FormattedMainView";
 
 /** Create a StringAtom containing a StringLineAtom with the given line tag. */
 function createLineAtom(
-	lineTag: FormattedTextAsTree.LineTag,
+	lineTag: FormattedTextAsTreeDefault.LineTag,
 	indent: number = 0,
-): FormattedTextAsTree.FormattedAtomInsertable<
-	FormattedTextAsTree.CharacterFormat,
-	FormattedTextAsTree.StringLineAtom
-> {
+): FormattedTextAsTreeDefault.FormattedAtomInsertable {
 	return {
-		content: new FormattedTextAsTree.StringLineAtom({
+		content: new FormattedTextAsTreeDefault.StringLineAtom({
 			tag: lineTag,
 			indent,
 		}),
-		format: new FormattedTextAsTree.CharacterFormat(quillAttributesToFormat()),
+		format: new FormattedTextAsTreeDefault.CharacterFormat(quillAttributesToFormat()),
 	};
 }
 
@@ -129,7 +127,7 @@ function createLineAtom(
  * The caller should fall back to a full diff in that case.
  */
 function contentOpsToQuillDelta(
-	root: FormattedTextAsTree.Tree,
+	root: FormattedTextAsTreeDefault.Tree,
 	ops: readonly TextAsTree.TextOp[],
 	preEditContent: string,
 ): QuillDeltaOp[] | undefined {
@@ -165,7 +163,7 @@ function contentOpsToQuillDelta(
 					return undefined;
 				}
 
-				if (atom.content instanceof FormattedTextAsTree.StringLineAtom) {
+				if (atom.content instanceof FormattedTextAsTreeDefault.StringLineAtom) {
 					// Line atom is always "\n" — 1 UTF-16 unit.
 					const attributes: Record<string, unknown> = formatToFullQuillAttributes(atom.format);
 					const lineTag = atom.content.tag.value;
@@ -198,7 +196,7 @@ function contentOpsToQuillDelta(
 					return undefined;
 				}
 
-				if (atom.content instanceof FormattedTextAsTree.StringLineAtom) {
+				if (atom.content instanceof FormattedTextAsTreeDefault.StringLineAtom) {
 					// Line atom: insert newline with line tag attributes.
 					const attributes: Record<string, unknown> = {};
 					const lineTag = atom.content.tag.value;
@@ -258,7 +256,7 @@ function contentOpsToQuillDelta(
  * @internal
  */
 export function applyQuillDeltaToTree(
-	root: FormattedTextAsTree.Tree,
+	root: FormattedTextAsTreeDefault.Tree,
 	delta: Delta,
 	label?: unknown,
 ): void {
@@ -309,7 +307,7 @@ export function applyQuillDeltaToTree(
 					) {
 						// Indent only change on an existing line atom
 						const lineAtom = root.charactersWithFormatting()[cpPos]?.content;
-						if (lineAtom instanceof FormattedTextAsTree.StringLineAtom) {
+						if (lineAtom instanceof FormattedTextAsTreeDefault.StringLineAtom) {
 							lineAtom.indent = indent ?? 0;
 						}
 						// Case 4: clearing line formatting. Deletes StringLineAtom and inserts a plain
@@ -318,7 +316,7 @@ export function applyQuillDeltaToTree(
 						lineTag === undefined &&
 						content[utf16Pos] === "\n" &&
 						root.charactersWithFormatting()[cpPos]?.content instanceof
-							FormattedTextAsTree.StringLineAtom
+							FormattedTextAsTreeDefault.StringLineAtom
 					) {
 						// Quill is clearing line formatting (e.g. { retain: 1, attributes: { header: null } }).
 						// StringLineAtom and StringTextAtom are distinct schema types in the tree,
@@ -350,7 +348,7 @@ export function applyQuillDeltaToTree(
 					root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag, indent)]);
 				} else {
 					// Insert: add new text with formatting at current position
-					root.defaultFormat = new FormattedTextAsTree.CharacterFormat(
+					root.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat(
 						quillAttributesToFormat(op.attributes),
 					);
 					root.insertAt(cpPos, op.insert);
@@ -386,7 +384,7 @@ export function applyQuillDeltaToTree(
  * This is used to sync Quill's display when the tree changes externally
  * (e.g., from a remote collaborator's edit).
  */
-export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp[] {
+export function buildDeltaFromTree(root: FormattedTextAsTreeDefault.Tree): QuillDeltaOp[] {
 	const ops: QuillDeltaOp[] = [];
 	let index = 0;
 
@@ -395,7 +393,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 		if (atom === undefined) {
 			break;
 		}
-		if (atom.content instanceof FormattedTextAsTree.StringLineAtom) {
+		if (atom.content instanceof FormattedTextAsTreeDefault.StringLineAtom) {
 			// Line atom (header, bullet lists) emit a newline with a line tag attribute
 			const currentAttributes = formatToQuillAttributes(atom.format);
 			const lineTag = atom.content.tag.value;
@@ -449,7 +447,7 @@ export function buildDeltaFromTree(root: FormattedTextAsTree.Tree): QuillDeltaOp
 const FormattedTextEditorView = forwardRef<
 	FormattedEditorHandle,
 	{
-		root: PropTreeNode<FormattedTextAsTree.Tree>;
+		root: PropTreeNode<FormattedTextAsTreeDefault.Tree>;
 		undoRedo?: UndoRedo;
 		editLabel?: unknown;
 	}

--- a/packages/framework/quill-react/src/test/applyQuillDeltaToTree.test.ts
+++ b/packages/framework/quill-react/src/test/applyQuillDeltaToTree.test.ts
@@ -6,7 +6,11 @@
 import { strict as assert } from "node:assert";
 
 import { TreeViewConfiguration } from "@fluidframework/tree";
-import { independentView, FormattedTextAsTree } from "@fluidframework/tree/internal";
+import {
+	independentView,
+	FormattedTextAsTreeDefault,
+	FormattedTextAsTree,
+} from "@fluidframework/tree/internal";
 import DeltaPackage from "quill-delta";
 
 import {
@@ -18,15 +22,15 @@ const Delta = DeltaPackage.default;
 type Delta = DeltaPackage.default;
 
 /**
- * Build a fresh, independent (unhydrated) `FormattedTextAsTree.Tree` initialized from `initial`.
+ * Build a fresh, independent (unhydrated) `FormattedTextAsTreeDefault.Tree` initialized from `initial`.
  * Independent views give us an isolated tree per test without pulling in container/runtime fixtures.
  */
-function makeTree(initial: string = ""): FormattedTextAsTree.Tree {
+function makeTree(initial: string = ""): FormattedTextAsTreeDefault.Tree {
 	const view = independentView(
-		new TreeViewConfiguration({ schema: FormattedTextAsTree.Tree }),
+		new TreeViewConfiguration({ schema: FormattedTextAsTreeDefault.Tree }),
 		{},
 	);
-	view.initialize(FormattedTextAsTree.Tree.fromString(initial));
+	view.initialize(FormattedTextAsTreeDefault.Tree.fromString(initial));
 	return view.root;
 }
 
@@ -34,7 +38,7 @@ function makeTree(initial: string = ""): FormattedTextAsTree.Tree {
  * Build a tree containing a single `StringLineAtom` with the given line tag,
  * mirroring what `Quill` would emit when the user applies a header/list to an empty document.
  */
-function lineAtomTree(tag: "h1" | "h2" | "h3" | "h4" | "h5"): FormattedTextAsTree.Tree {
+function lineAtomTree(tag: "h1" | "h2" | "h3" | "h4" | "h5"): FormattedTextAsTreeDefault.Tree {
 	const tree = makeTree("");
 	applyQuillDeltaToTree(tree, new Delta().insert("\n", { header: Number(tag.slice(1)) }));
 	return tree;
@@ -104,7 +108,7 @@ describe("applyQuillDeltaToTree", () => {
 		applyQuillDeltaToTree(tree, new Delta().insert("\n", { header: 1 }));
 		assert.equal(tree.fullString(), "\n");
 		const atom = tree.charactersWithFormatting()[0]?.content;
-		assert(atom instanceof FormattedTextAsTree.StringLineAtom);
+		assert(atom instanceof FormattedTextAsTreeDefault.StringLineAtom);
 		assert.equal(atom.tag.value, "h1");
 	});
 
@@ -114,7 +118,7 @@ describe("applyQuillDeltaToTree", () => {
 		applyQuillDeltaToTree(tree, new Delta().retain(5).retain(1, { header: 2 }));
 		assert.equal(tree.fullString(), "hello\n");
 		const atom = tree.charactersWithFormatting()[5]?.content;
-		assert(atom instanceof FormattedTextAsTree.StringLineAtom);
+		assert(atom instanceof FormattedTextAsTreeDefault.StringLineAtom);
 		assert.equal(atom.tag.value, "h2");
 	});
 
@@ -124,7 +128,7 @@ describe("applyQuillDeltaToTree", () => {
 		applyQuillDeltaToTree(tree, new Delta().retain(5).retain(1, { header: 3 }));
 		assert.equal(tree.fullString(), "hello\n");
 		const atom = tree.charactersWithFormatting()[5]?.content;
-		assert(atom instanceof FormattedTextAsTree.StringLineAtom);
+		assert(atom instanceof FormattedTextAsTreeDefault.StringLineAtom);
 		assert.equal(atom.tag.value, "h3");
 	});
 
@@ -142,7 +146,7 @@ describe("applyQuillDeltaToTree", () => {
 		const tree = lineAtomTree("h1");
 		applyQuillDeltaToTree(tree, new Delta().retain(1, { indent: 2 }));
 		const atom = tree.charactersWithFormatting()[0]?.content;
-		assert(atom instanceof FormattedTextAsTree.StringLineAtom);
+		assert(atom instanceof FormattedTextAsTreeDefault.StringLineAtom);
 		assert.equal(atom.indent, 2);
 	});
 

--- a/packages/framework/quill-react/src/test/cleanup.test.tsx
+++ b/packages/framework/quill-react/src/test/cleanup.test.tsx
@@ -8,7 +8,7 @@ import { strict as assert } from "node:assert";
 import { toPropTreeNode } from "@fluidframework/react/internal";
 import { TreeViewConfiguration } from "@fluidframework/tree";
 import { independentView } from "@fluidframework/tree/alpha";
-import { FormattedTextAsTree, TextAsTree } from "@fluidframework/tree/internal";
+import { FormattedTextAsTreeDefault, TextAsTree } from "@fluidframework/tree/internal";
 import { cleanup as rtlCleanup, render } from "@testing-library/react";
 import globalJsdom from "global-jsdom";
 import Quill from "quill";
@@ -25,11 +25,11 @@ function createPlainRoot(text = ""): ReturnType<typeof toPropTreeNode<TextAsTree
 
 function createFormattedRoot(
 	text = "",
-): ReturnType<typeof toPropTreeNode<FormattedTextAsTree.Tree>> {
+): ReturnType<typeof toPropTreeNode<FormattedTextAsTreeDefault.Tree>> {
 	const view = independentView(
-		new TreeViewConfiguration({ schema: FormattedTextAsTree.Tree }),
+		new TreeViewConfiguration({ schema: FormattedTextAsTreeDefault.Tree }),
 	);
-	view.initialize(FormattedTextAsTree.Tree.fromString(text));
+	view.initialize(FormattedTextAsTreeDefault.Tree.fromString(text));
 	return toPropTreeNode(view.root);
 }
 

--- a/packages/framework/quill-react/src/test/quillAttributeUtils.test.ts
+++ b/packages/framework/quill-react/src/test/quillAttributeUtils.test.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { TreeViewConfiguration } from "@fluidframework/tree";
-import { independentView, FormattedTextAsTree } from "@fluidframework/tree/internal";
+import { independentView, FormattedTextAsTreeDefault } from "@fluidframework/tree/internal";
 import globalJsdom from "global-jsdom";
 import DeltaPackage from "quill-delta";
 
@@ -41,13 +41,13 @@ function makeFormat(
 		size: number;
 		font: string;
 	}> = {},
-): FormattedTextAsTree.CharacterFormat {
+): FormattedTextAsTreeDefault.CharacterFormat {
 	const tree = independentView(
-		new TreeViewConfiguration({ schema: FormattedTextAsTree.Tree }),
+		new TreeViewConfiguration({ schema: FormattedTextAsTreeDefault.Tree }),
 		{},
 	);
-	tree.initialize(FormattedTextAsTree.Tree.fromString(""));
-	return new FormattedTextAsTree.CharacterFormat({
+	tree.initialize(FormattedTextAsTreeDefault.Tree.fromString(""));
+	return new FormattedTextAsTreeDefault.CharacterFormat({
 		bold: props.bold ?? false,
 		italic: props.italic ?? false,
 		underline: props.underline ?? false,
@@ -126,24 +126,30 @@ describe("quillAttributeUtils", () => {
 		});
 
 		it("maps Quill header levels to LineTag values", () => {
-			assert.deepEqual(parseLineTag({ header: 1 }), FormattedTextAsTree.LineTag("h1"));
-			assert.deepEqual(parseLineTag({ header: 5 }), FormattedTextAsTree.LineTag("h5"));
+			assert.deepEqual(parseLineTag({ header: 1 }), FormattedTextAsTreeDefault.LineTag("h1"));
+			assert.deepEqual(parseLineTag({ header: 5 }), FormattedTextAsTreeDefault.LineTag("h5"));
 		});
 
 		it("falls back to h5 for unsupported header levels", () => {
-			assert.deepEqual(parseLineTag({ header: 99 }), FormattedTextAsTree.LineTag("h5"));
+			assert.deepEqual(parseLineTag({ header: 99 }), FormattedTextAsTreeDefault.LineTag("h5"));
 		});
 
 		it("maps Quill list types to LineTag values", () => {
-			assert.deepEqual(parseLineTag({ list: "bullet" }), FormattedTextAsTree.LineTag("li"));
-			assert.deepEqual(parseLineTag({ list: "ordered" }), FormattedTextAsTree.LineTag("ol"));
+			assert.deepEqual(
+				parseLineTag({ list: "bullet" }),
+				FormattedTextAsTreeDefault.LineTag("li"),
+			);
+			assert.deepEqual(
+				parseLineTag({ list: "ordered" }),
+				FormattedTextAsTreeDefault.LineTag("ol"),
+			);
 			assert.deepEqual(
 				parseLineTag({ list: "checked" }),
-				FormattedTextAsTree.LineTag("checked"),
+				FormattedTextAsTreeDefault.LineTag("checked"),
 			);
 			assert.deepEqual(
 				parseLineTag({ list: "unchecked" }),
-				FormattedTextAsTree.LineTag("unchecked"),
+				FormattedTextAsTreeDefault.LineTag("unchecked"),
 			);
 		});
 
@@ -154,11 +160,11 @@ describe("quillAttributeUtils", () => {
 		it("maps blockquote and code-block", () => {
 			assert.deepEqual(
 				parseLineTag({ blockquote: true }),
-				FormattedTextAsTree.LineTag("blockquote"),
+				FormattedTextAsTreeDefault.LineTag("blockquote"),
 			);
 			assert.deepEqual(
 				parseLineTag({ "code-block": "plain" }),
-				FormattedTextAsTree.LineTag("codeBlock"),
+				FormattedTextAsTreeDefault.LineTag("codeBlock"),
 			);
 		});
 

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -8,14 +8,17 @@ import { strict as assert } from "node:assert";
 import { toPropTreeNode, createUndoRedo, type UndoRedo } from "@fluidframework/react/internal";
 import { TreeViewConfiguration } from "@fluidframework/tree";
 import { TreeAlpha, type TreeViewAlpha } from "@fluidframework/tree/alpha";
-import { independentView, TextAsTree } from "@fluidframework/tree/internal";
+import {
+	FormattedTextAsTreeDefault,
+	independentView,
+	TextAsTree,
+} from "@fluidframework/tree/internal";
 import { render } from "@testing-library/react";
 import globalJsdom from "global-jsdom";
 import DeltaPackage from "quill-delta";
 
 import {
 	clipboardFormatMatcher,
-	FormattedTextAsTree,
 	FormattedMainView,
 	parseCssFontFamily,
 	parseCssFontSize,
@@ -34,16 +37,18 @@ type Delta = DeltaPackage.default;
 const Delta = DeltaPackage.default;
 
 // Configuration for creating formatted text views
-const formattedTreeConfig = new TreeViewConfiguration({ schema: FormattedTextAsTree.Tree });
+const formattedTreeConfig = new TreeViewConfiguration({
+	schema: FormattedTextAsTreeDefault.Tree,
+});
 
 /**
  * Creates a TreeView for formatted text, initialized with the provided initial value.
  */
 function createFormattedTreeView(initialValue = ""): {
-	tree: FormattedTextAsTree.Tree;
+	tree: FormattedTextAsTreeDefault.Tree;
 } {
 	const treeView = independentView(formattedTreeConfig);
-	treeView.initialize(FormattedTextAsTree.Tree.fromString(initialValue));
+	treeView.initialize(FormattedTextAsTreeDefault.Tree.fromString(initialValue));
 	return { tree: treeView.root };
 }
 
@@ -52,9 +57,9 @@ function createFormattedTreeView(initialValue = ""): {
  */
 function createFormattedTreeViewWithEvents(
 	initialValue = "",
-): TreeViewAlpha<typeof FormattedTextAsTree.Tree> {
+): TreeViewAlpha<typeof FormattedTextAsTreeDefault.Tree> {
 	const treeView = independentView(formattedTreeConfig);
-	treeView.initialize(FormattedTextAsTree.Tree.fromString(initialValue));
+	treeView.initialize(FormattedTextAsTreeDefault.Tree.fromString(initialValue));
 	return treeView;
 }
 
@@ -379,8 +384,8 @@ describe("textEditor", () => {
 		});
 
 		// Helper to create default format
-		function createPlainFormat(): FormattedTextAsTree.CharacterFormat {
-			return new FormattedTextAsTree.CharacterFormat({
+		function createPlainFormat(): FormattedTextAsTreeDefault.CharacterFormat {
+			return new FormattedTextAsTreeDefault.CharacterFormat({
 				bold: false,
 				italic: false,
 				underline: false,
@@ -413,7 +418,7 @@ describe("textEditor", () => {
 
 							assert.ok(!rendered.container.querySelector("strong"), "Initially: no <strong>");
 
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: true,
 								italic: false,
 								underline: false,
@@ -430,7 +435,7 @@ describe("textEditor", () => {
 
 						it("deletes bold text and removes <strong> tag", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: true,
 								italic: false,
 								underline: false,
@@ -477,7 +482,7 @@ describe("textEditor", () => {
 
 							assert.ok(!rendered.container.querySelector("em"), "Initially: no <em>");
 
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: true,
 								underline: false,
@@ -494,7 +499,7 @@ describe("textEditor", () => {
 
 						it("deletes italic text and removes <em> tag", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: true,
 								underline: false,
@@ -538,7 +543,7 @@ describe("textEditor", () => {
 
 							assert.ok(!rendered.container.querySelector("u"), "Initially: no <u>");
 
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: false,
 								underline: true,
@@ -555,7 +560,7 @@ describe("textEditor", () => {
 
 						it("deletes underlined text and removes <u> tag", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: false,
 								underline: true,
@@ -602,7 +607,7 @@ describe("textEditor", () => {
 								"Initially: no .ql-size-huge",
 							);
 
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: false,
 								underline: false,
@@ -619,7 +624,7 @@ describe("textEditor", () => {
 
 						it("deletes huge size text and removes .ql-size-huge", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: false,
 								underline: false,
@@ -672,7 +677,7 @@ describe("textEditor", () => {
 								"Initially: no .ql-font-monospace",
 							);
 
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: false,
 								underline: false,
@@ -689,7 +694,7 @@ describe("textEditor", () => {
 
 						it("deletes monospace font text and removes .ql-font-monospace", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTree.CharacterFormat({
+							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
 								bold: false,
 								italic: false,
 								underline: false,
@@ -1013,8 +1018,8 @@ describe("textEditor", () => {
 				tree.removeRange(5, 6);
 				tree.insertWithFormattingAt(5, [
 					{
-						content: new FormattedTextAsTree.StringLineAtom({
-							tag: FormattedTextAsTree.LineTag("h1"),
+						content: new FormattedTextAsTreeDefault.StringLineAtom({
+							tag: FormattedTextAsTreeDefault.LineTag("h1"),
 							indent: 0,
 						}),
 						format: createPlainFormat(),
@@ -1030,8 +1035,8 @@ describe("textEditor", () => {
 				tree.removeRange(4, 5);
 				tree.insertWithFormattingAt(4, [
 					{
-						content: new FormattedTextAsTree.StringLineAtom({
-							tag: FormattedTextAsTree.LineTag("li"),
+						content: new FormattedTextAsTreeDefault.StringLineAtom({
+							tag: FormattedTextAsTreeDefault.LineTag("li"),
 							indent: 0,
 						}),
 						format: createPlainFormat(),
@@ -1051,8 +1056,8 @@ describe("textEditor", () => {
 				const { tree } = createFormattedTreeView("abc");
 				tree.insertWithFormattingAt(3, [
 					{
-						content: new FormattedTextAsTree.StringLineAtom({
-							tag: FormattedTextAsTree.LineTag("ol"),
+						content: new FormattedTextAsTreeDefault.StringLineAtom({
+							tag: FormattedTextAsTreeDefault.LineTag("ol"),
 							indent: 2,
 						}),
 						format: createPlainFormat(),
@@ -1070,8 +1075,8 @@ describe("textEditor", () => {
 				const { tree } = createFormattedTreeView("abc");
 				tree.insertWithFormattingAt(3, [
 					{
-						content: new FormattedTextAsTree.StringLineAtom({
-							tag: FormattedTextAsTree.LineTag("ol"),
+						content: new FormattedTextAsTreeDefault.StringLineAtom({
+							tag: FormattedTextAsTreeDefault.LineTag("ol"),
 							indent: 0,
 						}),
 						format: createPlainFormat(),


### PR DESCRIPTION
## Description

Make FormattedTextAsTree generic, moving special case to FormattedTextAsTreeDefault.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
