### PR TITLE
feat(tree): shared branch names

### DIFF
--- a/.changeset/legal-monkeys-heal.md
+++ b/.changeset/legal-monkeys-heal.md
@@ -5,7 +5,7 @@
 ---
 Shared branch names
 
-The existing `createSharedBranch` alpha API now takes an optional `name` string parameter that is associated with the shared branch.
+The existing [`createSharedBranch`](https://fluidframework.com/docs/api/tree/itreealpha-interface#createsharedbranch-methodsignature) alpha API now takes an optional `name` string parameter that is associated with the shared branch.
 This name can be retrieved by passing the shared branch ID to `getSharedBranchName`.
 
 Note that, unlike the shared branch IDs, shared branch names are not guaranteed to be unique.

--- a/.changeset/legal-monkeys-heal.md
+++ b/.changeset/legal-monkeys-heal.md
@@ -9,3 +9,13 @@ The existing `createSharedBranch` alpha API now takes an optional `name` string 
 This name can be retrieved by passing the shared branch ID to `getSharedBranchName`.
 
 Note that, unlike the shared branch IDs, shared branch names are not guaranteed to be unique.
+
+## Compatibility Implications
+
+This change breaks compatibility in the following ways:
+- A document written by a client running an earlier FF version cannot be opened by a client running this version.
+- A document written by a client running this version cannot be opened by a client running an earlier FF version.
+- Clients running earlier FF versions will crash upon receiving ops from clients running this version.
+- Clients running this version will crash upon receiving ops from clients running earlier FF versions.
+
+These breaks are only applicable for clients with `enableSharedBranches` turned on. Other clients are unaffected.

--- a/.changeset/legal-monkeys-heal.md
+++ b/.changeset/legal-monkeys-heal.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Shared branch names
+
+The existing `createSharedBranch` alpha API now takes an optional `name` string parameter that is associated with the shared branch.
+This name can be retrieved by passing the shared branch ID to `getSharedBranchName`.
+
+Note that, unlike the shared branch IDs, shared branch names are not guaranteed to be unique.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -678,10 +678,11 @@ export interface ITree extends ViewableTree, IFluidLoadable {
 
 // @alpha @sealed
 export interface ITreeAlpha extends ITree {
-    createSharedBranch(): string;
+    createSharedBranch(name?: string): string;
     exportSimpleSchema(): SimpleTreeSchema;
     exportVerbose(): VerboseTree | undefined;
     getSharedBranchIds(): string[];
+    getSharedBranchName(branchId: string): string | undefined;
     viewSharedBranchWith<TRoot extends ImplicitFieldSchema>(branchId: string, config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -1105,7 +1105,14 @@ class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset> {
 
 		const trunkBase =
 			this.parentBranch === undefined ? undefined : forkPointFromMainTrunk.revision;
-		return { trunk, peerLocalBranches, base: trunkBase, id: this.id, session: this.sessionId };
+		return {
+			trunk,
+			peerLocalBranches,
+			base: trunkBase,
+			id: this.id,
+			name: this.branchName,
+			session: this.sessionId,
+		};
 	}
 
 	public loadSummaryData(

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -9,6 +9,7 @@ import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { SessionId } from "@fluidframework/id-compressor";
 import {
 	TelemetryEventBatcher,
+	UsageError,
 	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 import { BTree } from "@tylerbu/sorted-btree-es6";
@@ -151,15 +152,23 @@ export class EditManager<
 			this.telemetryEventBatcher,
 		);
 
-		this.createAndAddSharedBranch("main", undefined, undefined, mainTrunk);
+		this.createAndAddSharedBranch("main", "main", undefined, undefined, mainTrunk);
 	}
 
 	public getLocalBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChangeset> {
 		return this.getSharedBranch(branchId).localBranch;
 	}
 
+	public getSharedBranchName(branchId: BranchId): string | undefined {
+		return this.getSharedBranch(branchId).branchName;
+	}
+
 	private getSharedBranch(branchId: BranchId): SharedBranch<TEditor, TChangeset> {
-		return this.sharedBranches.get(branchId) ?? fail(0xc56 /* Branch does not exist */);
+		const branch = this.sharedBranches.get(branchId);
+		if (branch === undefined) {
+			throw new UsageError("No shared branch with such ID");
+		}
+		return branch;
 	}
 
 	/**
@@ -404,6 +413,7 @@ export class EditManager<
 			for (const [branchId, branchData] of data.branches) {
 				const branch = this.createSharedBranch(
 					branchId,
+					branchData.name,
 					branchData.session,
 					mainBranch,
 					mainBranch.trunk.fork(),
@@ -451,6 +461,7 @@ export class EditManager<
 		sessionId: SessionId,
 		referenceSequenceNumber: SeqNumber,
 		branchId: BranchId,
+		branchName?: string,
 	): void {
 		if (sessionId === this.localSessionId) {
 			assert(this.sharedBranches.has(branchId), 0xc59 /* Expected branch to already exist */);
@@ -459,13 +470,14 @@ export class EditManager<
 
 		const mainBranch = this.getSharedBranch("main");
 		const branchTrunk = mainBranch.rebasePeer(sessionId, referenceSequenceNumber).fork();
-		this.createAndAddSharedBranch(branchId, sessionId, mainBranch, branchTrunk);
+		this.createAndAddSharedBranch(branchId, branchName, sessionId, mainBranch, branchTrunk);
 	}
 
-	public addNewBranch(branchId: BranchId): void {
+	public addNewBranch(branchId: BranchId, branchName?: string): void {
 		const main = this.getSharedBranch("main") ?? fail(0xc5a /* Main branch must exist */);
 		this.createAndAddSharedBranch(
 			branchId,
+			branchName,
 			this.localSessionId,
 			main,
 			this.getLocalBranch("main").fork(),
@@ -484,11 +496,18 @@ export class EditManager<
 
 	private createAndAddSharedBranch(
 		branchId: BranchId,
+		branchName: string | undefined,
 		sessionId: SessionId | undefined,
 		parent: SharedBranch<TEditor, TChangeset> | undefined,
 		branch: SharedTreeBranch<TEditor, TChangeset>,
 	): SharedBranch<TEditor, TChangeset> {
-		const sharedBranch = this.createSharedBranch(branchId, sessionId, parent, branch);
+		const sharedBranch = this.createSharedBranch(
+			branchId,
+			branchName,
+			sessionId,
+			parent,
+			branch,
+		);
 		this.addSharedBranch(branchId, sharedBranch);
 		return sharedBranch;
 	}
@@ -516,6 +535,7 @@ export class EditManager<
 
 	private createSharedBranch(
 		branchId: BranchId,
+		branchName: string | undefined,
 		sessionId: SessionId | undefined,
 		parent: SharedBranch<TEditor, TChangeset> | undefined,
 		branch: SharedTreeBranch<TEditor, TChangeset>,
@@ -524,6 +544,7 @@ export class EditManager<
 			parent,
 			branch,
 			branchId,
+			branchName,
 			sessionId,
 			minimumPossibleSequenceId,
 			this.changeFamily,
@@ -696,6 +717,7 @@ class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset> {
 		public readonly parentBranch: SharedBranch<TEditor, TChangeset> | undefined,
 		public readonly trunk: SharedTreeBranch<TEditor, TChangeset>,
 		private readonly id: BranchId,
+		public readonly branchName: string | undefined,
 		private readonly sessionId: SessionId | undefined,
 		baseCommitSequenceId: SequenceId,
 		private readonly changeFamily: ChangeFamily<TEditor, TChangeset>,

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -167,7 +167,7 @@ export const EditManagerFormatVersion = strictEnum("editManager.FormatVersion", 
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
-	vSharedBranches: "shared-branches|v0.1",
+	vSharedBranches: "shared-branches|v0.2",
 });
 export type EditManagerFormatVersion = Values<typeof EditManagerFormatVersion>;
 export const supportedEditManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> =

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -103,7 +103,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 					type: "branch",
 					sessionId: originatorId,
 					branchId,
-					branchName: encodedBranchName as string | undefined,
+					branchName: encodedBranchName,
 				};
 			}
 

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -68,6 +68,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 					return {
 						originatorId: message.sessionId,
 						branchId: encodeBranchId(context.idCompressor, message.branchId),
+						branchName: message.branchName,
 						version,
 					};
 				}
@@ -85,6 +86,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				originatorId,
 				changeset,
 				branchId: encodedBranchId,
+				branchName: encodedBranchName,
 			} = encoded;
 
 			const changeContext: ChangeEncodingContext = {
@@ -97,7 +99,12 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 			const branchId = decodeBranchId(context.idCompressor, encodedBranchId, changeContext);
 
 			if (changeset === undefined) {
-				return { type: "branch", sessionId: originatorId, branchId };
+				return {
+					type: "branch",
+					sessionId: originatorId,
+					branchId,
+					branchName: encodedBranchName as string | undefined,
+				};
 			}
 
 			assert(encodedRevision !== undefined, 0xc6a /* Commit messages must have a revision */);

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -56,7 +56,7 @@ export const MessageFormatVersion = strictEnum("MessageFormatVersion", {
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
-	vSharedBranches: "shared-branches|v0.1",
+	vSharedBranches: "shared-branches|v0.2",
 });
 export type MessageFormatVersion = Values<typeof MessageFormatVersion>;
 export const supportedMessageFormatVersions: ReadonlySet<MessageFormatVersion> = new Set([

--- a/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
@@ -30,7 +30,16 @@ export interface Message {
 	 */
 	readonly changeset?: JsonCompatibleReadOnly;
 
+	/**
+	 * Unique ID associated with the branch.
+	 */
 	readonly branchId?: EncodedBranchId;
+
+	/**
+	 * Application-defined name of the branch, if any.
+	 * Not guaranteed to be unique.
+	 */
+	readonly branchName?: string;
 
 	/**
 	 * The version of the message format.

--- a/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
@@ -46,5 +46,6 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 		originatorId: SessionIdSchema,
 		changeset: Type.Optional(tChange),
 		branchId: Type.Optional(Type.Number()),
+		branchName: Type.Optional(Type.String()),
 		version: Type.Literal(MessageFormatVersion.vSharedBranches),
 	});

--- a/packages/dds/tree/src/shared-tree-core/messageTypes.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageTypes.ts
@@ -24,4 +24,5 @@ export interface CommitMessage<TChange> extends MessageBase {
 export interface BranchMessage extends MessageBase {
 	type: "branch";
 	branchId: BranchId;
+	branchName?: string;
 }

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -132,7 +132,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 
 	private static readonly maxBranchNameLength = 1024;
 
-
 	/**
 	 * @param summarizables - Summarizers for all indexes used by this tree
 	 * @param changeFamily - The change family
@@ -532,7 +531,9 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 	}
 	public createSharedBranch(branchName?: string): string {
 		if (branchName !== undefined && branchName.length > SharedTreeCore.maxBranchNameLength) {
-			throw new UsageError(`Branch name is too long: ${branchName.length} > maxBranchNameLength`);
+			throw new UsageError(
+				`Branch name is too long: ${branchName.length} > maxBranchNameLength`,
+			);
 		}
 		const branchId = this.idCompressor.generateCompressedId();
 		this.addBranch(branchId, branchName);

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -593,7 +593,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				break;
 			}
 			case "branch": {
-				this.submitBranchCreation(message.branchId);
+				this.submitBranchCreation(message.branchId, message.branchName);
 				break;
 			}
 			default: {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -130,6 +130,9 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 
 	private readonly schemaAndPolicy: ClonableSchemaAndPolicy;
 
+	private static readonly maxBranchNameLength = 1024;
+
+
 	/**
 	 * @param summarizables - Summarizers for all indexes used by this tree
 	 * @param changeFamily - The change family
@@ -528,8 +531,8 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			.map((id) => this.idCompressor.decompress(id));
 	}
 	public createSharedBranch(branchName?: string): string {
-		if (branchName !== undefined && branchName.length > 1024) {
-			throw new UsageError(`Branch name is too long: ${branchName.length} > 1024`);
+		if (branchName !== undefined && branchName.length > SharedTreeCore.maxBranchNameLength) {
+			throw new UsageError(`Branch name is too long: ${branchName.length} > maxBranchNameLength`);
 		}
 		const branchId = this.idCompressor.generateCompressedId();
 		this.addBranch(branchId, branchName);

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -11,6 +11,7 @@ import type {
 	IIdCompressor,
 	SessionId,
 	SessionSpaceCompressedId,
+	StableId,
 } from "@fluidframework/id-compressor";
 import type {
 	IExperimentalIncrementalSummaryContext,
@@ -23,7 +24,7 @@ import type {
 	IChannelView,
 	IFluidSerializer,
 } from "@fluidframework/shared-object-base/internal";
-import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
+import { createChildLogger, UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { CodecWriteOptions, DependentFormatVersion, IJsonCodec } from "../codec/index.js";
 import {
@@ -397,9 +398,9 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		this.getResubmitMachine(branchId).onCommitSubmitted(enrichedCommit);
 	}
 
-	protected submitBranchCreation(branchId: BranchId): void {
+	protected submitBranchCreation(branchId: BranchId, branchName?: string): void {
 		this.submitMessage(
-			{ type: "branch", sessionId: this.editManager.localSessionId, branchId },
+			{ type: "branch", sessionId: this.editManager.localSessionId, branchId, branchName },
 			this.schemaAndPolicy,
 		);
 	}
@@ -477,6 +478,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 						messagesSessionId,
 						brand(envelope.referenceSequenceNumber),
 						message.branchId,
+						message.branchName,
 					);
 					break;
 				}
@@ -525,19 +527,27 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			.filter((id): id is SessionSpaceCompressedId => id !== "main")
 			.map((id) => this.idCompressor.decompress(id));
 	}
-	public createSharedBranch(): string {
+	public createSharedBranch(branchName?: string): string {
 		const branchId = this.idCompressor.generateCompressedId();
-		this.addBranch(branchId);
-		this.submitBranchCreation(branchId);
+		this.addBranch(branchId, branchName);
+		this.submitBranchCreation(branchId, branchName);
 		return this.idCompressor.decompress(branchId);
 	}
 
-	protected addBranch(branchId: BranchId): void {
-		this.editManager.addNewBranch(branchId);
+	protected addBranch(branchId: BranchId, branchName?: string): void {
+		this.editManager.addNewBranch(branchId, branchName);
 	}
 
 	public getSharedBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChange> {
 		return this.editManager.getLocalBranch(branchId);
+	}
+
+	public getSharedBranchName(branchId: string): string | undefined {
+		const compressedId = this.idCompressor.tryRecompress(branchId as StableId);
+		if (compressedId === undefined) {
+			throw new UsageError(`No branch found with id: ${branchId}`);
+		}
+		return this.editManager.getSharedBranchName(compressedId);
 	}
 
 	public didAttach(): void {
@@ -637,7 +647,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				break;
 			}
 			case "branch": {
-				this.editManager.addNewBranch(message.branchId);
+				this.editManager.addNewBranch(message.branchId, message.branchName);
 				break;
 			}
 			default: {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -528,6 +528,9 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			.map((id) => this.idCompressor.decompress(id));
 	}
 	public createSharedBranch(branchName?: string): string {
+		if (branchName !== undefined && branchName.length > 1024) {
+			throw new UsageError(`Branch name is too long: ${branchName.length} > 1024`);
+		}
 		const branchId = this.idCompressor.generateCompressedId();
 		this.addBranch(branchId, branchName);
 		this.submitBranchCreation(branchId, branchName);

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -336,6 +336,7 @@ export class SharedTreeKernel
 			viewWith: this.viewWith.bind(this),
 			viewSharedBranchWith: this.viewBranchWith.bind(this),
 			createSharedBranch: this.createSharedBranch.bind(this),
+			getSharedBranchName: this.getSharedBranchName.bind(this),
 			getSharedBranchIds: this.getSharedBranchIds.bind(this),
 			kernel: this,
 		};

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -112,8 +112,19 @@ export interface ITreeAlpha extends ITree {
 	/**
 	 * Creates a fork of the current state of the main branch.
 	 * This new branch will be shared with and editable by all clients.
+	 * @param name - Optional name for the new branch.
+	 * This name is not guaranteed to be unique.
+	 * @returns The ID of the new branch, which can be used to {@link ITreeAlpha.viewSharedBranchWith | view} the branch.
 	 */
-	createSharedBranch(): string;
+	createSharedBranch(name?: string): string;
+
+	/**
+	 * Retrieves the name, if any, of the shared branch with the given ID.
+	 * @param branchId - The ID of the shared branch to retrieve the name of.
+	 * @returns The name of the shared branch, or `undefined` if the branch has no assigned name.
+	 * @throws UsageError if the branch with the given ID does not exist.
+	 */
+	getSharedBranchName(branchId: string): string | undefined;
 
 	/**
 	 * Returns a list of all shared branches that currently exist on this tree.

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -114,6 +114,7 @@ export interface ITreeAlpha extends ITree {
 	 * This new branch will be shared with and editable by all clients.
 	 * @param name - Optional name for the new branch.
 	 * This name is not guaranteed to be unique.
+	 * (Maximum {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length | length}: 1024)
 	 * @returns The ID of the new branch, which can be used to {@link ITreeAlpha.viewSharedBranchWith | view} the branch.
 	 */
 	createSharedBranch(name?: string): string;
@@ -122,7 +123,7 @@ export interface ITreeAlpha extends ITree {
 	 * Retrieves the name, if any, of the shared branch with the given ID.
 	 * @param branchId - The ID of the shared branch to retrieve the name of.
 	 * @returns The name of the shared branch, or `undefined` if the branch has no assigned name.
-	 * @throws UsageError if the branch with the given ID does not exist.
+	 * @throws if the branch with the given ID does not exist.
 	 */
 	getSharedBranchName(branchId: string): string | undefined;
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2842,100 +2842,139 @@ describe("SharedTree", () => {
 		assert.deepEqual(tree.exportSimpleSchema(), expected);
 	});
 
-	it("supports multiple shared branches", () => {
-		const provider = new TestTreeProviderLite(
-			2,
-			configuredSharedTree({
-				jsonValidator: FormatValidatorBasic,
-				enableSharedBranches: true,
-			}).getFactory(),
-		);
-		const tree1 = provider.trees[0];
+	describe("Shared Branches", () => {
+		it("supports multiple shared branches", () => {
+			const provider = new TestTreeProviderLite(
+				2,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					enableSharedBranches: true,
+				}).getFactory(),
+			);
+			const tree1 = provider.trees[0];
 
-		const config = new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation });
-		const mainView1 = tree1.viewWith(config);
-		mainView1.initialize(["A"]);
-		provider.synchronizeMessages();
+			const config = new TreeViewConfiguration({
+				schema: StringArray,
+				enableSchemaValidation,
+			});
+			const mainView1 = tree1.viewWith(config);
+			mainView1.initialize(["A"]);
+			provider.synchronizeMessages();
 
-		assert.deepEqual([...mainView1.root], ["A"]);
-		const tree2 = provider.trees[1];
-		provider.synchronizeMessages();
+			assert.deepEqual([...mainView1.root], ["A"]);
+			const tree2 = provider.trees[1];
+			provider.synchronizeMessages();
 
-		const branchId = tree1.createSharedBranch();
-		const branchView1 = tree1.viewSharedBranchWith(branchId, config);
-		assert.deepEqual([...branchView1.root], ["A"]);
+			const branchId = tree1.createSharedBranch();
+			const branchView1 = tree1.viewSharedBranchWith(branchId, config);
+			assert.deepEqual([...branchView1.root], ["A"]);
 
-		mainView1.root.insertAtEnd("X");
-		branchView1.root.insertAtEnd("B");
-		assert.deepEqual([...branchView1.root], ["A", "B"]);
-		assert.deepEqual([...mainView1.root], ["A", "X"]);
-		provider.synchronizeMessages();
+			mainView1.root.insertAtEnd("X");
+			branchView1.root.insertAtEnd("B");
+			assert.deepEqual([...branchView1.root], ["A", "B"]);
+			assert.deepEqual([...mainView1.root], ["A", "X"]);
+			provider.synchronizeMessages();
 
-		const branchView2 = tree2.viewSharedBranchWith(branchId, config);
-		assert.deepEqual([...branchView2.root], ["A", "B"]);
+			const branchView2 = tree2.viewSharedBranchWith(branchId, config);
+			assert.deepEqual([...branchView2.root], ["A", "B"]);
 
-		branchView2.root.insertAtEnd("C");
-		assert.deepEqual([...branchView2.root], ["A", "B", "C"]);
-		provider.synchronizeMessages();
+			branchView2.root.insertAtEnd("C");
+			assert.deepEqual([...branchView2.root], ["A", "B", "C"]);
+			provider.synchronizeMessages();
 
-		assert.deepEqual([...branchView1.root], ["A", "B", "C"]);
-		assert.deepEqual([...mainView1.root], ["A", "X"]);
+			assert.deepEqual([...branchView1.root], ["A", "B", "C"]);
+			assert.deepEqual([...mainView1.root], ["A", "X"]);
 
-		const mainView2 = tree2.viewWith(config);
-		assert.deepEqual([...mainView2.root], ["A", "X"]);
-	});
+			const mainView2 = tree2.viewWith(config);
+			assert.deepEqual([...mainView2.root], ["A", "X"]);
+		});
 
-	describe("can load a shared branch from summary", () => {
-		for (const subCase of [
-			"based on a commit in the collab window",
-			"based on a commit outside the collab window",
-		] as const) {
-			it(subCase, async () => {
-				const internalOption = resolveOptions({ enableSharedBranches: true });
-				const provider = await TestTreeProvider.create(
-					1,
-					SummarizeType.onDemand,
-					new SharedTreeTestFactory(() => {}, undefined, internalOption),
-				);
-				const tree1 = provider.trees[0];
-				const config = new TreeViewConfiguration({
-					schema: StringArray,
-					enableSchemaValidation,
-				});
-				const mainView1 = tree1.viewWith(config);
-				mainView1.initialize([]);
-				mainView1.root.insertAtEnd("A");
-				const branchId = tree1.createSharedBranch();
-				mainView1.root.insertAtEnd("B");
-				await provider.ensureSynchronized();
+		it("shared branches can be named on creation", () => {
+			const provider = new TestTreeProviderLite(
+				2,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					enableSharedBranches: true,
+				}).getFactory(),
+			);
+			const tree1 = provider.trees[0];
+			const tree2 = provider.trees[1];
 
-				const branchView1 = tree1.viewSharedBranchWith(branchId, config);
-				branchView1.root.insertAtEnd("X");
+			const config = new TreeViewConfiguration({
+				schema: StringArray,
+				enableSchemaValidation,
+			});
+			const mainView1 = tree1.viewWith(config);
+			mainView1.initialize([]);
+			provider.synchronizeMessages();
 
-				await provider.ensureSynchronized();
+			const branch1Id = tree1.createSharedBranch("branch1");
+			const branch2Id = tree1.createSharedBranch("branch2");
+			const branch3Id = tree1.createSharedBranch();
 
-				if (subCase === "based on a commit outside the collab window") {
-					const seqNumber = provider.containers[0].deltaManager.lastSequenceNumber;
-					while (provider.containers[0].deltaManager.minimumSequenceNumber < seqNumber) {
+			assert.equal(tree1.getSharedBranchName(branch1Id), "branch1");
+			assert.equal(tree1.getSharedBranchName(branch2Id), "branch2");
+			assert.equal(tree1.getSharedBranchName(branch3Id), undefined);
+
+			provider.synchronizeMessages();
+
+			assert.equal(tree2.getSharedBranchName(branch1Id), "branch1");
+			assert.equal(tree2.getSharedBranchName(branch2Id), "branch2");
+			assert.equal(tree2.getSharedBranchName(branch3Id), undefined);
+		});
+
+		describe("can load a shared branch from summary", () => {
+			for (const subCase of [
+				"based on a commit in the collab window",
+				"based on a commit outside the collab window",
+			] as const) {
+				it(subCase, async () => {
+					const internalOption = resolveOptions({ enableSharedBranches: true });
+					const provider = await TestTreeProvider.create(
+						1,
+						SummarizeType.onDemand,
+						new SharedTreeTestFactory(() => {}, undefined, internalOption),
+					);
+					const tree1 = provider.trees[0];
+					const config = new TreeViewConfiguration({
+						schema: StringArray,
+						enableSchemaValidation,
+					});
+					const mainView1 = tree1.viewWith(config);
+					mainView1.initialize([]);
+					mainView1.root.insertAtEnd("A");
+					const branchId = tree1.createSharedBranch();
+					mainView1.root.insertAtEnd("B");
+					await provider.ensureSynchronized();
+
+					const branchView1 = tree1.viewSharedBranchWith(branchId, config);
+					branchView1.root.insertAtEnd("X");
+
+					await provider.ensureSynchronized();
+
+					if (subCase === "based on a commit outside the collab window") {
+						const seqNumber = provider.containers[0].deltaManager.lastSequenceNumber;
+						while (provider.containers[0].deltaManager.minimumSequenceNumber < seqNumber) {
+							mainView1.root.insertAtEnd("C");
+							await provider.ensureSynchronized();
+						}
 						mainView1.root.insertAtEnd("C");
 						await provider.ensureSynchronized();
 					}
-					mainView1.root.insertAtEnd("C");
+
+					const lengthOnMainBranch = mainView1.root.length;
+
+					// The summary created here should include the shared branch
+					await provider.summarize();
 					await provider.ensureSynchronized();
-				}
-
-				const lengthOnMainBranch = mainView1.root.length;
-
-				// The summary created here should include the shared branch
-				await provider.summarize();
-				await provider.ensureSynchronized();
-				const loadingTree = await provider.createTree();
-				const loadingMainView = loadingTree.viewWith(config);
-				assert.equal(loadingMainView.root.length, lengthOnMainBranch);
-				const loadingBranchView = loadingTree.viewSharedBranchWith(branchId, config);
-				assert.deepEqual([...loadingBranchView.root], ["A", "X"]);
-			});
-		}
+					const loadingTree = await provider.createTree();
+					const loadingMainView = loadingTree.viewWith(config);
+					assert.equal(loadingMainView.root.length, lengthOnMainBranch);
+					const loadingBranchView = loadingTree.viewSharedBranchWith(branchId, config);
+					assert.deepEqual([...loadingBranchView.root], ["A", "X"]);
+				});
+			}
+		});
 	});
 
 	it("Can process nested transactions from two different trees", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2978,7 +2978,7 @@ describe("SharedTree", () => {
 					const mainView1 = tree1.viewWith(config);
 					mainView1.initialize([]);
 					mainView1.root.insertAtEnd("A");
-					const branchId = tree1.createSharedBranch();
+					const branchId = tree1.createSharedBranch("branch");
 					mainView1.root.insertAtEnd("B");
 					await provider.ensureSynchronized();
 
@@ -3007,6 +3007,8 @@ describe("SharedTree", () => {
 					assert.equal(loadingMainView.root.length, lengthOnMainBranch);
 					const loadingBranchView = loadingTree.viewSharedBranchWith(branchId, config);
 					assert.deepEqual([...loadingBranchView.root], ["A", "X"]);
+					// Check that the branch name is preserved in the summary
+					assert.equal(loadingTree.getSharedBranchName(branchId), "branch");
 				});
 			}
 		});

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2929,6 +2929,35 @@ describe("SharedTree", () => {
 			assert.equal(tree2.getSharedBranchName(branch3Id), name3);
 		});
 
+		it("shared branches names cannot exceed a length of 1024", () => {
+			const provider = new TestTreeProviderLite(
+				2,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					enableSharedBranches: true,
+				}).getFactory(),
+			);
+			const tree1 = provider.trees[0];
+			const tree2 = provider.trees[1];
+
+			const config = new TreeViewConfiguration({
+				schema: StringArray,
+				enableSchemaValidation,
+			});
+			const mainView1 = tree1.viewWith(config);
+			mainView1.initialize([]);
+			provider.synchronizeMessages();
+
+			const validName = "v".repeat(1024);
+			const branch1Id = tree1.createSharedBranch(validName);
+			assert.equal(tree1.getSharedBranchName(branch1Id), validName);
+			provider.synchronizeMessages();
+			assert.equal(tree2.getSharedBranchName(branch1Id), validName);
+
+			const invalidName = "i".repeat(1025);
+			assert.throws(() => tree1.createSharedBranch(invalidName), /Branch name is too long/);
+		});
+
 		describe("can load a shared branch from summary", () => {
 			for (const subCase of [
 				"based on a commit in the collab window",

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2908,18 +2908,22 @@ describe("SharedTree", () => {
 			mainView1.initialize([]);
 			provider.synchronizeMessages();
 
-			const branch1Id = tree1.createSharedBranch("branch1");
-			const branch2Id = tree1.createSharedBranch("branch2");
+			/** A basic name */
+			const name1 = "branch1";
+			/** A name with special characters that need escaping */
+			const name2 = '" \\ \b \f \n \r \t \u00E9';
+			const branch1Id = tree1.createSharedBranch(name1);
+			const branch2Id = tree1.createSharedBranch(name2);
 			const branch3Id = tree1.createSharedBranch();
 
-			assert.equal(tree1.getSharedBranchName(branch1Id), "branch1");
-			assert.equal(tree1.getSharedBranchName(branch2Id), "branch2");
+			assert.equal(tree1.getSharedBranchName(branch1Id), name1);
+			assert.equal(tree1.getSharedBranchName(branch2Id), name2);
 			assert.equal(tree1.getSharedBranchName(branch3Id), undefined);
 
 			provider.synchronizeMessages();
 
-			assert.equal(tree2.getSharedBranchName(branch1Id), "branch1");
-			assert.equal(tree2.getSharedBranchName(branch2Id), "branch2");
+			assert.equal(tree2.getSharedBranchName(branch1Id), name1);
+			assert.equal(tree2.getSharedBranchName(branch2Id), name2);
 			assert.equal(tree2.getSharedBranchName(branch3Id), undefined);
 		});
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2929,7 +2929,7 @@ describe("SharedTree", () => {
 			assert.equal(tree2.getSharedBranchName(branch3Id), name3);
 		});
 
-		it("shared branches names cannot exceed a length of 1024", () => {
+		it("shared branch names cannot exceed a length of 1024", () => {
 			const provider = new TestTreeProviderLite(
 				2,
 				configuredSharedTree({

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2912,19 +2912,21 @@ describe("SharedTree", () => {
 			const name1 = "branch1";
 			/** A name with special characters that need escaping */
 			const name2 = '" \\ \b \f \n \r \t \u00E9';
+			/** A name with special characters that do not need escaping */
+			const name3 = "こんにちは 👋 café © ™ € £ ¥ < > & ' `";
 			const branch1Id = tree1.createSharedBranch(name1);
 			const branch2Id = tree1.createSharedBranch(name2);
-			const branch3Id = tree1.createSharedBranch();
+			const branch3Id = tree1.createSharedBranch(name3);
 
 			assert.equal(tree1.getSharedBranchName(branch1Id), name1);
 			assert.equal(tree1.getSharedBranchName(branch2Id), name2);
-			assert.equal(tree1.getSharedBranchName(branch3Id), undefined);
+			assert.equal(tree1.getSharedBranchName(branch3Id), name3);
 
 			provider.synchronizeMessages();
 
 			assert.equal(tree2.getSharedBranchName(branch1Id), name1);
 			assert.equal(tree2.getSharedBranchName(branch2Id), name2);
-			assert.equal(tree2.getSharedBranchName(branch3Id), undefined);
+			assert.equal(tree2.getSharedBranchName(branch3Id), name3);
 		});
 
 		describe("can load a shared branch from summary", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1083,10 +1083,11 @@ export interface ITree extends ViewableTree, IFluidLoadable {
 
 // @alpha @sealed
 export interface ITreeAlpha extends ITree {
-    createSharedBranch(): string;
+    createSharedBranch(name?: string): string;
     exportSimpleSchema(): SimpleTreeSchema;
     exportVerbose(): VerboseTree | undefined;
     getSharedBranchIds(): string[];
+    getSharedBranchName(branchId: string): string | undefined;
     viewSharedBranchWith<TRoot extends ImplicitFieldSchema>(branchId: string, config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 


### PR DESCRIPTION
## Description

Adds the option to associate an application-defined string with a shared branch.
This allows applications/end users to more easily communicate about the nature/purpose of a given shared branch without resorting to additional (out of document) storage.

## Breaking Changes

This change breaks compatibility in the following ways:
- A document written by a client running an earlier FF version cannot be opened by a client running this version.
- A document written by a client running this version cannot be opened by a client running an earlier FF version.
- Clients running earlier FF versions will crash upon receiving ops from clients running this version.
- Clients running this version will crash upon receiving ops from clients running earlier FF versions.

These breaks are only applicable for clients with `enableSharedBranches` turned on. Other clients are unaffected. `enableSharedBranches` is advertised as experimental, which makes these brakes acceptable on a minor release.
