### PR TITLE
fix(ODSP Driver): Harden ODSP host name validation

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -13,7 +13,14 @@ const odspTenants = new Map<string, string>([
  * @internal
  */
 export function isOdspHostname(server: string): boolean {
-	return server.endsWith("sharepoint.com") || server.endsWith("sharepoint-df.com");
+	// Normalize: strip scheme and any path/port, then lowercase, so we compare the bare host.
+	const host = (server.replace(/^https?:\/\//i, "").split(/[/:]/)[0] ?? "").toLowerCase();
+	return (
+		host === "sharepoint.com" ||
+		host.endsWith(".sharepoint.com") ||
+		host === "sharepoint-df.com" ||
+		host.endsWith(".sharepoint-df.com")
+	);
 }
 
 // eslint-disable-next-line jsdoc/require-description -- TODO: Add documentation

--- a/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { getAadTenant } from "../odspDocLibUtils.js";
+import { getAadTenant, isOdspHostname } from "../odspDocLibUtils.js";
 
 describe("getAadTenant", () => {
 	it("returns `onmicrosoft` tenant if ODSP personal site url is passed", () => {
@@ -42,4 +42,34 @@ describe("getAadTenant", () => {
 		const result = getAadTenant("vanity.com");
 		assert.strictEqual(result, "vanity.com");
 	});
+});
+
+describe("isOdspHostname", () => {
+	for (const server of [
+		"sharepoint.com",
+		"contoso.sharepoint.com",
+		"contoso-my.sharepoint.com",
+		"sharepoint-df.com",
+		"contoso.sharepoint-df.com",
+		"CONTOSO.SharePoint.com",
+		"https://contoso.sharepoint.com/sites/foo",
+		"contoso.sharepoint.com:443",
+	]) {
+		it(`accepts ODSP host "${server}"`, () => {
+			assert.strictEqual(isOdspHostname(server), true);
+		});
+	}
+
+	for (const server of [
+		"evilsharepoint.com",
+		"notsharepoint-df.com",
+		"attacker.com",
+		"contoso.sharepoint.com.evil.com",
+		"sharepoint.com.evil.com",
+		"",
+	]) {
+		it(`rejects non-ODSP host "${server}"`, () => {
+			assert.strictEqual(isOdspHostname(server), false);
+		});
+	}
 });


### PR DESCRIPTION
## Description

Harden the ODSP host name validation logic to include more cases.