### PR TITLE
chore: remove PreToolUse hooks from .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,24 +4,7 @@
 	},
 	"skipAutoPermissionPrompt": true,
 	"hooks": {
-		"PreToolUse": [
-			{
-				"matcher": "Bash",
-				"hooks": [
-					{
-						"type": "command",
-						"if": "Bash(git push*)",
-						"command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"Before pushing: if ci-readiness-check has NOT been run this session, you MUST either (a) run it now by loading .claude/skills/ci-readiness-check/SKILL.md and following its checklist, or (b) explicitly tell the user you are skipping it and why before proceeding. Silent skips are not allowed.\"}}'",
-						"statusMessage": "Checking CI readiness..."
-					},
-					{
-						"type": "command",
-						"if": "Bash(gh pr create*)",
-						"command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"Before creating this PR, load and follow the fluid-pr-guide skill for title and body conventions.\"}}'"
-					}
-				]
-			}
-		]
+		"PreToolUse": []
 	},
 	"sandbox": {
 		"enabled": true,


### PR DESCRIPTION
## Description

Removes the PreToolUse hooks from `.claude/settings.json` that were blocking CI readiness checks and PR creation guidance hooks. These hooks were causing errors ("hook errored") and preventing normal git/CLI operations.

## Changes

- Cleared the `PreToolUse` hooks array in `.claude/settings.json`