### PR TITLE
Add an internal ODSP file-version manager for point-in-time load

### DIFF
--- a/.changeset/odsp-file-version-manager.md
+++ b/.changeset/odsp-file-version-manager.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/odsp-driver": minor
+"__section": other
+"__includeInReleaseNotes": false
+---
+
+Add an internal ODSP file-version manager
+
+Adds `OdspVersionManager` and `IOdspFileVersionFetcher` (with `createOdspFileVersionFetcher`) to `@fluidframework/odsp-driver`. Given a target sequence number, the manager selects the closest ODSP file version at or before it — the base for loading or replaying a document at a point in time. These are internal to the package (not exported from its public entry points) and not yet wired into a call site, so there is no consumer-facing change.

--- a/.changeset/odsp-file-version-manager.md
+++ b/.changeset/odsp-file-version-manager.md
@@ -1,9 +1,0 @@
----
-"@fluidframework/odsp-driver": minor
-"__section": other
-"__includeInReleaseNotes": false
----
-
-Add an internal ODSP file-version manager
-
-Adds `OdspVersionManager` and `IOdspFileVersionFetcher` (with `createOdspFileVersionFetcher`) to `@fluidframework/odsp-driver`. Given a target sequence number, the manager selects the closest ODSP file version at or before it — the base for loading or replaying a document at a point in time. These are internal to the package (not exported from its public entry points) and not yet wired into a call site, so there is no consumer-facing change.

