### PR TITLE
fix(container-runtime): prevent invalid handle reuse after parent skip recursion

### DIFF
--- a/.changeset/summarizer-handle-after-parent-skip.md
+++ b/.changeset/summarizer-handle-after-parent-skip.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": fix
+---
+Fix summarizer emitting invalid nested handles after a parent skipped recursion
+
+Fixes a bug where a `SummarizerNode` could emit a `SummaryType.Handle` for a child even though the child's content was not directly present in the referenced summary version. This happened when the child's parent had previously emitted a handle (skipped recursion), causing the child's content to only be transitively reachable through the parent's handle chain. On subsequent summaries, if the parent became dirty and re-summarized while the child had not changed, the child would emit a handle pointing to a version where its path could not be resolved by the storage service, producing errors like:
+
+```
+ODSP fetch error [404] ... fluidElementNotFound
+Cannot locate node with path '.app/.channels/<dataStore>/.channels/root' under '<snapshotId>'
+```
+
+This surfaced most visibly on SharedTree, whose incremental summary builder emits many nested chunk-level handles, but the underlying issue affected any DDS relying on nested handle reuse across summaries.
+
+The fix ensures that when a parent node skips recursion, all of its descendants clear their tracked reference sequence number so they will re-emit a full summary tree next time, rather than an unresolvable handle.

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -345,13 +345,17 @@ export class SummarizerNode implements IRootSummarizerNode {
 			this.wipReferenceSequenceNumber !== undefined,
 			0x1a4 /* "Not tracking a summary" */,
 		);
-		if (parentSkipRecursion && this._lastSummaryReferenceSequenceNumber === undefined) {
-			// This case the child is added after the latest non-failure summary.
-			// This node and all children should consider themselves as still not
-			// having a successful summary yet.
-			// We cannot "reuse" this node if unchanged since that summary, because
-			// handles will be unable to point to that node. It never made it to the
-			// tree itself, and only exists as an attach op in the _outstandingOps.
+		if (parentSkipRecursion) {
+			// When the parent skipped recursion (emitted a handle instead of a full subtree),
+			// this node's content is not directly stored in the new summary version. It is only
+			// transitively accessible via the parent's handle reference. We must clear
+			// _lastSummaryReferenceSequenceNumber so that this node does not attempt to emit a
+			// handle in future summaries pointing to this version, because the storage service
+			// cannot resolve nested paths through handle references.
+			this._lastSummaryReferenceSequenceNumber = undefined;
+			for (const child of this.children.values()) {
+				child.completeSummaryCore(proposalHandle, true);
+			}
 			this.clearSummary();
 			return;
 		}

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -356,6 +356,103 @@ describe("Runtime", () => {
 				});
 			});
 
