### PR TITLE
build(client): fix build:docs dependencies

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -152,11 +152,12 @@ module.exports = {
 		"build:api-reports:legacy": ["api-extractor:esnext", "build:esnext"],
 		"ci:build:api-reports:current": ["api-extractor:esnext", "build:esnext"],
 		"ci:build:api-reports:legacy": ["api-extractor:esnext", "build:esnext"],
-		// With most packages in client building ESM first, there is ideally just "build:esnext" dependency.
+		// With most packages in client building ESM first, there is ideally just "build:esnext" and "api-extractor:esnext" dependencies.
 		// The package's local 'api-extractor.json' may use the entrypoint from either CJS or ESM,
-		// therefore we need to require both before running api-extractor.
-		"build:docs": ["tsc", "build:esnext"],
-		"ci:build:docs": ["tsc", "build:esnext"],
+		// therefore we need to require both before running api-extractor until other packages are
+		// updated to use ESM entrypoints or customize their build configs.
+		"build:docs": ["tsc", "build:esnext", "api-extractor:esnext"],
+		"ci:build:docs": ["tsc", "build:esnext", "api-extractor:esnext"],
 		"build:readme": {
 			dependsOn: ["compile"],
 			script: true,


### PR DESCRIPTION
Many API reports are generated from generated entrypoints and not directly from build. So add common dependency on api-extractor:esnext.