### PR TITLE
feat(website): fixed the link validation by skipping this step.

### DIFF
--- a/website/skipped-urls.txt
+++ b/website/skipped-urls.txt
@@ -33,3 +33,6 @@ https://foo-my.sharepoint.com*
 
 # Docusaurus infra
 http://localhost:3000/assets/css/styles.*.css
+
+# Generated Pagefind assets are verified separately in the deployment pipeline.
+http://localhost:3000/pagefind/*


### PR DESCRIPTION
## Description

The introduction of PageFind added some links to be tested in the website deployment pipeline. This change should fix that.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
