### PR TITLE
fix(driver-utils): fix hasCompressionMarkup recursion — snapshot[key] → snapshot.trees[key]

### DIFF
--- a/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
@@ -360,7 +360,10 @@ export class DocumentStorageServiceCompressionAdapter extends DocumentStorageSer
 			}
 		}
 		for (const key of Object.keys(snapshot.trees)) {
-			const value = snapshot[key] as ISnapshotTree;
+			// snapshot.trees[key], not snapshot[key]: ISnapshotTree subtrees live in the `trees`
+			// map, not as direct properties on the snapshot object. Using snapshot[key] always
+			// returns undefined, silently preventing any recursion into subtrees.
+			const value = snapshot.trees[key];
 			if (value !== undefined) {
 				const found = this.hasCompressionMarkup(value);
 				if (found) {


### PR DESCRIPTION
## The bug

`hasCompressionMarkup()` in `DocumentStorageServiceCompressionAdapter` tries to recursively search the snapshot tree for the `.metadata.blobHeaders` compression markup blob. The recursion was silently broken:

```ts
for (const key of Object.keys(snapshot.trees)) {
-    const value = snapshot[key] as ISnapshotTree;   // always undefined
+    const value = snapshot.trees[key];              // correct
```

`ISnapshotTree` stores subtrees in `snapshot.trees`, not as direct properties on the snapshot object. `snapshot[key]` is **always `undefined`**, so the loop body never executes and `hasCompressionMarkup()` only ever checks root-level blobs.

This meant `_isCompressionEnabled` stayed `false` when the `.metadata.blobHeaders` markup blob was nested inside a DDS subtree, causing `readBlob()` to return raw LZ4-compressed bytes that then hit `JSON.parse` → **"Failed to get Channel: … is not valid JSON"**.

## Why it was latent until Fluid 2.82

Before Fluid 2.82, the `.metadata` blob (which determines where `putCompressionMarkup` places the markup) was at the summary root. `hasCompressionMarkup()` found it at root level without any recursion — the bug didn't matter.

With Fluid 2.82 + SharedTree, `versionedSummarizer.ts` writes its own `.metadata` blob inside the DDS subtree (`sheetSetData/`). `findMetadataHolderSummary` finds this nested `.metadata` first (DFS), so `putCompressionMarkup` places `.metadata.blobHeaders` inside `sheetSetData/` — now the broken recursion matters and `_isCompressionEnabled` is never set.

The bug has been present since #15656 and is in every release through `client_v2.102.0` and current HEAD.

## The fix

One functional line changed. No behaviour change for backends where `.metadata.blobHeaders` is at the root level (existing test fixtures and Azure FRS).

## Verification

Tested against Autodesk's cedit/routerlicious backend (developer-dev ring, `fluid` tenant) with a 2-client SharedTree + AWSClient repro across `routerlicious-client` v4.0.3–v4.0.7 (Fluid 2.72–2.82):

- **Without fix:** v4.0.4–v4.0.7 reproduce "Failed to get Channel" (`compress=1/2, decompress=0`)
- **With this fix only:** all 5 versions pass (`compress=1/2, decompress≥1`)

Also confirmed: PropertyDDS never triggers the bug (its summarizer writes no `.metadata` blob in the DDS subtree, so `.metadata.blobHeaders` always lands at root).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)