### PR TITLE
fix(property-changeset): don't throw on a duplicate identical insert into an indexed collection

### DIFF
--- a/.changeset/fix-duplicate-insert-indexed-collection.md
+++ b/.changeset/fix-duplicate-insert-indexed-collection.md
@@ -1,0 +1,10 @@
+---
+"@fluid-experimental/property-changeset": patch
+"__section": fix
+---
+
+Crash-looping from duplicate inserts in indexed collection ChangeSets has been fixed
+
+Previously, merging a ChangeSet into an indexed collection (a set- or map-typed property) would throw `CS-003: Internal error: Added an already existing entry` whenever the incoming insert's key already had an insert recorded in the base ChangeSet — even when the two inserts were identical, such as from a duplicated or replayed operation. Because this merge runs on the normal op-processing path, a duplicate op could put a document's summarizer into a crash-loop.
+
+Now, an insert that exactly matches an already-recorded insert for the same key is treated as a safe no-op. A mismatched value for the same key is still treated as a genuine conflict and continues to throw.

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/indexedCollection.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/indexedCollection.ts
@@ -315,6 +315,16 @@ export namespace ChangeSetIndexedCollectionFunctions {
 					) {
 						baseInserted[typeid] = baseInserted[typeid] || {};
 						baseInserted[typeid][key] = cloneDeep(insertedEntries[key]);
+					} else if (isPrimitiveTypeid && isEqual(baseInserted[key], insertedEntries[key])) {
+						// The same insert is being merged into this ChangeSet a second time (e.g. a
+						// duplicated/replayed op). Re-applying identical insert data is a safe no-op;
+						// only a genuine value mismatch below is a real conflict.
+					} else if (
+						!isPrimitiveTypeid &&
+						baseInserted[typeid] &&
+						isEqual(baseInserted[typeid][key], insertedEntries[key])
+					) {
+						// Same as above, for typed/polymorphic collections.
 					} else {
 						throw new Error(MSG.ALREADY_EXISTING_ENTRY + key);
 					}

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/indexedCollection.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/indexedCollection.spec.ts
@@ -117,4 +117,52 @@ describe("Indexed Collection Operations", function () {
 
 		expect(modification).to.deep.equal(originalCS);
 	});
+
+	it("applying an identical duplicate insert into an indexed collection should be a no-op (CS-003)", () => {
+		// Base ChangeSet that already has an insert for key "1"
+		const base = {
+			insert: {
+				"test:test-1.0.0": {
+					test: {
+						"map<Bool>": { entries: { insert: { "1": true } } },
+					},
+				},
+			},
+		};
+
+		// The exact same insert being merged in a second time (e.g. from a duplicated/replayed op)
+		const duplicateInsert = cloneDeep(base);
+
+		const expected = cloneDeep(base);
+
+		expect(() => new ChangeSet(base).applyChangeSet(duplicateInsert)).to.not.throw();
+		expect(base).to.deep.equal(expected);
+	});
+
+	it("applying a conflicting insert for an already-existing key should still throw", () => {
+		const base = {
+			insert: {
+				"test:test-1.0.0": {
+					test: {
+						"map<Bool>": { entries: { insert: { "1": true } } },
+					},
+				},
+			},
+		};
+
+		// Same key, different value: a genuine conflict, not a duplicate/replay
+		const conflictingInsert = {
+			insert: {
+				"test:test-1.0.0": {
+					test: {
+						"map<Bool>": { entries: { insert: { "1": false } } },
+					},
+				},
+			},
+		};
+
+		expect(() => new ChangeSet(base).applyChangeSet(conflictingInsert)).to.throw(
+			/Added an already existing entry/,
+		);
+	});
 });


### PR DESCRIPTION
## Description

`ChangeSetIndexedCollectionFunctions`'s merge logic throws `CS-003: Internal error: Added an already existing entry: <key>` whenever an incoming insert's key already has an insert recorded in the base ChangeSet — even when the two inserts are identical (e.g. from a duplicated or replayed op). Since this runs on the normal op-processing path (`SharedPropertyTree._applyRemoteChangeSet` → `processMessage`), a duplicate op can put a document's summarizer into a crash-loop.

This PR treats an insert that exactly matches the already-recorded insert for the same key as a safe no-op, for both primitive and typed/polymorphic collections. A mismatched value for the same key is still treated as a genuine conflict and continues to throw.

To reproduce: apply a ChangeSet insert for a key to a base ChangeSet that already has an identical insert for that same key (see the new test cases in `indexedCollection.spec.ts` for a minimal repro). Before this change that throws; after, it's a no-op.

## Reviewer Guidance

I haven't been able to run this package's own test suite locally yet (environment setup issue unrelated to this change — Azure DevOps Artifacts feed auth). The two new test cases closely follow this file's existing patterns, and the equivalent fix (applied to the compiled/patched form of this exact function) has been running against a real local Fluid server with 113 passing tests in a downstream consumer — but I'd like CI/a reviewer to confirm this package's own suite passes before merging. Opening as a draft until I can confirm locally.
