### PR TITLE
feat(tree): `computeNetChangeIfRebasedOnto`

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1798,6 +1798,7 @@ export interface TreeBranch extends IDisposable {
 // @alpha @sealed
 export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
     applyChange(change: JsonCompatibleReadOnly): void;
+    computeNetChangeIfRebasedOnto(branch: TreeBranch): JsonCompatibleReadOnly | undefined;
     readonly events: Listenable_2<TreeBranchEvents>;
     // (undocumented)
     fork(): TreeBranchAlpha;

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -537,5 +537,11 @@ export class SchematizingSimpleTreeView<
 		return this.checkout.isMissingEditsFrom(context);
 	}
 
+	public computeNetChangeIfRebasedOnto(
+		context: TreeBranchAlpha,
+	): JsonCompatibleReadOnly | undefined {
+		return this.checkout.computeNetChangeIfRebasedOnto(context);
+	}
+
 	// #endregion Branching
 }

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -103,8 +103,25 @@ function decodeSerializedChangeV1(
  * @remarks Such changes are not expected to be durable beyond the scope of a single session.
  */
 export const SerializedChange = {
+	/** Utilities for version 1 of the serialized change format. */
 	V1: {
+		/**
+		 * Encodes a SharedTree change into the version 1 serialized change format.
+		 * @param idCompressor - The ID compressor to use for encoding.
+		 * @param changeFamily - The change family to use for encoding.
+		 * @param change - The change to encode.
+		 * @param changeRevision - The revision tag for the change.
+		 * @param contextRevision - The optional context revision tag.
+		 * @returns The encoded change in the version 1 serialized change format.
+		 */
 		encode: encodeSerializedChangeV1,
+		/**
+		 * Decodes a version 1 serialized change into a SharedTree change.
+		 * @param idCompressor - The ID compressor to use for decoding.
+		 * @param changeFamily - The change family to use for decoding.
+		 * @param serializedChange - The serialized change to decode.
+		 * @returns The decoded SharedTree change.
+		 */
 		decode: decodeSerializedChangeV1,
 	},
 } as const;

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -97,14 +97,9 @@ function decodeSerializedChangeV1(
 	return tagChange(treeChange, revision);
 }
 
-export const SerializedChange: {
-	readonly V1: {
-		readonly encode: typeof encodeSerializedChangeV1;
-		readonly decode: typeof decodeSerializedChangeV1;
-	};
-} = {
+export const SerializedChange = {
 	V1: {
 		encode: encodeSerializedChangeV1,
 		decode: decodeSerializedChangeV1,
 	},
-};
+} as const;

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -51,7 +51,7 @@ function encodeSerializedChangeV1(
 	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
 	change: SharedTreeChange,
 	changeRevision: RevisionTag,
-	contextRevision: RevisionTag | undefined = changeRevision,
+	contextRevision?: RevisionTag,
 ): JsonCompatibleReadOnly {
 	const context: ChangeEncodingContext = {
 		idCompressor,

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
+import { isStableId } from "@fluidframework/id-compressor/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
+import {
+	type ChangeFamily,
+	type RevisionTag,
+	tagChange,
+	type ChangeEncodingContext,
+	type TaggedChange,
+} from "../core/index.js";
+import type { JsonCompatibleReadOnly } from "../util/index.js";
+
+import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
+import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
+import { SharedTreeChangeFormatVersion } from "./sharedTreeChangeCodecs.js";
+
+/**
+ * Represents a serialized change for SharedTree.
+ *
+ * Data in this format is not expected to be durable beyond the scope of a single session.
+ */
+interface SerializedChange {
+	readonly version: 1;
+	readonly revision: RevisionTag;
+	readonly change: JsonCompatibleReadOnly;
+	readonly originatorId: SessionId;
+}
+
+function isSerializedChangeV1(value: unknown): value is SerializedChange {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const change = value as Partial<SerializedChange>;
+	return (
+		change.version === 1 &&
+		(change.revision === "root" || typeof change.revision === "number") &&
+		typeof change.originatorId === "string" &&
+		isStableId(change.originatorId) &&
+		change.change !== undefined
+	);
+}
+
+function encodeSerializedChangeV1(
+	idCompressor: IIdCompressor,
+	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
+	change: SharedTreeChange,
+	changeRevision: RevisionTag,
+	contextRevision: RevisionTag | undefined = changeRevision,
+): JsonCompatibleReadOnly {
+	const context: ChangeEncodingContext = {
+		idCompressor,
+		originatorId: idCompressor.localSessionId,
+		revision: contextRevision,
+		isSummary: false,
+	};
+	const encodedChange = changeFamily.codecs
+		.resolve(SharedTreeChangeFormatVersion.v4)
+		.encode(change, context);
+
+	return {
+		version: 1,
+		revision: changeRevision,
+		originatorId: idCompressor.localSessionId,
+		change: encodedChange,
+	} satisfies SerializedChange;
+}
+
+function decodeSerializedChangeV1(
+	idCompressor: IIdCompressor,
+	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
+	serializedChange: JsonCompatibleReadOnly,
+): TaggedChange<SharedTreeChange> {
+	if (!isSerializedChangeV1(serializedChange)) {
+		throw new UsageError(`Cannot apply change. Invalid serialized change format.`);
+	}
+	const { revision, originatorId, change } = serializedChange;
+	if (originatorId !== idCompressor.localSessionId) {
+		throw new UsageError(
+			`Cannot apply change. A serialized changed must be applied to the same SharedTree as it was created from.`,
+		);
+	}
+	const context: ChangeEncodingContext = {
+		idCompressor,
+		originatorId: idCompressor.localSessionId,
+		revision,
+		isSummary: false,
+	};
+	const treeChange = changeFamily.codecs
+		.resolve(SharedTreeChangeFormatVersion.v4)
+		.decode(change, context);
+	return tagChange(treeChange, revision);
+}
+
+export const SerializedChange: {
+	readonly V1: {
+		readonly encode: typeof encodeSerializedChangeV1;
+		readonly decode: typeof decodeSerializedChangeV1;
+	};
+} = {
+	V1: {
+		encode: encodeSerializedChangeV1,
+		decode: decodeSerializedChangeV1,
+	},
+};

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -97,6 +97,11 @@ function decodeSerializedChangeV1(
 	return tagChange(treeChange, revision);
 }
 
+/**
+ * Provides utilities for serializing and deserializing SharedTree changes.
+ *
+ * @remarks Such changes are not expected to be durable beyond the scope of a single session.
+ */
 export const SerializedChange = {
 	V1: {
 		encode: encodeSerializedChangeV1,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -58,6 +58,7 @@ import {
 	type TaggedChange,
 	deltaFieldMapHasVisibleChanges,
 	findCommonAncestor,
+	rebaseBranch,
 } from "../core/index.js";
 import {
 	type FieldBatchCodec,
@@ -1306,6 +1307,38 @@ export class TreeCheckout implements ITreeCheckout {
 			throw new UsageError("Branches do not share a common ancestor.");
 		}
 		return targetPath.length > 0;
+	}
+
+	public computeNetChangeIfRebasedOnto(
+		branch: TreeBranch,
+	): JsonCompatibleReadOnly | undefined {
+		const branchCheckout = getCheckout(branch);
+		const rebased = rebaseBranch(
+			this.mintRevisionTag,
+			this.changeFamily.rebaser,
+			this.#transaction.branch.getHead(),
+			branchCheckout.#transaction.branch.getHead(),
+		);
+
+		const context: ChangeEncodingContext = {
+			idCompressor: this.idCompressor,
+			originatorId: this.idCompressor.localSessionId,
+			revision: undefined,
+			isSummary: false,
+		};
+		if (rebased.sourceChange === undefined) {
+			return undefined;
+		}
+		const encodedChange = this.changeFamily.codecs
+			.resolve(4)
+			.encode(rebased.sourceChange, context);
+		const revision = this.mintRevisionTag();
+		return {
+			version: 1,
+			revision,
+			originatorId: this.idCompressor.localSessionId,
+			change: encodedChange,
+		} satisfies SerializedChange;
 	}
 
 	public merge(branch: TreeBranch): void;

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -6,8 +6,7 @@
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { IFluidHandle, Listenable } from "@fluidframework/core-interfaces/internal";
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
-import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
-import { isStableId } from "@fluidframework/id-compressor/internal";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 import { type TelemetryLoggerExt, UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -52,7 +51,6 @@ import {
 	type ChangeMetadata,
 	type LabelTree,
 	type TransactionLabels,
-	type ChangeEncodingContext,
 	type ReadOnlyDetachedFieldIndex,
 	makeAnonChange,
 	type TaggedChange,
@@ -120,6 +118,7 @@ import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamil
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { ISharedTreeEditor, SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { extractTransactionChangeProcessor } from "./transactionPostProcessor.js";
+import { SerializedChange } from "./serializedChange.js";
 
 /**
  * Yields all defined (non-`undefined`) labels from a {@link LabelTree}, depth-first.
@@ -764,24 +763,16 @@ export class TreeCheckout implements ITreeCheckout {
 					kind,
 					isLocal: true,
 					getChange: () => {
-						const context: ChangeEncodingContext = {
-							idCompressor: this.idCompressor,
-							originatorId: this.idCompressor.localSessionId,
-							revision,
-							isSummary: false,
-						};
-						const encodedChange = this.changeFamily.codecs.resolve(4).encode(change, context);
-
 						assert(
 							commit.parent !== undefined,
 							0xca4 /* Expected applied commit to be parented */,
 						);
-						return {
-							version: 1,
+						return SerializedChange.V1.encode(
+							this.idCompressor,
+							this.changeFamily,
+							change,
 							revision,
-							originatorId: this.idCompressor.localSessionId,
-							change: encodedChange,
-						} satisfies SerializedChange;
+						);
 					},
 					getRevertible: (onDisposed) => getRevertible?.(onDisposed),
 					label: this.labelTreeNode?.label,
@@ -860,24 +851,13 @@ export class TreeCheckout implements ITreeCheckout {
 	 */
 	@throwIfBroken
 	public applySerializedChange(serializedChange: JsonCompatibleReadOnly): void {
-		if (!isSerializedChange(serializedChange)) {
-			throw new UsageError(`Cannot apply change. Invalid serialized change format.`);
-		}
-		const { revision, originatorId, change } = serializedChange;
-		if (originatorId !== this.idCompressor.localSessionId) {
-			throw new UsageError(
-				`Cannot apply change. A serialized changed must be applied to the same SharedTree as it was created from.`,
-			);
-		}
-		const context: ChangeEncodingContext = {
-			idCompressor: this.idCompressor,
-			originatorId: this.idCompressor.localSessionId,
-			revision,
-			isSummary: false,
-		};
-		const decodedChange = this.changeFamily.codecs.resolve(4).decode(change, context);
+		const change = SerializedChange.V1.decode(
+			this.idCompressor,
+			this.changeFamily,
+			serializedChange,
+		);
 		// Apply the change to the branch, but _not_ the `activeBranch` - we do not support squashing serialized commits in a transaction.
-		this.#transaction.branch.apply(tagChange(decodedChange, revision));
+		this.#transaction.branch.apply(change);
 	}
 
 	// #region TreeBranchAlpha
@@ -1320,25 +1300,17 @@ export class TreeCheckout implements ITreeCheckout {
 			branchCheckout.#transaction.branch.getHead(),
 		);
 
-		const context: ChangeEncodingContext = {
-			idCompressor: this.idCompressor,
-			originatorId: this.idCompressor.localSessionId,
-			revision: undefined,
-			isSummary: false,
-		};
 		if (rebased.sourceChange === undefined) {
 			return undefined;
 		}
-		const encodedChange = this.changeFamily.codecs
-			.resolve(4)
-			.encode(rebased.sourceChange, context);
 		const revision = this.mintRevisionTag();
-		return {
-			version: 1,
+		return SerializedChange.V1.encode(
+			this.idCompressor,
+			this.changeFamily,
+			rebased.sourceChange,
 			revision,
-			originatorId: this.idCompressor.localSessionId,
-			change: encodedChange,
-		} satisfies SerializedChange;
+			undefined,
+		);
 	}
 
 	public merge(branch: TreeBranch): void;
@@ -1801,27 +1773,6 @@ function verboseFromCursor(
 		type: reader.type,
 		fields: fields as CustomTreeNode<IFluidHandle>,
 	};
-}
-
-interface SerializedChange {
-	version: 1;
-	revision: RevisionTag;
-	change: JsonCompatibleReadOnly;
-	originatorId: SessionId;
-}
-
-function isSerializedChange(value: unknown): value is SerializedChange {
-	if (typeof value !== "object" || value === null) {
-		return false;
-	}
-	const change = value as Partial<SerializedChange>;
-	return (
-		change.version === 1 &&
-		(change.revision === "root" || typeof change.revision === "number") &&
-		typeof change.originatorId === "string" &&
-		isStableId(change.originatorId) &&
-		change.change !== undefined
-	);
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -376,6 +376,16 @@ export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
 	 * @throws UsageError if the branches are unrelated.
 	 */
 	isMissingEditsFrom(branch: TreeBranch): boolean;
+
+	/**
+	 * Computes the net change that would result if this branch were {@link TreeBranch.rebaseOnto | rebased onto} the given branch.
+	 * Note that this method does not actually perform the rebase and therefore has no effect on this branch.
+	 *
+	 * @param branch - The branch that would be rebased onto.
+	 * @returns The net change that would result if this branch were rebased onto the given branch,
+	 * or `undefined` if rebasing would have no impact.
+	 */
+	computeNetChangeIfRebasedOnto(branch: TreeBranch): JsonCompatibleReadOnly | undefined;
 }
 
 /**

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -204,6 +204,9 @@ describe("schematizeTree", () => {
 			rebaseOnto(): void {
 				throw new Error("Function not implemented.");
 			},
+			computeNetChangeIfRebasedOnto(branch: unknown): never {
+				throw new Error("Function not implemented.");
+			},
 			isMissingEditsFrom(branch: unknown): never {
 				throw new Error("Function not implemented.");
 			},

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -455,9 +455,11 @@ describe("simple-tree tree", () => {
 
 				rebasedView.rebaseOnto(targetView);
 
-				const change = appliedView.computeNetChangeIfRebasedOnto(targetView);
-				if (change !== undefined) {
-					appliedView.applyChange(change);
+				// Validating the output of `computeNetChangeIfRebasedOnto` directly would make the test brittle since the internals of the format are implementation details.
+				// Instead, we apply the net change to the applied view and then compare the resulting state to the rebased view to ensure they are equivalent.
+				const netChange = appliedView.computeNetChangeIfRebasedOnto(targetView);
+				if (netChange !== undefined) {
+					appliedView.applyChange(netChange);
 				}
 
 				assert.deepEqual([...appliedView.root], [...rebasedView.root]);

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -31,7 +31,8 @@ import {
 } from "../../../simple-tree/index.js";
 import { SharedTree } from "../../../treeFactory.js";
 import type { JsonCompatibleReadOnly, requireAssignableTo } from "../../../util/index.js";
-import { getView } from "../../utils.js";
+import { getView, StringArray } from "../../utils.js";
+import { getViewForForkedBranch } from "../utils.js";
 
 const schema = new SchemaFactory("com.example");
 
@@ -425,6 +426,43 @@ describe("simple-tree tree", () => {
 			});
 			assert.equal(viewA.root, 5);
 		});
+	});
+
+	describe("computeNetChangeIfRebasedOnto", () => {
+		const scenarios = [
+			{ editSource: false, editTarget: false },
+			{ editSource: true, editTarget: false },
+			{ editSource: false, editTarget: true },
+			{ editSource: true, editTarget: true },
+		];
+		for (const { editSource, editTarget } of scenarios) {
+			it(`when source branch is ${editSource ? "edited" : "not edited"} and target branch is ${
+				editTarget ? "edited" : "not edited"
+			}`, () => {
+				const config = new TreeViewConfiguration({ schema: StringArray });
+				const targetView = getView(config);
+				targetView.initialize([]);
+				const sourceView = targetView.fork();
+
+				if (editSource) {
+					sourceView.root.insertAtEnd("source edit");
+				}
+				if (editTarget) {
+					targetView.root.insertAtEnd("target edit");
+				}
+				const rebasedView = getViewForForkedBranch(sourceView).forkView;
+				const appliedView = getViewForForkedBranch(sourceView).forkView;
+
+				rebasedView.rebaseOnto(targetView);
+
+				const change = appliedView.computeNetChangeIfRebasedOnto(targetView);
+				if (change !== undefined) {
+					appliedView.applyChange(change);
+				}
+
+				assert.deepEqual([...appliedView.root], [...rebasedView.root]);
+			});
+		}
 	});
 
 	describe("isMissingEditsFrom", () => {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1552,6 +1552,9 @@ export class MockTreeCheckout implements ITreeCheckout {
 	public rebaseOnto(branch: unknown): void {
 		throw new Error("Method 'rebaseOnto' not implemented in MockTreeCheckout.");
 	}
+	public computeNetChangeIfRebasedOnto(branch: unknown): never {
+		throw new Error("Method 'getRebaseChanges' not implemented in MockTreeCheckout.");
+	}
 	public isMissingEditsFrom(branch: unknown): never {
 		throw new Error("Method 'isMissingEditsFrom' not implemented in MockTreeCheckout.");
 	}

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2232,6 +2232,7 @@ export interface TreeBranch extends IDisposable {
 // @alpha @sealed
 export interface TreeBranchAlpha extends TreeBranch, TreeContextAlpha {
     applyChange(change: JsonCompatibleReadOnly): void;
+    computeNetChangeIfRebasedOnto(branch: TreeBranch): JsonCompatibleReadOnly | undefined;
     readonly events: Listenable<TreeBranchEvents>;
     // (undocumented)
     fork(): TreeBranchAlpha;


### PR DESCRIPTION
## Description

Adds a new alpha API for computing the expected change from rebasing one branch over another.

This is a prerequisite of https://github.com/microsoft/FluidFramework/pull/27649.

## Breaking Changes

None