### PR TITLE
refactor(build-infra): use gitignore utils

### DIFF
--- a/build-tools/packages/build-infrastructure/src/workspaceCompat.ts
+++ b/build-tools/packages/build-infrastructure/src/workspaceCompat.ts
@@ -6,8 +6,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import globby from "globby";
-
+import { globSync } from "tinyglobby";
 import type {
 	// eslint-disable-next-line import-x/no-deprecated -- back-compat code
 	IFluidBuildDir,
@@ -16,6 +15,7 @@ import type {
 	ReleaseGroupDefinition,
 	WorkspaceDefinition,
 } from "./config.js";
+import { filterByGitignoreSync } from "./gitignore.js";
 import type { IBuildProject, IWorkspace, WorkspaceName } from "./types.js";
 import { Workspace } from "./workspace.js";
 
@@ -99,20 +99,21 @@ function loadWorkspacesFromLegacyConfigEntry(
 		];
 	}
 
-	const packageJsonPaths = globby
-		.sync(["**/package.json"], {
-			cwd: path.dirname(packagePath),
-			gitignore: true,
-			onlyFiles: true,
-			absolute: true,
-			// BACK-COMPAT HACK - only search two levels below entries for package.jsons. This avoids finding some test
-			// files and treating them as packages. This is only needed when loading old configs.
-			deep: 2,
-		})
-		.map(
-			// Make the paths relative to the repo root
-			(filePath) => path.relative(buildProject.root, filePath),
-		);
+	const cwd = path.dirname(packagePath);
+	const allFiles = globSync(["**/package.json"], {
+		cwd,
+		onlyFiles: true,
+		absolute: true,
+		// BACK-COMPAT HACK - only search two levels below entries for package.jsons. This avoids finding some test
+		// files and treating them as packages. This is only needed when loading old configs.
+		deep: 2,
+	});
+
+	// Apply gitignore filtering
+	const packageJsonPaths = filterByGitignoreSync(allFiles, cwd).map(
+		// Make the paths relative to the buildProject root
+		(filePath) => path.relative(buildProject.root, filePath),
+	);
 	const workspaces = packageJsonPaths.flatMap((pkgPath) => {
 		const dir = path.dirname(pkgPath);
 		return loadWorkspacesFromLegacyConfigEntry(dir, buildProject);


### PR DESCRIPTION
## Description

Migrates the legacy workspace compatibility package discovery path from `globby.sync(..., { gitignore: true })` to `tinyglobby.globSync` plus the gitignore utility introduced in the parent PR.

This keeps the behavior change separate from the helper and test coverage, making the review surface limited to wiring the helper into `workspaceCompat`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Review this after #27616. This PR should contain only the `workspaceCompat` migration and any lockfile adjustment needed after removing `globby` from build-infrastructure.