### PR TITLE
feat(odsp-driver): support ProgID on create container requests

### DIFF
--- a/.changeset/add-odsp-create-progid.md
+++ b/.changeset/add-odsp-create-progid.md
@@ -1,0 +1,23 @@
+---
+"@fluidframework/odsp-driver": minor
+"__section": feature
+---
+
+Add support for setting ProgID when creating ODSP containers
+
+The ODSP create-container request helper now accepts an optional ProgID value and passes it to ODSP when creating the file.
+This allows hosts to provide routing metadata for files that share the same extension but should open in different experiences.
+
+#### Usage
+
+```typescript
+const request = createOdspCreateContainerRequest(
+	siteUrl,
+	driveId,
+	filePath,
+	fileName,
+	undefined,
+	undefined,
+	progId,
+);
+```

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
@@ -11,7 +11,7 @@ export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined;
 export function createLocalOdspDocumentServiceFactory(localSnapshot: Uint8Array | string): IDocumentServiceFactory;
 
 // @beta @legacy
-export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createShareLinkType?: ISharingLinkKind, containerPackageInfo?: IContainerPackageInfo | undefined): IRequest;
+export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createShareLinkType?: ISharingLinkKind, containerPackageInfo?: IContainerPackageInfo | undefined, progId?: string): IRequest;
 
 // @beta @legacy
 export function createOdspUrl(l: OdspFluidDataStoreLocator): string;

