### PR TITLE
Add file restrictions to ensure protection of user tokens

### DIFF
--- a/packages/utils/tool-utils/src/fluidToolRc.ts
+++ b/packages/utils/tool-utils/src/fluidToolRc.ts
@@ -38,9 +38,12 @@ export interface IResources {
 
 const getRCFileName = (): string => path.join(os.homedir(), ".fluidtoolrc");
 
-// TODO: Add documentation
-// eslint-disable-next-line jsdoc/require-description
 /**
+ * Loads the Fluid tool resource cache from `.fluidtoolrc` in the current user's home directory.
+ *
+ * @returns The parsed resources, or an empty object if the file does not exist or contains invalid
+ * JSON.
+ * @throws If the file exists but cannot be read.
  * @internal
  */
 export async function loadRC(): Promise<IResources> {
@@ -59,20 +62,44 @@ export async function loadRC(): Promise<IResources> {
 	return {};
 }
 
-// TODO: Add documentation
-// eslint-disable-next-line jsdoc/require-description
 /**
+ * Saves the Fluid tool resources to `.fluidtoolrc` in the current user's home directory.
+ *
+ * On POSIX filesystems, successful completion ensures the file has owner-only read/write
+ * permissions. Windows continues to rely on the access controls inherited from the user's home
+ * directory.
+ *
+ * @param rc - The resources to serialize and save.
+ * @throws If serialization, writing, or updating the file permissions fails. A permission-update
+ * failure occurs after the new contents have already been written.
  * @internal
  */
 export async function saveRC(rc: IResources): Promise<void> {
 	const writeFile = util.promisify(fs.writeFile);
+	const chmod = util.promisify(fs.chmod);
 	const content = JSON.stringify(rc, undefined, 2);
-	return writeFile(getRCFileName(), Buffer.from(content, "utf8"));
+	const fileName = getRCFileName();
+	// This per-user file holds ODSP access tokens and may also hold development secrets.
+	// On POSIX filesystems, `mode` creates a new file as owner-readable/writable only (0600).
+	// Because `mode` does not change an existing file, chmod also repairs caches that were
+	// previously created with broader permissions. On Windows, these calls normally succeed,
+	// but Node only uses the write bit: 0600 keeps the file writable without restricting who can
+	// read it. Confidentiality therefore depends on ACLs inherited from the user's home directory.
+	// If the filesystem rejects chmod, saveRC rejects after the file has already been written.
+	await writeFile(fileName, Buffer.from(content, "utf8"), { mode: 0o600 });
+	await chmod(fileName, 0o600);
 }
 
-// TODO: Add documentation
-// eslint-disable-next-line jsdoc/require-description
 /**
+ * Acquires the inter-process lock for `.fluidtoolrc` in the current user's home directory.
+ *
+ * The lock may be acquired before the resource file exists. While another process holds the lock,
+ * acquisition retries indefinitely. Locks whose modification time has not been updated for 60
+ * seconds are considered stale.
+ *
+ * @returns An asynchronous callback that releases the lock. The caller must invoke it after
+ * completing the protected operation, including when that operation fails.
+ * @throws If a filesystem error prevents the lock from being acquired.
  * @internal
  */
 export async function lockRC(): Promise<() => Promise<void>> {

--- a/packages/utils/tool-utils/src/test/fluidToolRc.spec.ts
+++ b/packages/utils/tool-utils/src/test/fluidToolRc.spec.ts
@@ -26,6 +26,7 @@ describe("fluidToolRc saveRC", () => {
 	let originalHome: string | undefined;
 	let originalUserProfile: string | undefined;
 
+	// Isolate each test from the user's real home directory and .fluidtoolrc file.
 	beforeEach(() => {
 		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "fluidtoolrc-test-"));
 		originalHome = process.env.HOME;
@@ -35,6 +36,7 @@ describe("fluidToolRc saveRC", () => {
 		process.env.USERPROFILE = tempHome;
 	});
 
+	// Restore the process environment and remove the isolated home directory after each test.
 	afterEach(() => {
 		if (originalHome === undefined) {
 			delete process.env.HOME;

--- a/packages/utils/tool-utils/src/test/fluidToolRc.spec.ts
+++ b/packages/utils/tool-utils/src/test/fluidToolRc.spec.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { loadRC, saveRC } from "../fluidToolRc.js";
+
+// Permission bits are not meaningful on Windows (chmod only toggles the read-only bit there).
+const itPosix = process.platform === "win32" ? it.skip : it;
+
+/**
+ * Returns the octal group/other permission digits of a file mode (e.g. "00" for 0600, "44" for 0644),
+ * avoiding bitwise operators (disallowed by the repo lint config).
+ */
+function groupOtherPerms(mode: number): string {
+	return mode.toString(8).slice(-2);
+}
+
+describe("fluidToolRc saveRC", () => {
+	let tempHome: string;
+	let originalHome: string | undefined;
+	let originalUserProfile: string | undefined;
+
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "fluidtoolrc-test-"));
+		originalHome = process.env.HOME;
+		originalUserProfile = process.env.USERPROFILE;
+		// getRCFileName() resolves os.homedir() at call time, which honors these on POSIX/Windows.
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		if (originalUserProfile === undefined) {
+			delete process.env.USERPROFILE;
+		} else {
+			process.env.USERPROFILE = originalUserProfile;
+		}
+		fs.rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	itPosix("creates ~/.fluidtoolrc with owner-only (0600) permissions", async () => {
+		await saveRC({ tokens: { version: 1, data: {} } });
+		const stat = fs.statSync(path.join(tempHome, ".fluidtoolrc"));
+		assert.strictEqual(
+			groupOtherPerms(stat.mode),
+			"00",
+			`expected no group/other permissions, got 0${stat.mode.toString(8).slice(-3)}`,
+		);
+	});
+
+	itPosix("repairs a pre-existing world-readable (0644) file to 0600", async () => {
+		const fileName = path.join(tempHome, ".fluidtoolrc");
+		fs.writeFileSync(fileName, "{}", { mode: 0o644 });
+		fs.chmodSync(fileName, 0o644); // force 0644 regardless of the process umask
+		await saveRC({ tokens: { version: 1, data: {} } });
+		const stat = fs.statSync(fileName);
+		assert.strictEqual(
+			groupOtherPerms(stat.mode),
+			"00",
+			`expected the existing file to be repaired to 0600, got 0${stat.mode.toString(8).slice(-3)}`,
+		);
+	});
+
+	it("round-trips saved content", async () => {
+		const rc = { tokens: { version: 1, data: { user1: {} } } };
+		await saveRC(rc);
+		assert.deepStrictEqual(await loadRC(), rc);
+	});
+});


### PR DESCRIPTION
Add file access restrictions to local file created that contains user tokens. Restrictions work on POSIX systems. On windows systems, still relies on correct permissions for folder structure to provide the protection.