### PR TITLE
Fix bug in System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe

### DIFF
--- a/.changeset/recursive-types-multiple.md
+++ b/.changeset/recursive-types-multiple.md
@@ -7,7 +7,7 @@ Fix insertable types when using typesRecursive with multiple allowed types
 
 The allowed types produced by `SchemaFactoryBeta.typesRecursive` (and `SchemaFactoryAlpha.typesRecursive`) are now processed correctly when used in a recursive schema that permits more than one type.
 
-Previously, passing such a their output to a recursive schema (for example `factory.arrayRecursive` or `factory.mapRecursive`) computed the node's insertable content type as `never`.
+Previously, passing their output to a recursive schema (for example `factory.arrayRecursive` or `factory.mapRecursive`) computed the node's insertable content type as `never`.
 This caused valid insertions to fail to compile.
 Recursive schemas built from a `typesRecursive` list with two or more types now accept insertable content for each of the allowed types as expected.
 Recursive schemas that use a single type were unaffected.

--- a/.changeset/recursive-types-multiple.md
+++ b/.changeset/recursive-types-multiple.md
@@ -1,0 +1,13 @@
+---
+"@fluidframework/tree": patch
+"fluid-framework": patch
+"__section": fix
+---
+Fix insertable types when using typesRecursive with multiple allowed types
+
+The allowed types produced by `SchemaFactoryBeta.typesRecursive` (and `SchemaFactoryAlpha.typesRecursive`) are now processed correctly when used in a recursive schema that permits more than one type.
+
+Previously, passing such a their output to a recursive schema (for example `factory.arrayRecursive` or `factory.mapRecursive`) computed the node's insertable content type as `never`.
+This caused valid insertions to fail to compile.
+Recursive schemas built from a `typesRecursive` list with two or more types now accept insertable content for each of the allowed types as expected.
+Recursive schemas that use a single type were unaffected.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1484,7 +1484,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -737,7 +737,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -749,7 +749,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -391,7 +391,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -391,7 +391,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/dds/tree/src/simple-tree/api/typesUnsafe.ts
+++ b/packages/dds/tree/src/simple-tree/api/typesUnsafe.ts
@@ -21,6 +21,7 @@ import type {
 	TreeLeafValue,
 	FlexListToUnion,
 	LazyItem,
+	NumberKeys,
 	AnnotatedAllowedType,
 	AnnotatedAllowedTypes,
 } from "../core/index.js";
