### PR TITLE
feat(tree): no-commit option on `applyChange`

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1797,7 +1797,7 @@ export interface TreeBranch extends IDisposable {
 
 // @alpha @sealed
 export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
-    applyChange(change: JsonCompatibleReadOnly): void;
+    applyChange(change: JsonCompatibleReadOnly, generateCommit?: boolean): void;
     readonly events: Listenable_2<TreeBranchEvents>;
     // (undocumented)
     fork(): TreeBranchAlpha;

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -166,8 +166,8 @@ export class SchematizingSimpleTreeView<
 		return true;
 	}
 
-	public applyChange(change: JsonCompatibleReadOnly): void {
-		this.checkout.applySerializedChange(change);
+	public applyChange(change: JsonCompatibleReadOnly, generateCommit?: boolean): void {
+		this.checkout.applySerializedChange(change, generateCommit);
 	}
 
 	public hasRootSchema<TSchema extends ImplicitFieldSchema>(

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -858,7 +858,10 @@ export class TreeCheckout implements ITreeCheckout {
 	 * Applies the given serialized change (as was produced via a `"changed"` event of another checkout) to this checkout.
 	 */
 	@throwIfBroken
-	public applySerializedChange(serializedChange: JsonCompatibleReadOnly): void {
+	public applySerializedChange(
+		serializedChange: JsonCompatibleReadOnly,
+		generateCommit: boolean = true,
+	): void {
 		if (!isSerializedChange(serializedChange)) {
 			throw new UsageError(`Cannot apply change. Invalid serialized change format.`);
 		}
@@ -875,15 +878,29 @@ export class TreeCheckout implements ITreeCheckout {
 			isSummary: false,
 		};
 		const decodedChange = this.changeFamily.codecs.resolve(4).decode(change, context);
-		// Apply the change to the branch, but _not_ the `activeBranch` - we do not support squashing serialized commits in a transaction.
-		this.#transaction.branch.apply(tagChange(decodedChange, revision));
+
+		if (generateCommit) {
+			// Apply the change to the branch, but _not_ the `activeBranch` - we do not support squashing serialized commits in a transaction.
+			this.#transaction.branch.apply(tagChange(decodedChange, revision));
+		} else {
+			this.applyInternalChange(decodedChange);
+			this.emitChangedLocked(() => {
+				this.#events.emit("changed", {
+					isLocal: true,
+					kind: CommitKind.Default,
+					labels: new Set<unknown>(),
+					getChange: () => serializedChange,
+					getRevertible: () => undefined,
+				});
+			});
+		}
 	}
 
 	// #region TreeBranchAlpha
 
 	@throwIfBroken
-	public applyChange(change: JsonCompatibleReadOnly): void {
-		this.applySerializedChange(change);
+	public applyChange(change: JsonCompatibleReadOnly, generateCommit?: boolean): void {
+		this.applySerializedChange(change, generateCommit);
 	}
 
 	public isBranch(): this is TreeBranchAlpha {
@@ -1772,7 +1789,11 @@ function verboseFromCursor(
 
 interface SerializedChange {
 	version: 1;
-	revision: RevisionTag;
+	/**
+	 * The revision associated with the change.
+	 * Undefined if the change is not associated with a revision (e.g. a rebase).
+	 */
+	revision: RevisionTag | undefined;
 	change: JsonCompatibleReadOnly;
 	originatorId: SessionId;
 }
@@ -1784,7 +1805,9 @@ function isSerializedChange(value: unknown): value is SerializedChange {
 	const change = value as Partial<SerializedChange>;
 	return (
 		change.version === 1 &&
-		(change.revision === "root" || typeof change.revision === "number") &&
+		(change.revision === undefined ||
+			change.revision === "root" ||
+			typeof change.revision === "number") &&
 		typeof change.originatorId === "string" &&
 		isStableId(change.originatorId) &&
 		change.change !== undefined

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -356,6 +356,8 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
 	/**
 	 * Apply a serialized change to this branch.
 	 * @param change - the change to apply.
+	 * @param generateCommit - whether to generate a commit for this change. Defaults to true.
+	 * Typically set to false when applying the net change corresponding to a rebase.
 	 * Changes are acquired via `getChange` in a branch's {@link TreeBranchEvents.changed | "changed"} event.
 	 * @remarks Changes may only be applied to a SharedTree with the same IdCompressor instance and branch state from which they were generated.
 	 * They may be created by one branch and applied to another, but only if both branches share the same history at the time of creation and application.
@@ -364,7 +366,7 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
 	 * TODO: This method will support applying changes from different IdCompressor instances as long as they have the same local session ID.
 	 * Update the tests and docs to match when that is done.
 	 */
-	applyChange(change: JsonCompatibleReadOnly): void;
+	applyChange(change: JsonCompatibleReadOnly, generateCommit?: boolean): void;
 
 	/**
 	 * Determines if there are changes on the given branch that are not present on this branch.

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -9,7 +9,7 @@ import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
-import type { Revertible } from "../../../core/index.js";
+import { CommitKind, type ChangeMetadata, type Revertible } from "../../../core/index.js";
 import { Tree } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { UnhydratedFlexTreeNode } from "../../../simple-tree/core/index.js";
@@ -424,6 +424,46 @@ describe("simple-tree tree", () => {
 				viewA.applyChange(change);
 			});
 			assert.equal(viewA.root, 5);
+		});
+
+		it("does not generate a commit when generateCommit is false", () => {
+			// Setup
+			const config = new TreeViewConfiguration({ schema: schema.number });
+			const viewA = getView(config);
+			viewA.initialize(3);
+			const viewB = viewA.fork();
+
+			let change: JsonCompatibleReadOnly | undefined;
+			viewB.events.on("changed", (metadata) => {
+				assert(metadata.isLocal);
+				change = metadata.getChange();
+			});
+
+			viewB.root = 4;
+			assert(change !== undefined);
+
+			const changedFired: ChangeMetadata[] = [];
+			viewA.events.on("changed", (metadata) => {
+				changedFired.push(metadata);
+			});
+
+			const headCommitBefore = viewA.checkout.mainBranch.getHead();
+
+			// Act
+			viewA.applyChange(change, false);
+
+			// Verify
+			const headCommitAfter = viewA.checkout.mainBranch.getHead();
+			assert.equal(headCommitAfter, headCommitBefore);
+			assert.equal(viewA.root, 4);
+			assert.equal(changedFired.length, 1);
+			const { isLocal, getChange, getRevertible, kind, labels, label } = changedFired[0];
+			assert.equal(isLocal, true);
+			assert.equal(kind, CommitKind.Default);
+			assert.equal(labels.size, 0);
+			assert.equal(label, undefined);
+			assert.equal(getChange(), change);
+			assert.equal(getRevertible(), undefined);
 		});
 	});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2231,7 +2231,7 @@ export interface TreeBranch extends IDisposable {
 
 // @alpha @sealed
 export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
-    applyChange(change: JsonCompatibleReadOnly): void;
+    applyChange(change: JsonCompatibleReadOnly, generateCommit?: boolean): void;
     readonly events: Listenable<TreeBranchEvents>;
     // (undocumented)
     fork(): TreeBranchAlpha;


### PR DESCRIPTION
## Description

Adds an optional parameter to `TreeBranchAlpha.applyChange` that makes it possible not to generate a commit for the applied change. This makes sense when the change being applied does not correspond to a real commit but instead correspond to rebase.

This is used in https://github.com/microsoft/FluidFramework/pull/27649.

## Breaking Changes

None