### PR TITLE
Revert "fix(container-loader): prevent 0x3eb assert when read-only is forced from a connected handler"

### DIFF
--- a/.changeset/fix-catchupmonitor-reentrant-readonly.md
+++ b/.changeset/fix-catchupmonitor-reentrant-readonly.md
@@ -1,9 +1,0 @@
----
-"@fluidframework/container-loader": minor
-"__section": fix
----
-Fix container crash when read-only mode is forced from a connected event handler
-
-Forcing a container into read-only mode synchronously from within a "connected" event handler could leave an internal catch-up monitor in an inconsistent state, causing a later reconnection to fail with an assert ("catchUpMonitor should be gone", `0x3eb`).
-
-This occurred when a client established an already-caught-up read connection and application code reacted to the resulting connection transition by disconnecting (for example, by forcing read-only mode). The catch-up monitor is now stored before it can synchronously notify listeners, so a re-entrant disconnect during the connection transition is handled correctly and subsequent reconnections proceed normally.

--- a/packages/loader/container-loader/src/catchUpMonitor.ts
+++ b/packages/loader/container-loader/src/catchUpMonitor.ts
@@ -16,13 +16,7 @@ type CaughtUpListener = () => void;
 /**
  * Monitor that emits an event when a Container has caught up to a given point in the op stream
  */
-export interface ICatchUpMonitor extends IDisposable {
-	/**
-	 * Evaluate whether the container is already caught up, synchronously notifying the listener if so.
-	 * @remarks Must be called after the owner has stored its reference to the monitor.
-	 */
-	start(): void;
-}
+export type ICatchUpMonitor = IDisposable;
 
 /**
  * Monitors a Container's DeltaManager, notifying listeners when all ops have been processed
@@ -43,14 +37,6 @@ export class CatchUpMonitor implements ICatchUpMonitor {
 
 	/**
 	 * Create the CatchUpMonitor, setting the target sequence number to wait for based on DeltaManager's current state.
-	 *
-	 * @remarks
-	 * The constructor only wires up the op listener. Call {@link CatchUpMonitor.start} once the monitor
-	 * reference has been stored to evaluate whether the container is already caught up. This ordering is
-	 * important: `start` can synchronously invoke the listener (when already caught up), which may re-enter
-	 * the owner and observe the monitor. If that synchronous check ran from the constructor, the owner's
-	 * field would not yet be assigned, so re-entrant cleanup (e.g. a disconnect) would silently no-op and
-	 * leave a stale monitor behind (see assert 0x3eb).
 	 */
 	constructor(
 		private readonly deltaManager: IDeltaManager<unknown, unknown>,
@@ -64,15 +50,7 @@ export class CatchUpMonitor implements ICatchUpMonitor {
 		);
 
 		this.deltaManager.on("op", this.opHandler);
-	}
 
-	/**
-	 * Evaluate whether the container is already caught up, synchronously notifying the listener if so.
-	 * @remarks
-	 * Must be called by the owner after storing its reference to this monitor, so that any re-entrancy
-	 * triggered by the listener observes a fully-constructed, assigned monitor.
-	 */
-	public start(): void {
 		// Simulate the last processed op to set caughtUp in case we already are
 		this.opHandler({ sequenceNumber: this.deltaManager.lastSequenceNumber });
 	}

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -277,17 +277,10 @@ export class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
 				// we might get callback right away, and it will screw up state transition (as code outside of switch
 				// statement will overwrite current state).
 				assert(this.catchUpMonitor === undefined, 0x3eb /* catchUpMonitor should be gone */);
-				// Assign the field BEFORE starting the monitor. `start()` may synchronously fire
-				// transitionToConnectedState (when already caught up), which can re-enter this handler
-				// (e.g. an app "connected" listener forcing readonly, triggering a disconnect). The
-				// Disconnected case clears this.catchUpMonitor, so the field must already reference the
-				// monitor for that cleanup to take effect; otherwise a stale monitor survives and the
-				// next Connected transition trips assert 0x3eb.
 				this.catchUpMonitor = new CatchUpMonitor(
 					this.deltaManager,
 					this.transitionToConnectedState,
 				);