@@ -260,7 +261,7 @@ export namespace System_Unsafe {
 					>
 						? InsertableTypedNodeUnsafe<TSchema>
 						: never;
-				}[number];
+				}[NumberKeys<TList>];
 
 	/**
 	 * {@link Unenforced} version of {@link InsertableTypedNode}.

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -1253,39 +1253,29 @@ describe("SchemaFactory Recursive methods", () => {
 				allowUnused<requireAssignableTo<number, Insertable>>();
 			}
 
-			//  more than one type
+			//  more than one type, end to end
 			{
 				const types = SchemaFactoryAlpha.typesRecursive([factory.string, factory.number]);
 				class Recursive extends factory.arrayRecursive("Recursive", types) {}
 
-				type _check = ValidateRecursiveSchema<typeof Recursive>;
+				allowUnused<ValidateRecursiveSchema<typeof Recursive>>();
 
 				const node = new Recursive([]);
 				const node2 = new Recursive([2, "2"]);
 				const popped = node2[0];
 				// Current compiler settings for tests don't include undefined here, but adding it if required by compiler is valid.
-				type _check2 = requireTrue<areSafelyAssignable<typeof popped, string | number>>;
+				allowUnused<requireTrue<areSafelyAssignable<typeof popped, string | number>>>();
 			}
 
-			//  more than one type
+			//  more than one type, minimal
 			{
 				const types = SchemaFactoryAlpha.typesRecursive([factory.string, factory.number]);
 				const schema = factory.arrayRecursive("Recursive", types);
 				type Builder = ConstructorParameters<typeof schema>[0];
 				allowUnused<requireAssignableTo<number[], Builder>>();
-			}
 
-			//  more than one type
-			{
-				const factoryStable = new SchemaFactory("");
-				const types = SchemaFactoryBeta.typesRecursive([
-					factoryStable.string,
-					factoryStable.number,
-				]);
-				const schema = factoryStable.arrayRecursive("Recursive", types);
-				type Builder = ConstructorParameters<typeof schema>[0];
-				allowUnused<requireAssignableTo<number[], Builder>>();
-
+				// The bug which these various more than one type tests detected turned out to be in System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe
+				// See its unit tests for more details.
 				type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
 					typeof types
 				>;

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -1186,7 +1186,31 @@ describe("SchemaFactory Recursive methods", () => {
 			>();
 		});
 
-		it("minimal use: already staged", () => {
+		it("multiple types", () => {
+			const types = SchemaFactoryAlpha.typesRecursive([
+				SchemaFactoryAlpha.number,
+				SchemaFactoryAlpha.string,
+			]);
+
+			allowUnused<requireAssignableTo<typeof types, ImplicitAllowedTypes>>();
+			allowUnused<requireAssignableTo<typeof types, AllowedTypes>>();
+
+			allowUnused<
+				requireTrue<
+					areSafelyAssignable<
+						typeof types,
+						AllowedTypesFull<
+							readonly [
+								AnnotatedAllowedType<typeof SchemaFactoryAlpha.number>,
+								AnnotatedAllowedType<typeof SchemaFactoryAlpha.string>,
+							]
+						>
+					>
+				>
+			>();
+		});
+
+		it("minimal use: already annotated", () => {
 			const ref = {
 				type: () => SchemaFactoryAlpha.number,
 				metadata: {},
@@ -1207,6 +1231,69 @@ describe("SchemaFactory Recursive methods", () => {
 			>();
 		});
 
+		it("unannotated not actually recursive", () => {
+			const factory = new SchemaFactoryAlpha("");
+
+			//  one type
+			{
+				const types = SchemaFactoryAlpha.typesRecursive([factory.number]);
+				class Recursive extends factory.arrayRecursive("Recursive", types) {}
+
+				type _check = ValidateRecursiveSchema<typeof Recursive>;
+
+				const node = new Recursive([]);
+				const node2 = new Recursive([2]);
+				const popped = node2[0];
+				// Current compiler settings for tests don't include undefined here, but adding it if required by compiler is valid.
+				type _check2 = requireTrue<areSafelyAssignable<typeof popped, number>>;
+
+				type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+					typeof types
+				>;
+				allowUnused<requireAssignableTo<number, Insertable>>();
+			}
+
+			//  more than one type
+			{
+				const types = SchemaFactoryAlpha.typesRecursive([factory.string, factory.number]);
+				class Recursive extends factory.arrayRecursive("Recursive", types) {}
+
+				type _check = ValidateRecursiveSchema<typeof Recursive>;
+
+				const node = new Recursive([]);
+				const node2 = new Recursive([2, "2"]);
+				const popped = node2[0];
+				// Current compiler settings for tests don't include undefined here, but adding it if required by compiler is valid.
+				type _check2 = requireTrue<areSafelyAssignable<typeof popped, string | number>>;
+			}
+
+			//  more than one type
+			{
+				const types = SchemaFactoryAlpha.typesRecursive([factory.string, factory.number]);
+				const schema = factory.arrayRecursive("Recursive", types);
+				type Builder = ConstructorParameters<typeof schema>[0];
+				allowUnused<requireAssignableTo<number[], Builder>>();
+			}
+
+			//  more than one type
+			{
+				const factoryStable = new SchemaFactory("");
+				const types = SchemaFactoryBeta.typesRecursive([
+					factoryStable.string,
+					factoryStable.number,
+				]);
+				const schema = factoryStable.arrayRecursive("Recursive", types);
+				type Builder = ConstructorParameters<typeof schema>[0];
+				allowUnused<requireAssignableTo<number[], Builder>>();
+
+				type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+					typeof types
+				>;
+				allowUnused<requireAssignableTo<number, Insertable>>();
+				allowUnused<requireAssignableTo<string, Insertable>>();
+			}
+		});
+
 		it("recursive unannotated", () => {
 			const factory = new SchemaFactoryAlpha("");
 
@@ -1216,11 +1303,32 @@ describe("SchemaFactory Recursive methods", () => {
 				type _check = ValidateRecursiveSchema<typeof Recursive>;
 			}
 
+			// No "types" wrapper, more than one type
+			{
+				class Recursive extends factory.arrayRecursive("Recursive", [
+					factory.string,
+					() => Recursive,
+				]) {}
+				type _check = ValidateRecursiveSchema<typeof Recursive>;
+			}
+
 			//  "types" wrapper
 			{
 				class Recursive extends factory.arrayRecursive(
 					"Recursive",
 					SchemaFactoryAlpha.typesRecursive([() => Recursive]),
+				) {}
+
+				type _check = ValidateRecursiveSchema<typeof Recursive>;
+
+				const node = new Recursive([]);
+			}
+
+			//  "types" wrapper, more than one type
+			{
+				class Recursive extends factory.arrayRecursive(
+					"Recursive",
+					SchemaFactoryAlpha.typesRecursive([factory.string, () => Recursive]),
 				) {}
 
 				type _check = ValidateRecursiveSchema<typeof Recursive>;
@@ -1242,10 +1350,41 @@ describe("SchemaFactory Recursive methods", () => {
 				type _check = ValidateRecursiveSchema<typeof Recursive>;
 			}
 
+			// Valid
 			{
 				class Recursive extends factory.arrayRecursive(
 					"Recursive",
 					SchemaFactoryAlpha.typesRecursive([{ type: () => Recursive, metadata: {} }]),
+				) {}
+
+				type _check = ValidateRecursiveSchema<typeof Recursive>;
+
+				const node = new Recursive([]);
+			}
+
+			// Valid with second type
+			{
+				class Recursive extends factory.arrayRecursive(
+					"Recursive",
+					SchemaFactoryAlpha.typesRecursive([
+						factory.string,
+						{ type: () => Recursive, metadata: {} },
+					]),
+				) {}
+
+				type _check = ValidateRecursiveSchema<typeof Recursive>;
+
+				const node = new Recursive([]);
+			}
+
+			// Valid with second annotated type
+			{
+				class Recursive extends factory.arrayRecursive(
+					"Recursive",
+					SchemaFactoryAlpha.typesRecursive([
+						{ type: () => factory.string, metadata: {} },
+						{ type: () => Recursive, metadata: {} },
+					]),
 				) {}
 
 				type _check = ValidateRecursiveSchema<typeof Recursive>;

--- a/packages/dds/tree/src/test/simple-tree/api/typesUnsafe.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/typesUnsafe.spec.ts
@@ -9,10 +9,14 @@ import type {
 	UnannotateAllowedTypeUnsafe,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../simple-tree/api/typesUnsafe.js";
-import { allowUnused } from "../../../simple-tree/index.js";
+import { allowUnused, SchemaFactoryBeta } from "../../../simple-tree/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { numberSchema } from "../../../simple-tree/leafNodeSchema.js";
-import type { areSafelyAssignable, requireTrue } from "../../../util/index.js";
+import type {
+	areSafelyAssignable,
+	requireAssignableTo,
+	requireTrue,
+} from "../../../util/index.js";
 
 type MapInlined = System_Unsafe.ReadonlyMapInlined<string, typeof numberSchema>;
 
@@ -21,8 +25,7 @@ type _check = requireTrue<areSafelyAssignable<MapInlined, ReadonlyMap<string, nu
 // UnannotateAllowedTypeUnsafe
 {
 	type num = UnannotateAllowedTypeUnsafe<typeof numberSchema>;
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	allowUnused<requireTrue<areSafelyAssignable<num, typeof numberSchema>>>;
+	allowUnused<requireTrue<areSafelyAssignable<num, typeof numberSchema>>>();
 
 	const annotatedAllowedType = {
 		type: numberSchema,
@@ -30,6 +33,50 @@ type _check = requireTrue<areSafelyAssignable<MapInlined, ReadonlyMap<string, nu
 	} satisfies AnnotatedAllowedTypeUnsafe;
 
 	type annotated = UnannotateAllowedTypeUnsafe<typeof annotatedAllowedType>;
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	allowUnused<requireTrue<areSafelyAssignable<annotated, typeof numberSchema>>>;
+	allowUnused<requireTrue<areSafelyAssignable<annotated, typeof numberSchema>>>();
+}
+
+// InsertableTreeNodeFromImplicitAllowedTypesUnsafe
+{
+	// One type
+	{
+		const types = [SchemaFactoryBeta.number] as const;
+		type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+			typeof types
+		>;
+		allowUnused<requireTrue<areSafelyAssignable<number, Insertable>>>();
+	}
+
+	// Multiple types
+	{
+		const types = [SchemaFactoryBeta.string, SchemaFactoryBeta.number] as const;
+		type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+			typeof types
+		>;
+		allowUnused<requireTrue<areSafelyAssignable<number | string, Insertable>>>();
+	}
+
+	// One annotated
+	{
+		const types = SchemaFactoryBeta.typesRecursive([SchemaFactoryBeta.number]);
+		type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+			typeof types
+		>;
+		allowUnused<requireTrue<areSafelyAssignable<number, Insertable>>>();
+	}
+
+	// Multiple annotated
+	{
+		const types = SchemaFactoryBeta.typesRecursive([
+			SchemaFactoryBeta.string,
+			SchemaFactoryBeta.number,
+		]);
+
+		type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+			typeof types
+		>;
+		allowUnused<requireAssignableTo<number, Insertable>>();
+		allowUnused<requireAssignableTo<string, Insertable>>();
+		allowUnused<requireTrue<areSafelyAssignable<number | string, Insertable>>>();
+	}
 }

--- a/packages/dds/tree/src/test/simple-tree/api/typesUnsafe.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/typesUnsafe.spec.ts
@@ -56,27 +56,36 @@ type _check = requireTrue<areSafelyAssignable<MapInlined, ReadonlyMap<string, nu
 		allowUnused<requireTrue<areSafelyAssignable<number | string, Insertable>>>();
 	}
 
-	// One annotated
+	// AllowedTypesFullFromMixedUnsafe:
+	// SchemaFactoryBeta.typesRecursive uses AllowedTypesFullFromMixedUnsafe which produces an intersection of
+	// UnannotateAllowedTypesListUnsafe<...> & AnnotatedAllowedTypes<...>
+	// This intersection can cause issues, and has caused issues in the past.
+	// These tests are regression tests for one such issue, where the intersection caused
+	// InsertableTreeNodeFromImplicitAllowedTypesUnsafe to produce `never` instead of the desired type union
+	// when multiple types were provided.
 	{
-		const types = SchemaFactoryBeta.typesRecursive([SchemaFactoryBeta.number]);
-		type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
-			typeof types
-		>;
-		allowUnused<requireTrue<areSafelyAssignable<number, Insertable>>>();
-	}
+		// One type
+		{
+			const types = SchemaFactoryBeta.typesRecursive([SchemaFactoryBeta.number]);
+			type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+				typeof types
+			>;
+			allowUnused<requireTrue<areSafelyAssignable<number, Insertable>>>();
+		}
 
-	// Multiple annotated
-	{
-		const types = SchemaFactoryBeta.typesRecursive([
-			SchemaFactoryBeta.string,
-			SchemaFactoryBeta.number,
-		]);
+		// Multiple types
+		{
+			const types = SchemaFactoryBeta.typesRecursive([
+				SchemaFactoryBeta.string,
+				SchemaFactoryBeta.number,
+			]);
 
-		type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
-			typeof types
-		>;
-		allowUnused<requireAssignableTo<number, Insertable>>();
-		allowUnused<requireAssignableTo<string, Insertable>>();
-		allowUnused<requireTrue<areSafelyAssignable<number | string, Insertable>>>();
+			type Insertable = System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
+				typeof types
+			>;
+			allowUnused<requireAssignableTo<number, Insertable>>();
+			allowUnused<requireAssignableTo<string, Insertable>>();
+			allowUnused<requireTrue<areSafelyAssignable<number | string, Insertable>>>();
+		}
 	}
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1935,7 +1935,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -1182,7 +1182,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -1548,7 +1548,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -825,7 +825,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -791,7 +791,7 @@ export namespace System_Unsafe {
     // @system
     export type InsertableTreeNodeFromAllowedTypesUnsafe<TList extends AllowedTypesUnsafe> = IsUnion<TList> extends true ? never : {
         readonly [Property in keyof TList]: TList[Property] extends LazyItem<infer TSchema extends TreeNodeSchemaUnsafe> ? InsertableTypedNodeUnsafe<TSchema> : never;
-    }[number];
+    }[NumberKeys<TList>];
     // @system
     export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends ImplicitAllowedTypesUnsafe> = [TSchema] extends [TreeNodeSchemaUnsafe] ? InsertableTypedNodeUnsafe<TSchema> : [TSchema] extends [AllowedTypesUnsafe] ? InsertableTreeNodeFromAllowedTypesUnsafe<TSchema> : never;
     // @system


### PR DESCRIPTION
## Description

System_Unsafe.InsertableTreeNodeFromImplicitAllowedTypesUnsafe now handles multiple types correctly when dealing with output from SchemaFactoryBeta.typesRecursive.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
