### PR TITLE
feat: add imperative payload sharing for local Fluid handles

### DIFF
--- a/.changeset/shaky-dragons-repair.md
+++ b/.changeset/shaky-dragons-repair.md
@@ -1,0 +1,19 @@
+---
+"@fluidframework/core-interfaces": minor
+"@fluidframework/container-runtime": minor
+"__section": feature
+---
+Start sharing local handle payloads before attachment
+
+Locally created Fluid handles can now expose an optional `sharePayload()` method that starts
+sharing their payload without attaching the handle to the Fluid object graph. Blob handles
+implement this method, allowing applications to begin uploading a blob before serializing its
+handle into a DDS.
+
+```typescript
+const handle = await runtime.uploadBlob(bytes);
+
+if (isLocalFluidHandle(handle) && handle.sharePayload !== undefined) {
+	handle.sharePayload();
+}
+```

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -375,6 +375,7 @@ export interface ILayerIncompatibilityError extends IErrorBase {
 export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
     readonly events: Listenable<IFluidHandleEvents & ILocalFluidHandleEvents>;
     readonly payloadShareError: unknown;
+    sharePayload?(): void;
 }
 
 // @beta @legacy

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.beta.api.md
@@ -357,6 +357,7 @@ export interface ILayerIncompatibilityError extends IErrorBase {
 export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
     readonly events: Listenable<IFluidHandleEvents & ILocalFluidHandleEvents>;
     readonly payloadShareError: unknown;
+    sharePayload?(): void;
 }
 
 // @beta @legacy

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -164,6 +164,23 @@ export interface ILocalFluidHandleEvents extends IFluidHandleEvents {
  */
 export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
 	/**
+	 * Starts sharing the handle's payload without attaching the handle to the Fluid object graph.
+	 *
+	 * @remarks
+	 * This method starts the same asynchronous payload-sharing process that normally begins when the
+	 * handle is attached. Calling it multiple times has no additional effect, and calling it for an
+	 * already-shared payload is a no-op.
+	 *
+	 * This method does not wait for the payload to be uploaded or shared. Progress and failures can be
+	 * observed through {@link ILocalFluidHandle.events}.
+	 *
+	 * This method is optional for compatibility with older implementations of
+	 * {@link ILocalFluidHandle}.
+	 *
+	 * The behavior of this method while the container is in staging mode is not currently defined.
+	 */
+	sharePayload?(): void;
+	/**
 	 * The error encountered by the handle while sharing the payload, if one has occurred.  Undefined if no error has occurred.
 	 */
 	readonly payloadShareError: unknown;

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -173,11 +173,6 @@ export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
 	 *
 	 * This method does not wait for the payload to be uploaded or shared. Progress and failures can be
 	 * observed through {@link ILocalFluidHandle.events}.
-	 *
-	 * This method is optional for compatibility with older implementations of
-	 * {@link ILocalFluidHandle}.
-	 *
-	 * The behavior of this method while the container is in staging mode is not currently defined.
 	 */
 	sharePayload?(): void;
 	/**

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -102,6 +102,7 @@ export class BlobHandle
 		public get: () => Promise<ArrayBufferLike>,
 		public readonly payloadPending: boolean,
 		private readonly sharePayloadCallback?: () => void,
+		private readonly attachGraphCallback?: () => void,
 	) {
 		super();
 		this._payloadState = payloadPending ? "pending" : "shared";
@@ -119,7 +120,7 @@ export class BlobHandle
 	};
 
 	public sharePayload(): void {
-		if (this.payloadSharingStarted) {
+		if (this.payloadState === "shared" || this.payloadSharingStarted) {
 			return;
 		}
 		this.payloadSharingStarted = true;
@@ -129,6 +130,7 @@ export class BlobHandle
 	public attachGraph(): void {
 		if (!this.attached) {
 			this.attached = true;
+			this.attachGraphCallback?.();
 			this.sharePayload();
 		}
 	}
@@ -262,11 +264,10 @@ export class BlobManager {
 	 */
 	private readonly localBlobCache: Map<string, LocalBlobRecord> = new Map();
 	/**
-	 * Blobs whose payload sharing has started but that have not finished blob-attaching are the set we need to
-	 * provide from getPendingState(). This stores their local IDs, and then we can look them up against the
-	 * localBlobCache.
+	 * Blobs with an attached handle that have not finished blob-attaching are the set we need to provide from
+	 * getPendingState(). This stores their local IDs, and then we can look them up against the localBlobCache.
 	 */
-	private readonly pendingBlobsWithSharingStarted: Set<string> = new Set();
+	private readonly pendingBlobsWithAttachedHandles: Set<string> = new Set();
 	/**
 	 * Local IDs for any pending blobs we loaded with and have not yet started the upload/attach flow for.
 	 */
@@ -352,10 +353,10 @@ export class BlobManager {
 					blob: stringToBuffer(serializableBlobRecord.blob, "base64"),
 				};
 				this.localBlobCache.set(localId, localBlobRecord);
-				// Since we received these blobs from pending state, their sharing flow had already started.
-				// Add them back here in case we need to round-trip them again due to another
-				// getPendingBlobs() call.
-				this.pendingBlobsWithSharingStarted.add(localId);
+				// Since we received these blobs from pending state, we'll assume they were only added to the
+				// pending state at generation time because their handles were attached. We add them back here
+				// in case we need to round-trip them back out again due to another getPendingBlobs() call.
+				this.pendingBlobsWithAttachedHandles.add(localId);
 				this.pendingOnlyLocalIds.add(localId);
 			}
 		}
