### PR TITLE
Use npmjs mirror in all non-client workspaces

### DIFF
--- a/build-tools/pnpm-workspace.yaml
+++ b/build-tools/pnpm-workspace.yaml
@@ -11,11 +11,19 @@
 packages:
   - "packages/*"
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/common/build/build-common/pnpm-workspace.yaml
+++ b/common/build/build-common/pnpm-workspace.yaml
@@ -8,11 +8,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/common/build/eslint-config-fluid/pnpm-workspace.yaml
+++ b/common/build/eslint-config-fluid/pnpm-workspace.yaml
@@ -8,11 +8,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/common/build/eslint-plugin-fluid/pnpm-workspace.yaml
+++ b/common/build/eslint-plugin-fluid/pnpm-workspace.yaml
@@ -8,11 +8,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/common/lib/common-utils/pnpm-workspace.yaml
+++ b/common/lib/common-utils/pnpm-workspace.yaml
@@ -8,11 +8,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/common/lib/protocol-definitions/pnpm-workspace.yaml
+++ b/common/lib/protocol-definitions/pnpm-workspace.yaml
@@ -8,11 +8,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/packages/test/test-version-utils/compat-workspaces/full/pnpm-workspace.yaml
+++ b/packages/test/test-version-utils/compat-workspaces/full/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 packages:
   - '*'
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # The security settings below are intentional — do not relax them.
 minimumReleaseAge: 1440
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -238,6 +238,49 @@ strictPeerDependencies: true
 # The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
 # correctly as of 7/16/2026.
 trustPolicy: off
+# These exclusions are inert with trustPolicy disabled, but were kept in case we are able to restore trustPolicy enforcement
+# at some future point.
+trustPolicyExclude:
+  # @octokit/endpoint@9.0.6 (published 2025-02-14, by octokitbot) — pipeline regression.
+  # Prior trusted: @octokit/endpoint@10.1.3 (provenance, 2025-02-13, by octokitbot), with
+  # verified provenance from octokit/endpoint.js .github/workflows/release.yml @ refs/heads/main.
+  # Same publisher account (octokitbot); the v9 maintenance branch publish bypassed release.yml.
+  # Pulled in transitively via danger@13 → @octokit/rest@20 → @octokit/core@5 → @octokit/request@8.
+  # No reachable direct-dep bump escapes this without overriding @octokit/rest itself.
+  - "@octokit/endpoint@9.0.6"
+  # axios@0.30.3 is the last legitimate 0.30.x release (published 2026-02-18). The trust
+  # downgrade fires because 0.30.x was published via direct CLI rather than the OIDC/GitHub
+  # Actions provenance pipeline used by earlier versions. The compromised versions were
+  # 0.30.4 and 1.14.1 (supply chain attack on 2026-03-31, attributed to Sapphire Sleet).
+  # See: https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/
+  - "axios@0.30.3"
+  # chokidar@4.0.3 (published 2024-12-18, by paulmillr) — pipeline regression.
+  # Prior trusted: chokidar@4.0.1 (provenance, 2024-09-22, by paulmillr).
+  # Same publisher (sole maintainer); provenance attestation was dropped after 4.0.1.
+  # Pulled in transitively via mocha@11 (chokidar ^4.0.1) and sass@1 (chokidar ^4.0.0).
+  # chokidar@5.0.0 has restored provenance but no upstream consumer pins ^5 yet.
+  - "chokidar@4.0.3"
+  # detect-port@1.6.1 (published 2024-05-08, by fengmk2) — pipeline regression.
+  # Prior trusted: detect-port@1.6.0 (provenance, 2024-05-08, by fengmk2).
+  # Same publisher; provenance attestation was lost on the immediately-following patch release.
+  # Pulled in transitively under @fluidframework/azure-local-service.
+  - "detect-port@1.6.1"
+  # semver@5.7.2 (published 2023-07-10, by lukekarrys) — legacy maintenance line.
+  # Prior trusted: semver@7.5.4 (provenance, 2023-07-07, by npm-cli-ops).
+  # Different publisher account because the 5.x and 6.x maintenance lines are
+  # hand-published by lukekarrys (a long-time npm/node-semver maintainer), while the
+  # current 7.x line publishes through the npm-cli OIDC/Actions pipeline. The 5.x/6.x
+  # lines will not be retroactively re-published with provenance. Pulled in by widely-
+  # used legacy tooling that pins ^5 / ^6.
+  # Note: multiple versions of the same package must be combined with "||" — pnpm's
+  # trust-policy evaluator returns on the first name match and does not aggregate
+  # subsequent entries for the same package.
+  - "semver@5.7.2||6.3.1"
+  # undici-types@6.21.0 (published 2024-11-13, by matteo.collina) — pipeline regression.
+  # Prior trusted: undici-types@6.19.2 (provenance, 2024-06-18, by matteo.collina).
+  # Same publisher (undici project lead). Type-only package (.d.ts shipped from undici
+  # repo); provenance attestation was lost on a subsequent 6.x release.
+  - "undici-types@6.21.0"
 
 # Disable pnpm update notifications since we use corepack to install package managers
 updateNotifier: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -236,7 +236,11 @@ strictDepBuilds: true
 strictPeerDependencies: true
 
 # The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