--- a/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
@@ -1,0 +1,179 @@
+# ODSP Version History Load — Design Catechism
+
+## How to read this document
+
+This spec is a **catechism**: a hierarchical series of questions and answers that is the prose
+mirror of the test suite. Each topic-level question (`###`) corresponds to a `describe` block; each
+leaf question maps to one test, linked by a stable **code ID** at the end of the answer. The same ID
+appears as a `// @q <id>` tag on the matching test.
+
+ID format: `<area>-<topic>-<nn>`. Area is `M` (the version manager — [Part II](#part-ii--the-version-manager))
+or `F` (the file-version fetcher — [Part III](#part-iii--the-file-version-fetcher)). Topic is a short
+mnemonic (e.g. `SELECT`, `RESOLVE`). `nn` is a zero-padded counter. IDs are append-only: existing IDs
+never renumber, so links stay stable across edits.
+
+The contract:
+
+- **Every leaf Q&A has a test, and every test has a leaf Q&A**, joined by its code ID. A change to
+  behavior is a change to both.
+- **This document reflects the code as it is now.** Future/aspirational work lives in
+  [Part IV — Directional](#part-iv--directional), written as questions that cannot yet be answered
+  "yes".
+
+### Terminology (legend)
+
+This code is one piece of a larger capability — letting a document be viewed or recovered at an
+earlier point in time — which spans two repositories:
+
+- **Part 1 — point-in-time load** (this repository): given a target sequence number, produce a
+  read-only view of the document at that number.
+- **Part 2 — capture & marker** (a separate host repository): record the markers that name the points
+  worth returning to. Out of scope for this document.
+
+Part 1 is built in three components:
+
+- **Component A — the version manager**: choose which file version to load or replay from. **This
+  folder is Component A**, and this document is mostly about it.
+- **Component B — the recomposed driver**: load the chosen version and replay ops forward to the exact
+  target. Not built yet.
+- **Component C — the loader hookup**: expose Component B through the container loader. Not built yet.
+
+## Part I — Foundations
+
+These are conceptual answers with no single test; they frame everything below.
+
+### What problem does this code solve?
+
+Given a target Fluid **sequence number** (Fluid numbers every change to a document: op 1, 2, 3, …),
+we want to materialize the document as it was at that number. The first step is choosing a **base**:
+the most recent saved version whose state is at or before the target, from which the remaining ops
+can be replayed. This code finds that base.
+
+### What is an ODSP file version, and how is it different from a Fluid snapshot?
+
+Two different things are both called a "version":
+
+- A **file version** is an entry in the file's version history — a recoverable saved state of the whole
+  file, addressed by a label such as `"42.0"`. These are what a user could restore to.
+- A **Fluid snapshot** is an internal checkpoint the runtime writes; the driver's snapshot list
+  (`getVersions`) enumerates these, not the file versions.
+
+Selecting a base uses the **file version history**, enumerated by the driveItem `/versions` API — not
+the driver's snapshot list.
+
+### Why the closest version at or before the target, rather than any earlier one?
+
+Any base at or before the target can be replayed forward to the target and yields the same state, so
+the choice is not about correctness. The **closest** one minimizes how many ops must be replayed, and
+minimizes the chance that the needed ops have been trimmed from retention. So selection returns the
+greatest version sequence number that is still less than or equal to the target.
+
+### How is a version's sequence number obtained?
+
+By fetching that version's snapshot from the **version-scoped snapshot endpoint**
+(`.../versions/{label}/opStream/snapshots/trees/latest?blobs=2`), which returns the snapshot in the
+driver's normal (`application/json` or `application/ms-fluid`) framing. The driver's existing snapshot
+parser reads it, and the sequence number is `trees[0].sequenceNumber`. `blobs=2` inlines blob contents
+so the parser has everything it needs.
+
+### What is `minimumSequenceNumber`, and is it used for selection?
+
+It is the collaboration-window floor at a version (the point below which ops may be trimmed). It is
+carried on `ResolvedVersion` when read, but it is **not** an input to base selection — a version is a
+single point at its `sequenceNumber`, not a range.
+
+### What is deliberately not built here?
+
+Loading the base and replaying ops to the exact target (Component B), the loader hookup (Component C),
+and any test against a live ODSP file. See [Part IV](#part-iv--directional).
+
+## Part II — The Version Manager
+
+`OdspVersionManager` selects the base version. It depends on an injected `IOdspFileVersionFetcher`, so
+these behaviors are tested with an in-memory fake.
+
+### Which version does `findBaseForSeq` pick for a target sequence number?
+
+The list is newest-first, and the tip (index 0, the live document) is not a base candidate. Among the
+remaining versions, the answer is the greatest sequence number less than or equal to the target.
+
+- **Target between two versions?** The closer, older one. `M-SELECT-01`
+- **Target equal to a version?** That version, an exact match (zero ops to replay). `M-SELECT-02`
+- **Target newer than every version?** The newest recoverable version. `M-SELECT-03`
+- **Target older than every version?** `noBaseVersion`, reporting the oldest sequence number seen.
+  `M-SELECT-04`
+
+### How does it handle duplicate versions and the tip?
+
+- **Two versions share a sequence number?** Return the newest label (a metadata-only re-save leaves the
+  sequence number unchanged; the newest is closest to the head). `M-DEDUP-01`
+- **The tip (index 0)?** Never treated as a base; its sequence number is never even resolved.
+  `M-TIP-01`
+- **Only the tip exists?** `noBaseVersion`. `M-TIP-02`
+- **No versions at all?** `noBaseVersion`. `M-EMPTY-01`
+
+### What work does it avoid?
+
+- **Resolving more versions than needed?** It stops at the first version at or before the target and
+  does not resolve older ones. `M-STOP-01`
+- **Re-fetching across calls?** The version list and each resolved sequence number are cached.
+  `M-CACHE-01`
+- **Stale caches?** `refresh()` drops them so the next query re-enumerates. `M-CACHE-02`
+
+### What happens when a version cannot be resolved?
+
+The failure propagates; it is never swallowed into a wrong base. `M-ERR-01`
+
+### What does `listVersions` return?
+
+Every version with its resolved sequence number, newest-first. `M-LIST-01`
+
+## Part III — The File-Version Fetcher
+
+`createOdspFileVersionFetcher` is the real `IOdspFileVersionFetcher`, talking to ODSP. Its behaviors
+are tested against a stubbed `fetch` that returns canned responses through the real request,
+authentication, and snapshot-parsing code.
+
+### How does it enumerate versions?
+
+It calls the driveItem versions URL — built from the same API root as the snapshot call — and maps
+the `value` array to versions (newest-first). `F-LIST-01`
+
+### How does it resolve a version's sequence number?
+
+- **A well-formed snapshot?** It calls the version-scoped snapshot URL (`.../versions/{label}/opStream/snapshots/trees/latest?blobs=2`),
+  parses the response, and returns `trees[0].sequenceNumber`. `F-RESOLVE-01`
+- **A snapshot with no sequence number?** It throws, naming the version, rather than returning a wrong
+  value. `F-RESOLVE-02`
+
+## Part IV — Directional
+
+Aspirational behaviors, written as questions that cannot yet be answered "yes".
+
+### Should sequence-number resolution be lazy or binary-search, rather than eager?
+
+Resolving each version costs one snapshot fetch. With up to ~50 versions, an eager newest-to-oldest
+scan can fetch more than necessary. The public contract (`findBaseForSeq`) already hides the strategy,
+so a binary search over versions could replace it without changing callers.
+
+### Should there be a component that loads the base and replays ops to the exact target? (Component B)
+
+The manager only chooses the base. Materializing the document at an arbitrary target requires loading
+that version read-only and replaying the ops between the base and the target — sourcing later ops from
+the live op stream when the historical range has been trimmed.
+
+### Should this be exposed through the container loader? (Component C)
+
+Once Component B exists, a loader-facing entry point would let callers request "load at sequence
+number N" directly.
+
+### Should there be an end-to-end test against a real ODSP file?
+
+The fetcher is covered by stubbed-`fetch` integration tests, but not against a live file (which needs
+tenant credentials). An end-to-end test would exercise the real endpoints.
+
+### Should the raw driveItem `/content` download be a supported fallback?
+
+The `/content` download also contains a version's snapshot, but wrapped in a container framing the
+snapshot parser does not read directly. If the version-scoped snapshot endpoint is ever unavailable,
+unwrapping `/content` could be a fallback path.

--- a/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
@@ -162,10 +162,23 @@ The manager only chooses the base. Materializing the document at an arbitrary ta
 that version read-only and replaying the ops between the base and the target — sourcing later ops from
 the live op stream when the historical range has been trimmed.
 
+Where would it live? In **this package**. Loading a historical file version is a storage-layer concern:
+it needs the version-scoped snapshot fetch, the epoch tracker, and authentication — all internal to this
+driver — and it consumes the version manager directly. A generic wrapping driver that only replays ops
+over an inner document service (the pattern `@fluidframework/replay-driver` uses) cannot reach the
+version-scoped base fetch, so the recomposition belongs beside `OdspDocumentService` /
+`OdspDocumentServiceFactory` rather than in a separate package. Because it consumes the version manager
+in-package, the version manager itself needs no exported surface; only the recomposed factory is exposed
+(as a legacy/alpha entry point) for the loader hookup to construct.
+
+A base is only needed when the live document's own snapshot no longer covers the target; when it does,
+loading paused at the target from the live snapshot suffices, and no historical version is loaded.
+
 ### Should this be exposed through the container loader? (Component C)
 
-Once Component B exists, a loader-facing entry point would let callers request "load at sequence
-number N" directly.
+Once Component B exists, a thin combining layer would construct the recomposed factory together with a
+standard loader, letting callers request "load at sequence number N" directly. It depends only on
+Component B's exposed factory, never on the version manager.
 
 ### Should there be an end-to-end test against a real ODSP file?
 

--- a/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
@@ -65,8 +65,11 @@ the driver's snapshot list.
 
 Any base at or before the target can be replayed forward to the target and yields the same state, so
 the choice is not about correctness. The **closest** one minimizes how many ops must be replayed, and
-minimizes the chance that the needed ops have been trimmed from retention. So selection returns the
-greatest version sequence number that is still less than or equal to the target.
+minimizes the chance that the needed ops have been trimmed from retention. Selection therefore aims for
+the greatest version sequence number at or before the target. Because versions are enumerated
+newest-first and version order is expected to track sequence order, an early-stop scan finds it; if that
+ordering is ever violated, a valid but not-strictly-closest base may be chosen (still correct, just less
+optimal) — see [Part IV](#part-iv--directional) for the planned order-tolerant search.
 
 ### How is a version's sequence number obtained?
 
@@ -75,12 +78,6 @@ By fetching that version's snapshot from the **version-scoped snapshot endpoint*
 driver's normal (`application/json` or `application/ms-fluid`) framing. The driver's existing snapshot
 parser reads it, and the sequence number is `trees[0].sequenceNumber`. `blobs=2` inlines blob contents
 so the parser has everything it needs.
-
-### What is `minimumSequenceNumber`, and is it used for selection?
-
-It is the collaboration-window floor at a version (the point below which ops may be trimmed). It is
-carried on `ResolvedVersion` when read, but it is **not** an input to base selection — a version is a
-single point at its `sequenceNumber`, not a range.
 
 ### What is deliberately not built here?
 
@@ -95,7 +92,9 @@ these behaviors are tested with an in-memory fake.
 ### Which version does `findBaseForSeq` pick for a target sequence number?
 
 The list is newest-first, and the tip (index 0, the live document) is not a base candidate. Among the
-remaining versions, the answer is the greatest sequence number less than or equal to the target.
+remaining versions, the answer is the closest one at or before the target — the greatest sequence number
+at or before the target when version order tracks sequence order, which an early-stop newest-first scan
+finds.
 
 - **Target between two versions?** The closer, older one. `M-SELECT-01`
 - **Target equal to a version?** That version, an exact match (zero ops to replay). `M-SELECT-02`
@@ -118,7 +117,11 @@ remaining versions, the answer is the greatest sequence number less than or equa
   does not resolve older ones. `M-STOP-01`
 - **Re-fetching across calls?** The version list and each resolved sequence number are cached.
   `M-CACHE-01`
-- **Stale caches?** `refresh()` drops them so the next query re-enumerates. `M-CACHE-02`
+- **Stale caches?** `refresh()` drops both the version list and the resolved sequence numbers, so the
+  next query re-enumerates and re-resolves. `M-CACHE-02`
+- **A `refresh()` while a fetch is still in flight?** The cache holds the pending fetch rather than its
+  eventual value, so a fetch that started before the refresh cannot write its now-stale result back over
+  the cleared cache; the next query re-fetches. `M-CACHE-03`
 
 ### What happens when a version cannot be resolved?
 
@@ -136,8 +139,11 @@ authentication, and snapshot-parsing code.
 
 ### How does it enumerate versions?
 
-It calls the driveItem versions URL — built from the same API root as the snapshot call — and maps
-the `value` array to versions (newest-first). `F-LIST-01`
+It calls the driveItem versions URL — built from the same API root as the snapshot call — and maps the
+`value` array of each page to versions (newest-first). `F-LIST-01` A long history is paged, so it follows
+`@odata.nextLink` until it is absent and concatenates every page; a base version beyond the first page is
+therefore still found rather than mistaken for `noBaseVersion`. `F-LIST-02` A response without a `value`
+field yields an empty list rather than an error. `F-LIST-03`
 
 ### How does it resolve a version's sequence number?
 
@@ -145,6 +151,19 @@ the `value` array to versions (newest-first). `F-LIST-01`
   parses the response, and returns `trees[0].sequenceNumber`. `F-RESOLVE-01`
 - **A snapshot with no sequence number?** It throws, naming the version, rather than returning a wrong
   value. `F-RESOLVE-02`
+- **A binary (`application/ms-fluid`) snapshot?** It reads it with the driver's compact-snapshot parser
+  and returns the same sequence number the JSON path would. `F-RESOLVE-03`
+
+### How does it handle request failures?
+
+- **A non-success response while enumerating?** The failure propagates rather than being read as an
+  empty result. `F-ERROR-01`
+- **A non-success response while resolving?** Likewise, it propagates rather than yielding a wrong value.
+  `F-ERROR-03`
+- **An authentication failure while enumerating?** The shared token-refresh wrapper refreshes the token
+  and retries the request once. `F-ERROR-04`
+- **An authentication failure while resolving?** Likewise, it refreshes the token and retries once.
+  `F-ERROR-02`
 
 ## Part IV — Directional
 
@@ -155,6 +174,46 @@ Aspirational behaviors, written as questions that cannot yet be answered "yes".
 Resolving each version costs one snapshot fetch. With up to ~50 versions, an eager newest-to-oldest
 scan can fetch more than necessary. The public contract (`findBaseForSeq`) already hides the strategy,
 so a binary search over versions could replace it without changing callers.
+
+The version list is effectively a sorted array: it is newest-first, and a version's sequence number is
+monotonically non-increasing toward older versions (a newer version is a later state). That makes it
+searchable for "the greatest sequence number at or before the target". The search must be "fuzzy" rather
+than textbook, for two reasons: versions can share a sequence number (a metadata-only re-save leaves it
+unchanged), so it is a sorted array with duplicates; and the ordering can have small local inversions.
+The robust shape is therefore binary/interpolation to get close, then a short local walk (older if the
+probe overshot the target, newer while still at or before it) to pin the exact base and absorb ties and
+inversions.
+
+Two further refinements reduce fetches. First, a version's sequence number never changes, so once
+resolved it can be cached indefinitely; refreshing only needs to reconcile which versions still exist
+(dropping ones that aged out), not re-resolve sequence numbers. Second, selection does not need the exact
+closest version — any version within a bounded number of ops of the target is "close enough", because the
+recomposed driver replays the remaining ops anyway; a tolerance lets the search stop early.
+
+### Could the version list's `lastModifiedDateTime` seed the search?
+
+Each version carries a `lastModifiedDateTime` in the list response, for free — unlike a sequence number,
+which costs a fetch to resolve. If the target is accompanied by a wall-clock time (for example, a time
+recorded when a mark was made), that timestamp does not replace the search — it replaces its **first
+probe**. Instead of starting at the blind midpoint, seed at the newest version whose
+`lastModifiedDateTime` is at or before the target time (a comparison over the already-fetched list, zero
+fetches), then converge:
+
+1. Resolve the seed version's sequence number (the first fetch).
+2. If it overshot the target (`seq > target`), step toward older versions; if it is at or before the
+   target, step toward newer versions while still at or before it — to land on the greatest sequence
+   number at or before the target.
+3. Because time, list order, and sequence number all move together, this correction is usually zero or
+   one step. If the seed is far off (large clock drift), fall back to binary search over the residual
+   interval, bounding the worst case at ~log N.
+
+The timestamp is only a seed, never the answer: time does not map linearly to sequence number (edits are
+bursty) and clocks can skew, so the neighbourhood it points to must still be pinned by resolving sequence
+numbers. Timestamps are ISO-8601 UTC; any caller-supplied time must be normalized to UTC before
+comparison. It also allows locating a version by time when no sequence number is available. This is why
+`lastModifiedDateTime` is carried on a version even though base selection itself does not use it today.
+
+
 
 ### Should there be a component that loads the base and replays ops to the exact target? (Component B)
 
@@ -169,10 +228,36 @@ over an inner document service (the pattern `@fluidframework/replay-driver` uses
 version-scoped base fetch, so the recomposition belongs beside `OdspDocumentService` /
 `OdspDocumentServiceFactory` rather than in a separate package. Because it consumes the version manager
 in-package, the version manager itself needs no exported surface; only the recomposed factory is exposed
-(as a legacy/alpha entry point) for the loader hookup to construct.
+(defaulting to an internal entry point) for the loader hookup to construct.
 
 A base is only needed when the live document's own snapshot no longer covers the target; when it does,
 loading paused at the target from the live snapshot suffices, and no historical version is loaded.
+
+### How would Component B reach a target between snapshots, and handle trimmed ops?
+
+A snapshot already contains the full accumulated state at its sequence number — every op at or below it
+is baked in. So to reach a target `T`, Component B loads the closest base snapshot (`seq ≤ T`) and
+replays only the ops in `(base, T]` on top of it. Those ops come from the op stream (delta storage), and
+may also be bundled with a snapshot (the `deltas=1` query parameter, deliberately omitted here because
+the manager only needs the sequence number, not the ops).
+
+Ops in the op stream are retained for a window and can be trimmed. The resolution is not to fetch the
+trimmed ops from somewhere else — it is to **start from a newer snapshot that already absorbed them**. If
+the ops just after the base are gone but another snapshot exists later in `(base, T]`, that snapshot's
+state already includes the trimmed ops, so Component B starts there and replays only the retained tail.
+Trimmed ops are never re-fetched; a later snapshot makes them unnecessary.
+
+The target is only unreachable when all of the following hold: the nearest snapshot at or before `T` is
+old, the ops between it and `T` have been trimmed, and no snapshot falls anywhere in between to bridge
+the gap. In that case the exact state at `T` cannot be reconstructed, and Component B reports it
+(for example, a `missing ops` / not-materializable outcome) rather than returning a wrong state — a
+consumer may still choose to fall back to the nearest reachable state at or before `T`. This is rare in
+practice because snapshots are written frequently relative to the op-retention window.
+
+Note that `minimumSequenceNumber` is not the signal for any of this: it is the collaboration-window floor
+baked into a snapshot, used when a snapshot is loaded, not an indicator of which ops the op stream still
+retains. Op availability is determined by asking the op stream for the range, not by a version's minimum
+sequence number.
 
 ### Should this be exposed through the container loader? (Component C)
 

--- a/packages/drivers/odsp-driver/src/odspVersionManager/index.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export {
+	OdspVersionManager,
+	type BaseForSeq,
+	type IOdspVersionManager,
+	type OdspFileVersionRef,
+	type IOdspFileVersionFetcher,
+	type ResolvedVersion,
+} from "./odspVersionManager.js";
+export {
+	createOdspFileVersionFetcher,
+	type OdspFileVersionFetcherProps,
+} from "./odspFileVersionFetcher.js";

--- a/packages/drivers/odsp-driver/src/odspVersionManager/index.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/index.ts
@@ -4,14 +4,9 @@
  */
 
 export {
-	OdspVersionManager,
+	createOdspVersionManager,
 	type BaseForSeq,
 	type IOdspVersionManager,
 	type OdspFileVersionRef,
-	type IOdspFileVersionFetcher,
 	type ResolvedVersion,
 } from "./odspVersionManager.js";
-export {
-	createOdspFileVersionFetcher,
-	type OdspFileVersionFetcherProps,
-} from "./odspFileVersionFetcher.js";

--- a/packages/drivers/odsp-driver/src/odspVersionManager/odspFileVersionFetcher.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/odspFileVersionFetcher.ts
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * An {@link IOdspFileVersionFetcher} backed by the ODSP REST APIs:
+ * - GET /_api/v2.1/.../versions -- enumerate the file's versions.
+ * - GET /_api/v2.1/.../versions/{label}/opStream/snapshots/trees/latest?blobs=2 -- fetch a version's
+ *   snapshot and read its sequence number, parsed with the driver's snapshot parser.
+ */
+
+import type {
+	IOdspUrlParts,
+	InstrumentedStorageTokenFetcher,
+} from "@fluidframework/odsp-driver-definitions/internal";
+import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+
+import { parseCompactSnapshotResponse } from "../compactSnapshotParser.js";
+import type { IOdspSnapshot } from "../contracts.js";
+import type { EpochTracker } from "../epochTracker.js";
+import { getHeadersWithAuth } from "../getUrlAndHeadersWithAuth.js";
+import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser.js";
+import { getApiRoot } from "../odspUrlHelper.js";
+import { getWithRetryForTokenRefresh } from "../odspUtils.js";
+
+import type { OdspFileVersionRef, IOdspFileVersionFetcher } from "./odspVersionManager.js";
+
+/**
+ * Raw shape of a OneDrive/SharePoint driveItem version (an entry in the `/versions` response).
+ * @see https://learn.microsoft.com/en-us/onedrive/developer/rest-api/resources/driveitemversion
+ */
+interface IDriveItemVersion {
+	/** The version's label, e.g. "42.0". */
+	readonly id: string;
+	readonly lastModifiedDateTime: string;
+	readonly size: number;
+}
+
+/**
+ * Inputs needed to make authenticated requests against a specific ODSP file.
+ */
+export interface OdspFileVersionFetcherProps {
+	readonly urlParts: IOdspUrlParts;
+	readonly getAuthHeader: InstrumentedStorageTokenFetcher;
+	readonly epochTracker: EpochTracker;
+	readonly logger: TelemetryLoggerExt;
+}
+
+/**
+ * Create an {@link IOdspFileVersionFetcher} that talks to a specific ODSP file.
+ */
+export function createOdspFileVersionFetcher(
+	props: OdspFileVersionFetcherProps,
+): IOdspFileVersionFetcher {
+	const { urlParts, getAuthHeader, epochTracker, logger } = props;
+	const { siteUrl, driveId, itemId } = urlParts;
+
+	const listFileVersions = async (): Promise<OdspFileVersionRef[]> =>
+		getWithRetryForTokenRefresh(async (options) => {
+			// The file's version history (distinct from the driver's snapshot list), from the same API
+			// root as the snapshot call so consumer (ODC) and enterprise (SPO) hosts are handled alike.
+			const url = `${getApiRoot(new URL(siteUrl))}/drives/${driveId}/items/${itemId}/versions`;
+			const method = "GET";
+			const token = await getAuthHeader(
+				{ ...options, request: { url, method } },
+				"FileVersions",
+			);
+			const headers = getHeadersWithAuth(token);
+			const response = await epochTracker.fetchAndParseAsJSON<{ value?: IDriveItemVersion[] }>(
+				url,
+				{ method, headers },
+				"versions",
+			);
+			// The API returns versions newest-first.
+			return (response.content.value ?? []).map((version) => ({
+				versionId: version.id,
+				lastModifiedDateTime: version.lastModifiedDateTime,
+				sizeBytes: version.size,
+			}));
+		});
+
+	const resolveSequenceNumber = async (versionId: string): Promise<number> =>
+		getWithRetryForTokenRefresh(async (options) => {
+			// Fetch the version's snapshot from the version-scoped snapshot endpoint, which returns the
+			// driver's native json / ms-fluid framing. `blobs=2` inlines blob contents (including the
+			// `.protocol/attributes` blob that holds the sequence number). `deltas=1` is intentionally
+			// omitted; it would bundle the op stream and its op-level sequence numbers.
+			const url = `${getApiRoot(new URL(siteUrl))}/drives/${driveId}/items/${itemId}/versions/${encodeURIComponent(
+				versionId,
+			)}/opStream/snapshots/trees/latest?blobs=2`;
+			const method = "GET";
+			const token = await getAuthHeader(
+				{ ...options, request: { url, method } },
+				"FileVersionSnapshot",
+			);
+			const headers = getHeadersWithAuth(token);
+			const response = await epochTracker.fetch(url, { method, headers }, "treesLatest");
+			const contentType = response.headers.get("content-type") ?? "";
+			if (contentType.includes("application/json")) {
+				const snapshotJson = (await response.content.json()) as IOdspSnapshot;
+				return requireSequenceNumber(
+					convertOdspSnapshotToSnapshotTreeAndBlobs(snapshotJson).sequenceNumber,
+					versionId,
+				);
+			}
+			// application/ms-fluid (compact binary)
+			const bytes = new Uint8Array(await response.content.arrayBuffer());
+			return requireSequenceNumber(
+				parseCompactSnapshotResponse(bytes, logger).sequenceNumber,
+				versionId,
+			);
+		});
+
+	return { listFileVersions, resolveSequenceNumber };
+}
+
+/**
+ * A version's snapshot must carry a sequence number; a missing one is surfaced as an error rather
+ * than returning a wrong value.
+ */
+function requireSequenceNumber(sequenceNumber: number | undefined, versionId: string): number {
+	if (sequenceNumber === undefined) {
+		throw new Error(`ODSP file version ${versionId} snapshot is missing a sequenceNumber`);
+	}
+	return sequenceNumber;
+}

--- a/packages/drivers/odsp-driver/src/odspVersionManager/odspFileVersionFetcher.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/odspFileVersionFetcher.ts
@@ -16,7 +16,7 @@ import type {
 } from "@fluidframework/odsp-driver-definitions/internal";
 import type { TelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { parseCompactSnapshotResponse } from "../compactSnapshotParser.js";
+import { currentReadVersion, parseCompactSnapshotResponse } from "../compactSnapshotParser.js";
 import type { IOdspSnapshot } from "../contracts.js";
 import type { EpochTracker } from "../epochTracker.js";
 import { getHeadersWithAuth } from "../getUrlAndHeadersWithAuth.js";
@@ -34,7 +34,13 @@ interface IDriveItemVersion {
 	/** The version's label, e.g. "42.0". */
 	readonly id: string;
 	readonly lastModifiedDateTime: string;
-	readonly size: number;
+}
+
+/** A single page of the driveItem `/versions` response. */
+interface IDriveItemVersionsPage {
+	readonly value?: IDriveItemVersion[];
+	/** Absolute URL of the next page, present only while more versions remain. */
+	readonly "@odata.nextLink"?: string;
 }
 
 /**
@@ -58,34 +64,41 @@ export function createOdspFileVersionFetcher(
 
 	const listFileVersions = async (): Promise<OdspFileVersionRef[]> =>
 		getWithRetryForTokenRefresh(async (options) => {
+			const method = "GET";
+			const versions: OdspFileVersionRef[] = [];
 			// The file's version history (distinct from the driver's snapshot list), from the same API
 			// root as the snapshot call so consumer (ODC) and enterprise (SPO) hosts are handled alike.
-			const url = `${getApiRoot(new URL(siteUrl))}/drives/${driveId}/items/${itemId}/versions`;
-			const method = "GET";
-			const token = await getAuthHeader(
-				{ ...options, request: { url, method } },
-				"FileVersions",
-			);
-			const headers = getHeadersWithAuth(token);
-			const response = await epochTracker.fetchAndParseAsJSON<{ value?: IDriveItemVersion[] }>(
-				url,
-				{ method, headers },
-				"versions",
-			);
-			// The API returns versions newest-first.
-			return (response.content.value ?? []).map((version) => ({
-				versionId: version.id,
-				lastModifiedDateTime: version.lastModifiedDateTime,
-				sizeBytes: version.size,
-			}));
+			// A long history is paged, so follow `@odata.nextLink` until it is absent; otherwise a base
+			// version beyond the first page would be missed and wrongly reported as "no base version".
+			let url = `${getApiRoot(new URL(siteUrl))}/drives/${driveId}/items/${itemId}/versions`;
+			do {
+				const token = await getAuthHeader(
+					{ ...options, request: { url, method } },
+					"FileVersions",
+				);
+				const headers = getHeadersWithAuth(token);
+				const response = await epochTracker.fetchAndParseAsJSON<{
+					value?: IDriveItemVersion[];
+				}>(url, { method, headers }, "versions");
+				const page = response.content as IDriveItemVersionsPage;
+				// The API returns versions newest-first.
+				for (const version of page.value ?? []) {
+					versions.push({
+						versionId: version.id,
+						lastModifiedDateTime: version.lastModifiedDateTime,
+					});
+				}
+				url = page["@odata.nextLink"] ?? "";
+			} while (url);
+			return versions;
 		});
 
 	const resolveSequenceNumber = async (versionId: string): Promise<number> =>
 		getWithRetryForTokenRefresh(async (options) => {
-			// Fetch the version's snapshot from the version-scoped snapshot endpoint, which returns the
-			// driver's native json / ms-fluid framing. `blobs=2` inlines blob contents (including the
-			// `.protocol/attributes` blob that holds the sequence number). `deltas=1` is intentionally
-			// omitted; it would bundle the op stream and its op-level sequence numbers.
+			// A file version's sequence number lives inside that version's snapshot, so fetch the snapshot
+			// from the version-scoped endpoint. `blobs=2` inlines blob contents so the `.protocol/attributes`
+			// blob (which carries the sequence number) is included; `deltas=1` is intentionally omitted, as
+			// it would bundle the op stream and its op-level sequence numbers.
 			const url = `${getApiRoot(new URL(siteUrl))}/drives/${driveId}/items/${itemId}/versions/${encodeURIComponent(
 				versionId,
 			)}/opStream/snapshots/trees/latest?blobs=2`;
@@ -95,33 +108,31 @@ export function createOdspFileVersionFetcher(
 				"FileVersionSnapshot",
 			);
 			const headers = getHeadersWithAuth(token);
+			// The server can return the snapshot in one of two equivalent framings: verbose JSON, or
+			// "ms-fluid" — ODSP's compact binary encoding of the same snapshot. Advertise both, and pin the
+			// binary format version (as the driver's own snapshot fetch does) so the server cannot hand back
+			// a binary version this code's parser does not understand.
+			headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
 			const response = await epochTracker.fetch(url, { method, headers }, "treesLatest");
 			const contentType = response.headers.get("content-type") ?? "";
+			let sequenceNumber: number | undefined;
 			if (contentType.includes("application/json")) {
+				// JSON framing: read it with the driver's JSON snapshot parser.
 				const snapshotJson = (await response.content.json()) as IOdspSnapshot;
-				return requireSequenceNumber(
-					convertOdspSnapshotToSnapshotTreeAndBlobs(snapshotJson).sequenceNumber,
-					versionId,
-				);
+				sequenceNumber =
+					convertOdspSnapshotToSnapshotTreeAndBlobs(snapshotJson).sequenceNumber;
+			} else {
+				// ms-fluid framing: the compact binary form; read it with the driver's compact-snapshot parser.
+				const bytes = new Uint8Array(await response.content.arrayBuffer());
+				sequenceNumber = parseCompactSnapshotResponse(bytes, logger).sequenceNumber;
 			}
-			// application/ms-fluid (compact binary)
-			const bytes = new Uint8Array(await response.content.arrayBuffer());
-			return requireSequenceNumber(
-				parseCompactSnapshotResponse(bytes, logger).sequenceNumber,
-				versionId,
-			);
+			// A version's snapshot must carry a sequence number; a missing one is surfaced as an error
+			// naming the version, rather than returning a wrong value.
+			if (sequenceNumber === undefined) {
+				throw new Error(`ODSP file version ${versionId} snapshot is missing a sequenceNumber`);
+			}
+			return sequenceNumber;
 		});
 
 	return { listFileVersions, resolveSequenceNumber };
-}
-
-/**
- * A version's snapshot must carry a sequence number; a missing one is surfaced as an error rather
- * than returning a wrong value.
- */
-function requireSequenceNumber(sequenceNumber: number | undefined, versionId: string): number {
-	if (sequenceNumber === undefined) {
-		throw new Error(`ODSP file version ${versionId} snapshot is missing a sequenceNumber`);
-	}
-	return sequenceNumber;
 }

--- a/packages/drivers/odsp-driver/src/odspVersionManager/odspVersionManager.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/odspVersionManager.ts
@@ -1,0 +1,161 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Selects the ODSP file version whose snapshot sits at or before a target Fluid sequence number —
+ * the base to load or replay from when materializing a document at a point in time.
+ *
+ * The selection logic depends on an injected {@link IOdspFileVersionFetcher}, so it is independent of
+ * how versions are enumerated and resolved (real ODSP, a test double, or an alternative backend).
+ */
+
+/**
+ * A single ODSP file version, as listed by the file's version history.
+ */
+export interface OdspFileVersionRef {
+	/**
+	 * The version's label (e.g. `"42.0"`), used to address the version when fetching it.
+	 */
+	readonly versionId: string;
+	/**
+	 * Last-modified timestamp of this version, ISO-8601.
+	 */
+	readonly lastModifiedDateTime: string;
+	/**
+	 * Size in bytes of this version's content.
+	 */
+	readonly sizeBytes: number;
+}
+
+/**
+ * An ODSP file version together with its resolved Fluid sequence number.
+ */
+export interface ResolvedVersion extends OdspFileVersionRef {
+	/**
+	 * The Fluid sequence number the version's snapshot represents.
+	 */
+	readonly sequenceNumber: number;
+	/**
+	 * The collaboration-window floor at this version, if read. Not used for selection.
+	 */
+	readonly minimumSequenceNumber?: number;
+}
+
+/**
+ * Result of resolving the base version for a target sequence number.
+ *
+ * @remarks
+ * There is intentionally no `targetIsLive` case: when the target is at/after the newest recoverable
+ * version, the greatest version with `seq <= target` IS that newest version, so it is a normal
+ * `found`. A consumer may separately choose to load the live file when the target is near the head.
+ */
+export type BaseForSeq =
+	| {
+			/** A recoverable version with `sequenceNumber <= target` was found. */
+			readonly kind: "found";
+			readonly base: ResolvedVersion;
+	  }
+	| {
+			/** No recoverable version has `sequenceNumber <= target` (target predates retained history). */
+			readonly kind: "noBaseVersion";
+			/** The oldest sequence number that was resolved while searching, if any. */
+			readonly oldestResolvedSeq?: number;
+	  };
+
+/**
+ * Provides a file's versions and resolves each version's Fluid sequence number. Injected into
+ * {@link OdspVersionManager} so the selection logic does not depend on how versions are fetched.
+ */
+export interface IOdspFileVersionFetcher {
+	/**
+	 * Enumerate the file's versions, newest-first.
+	 */
+	listFileVersions(): Promise<OdspFileVersionRef[]>;
+	/**
+	 * Resolve a single version's Fluid sequence number. Throws on failure rather than returning a
+	 * wrong value.
+	 */
+	resolveSequenceNumber(versionId: string): Promise<number>;
+}
+
+/**
+ * Selects the file version to use as the base for loading or replaying to a target sequence number.
+ */
+export interface IOdspVersionManager {
+	/**
+	 * Given a target sequence number, return the closest version at or before it (`found`), or
+	 * `noBaseVersion` if the target predates the oldest retained version.
+	 */
+	findBaseForSeq(target: number): Promise<BaseForSeq>;
+	/**
+	 * Return every version with its resolved sequence number, newest-first.
+	 */
+	listVersions(): Promise<ResolvedVersion[]>;
+	/**
+	 * Drop cached version enumeration and resolved sequence numbers so the next query re-fetches.
+	 */
+	refresh(): void;
+}
+
+/**
+ * Default {@link IOdspVersionManager}. Caches the version list and resolved sequence numbers. The
+ * resolution strategy (eager, newest-to-oldest, stopping at the first usable base) is hidden behind
+ * {@link findBaseForSeq} and can change without affecting callers.
+ */
+export class OdspVersionManager implements IOdspVersionManager {
+	private versionsCache: OdspFileVersionRef[] | undefined;
+	private readonly seqByVersion = new Map<string, number>();
+
+	public constructor(private readonly fetcher: IOdspFileVersionFetcher) {}
+
+	public refresh(): void {
+		this.versionsCache = undefined;
+		this.seqByVersion.clear();
+	}
+
+	public async findBaseForSeq(target: number): Promise<BaseForSeq> {
+		// Recoverable base candidates = every version except the tip (index 0 ≈ the live document).
+		const versions = await this.getVersions();
+		const candidates = versions.slice(1);
+
+		// The list is newest-first (descending sequence number), so the first candidate whose seq is
+		// at or before the target is the greatest seq <= target — that is the closest base. Scanning
+		// this way also yields the newest of any versions that share a sequence number (dedup), and
+		// avoids resolving older versions than necessary.
+		let oldestResolvedSeq: number | undefined;
+		for (const version of candidates) {
+			const sequenceNumber = await this.resolveSeq(version.versionId);
+			oldestResolvedSeq = sequenceNumber;
+			if (sequenceNumber <= target) {
+				return { kind: "found", base: { ...version, sequenceNumber } };
+			}
+		}
+		return { kind: "noBaseVersion", oldestResolvedSeq };
+	}
+
+	public async listVersions(): Promise<ResolvedVersion[]> {
+		const versions = await this.getVersions();
+		const resolved: ResolvedVersion[] = [];
+		for (const version of versions) {
+			resolved.push({ ...version, sequenceNumber: await this.resolveSeq(version.versionId) });
+		}
+		return resolved;
+	}
+
+	private async getVersions(): Promise<OdspFileVersionRef[]> {
+		this.versionsCache ??= await this.fetcher.listFileVersions();
+		return this.versionsCache;
+	}
+
+	private async resolveSeq(versionId: string): Promise<number> {
+		const cached = this.seqByVersion.get(versionId);
+		if (cached !== undefined) {
+			return cached;
+		}
+		const sequenceNumber = await this.fetcher.resolveSequenceNumber(versionId);
+		this.seqByVersion.set(versionId, sequenceNumber);
+		return sequenceNumber;
+	}
+}

--- a/packages/drivers/odsp-driver/src/odspVersionManager/odspVersionManager.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/odspVersionManager.ts
@@ -11,6 +11,11 @@
  * how versions are enumerated and resolved (real ODSP, a test double, or an alternative backend).
  */
 
+import {
+	createOdspFileVersionFetcher,
+	type OdspFileVersionFetcherProps,
+} from "./odspFileVersionFetcher.js";
+
 /**
  * A single ODSP file version, as listed by the file's version history.
  */
@@ -23,10 +28,6 @@ export interface OdspFileVersionRef {
 	 * Last-modified timestamp of this version, ISO-8601.
 	 */
 	readonly lastModifiedDateTime: string;
-	/**
-	 * Size in bytes of this version's content.
-	 */
-	readonly sizeBytes: number;
 }
 
 /**
@@ -37,10 +38,6 @@ export interface ResolvedVersion extends OdspFileVersionRef {
 	 * The Fluid sequence number the version's snapshot represents.
 	 */
 	readonly sequenceNumber: number;
-	/**
-	 * The collaboration-window floor at this version, if read. Not used for selection.
-	 */
-	readonly minimumSequenceNumber?: number;
 }
 
 /**
@@ -66,7 +63,7 @@ export type BaseForSeq =
 
 /**
  * Provides a file's versions and resolves each version's Fluid sequence number. Injected into
- * {@link OdspVersionManager} so the selection logic does not depend on how versions are fetched.
+ * the version manager so the selection logic does not depend on how versions are fetched.
  */
 export interface IOdspFileVersionFetcher {
 	/**
@@ -89,14 +86,6 @@ export interface IOdspVersionManager {
 	 * `noBaseVersion` if the target predates the oldest retained version.
 	 */
 	findBaseForSeq(target: number): Promise<BaseForSeq>;
-	/**
-	 * Return every version with its resolved sequence number, newest-first.
-	 */
-	listVersions(): Promise<ResolvedVersion[]>;
-	/**
-	 * Drop cached version enumeration and resolved sequence numbers so the next query re-fetches.
-	 */
-	refresh(): void;
 }
 
 /**
@@ -105,8 +94,8 @@ export interface IOdspVersionManager {
  * {@link findBaseForSeq} and can change without affecting callers.
  */
 export class OdspVersionManager implements IOdspVersionManager {
-	private versionsCache: OdspFileVersionRef[] | undefined;
-	private readonly seqByVersion = new Map<string, number>();
+	private versionsCache: Promise<OdspFileVersionRef[]> | undefined;
+	private readonly seqByVersion = new Map<string, Promise<number>>();
 
 	public constructor(private readonly fetcher: IOdspFileVersionFetcher) {}
 
@@ -120,14 +109,19 @@ export class OdspVersionManager implements IOdspVersionManager {
 		const versions = await this.getVersions();
 		const candidates = versions.slice(1);
 
-		// The list is newest-first (descending sequence number), so the first candidate whose seq is
-		// at or before the target is the greatest seq <= target — that is the closest base. Scanning
-		// this way also yields the newest of any versions that share a sequence number (dedup), and
-		// avoids resolving older versions than necessary.
+		// Versions are listed newest-first, and version order is expected to track sequence number, so
+		// the first candidate whose seq is at or before the target is taken as the closest base. Because
+		// any base at or before the target replays forward to the same state, this early stop is an
+		// optimization, not a correctness requirement: if version order and sequence order ever diverge,
+		// a base that is valid but not strictly the closest may be chosen.
+		// Scanning newest-first also yields the newest of versions sharing a sequence number (dedup).
 		let oldestResolvedSeq: number | undefined;
 		for (const version of candidates) {
 			const sequenceNumber = await this.resolveSeq(version.versionId);
-			oldestResolvedSeq = sequenceNumber;
+			oldestResolvedSeq =
+				oldestResolvedSeq === undefined
+					? sequenceNumber
+					: Math.min(oldestResolvedSeq, sequenceNumber);
 			if (sequenceNumber <= target) {
 				return { kind: "found", base: { ...version, sequenceNumber } };
 			}
@@ -137,25 +131,40 @@ export class OdspVersionManager implements IOdspVersionManager {
 
 	public async listVersions(): Promise<ResolvedVersion[]> {
 		const versions = await this.getVersions();
-		const resolved: ResolvedVersion[] = [];
-		for (const version of versions) {
-			resolved.push({ ...version, sequenceNumber: await this.resolveSeq(version.versionId) });
-		}
-		return resolved;
+		// Resolution order does not matter here, so resolve concurrently; the newest-first array order is
+		// preserved by Promise.all regardless of completion order.
+		return Promise.all(
+			versions.map(async (version) => ({
+				...version,
+				sequenceNumber: await this.resolveSeq(version.versionId),
+			})),
+		);
 	}
 
 	private async getVersions(): Promise<OdspFileVersionRef[]> {
-		this.versionsCache ??= await this.fetcher.listFileVersions();
+		// Cache the pending promise, not the awaited value, so concurrent callers share one fetch and a
+		// refresh() that runs while the fetch is in flight is not overwritten when the fetch settles.
+		this.versionsCache ??= this.fetcher.listFileVersions();
 		return this.versionsCache;
 	}
 
 	private async resolveSeq(versionId: string): Promise<number> {
-		const cached = this.seqByVersion.get(versionId);
-		if (cached !== undefined) {
-			return cached;
+		// Cache the pending promise (a version's sequence number never changes) so concurrent callers
+		// coalesce and a refresh() is not clobbered by a fetch that was already in flight.
+		let pending = this.seqByVersion.get(versionId);
+		if (pending === undefined) {
+			pending = this.fetcher.resolveSequenceNumber(versionId);
+			this.seqByVersion.set(versionId, pending);
 		}
-		const sequenceNumber = await this.fetcher.resolveSequenceNumber(versionId);
-		this.seqByVersion.set(versionId, sequenceNumber);
-		return sequenceNumber;
+		return pending;
 	}
+}
+
+/**
+ * Create an {@link IOdspVersionManager} for a specific ODSP file, wired to the real ODSP REST APIs.
+ */
+export function createOdspVersionManager(
+	props: OdspFileVersionFetcherProps,
+): IOdspVersionManager {
+	return new OdspVersionManager(createOdspFileVersionFetcher(props));
 }

--- a/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
@@ -1,0 +1,163 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type {
+	IOdspResolvedUrl,
+	IOdspUrlParts,
+	InstrumentedStorageTokenFetcher,
+} from "@fluidframework/odsp-driver-definitions/internal";
+import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
+import { stub } from "sinon";
+
+import type { IOdspSnapshot } from "../contracts.js";
+import { EpochTracker } from "../epochTracker.js";
+import { LocalPersistentCache } from "../odspCache.js";
+import { getHashedDocumentId } from "../odspPublicUtils.js";
+import { createOdspFileVersionFetcher } from "../odspVersionManager/index.js";
+
+import { createResponse, type MockResponse } from "./mockFetch.js";
+
+/**
+ * Integration tests for `createOdspFileVersionFetcher`. These exercise the real code path — URL
+ * construction, `getAuthHeader`, `EpochTracker.fetch`, content-type branching, and the driver's
+ * snapshot parser — against a stubbed `globalThis.fetch` (no live ODSP server).
+ */
+describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
+	const siteUrl = "https://microsoft.sharepoint.com";
+	const driveId = "driveId";
+	const itemId = "itemId";
+	const urlParts: IOdspUrlParts = { siteUrl, driveId, itemId };
+
+	// getAuthHeader is stubbed to a fixed token; getHeadersWithAuth turns it into the Authorization header.
+	const getAuthHeader: InstrumentedStorageTokenFetcher = async () => "Bearer token";
+	const logger = createChildLogger();
+
+	let epochTracker: EpochTracker;
+	let fetcher: ReturnType<typeof createOdspFileVersionFetcher>;
+
+	beforeEach(async () => {
+		const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
+		const resolvedUrl = {
+			siteUrl,
+			driveId,
+			itemId,
+			odspResolvedUrl: true,
+		} as unknown as IOdspResolvedUrl;
+		epochTracker = new EpochTracker(
+			new LocalPersistentCache(),
+			{ docId: hashedDocumentId, resolvedUrl },
+			createChildLogger(),
+		);
+		fetcher = createOdspFileVersionFetcher({ urlParts, getAuthHeader, epochTracker, logger });
+	});
+
+	afterEach(async () => {
+		await epochTracker.removeEntries().catch(() => {});
+	});
+
+	/**
+	 * Run `fn` with `globalThis.fetch` stubbed to return `responses` in order, capturing the requested
+	 * URLs so tests can assert URL construction.
+	 */
+	async function withFetch<T>(
+		responses: MockResponse[],
+		fn: () => Promise<T>,
+	): Promise<{ result: T; urls: string[] }> {
+		const urls: string[] = [];
+		const fetchStub = stub(globalThis, "fetch");
+		fetchStub.callsFake(async (url) => {
+			urls.push(typeof url === "string" ? url : url instanceof URL ? url.href : url.url);
+			const next = responses.shift();
+			assert(next !== undefined, "unexpected extra fetch call");
+			return next as unknown as Response;
+		});
+		try {
+			const result = await fn();
+			assert.equal(responses.length, 0, "all stubbed responses should be consumed");
+			return { result, urls };
+		} finally {
+			fetchStub.restore();
+		}
+	}
+
+	const jsonHeaders = { "content-type": "application/json" };
+
+	/** A minimal but parser-valid ODSP JSON snapshot carrying the given sequence number. */
+	function snapshotWithSeq(sequenceNumber: number): IOdspSnapshot {
+		return {
+			id: "id",
+			trees: [{ entries: [{ path: "path", type: "tree" }], id: "id", sequenceNumber }],
+			blobs: [],
+		};
+	}
+
+	/** A snapshot missing its sequence number (models a malformed response). */
+	const snapshotMissingSeq = {
+		id: "id",
+		trees: [{ entries: [{ path: "path", type: "tree" }], id: "id" }],
+		blobs: [],
+	} as unknown as IOdspSnapshot;
+
+	it("listFileVersions parses the /versions response and calls the versions URL", async () => {
+		// @q F-LIST-01
+		const { result, urls } = await withFetch(
+			[
+				await createResponse(
+					jsonHeaders,
+					{
+						value: [
+							{ id: "42.0", lastModifiedDateTime: "2026-01-02T00:00:00Z", size: 111 },
+							{ id: "40.0", lastModifiedDateTime: "2026-01-01T00:00:00Z", size: 222 },
+						],
+					},
+					200,
+				),
+			],
+			async () => fetcher.listFileVersions(),
+		);
+
+		assert.deepEqual(
+			result.map((v) => [v.versionId, v.sizeBytes]),
+			[
+				["42.0", 111],
+				["40.0", 222],
+			],
+		);
+		assert.ok(
+			urls[0]?.includes(`/_api/v2.1/drives/${driveId}/items/${itemId}/versions`),
+			`expected the versions URL, got ${urls[0]}`,
+		);
+	});
+
+	it("resolveSequenceNumber reads trees[0].sequenceNumber and calls the versioned snapshot URL", async () => {
+		// @q F-RESOLVE-01
+		const { result, urls } = await withFetch(
+			[await createResponse(jsonHeaders, snapshotWithSeq(448), 200)],
+			async () => fetcher.resolveSequenceNumber("42.0"),
+		);
+
+		assert.equal(result, 448);
+		assert.ok(
+			urls[0]?.includes(
+				`/versions/42.0/opStream/snapshots/trees/latest?blobs=2`,
+			),
+			`expected the fileVersion snapshot URL, got ${urls[0]}`,
+		);
+	});
+
+	it("resolveSequenceNumber throws (does not return a wrong value) when the snapshot has no sequence number", async () => {
+		// @q F-RESOLVE-02
+		await assert.rejects(
+			async () =>
+				withFetch(
+					[await createResponse(jsonHeaders, snapshotMissingSeq, 200)],
+					async () => fetcher.resolveSequenceNumber("42.0"),
+				),
+			/42\.0/,
+		);
+	});
+});

--- a/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
@@ -142,9 +142,7 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 
 		assert.equal(result, 448);
 		assert.ok(
-			urls[0]?.includes(
-				`/versions/42.0/opStream/snapshots/trees/latest?blobs=2`,
-			),
+			urls[0]?.includes(`/versions/42.0/opStream/snapshots/trees/latest?blobs=2`),
 			`expected the fileVersion snapshot URL, got ${urls[0]}`,
 		);
 	});
@@ -153,9 +151,8 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 		// @q F-RESOLVE-02
 		await assert.rejects(
 			async () =>
-				withFetch(
-					[await createResponse(jsonHeaders, snapshotMissingSeq, 200)],
-					async () => fetcher.resolveSequenceNumber("42.0"),
+				withFetch([await createResponse(jsonHeaders, snapshotMissingSeq, 200)], async () =>
+					fetcher.resolveSequenceNumber("42.0"),
 				),
 			/42\.0/,
 		);

--- a/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
+import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import type {
 	IOdspResolvedUrl,
 	IOdspUrlParts,
@@ -13,13 +14,15 @@ import type {
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { stub } from "sinon";
 
+import { convertToCompactSnapshot } from "../compactSnapshotWriter.js";
 import type { IOdspSnapshot } from "../contracts.js";
 import { EpochTracker } from "../epochTracker.js";
 import { LocalPersistentCache } from "../odspCache.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
-import { createOdspFileVersionFetcher } from "../odspVersionManager/index.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import { createOdspFileVersionFetcher } from "../odspVersionManager/odspFileVersionFetcher.js";
 
-import { createResponse, type MockResponse } from "./mockFetch.js";
+import { createResponse, type MockResponse, notFound } from "./mockFetch.js";
 
 /**
  * Integration tests for `createOdspFileVersionFetcher`. These exercise the real code path — URL
@@ -102,6 +105,22 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 		blobs: [],
 	} as unknown as IOdspSnapshot;
 
+	const msFluidHeaders = { "content-type": "application/ms-fluid" };
+
+	/** Serialize a minimal snapshot carrying `sequenceNumber` into the compact (ms-fluid) binary form. */
+	function compactSnapshotBytesWithSeq(sequenceNumber: number): Uint8Array {
+		const snapshotTree: ISnapshotTree = { id: "id", blobs: {}, trees: {} };
+		const snapshot: ISnapshot = {
+			snapshotTree,
+			blobContents: new Map(),
+			ops: [],
+			sequenceNumber,
+			latestSequenceNumber: sequenceNumber,
+			snapshotFormatV: 1,
+		};
+		return convertToCompactSnapshot(snapshot);
+	}
+
 	it("listFileVersions parses the /versions response and calls the versions URL", async () => {
 		// @q F-LIST-01
 		const { result, urls } = await withFetch(
@@ -110,8 +129,8 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 					jsonHeaders,
 					{
 						value: [
-							{ id: "42.0", lastModifiedDateTime: "2026-01-02T00:00:00Z", size: 111 },
-							{ id: "40.0", lastModifiedDateTime: "2026-01-01T00:00:00Z", size: 222 },
+							{ id: "42.0", lastModifiedDateTime: "2026-01-02T00:00:00Z" },
+							{ id: "40.0", lastModifiedDateTime: "2026-01-01T00:00:00Z" },
 						],
 					},
 					200,
@@ -121,16 +140,56 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 		);
 
 		assert.deepEqual(
-			result.map((v) => [v.versionId, v.sizeBytes]),
+			result.map((v) => [v.versionId, v.lastModifiedDateTime]),
 			[
-				["42.0", 111],
-				["40.0", 222],
+				["42.0", "2026-01-02T00:00:00Z"],
+				["40.0", "2026-01-01T00:00:00Z"],
 			],
 		);
 		assert.ok(
 			urls[0]?.includes(`/_api/v2.1/drives/${driveId}/items/${itemId}/versions`),
 			`expected the versions URL, got ${urls[0]}`,
 		);
+	});
+
+	it("follows @odata.nextLink to include versions past the first page", async () => {
+		// @q F-LIST-02
+		const nextLink = "https://microsoft.sharepoint.com/_api/v2.1/versions?page=2";
+		const { result, urls } = await withFetch(
+			[
+				await createResponse(
+					jsonHeaders,
+					{
+						value: [{ id: "42.0", lastModifiedDateTime: "2026-01-03T00:00:00Z" }],
+						"@odata.nextLink": nextLink,
+					},
+					200,
+				),
+				await createResponse(
+					jsonHeaders,
+					{ value: [{ id: "41.0", lastModifiedDateTime: "2026-01-02T00:00:00Z" }] },
+					200,
+				),
+			],
+			async () => fetcher.listFileVersions(),
+		);
+
+		assert.deepEqual(
+			result.map((v) => v.versionId),
+			["42.0", "41.0"],
+			"versions from both pages should be included, newest-first",
+		);
+		assert.equal(urls.length, 2, "should follow the nextLink for a second page");
+		assert.equal(urls[1], nextLink, "the second request should target the nextLink URL");
+	});
+
+	it("returns an empty list when the response has no value field", async () => {
+		// @q F-LIST-03
+		const { result } = await withFetch(
+			[await createResponse(jsonHeaders, {}, 200)],
+			async () => fetcher.listFileVersions(),
+		);
+		assert.deepEqual(result, [], "a missing value field is treated as an empty version list");
 	});
 
 	it("resolveSequenceNumber reads trees[0].sequenceNumber and calls the versioned snapshot URL", async () => {
@@ -155,6 +214,92 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 					fetcher.resolveSequenceNumber("42.0"),
 				),
 			/42\.0/,
+		);
+	});
+
+	it("resolveSequenceNumber parses an application/ms-fluid (binary) snapshot", async () => {
+		// @q F-RESOLVE-03
+		const { result } = await withFetch(
+			[await createResponse(msFluidHeaders, compactSnapshotBytesWithSeq(448), 200)],
+			async () => fetcher.resolveSequenceNumber("42.0"),
+		);
+		assert.equal(result, 448);
+	});
+
+	it("listFileVersions surfaces a non-success response as an error", async () => {
+		// @q F-ERROR-01
+		await assert.rejects(async () =>
+			withFetch([await notFound()], async () => fetcher.listFileVersions()),
+		);
+	});
+
+	it("resolveSequenceNumber refreshes the token and retries after an auth failure", async () => {
+		// @q F-ERROR-02
+		const refreshFlags: boolean[] = [];
+		const trackingAuth: InstrumentedStorageTokenFetcher = async (options) => {
+			refreshFlags.push(options.refresh);
+			return "******";
+		};
+		const authRetryFetcher = createOdspFileVersionFetcher({
+			urlParts,
+			getAuthHeader: trackingAuth,
+			epochTracker,
+			logger,
+		});
+		const { result } = await withFetch(
+			[
+				await createResponse(jsonHeaders, undefined, 401), // auth failure -> triggers a token refresh
+				await createResponse(jsonHeaders, snapshotWithSeq(448), 200), // retry succeeds
+			],
+			async () => authRetryFetcher.resolveSequenceNumber("42.0"),
+		);
+		assert.equal(result, 448);
+		assert.deepEqual(
+			refreshFlags,
+			[false, true],
+			"the first attempt uses a cached token; the retry forces a refresh",
+		);
+	});
+
+	it("resolveSequenceNumber surfaces a non-success response as an error", async () => {
+		// @q F-ERROR-03
+		await assert.rejects(async () =>
+			withFetch([await notFound()], async () => fetcher.resolveSequenceNumber("42.0")),
+		);
+	});
+
+	it("listFileVersions refreshes the token and retries after an auth failure", async () => {
+		// @q F-ERROR-04
+		const refreshFlags: boolean[] = [];
+		const trackingAuth: InstrumentedStorageTokenFetcher = async (options) => {
+			refreshFlags.push(options.refresh);
+			return "******";
+		};
+		const authRetryFetcher = createOdspFileVersionFetcher({
+			urlParts,
+			getAuthHeader: trackingAuth,
+			epochTracker,
+			logger,
+		});
+		const { result } = await withFetch(
+			[
+				await createResponse(jsonHeaders, undefined, 401), // auth failure -> triggers a token refresh
+				await createResponse(
+					jsonHeaders,
+					{ value: [{ id: "42.0", lastModifiedDateTime: "2026-01-02T00:00:00Z" }] },
+					200,
+				), // retry succeeds
+			],
+			async () => authRetryFetcher.listFileVersions(),
+		);
+		assert.deepEqual(
+			result.map((v) => v.versionId),
+			["42.0"],
+		);
+		assert.deepEqual(
+			refreshFlags,
+			[false, true],
+			"the first attempt uses a cached token; the retry forces a refresh",
 		);
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/odspVersionManager.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspVersionManager.spec.ts
@@ -1,0 +1,207 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+	OdspVersionManager,
+	type OdspFileVersionRef,
+	type IOdspFileVersionFetcher,
+} from "../odspVersionManager/index.js";
+
+/**
+ * Build an {@link OdspFileVersionRef} with the given label. Timestamp/size are irrelevant to the
+ * manager's selection logic, so they are fixed.
+ */
+function ref(versionId: string): OdspFileVersionRef {
+	return { versionId, lastModifiedDateTime: "2026-01-01T00:00:00.000Z", sizeBytes: 1000 };
+}
+
+interface FakeFetcher extends IOdspFileVersionFetcher {
+	/** Number of times the version list was fetched. */
+	readonly listCalls: () => number;
+	/** Version ids passed to resolveSequenceNumber, in call order. */
+	readonly resolvedIds: () => string[];
+}
+
+/*
+ * Create a manager backed by in-memory fakes so the selection logic can be tested without ODSP.
+ * `versions` is the newest-first list the fake `listFileVersions` returns; `seqByVersion` maps a
+ * versionId to the sequence number the fake `resolveSequenceNumber` returns (a missing id makes it
+ * throw, modelling a parse failure).
+ */
+function makeManager(
+	versions: OdspFileVersionRef[],
+	seqByVersion: Record<string, number>,
+): { manager: OdspVersionManager; fetcher: FakeFetcher } {
+	let listCallCount = 0;
+	const resolved: string[] = [];
+	const fetcher: FakeFetcher = {
+		listFileVersions: async () => {
+			listCallCount++;
+			return versions;
+		},
+		resolveSequenceNumber: async (versionId: string) => {
+			resolved.push(versionId);
+			const seq: number | undefined = seqByVersion[versionId];
+			if (seq === undefined) {
+				throw new Error(`no sequence number configured for version ${versionId}`);
+			}
+			return seq;
+		},
+		listCalls: () => listCallCount,
+		resolvedIds: () => [...resolved],
+	};
+	return { manager: new OdspVersionManager(fetcher), fetcher };
+}
+
+describe("OdspVersionManager", () => {
+	describe("findBaseForSeq: which version does it pick for a target sequence number?", () => {
+		// Timeline (newest-first): tip=460, then recoverable versions 448 and 418.
+		const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+		const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+
+		it("returns the closest version at or before the target (target between two versions)", async () => {
+			// @q M-SELECT-01
+			const { manager } = makeManager(versions, seqs);
+			const result = await manager.findBaseForSeq(430);
+			assert.equal(result.kind, "found");
+			assert.equal(result.kind === "found" && result.base.versionId, "40.0");
+			assert.equal(result.kind === "found" && result.base.sequenceNumber, 418);
+		});
+
+		it("returns an exact match (0-op replay) when the target equals a version's sequence number", async () => {
+			// @q M-SELECT-02
+			const { manager } = makeManager(versions, seqs);
+			const result = await manager.findBaseForSeq(448);
+			assert.equal(result.kind, "found");
+			assert.equal(result.kind === "found" && result.base.versionId, "42.0");
+			assert.equal(result.kind === "found" && result.base.sequenceNumber, 448);
+		});
+
+		it("returns the newest recoverable version when the target is newer than all versions", async () => {
+			// @q M-SELECT-03
+			const { manager } = makeManager(versions, seqs);
+			const result = await manager.findBaseForSeq(500);
+			assert.equal(result.kind, "found");
+			assert.equal(result.kind === "found" && result.base.versionId, "42.0");
+			assert.equal(result.kind === "found" && result.base.sequenceNumber, 448);
+		});
+
+		it("returns noBaseVersion (with the oldest resolved seq) when the target predates all versions", async () => {
+			// @q M-SELECT-04
+			const { manager } = makeManager(versions, seqs);
+			const result = await manager.findBaseForSeq(400);
+			assert.equal(result.kind, "noBaseVersion");
+			assert.equal(result.kind === "noBaseVersion" && result.oldestResolvedSeq, 418);
+		});
+	});
+
+	describe("findBaseForSeq: dedup and the tip", () => {
+		it("returns the newest of versions sharing a sequence number (dedup)", async () => {
+			// @q M-DEDUP-01
+			// Two recoverable versions share seq 448 (a metadata-only re-snap); newest is 42.0.
+			const versions = [ref("tip"), ref("42.0"), ref("41.5"), ref("40.0")];
+			const seqs = { tip: 460, "42.0": 448, "41.5": 448, "40.0": 418 };
+			const { manager } = makeManager(versions, seqs);
+			const result = await manager.findBaseForSeq(448);
+			assert.equal(result.kind, "found");
+			assert.equal(result.kind === "found" && result.base.versionId, "42.0");
+		});
+
+		it("never treats the tip (index 0) as a recoverable base", async () => {
+			// @q M-TIP-01
+			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const { manager, fetcher } = makeManager(versions, seqs);
+			await manager.findBaseForSeq(500);
+			assert.ok(
+				!fetcher.resolvedIds().includes("tip"),
+				"the tip's sequence number should never be resolved",
+			);
+		});
+
+		it("returns noBaseVersion when only the tip exists", async () => {
+			// @q M-TIP-02
+			const { manager } = makeManager([ref("tip")], { tip: 460 });
+			const result = await manager.findBaseForSeq(100);
+			assert.equal(result.kind, "noBaseVersion");
+		});
+
+		it("returns noBaseVersion when the version list is empty", async () => {
+			// @q M-EMPTY-01
+			const { manager } = makeManager([], {});
+			const result = await manager.findBaseForSeq(100);
+			assert.equal(result.kind, "noBaseVersion");
+		});
+	});
+
+	describe("efficiency: does it avoid unnecessary work?", () => {
+		it("stops resolving once it finds the closest base (does not resolve older versions)", async () => {
+			// @q M-STOP-01
+			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const { manager, fetcher } = makeManager(versions, seqs);
+			// target 448 matches 42.0, so 40.0 should never be resolved.
+			await manager.findBaseForSeq(448);
+			assert.deepEqual(fetcher.resolvedIds(), ["42.0"]);
+		});
+
+		it("caches the version list and resolved sequence numbers across calls", async () => {
+			// @q M-CACHE-01
+			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const { manager, fetcher } = makeManager(versions, seqs);
+			await manager.findBaseForSeq(430); // resolves 42.0 then 40.0
+			await manager.findBaseForSeq(430); // should hit caches only
+			assert.equal(fetcher.listCalls(), 1, "version list should be fetched once");
+			assert.deepEqual(
+				fetcher.resolvedIds(),
+				["42.0", "40.0"],
+				"each version should be resolved at most once",
+			);
+		});
+
+		it("re-enumerates after refresh()", async () => {
+			// @q M-CACHE-02
+			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const { manager, fetcher } = makeManager(versions, seqs);
+			await manager.findBaseForSeq(430);
+			manager.refresh();
+			await manager.findBaseForSeq(430);
+			assert.equal(fetcher.listCalls(), 2, "refresh should force a re-enumeration");
+		});
+	});
+
+	describe("error handling", () => {
+		it("propagates (does not swallow) a failure to resolve a version's sequence number", async () => {
+			// @q M-ERR-01
+			// 42.0 has no configured seq -> resolveSequenceNumber throws.
+			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+			const seqs = { tip: 460, "40.0": 418 };
+			const { manager } = makeManager(versions, seqs);
+			await assert.rejects(async () => manager.findBaseForSeq(430), /42\.0/);
+		});
+	});
+
+	describe("listVersions", () => {
+		it("returns every version with its resolved sequence number, newest-first", async () => {
+			// @q M-LIST-01
+			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
+			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const { manager } = makeManager(versions, seqs);
+			const resolved = await manager.listVersions();
+			assert.deepEqual(
+				resolved.map((v) => [v.versionId, v.sequenceNumber]),
+				[
+					["tip", 460],
+					["42.0", 448],
+					["40.0", 418],
+				],
+			);
+		});
+	});
+});

--- a/packages/drivers/odsp-driver/src/test/odspVersionManager.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspVersionManager.spec.ts
@@ -5,18 +5,20 @@
 
 import { strict as assert } from "node:assert";
 
+/* eslint-disable import-x/no-internal-modules */
 import {
 	OdspVersionManager,
 	type OdspFileVersionRef,
 	type IOdspFileVersionFetcher,
-} from "../odspVersionManager/index.js";
+} from "../odspVersionManager/odspVersionManager.js";
+/* eslint-enable import-x/no-internal-modules */
 
 /**
  * Build an {@link OdspFileVersionRef} with the given label. Timestamp/size are irrelevant to the
  * manager's selection logic, so they are fixed.
  */
 function ref(versionId: string): OdspFileVersionRef {
-	return { versionId, lastModifiedDateTime: "2026-01-01T00:00:00.000Z", sizeBytes: 1000 };
+	return { versionId, lastModifiedDateTime: "2026-01-01T00:00:00.000Z" };
 }
 
 interface FakeFetcher extends IOdspFileVersionFetcher {
@@ -164,15 +166,51 @@ describe("OdspVersionManager", () => {
 			);
 		});
 
-		it("re-enumerates after refresh()", async () => {
+		it("re-enumerates and re-resolves after refresh()", async () => {
 			// @q M-CACHE-02
 			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
 			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
 			const { manager, fetcher } = makeManager(versions, seqs);
-			await manager.findBaseForSeq(430);
+			await manager.findBaseForSeq(430); // resolves 42.0 then 40.0
 			manager.refresh();
-			await manager.findBaseForSeq(430);
+			await manager.findBaseForSeq(430); // must re-fetch the list AND re-resolve seqs
 			assert.equal(fetcher.listCalls(), 2, "refresh should force a re-enumeration");
+			assert.deepEqual(
+				fetcher.resolvedIds(),
+				["42.0", "40.0", "42.0", "40.0"],
+				"refresh should also clear the resolved sequence-number cache",
+			);
+		});
+
+		it("does not let a fetch in flight during refresh() repopulate the cache", async () => {
+			// @q M-CACHE-03
+			let listCalls = 0;
+			const gates: ((versions: OdspFileVersionRef[]) => void)[] = [];
+			const fetcher: IOdspFileVersionFetcher = {
+				listFileVersions: async () => {
+					listCalls++;
+					return new Promise<OdspFileVersionRef[]>((resolve) => gates.push(resolve));
+				},
+				resolveSequenceNumber: async (versionId: string) => Number.parseInt(versionId, 10),
+			};
+			const manager = new OdspVersionManager(fetcher);
+
+			// Start a query so the version-list fetch is in flight, then refresh before it settles.
+			const first = manager.listVersions();
+			manager.refresh();
+			gates[0]?.([ref("2"), ref("1")]); // the in-flight fetch settles AFTER the refresh
+			await first;
+
+			// The refresh must not have been overwritten by the late fetch: the next query re-fetches.
+			const second = manager.listVersions();
+			gates[1]?.([ref("2"), ref("1")]);
+			await second;
+
+			assert.equal(
+				listCalls,
+				2,
+				"a refresh() during an in-flight fetch must force a re-fetch",
+			);
 		});
 	});
 


### PR DESCRIPTION
## Description

First component of point-in-time document load in `@fluidframework/odsp-driver`: an ODSP **file-version manager** that, given a target Fluid sequence number, selects the closest ODSP file version at or before it — the base from which a document can be loaded or replayed to that point in time.

Two pieces:

- `OdspVersionManager` — the selection logic (closest version ≤ target, dedup, tip handling, caching/refresh). It depends on an injected `IOdspFileVersionFetcher`, so the logic is unit-tested without ODSP.
- `createOdspFileVersionFetcher` — the real implementation: enumerates the file's versions (following `@odata.nextLink` paging) and resolves each version's sequence number from the version-scoped snapshot endpoint, reusing the driver's existing auth/epoch/fetch and snapshot parser.

These are **internal to the package** (not exported from its public entry points) and **not yet wired into a call site**, so there is no consumer-facing change. This is an incremental prototype; follow-ups will add the load/replay driver and the loader hookup.

Design notes and rationale live alongside the code in `packages/drivers/odsp-driver/src/odspVersionManager/DEV.md` — a "catechism" that mirrors the test suite (each documented behavior maps to a test via a stable ID).

Work item: https://dev.azure.com/fluidframework/internal/_workitems/edit/77292

## Reviewer Guidance

This is an incremental prototype posted for early feedback:

- The selection logic is fully unit-tested (14 tests, fetcher mocked), including caching and refresh — with a concurrent-refresh case that proves an in-flight fetch cannot repopulate a cleared cache.
- The fetcher has stubbed-`fetch` integration tests (10 tests) covering version enumeration with `@odata.nextLink` paging (and the empty-response fallback), sequence-number resolution from both JSON and `application/ms-fluid` (binary) snapshots, the missing-sequence-number error, non-success responses, and token-refresh retry.
- Feedback welcome on the `IOdspFileVersionFetcher` seam and the DEV.md catechism approach.