@@ -525,13 +526,18 @@ export class BlobManager {
 			async () => blob,
 			true, // payloadPending
 			() => {
-				this.pendingBlobsWithSharingStarted.add(localId);
 				const uploadAndAttachP = this.uploadAndAttach(localId, signal);
 				uploadAndAttachP.then(blobHandle.notifyShared).catch((error) => {
 					// TODO: notifyShared won't fail directly, but it emits an event to the customer.
 					// Consider what to do if the customer's code throws. reportError is nice.
 				});
 				uploadAndAttachP.catch(blobHandle.notifyFailed);
+			},
+			() => {
+				const localBlobRecord = this.localBlobCache.get(localId);
+				if (localBlobRecord !== undefined && localBlobRecord.state !== "attached") {
+					this.pendingBlobsWithAttachedHandles.add(localId);
+				}
 			},
 		);
 
@@ -551,7 +557,7 @@ export class BlobManager {
 	): Promise<void> => {
 		if (signal?.aborted === true) {
 			this.localBlobCache.delete(localId);
-			this.pendingBlobsWithSharingStarted.delete(localId);
+			this.pendingBlobsWithAttachedHandles.delete(localId);
 			throw createAbortError();
 		}
 		const localBlobRecordInitial = this.localBlobCache.get(localId);
@@ -594,7 +600,7 @@ export class BlobManager {
 					removeListeners();
 					uploadHasBecomeIrrelevant = true;
 					this.localBlobCache.delete(localId);
-					this.pendingBlobsWithSharingStarted.delete(localId);
+					this.pendingBlobsWithAttachedHandles.delete(localId);
 					reject(createAbortError());
 				};
 				const onProcessedBlobAttach = (_localId: string, _storageId: string): void => {
@@ -631,7 +637,7 @@ export class BlobManager {
 							removeListeners();
 							// If the storage call errors, we can't recover. Reject to throw back to the caller.
 							this.localBlobCache.delete(localId);
-							this.pendingBlobsWithSharingStarted.delete(localId);
+							this.pendingBlobsWithAttachedHandles.delete(localId);
 							// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
 							reject(error);
 						}
@@ -700,7 +706,7 @@ export class BlobManager {
 					const onSignalAbort = (): void => {
 						removeListeners();
 						this.localBlobCache.delete(localId);
-						this.pendingBlobsWithSharingStarted.delete(localId);
+						this.pendingBlobsWithAttachedHandles.delete(localId);
 						reject(createAbortError());
 					};
 					const removeListeners = (): void => {
@@ -740,9 +746,10 @@ export class BlobManager {
 		const { localId, blobId: storageId } = metadata;
 		// Any blob that we're actively trying to advance to attached state must be in attaching state.
 		// Decline to resubmit for anything else.
-		// For example, we might be asked to resubmit stashed messages for blobs whose sharing flow was not
-		// captured in pending state. These won't have a localBlobCache entry, so we shouldn't try to attach
-		// them since they won't be accessible to the customer and would just be considered garbage immediately.
+		// For example, we might be asked to resubmit stashed messages for blobs that never had their handle
+		// attached - these won't have a localBlobCache entry because we filter them out when generating
+		// pending state. We shouldn't try to attach them since they won't be accessible to the customer
+		// and would just be considered garbage immediately.
 		// TODO: Is it possible that we'd be asked to resubmit for a pending blob before we call sharePendingBlobs?
 		const localBlobRecord = this.localBlobCache.get(localId);
 		if (localBlobRecord?.state === "attaching") {
@@ -772,10 +779,10 @@ export class BlobManager {
 			// callsites that update localBlobCache entries must take proper caution to handle the case
 			// that a blob attach message is processed concurrently.
 			this.localBlobCache.set(localId, attachedBlobRecord);
-			// Note there may or may not be an entry in pendingBlobsWithSharingStarted for this localId,
+			// Note there may or may not be an entry in pendingBlobsWithAttachedHandles for this localId,
 			// in particular for the non-payloadPending case since we should be reaching this point
 			// before even returning a handle to the caller.
-			this.pendingBlobsWithSharingStarted.delete(localId);
+			this.pendingBlobsWithAttachedHandles.delete(localId);
 			this.pendingOnlyLocalIds.delete(localId);
 		}
 		this.redirectTable.set(localId, storageId);
@@ -945,7 +952,7 @@ export class BlobManager {
 	 */
 	public getPendingBlobs(): IPendingBlobs | undefined {
 		const pendingBlobs: IPendingBlobs = {};
-		for (const localId of this.pendingBlobsWithSharingStarted) {
+		for (const localId of this.pendingBlobsWithAttachedHandles) {
 			const localBlobRecord = this.localBlobCache.get(localId);
 			assert(localBlobRecord !== undefined, 0xc83 /* Pending blob must be in local cache */);
 			assert(

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -66,6 +66,7 @@ export class BlobHandle
 		IFluidHandleInternalPayloadPending<ArrayBufferLike>
 {
 	private attached: boolean = false;
+	private payloadSharingStarted: boolean = false;
 
 	public get isAttached(): boolean {
 		return this.routeContext.isAttached && this.attached;
@@ -100,7 +101,7 @@ export class BlobHandle
 		// TODO: just take the blob rather than a get function?
 		public get: () => Promise<ArrayBufferLike>,
 		public readonly payloadPending: boolean,
-		private readonly onAttachGraph?: () => void,
+		private readonly sharePayloadCallback?: () => void,
 	) {
 		super();
 		this._payloadState = payloadPending ? "pending" : "shared";
@@ -117,10 +118,18 @@ export class BlobHandle
 		this._events?.emit("payloadShareFailed", error);
 	};
 
+	public sharePayload(): void {
+		if (this.payloadSharingStarted) {
+			return;
+		}
+		this.payloadSharingStarted = true;
+		this.sharePayloadCallback?.();
+	}
+
 	public attachGraph(): void {
 		if (!this.attached) {
 			this.attached = true;
-			this.onAttachGraph?.();
+			this.sharePayload();
 		}
 	}
 }
@@ -253,10 +262,11 @@ export class BlobManager {
 	 */
 	private readonly localBlobCache: Map<string, LocalBlobRecord> = new Map();
 	/**
-	 * Blobs with an attached handle that have not finished blob-attaching are the set we need to provide from
-	 * getPendingState().  This stores their local IDs, and then we can look them up against the localBlobCache.
+	 * Blobs whose payload sharing has started but that have not finished blob-attaching are the set we need to
+	 * provide from getPendingState(). This stores their local IDs, and then we can look them up against the
+	 * localBlobCache.
 	 */
-	private readonly pendingBlobsWithAttachedHandles: Set<string> = new Set();
+	private readonly pendingBlobsWithSharingStarted: Set<string> = new Set();
 	/**
 	 * Local IDs for any pending blobs we loaded with and have not yet started the upload/attach flow for.
 	 */
@@ -342,10 +352,10 @@ export class BlobManager {
 					blob: stringToBuffer(serializableBlobRecord.blob, "base64"),
 				};
 				this.localBlobCache.set(localId, localBlobRecord);
-				// Since we received these blobs from pending state, we'll assume they were only added to the
-				// pending state at generation time because their handles were attached. We add them back here
-				// in case we need to round-trip them back out again due to another getPendingBlobs() call.
-				this.pendingBlobsWithAttachedHandles.add(localId);
+				// Since we received these blobs from pending state, their sharing flow had already started.
+				// Add them back here in case we need to round-trip them again due to another
+				// getPendingBlobs() call.
+				this.pendingBlobsWithSharingStarted.add(localId);
 				this.pendingOnlyLocalIds.add(localId);
 			}
 		}
@@ -515,7 +525,7 @@ export class BlobManager {
 			async () => blob,
 			true, // payloadPending
 			() => {
-				this.pendingBlobsWithAttachedHandles.add(localId);
+				this.pendingBlobsWithSharingStarted.add(localId);
 				const uploadAndAttachP = this.uploadAndAttach(localId, signal);
 				uploadAndAttachP.then(blobHandle.notifyShared).catch((error) => {
 					// TODO: notifyShared won't fail directly, but it emits an event to the customer.
@@ -541,7 +551,7 @@ export class BlobManager {
 	): Promise<void> => {
 		if (signal?.aborted === true) {
 			this.localBlobCache.delete(localId);
-			this.pendingBlobsWithAttachedHandles.delete(localId);
+			this.pendingBlobsWithSharingStarted.delete(localId);
 			throw createAbortError();
 		}
 		const localBlobRecordInitial = this.localBlobCache.get(localId);
@@ -584,7 +594,7 @@ export class BlobManager {
 					removeListeners();
 					uploadHasBecomeIrrelevant = true;
 					this.localBlobCache.delete(localId);
-					this.pendingBlobsWithAttachedHandles.delete(localId);
+					this.pendingBlobsWithSharingStarted.delete(localId);
 					reject(createAbortError());
 				};
 				const onProcessedBlobAttach = (_localId: string, _storageId: string): void => {
@@ -621,7 +631,7 @@ export class BlobManager {
 							removeListeners();
 							// If the storage call errors, we can't recover. Reject to throw back to the caller.
 							this.localBlobCache.delete(localId);
-							this.pendingBlobsWithAttachedHandles.delete(localId);
+							this.pendingBlobsWithSharingStarted.delete(localId);
 							// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
 							reject(error);
 						}
@@ -690,7 +700,7 @@ export class BlobManager {
 					const onSignalAbort = (): void => {
 						removeListeners();
 						this.localBlobCache.delete(localId);
-						this.pendingBlobsWithAttachedHandles.delete(localId);
+						this.pendingBlobsWithSharingStarted.delete(localId);
 						reject(createAbortError());
 					};
 					const removeListeners = (): void => {
@@ -730,10 +740,9 @@ export class BlobManager {
 		const { localId, blobId: storageId } = metadata;
 		// Any blob that we're actively trying to advance to attached state must be in attaching state.
 		// Decline to resubmit for anything else.
-		// For example, we might be asked to resubmit stashed messages for blobs that never had their handle
-		// attached - these won't have a localBlobCache entry because we filter them out when generating
-		// pending state. We shouldn't try to attach them since they won't be accessible to the customer
-		// and would just be considered garbage immediately.
+		// For example, we might be asked to resubmit stashed messages for blobs whose sharing flow was not
+		// captured in pending state. These won't have a localBlobCache entry, so we shouldn't try to attach
+		// them since they won't be accessible to the customer and would just be considered garbage immediately.
 		// TODO: Is it possible that we'd be asked to resubmit for a pending blob before we call sharePendingBlobs?
 		const localBlobRecord = this.localBlobCache.get(localId);
 		if (localBlobRecord?.state === "attaching") {
@@ -763,10 +772,10 @@ export class BlobManager {
 			// callsites that update localBlobCache entries must take proper caution to handle the case
 			// that a blob attach message is processed concurrently.
 			this.localBlobCache.set(localId, attachedBlobRecord);
-			// Note there may or may not be an entry in pendingBlobsWithAttachedHandles for this localId,
+			// Note there may or may not be an entry in pendingBlobsWithSharingStarted for this localId,
 			// in particular for the non-payloadPending case since we should be reaching this point
 			// before even returning a handle to the caller.
-			this.pendingBlobsWithAttachedHandles.delete(localId);
+			this.pendingBlobsWithSharingStarted.delete(localId);
 			this.pendingOnlyLocalIds.delete(localId);
 		}
 		this.redirectTable.set(localId, storageId);
@@ -936,7 +945,7 @@ export class BlobManager {
 	 */
 	public getPendingBlobs(): IPendingBlobs | undefined {
 		const pendingBlobs: IPendingBlobs = {};
-		for (const localId of this.pendingBlobsWithAttachedHandles) {
+		for (const localId of this.pendingBlobsWithSharingStarted) {
 			const localBlobRecord = this.localBlobCache.get(localId);
 			assert(localBlobRecord !== undefined, 0xc83 /* Pending blob must be in local cache */);
 			assert(

--- a/packages/runtime/container-runtime/src/test/blobs/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobs/blobManager.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
+import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { ISequencedMessageEnvelope } from "@fluidframework/runtime-definitions/internal";
 import {
 	isFluidHandlePayloadPending,
@@ -13,6 +14,8 @@ import {
 } from "@fluidframework/runtime-utils/internal";
 import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 
+// eslint-disable-next-line import-x/no-internal-modules
+import { BlobHandle } from "../../blobManager/blobManager.js";
 import {
 	getGCNodePathFromLocalId,
 	type IBlobManagerLoadInfo,
@@ -31,6 +34,37 @@ import {
 	waitHandlePayloadShared,
 	type UnprocessedMessage,
 } from "./blobTestUtils.js";
+
+describe("BlobHandle", () => {
+	it("Does not invoke the sharing callback for an already-shared payload", () => {
+		let sharePayloadCallbackCalls = 0;
+		const routeContext: IFluidHandleContext = {
+			get IFluidHandleContext() {
+				return routeContext;
+			},
+			absolutePath: "",
+			isAttached: true,
+			attachGraph: () => undefined,
+			resolveHandle: async () => {
+				throw new Error("Not implemented");
+			},
+		};
+		const handle = new BlobHandle(
+			"/blob",
+			routeContext,
+			async () => textToBlob("hello"),
+			false,
+			() => {
+				sharePayloadCallbackCalls++;
+			},
+		);
+
+		handle.sharePayload();
+
+		assert.strictEqual(handle.payloadState, "shared");
+		assert.strictEqual(sharePayloadCallbackCalls, 0);
+	});
+});
 
 for (const createBlobPayloadPending of [false, true]) {
 	describe(`BlobManager (pending payloads: ${createBlobPayloadPending})`, () => {
@@ -268,6 +302,14 @@ for (const createBlobPayloadPending of [false, true]) {
 					assert(handle.payloadShareError instanceof Error);
 					assert.strictEqual(handle.payloadShareError.message, "fake driver error");
 					assert.strictEqual(toFluidHandleInternal(handle).isAttached, false);
+
+					attachHandle(handle);
+					assert.strictEqual(toFluidHandleInternal(handle).isAttached, true);
+					assert.strictEqual(
+						blobManager.getPendingBlobs(),
+						undefined,
+						"A failed payload should not be added to pending state when later attached",
+					);
 				});
 
 				it("Treats sharing an already-shared payload as a no-op", async function () {

--- a/packages/runtime/container-runtime/src/test/blobs/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobs/blobManager.spec.ts
@@ -186,6 +186,8 @@ for (const createBlobPayloadPending of [false, true]) {
 					const { mockBlobStorage, mockOrderingService, blobManager } = createTestMaterial({
 						createBlobPayloadPending,
 					});
+					// Hold each service at its boundary so the test can inspect upload, BlobAttach
+					// submission, and sequencing independently.
 					mockBlobStorage.pause();
 					mockOrderingService.pause();
 
@@ -197,6 +199,7 @@ for (const createBlobPayloadPending of [false, true]) {
 					assert.strictEqual(internalHandle.isAttached, false);
 					assert.strictEqual(mockBlobStorage.blobsReceived, 0);
 
+					// Repeated calls before the first upload completes must still start only one flow.
 					handle.sharePayload();
 					handle.sharePayload();
 
@@ -212,6 +215,7 @@ for (const createBlobPayloadPending of [false, true]) {
 						"Sharing the payload should not attach the handle",
 					);
 
+					// Complete the upload while leaving BlobAttach queued but unsequenced.
 					await mockBlobStorage.waitCreateOne();
 					await mockOrderingService.waitMessageAvailable();
 					assert.strictEqual(
@@ -220,6 +224,7 @@ for (const createBlobPayloadPending of [false, true]) {
 						"Expected one BlobAttach message",
 					);
 
+					// Graph attachment after sharing starts must not restart the payload-sharing flow.
 					attachHandle(handle);
 					handle.sharePayload();
 					assert.strictEqual(internalHandle.isAttached, true);
@@ -229,6 +234,7 @@ for (const createBlobPayloadPending of [false, true]) {
 						"Attaching the handle after sharing starts should not start another upload",
 					);
 
+					// Processing BlobAttach completes payload sharing.
 					mockOrderingService.sequenceOne();
 					await waitHandlePayloadShared(handle);
 					assert.strictEqual(handle.payloadShareError, undefined);
@@ -243,6 +249,7 @@ for (const createBlobPayloadPending of [false, true]) {
 					const { mockBlobStorage, blobManager } = createTestMaterial({
 						createBlobPayloadPending,
 					});
+					// Hold the upload so the test can complete it with a controlled failure.
 					mockBlobStorage.pause();
 
 					const handle = await blobManager.createBlob(textToBlob("hello"));
@@ -251,6 +258,7 @@ for (const createBlobPayloadPending of [false, true]) {
 					const payloadSharedP = waitHandlePayloadShared(handle);
 
 					handle.sharePayload();
+					// Fail before a BlobAttach message can be submitted.
 					await mockBlobStorage.waitCreateOne({
 						error: new LoggingError("fake driver error"),
 					});
@@ -270,10 +278,13 @@ for (const createBlobPayloadPending of [false, true]) {
 					const { mockBlobStorage, mockOrderingService, blobManager } = createTestMaterial({
 						createBlobPayloadPending,
 					});
+					// Legacy creation waits for upload and BlobAttach processing, so this handle's
+					// payload is already shared when createBlob returns.
 					const handle = await blobManager.createBlob(textToBlob("hello"));
 					assert(isLocalFluidHandle(handle), "Expected a local blob handle");
 					assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
 
+					// Calling sharePayload again must not repeat either side effect.
 					const blobsReceived = mockBlobStorage.blobsReceived;
 					const messagesReceived = mockOrderingService.messagesReceived;
 					handle.sharePayload();

--- a/packages/runtime/container-runtime/src/test/blobs/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobs/blobManager.spec.ts
@@ -9,6 +9,7 @@ import type { ISequencedMessageEnvelope } from "@fluidframework/runtime-definiti
 import {
 	isFluidHandlePayloadPending,
 	isLocalFluidHandle,
+	toFluidHandleInternal,
 } from "@fluidframework/runtime-utils/internal";
 import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 
@@ -175,6 +176,111 @@ for (const createBlobPayloadPending of [false, true]) {
 					assert(blobManager.hasBlob(localId));
 					const blobFromManager = await blobManager.getBlob(localId, createBlobPayloadPending);
 					assert.strictEqual(blobToText(blobFromManager), "hello", "Blob content mismatch");
+				});
+
+				it("Can start sharing a payload before attaching its handle", async function () {
+					if (!createBlobPayloadPending) {
+						this.skip();
+					}
+
+					const { mockBlobStorage, mockOrderingService, blobManager } = createTestMaterial({
+						createBlobPayloadPending,
+					});
+					mockBlobStorage.pause();
+					mockOrderingService.pause();
+
+					const handle = await blobManager.createBlob(textToBlob("hello"));
+					assert(isLocalFluidHandle(handle), "Expected a local pending-payload handle");
+					assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
+					const internalHandle = toFluidHandleInternal(handle);
+
+					assert.strictEqual(internalHandle.isAttached, false);
+					assert.strictEqual(mockBlobStorage.blobsReceived, 0);
+
+					handle.sharePayload();
+					handle.sharePayload();
+
+					await mockBlobStorage.waitBlobAvailable();
+					assert.strictEqual(
+						mockBlobStorage.blobsReceived,
+						1,
+						"Repeated sharePayload calls should not start another upload",
+					);
+					assert.strictEqual(
+						internalHandle.isAttached,
+						false,
+						"Sharing the payload should not attach the handle",
+					);
+
+					await mockBlobStorage.waitCreateOne();
+					await mockOrderingService.waitMessageAvailable();
+					assert.strictEqual(
+						mockOrderingService.messagesReceived,
+						1,
+						"Expected one BlobAttach message",
+					);
+
+					attachHandle(handle);
+					handle.sharePayload();
+					assert.strictEqual(internalHandle.isAttached, true);
+					assert.strictEqual(
+						mockBlobStorage.blobsReceived,
+						1,
+						"Attaching the handle after sharing starts should not start another upload",
+					);
+
+					mockOrderingService.sequenceOne();
+					await waitHandlePayloadShared(handle);
+					assert.strictEqual(handle.payloadShareError, undefined);
+					assert.strictEqual(handle.payloadState, "shared");
+				});
+
+				it("Surfaces failures when payload sharing starts imperatively", async function () {
+					if (!createBlobPayloadPending) {
+						this.skip();
+					}
+
+					const { mockBlobStorage, blobManager } = createTestMaterial({
+						createBlobPayloadPending,
+					});
+					mockBlobStorage.pause();
+
+					const handle = await blobManager.createBlob(textToBlob("hello"));
+					assert(isLocalFluidHandle(handle), "Expected a local pending-payload handle");
+					assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
+					const payloadSharedP = waitHandlePayloadShared(handle);
+
+					handle.sharePayload();
+					await mockBlobStorage.waitCreateOne({
+						error: new LoggingError("fake driver error"),
+					});
+
+					await assert.rejects(payloadSharedP, { message: "fake driver error" });
+					assert.strictEqual(handle.payloadState, "pending");
+					assert(handle.payloadShareError instanceof Error);
+					assert.strictEqual(handle.payloadShareError.message, "fake driver error");
+					assert.strictEqual(toFluidHandleInternal(handle).isAttached, false);
+				});
+
+				it("Treats sharing an already-shared payload as a no-op", async function () {
+					if (createBlobPayloadPending) {
+						this.skip();
+					}
+
+					const { mockBlobStorage, mockOrderingService, blobManager } = createTestMaterial({
+						createBlobPayloadPending,
+					});
+					const handle = await blobManager.createBlob(textToBlob("hello"));
+					assert(isLocalFluidHandle(handle), "Expected a local blob handle");
+					assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
+
+					const blobsReceived = mockBlobStorage.blobsReceived;
+					const messagesReceived = mockOrderingService.messagesReceived;
+					handle.sharePayload();
+
+					assert.strictEqual(handle.payloadState, "shared");
+					assert.strictEqual(mockBlobStorage.blobsReceived, blobsReceived);
+					assert.strictEqual(mockOrderingService.messagesReceived, messagesReceived);
 				});
 
 				it("Can retrieve a blob using its storageId", async () => {

--- a/packages/runtime/container-runtime/src/test/blobs/pendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobs/pendingBlobs.spec.ts
@@ -75,11 +75,13 @@ for (const createBlobPayloadPending of [false, true]) {
 				const { mockBlobStorage, blobManager } = createTestMaterial({
 					createBlobPayloadPending,
 				});
+				// Keep the upload in flight so pending state can be inspected before sharing completes.
 				mockBlobStorage.pause();
 
 				const handle = await blobManager.createBlob(textToBlob("hello"));
 				assert(isLocalFluidHandle(handle), "Expected a local pending-payload handle");
 				assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
+				// Starting payload sharing, rather than graph attachment, should make the blob pending.
 				handle.sharePayload();
 
 				await mockBlobStorage.waitBlobAvailable();

--- a/packages/runtime/container-runtime/src/test/blobs/pendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobs/pendingBlobs.spec.ts
@@ -67,7 +67,7 @@ for (const createBlobPayloadPending of [false, true]) {
 				assert.strictEqual(redirectTable, undefined);
 			});
 
-			it("getPendingBlobs while imperatively sharing an unattached handle", async function () {
+			it("tracks an imperatively sharing blob only after its handle is attached", async function () {
 				if (!createBlobPayloadPending) {
 					this.skip();
 				}
@@ -81,18 +81,54 @@ for (const createBlobPayloadPending of [false, true]) {
 				const handle = await blobManager.createBlob(textToBlob("hello"));
 				assert(isLocalFluidHandle(handle), "Expected a local pending-payload handle");
 				assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
-				// Starting payload sharing, rather than graph attachment, should make the blob pending.
 				handle.sharePayload();
 
 				await mockBlobStorage.waitBlobAvailable();
 
 				const { localId } = unpackHandle(handle);
+				assert.strictEqual(
+					blobManager.getPendingBlobs(),
+					undefined,
+					"An unattached handle should not make its blob part of pending state",
+				);
+
+				attachHandle(handle);
 				assert.deepStrictEqual(blobManager.getPendingBlobs(), {
 					[localId]: {
 						state: "localOnly",
 						blob: getSerializedBlobForString("hello"),
 					},
 				});
+			});
+
+			it("does not track a blob attached after BlobAttach processing", async function () {
+				if (!createBlobPayloadPending) {
+					this.skip();
+				}
+
+				const { mockOrderingService, blobManager } = createTestMaterial({
+					createBlobPayloadPending,
+				});
+				mockOrderingService.pause();
+
+				const handle = await blobManager.createBlob(textToBlob("hello"));
+				assert(isLocalFluidHandle(handle), "Expected a local pending-payload handle");
+				assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
+				handle.sharePayload();
+
+				await mockOrderingService.waitMessageAvailable();
+				// Process BlobAttach synchronously, then attach the handle before notifyShared runs in a
+				// subsequent promise continuation.
+				mockOrderingService.sequenceOne();
+				assert.strictEqual(
+					handle.payloadState,
+					"pending",
+					"Expected the payload notification to still be pending",
+				);
+				attachHandle(handle);
+
+				assert.strictEqual(blobManager.getPendingBlobs(), undefined);
+				await ensureBlobsShared([handle]);
 			});
 
 			it("getPendingBlobs while attaching", async () => {

--- a/packages/runtime/container-runtime/src/test/blobs/pendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobs/pendingBlobs.spec.ts
@@ -5,6 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
+import { isLocalFluidHandle } from "@fluidframework/runtime-utils/internal";
+
 import type { IPendingBlobs, SerializableLocalBlobRecord } from "../../blobManager/index.js";
 
 import {
@@ -63,6 +65,32 @@ for (const createBlobPayloadPending of [false, true]) {
 				const { ids, redirectTable } = getSummaryContentsWithFormatValidation(blobManager);
 				assert.strictEqual(ids, undefined);
 				assert.strictEqual(redirectTable, undefined);
+			});
+
+			it("getPendingBlobs while imperatively sharing an unattached handle", async function () {
+				if (!createBlobPayloadPending) {
+					this.skip();
+				}
+
+				const { mockBlobStorage, blobManager } = createTestMaterial({
+					createBlobPayloadPending,
+				});
+				mockBlobStorage.pause();
+
+				const handle = await blobManager.createBlob(textToBlob("hello"));
+				assert(isLocalFluidHandle(handle), "Expected a local pending-payload handle");
+				assert(handle.sharePayload !== undefined, "Expected sharePayload to be available");
+				handle.sharePayload();
+
+				await mockBlobStorage.waitBlobAvailable();
+
+				const { localId } = unpackHandle(handle);
+				assert.deepStrictEqual(blobManager.getPendingBlobs(), {
+					[localId]: {
+						state: "localOnly",
+						blob: getSerializedBlobForString("hello"),
+					},
+				});
 			});
 
 			it("getPendingBlobs while attaching", async () => {


### PR DESCRIPTION
## Description

Fixes [AB#77539](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/77539)

This change adds an optional `ILocalFluidHandle.sharePayload()` API and implements it for blob handles.

This imperative API lets a consumer start the existing asynchronous payload upload and `BlobAttach` flow before serializing the handle into a DDS/marking the handle as attached to the Fluid object graph.

`attachGraph()` preserves the existing behavior by starting payload sharing when needed but does not start a second upload if `sharePayload()` was called first. Pending state continues to include only blobs whose handles have been attached to the Fluid object graph while payload sharing remains unfinished, calling `sharePayload()` alone does not make an unattached blob part of pending state.

The interface member is optional to preserve compatibility with older `ILocalFluidHandle` implementations.
