### PR TITLE
fix(driver-utils): backport hasCompressionMarkup recursion fix for 2.82.1 (#27624)

### DIFF
--- a/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
@@ -360,7 +360,10 @@ export class DocumentStorageServiceCompressionAdapter extends DocumentStorageSer
 			}
 		}
 		for (const key of Object.keys(snapshot.trees)) {
-			const value = snapshot[key] as ISnapshotTree;
+			// snapshot.trees[key], not snapshot[key]: ISnapshotTree subtrees live in the `trees`
+			// map, not as direct properties on the snapshot object. Using snapshot[key] always
+			// returns undefined, silently preventing any recursion into subtrees.
+			const value = snapshot.trees[key];
 			if (value !== undefined) {
 				const found = this.hasCompressionMarkup(value);
 				if (found) {


### PR DESCRIPTION
## Summary

Backports the fix from #27624 to `release/client/2.82` for the upcoming 2.82.1 patch release.

`hasCompressionMarkup()` in `DocumentStorageServiceCompressionAdapter` used `snapshot[key]` instead of `snapshot.trees[key]` when recursing into `ISnapshotTree` subtrees. `ISnapshotTree` subtrees live under `.trees`, not as direct properties, so `snapshot[key]` was always `undefined` and the recursion silently never ran past the root level.

This became user-visible starting with Fluid 2.82 + SharedTree, where `versionedSummarizer.ts` can write a nested `.metadata` blob inside a DDS subtree. When `putCompressionMarkup` places `.metadata.blobHeaders` there, `hasCompressionMarkup()` fails to find it, `_isCompressionEnabled` stays `false`, and `readBlob()` returns raw LZ4-compressed bytes that fail `JSON.parse` with `"Failed to get Channel: … is not valid JSON"`.

One functional line changed; no behavior change for backends where `.metadata.blobHeaders` is at the summary root (existing test fixtures, Azure FRS).

See #27624 for full repro details and verification against Autodesk's routerlicious backend.

## Test plan

- [x] Cherry-picked cleanly from `main` (d639a8b5b1) with no conflicts
- [x] Same verification as #27624 (2-client SharedTree + AWSClient repro against routerlicious-client v4.0.3–v4.0.7)