-# correctly as of 7/16/2026.
+# correctly as of 7/16/2026. If this is turned back on...
+# See: https://github.com/orgs/pnpm/discussions/11084 for some discussion.
+# Enabling no-downgrade requires every transitive trust-policy violation to either be remediated
+# at the source or excluded below with a documented rationale. Run `flub check trustPolicy` to
+# surface current violations.
 trustPolicy: off
 # These exclusions are inert with trustPolicy disabled, but were kept in case we are able to restore trustPolicy enforcement
 # at some future point.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -227,7 +227,7 @@ peerDependencyRules:
 publicHoistPattern:
   - '@arethetypeswrong/cli'
 
-registry: https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/
+registry: https://packagefeedproxy.microsoft.io/npm/
 
 resolutionMode: highest
 
@@ -235,52 +235,9 @@ strictDepBuilds: true
 
 strictPeerDependencies: true
 
-# See: https://github.com/orgs/pnpm/discussions/11084 for some discussion.
-# Enabling no-downgrade requires every transitive trust-policy violation to either be remediated
-# at the source or excluded below with a documented rationale. Run `flub check trustPolicy` to
-# surface current violations.
-trustPolicy: no-downgrade
-trustPolicyExclude:
-  # @octokit/endpoint@9.0.6 (published 2025-02-14, by octokitbot) — pipeline regression.
-  # Prior trusted: @octokit/endpoint@10.1.3 (provenance, 2025-02-13, by octokitbot), with
-  # verified provenance from octokit/endpoint.js .github/workflows/release.yml @ refs/heads/main.
-  # Same publisher account (octokitbot); the v9 maintenance branch publish bypassed release.yml.
-  # Pulled in transitively via danger@13 → @octokit/rest@20 → @octokit/core@5 → @octokit/request@8.
-  # No reachable direct-dep bump escapes this without overriding @octokit/rest itself.
-  - "@octokit/endpoint@9.0.6"
-  # axios@0.30.3 is the last legitimate 0.30.x release (published 2026-02-18). The trust
-  # downgrade fires because 0.30.x was published via direct CLI rather than the OIDC/GitHub
-  # Actions provenance pipeline used by earlier versions. The compromised versions were
-  # 0.30.4 and 1.14.1 (supply chain attack on 2026-03-31, attributed to Sapphire Sleet).
-  # See: https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/
-  - "axios@0.30.3"
-  # chokidar@4.0.3 (published 2024-12-18, by paulmillr) — pipeline regression.
-  # Prior trusted: chokidar@4.0.1 (provenance, 2024-09-22, by paulmillr).
-  # Same publisher (sole maintainer); provenance attestation was dropped after 4.0.1.
-  # Pulled in transitively via mocha@11 (chokidar ^4.0.1) and sass@1 (chokidar ^4.0.0).
-  # chokidar@5.0.0 has restored provenance but no upstream consumer pins ^5 yet.
-  - "chokidar@4.0.3"
-  # detect-port@1.6.1 (published 2024-05-08, by fengmk2) — pipeline regression.
-  # Prior trusted: detect-port@1.6.0 (provenance, 2024-05-08, by fengmk2).
-  # Same publisher; provenance attestation was lost on the immediately-following patch release.
-  # Pulled in transitively under @fluidframework/azure-local-service.
-  - "detect-port@1.6.1"
-  # semver@5.7.2 (published 2023-07-10, by lukekarrys) — legacy maintenance line.
-  # Prior trusted: semver@7.5.4 (provenance, 2023-07-07, by npm-cli-ops).
-  # Different publisher account because the 5.x and 6.x maintenance lines are
-  # hand-published by lukekarrys (a long-time npm/node-semver maintainer), while the
-  # current 7.x line publishes through the npm-cli OIDC/Actions pipeline. The 5.x/6.x
-  # lines will not be retroactively re-published with provenance. Pulled in by widely-
-  # used legacy tooling that pins ^5 / ^6.
-  # Note: multiple versions of the same package must be combined with "||" — pnpm's
-  # trust-policy evaluator returns on the first name match and does not aggregate
-  # subsequent entries for the same package.
-  - "semver@5.7.2||6.3.1"
-  # undici-types@6.21.0 (published 2024-11-13, by matteo.collina) — pipeline regression.
-  # Prior trusted: undici-types@6.19.2 (provenance, 2024-06-18, by matteo.collina).
-  # Same publisher (undici project lead). Type-only package (.d.ts shipped from undici
-  # repo); provenance attestation was lost on a subsequent 6.x release.
-  - "undici-types@6.21.0"
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026.
+trustPolicy: off
 
 # Disable pnpm update notifications since we use corepack to install package managers
 updateNotifier: false

