### PR TITLE
ci(docs): drop legacy-account uploads, write docs storage to Torus only

### DIFF
--- a/tools/pipelines/publish-api-model-artifact.yml
+++ b/tools/pipelines/publish-api-model-artifact.yml
@@ -208,22 +208,8 @@ stages:
                   verbose: true # Optional
                   #quiet: # Optional
 
-              # During the storage migration we dual-write each artifact to the legacy account
-              # (fluid-docs / STORAGE_ACCOUNT, served by the current AFD origin) and the new Torus
-              # account (fluid-docs-torus / STORAGE_ACCOUNT_NEW). Once the AFD origin is repointed and
-              # verified, the legacy tasks can be removed.
               - task: AzureCLI@2
-                displayName: 'Upload JSON (legacy)'
-                continueOnError: true
-                inputs:
-                  azureSubscription: 'fluid-docs'
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name $(STORAGE_ACCOUNT) --auth-mode login --verbose
-
-              - task: AzureCLI@2
-                displayName: 'Upload JSON (Torus)'
+                displayName: 'Upload JSON'
                 continueOnError: true
                 inputs:
                   azureSubscription: 'fluid-docs-torus'
@@ -233,18 +219,7 @@ stages:
                     az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name $(STORAGE_ACCOUNT_NEW) --auth-mode login --verbose
 
               - task: AzureCLI@2
-                displayName: 'Upload JSON as latest.tar.gz (legacy)'
-                continueOnError: true
-                condition: eq(variables['Build.SourceBranchName'], 'main')
-                inputs:
-                  azureSubscription: 'fluid-docs'
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite --verbose
-
-              - task: AzureCLI@2
-                displayName: 'Upload JSON as latest.tar.gz (Torus)'
+                displayName: 'Upload JSON as latest.tar.gz'
                 continueOnError: true
                 condition: eq(variables['Build.SourceBranchName'], 'main')
                 inputs:
@@ -255,18 +230,7 @@ stages:
                     az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name $(STORAGE_ACCOUNT_NEW) --auth-mode login --overwrite --verbose
 
               - task: AzureCLI@2
-                displayName: 'Upload JSON as latest-v*.tar.gz (legacy)'
-                continueOnError: true
-                condition: eq(variables.isLatestMinorOfMajorTrain, true)
-                inputs:
-                  azureSubscription: 'fluid-docs'
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest-v$(majorVersion).tar.gz --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite --verbose
-
-              - task: AzureCLI@2
-                displayName: 'Upload JSON as latest-v*.tar.gz (Torus)'
+                displayName: 'Upload JSON as latest-v*.tar.gz'
                 continueOnError: true
                 condition: eq(variables.isLatestMinorOfMajorTrain, true)
                 inputs:

--- a/tools/pipelines/publish-api-model-artifact.yml
+++ b/tools/pipelines/publish-api-model-artifact.yml
@@ -216,7 +216,7 @@ stages:
                   scriptType: bash
                   scriptLocation: inlineScript
                   inlineScript: |
-                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name $(STORAGE_ACCOUNT_NEW) --auth-mode login --verbose
+                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name $(STORAGE_ACCOUNT) --auth-mode login --verbose
 
               - task: AzureCLI@2
                 displayName: 'Upload JSON as latest.tar.gz'
@@ -227,7 +227,7 @@ stages:
                   scriptType: bash
                   scriptLocation: inlineScript
                   inlineScript: |
-                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name $(STORAGE_ACCOUNT_NEW) --auth-mode login --overwrite --verbose
+                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite --verbose
 
               - task: AzureCLI@2
                 displayName: 'Upload JSON as latest-v*.tar.gz'
@@ -238,7 +238,7 @@ stages:
                   scriptType: bash
                   scriptLocation: inlineScript
                   inlineScript: |
-                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest-v$(majorVersion).tar.gz --account-name $(STORAGE_ACCOUNT_NEW) --auth-mode login --overwrite --verbose
+                    az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest-v$(majorVersion).tar.gz --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite --verbose
 
 # Runs TriggerBuild@4 to trigger the deploy-website pipeline
 # this stage runs depending on the check_branch_version stage and deployOverride parameter

--- a/tools/pipelines/templates/include-upload-release-reports.yml
+++ b/tools/pipelines/templates/include-upload-release-reports.yml
@@ -40,7 +40,7 @@ steps:
         # for manifest files for a particular build (immutable) or for those for a particular
         # release (updates with our release cycle), but using a shorter TTL for all risks only small
         # perf losses while remaining simple.