+			describe("Handle Reuse After Parent Skip Recursion", () => {
+				it("Should not reuse handle for child when parent previously used a handle", async () => {
+					// Regression test: When a parent node emits a handle (skips recursion),
+					// its children's content is not directly stored in the new summary version.
+					// In the next summary, if the parent is re-summarized but a child hasn't changed,
+					// the child must NOT emit a handle, because the storage service cannot resolve
+					// nested paths through handle references (fluidElementNotFound error).
+
+					// Setup: root -> mid -> leaf, all loaded from a summary at refSeq 10
+					createRoot({ refSeq: 10 });
+					createMid({ type: CreateSummarizerNodeSource.FromSummary });
+					createLeaf({ type: CreateSummarizerNodeSource.FromSummary });
+					assert(midNode !== undefined, "midNode should be created");
+					assert(leafNode !== undefined, "leafNode should be created");
+					const mid = midNode;
+					const leaf = leafNode;
+
+					// Summary 1: mid has no changes -> emits handle (skips recursion)
+					// root is changed so it re-summarizes
+					rootNode.recordChange(fakeOp(11));
+					rootNode.startSummary(20, logger, 10);
+					const result1 = await rootNode.summarize(false);
+					assert(result1.summary.type === SummaryType.Tree, "root should be tree");
+					// root calls summarizeInternalFn which would call mid.summarize
+					// mid hasn't changed so it uses handle
+					const midResult1 = await mid.summarize(false);
+					assert(
+						midResult1.summary.type === SummaryType.Handle,
+						"mid should be handle in summary 1",
+					);
+					rootNode.completeSummary("handle-1");
+					await rootNode.refreshLatestSummary("handle-1", 20);
+
+					// Between summaries: mid gets marked dirty (e.g., GC state change)
+					// but leaf has not changed at all
+					mid.recordChange(fakeOp(21));
+
+					// Summary 2: mid is dirty -> will be fully re-summarized
+					// leaf has NOT changed -> previously would incorrectly emit a handle
+					rootNode.startSummary(30, logger, 20);
+					const leafResult2 = await leaf.summarize(false);
+
+					// The fix: leaf must NOT emit a handle because its content was not
+					// directly stored in the previous summary version (it was only
+					// transitively accessible via mid's handle reference).
+					assert(
+						leafResult2.summary.type === SummaryType.Tree,
+						"leaf should be tree (not handle) since its parent used a handle in the previous summary",
+					);
+					assertSummarizeCalls(1, 0, 1);
+				});
+
+				it("Should correctly re-enable handle reuse after child is directly summarized", async () => {
+					// After the child is fully re-summarized and the summary is acked,
+					// it should be able to use handles again in subsequent summaries.
+
+					createRoot({ refSeq: 10 });
+					createMid({ type: CreateSummarizerNodeSource.FromSummary });
+					createLeaf({ type: CreateSummarizerNodeSource.FromSummary });
+					assert(midNode !== undefined, "midNode should be created");
+					assert(leafNode !== undefined, "leafNode should be created");
+					const mid = midNode;
+					const leaf = leafNode;
+
+					// Summary 1: mid uses handle (unchanged), root is dirty
+					rootNode.recordChange(fakeOp(11));
+					rootNode.startSummary(20, logger, 10);
+					await rootNode.summarize(false);
+					await mid.summarize(false); // handle
+					rootNode.completeSummary("handle-1");
+					await rootNode.refreshLatestSummary("handle-1", 20);
+
+					// Summary 2: root and mid are dirty, leaf is re-summarized (forced by fix)
+					rootNode.recordChange(fakeOp(21));
+					mid.recordChange(fakeOp(21));
+					rootNode.startSummary(30, logger, 20);
+					await rootNode.summarize(false);
+					const midResult2 = await mid.summarize(false);
+					assert(midResult2.summary.type === SummaryType.Tree, "mid should be tree");
+					const leafResult2 = await leaf.summarize(false);
+					assert(leafResult2.summary.type === SummaryType.Tree, "leaf should be tree");
+					rootNode.completeSummary("handle-2");
+					await rootNode.refreshLatestSummary("handle-2", 30);
+
+					// Summary 3: root is dirty but mid and leaf are not -> leaf should use handle
+					rootNode.recordChange(fakeOp(31));
+					rootNode.startSummary(40, logger, 30);
+					await rootNode.summarize(false);
+					await mid.summarize(false);
+					const leafResult3 = await leaf.summarize(false);
+					assert(
+						leafResult3.summary.type === SummaryType.Handle,
+						"leaf should use handle after being directly summarized and acked",
+					);
+				});
+			});
+
 			describe("Refresh Latest Summary", () => {
 				it("Should not refresh latest if already passed ref seq number", async () => {
 					createRoot({ refSeq: summaryRefSeq });


### PR DESCRIPTION
## Description

Fixes a summarizer bug that caused ODSP `404 fluidElementNotFound` errors during incremental summarization, most visibly for containers using SharedTree as the root DDS:

```
ODSP fetch error [404] ... fluidElementNotFound
Cannot locate node with path '.app/.channels/<dataStore>/.channels/root' under '<snapshotId>'
```

### Root cause

When a `SummarizerNode` emits a `SummaryType.Handle` (skips recursion), its subtree's content is not directly stored in the resulting summary version — the child paths are only reachable transitively through the parent's handle reference. However, `completeSummaryCore` was still promoting each descendant's `_lastSummaryReferenceSequenceNumber` (via `refreshLatestSummaryFromPending`) as if their content had been written.

On a later summary, if the parent became dirty and re-summarized while a descendant had not changed, the descendant would emit a handle pointing back to the version where its content only lived behind the parent's handle. The ODSP snapshot upload path (`odspSummaryUploadManager.writeSummaryTree`) then constructed an id like `${parentHandle}/${rootNodeName}${handlePath}` that the server cannot resolve, because it does not follow nested handle references, yielding `fluidElementNotFound`.

### Why this is disproportionately visible on SharedTree

SharedTree's `ForestIncrementalSummaryBuilder` emits many nested chunk-level handles inside the DDS itself — a pattern unique among current DDSes. Workloads with large trees and frequent GC state churn on the containing data store made the bad handle emission a near-certainty. Other DDSes only reuse handles at the DDS-root boundary and largely dodge the bug.

### Fix

In `SummarizerNode.completeSummaryCore`, when `parentSkipRecursion` is true, clear `_lastSummaryReferenceSequenceNumber` on the entire descendant subtree (not just newly-created nodes, which was the prior guard). This forces those descendants to emit a full `SummaryType.Tree` the next time they are summarized instead of an unresolvable handle. Once they've been directly summarized and acked, normal handle reuse resumes.

The clearing also indirectly disables SharedTree's chunk-level incremental handles for that next summary, since `summarizerNode.ts` passes `incrementalSummaryContext: undefined` when there is no tracked reference sequence number.

### Cost

Bounded and rare: it only triggers on the summary immediately after a parent used a handle *and* then became dirty. Cost is one extra full serialization of the affected subtree, one time per cycle. The prior behavior produced broken summaries and forced full retries, which is strictly worse.

### Repro / verification

Two regression tests were added in `summarizerNode.spec.ts` under `Handle Reuse After Parent Skip Recursion`:

1. After a parent emits a handle and later becomes dirty, an unchanged descendant must emit a full tree (not a handle).
2. After that forced re-summarization is acked, normal handle reuse resumes on the following summary.

All 998 `container-runtime` tests pass locally. Linting and formatting are clean.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- Please sanity-check the interaction with `SummarizerNodeWithGc.completeSummaryCore`. With the fix, when the parent skips recursion, `super.completeSummaryCore` does not add the descendant to `pendingSummaries`; the GC subclass's lookup then gracefully no-ops, and the 15 GC-focused tests still pass.
- I considered narrowing the fix to only clear descendants that had actually been loaded from a previous summary (rather than "all descendants"), but the extra bookkeeping did not seem worth it given how rarely this path fires and how surgical the fallout is (one extra tree serialization).