--- a/server/gitrest/pnpm-workspace.yaml
+++ b/server/gitrest/pnpm-workspace.yaml
@@ -11,13 +11,21 @@
 packages:
   - "packages/*"
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@fluidframework/*" # Exclude all @fluidframework scoped packages from the minimumReleaseAge check, because they are published internally and oftentimes we need to update immediately after a previous internal release
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/server/historian/pnpm-workspace.yaml
+++ b/server/historian/pnpm-workspace.yaml
@@ -11,13 +11,21 @@
 packages:
   - "packages/*"
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@fluidframework/*" # Exclude all @fluidframework scoped packages from the minimumReleaseAge check, because they are published internally and oftentimes we need to update immediately after a previous internal release
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/server/routerlicious/pnpm-workspace.yaml
+++ b/server/routerlicious/pnpm-workspace.yaml
@@ -11,11 +11,19 @@
 packages:
   - "packages/*"
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/tools/api-markdown-documenter/pnpm-workspace.yaml
+++ b/tools/api-markdown-documenter/pnpm-workspace.yaml
@@ -7,11 +7,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/tools/benchmark/pnpm-workspace.yaml
+++ b/tools/benchmark/pnpm-workspace.yaml
@@ -7,11 +7,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/tools/getkeys/pnpm-workspace.yaml
+++ b/tools/getkeys/pnpm-workspace.yaml
@@ -1,11 +1,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/tools/test-tools/pnpm-workspace.yaml
+++ b/tools/test-tools/pnpm-workspace.yaml
@@ -7,11 +7,19 @@
 packages:
   - "."
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -16,11 +16,19 @@ allowBuilds:
   linkcheck-bin: true
   unrs-resolver: true
 
+# Use the internal registry.npmjs.org mirror. This is required by network policies; see the root
+# pnpm-workspace.yaml for more details.
+registry: https://packagefeedproxy.microsoft.io/npm/
+
 # Supply chain security settings - see /DEV.md for documentation
 minimumReleaseAge: 1440
 resolutionMode: highest
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
+# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# correctly as of 7/16/2026. See the root pnpm-workspace.yaml and
+# https://github.com/orgs/pnpm/discussions/11084 for more discussion.
+# The exclusions below are inert while trustPolicy is disabled, but are kept in case we can restore enforcement later.
+trustPolicy: off
 # List of packages known to be safe but for whatever reason were published at a date after another version of the same
 # package (including later major versions) which had better provenance information.
 # ALWAYS REVIEW CAREFULLY BEFORE ADDING SOMETHING TO THIS LIST.


### PR DESCRIPTION
## Description

Follow-up to #27705 that addresses remaining pnpm workspaces in this repo.