-				this.catchUpMonitor.start();
 				return;
 			}
 			case ConnectionState.Disconnected: {

--- a/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
+++ b/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
@@ -86,7 +86,7 @@ describe("CatchUpMonitor", () => {
 		assert(caughtUp, "Should be considered caught up now");
 	});
 
-	it("Emits caught up immediately when started if last known/processed sequence numbers match", () => {
+	it("Emits caught up immediately if last known/processed sequence numbers match", () => {
 		const mockDeltaManager = MockDeltaManagerForCatchingUp.create({
 			lastSequenceNumber: 10,
 			lastKnownSeqNumber: 10,
@@ -97,9 +97,7 @@ describe("CatchUpMonitor", () => {
 			caughtUp = true;
 		});
 
-		assert(!caughtUp, "caughtUp should not fire from the constructor");
-		monitor.start();
-		assert(caughtUp, "caughtUp should have fired immediately once started");
+		assert(caughtUp, "caughtUp should have fired immediately");
 	});
 
 	it("Only emits caughtUp once", () => {

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -313,68 +313,6 @@ describe("ConnectionStateHandler Tests", () => {
 		);
 	});
 
-	// Regression test for assert 0x3eb ("catchUpMonitor should be gone").
-	//
-	// Repro conditions (both are required to exercise the original bug):
-	//   1. The connection is already caught up at the moment of the Connected transition, so
-	//      CatchUpMonitor fires its listener *synchronously* (from `start()`).
-	//   2. Something re-enters with a synchronous Disconnected from within that "connected"
-	//      notification (e.g. an app/runtime handler reacting to the "connected" event by
-	//      disconnecting - such as a container forced into readonly mode).
-	//
-	// Before the fix, the CatchUpMonitor's synchronous caught-up check ran from its constructor,
-	// before `this.catchUpMonitor` was assigned, so the re-entrant Disconnected handler's
-	// `this.catchUpMonitor = undefined` no-oped and left a stale monitor attached - the next
-	// reconnect's transition to Connected then tripped assert 0x3eb. The fix assigns the field
-	// before calling `start()`, so the re-entrant disconnect disposes and clears the monitor
-	// correctly and the reconnect succeeds.
-	it("read client: re-entrant disconnect from a synchronous 'connected' notification reconnects cleanly (0x3eb regression)", () => {
-		// Condition 1: connection is already caught up at connect time (lastSequenceNumber === lastKnownSeqNumber),
-		// so CatchUpMonitor fires transitionToConnectedState synchronously from its constructor.
-		deltaManagerForCatchingUp.lastSequenceNumber =
-			deltaManagerForCatchingUp.lastKnownSeqNumber;
-
-		// Condition 2: simulate a host/runtime handler that synchronously disconnects in response to the
-		// "connected" notification. connectionStateChanged is invoked by transitionToConnectedState, which
-		// runs inside the CatchUpMonitor constructor for an already-caught-up connection.
-		let reentered = false;
-		handlerInputs.connectionStateChanged = (value): void => {
-			if (value === ConnectionState.Connected && !reentered) {
-				reentered = true;
-				connectionStateHandler.receivedDisconnectEvent({ text: "re-entrant disconnect" });
-			}
-		};
-
-		connectionStateHandler = createHandler(
-			true, // connectedRaisedWhenCaughtUp -> ConnectionStateCatchup wrapper (where 0x3eb lives)
-			false,
-		); // readClientsWaitForJoinSignal -> read connection goes straight to Connected
-
-		// Initial read connection: Connected is raised synchronously and the re-entrant disconnect fires.
-		// With the fix, the monitor field is already assigned, so the Disconnected handler disposes and
-		// clears it - no stale monitor is left behind.
-		connectionStateHandler.establishingConnection({ text: "read" });
-		connectionStateHandler.receivedConnectEvent(connectionDetails);
-		assert.strictEqual(
-			connectionStateHandler.connectionState,
-			ConnectionState.Disconnected,
-			"Re-entrant disconnect should have moved handler back to Disconnected",
-		);
-
-		// The reconnect (async in production) transitions to Connected again. Because the stale monitor
-		// was cleared, this no longer trips assert 0x3eb and the handler reaches Connected.
-		connectionStateHandler.establishingConnection({ text: "reconnect" });
-		assert.doesNotThrow(
-			() => connectionStateHandler.receivedConnectEvent(connectionDetails),
-			"Reconnect should not hit assert 0x3eb - the stale catchUpMonitor must have been cleared",
-		);
-		assert.strictEqual(
-			connectionStateHandler.connectionState,
-			ConnectionState.Connected,
-			"Reconnect should reach Connected cleanly",
-		);
-	});
-
 	it("Should move to connected after receiving join op for read client", async () => {
 		connectionStateHandler = createHandler(
 			false, // connectedRaisedWhenCaughtUp


### PR DESCRIPTION
Reverts microsoft/FluidFramework#27637 to restore downstream integration pipelines.