-        az storage blob upload -f "$file" -c 'manifest-files' -n "$blobName" --account-name $(STORAGE_ACCOUNT_NEW) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
+        az storage blob upload -f "$file" -c 'manifest-files' -n "$blobName" --account-name $(STORAGE_ACCOUNT) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
       done
 
 # Clean up the working folders unconditionally so a failed upload task can't leave stale

--- a/tools/pipelines/templates/include-upload-release-reports.yml
+++ b/tools/pipelines/templates/include-upload-release-reports.yml
@@ -12,43 +12,8 @@ steps:
     SourceFolder: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}/upload_release_reports
     TargetFolder: $(Build.ArtifactStagingDirectory)/release_reports
 
-# During the storage migration we dual-write the release reports to the legacy account
-# (fluid-docs / STORAGE_ACCOUNT, served by the current AFD origin) and the new Torus account
-# (fluid-docs-torus / STORAGE_ACCOUNT_NEW). Once the AFD origin is repointed and verified, the
-# legacy task can be removed. Only the second task cleans up the working folders.
 - task: AzureCLI@2
-  displayName: Upload release reports (legacy)
-  continueOnError: true
-  inputs:
-    azureSubscription: 'fluid-docs'
-    scriptType: bash
-    workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-    scriptLocation: inlineScript
-    inlineScript: |
-      blobPrefix=""
-      if [[ '${{ parameters.buildDirectory }}' == */server/* ]]; then
-        if [ "$(release)" == "release" ]; then
-          blobPrefix="server/release"
-        else
-          blobPrefix="server/prerelease"
-        fi
-      fi
-      for file in upload_release_reports/*; do
-        fileName="$(basename "$file")"
-        if [ -n "$blobPrefix" ]; then
-          blobName="$blobPrefix/$fileName"
-        else
-          blobName="$fileName"
-        fi
-        # Use 5 minute TTL for manifest files. This could be lengthened significantly
-        # for manifest files for a particular build (immutable) or for those for a particular
-        # release (updates with our release cycle), but using a shorter TTL for all risks only small
-        # perf losses while remaining simple.
-        az storage blob upload -f "$file" -c 'manifest-files' -n "$blobName" --account-name $(STORAGE_ACCOUNT) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
-      done
-
-- task: AzureCLI@2
-  displayName: Upload release reports (Torus)
+  displayName: Upload release reports
   continueOnError: true
   inputs:
     azureSubscription: 'fluid-docs-torus'
@@ -78,7 +43,7 @@ steps:
         az storage blob upload -f "$file" -c 'manifest-files' -n "$blobName" --account-name $(STORAGE_ACCOUNT_NEW) --content-cache max-age=300 --auth-mode login --overwrite true --verbose
       done
 
-# Clean up the working folders unconditionally so a failed/dual upload task can't leave stale
+# Clean up the working folders unconditionally so a failed upload task can't leave stale
 # directories behind for the next run on a self-hosted agent.
 - task: Bash@3
   displayName: Clean up release report working folders


### PR DESCRIPTION
## What

Follow-up to #27503. Removes the `(legacy)` dual-write upload tasks so the docs storage uploads go **only** to the new Torus account (`fluid-docs-torus` / `$(STORAGE_ACCOUNT_NEW)` = `fluidframeworkcdn`).

- `publish-api-model-artifact.yml`: 6 upload tasks → 3 (drop the 3 legacy ones)
- `templates/include-upload-release-reports.yml`: 2 upload tasks → 1 (drop the legacy one; keep the `always()` cleanup step)

Remaining tasks renamed back to their original names (the `(Torus)` qualifier is redundant now).

## Why

The AFD origin behind `storage.fluidframework.com` was cut over to the `fluidframeworkcdn` (Torus) account via managed identity on **2026-06-26** and verified in production (both the FF "Website validation" and office-bohemia "External Partner to Loop Integration" consumer pipelines are green; endpoint serves 200s). The old MSIT `fluidframework` account is no longer the CDN origin, so dual-writing to it is dead weight. This completes SFI task **#47248** (MI auth, no SAS).

## Note

The old account is now write-free from these pipelines and can be decommissioned separately (it still holds non-served archives: `$web`, historical `api-extractor` SHA tarballs, `storybook`).