--- a/packages/drivers/odsp-driver/src/createFile/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createFile.ts
@@ -348,8 +348,13 @@ export async function createNewFluidFileFromSummary(
 	// Build share link parameter based on the createLinkType provided so that the
 	// snapshot api can create and return the share link along with creation of file in the response.
 	const createShareLinkParam = buildOdspShareLinkReqParams(newFileInfo.createLinkType);
+	const progIdParam =
+		newFileInfo.progId === undefined
+			? undefined
+			: `progId=${encodeURIComponent(newFileInfo.progId)}`;
+	const queryParams = [createShareLinkParam, progIdParam].filter(Boolean).join("&");
 	const initialUrl = `${baseUrl}:/opStream/snapshots/snapshot${
-		createShareLinkParam ? `?${createShareLinkParam}` : ""
+		queryParams ? `?${queryParams}` : ""
 	}`;
 
 	return createNewFluidContainerCore<ICreateFileResponse>({

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -22,6 +22,7 @@ import { buildOdspShareLinkReqParams, getContainerPackageName } from "./odspUtil
  * will be deprecated soon, so for any new implementation please provide createShareLinkType of type ShareLink
  * @param containerPackageInfo - Container package information which will be used to extract the container package name.
  * If not given that means that the container package does not have a name.
+ * @param progId - Programmatic identifier that ODSP can use to route the created file to the intended experience.
  * @legacy
  * @beta
  */
@@ -32,12 +33,17 @@ export function createOdspCreateContainerRequest(
 	fileName: string,
 	createShareLinkType?: ISharingLinkKind,
 	containerPackageInfo?: IContainerPackageInfo | undefined,
+	progId?: string,
 ): IRequest {
 	const shareLinkRequestParams = buildOdspShareLinkReqParams(createShareLinkType);
+	const containerPackageParam = containerPackageInfo
+		? `&containerPackageName=${getContainerPackageName(containerPackageInfo)}`
+		: "";
+	const progIdParam = progId === undefined ? "" : `&progId=${encodeURIComponent(progId)}`;
 	const createNewRequest: IRequest = {
 		url: `${siteUrl}?driveId=${encodeURIComponent(driveId)}&path=${encodeURIComponent(
 			filePath,
-		)}${containerPackageInfo ? `&containerPackageName=${getContainerPackageName(containerPackageInfo)}` : ""}${shareLinkRequestParams ? `&${shareLinkRequestParams}` : ""}`,
+		)}${containerPackageParam}${shareLinkRequestParams ? `&${shareLinkRequestParams}` : ""}${progIdParam}`,
 		headers: {
 			[DriverHeader.createNew]: {
 				fileName,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -130,6 +130,7 @@ export class OdspDocumentServiceFactoryCore
 				filePath,
 				filename: odspResolvedUrl.fileName,
 				createLinkType: createShareLinkParam,
+				progId: searchParams.get("progId") ?? undefined,
 			};
 		} else {
 			throw new Error("A new or existing file must be specified to create container!");

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -311,6 +311,7 @@ export interface INewFileInfo extends IFileInfoBase {
 	type: "New";
 	filename: string;
 	filePath: string;
+	progId?: string;
 	/**
 	 * application can request creation of a share link along with the creation of a new file
 	 * by passing in an optional param to specify the kind of sharing link

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -19,6 +19,7 @@ import {
 	SharingLinkScope,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { createChildLogger, MockLogger } from "@fluidframework/telemetry-utils/internal";
+import { stub } from "sinon";
 
 import { useCreateNewModule } from "../createFile/index.js";
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest.js";
@@ -38,7 +39,7 @@ import {
 	getOdspResolvedUrl,
 } from "../odspUtils.js";
 
-import { mockFetchOk, mockFetchOKIf } from "./mockFetch.js";
+import { mockFetchOk, mockFetchOKIf, okResponse } from "./mockFetch.js";
 
 const createUtLocalCache = (): LocalPersistentCache => new LocalPersistentCache();
 
@@ -295,6 +296,52 @@ describe("Create New Utils Tests", () => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		test(snapshot);
 		await epochTracker.removeEntries().catch(() => {});
+	});
+
+	it("Should pass progId as a query parameter when creating a Fluid file", async () => {
+		const progId = "Cowork Prog/Id";
+		newFileParams.progId = progId;
+		newFileParams.createLinkType = createLinkType;
+		const fetchStub = stub(globalThis, "fetch");
+		fetchStub.callsFake(async (url) => {
+			const requestUrl = new URL(url as string);
+			assert.strictEqual(requestUrl.searchParams.get("progId"), progId, "ProgID should match");
+			assert.strictEqual(
+				requestUrl.searchParams.get("createLinkScope"),
+				createLinkType.scope,
+				"Share link scope should still be present",
+			);
+			assert.strictEqual(
+				requestUrl.searchParams.get("createLinkRole"),
+				createLinkType.role,
+				"Share link role should still be present",
+			);
+			assert(
+				requestUrl.href.includes(`progId=${encodeURIComponent(progId)}`),
+				"ProgID should be encoded in the ODSP create URL",
+			);
+			return okResponse(
+				{ "x-fluid-epoch": "epoch1" },
+				{ itemId: "itemId1", id: "Summary handle" },
+			) as unknown as Promise<Response>;
+		});
+
+		try {
+			await useCreateNewModule(createChildLogger(), async (module) =>
+				module.createNewFluidFile(
+					async (_options) => "token",
+					newFileParams,
+					createChildLogger(),
+					createSummary(),
+					epochTracker,
+					fileEntry,
+					false /* createNewCaching */,
+					false /* forceAccessTokenViaAuthorizationHeader */,
+				),
+			);
+		} finally {
+			fetchStub.restore();
+		}
 	});
 
 	it("Should save 'sharing' information received during createNewFluidFile", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -13,6 +13,7 @@ import {
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger, isFluidError } from "@fluidframework/telemetry-utils/internal";
+import { stub } from "sinon";
 
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest.js";
 import { LocalPersistentCache } from "../odspCache.js";
@@ -116,6 +117,38 @@ describe("Odsp Create Container Test", () => {
 			snapshotUrl,
 			"Snapshot url should match",
 		);
+	});
+
+	it("passes progId from the create request to the ODSP create-file URL", async () => {
+		const progId = "Cowork Prog/Id";
+		request = createOdspCreateContainerRequest(
+			siteUrl,
+			driveId,
+			filePath,
+			fileName,
+			undefined /* createShareLinkType */,
+			undefined /* containerPackageInfo */,
+			progId,
+		);
+		const resolved = await resolver.resolve(request);
+		const summary = createSummary(true, true);
+		const fetchStub = stub(globalThis, "fetch");
+		fetchStub.callsFake(async (url) => {
+			const requestUrl = new URL(url as string);
+			assert.strictEqual(requestUrl.searchParams.get("progId"), progId, "ProgID should match");
+			return okResponse(
+				{ "x-fluid-epoch": "epoch1" },
+				expectedResponse,
+			) as unknown as Promise<Response>;
+		});
+
+		try {
+			const docService = await createService(summary, resolved);
+			const finalResolverUrl = getOdspResolvedUrl(docService.resolvedUrl);
+			assert.strictEqual(finalResolverUrl.itemId, itemId, "ItemId should match");
+		} finally {
+			fetchStub.restore();
+		}
 	});
 
 	it("No App Summary", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -7,6 +7,11 @@ import { strict as assert } from "node:assert";
 
 import type { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions/internal";
+import {
+	type ISharingLinkKind,
+	SharingLinkRole,
+	SharingLinkScope,
+} from "@fluidframework/odsp-driver-definitions/internal";
 
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest.js";
 import { createOdspUrl } from "../createOdspUrl.js";
@@ -39,6 +44,66 @@ describe("Odsp Driver Resolver", () => {
 			filePath,
 		)}`;
 		assert.strictEqual(request.url, url, "Request url should match");
+	});
+
+	it("Can create new request with progId", async () => {
+		const progId = "Cowork Prog/Id";
+		request = createOdspCreateContainerRequest(
+			siteUrl,
+			driveId,
+			filePath,
+			fileName,
+			undefined /* createShareLinkType */,
+			undefined /* containerPackageInfo */,
+			progId,
+		);
+
+		const [, queryString] = request.url.split("?");
+		const searchParams = new URLSearchParams(queryString);
+		assert.strictEqual(searchParams.get("progId"), progId, "ProgID should match");
+		assert(
+			request.url.includes(`progId=${encodeURIComponent(progId)}`),
+			"ProgID should be encoded in the request URL",
+		);
+	});
+
+	it("Can create new request with share link, container package name, and progId", async () => {
+		const progId = "Cowork Prog/Id";
+		const createShareLinkType: ISharingLinkKind = {
+			scope: SharingLinkScope.users,
+			role: SharingLinkRole.edit,
+		};
+
+		request = createOdspCreateContainerRequest(
+			siteUrl,
+			driveId,
+			filePath,
+			fileName,
+			createShareLinkType,
+			{ name: packageName },
+			progId,
+		);
+
+		const [, queryString] = request.url.split("?");
+		const searchParams = new URLSearchParams(queryString);
+		assert.strictEqual(searchParams.get("driveId"), driveId, "Drive id should match");
+		assert.strictEqual(searchParams.get("path"), filePath, "filePath should match");
+		assert.strictEqual(
+			searchParams.get("containerPackageName"),
+			packageName,
+			"Container package name should match",
+		);
+		assert.strictEqual(
+			searchParams.get("createLinkScope"),
+			createShareLinkType.scope,
+			"Share link scope should match",
+		);
+		assert.strictEqual(
+			searchParams.get("createLinkRole"),
+			createShareLinkType.role,
+			"Share link role should match",
+		);
+		assert.strictEqual(searchParams.get("progId"), progId, "ProgID should match");
 	});
 
 	it("Should resolve createNew request", async () => {


### PR DESCRIPTION
## Description

Adds create-time ProgID propagation to the ODSP driver so hosts can provide routing metadata when creating ODSP-backed Fluid files. The optional \`progId\` argument is carried from \`createOdspCreateContainerRequest\` through the create-container flow and appended as a URL-encoded query parameter on the ODSP snapshot create-file API call.

This supports [AB#76947](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/76947) for \`.page\` files that need to share an extension while routing to different experiences.