### PR TITLE
fix(driver-utils): fix LZ4 blob decompression bypass in DocumentStorageServiceCompressionAdapter

### DIFF
--- a/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
@@ -360,7 +360,10 @@ export class DocumentStorageServiceCompressionAdapter extends DocumentStorageSer
 			}
 		}
 		for (const key of Object.keys(snapshot.trees)) {
-			const value = snapshot[key] as ISnapshotTree;
+			// snapshot.trees[key], not snapshot[key]: ISnapshotTree subtrees live in the `trees`
+			// map, not as direct properties on the snapshot object. Using snapshot[key] always
+			// returns undefined, silently preventing any recursion into subtrees.
+			const value = snapshot.trees[key];
 			if (value !== undefined) {
 				const found = this.hasCompressionMarkup(value);
 				if (found) {
@@ -400,14 +403,29 @@ export class DocumentStorageServiceCompressionAdapter extends DocumentStorageSer
 	 */
 	public override async readBlob(id: string): Promise<ArrayBufferLike> {
 		const originalBlob = await super.readBlob(id);
-		if (this._isCompressionEnabled) {
-			const decompressedBlob =
-				DocumentStorageServiceCompressionAdapter.decodeBlob(originalBlob);
-			//			console.log(`Miso summary-blob Blob read END : ${id} ${decompressedBlob.byteLength}`);
-			return decompressedBlob;
-		} else {
-			return originalBlob;
-		}
+		// Always attempt to decode rather than guarding on _isCompressionEnabled.
+		//
+		// _isCompressionEnabled is set by hasCompressionMarkup(), which must find the
+		// ".metadata.blobHeaders" markup blob in the snapshot tree. Two independent failures
+		// can prevent that:
+		//
+		// 1. The recursion bug fixed above: hasCompressionMarkup() used snapshot[key] instead
+		//    of snapshot.trees[key], so it never descended into subtrees. With DDS types that
+		//    nest ".metadata" below the root (e.g. SharedTree's "sheetSetData/" subtree in
+		//    Fluid 2.82+), the markup blob was never found and _isCompressionEnabled stayed false.
+		//
+		// 2. Backend dropping the empty markup blob: some historian/gitrest deployments do not
+		//    round-trip the empty ".metadata.blobHeaders" blob (content=""), so even with the
+		//    recursion fixed the markup may be absent from the snapshot returned by the server.
+		//
+		// In both cases the compressed blob (first byte 0xB1 = LZ4 prefix) was returned raw,
+		// reaching JSON.parse as U+FFFD garbage and throwing "Failed to get Channel".
+		//
+		// decodeBlob() is safe to call unconditionally: it inspects the first byte of the blob
+		// for the 0xBx algorithm prefix written by encodeBlob(). If present it decompresses;
+		// if not, it returns the blob unchanged. This makes decompression content-driven rather
+		// than metadata-driven, eliminating both failure modes.
+		return DocumentStorageServiceCompressionAdapter.decodeBlob(originalBlob);
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Two bugs in `DocumentStorageServiceCompressionAdapter` cause compressed summary blobs to reach `JSON.parse` raw, throwing:

```
Failed to get Channel: SyntaxError: Unexpected token '…' is not valid JSON: /sheetSetData
```

Both bugs are in `@fluidframework/driver-utils`. They have existed since the compression feature was introduced (#15656) but are **only observable under a precise combination of conditions** — which is why they went unnoticed for so long. See **Root cause of latency** below.

---

### Bug 1 — `hasCompressionMarkup()` recursion never descends into subtrees

```ts
for (const key of Object.keys(snapshot.trees)) {
-    const value = snapshot[key] as ISnapshotTree;  // always undefined — wrong object
+    const value = snapshot.trees[key];              // correct
```

`ISnapshotTree` stores subtrees in `snapshot.trees`, not as direct properties on the snapshot object. `snapshot[key]` always returns `undefined`, silently preventing recursion. `hasCompressionMarkup()` only ever checks root-level blobs.

### Bug 2 — `readBlob()` guards decompression on `_isCompressionEnabled`

`_isCompressionEnabled` is set by `hasCompressionMarkup()` in `getSnapshotTree()`. Two things can prevent it from being set correctly:
- Bug 1 (recursion never finds the markup blob in subtrees)
- Some backend deployments do not round-trip the empty `.metadata.blobHeaders` blob (`content=""`), so even with Bug 1 fixed, `_isCompressionEnabled` stays `false`

Result: the raw `0xB1`+LZ4 blob reaches `JSON.parse` → `"Failed to get Channel"`.

---

## Fix

**Fix 1 (`hasCompressionMarkup`):** `snapshot[key]` → `snapshot.trees[key]`.

**Fix 2 (`readBlob`):** Always call `decodeBlob()` unconditionally, removing the `_isCompressionEnabled` guard.

`decodeBlob()` is safe to call on any blob: it inspects the first byte for the `0xBx` algorithm prefix written by `encodeBlob()`. If present it decompresses; if not, it returns the blob unchanged. This makes decompression **content-driven** (from the blob's own prefix byte) rather than **metadata-driven**, eliminating both failure modes.

---

## Root cause of latency — why this went unnoticed

This combination of bugs is only observable when **all three** of the following apply:

**1. LZ4 compression must be explicitly enabled**

`applyStorageCompression(factory, undefined)` returns the original factory unchanged — the compression adapter is never created. This is the default for most callers including standard `AzureClient` usage. The bug only manifests when `summaryCompression: { algorithm: LZ4, minSizeToCompress: N }` is explicitly passed (e.g. Autodesk's `AWSClient` wrapper).

**2. SharedTree must be the DDS (not PropertyDDS or SharedMap)**

`findMetadataHolderSummary()` does a DFS that descends into subtrees **before** checking blobs at the current level. SharedTree's `versionedSummarizer.ts` writes its own `.metadata` blob (`summarizablesMetadataKey = ".metadata"`) inside the DDS subtree. This causes `findMetadataHolderSummary()` to find that `.metadata` first and place the `blobHeaders` markup **inside the DDS subtree** rather than at the container root.

PropertyDDS (`SharedPropertyTree`) writes no `.metadata` blob, so the DFS falls back to the container root's `.metadata` — the markup ends up at root level, `hasCompressionMarkup()` finds it without needing to recurse, and the bug is invisible.

**3. The snapshot tree must be nested, not flat**

In tests and in Azure's FRS backend, the test fixture for `hasCompressionMarkup` places `.metadata.blobHeaders` at the **root level** of the snapshot tree. `hasCompressionMarkup()` finds it there without recursing, so Bug 1 is never triggered. Only backends that return nested snapshot trees (where `.metadata.blobHeaders` is inside the DDS subtree) expose the recursion bug.

**Result:** the bug is invisible to:
- All callers not enabling explicit LZ4 compression
- All tests (test snapshot fixtures have `.metadata.blobHeaders` at root)
- PropertyDDS users (no `.metadata` in DDS subtree → markup at root → found without recursion)
- Any backend returning flat snapshot trees

It only surfaces with the combination of explicit LZ4 + SharedTree + a backend that returns nested snapshot trees — which is Autodesk's cedit/routerlicious deployment.

---

## Verification

Verified against Autodesk's cedit/routerlicious backend (developer-dev and developer-stg rings, `fluid` tenant) using a 2-client SharedTree collaboration harness across `routerlicious-client` v4.0.3–v4.0.7 (Fluid 2.72–2.82):

| version | Fluid | DDS | before fix | after fix |
|---|---|---|---|---|
| v4.0.3 | 2.72.0 | SharedTree | loaded OK `decompress=1` | loaded OK `decompress=1` |
| v4.0.4 | 2.82.0 | SharedTree | **REPRODUCED** `decompress=0` | loaded OK `decompress=1` |
| v4.0.5 | 2.82.0 | SharedTree | **REPRODUCED** `decompress=0` | loaded OK `decompress=1` |
| v4.0.6 | 2.82.0 | SharedTree | **REPRODUCED** `decompress=0` | loaded OK `decompress=1` |
| v4.0.7 | 2.82.0 | SharedTree | **REPRODUCED** `decompress=0` | loaded OK `decompress=1` |

PropertyDDS (same backend, same compression config, all versions): never reproduced — confirmed the structural reason above.

Confirmed both bugs are present unchanged in every release from `client_v2.82.0` through `client_v2.102.0` and current HEAD.

---

## Checklist

- [x] Root cause identified with concrete evidence across three independent conditions
- [x] Fix is minimal — one-line recursion fix + collapsing `readBlob` to always decode
- [x] No behavioural change for uncompressed blobs (`decodeBlob` no-ops when `0xBx` prefix absent)
- [x] Verified end-to-end against real backend across 5 client versions
- [x] Explains why no existing test catches this (test fixtures hardcode flat snapshot tree)