### PR TITLE
refactor(tree): convert SchemaCompatibilityTester class to checkSchemaCompatibility function

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -32,7 +32,7 @@ import {
 	tryGetTreeNodeForField,
 	setField,
 	normalizeFieldSchema,
-	SchemaCompatibilityTester,
+	checkSchemaCompatibility,
 	type InsertableContent,
 	type TreeViewConfiguration,
 	type TreeViewAlpha,
@@ -57,6 +57,7 @@ import {
 	toInitialSchema,
 	toUpgradeSchema,
 	type TreeBranchAlpha,
+	type TreeSchema,
 } from "../simple-tree/index.js";
 import {
 	type Breakable,
@@ -98,7 +99,7 @@ export class SchematizingSimpleTreeView<
 		IEmitter<TreeViewEvents & TreeBranchEvents> &
 		HasListeners<TreeViewEvents & TreeBranchEvents> = createEmitter();
 
-	private readonly viewSchema: SchemaCompatibilityTester;
+	private readonly viewSchema: TreeSchema;
 
 	/**
 	 * Events to unregister upon flex-tree view disposal.
@@ -143,7 +144,7 @@ export class SchematizingSimpleTreeView<
 
 		const configAlpha = new TreeViewConfigurationAlpha({ schema: config.schema });
 
-		this.viewSchema = new SchemaCompatibilityTester(configAlpha);
+		this.viewSchema = configAlpha;
 		// This must be initialized before `update` can be called.
 		this.currentCompatibility = {
 			canView: false,
@@ -258,7 +259,7 @@ export class SchematizingSimpleTreeView<
 			);
 		}
 
-		const newSchema = toUpgradeSchema(this.viewSchema.viewSchema.root);
+		const newSchema = toUpgradeSchema(this.viewSchema.root);
 		this.runSchemaEdit(() => this.checkout.updateSchema(newSchema));
 	}
 
@@ -347,7 +348,10 @@ export class SchematizingSimpleTreeView<
 	private update(): void {
 		this.disposeFlexView();
 
-		const compatibility = this.viewSchema.checkCompatibility(this.checkout.storedSchema);
+		const compatibility = checkSchemaCompatibility(
+			this.viewSchema,
+			this.checkout.storedSchema,
+		);
 
 		this.currentCompatibility = {
 			...compatibility,

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -100,7 +100,7 @@ export {
 export type { TreeSchemaEncodingOptions } from "./getJsonSchema.js";
 export { getJsonSchema } from "./getJsonSchema.js";
 export { getSimpleSchema } from "./getSimpleSchema.js";
-export { SchemaCompatibilityTester } from "./schemaCompatibilityTester.js";
+export { checkSchemaCompatibility } from "./schemaCompatibilityTester.js";
 export type {
 	Unenforced,
 	FieldSchemaAlphaUnsafe,

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -15,6 +15,7 @@ import type { SchemaCompatibilityStatus } from "./tree.js";
  * Determines the compatibility of a stored document
  * (based on its stored schema) with a viewer (based on its view schema).
  *
+ * @remarks
  * Adapters can be provided to handle differences between the two schema.
  * Adapters should only use to types in the `view` SchemaRepository.
  *

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -12,58 +12,45 @@ import { getDiscrepanciesInAllowedContent } from "./discrepancies.js";
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**
- * A collection of View information for schema
- * @remarks
- * This contains everything needed to determine compatibility with a given stored schema.
+ * Determines the compatibility of a stored document
+ * (based on its stored schema) with a viewer (based on its view schema).
+ *
+ * Adapters can be provided to handle differences between the two schema.
+ * Adapters should only use to types in the `view` SchemaRepository.
+ *
+ * TODO: this API violates the parse don't validate design philosophy.
+ * It should be wrapped with (or replaced by) a parse style API.
  */
-export class SchemaCompatibilityTester {
-	public constructor(
-		/**
-		 * Schema for the view
-		 */
-		public readonly viewSchema: TreeSchema,
-	) {}
+export function checkSchemaCompatibility(
+	viewSchema: TreeSchema,
+	stored: TreeStoredSchema,
+): Omit<SchemaCompatibilityStatus, "canInitialize"> {
+	// The public API surface assumes defaultSchemaPolicy
+	const policy = defaultSchemaPolicy;
 
-	/**
-	 * Determines the compatibility of a stored document
-	 * (based on its stored schema) with a viewer (based on its view schema).
-	 *
-	 * Adapters can be provided to handle differences between the two schema.
-	 * Adapters should only use to types in the `view` SchemaRepository.
-	 *
-	 * TODO: this API violates the parse don't validate design philosophy.
-	 * It should be wrapped with (or replaced by) a parse style API.
-	 */
-	public checkCompatibility(
-		stored: TreeStoredSchema,
-	): Omit<SchemaCompatibilityStatus, "canInitialize"> {
-		// The public API surface assumes defaultSchemaPolicy
-		const policy = defaultSchemaPolicy;
+	// View schema allows a subset of documents that stored schema does, and the discrepancies are allowed by policy
+	// determined by the view schema (i.e. objects with extra optional fields in the stored schema have opted into allowing this.
+	// In the future, this would also include things like:
+	// - fields with more allowed types in the stored schema than in the view schema have out-of-schema "unknown content" adapters
+	let canView = true;
 
-		// View schema allows a subset of documents that stored schema does, and the discrepancies are allowed by policy
-		// determined by the view schema (i.e. objects with extra optional fields in the stored schema have opted into allowing this.
-		// In the future, this would also include things like:
-		// - fields with more allowed types in the stored schema than in the view schema have out-of-schema "unknown content" adapters
-		let canView = true;
-
-		for (const _discrepancy of getDiscrepanciesInAllowedContent(this.viewSchema, stored)) {
-			canView = false;
-			break;
-		}
-
-		const wouldUpgradeTo = toUpgradeSchema(this.viewSchema.root);
-
-		const canUpgrade = allowsRepoSuperset(policy, stored, wouldUpgradeTo);
-
-		// If true, then upgrading has no effect on what can be stored in the document.
-		// TODO: This should likely be changed to indicate up a schema upgrade would be a no-op, including stored schema metadata.
-		const isEquivalent =
-			canView && canUpgrade && allowsRepoSuperset(policy, wouldUpgradeTo, stored);
-
-		return {
-			canView,
-			canUpgrade,
-			isEquivalent,
-		};
+	for (const _discrepancy of getDiscrepanciesInAllowedContent(viewSchema, stored)) {
+		canView = false;
+		break;
 	}
+
+	const wouldUpgradeTo = toUpgradeSchema(viewSchema.root);
+
+	const canUpgrade = allowsRepoSuperset(policy, stored, wouldUpgradeTo);
+
+	// If true, then upgrading has no effect on what can be stored in the document.
+	// TODO: This should likely be changed to indicate up a schema upgrade would be a no-op, including stored schema metadata.
+	const isEquivalent =
+		canView && canUpgrade && allowsRepoSuperset(policy, wouldUpgradeTo, stored);
+
+	return {
+		canView,
+		canUpgrade,
+		isEquivalent,
+	};
 }

--- a/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
+++ b/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
@@ -13,7 +13,7 @@ import { toInitialSchema } from "../toStoredSchema.js";
 import { createTreeSchema } from "../treeSchema.js";
 
 import { TreeViewConfigurationAlpha, TreeViewConfiguration } from "./configuration.js";
-import { SchemaCompatibilityTester } from "./schemaCompatibilityTester.js";
+import { checkSchemaCompatibility } from "./schemaCompatibilityTester.js";
 import { generateSchemaFromSimpleSchema } from "./schemaFromSimple.js";
 import {
 	decodeSchemaCompatibilitySnapshot,
@@ -78,8 +78,7 @@ export function checkCompatibility(
 ): Omit<SchemaCompatibilityStatus, "canInitialize"> {
 	const viewAsAlpha = new TreeViewConfigurationAlpha({ schema: view.schema });
 	const stored = toInitialSchema(viewWhichCreatedStoredSchema.schema);
-	const tester = new SchemaCompatibilityTester(viewAsAlpha);
-	return tester.checkCompatibility(stored);
+	return checkSchemaCompatibility(viewAsAlpha, stored);
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/storedSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/storedSchema.ts
@@ -13,7 +13,7 @@ import { normalizeFieldSchema, type ImplicitFieldSchema } from "../fieldSchema.j
 import { toStoredSchema } from "../toStoredSchema.js";
 
 import { TreeViewConfigurationAlpha } from "./configuration.js";
-import { SchemaCompatibilityTester } from "./schemaCompatibilityTester.js";
+import { checkSchemaCompatibility } from "./schemaCompatibilityTester.js";
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**
@@ -104,6 +104,5 @@ export function comparePersistedSchema(
 	const config = new TreeViewConfigurationAlpha({
 		schema: normalizeFieldSchema(view),
 	});
-	const viewSchema = new SchemaCompatibilityTester(config);
-	return viewSchema.checkCompatibility(stored);
+	return checkSchemaCompatibility(config, stored);
 }

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -578,7 +578,7 @@ export interface TreeViewAlpha<
  * See SharedTree's README for more information about choosing a compatibility policy.
  *
  * @privateRemarks
- * See {@link SchemaCompatibilityTester} for the implementation of this compatibility checking.
+ * See {@link checkSchemaCompatibility} for the implementation of this compatibility checking.
  *
  * @sealed @public
  */

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -140,7 +140,7 @@ export {
 	extractPersistedSchema,
 	comparePersistedSchema,
 	type ConciseTree,
-	SchemaCompatibilityTester,
+	checkSchemaCompatibility,
 	type Unenforced,
 	type System_Unsafe,
 	type ArrayNodeCustomizableSchemaUnsafe,

--- a/packages/dds/tree/src/simple-tree/simpleSchemaFormatV1.ts
+++ b/packages/dds/tree/src/simple-tree/simpleSchemaFormatV1.ts
@@ -7,7 +7,7 @@
  * This file contains a format for serializing the compatibility impacting subset of simple schema.
 
  * This format can be used for both view and stored simple schema.
- * This only includes all parts of the schema that impact compatibility according to checkSchemaCompatibility.
+ * This only includes all parts of the schema that impact compatibility according to {@link checkSchemaCompatibility}.
  * It may not include some details which impact maintenance of application enforced invariants (like persisted metadata or logic in view schema).
  */
 

--- a/packages/dds/tree/src/simple-tree/simpleSchemaFormatV1.ts
+++ b/packages/dds/tree/src/simple-tree/simpleSchemaFormatV1.ts
@@ -7,7 +7,7 @@
  * This file contains a format for serializing the compatibility impacting subset of simple schema.
 
  * This format can be used for both view and stored simple schema.
- * This only includes all parts of the schema that impact compatibility according to SchemaCompatibilityTester.
+ * This only includes all parts of the schema that impact compatibility according to checkSchemaCompatibility.
  * It may not include some details which impact maintenance of application enforced invariants (like persisted metadata or logic in view schema).
  */
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -10,7 +10,7 @@ import { defaultSchemaPolicy } from "../../../feature-libraries/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { getDiscrepanciesInAllowedContent } from "../../../simple-tree/api/discrepancies.js";
 import {
-	SchemaCompatibilityTester,
+	checkSchemaCompatibility,
 	SchemaFactoryAlpha,
 	TreeViewConfigurationAlpha,
 	schemaStatics,
@@ -64,9 +64,7 @@ describe("Schema Evolution Examples", () => {
 	 */
 	it("basic usage", () => {
 		// Compose all the view information together.
-		const view = new SchemaCompatibilityTester(
-			new TreeViewConfigurationAlpha({ schema: root }),
-		);
+		const viewConfig = new TreeViewConfigurationAlpha({ schema: root });
 
 		// Now lets imagine using this application on a new empty document.
 		// TreeStoredSchemaRepository defaults to a state that permits no document states at all.
@@ -76,7 +74,7 @@ describe("Schema Evolution Examples", () => {
 
 		{
 			// When we open this document, we should check it's compatibility with our application:
-			const compat = view.checkCompatibility(stored);
+			const compat = checkSchemaCompatibility(viewConfig, stored);
 
 			// Sadly for our application, we did not allow empty roots in our view schema,
 			// nor did we provide an adapter capable of handling empty roots.
@@ -98,11 +96,9 @@ describe("Schema Evolution Examples", () => {
 
 			// This example picks the first approach.
 			// Lets simulate the developers of the app making this change by modifying the view schema:
-			const view2 = new SchemaCompatibilityTester(
-				new TreeViewConfigurationAlpha({ schema: tolerantRoot }),
-			);
+			const view2Config = new TreeViewConfigurationAlpha({ schema: tolerantRoot });
 			// When we open this document, we should check it's compatibility with our application:
-			const compat = view2.checkCompatibility(stored);
+			const compat = checkSchemaCompatibility(view2Config, stored);
 
 			// The adjusted view schema can be used read this document, no adapters needed.
 			assert.equal(compat.canUpgrade, true);
@@ -137,7 +133,7 @@ describe("Schema Evolution Examples", () => {
 			// That will cause the document stored schema to change,
 			// which will notify and applications with the document open.
 			// They can recheck their compatibility:
-			const compatNew = view2.checkCompatibility(stored);
+			const compatNew = checkSchemaCompatibility(view2Config, stored);
 			const report = [
 				...getDiscrepanciesInAllowedContent(
 					new TreeViewConfigurationAlpha({ schema: tolerantRoot }),
@@ -161,12 +157,12 @@ describe("Schema Evolution Examples", () => {
 			// And canvas is still the same storage wise, but its view schema references the updated positionedCanvasItem2:
 			const canvas2 = builder.array("Canvas", positionedCanvasItem2);
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const view3 = new SchemaCompatibilityTester(
-				new TreeViewConfigurationAlpha({ schema: builder.optional(canvas2) }),
-			);
+			const view3Config = new TreeViewConfigurationAlpha({
+				schema: builder.optional(canvas2),
+			});
 
 			// With this new schema, we can load the document just like before:
-			const compat2 = view3.checkCompatibility(stored);
+			const compat2 = checkSchemaCompatibility(view3Config, stored);
 			assert.deepEqual(compat2, { canView: false, canUpgrade: true, isEquivalent: false });
 
 			// This is the same case as above where we can choose to do a schema update if we want:
@@ -174,7 +170,7 @@ describe("Schema Evolution Examples", () => {
 			assert(stored.tryUpdateTreeSchema(counter));
 
 			// And recheck compat:
-			const compat3 = view3.checkCompatibility(stored);
+			const compat3 = checkSchemaCompatibility(view3Config, stored);
 			assert.deepEqual(compat3, { canView: true, canUpgrade: true, isEquivalent: true });
 		}
 	});

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../core/index.js";
 import { allowsRepoSuperset, defaultSchemaPolicy } from "../../../feature-libraries/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import { SchemaCompatibilityTester } from "../../../simple-tree/api/schemaCompatibilityTester.js";
+import { checkSchemaCompatibility } from "../../../simple-tree/api/schemaCompatibilityTester.js";
 import {
 	type ImplicitFieldSchema,
 	type SchemaCompatibilityStatus,
@@ -30,12 +30,10 @@ const factory = new SchemaFactoryAlpha("");
 
 function expectCompatibility(
 	{ view, stored }: { view: ImplicitFieldSchema; stored: TreeStoredSchema },
-	expected: ReturnType<SchemaCompatibilityTester["checkCompatibility"]>,
+	expected: ReturnType<typeof checkSchemaCompatibility>,
 ) {
-	const viewSchema = new SchemaCompatibilityTester(
-		new TreeViewConfigurationAlpha({ schema: view }),
-	);
-	const compatibility = viewSchema.checkCompatibility(stored);
+	const viewSchema = new TreeViewConfigurationAlpha({ schema: view });
+	const compatibility = checkSchemaCompatibility(viewSchema, stored);
 	assert.deepEqual(compatibility, expected);
 
 	// This does not include staged allowed types.
@@ -51,8 +49,8 @@ function expectCompatibility(
 	}
 }
 
-describe("SchemaCompatibilityTester", () => {
-	describe(".checkCompatibility", () => {
+describe("checkSchemaCompatibility", () => {
+	describe("function", () => {
 		it("works with never trees", () => {
 			class NeverObject extends factory.objectRecursive("NeverObject", {
 				foo: factory.requiredRecursive([() => NeverObject]),

--- a/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
@@ -19,13 +19,14 @@ import {
 } from "../../../shared-tree/index.js";
 import {
 	extractPersistedSchema,
-	SchemaCompatibilityTester,
+	checkSchemaCompatibility,
 	SchemaFactoryAlpha,
 	schemaStatics,
 	toUpgradeSchema,
 	TreeViewConfiguration,
 	TreeViewConfigurationAlpha,
 	type ValidateRecursiveSchema,
+	type TreeSchema,
 } from "../../../simple-tree/index.js";
 import { TestSchemaRepository, TestTreeProviderLite } from "../../utils.js";
 
@@ -224,26 +225,24 @@ describe("staged allowed type upgrade", () => {
 		const stored = new TestSchemaRepository(defaultSchemaPolicy);
 		assert(stored.tryUpdateRootFieldSchema(storedEmptyFieldSchema));
 
-		let view = new SchemaCompatibilityTester(
-			new TreeViewConfigurationAlpha({ schema: schemaA }),
-		);
+		let viewConfig: TreeSchema = new TreeViewConfigurationAlpha({ schema: schemaA });
 
 		// open document, and check its compatibility with our application
-		const compat = view.checkCompatibility(stored);
+		const compat = checkSchemaCompatibility(viewConfig, stored);
 		assert.deepEqual(compat, { canView: false, canUpgrade: true, isEquivalent: false });
 		assert(stored.tryUpdateRootFieldSchema(toUpgradeSchema(schemaA).rootFieldSchema));
 		assert(stored.tryUpdateTreeSchema(schemaStatics.number));
 
 		// view schema is A
-		assert.deepEqual(view.checkCompatibility(stored), {
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
 		});
 
 		// view schema is B (includes staged string)
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaB }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaB });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
@@ -253,15 +252,15 @@ describe("staged allowed type upgrade", () => {
 		assert(stored.tryUpdateRootFieldSchema(toUpgradeSchema(schemaB).rootFieldSchema));
 
 		// nothing has changed, so compatibility is the same
-		assert.deepEqual(view.checkCompatibility(stored), {
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
 		});
 
 		// view schema now wants full support for string (not just staged)
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaC }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaC });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: false,
 			canUpgrade: true,
 			isEquivalent: false,
@@ -272,8 +271,8 @@ describe("staged allowed type upgrade", () => {
 		assert(stored.tryUpdateTreeSchema(schemaStatics.string));
 
 		// validate C is now fully supported
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaC }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaC });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
@@ -345,18 +344,16 @@ describe("staged optional upgrade", () => {
 		const stored = new TestSchemaRepository(defaultSchemaPolicy, toUpgradeSchema(schemaA));
 
 		// View A: can view, can upgrade (no-op), is equivalent
-		let view = new SchemaCompatibilityTester(
-			new TreeViewConfigurationAlpha({ schema: schemaA }),
-		);
-		assert.deepEqual(view.checkCompatibility(stored), {
+		let viewConfig: TreeSchema = new TreeViewConfigurationAlpha({ schema: schemaA });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
 		});
 
 		// View B (staged optional): can view required stored, upgrade is a no-op
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaB }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaB });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
@@ -364,15 +361,15 @@ describe("staged optional upgrade", () => {
 
 		// Upgrading with B is a no-op — stored stays required
 		assert(stored.tryUpdateRootFieldSchema(toUpgradeSchema(schemaB).rootFieldSchema));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
 		});
 
 		// View C (fully optional) cannot yet view a required stored field
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaC }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaC });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: false,
 			canUpgrade: true,
 			isEquivalent: false,
@@ -382,7 +379,7 @@ describe("staged optional upgrade", () => {
 		assert(stored.tryUpdateRootFieldSchema(toUpgradeSchema(schemaC).rootFieldSchema));
 
 		// View C is now compatible and equivalent
-		assert.deepEqual(view.checkCompatibility(stored), {
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: true,
 			isEquivalent: true,
@@ -390,16 +387,16 @@ describe("staged optional upgrade", () => {
 
 		// View B after full upgrade: can view (optional kinds match), but upgrade target
 		// is required which is no longer a valid upgrade from optional stored
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaB }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaB });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: true,
 			canUpgrade: false,
 			isEquivalent: false,
 		});
 
 		// View A (required) is no longer compatible with optional stored
-		view = new SchemaCompatibilityTester(new TreeViewConfigurationAlpha({ schema: schemaA }));
-		assert.deepEqual(view.checkCompatibility(stored), {
+		viewConfig = new TreeViewConfigurationAlpha({ schema: schemaA });
+		assert.deepEqual(checkSchemaCompatibility(viewConfig, stored), {
 			canView: false,
 			canUpgrade: false,
 			isEquivalent: false,


### PR DESCRIPTION
## Description

Converts the `SchemaCompatibilityTester` class into a standalone `checkSchemaCompatibility` function. The class only stored a `viewSchema` in its constructor and had a single `checkCompatibility` method, making it an unnecessary wrapper — a plain function is simpler and more idiomatic.

This is an internal-only refactor; `SchemaCompatibilityTester` was not part of the public API surface. No behavioral changes.

### Changes

- **`schemaCompatibilityTester.ts`** — replaced class with exported `checkSchemaCompatibility(viewSchema, stored)` function
- **`schematizingTreeView.ts`** — field type changed from `SchemaCompatibilityTester` to `TreeSchema`; call sites updated
- **`snapshotCompatibilityChecker.ts`**, **`storedSchema.ts`** — replaced `new SchemaCompatibilityTester(…).checkCompatibility(…)` with direct function call
- **`api/index.ts`**, **`simple-tree/index.ts`** — updated re-exports
- **Test files** — updated imports, call sites, and describe block names
- **Doc comments** — updated `@link` and prose references

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Straightforward mechanical refactor — each call site simply inlines what was previously a constructor + method call into a single function call.