### PR TITLE
test(client-tree): enable one 8915 case

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2319,8 +2319,7 @@ describe("SharedTree", () => {
 				new TreeViewConfiguration({ schema: JsonAsTree.Array, enableSchemaValidation }),
 			);
 			view1Json.upgradeSchema();
-			// TODO:#8915: This should be able to insert the _number_ 44, not the string, but currently cannot - see bug #8915
-			view1Json.root.insertAtEnd("44");
+			view1Json.root.insertAtEnd(44);
 
 			tree1.containerRuntime.connected = true;
 
@@ -2467,10 +2466,14 @@ describe("SharedTree", () => {
 			const view = tree.viewWith(
 				new TreeViewConfiguration({ schema, enableSchemaValidation }),
 			);
+			view.initialize({ foo: [] });
 			Tree.runTransaction(view, () => {
-				view.initialize({ foo: [] });
 				view.root.foo.insertAtStart("a");
 				view.root.foo.insertAtStart("b");
+				// This dispose does not seem to be enough to prevent
+				//   Error: Cannot create a second tree view from the same checkout
+				// when creating view2 below.
+				view.dispose();
 
 				// Update schema which now allows all primitives under field "foo".
 				const view2 = tree.viewWith(


### PR DESCRIPTION
At some point upgraded views started reflecting new schema, allowing edits to use it.

Under a transaction, original views must have been disposed. Otherwise "Cannot create a second tree view from the same checkout" is thrown. Also `initialize` needs called before `runTransation` to ensure tree is within schema compliance.