### PR TITLE
docs(tree): improve withDefault API docs and cross-link with user-facing docs

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
@@ -80,6 +80,8 @@ import type {
  * Values should be preferred over generator functions when possible, as they are simpler and more efficient.
  * Generator functions should be used when the default value needs to be dynamic or when it is not possible to provide a value directly.
  *
+ * See {@link SchemaStaticsAlpha.withDefault} for the primary API that uses this type.
+ *
  * @example
  * ```typescript
  * // Provide a value directly
@@ -102,27 +104,63 @@ export type NodeProvider<T> = T | (() => T);
  */
 export interface SchemaStaticsAlpha {
 	/**
-	 * Creates a field schema with a default value. Fields with defaults (whether required or optional) are recognized by the type system as optional in constructors,
-	 * allowing them to be omitted when creating new nodes.
+	 * Creates a field schema with a default value.
+	 *
+	 * @remarks
+	 * Fields with defaults are optional in constructors, allowing them to be omitted when creating new nodes.
+	 * This works with both {@link SchemaStatics.required | required} and {@link SchemaStatics.optional | optional} fields:
+	 *
+	 * - **Required fields with defaults**: The field is always present in the tree, but can be omitted from the constructor.
+	 * The default value is used when the field is not provided.
+	 *
+	 * - **Optional fields with defaults**: Optional fields already default to `undefined`, but `withDefault` lets you
+	 * specify a different default value.
+	 *
+	 * The default value can be provided in two ways (see {@link NodeProvider}):
+	 *
+	 * 1. **A value**: The value is deep-copied for each use, ensuring independence between instances.
+	 * Prefer this when the default is a fixed value.
+	 *
+	 * 2. **A generator function**: A function called each time a default is needed. Use this for dynamic defaults
+	 * (e.g., timestamps, UUIDs) or when explicit control over value creation is required.
+	 *
+	 * Defaults are evaluated eagerly during node construction.
+	 *
+	 * For recursive schemas, use {@link SchemaStaticsAlpha.withDefaultRecursive} instead.
+	 *
+	 * See the {@link https://fluidframework.com/docs/data-structures/tree/schema-definition/default-field-values | Default Field Values documentation}
+	 * for a comprehensive guide with additional examples.
 	 *
 	 * @param fieldSchema - The field schema to add a default to (e.g., `factory.required(factory.string)` or `factory.optional(factory.number)`)
 	 * @param defaultValue - A {@link NodeProvider} specifying the default value.
 	 *
 	 * @example
+	 * A schema with a mix of required, defaulted, and dynamic fields:
 	 * ```typescript
-	 * const MySchema = factory.objectAlpha("MyObject", {
-	 *     // Provide values directly
-	 *     name: factory.withDefault(factory.required(factory.string), "untitled"),
-	 *     count: factory.withDefault(factory.required(factory.number), 0),
-	 *     metadata: factory.withDefault(factory.optional(Metadata), new Metadata({ version: 1 })),
+	 * const factory = new SchemaFactoryAlpha("example");
 	 *
-	 *     // Use generator functions for dynamic values
-	 *     timestamp: factory.withDefault(factory.required(factory.number), () => Date.now()),
-	 *     id: factory.withDefault(factory.required(factory.string), () => crypto.randomUUID()),
-	 * });
+	 * class Task extends factory.objectAlpha("Task", {
+	 *     // No default — must always be provided in the constructor
+	 *     title: factory.required(factory.string),
 	 *
-	 * const obj1 = new MySchema({}); // All defaults applied
-	 * const obj2 = new MySchema({ name: "custom" }); // name="custom", other defaults applied
+	 *     // Required field with a static default
+	 *     status: factory.withDefault(factory.required(factory.string), "todo"),
+	 *
+	 *     // Optional field with a custom default (instead of `undefined`)
+	 *     priority: factory.withDefault(factory.optional(factory.number), 0),
+	 *
+	 *     // Dynamic default using a generator function
+	 *     createdAt: factory.withDefault(factory.required(factory.number), () => Date.now()),
+	 * }) {}
+	 *
+	 * // Only `title` is required in the constructor; the rest use their defaults
+	 * const task = new Task({ title: "Write docs" });
+	 * // task.status === "todo"
+	 * // task.priority === 0
+	 * // task.createdAt is set to the current timestamp
+	 *
+	 * // Defaults can be overridden by providing explicit values
+	 * const urgentTask = new Task({ title: "Fix bug", status: "in-progress", priority: 1 });
 	 * ```
 	 *
 	 * @privateRemarks
@@ -208,6 +246,9 @@ export interface SchemaStaticsAlpha {
 	 * @remarks
 	 * This version of {@link SchemaStaticsAlpha.withDefault} has fewer type constraints to work around TypeScript limitations, see {@link Unenforced}.
 	 * See {@link ValidateRecursiveSchema} for additional information about using recursive schema.
+	 *
+	 * See the {@link https://fluidframework.com/docs/data-structures/tree/schema-definition/default-field-values#recursive-types | Default Field Values — Recursive Types documentation}
+	 * for usage examples and guidance on avoiding infinite recursion with recursive defaults.
 	 */
 	withDefaultRecursive: <
 		Kind extends FieldKind,

--- a/website/docs/data-structures/tree/schema-definition/default-field-values.mdx
+++ b/website/docs/data-structures/tree/schema-definition/default-field-values.mdx
@@ -5,12 +5,13 @@ sidebar_position: 2
 
 # Default Field Values
 
-The `withDefault` API is available on [`SchemaFactoryAlpha`](../../../api/fluid-framework/schemafactoryalpha-class). It allows you to specify default values for fields,
+The [`withDefault`](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefault-propertysignature) API is available on [`SchemaFactoryAlpha`](../../../api/fluid-framework/schemafactoryalpha-class). It allows you to specify default values for fields,
 making them optional in constructors even when the field is marked as [`required`](../../../api/fluid-framework/schemastatics-interface.md#required-propertysignature) in the schema.
 This provides a better developer experience by reducing boilerplate when creating objects.
 
-The `withDefault` API wraps a field schema and defines a default value to use when the field is not provided during
-construction. The default value must be of an allowed type of the field. You can provide defaults in two ways:
+[`withDefault`](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefault-propertysignature) wraps a field schema and defines a default value to use when the field is not provided during
+construction. The default value must be of an allowed type of the field. You can provide defaults in two ways
+(see [`NodeProvider`](../../../api/fluid-framework/nodeprovider-typealias)):
 
 - **A value**: When a value is provided directly, the data is copied for each use to ensure independence between instances.
 - **A generator function**: A function that is called each time to produce a fresh value.
@@ -164,7 +165,7 @@ class GameState extends sf.objectAlpha("GameState", {
 
 ## Recursive Types
 
-`withDefaultRecursive` is available for use inside [recursive schemas](./index.mdx#recursive-schema). Use `objectRecursiveAlpha` (rather than
+[`withDefaultRecursive`](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefaultrecursive-propertysignature) is available for use inside [recursive schemas](./index.mdx#recursive-schema). Use `objectRecursiveAlpha` (rather than
 `objectRecursive`) when defining recursive schemas with defaults, as it correctly makes defaulted fields optional in
 the constructor for all field kinds including `requiredRecursive`. It works the same as `withDefault` but is
 necessary to avoid TypeScript's circular reference limitations.
@@ -255,5 +256,8 @@ sf.withDefault(sf.optional(sf.string), () => 8080);
 - [Schema Definition](./index.mdx) — Overview of defining schemas with `SchemaFactory`
 - [Setting Properties as Optional](./index.mdx#setting-properties-as-optional) — Using `sf.optional()` for optional fields
 - [Recursive Schema](./index.mdx#recursive-schema) — Defining recursive types with `objectRecursive()`
-- [`SchemaFactoryAlpha` API](../../../api/fluid-framework/schemafactoryalpha-class) — API reference for `withDefault` and `withDefaultRecursive`
+- [`withDefault` API reference](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefault-propertysignature) — Type signatures and parameter details
+- [`withDefaultRecursive` API reference](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefaultrecursive-propertysignature) — Recursive variant
+- [`NodeProvider` API reference](../../../api/fluid-framework/nodeprovider-typealias) — The type used for default values
+- [`SchemaFactoryAlpha` API](../../../api/fluid-framework/schemafactoryalpha-class) — Full API reference for `SchemaFactoryAlpha`
 - [Schema Evolution](../schema-evolution/index.mdx) — Safely updating schemas over time


### PR DESCRIPTION
## Description

The `withDefault` API docs (TSDoc) and the user-facing documentation page existed independently without linking to each other, making it harder for users to discover the full picture from either entry point.

This PR improves the `withDefault` documentation in two ways:

- **API docs (TSDoc)**: Expanded the `withDefault` remarks with structured guidance on required vs optional field defaults, value vs generator defaults, and a self-contained example showing a realistic schema. Added `{@link}` references to the fluidframework.com default field values guide from both `withDefault` and `withDefaultRecursive`. Added a cross-reference from `NodeProvider` back to `withDefault`.

- **User-facing docs (website)**: Linked `withDefault`, `withDefaultRecursive`, and `NodeProvider` inline where they are first referenced, so users can jump to the API reference for type signatures and parameter details. Expanded the See Also section with direct links to individual API members.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Documentation-only change -- no API surface or behavioral changes. No changeset needed.