### PR TITLE
fix(odsp-driver): harden version-manager caching and fetch validation

### DIFF
--- a/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
@@ -9,8 +9,9 @@ appears as a `// @q <id>` tag on the matching test.
 
 ID format: `<area>-<topic>-<nn>`. Area is `M` (the version manager — [Part II](#part-ii--the-version-manager))
 or `F` (the file-version fetcher — [Part III](#part-iii--the-file-version-fetcher)). Topic is a short
-mnemonic (e.g. `SELECT`, `RESOLVE`). `nn` is a zero-padded counter. IDs are append-only: existing IDs
-never renumber, so links stay stable across edits.
+mnemonic (e.g. `SELECT`, `RESOLVE`). `nn` is a zero-padded counter assigned the lowest number available
+within its `<area>-<topic>` group. When a scenario is removed, the remaining IDs in that group are
+renumbered to close the gap, so the numbering stays compact with no reserved or retired IDs.
 
 The contract:
 
@@ -40,6 +41,38 @@ Part 1 is built in three components:
 - **Component C — the loader hookup**: expose Component B through the container loader. **Built** in
   `@fluidframework/container-loader` (`loadContainerToSequenceNumber`) — see
   [Part V](#part-v--components-b--c-as-built).
+
+### Vocabulary (the overloaded terms)
+
+Several words describe "the saved state of a document" at different layers, which is a frequent source of
+confusion. Everything is built from two primitives — **ops** and the **state** they produce — and the rest
+is either a bundle of ops or a saved snapshot of state.
+
+- **Op**: a single change, globally ordered by a **sequence number**. The full history *is* the ordered
+  ops; the document is those ops replayed.
+- **Summary**: the Fluid **runtime**'s serialized tree of current state. A summarizer client *produces* a
+  summary and proposes it via a `summarize` → `summaryAck` op handshake. ("Summary" = the act/content the
+  client generates.)
+- **Snapshot**: the stored, fetchable form of a summary (tree + blobs, carrying a `sequenceNumber`). To
+  load, you fetch a snapshot and replay ops forward. Note two different snapshot lists exist: the driver's
+  *Fluid* snapshot list (`getVersions`) is **not** the ODSP file-version history — a different address
+  space.
+- **ODSP file version**: an entry in the file's version history (driveItem `/versions`, labels like
+  `"42.0"`). ODSP surfaces stored snapshots as recoverable version rows, with a retention cap and dedup.
+  **This is what Component A selects over.**
+- **op stream / `opStream`**: overloaded. As a concept, the ordered op log. As a URL segment, a path prefix
+  under which *both* snapshots (`.../opStream/snapshots/...`) and raw ops (`.../opStream?filter=...`) live.
+- **delta storage**: the durable REST op log (`OdspDeltaStorageService`), which fetches raw ops by
+  sequence-number range and is retention-limited. Distinct from —
+- **trailing / bundled ops**: a small tail of ops baked *inside* a snapshot (up to `latestSequenceNumber`),
+  returned with the snapshot for free — not a separate fetch.
+- **sequence number** = an op's global order index (a snapshot's is the op its tree is current through);
+  **latestSequenceNumber** = the last bundled trailing op; **minimumSequenceNumber (MSN)** = the
+  collaboration-window floor (seq all connected clients have acked) — **not** a retention/trimming signal.
+
+Chain of custody for one saved state: a **summarizer** writes a **summary** → stored as a **snapshot** →
+surfaced by ODSP as a **file version**. Same state, three names because three layers own it.
+
 
 ## Part I — Foundations
 
@@ -108,45 +141,60 @@ these behaviors are tested with an in-memory fake.
 
 ### Which version does `findBaseForSeq` pick for a target sequence number?
 
-The list is newest-first, and the tip (index 0, the live document) is not a base candidate. Among the
-remaining versions, the answer is the closest one at or before the target — the greatest sequence number
-at or before the target when version order tracks sequence order, which an early-stop newest-first scan
-finds.
+The list is newest-first, and the tip (index 0, the newest version) is excluded: it is the one version
+whose sequence number is not yet static, so it cannot be a stable base. Among the remaining (sealed)
+versions the answer is the closest one at or before the target — the greatest sequence number at or before
+the target when version order tracks sequence order, which an early-stop newest-first scan finds.
 
 - **Target between two versions?** The closer, older one. `M-SELECT-01`
 - **Target equal to a version?** That version, an exact match (zero ops to replay). `M-SELECT-02`
-- **Target newer than every version?** The newest recoverable version. `M-SELECT-03`
+- **Target newer than every sealed version?** The newest sealed version. `M-SELECT-03`
 - **Target older than every version?** `noBaseVersion`, reporting the oldest sequence number seen.
   `M-SELECT-04`
 
-### How does it handle duplicate versions and the tip?
+### How does it handle the tip, duplicate versions, and empty history?
 
+- **The tip (index 0)?** Never treated as a base; its sequence number is never even resolved. `M-TIP-01`
+- **Only the tip exists?** `noBaseVersion` — the sole version is excluded as a base. The wired consumer
+  (the point-in-time document service factory) surfaces this as a `UsageError`; loading the live document
+  for a near-head target is a possible future consumer choice, not current behavior. `M-TIP-02`
 - **Two versions share a sequence number?** Return the newest label (a metadata-only re-save leaves the
   sequence number unchanged; the newest is closest to the head). `M-DEDUP-01`
-- **The tip (index 0)?** Never treated as a base; its sequence number is never even resolved.
-  `M-TIP-01`
-- **Only the tip exists?** `noBaseVersion`. `M-TIP-02`
 - **No versions at all?** `noBaseVersion`. `M-EMPTY-01`
 
-### What work does it avoid?
+### What work does it avoid when scanning?
 
-- **Resolving more versions than needed?** It stops at the first version at or before the target and
-  does not resolve older ones. `M-STOP-01`
-- **Re-fetching across calls?** The version list and each resolved sequence number are cached.
-  `M-CACHE-01`
-- **Stale caches?** `refresh()` drops both the version list and the resolved sequence numbers, so the
-  next query re-enumerates and re-resolves. `M-CACHE-02`
-- **A `refresh()` while a fetch is still in flight?** The cache holds the pending fetch rather than its
-  eventual value, so a fetch that started before the refresh cannot write its now-stale result back over
-  the cleared cache; the next query re-fetches. `M-CACHE-03`
+- **Resolving more versions than needed?** It stops at the first version at or before the target and does
+  not resolve older ones. `M-STOP-01`
+
+### What is cached, and what is re-fetched?
+
+Resolved sequence numbers are memoized; the version list is not. A sealed version's sequence number never
+changes, so once resolved it is reused for the manager's lifetime rather than re-fetched. The version
+list, by contrast, changes as new versions are cut, so it is **re-enumerated on every query**. This
+mirrors how Page History (`host-page-history`) works: its `PageHistoryVersionManager` pulls the ODSP
+version list fresh on each navigation (`refreshVersions()`), caching only the expensive loaded *content* —
+not the list. Page History's `#getOdspVersions` likewise dedups and drops the tip (`slice(1)`), the same
+two rules applied here.
+
+The manager is short-lived — the point-in-time document service factory creates one per load and calls
+`findBaseForSeq` once, then drops it — so the memoization caches never grow large and need no eviction.
+
+- **Re-resolving a sequence number across calls?** Each version's number is memoized, so a later query
+  reuses it rather than re-fetching. `M-CACHE-01`
+- **A version-list fetch that fails?** It propagates rather than being read as empty; the list is
+  re-enumerated on the next call. `M-CACHE-02`
 
 ### What happens when a version cannot be resolved?
 
-The failure propagates; it is never swallowed into a wrong base. `M-ERR-01`
+The failure propagates; it is never swallowed into a wrong base. `M-ERR-01` A failed resolution is not
+cached, so a later call re-attempts it rather than replaying the cached rejection. `M-ERR-02`
 
 ### What does `listVersions` return?
 
-Every version with its resolved sequence number, newest-first. `M-LIST-01`
+Every version with its resolved sequence number, newest-first. `M-LIST-01` The tip's number is resolved
+fresh on every call (never cached, since it is not yet stable), while sealed versions are served from the
+cache. `M-LIST-02`
 
 ### How does it verify a chosen base can be replayed to the target?
 
@@ -169,10 +217,9 @@ them.
 - **Either epoch unknown?** Fails closed — without both epochs the shared-lineage claim cannot be proven.
   `M-VALIDATE-03`
 
-A numbered version's snapshot is immutable, so its epoch is read once and cached per versionId; the
+A numbered version's snapshot is immutable, so its epoch is read once and memoized per versionId; the
 live document's epoch can change (a restore or download-and-reupload bumps it) and is therefore read
-fresh on every lineage check, never cached. `refresh()` clears the cached version epochs alongside the
-version list and resolved sequence numbers. `M-VALIDATE-CACHE-01`, `M-VALIDATE-CACHE-02`
+fresh on every lineage check, never cached. `M-VALIDATE-CACHE-01`
 
 **Op availability.** This is _not_ re-checked up front, and Component B adds no check of its own. Op
 retention trims a contiguous _prefix_ from the oldest end of the stream, and op sequence numbers are
@@ -206,8 +253,14 @@ field yields an empty list rather than an error. `F-LIST-03`
   parses the response, and returns `trees[0].sequenceNumber`. `F-RESOLVE-01`
 - **A snapshot with no sequence number?** It throws, naming the version, rather than returning a wrong
   value. `F-RESOLVE-02`
+- **A snapshot whose sequence number is present but not a valid non-negative integer?** It throws rather
+  than coercing a wrong value into base selection. `F-RESOLVE-06`
 - **A binary (`application/ms-fluid`) snapshot?** It reads it with the driver's compact-snapshot parser
   and returns the same sequence number the JSON path would. `F-RESOLVE-03`
+- **An unexpected content-type (e.g. an HTML error page)?** It throws rather than mis-parsing the body as
+  a compact snapshot. `F-RESOLVE-04`
+- **A version label with characters that need escaping?** The label is percent-encoded into the snapshot
+  URL. `F-RESOLVE-05`
 
 ### How does it handle request failures?
 
@@ -306,24 +359,48 @@ requested op and keeps requesting the remainder, so the fetch fails
 still not built is **recovering** from that case: bridging a trimmed range by starting from a newer
 intermediate snapshot is the part that is not built yet — the rest of this answer is its design.
 
-A snapshot already contains the full accumulated state at its sequence number — every op at or below it
-is baked in. So to reach a target `T`, Component B loads the closest base snapshot (`seq ≤ T`) and
-replays only the ops in `(base, T]` on top of it. Those ops come from the op stream (delta storage), and
-may also be bundled with a snapshot (the `deltas=1` query parameter, deliberately omitted here because
-the manager only needs the sequence number, not the ops).
+A snapshot already contains the full accumulated state at its sequence number — the tree *is* the
+materialized state at `sequenceNumber`, with every earlier op baked in (nothing is replayed to *reach*
+the snapshot). So to reach a target `T`, Component B loads the closest base snapshot (`seq ≤ T`) and
+replays only the ops in `(base, T]` on top of it.
 
-Ops in the op stream are retained for a window and can be trimmed. The resolution is not to fetch the
-trimmed ops from somewhere else — it is to **start from a newer snapshot that already absorbed them**. If
-the ops just after the base are gone but another snapshot exists later in `(base, T]`, that snapshot's
-state already includes the trimmed ops, so Component B starts there and replays only the retained tail.
-Trimmed ops are never re-fetched; a later snapshot makes them unnecessary.
+Those ops come from two distinct pools:
+
+1. **The snapshot's own bundled ops.** Every stored snapshot carries a frozen tail of the ops *after* its
+   base — a `deltas` section the summarizer writes into the snapshot itself (`writeOpsSection` in
+   `compactSnapshotWriter.ts`), surfaced by the parser as `ISnapshot.ops` with `latestSequenceNumber` = the
+   last such op (`odspSnapshotParser.ts`). This tail is intrinsic to the snapshot object: the version-scoped
+   snapshot endpoint returns it whether or not `deltas=1` is asked, and its first op is always `base + 1`
+   (`fetchSnapshot.ts` asserts `ops[0].sequenceNumber - 1 === sequenceNumber`). So `(base, latestSequenceNumber]`
+   is available for free, no extra fetch.
+2. **The standalone op log.** Anything beyond `latestSequenceNumber` is fetched from ODSP **delta storage** —
+   `OdspDeltaStorageService.get(from, to)`, which issues
+   `.../opStream?ump=1&filter=sequenceNumber ge {from} and sequenceNumber le {to-1}` (`odspDeltaStorageService.ts`;
+   URL built from `getUrlBase`/`getDeltaStorageUrl` in `odspDriverUrlResolver.ts`). This is the same op-fetch
+   path the container's DeltaManager uses.
+
+Ops in the standalone op log are retained for a window (time-based, best-effort ~7 days measured from each
+version's date — confirmed with the ODSP storage team, who reduced it from ~30 days earlier this year) and
+can be trimmed. There is no field that advertises the earliest retained op; a gap is
+discovered by asking the op stream for the range and getting a short result (delta storage assumes the
+server returns all ops it has in the requested range). The resolution is not to fetch the trimmed ops from
+somewhere else — it is to **start from a newer snapshot that already absorbed them**. If the ops just after
+the base are gone but another snapshot exists later in `(base, T]`, that snapshot's state already includes
+the trimmed ops, so Component B starts there and replays only the retained tail. Trimmed ops are never
+re-fetched; a later snapshot makes them unnecessary.
 
 The target is only unreachable when all of the following hold: the nearest snapshot at or before `T` is
 old, the ops between it and `T` have been trimmed, and no snapshot falls anywhere in between to bridge
 the gap. In that case the exact state at `T` cannot be reconstructed, and Component B reports it
 (for example, a `missing ops` / not-materializable outcome) rather than returning a wrong state — a
-consumer may still choose to fall back to the nearest reachable state at or before `T`. This is rare in
-practice because snapshots are written frequently relative to the op-retention window.
+consumer may still choose to fall back to the nearest reachable state at or before `T`.
+
+Put precisely, the exactly-recoverable targets are **every snapshot (they are durable, not op-retention-bound),
+plus any target whose replay ops `(base, T]` still fall within the op-retention window**. A target older than
+retention that lands *between* snapshots — no snapshot on it, and its ops trimmed — is not exactly
+reconstructable: ops cannot be un-applied, so overshooting to a later snapshot does not help. This is rare in
+practice because snapshots are written frequently relative to the op-retention window, but it is a real limit,
+not a bug — so the honest behavior is to report the nearest reachable point rather than a wrong state.
 
 Note that `minimumSequenceNumber` is not the signal for any of this: it is the collaboration-window floor
 baked into a snapshot, used when a snapshot is loaded, not an indicator of which ops the op stream still

--- a/packages/drivers/odsp-driver/src/odspVersionManager/odspFileVersionFetcher.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/odspFileVersionFetcher.ts
@@ -12,6 +12,8 @@
  *   or the live document's ODSP epoch (`x-fluid-epoch`) to compare their lineage.
  */
 
+import { NonRetryableError } from "@fluidframework/driver-utils/internal";
+import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
 import type {
 	IOdspUrlParts,
 	InstrumentedStorageTokenFetcher,
@@ -25,6 +27,7 @@ import { getHeadersWithAuth } from "../getUrlAndHeadersWithAuth.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser.js";
 import { getApiRoot } from "../odspUrlHelper.js";
 import { fetchArray, getWithRetryForTokenRefresh } from "../odspUtils.js";
+import { pkgVersion as driverVersion } from "../packageVersion.js";
 
 /**
  * A single ODSP file version, as listed by the file's version history.
@@ -137,10 +140,8 @@ export function createOdspFileVersionFetcher(
 
 	const resolveSequenceNumber = async (versionId: string): Promise<number> =>
 		getWithRetryForTokenRefresh(async (options) => {
-			// A file version's sequence number lives inside that version's snapshot, so fetch the snapshot
-			// from the version-scoped endpoint. `blobs=2` inlines blob contents so the `.protocol/attributes`
-			// blob (which carries the sequence number) is included; `deltas=1` is intentionally omitted, as
-			// it would bundle the op stream and its op-level sequence numbers.
+			// The sequence number lives in the version snapshot's `.protocol/attributes` blob, so fetch the
+			// version-scoped snapshot with `blobs=2` to inline it. No op stream needed.
 			const url = `${getApiRoot(new URL(siteUrl))}/drives/${driveId}/items/${itemId}/versions/${encodeURIComponent(
 				versionId,
 			)}/opStream/snapshots/trees/latest?blobs=2`;
@@ -150,10 +151,8 @@ export function createOdspFileVersionFetcher(
 				"FileVersionSnapshot",
 			);
 			const headers = getHeadersWithAuth(token);
-			// The server can return the snapshot in one of two equivalent framings: verbose JSON, or
-			// "ms-fluid" — ODSP's compact binary encoding of the same snapshot. Advertise both, and pin the
-			// binary format version (as the driver's own snapshot fetch does) so the server cannot hand back
-			// a binary version this code's parser does not understand.
+			// The snapshot comes back as JSON or "ms-fluid" (ODSP's compact binary form). Accept both and
+			// pin the binary version (as the driver's snapshot fetch does) so the parser can read it.
 			headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
 			const response = await epochTracker.fetch(url, { method, headers }, "treesLatest");
 			const contentType = response.headers.get("content-type") ?? "";
@@ -163,15 +162,34 @@ export function createOdspFileVersionFetcher(
 				const snapshotJson = (await response.content.json()) as IOdspSnapshot;
 				sequenceNumber =
 					convertOdspSnapshotToSnapshotTreeAndBlobs(snapshotJson).sequenceNumber;
-			} else {
+			} else if (contentType.includes("application/ms-fluid")) {
 				// ms-fluid framing: the compact binary form; read it with the driver's compact-snapshot parser.
 				const bytes = new Uint8Array(await response.content.arrayBuffer());
 				sequenceNumber = parseCompactSnapshotResponse(bytes, logger).sequenceNumber;
+			} else {
+				// Neither framing (e.g. an HTML error page). Throw the driver's typed bad-response error
+				// (like fetchSnapshot.ts): canRetry=false stops the loader re-driving, while the
+				// incorrectServerResponse errorType still earns one wire-retry from getWithRetryForTokenRefresh.
+				throw new NonRetryableError(
+					`ODSP file version ${versionId} snapshot returned an unexpected content-type`,
+					OdspErrorTypes.incorrectServerResponse,
+					{ driverVersion, contentType, accept: headers.accept },
+				);
 			}
-			// A version's snapshot must carry a sequence number; a missing one is surfaced as an error
-			// naming the version, rather than returning a wrong value.
-			if (sequenceNumber === undefined) {
-				throw new Error(`ODSP file version ${versionId} snapshot is missing a sequenceNumber`);
+			// The sequence number must be a non-negative integer; a missing or malformed one throws the same
+			// typed error as above rather than feeding a wrong value into base selection.
+			if (
+				!(
+					typeof sequenceNumber === "number" &&
+					Number.isInteger(sequenceNumber) &&
+					sequenceNumber >= 0
+				)
+			) {
+				throw new NonRetryableError(
+					`ODSP file version ${versionId} snapshot has a missing or invalid sequenceNumber (${String(sequenceNumber)})`,
+					OdspErrorTypes.incorrectServerResponse,
+					{ driverVersion, contentType, accept: headers.accept },
+				);
 			}
 			return sequenceNumber;
 		});

--- a/packages/drivers/odsp-driver/src/odspVersionManager/odspVersionManager.ts
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/odspVersionManager.ts
@@ -11,6 +11,7 @@
  * how versions are enumerated and resolved (real ODSP, a test double, or an alternative backend).
  */
 
+import { PromiseCache } from "@fluidframework/core-utils/internal";
 import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
 
@@ -42,9 +43,11 @@ export interface ResolvedVersion extends OdspFileVersionRef {
  * Result of resolving the base version for a target sequence number.
  *
  * @remarks
- * There is intentionally no `targetIsLive` case: when the target is at/after the newest recoverable
- * version, the greatest version with `seq <= target` IS that newest version, so it is a normal
- * `found`. A consumer may separately choose to load the live file when the target is near the head.
+ * The tip (newest) version is excluded from base selection, so when the target is at or after the head
+ * the base is the newest *sealed* version with `seq <= target` (a normal `found`); if the file's only
+ * version is the tip, the result is `noBaseVersion`. The wired consumer surfaces `noBaseVersion` as a
+ * `UsageError`; loading the live file for a near-head target is a possible future consumer choice, not
+ * current behavior.
  */
 export type BaseForSeq =
 	| {
@@ -53,7 +56,10 @@ export type BaseForSeq =
 			readonly base: ResolvedVersion;
 	  }
 	| {
-			/** No recoverable version has `sequenceNumber <= target` (target predates retained history). */
+			/**
+			 * No sealed version has `sequenceNumber <= target` — the target predates retained history, or
+			 * the only version is the excluded tip.
+			 */
 			readonly kind: "noBaseVersion";
 			/** The oldest sequence number that was resolved while searching, if any. */
 			readonly oldestResolvedSeq?: number;
@@ -77,34 +83,33 @@ export interface IOdspVersionManager {
 }
 
 /**
- * Default {@link IOdspVersionManager}. Caches the version list and resolved sequence numbers. The
+ * Default {@link IOdspVersionManager}. Caches resolved sequence numbers (which never change); the version
+ * list is re-enumerated on each query rather than cached, since new versions are cut over time. The
  * resolution strategy (eager, newest-to-oldest, stopping at the first usable base) is hidden behind
  * {@link findBaseForSeq} and can change without affecting callers.
  */
+// Exported only so the same-package tests can construct it with a fake IOdspFileVersionFetcher.
+// Deliberately kept out of the folder barrel and the package public index, so it is not public API.
 export class OdspVersionManager implements IOdspVersionManager {
-	private versionsCache: Promise<OdspFileVersionRef[]> | undefined;
-	private readonly seqByVersion = new Map<string, Promise<number>>();
-	private readonly epochByVersion = new Map<string, Promise<string | undefined>>();
+	// Sealed versions' sequence numbers, memoized so each is resolved at most once per manager instance
+	// (a sealed version's number is fixed once the version exists).
+	private readonly seqCache = new PromiseCache<string, number>();
+	// Sealed versions' ODSP epochs, memoized like their sequence numbers. The live document's epoch is NOT
+	// cached — it can change (restore/reupload), so validateLineageEpoch always reads it fresh.
+	private readonly epochCache = new PromiseCache<string, string | undefined>();
 
 	public constructor(private readonly fetcher: IOdspFileVersionFetcher) {}
 
-	public refresh(): void {
-		this.versionsCache = undefined;
-		this.seqByVersion.clear();
-		this.epochByVersion.clear();
-	}
-
 	public async findBaseForSeq(target: number): Promise<BaseForSeq> {
-		// Recoverable base candidates = every version except the tip (index 0 ≈ the live document).
-		const versions = await this.getVersions();
+		// Re-enumerate the list each call (it changes as new versions are cut).
+		const versions = await this.fetcher.listFileVersions();
+
+		// Start past the tip (index 0): the newest version's sequence number can still advance until a newer
+		// version is cut, so it is treated as the live head rather than a stable base. Scan the remaining
+		// (sealed) versions newest-first and return the first with sequence number <= target — the closest
+		// base — or noBaseVersion, reporting the oldest sequence number seen.
 		const candidates = versions.slice(1);
 
-		// Versions are listed newest-first, and version order is expected to track sequence number, so
-		// the first candidate whose seq is at or before the target is taken as the closest base. Because
-		// any base at or before the target replays forward to the same state, this early stop is an
-		// optimization, not a correctness requirement: if version order and sequence order ever diverge,
-		// a base that is valid but not strictly the closest may be chosen.
-		// Scanning newest-first also yields the newest of versions sharing a sequence number (dedup).
 		let oldestResolvedSeq: number | undefined;
 		for (const version of candidates) {
 			const sequenceNumber = await this.resolveSeq(version.versionId);
@@ -160,46 +165,36 @@ export class OdspVersionManager implements IOdspVersionManager {
 	}
 
 	public async listVersions(): Promise<ResolvedVersion[]> {
-		const versions = await this.getVersions();
-		// Resolution order does not matter here, so resolve concurrently; the newest-first array order is
+		const versions = await this.fetcher.listFileVersions();
+		// Resolution order does not matter, so resolve concurrently; the newest-first array order is
 		// preserved by Promise.all regardless of completion order.
 		return Promise.all(
-			versions.map(async (version) => ({
+			versions.map(async (version, index) => ({
 				...version,
-				sequenceNumber: await this.resolveSeq(version.versionId),
+				// Resolve the tip (index 0) fresh each call, since its sequence number can still change;
+				// sealed versions come from the cache.
+				sequenceNumber:
+					index === 0
+						? await this.fetcher.resolveSequenceNumber(version.versionId)
+						: await this.resolveSeq(version.versionId),
 			})),
 		);
 	}
 
-	private async getVersions(): Promise<OdspFileVersionRef[]> {
-		// Cache the pending promise, not the awaited value, so concurrent callers share one fetch and a
-		// refresh() that runs while the fetch is in flight is not overwritten when the fetch settles.
-		this.versionsCache ??= this.fetcher.listFileVersions();
-		return this.versionsCache;
-	}
-
 	private async resolveSeq(versionId: string): Promise<number> {
-		// Cache the pending promise (a version's sequence number never changes) so concurrent callers
-		// coalesce and a refresh() is not clobbered by a fetch that was already in flight.
-		let pending = this.seqByVersion.get(versionId);
-		if (pending === undefined) {
-			pending = this.fetcher.resolveSequenceNumber(versionId);
-			this.seqByVersion.set(versionId, pending);
-		}
-		return pending;
+		// Cached indefinitely (a sealed version's number is fixed); concurrent calls coalesce and a failed
+		// resolution is evicted so a later call retries.
+		return this.seqCache.addOrGet(versionId, async () =>
+			this.fetcher.resolveSequenceNumber(versionId),
+		);
 	}
 
 	private async resolveVersionEpoch(versionId: string): Promise<string | undefined> {
-		// A numbered version's snapshot is immutable, so its epoch never changes: cache the pending
-		// promise (like resolveSeq) so a base revisited across findBaseForSeq calls is not re-fetched,
-		// concurrent callers coalesce, and a refresh() in flight is not clobbered. The live document's
-		// epoch is deliberately NOT cached here - it can change and is always read fresh.
-		let pending = this.epochByVersion.get(versionId);
-		if (pending === undefined) {
-			pending = this.fetcher.getRecoverableVersionEpoch(versionId);
-			this.epochByVersion.set(versionId, pending);
-		}
-		return pending;
+		// Cached like resolveSeq (a sealed version's epoch is fixed). The live document's epoch is read
+		// fresh instead (see validateLineageEpoch).
+		return this.epochCache.addOrGet(versionId, async () =>
+			this.fetcher.getRecoverableVersionEpoch(versionId),
+		);
 	}
 }
 

--- a/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspFileVersionFetcher.spec.ts
@@ -208,12 +208,41 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 
 	it("resolveSequenceNumber throws (does not return a wrong value) when the snapshot has no sequence number", async () => {
 		// @q F-RESOLVE-02
+		// The typed incorrectServerResponse error is retried once by getWithRetryForTokenRefresh, so two
+		// responses are stubbed; the retry hits the same missing-seq snapshot and the error propagates.
 		await assert.rejects(
 			async () =>
-				withFetch([await createResponse(jsonHeaders, snapshotMissingSeq, 200)], async () =>
-					fetcher.resolveSequenceNumber("42.0"),
+				withFetch(
+					[
+						await createResponse(jsonHeaders, snapshotMissingSeq, 200),
+						await createResponse(jsonHeaders, snapshotMissingSeq, 200),
+					],
+					async () => fetcher.resolveSequenceNumber("42.0"),
 				),
 			/42\.0/,
+		);
+	});
+
+	it("resolveSequenceNumber throws when the snapshot's sequence number is not a valid integer", async () => {
+		// @q F-RESOLVE-06
+		// A present-but-malformed sequence number must be rejected, not coerced into base selection. A
+		// non-integer number reaches the validation (the parser passes numbers through); incorrectServerResponse
+		// is retried once, so two responses are stubbed.
+		const snapshotBadSeq = {
+			id: "id",
+			trees: [{ entries: [{ path: "path", type: "tree" }], id: "id", sequenceNumber: 3.5 }],
+			blobs: [],
+		} as unknown as IOdspSnapshot;
+		await assert.rejects(
+			async () =>
+				withFetch(
+					[
+						await createResponse(jsonHeaders, snapshotBadSeq, 200),
+						await createResponse(jsonHeaders, snapshotBadSeq, 200),
+					],
+					async () => fetcher.resolveSequenceNumber("42.0"),
+				),
+			/invalid sequenceNumber/,
 		);
 	});
 
@@ -224,6 +253,35 @@ describe("OdspFileVersionFetcher (integration, stubbed fetch)", () => {
 			async () => fetcher.resolveSequenceNumber("42.0"),
 		);
 		assert.equal(result, 448);
+	});
+
+	it("resolveSequenceNumber rejects on an unexpected content-type instead of mis-parsing", async () => {
+		// @q F-RESOLVE-04
+		// The typed incorrectServerResponse error is retried once by getWithRetryForTokenRefresh, so two
+		// responses are stubbed; the retry hits the same content-type and the error propagates.
+		await assert.rejects(
+			async () =>
+				withFetch(
+					[
+						await createResponse({ "content-type": "text/html" }, "<html></html>", 200),
+						await createResponse({ "content-type": "text/html" }, "<html></html>", 200),
+					],
+					async () => fetcher.resolveSequenceNumber("42.0"),
+				),
+			/unexpected content-type/,
+		);
+	});
+
+	it("resolveSequenceNumber percent-encodes the version label in the snapshot URL", async () => {
+		// @q F-RESOLVE-05
+		const { urls } = await withFetch(
+			[await createResponse(jsonHeaders, snapshotWithSeq(448), 200)],
+			async () => fetcher.resolveSequenceNumber("42 0#draft"),
+		);
+		assert.ok(
+			urls[0]?.includes("/versions/42%200%23draft/opStream/"),
+			`expected the label to be percent-encoded, got ${urls[0]}`,
+		);
 	});
 
 	it("listFileVersions surfaces a non-success response as an error", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspVersionManager.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspVersionManager.spec.ts
@@ -99,11 +99,13 @@ function makeManager(
 
 describe("OdspVersionManager", () => {
 	describe("findBaseForSeq: which version does it pick for a target sequence number?", () => {
-		// Timeline (newest-first): tip=460, then recoverable versions 448 and 418.
-		const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-		const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+		// Timeline (newest-first): 44.0 is the tip (excluded); sealed: 43.0=460, 42.0=448, 40.0=418.
+		// The tip's sequence number is intentionally left unconfigured, so any attempt to resolve it
+		// would throw — proving the tip is never resolved.
+		const versions = [ref("44.0"), ref("43.0"), ref("42.0"), ref("40.0")];
+		const seqs = { "43.0": 460, "42.0": 448, "40.0": 418 };
 
-		it("returns the closest version at or before the target (target between two versions)", async () => {
+		it("returns the closest sealed version at or before the target (target between two versions)", async () => {
 			// @q M-SELECT-01
 			const { manager } = makeManager(versions, seqs);
 			const result = await manager.findBaseForSeq(430);
@@ -121,13 +123,15 @@ describe("OdspVersionManager", () => {
 			assert.equal(result.kind === "found" && result.base.sequenceNumber, 448);
 		});
 
-		it("returns the newest recoverable version when the target is newer than all versions", async () => {
+		it("returns the newest SEALED version when the target is newer than all sealed versions (not the tip)", async () => {
 			// @q M-SELECT-03
-			const { manager } = makeManager(versions, seqs);
+			const { manager, fetcher } = makeManager(versions, seqs);
 			const result = await manager.findBaseForSeq(500);
 			assert.equal(result.kind, "found");
-			assert.equal(result.kind === "found" && result.base.versionId, "42.0");
-			assert.equal(result.kind === "found" && result.base.sequenceNumber, 448);
+			// 43.0, not the tip 44.0 — the tip is excluded from base selection.
+			assert.equal(result.kind === "found" && result.base.versionId, "43.0");
+			assert.equal(result.kind === "found" && result.base.sequenceNumber, 460);
+			assert.ok(!fetcher.resolvedIds().includes("44.0"), "the tip must never be resolved");
 		});
 
 		it("returns noBaseVersion (with the oldest resolved seq) when the target predates all versions", async () => {
@@ -139,35 +143,42 @@ describe("OdspVersionManager", () => {
 		});
 	});
 
-	describe("findBaseForSeq: dedup and the tip", () => {
-		it("returns the newest of versions sharing a sequence number (dedup)", async () => {
+	describe("findBaseForSeq: the tip, dedup, and empty history", () => {
+		it("never treats the tip as a base — the tip's sequence number is never resolved", async () => {
+			// @q M-TIP-01
+			// The tip 44.0 has no configured sequence number, so resolving it would throw. A successful
+			// result therefore proves the tip was skipped.
+			const { manager, fetcher } = makeManager([ref("44.0"), ref("43.0"), ref("42.0")], {
+				"43.0": 460,
+				"42.0": 448,
+			});
+			const result = await manager.findBaseForSeq(500);
+			assert.equal(result.kind, "found");
+			assert.equal(result.kind === "found" && result.base.versionId, "43.0");
+			assert.deepEqual(
+				fetcher.resolvedIds(),
+				["43.0"],
+				"only the newest sealed version is resolved; the tip is not",
+			);
+		});
+
+		it("returns noBaseVersion when the only version is the tip", async () => {
+			// @q M-TIP-02
+			const { manager, fetcher } = makeManager([ref("44.0")], {});
+			const result = await manager.findBaseForSeq(500);
+			assert.equal(result.kind, "noBaseVersion");
+			assert.deepEqual(fetcher.resolvedIds(), [], "the tip must never be resolved");
+		});
+
+		it("returns the newest of sealed versions sharing a sequence number (dedup)", async () => {
 			// @q M-DEDUP-01
-			// Two recoverable versions share seq 448 (a metadata-only re-snap); newest is 42.0.
-			const versions = [ref("tip"), ref("42.0"), ref("41.5"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "41.5": 448, "40.0": 418 };
+			// Two sealed versions share seq 448 (a metadata-only re-snap); newest is 42.0.
+			const versions = [ref("44.0"), ref("43.0"), ref("42.0"), ref("41.5"), ref("40.0")];
+			const seqs = { "43.0": 460, "42.0": 448, "41.5": 448, "40.0": 418 };
 			const { manager } = makeManager(versions, seqs);
 			const result = await manager.findBaseForSeq(448);
 			assert.equal(result.kind, "found");
 			assert.equal(result.kind === "found" && result.base.versionId, "42.0");
-		});
-
-		it("never treats the tip (index 0) as a recoverable base", async () => {
-			// @q M-TIP-01
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
-			const { manager, fetcher } = makeManager(versions, seqs);
-			await manager.findBaseForSeq(500);
-			assert.ok(
-				!fetcher.resolvedIds().includes("tip"),
-				"the tip's sequence number should never be resolved",
-			);
-		});
-
-		it("returns noBaseVersion when only the tip exists", async () => {
-			// @q M-TIP-02
-			const { manager } = makeManager([ref("tip")], { tip: 460 });
-			const result = await manager.findBaseForSeq(100);
-			assert.equal(result.kind, "noBaseVersion");
 		});
 
 		it("returns noBaseVersion when the version list is empty", async () => {
@@ -179,77 +190,54 @@ describe("OdspVersionManager", () => {
 	});
 
 	describe("efficiency: does it avoid unnecessary work?", () => {
-		it("stops resolving once it finds the closest base (does not resolve older versions)", async () => {
+		it("stops resolving once it finds the closest base (does not resolve older versions or the tip)", async () => {
 			// @q M-STOP-01
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const versions = [ref("44.0"), ref("43.0"), ref("42.0"), ref("40.0")];
+			const seqs = { "43.0": 460, "42.0": 448, "40.0": 418 };
 			const { manager, fetcher } = makeManager(versions, seqs);
-			// target 448 matches 42.0, so 40.0 should never be resolved.
+			// target 448: skips the tip, resolves 43.0 (too new) then 42.0 (match), so 40.0 is never resolved.
 			await manager.findBaseForSeq(448);
-			assert.deepEqual(fetcher.resolvedIds(), ["42.0"]);
+			assert.deepEqual(fetcher.resolvedIds(), ["43.0", "42.0"]);
 		});
 
-		it("caches the version list and resolved sequence numbers across calls", async () => {
+		it("caches resolved sequence numbers across calls but re-enumerates the list each call", async () => {
 			// @q M-CACHE-01
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const versions = [ref("44.0"), ref("43.0"), ref("42.0"), ref("40.0")];
+			const seqs = { "43.0": 460, "42.0": 448, "40.0": 418 };
 			const { manager, fetcher } = makeManager(versions, seqs);
-			await manager.findBaseForSeq(430); // resolves 42.0 then 40.0
-			await manager.findBaseForSeq(430); // should hit caches only
-			assert.equal(fetcher.listCalls(), 1, "version list should be fetched once");
+			await manager.findBaseForSeq(0); // scans all sealed (no match), resolving 43.0, 42.0, 40.0
+			await manager.findBaseForSeq(0); // list re-fetched; seqs served from cache
+			assert.equal(fetcher.listCalls(), 2, "the version list is re-enumerated on every call");
 			assert.deepEqual(
 				fetcher.resolvedIds(),
-				["42.0", "40.0"],
-				"each version should be resolved at most once",
+				["43.0", "42.0", "40.0"],
+				"each sealed version's sequence number is resolved at most once (cached)",
 			);
 		});
 
-		it("re-enumerates and re-resolves after refresh()", async () => {
+		it("does not memoize a failed version-list fetch — a later call retries", async () => {
 			// @q M-CACHE-02
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
-			const { manager, fetcher } = makeManager(versions, seqs);
-			await manager.findBaseForSeq(430); // resolves 42.0 then 40.0
-			manager.refresh();
-			await manager.findBaseForSeq(430); // must re-fetch the list AND re-resolve seqs
-			assert.equal(fetcher.listCalls(), 2, "refresh should force a re-enumeration");
-			assert.deepEqual(
-				fetcher.resolvedIds(),
-				["42.0", "40.0", "42.0", "40.0"],
-				"refresh should also clear the resolved sequence-number cache",
-			);
-		});
-
-		it("does not let a fetch in flight during refresh() repopulate the cache", async () => {
-			// @q M-CACHE-03
 			let listCalls = 0;
-			const gates: ((versions: OdspFileVersionRef[]) => void)[] = [];
 			const fetcher: IOdspFileVersionFetcher = {
 				listFileVersions: async () => {
 					listCalls++;
-					return new Promise<OdspFileVersionRef[]>((resolve) => gates.push(resolve));
+					if (listCalls === 1) {
+						throw new Error("transient list failure");
+					}
+					return [ref("44.0"), ref("43.0")];
 				},
 				resolveSequenceNumber: async (versionId: string) => Number.parseInt(versionId, 10),
 				getLiveDocumentEpoch: async () => "epoch",
 				getRecoverableVersionEpoch: async () => "epoch",
 			};
 			const manager = new OdspVersionManager(fetcher);
-
-			// Start a query so the version-list fetch is in flight, then refresh before it settles.
-			const first = manager.listVersions();
-			manager.refresh();
-			gates[0]?.([ref("2"), ref("1")]); // the in-flight fetch settles AFTER the refresh
-			await first;
-
-			// The refresh must not have been overwritten by the late fetch: the next query re-fetches.
-			const second = manager.listVersions();
-			gates[1]?.([ref("2"), ref("1")]);
-			await second;
-
+			await assert.rejects(async () => manager.findBaseForSeq(0), /transient list failure/);
+			const result = await manager.findBaseForSeq(0); // retries the list, succeeds
+			assert.equal(result.kind, "noBaseVersion");
 			assert.equal(
 				listCalls,
 				2,
-				"a refresh() during an in-flight fetch must force a re-fetch",
+				"the failed list fetch should be retried, not replayed from cache",
 			);
 		});
 	});
@@ -258,28 +246,77 @@ describe("OdspVersionManager", () => {
 		it("propagates (does not swallow) a failure to resolve a version's sequence number", async () => {
 			// @q M-ERR-01
 			// 42.0 has no configured seq -> resolveSequenceNumber throws.
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "40.0": 418 };
+			const versions = [ref("44.0"), ref("43.0"), ref("42.0"), ref("40.0")];
+			const seqs = { "43.0": 460, "40.0": 418 };
 			const { manager } = makeManager(versions, seqs);
 			await assert.rejects(async () => manager.findBaseForSeq(430), /42\.0/);
+		});
+
+		it("does not cache a failed resolution — a later call retries", async () => {
+			// @q M-ERR-02
+			let attempts = 0;
+			const fetcher: IOdspFileVersionFetcher = {
+				listFileVersions: async () => [ref("44.0"), ref("43.0")],
+				resolveSequenceNumber: async () => {
+					attempts++;
+					if (attempts === 1) {
+						throw new Error("transient");
+					}
+					return 448;
+				},
+				getLiveDocumentEpoch: async () => "epoch",
+				getRecoverableVersionEpoch: async () => "epoch",
+			};
+			const manager = new OdspVersionManager(fetcher);
+			await assert.rejects(async () => manager.findBaseForSeq(500), /transient/);
+			// The rejected resolution must not be cached: the next call retries and succeeds.
+			const result = await manager.findBaseForSeq(500);
+			assert.equal(result.kind === "found" && result.base.sequenceNumber, 448);
+			assert.equal(
+				attempts,
+				2,
+				"the failed resolution should be retried, not replayed from cache",
+			);
 		});
 	});
 
 	describe("listVersions", () => {
 		it("returns every version with its resolved sequence number, newest-first", async () => {
 			// @q M-LIST-01
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
+			const versions = [ref("44.0"), ref("43.0"), ref("42.0"), ref("40.0")];
+			const seqs = { "44.0": 480, "43.0": 460, "42.0": 448, "40.0": 418 };
 			const { manager } = makeManager(versions, seqs);
 			const resolved = await manager.listVersions();
 			assert.deepEqual(
 				resolved.map((v) => [v.versionId, v.sequenceNumber]),
 				[
-					["tip", 460],
+					["44.0", 480],
+					["43.0", 460],
 					["42.0", 448],
 					["40.0", 418],
 				],
 			);
+		});
+
+		it("resolves the tip fresh on each call (never cached) while sealed versions come from cache", async () => {
+			// @q M-LIST-02
+			const versions = [ref("44.0"), ref("43.0"), ref("42.0")];
+			const seqs = { "44.0": 480, "43.0": 460, "42.0": 448 };
+			const { manager, fetcher } = makeManager(versions, seqs);
+			await manager.listVersions();
+			await manager.listVersions();
+			const resolved = fetcher.resolvedIds();
+			assert.equal(
+				resolved.filter((id) => id === "44.0").length,
+				2,
+				"the tip is resolved fresh on every call",
+			);
+			assert.equal(
+				resolved.filter((id) => id === "43.0").length,
+				1,
+				"a sealed version is resolved once and cached",
+			);
+			assert.equal(resolved.filter((id) => id === "42.0").length, 1);
 		});
 	});
 
@@ -420,23 +457,6 @@ describe("OdspVersionManager", () => {
 				fetcher.liveEpochCalls(),
 				2,
 				"the live document's epoch must be re-read on every lineage check (never cached)",
-			);
-		});
-
-		it("re-reads a version's epoch after refresh()", async () => {
-			// @q M-VALIDATE-CACHE-02
-			const versions = [ref("tip"), ref("42.0"), ref("40.0")];
-			const seqs = { tip: 460, "42.0": 448, "40.0": 418 };
-			const { manager, fetcher } = makeManager(versions, seqs, { liveEpoch: "epoch" });
-
-			await manager.findBaseForSeq(430); // base 40.0 - fetches its epoch
-			manager.refresh();
-			await manager.findBaseForSeq(430); // refresh cleared the cache - must re-fetch
-
-			assert.deepEqual(
-				fetcher.versionEpochIds(),
-				["40.0", "40.0"],
-				"refresh should clear the cached version epoch so it is fetched again",
 			);
 		});
 	});


### PR DESCRIPTION
## Description

Follow-up to #27689 hardening the internal ODSP file-version manager in `@fluidframework/odsp-driver`.
Everything is internal to the package (not exported, not wired into a call site), so there is no
consumer-facing change and no changeset.

- **Caching.** Resolved sequence numbers and version epochs are memoized via `PromiseCache` (this
  converts the `epochByVersion` map added in #27748), so each is resolved at most once per manager
  instance and a failed resolution is retried rather than cached. The version list itself is re-fetched
  each call, since it changes as new versions are cut. The manager is short-lived — the point-in-time
  document service factory creates one per load, calls `findBaseForSeq` once, then drops it — so the
  caches need no eviction.
- **Fetcher hardening.** `resolveSequenceNumber` handles `application/json` and `application/ms-fluid`
  explicitly and throws a typed `incorrectServerResponse` on anything else (e.g. an HTML error page)
  rather than mis-parsing it; it also rejects a missing or non-integer sequence number instead of
  feeding a wrong value into base selection. Version labels are percent-encoded into the snapshot URL.
- **Docs & tests.** `DEV.md` and the manager/fetcher specs are updated to match.

## Reviewer Guidance

- Internal to `@fluidframework/odsp-driver` (no public API, no changeset).
- The version manager is created per load and used for a single `findBaseForSeq`, so its caches are plain
  memoization with no eviction or single-flight machinery.