### PR TITLE
feat(tree): Alpha ArrayNode APIs 

### DIFF
--- a/.changeset/metal-ideas-sip.md
+++ b/.changeset/metal-ideas-sip.md
@@ -1,0 +1,40 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+Add at, pop, shift, and unshift methods to TreeArrayNodeAlpha
+
+`TreeArrayNodeAlpha` now has `at`, `pop`, `shift`, and `unshift` methods, further aligning it with JavaScript's built-in Array API:
+
+- `at(index)`  `at` was already implemented at runtime, and consumers compiling with `lib: ES2022` or later could already see it through the inherited `ReadonlyArray` typings. This change adds no new runtime behavior, but makes `at` an explicitly declared, documented part of the API, independent of the consumer's TypeScript `lib` configuration.
+- `unshift(...items)` is an alias for `insertAtStart`, mirroring how `push` aliases `insertAtEnd`: it inserts new item(s) at the start of the array. Unlike `Array.prototype.unshift`, it does not return the new length of the array.
+- `pop()` removes and returns the last item in the array, or returns `undefined` (without modifying the array) if it is empty.
+- `shift()` removes and returns the first item in the array, or returns `undefined` (without modifying the array) if it is empty.
+
+These methods are available on `TreeArrayNodeAlpha`, which can be obtained from an existing `TreeArrayNode` via `asAlpha`, or by declaring the schema with `SchemaFactoryAlpha`'s `arrayAlpha`.
+
+#### Usage
+
+```typescript
+import { SchemaFactory, asAlpha } from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactory("example");
+const Inventory = sf.array("Inventory", sf.string);
+const inventory = asAlpha(new Inventory(["Apples", "Bananas", "Pears"]));
+
+// inventory: ["Apples", "Bananas", "Pears"]
+inventory.unshift("Oranges", "Grapes");
+// inventory: ["Oranges", "Grapes", "Apples", "Bananas", "Pears"]
+
+inventory.at(0); // "Oranges"
+inventory.at(-1); // "Pears"
+inventory.at(10); // undefined
+
+// inventory: ["Oranges", "Grapes", "Apples", "Bananas", "Pears"]
+inventory.pop(); // "Pears"
+// inventory ["Oranges", "Grapes", "Apples", "Bananas"]
+
+inventory.shift(); // "Oranges"
+// inventory: ["Grapes", "Apples", "Bananas"]
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1771,7 +1771,11 @@ export const TreeArrayNode: {
 
 // @alpha @sealed
 export interface TreeArrayNodeAlpha<TAllowedTypes extends System_Unsafe.ImplicitAllowedTypesUnsafe = ImplicitAllowedTypes, out T = [TAllowedTypes] extends [ImplicitAllowedTypes] ? TreeNodeFromImplicitAllowedTypes<TAllowedTypes> : TreeNodeFromImplicitAllowedTypes<ImplicitAllowedTypes>, in TNew = [TAllowedTypes] extends [ImplicitAllowedTypes] ? InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes> : InsertableTreeNodeFromImplicitAllowedTypes<ImplicitAllowedTypes>> extends TreeArrayNode<TAllowedTypes, T, TNew> {
+    at(index: number): T | undefined;
+    pop(): T | undefined;
+    shift(): T | undefined;
     splice(start: number, deleteCount?: number, ...items: readonly (TNew | IterableTreeArrayContent<TNew>)[]): T[];
+    unshift(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
 }
 
 // @beta @sealed

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -131,6 +131,8 @@ export interface TreeArrayNode<
 	 * Inserts new item(s) at the end of the array.
 	 *
 	 * @remarks
+	 * Unlike `Array.prototype.push`, this method does not return the new length of the array.
+	 *
 	 * The order of the inserted items relative to other concurrently inserted items at the same location is only partially specified:
 	 * Concurrently inserting `[A, B]` and `[X, Y]` at the same location may yield
 	 * either `[A, B, X, Y]` or `[X, Y, A, B]`, regardless of the order in which those edits are sequenced.
@@ -460,6 +462,41 @@ export interface TreeArrayNodeAlpha<
 		? InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>
 		: InsertableTreeNodeFromImplicitAllowedTypes<ImplicitAllowedTypes>,
 > extends TreeArrayNode<TAllowedTypes, T, TNew> {
+	/**
+	 * Returns the item located at the specified index.
+	 * @param index - The zero-based index of the item to retrieve.
+	 * Negative indices count back from the last item in the array: for `index < 0`, `index + array.length` is used.
+	 * @returns The item at the specified index, or `undefined` if the index is out of bounds.
+	 */
+	at(index: number): T | undefined;
+
+	/**
+	 * Removes the last item from the array and returns it.
+	 * @returns The removed item, or `undefined` if the array is empty (in which case the array is not modified).
+	 */
+	pop(): T | undefined;
+
+	/**
+	 * Removes the first item from the array and returns it.
+	 * @returns The removed item, or `undefined` if the array is empty (in which case the array is not modified).
+	 */
+	shift(): T | undefined;
+
+	/**
+	 * Inserts new item(s) at the start of the array.
+	 *
+	 * @param value - The content to insert.
+	 * @remarks
+	 * Unlike `Array.prototype.unshift`, this method does not return the new length of the array.
+	 *
+	 * The order of the inserted items relative to other concurrently inserted items at the same location is only partially specified:
+	 * Concurrently inserting `[A, B]` and `[X, Y]` at the same location may yield
+	 * either `[A, B, X, Y]` or `[X, Y, A, B]`, regardless of the order in which those edits are sequenced.
+	 * No other interleavings are possible. (e.g. `[A, X, B, Y]` is not possible.)
+	 *
+	 */
+	unshift(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
+
 	/**
 	 * Removes existing item(s) and/or adds new item(s).
 	 * @param start - The index at which to start changing the array. If negative, it is treated as `array.length + start`.
@@ -1009,6 +1046,23 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	}
 	public push(...value: Insertable<T>): void {
 		this.insertAt(this.length, ...value);
+	}
+	public unshift(...value: Insertable<T>): void {
+		this.insertAt(0, ...value);
+	}
+	public pop(): TreeNodeFromImplicitAllowedTypes<T> | undefined {
+		const value = this.at(-1);
+		if (value !== undefined) {
+			this.removeAt(this.length - 1);
+		}
+		return value;
+	}
+	public shift(): TreeNodeFromImplicitAllowedTypes<T> | undefined {
+		const value = this.at(0);
+		if (value !== undefined) {
+			this.removeAt(0);
+		}
+		return value;
 	}
 	public removeAt(index: number): void {
 		const field = getSequenceField(this);

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -109,6 +109,14 @@ export interface TreeArrayNode<
 > extends ReadonlyArrayNode<T> {
 	/**
 	 * Inserts new item(s) at a specified location.
+	 *
+	 * @remarks
+	 * All items inserted by a single call to this method are inserted consecutively.
+	 * The order of the inserted items relative to other concurrently inserted items at the same location is only partially specified:
+	 * Concurrently inserting `[A, B]` and `[X, Y]` at the same location may yield
+	 * either `[A, B, X, Y]` or `[X, Y, A, B]`, regardless of the order in which those edits are sequenced.
+	 * No other interleavings are possible. (e.g. `[A, X, B, Y]` is not possible.)
+	 *
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
 	 * @throws Throws if `index` is not in the range [0, `array.length`).
@@ -117,12 +125,18 @@ export interface TreeArrayNode<
 
 	/**
 	 * Inserts new item(s) at the start of the array.
+	 * @remarks
+	 * Equivalent to `insertAt(0, ...value)`:
+	 * see {@link (TreeArrayNode:interface).insertAt} for details, including merge semantics with concurrent edits.
 	 * @param value - The content to insert.
 	 */
 	insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
 
 	/**
 	 * Inserts new item(s) at the end of the array.
+	 * @remarks
+	 * Equivalent to `insertAt(array.length, ...value)`:
+	 * see {@link (TreeArrayNode:interface).insertAt} for details, including merge semantics with concurrent edits.
 	 * @param value - The content to insert.
 	 */
 	insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -133,10 +147,8 @@ export interface TreeArrayNode<
 	 * @remarks
 	 * Unlike `Array.prototype.push`, this method does not return the new length of the array.
 	 *
-	 * The order of the inserted items relative to other concurrently inserted items at the same location is only partially specified:
-	 * Concurrently inserting `[A, B]` and `[X, Y]` at the same location may yield
-	 * either `[A, B, X, Y]` or `[X, Y, A, B]`, regardless of the order in which those edits are sequenced.
-	 * No other interleavings are possible. (e.g. `[A, X, B, Y]` is not possible.)
+	 * Equivalent to `insertAt(array.length, ...value)`:
+	 * see {@link (TreeArrayNode:interface).insertAt} for details, including merge semantics with concurrent edits.
 	 *
 	 * @param value - The content to insert.
 	 */
@@ -489,11 +501,8 @@ export interface TreeArrayNodeAlpha<
 	 * @remarks
 	 * Unlike `Array.prototype.unshift`, this method does not return the new length of the array.
 	 *
-	 * The order of the inserted items relative to other concurrently inserted items at the same location is only partially specified:
-	 * Concurrently inserting `[A, B]` and `[X, Y]` at the same location may yield
-	 * either `[A, B, X, Y]` or `[X, Y, A, B]`, regardless of the order in which those edits are sequenced.
-	 * No other interleavings are possible. (e.g. `[A, X, B, Y]` is not possible.)
-	 *
+	 * Equivalent to `insertAt(0, ...value)`:
+	 * see {@link (TreeArrayNode:interface).insertAt} for details, including merge semantics with concurrent edits.
 	 */
 	unshift(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
 

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
@@ -162,7 +162,7 @@ describe("ArrayNode", () => {
 	): void {
 		describeHydration(title, (init) => {
 			function buildAlphaArray(
-				initial: number[],
+				initial: readonly number[],
 			): TreeArrayNodeAlpha<typeof schemaFactory.number> {
 				const list = init(schemaType, initial);
 				return asAlpha(list as TreeArrayNode<typeof schemaFactory.number>);

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
@@ -161,6 +161,13 @@ describe("ArrayNode", () => {
 		schemaType: typeof PojoEmulationNumberArray | typeof CustomizableNumberArray,
 	): void {
 		describeHydration(title, (init) => {
+			function buildAlphaArray(
+				initial: number[],
+			): TreeArrayNodeAlpha<typeof schemaFactory.number> {
+				const list = init(schemaType, initial);
+				return asAlpha(list as TreeArrayNode<typeof schemaFactory.number>);
+			}
+
 			it("fails at runtime if attempting to set content via index assignment", () => {
 				const array = init(schemaType, [0]);
 				const mutableArray = array as Mutable<typeof array>;
@@ -183,6 +190,67 @@ describe("ArrayNode", () => {
 				const jsArray = [0, 1, 2];
 				const array = init(schemaType, jsArray);
 				assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
+			});
+
+			describe("at", () => {
+				it("returns the item at the given index", () => {
+					const array = buildAlphaArray([0, 1, 2]);
+					assert.equal(array.at(0), 0);
+					assert.equal(array.at(1), 1);
+					assert.equal(array.at(2), 2);
+				});
+
+				it("supports negative indices, counting back from the end", () => {
+					const array = buildAlphaArray([0, 1, 2]);
+					assert.equal(array.at(-1), 2);
+					assert.equal(array.at(-3), 0);
+				});
+
+				it("returns undefined for out of bounds indices", () => {
+					const array = buildAlphaArray([0, 1, 2]);
+					assert.equal(array.at(3), undefined);
+					assert.equal(array.at(-4), undefined);
+				});
+			});
+
+			describe("pop", () => {
+				it("removes and returns the last item", () => {
+					const array = buildAlphaArray([1, 2, 3]);
+					assert.equal(array.pop(), 3);
+					assert.deepEqual([...array], [1, 2]);
+				});
+
+				it("removes the only item, leaving the array empty", () => {
+					const array = buildAlphaArray([1]);
+					assert.equal(array.pop(), 1);
+					assert.deepEqual([...array], []);
+				});
+
+				it("returns undefined on an empty array without modifying it", () => {
+					const array = buildAlphaArray([]);
+					assert.equal(array.pop(), undefined);
+					assert.deepEqual([...array], []);
+				});
+			});
+
+			describe("shift", () => {
+				it("removes and returns the first item", () => {
+					const array = buildAlphaArray([1, 2, 3]);
+					assert.equal(array.shift(), 1);
+					assert.deepEqual([...array], [2, 3]);
+				});
+
+				it("removes the only item, leaving the array empty", () => {
+					const array = buildAlphaArray([1]);
+					assert.equal(array.shift(), 1);
+					assert.deepEqual([...array], []);
+				});
+
+				it("returns undefined on an empty array without modifying it", () => {
+					const array = buildAlphaArray([]);
+					assert.equal(array.shift(), undefined);
+					assert.deepEqual([...array], []);
+				});
 			});
 
 			describe("removeAt", () => {
@@ -245,6 +313,14 @@ describe("ArrayNode", () => {
 				assert.deepEqual([...array], [1, 2, 3]);
 				array.push(4);
 				assert.deepEqual([...array], [1, 2, 3, 4]);
+			});
+
+			it("unshift inserts at the start, preserving argument order", () => {
+				const array = buildAlphaArray([3]);
+				array.unshift(2);
+				assert.deepEqual([...array], [2, 3]);
+				array.unshift(0, 1);
+				assert.deepEqual([...array], [0, 1, 2, 3]);
 			});
 
 			describe("removeRange", () => {
@@ -344,12 +420,6 @@ describe("ArrayNode", () => {
 			});
 
 			describe("splice", () => {
-				function buildAlphaArray(
-					initial: number[],
-				): TreeArrayNodeAlpha<typeof schemaFactory.number> {
-					const list = init(schemaType, initial);
-					return asAlpha(list as TreeArrayNode<typeof schemaFactory.number>);
-				}
 				it("splice first item", () => {
 					const initial = [0, 1, 2, 3];
 					const list = buildAlphaArray(initial);

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2205,7 +2205,11 @@ export const TreeArrayNode: {
 
 // @alpha @sealed
 export interface TreeArrayNodeAlpha<TAllowedTypes extends System_Unsafe.ImplicitAllowedTypesUnsafe = ImplicitAllowedTypes, out T = [TAllowedTypes] extends [ImplicitAllowedTypes] ? TreeNodeFromImplicitAllowedTypes<TAllowedTypes> : TreeNodeFromImplicitAllowedTypes<ImplicitAllowedTypes>, in TNew = [TAllowedTypes] extends [ImplicitAllowedTypes] ? InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes> : InsertableTreeNodeFromImplicitAllowedTypes<ImplicitAllowedTypes>> extends TreeArrayNode<TAllowedTypes, T, TNew> {
+    at(index: number): T | undefined;
+    pop(): T | undefined;
+    shift(): T | undefined;
     splice(start: number, deleteCount?: number, ...items: readonly (TNew | IterableTreeArrayContent<TNew>)[]): T[];
+    unshift(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
 }
 
 // @beta @sealed


### PR DESCRIPTION
## Description

Adds/exposes new alpha methods for ArrayNode. Some of these api's are aliases for already implemented methods, but might be benficial for LLMs that are familiar with the common array method names.

Added alpha methods:
- `at(index)` - Already implementted at runtime, but now officially declared and documented in the API
- `unshift(...items)` - Alias for `insertAtStart`. Unlike `Array.prototype.unshift`, it does not return the new length 
- `pop()` - Removes and returns the last item in the array or returns `undefined` if it is empty
- `shift()` - removes and returns the first item in the array, or returns `undefined` if it is empty

## Testing
Moved helper method `buildAlphaArray` one level up to be used in multiple new tests covering all 4 API's

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
