### PR TITLE
feat(container-loader): add createEmptyRuntimeCodeLoader

### DIFF
--- a/.changeset/empty-runtime-code-loader.md
+++ b/.changeset/empty-runtime-code-loader.md
@@ -4,20 +4,23 @@
 ---
 Add support for containers backed by an empty, no-op runtime
 
-A new `@alpha` `createEmptyRuntimeCodeLoader` function is now exported from `@fluidframework/container-loader`.
-It returns an `ICodeDetailsLoader` whose loaded module produces a minimal, no-op container runtime.
+Two new `@alpha` functions are now exported from `@fluidframework/container-loader`: `createEmptyRuntimeCodeLoader`, which returns an `ICodeDetailsLoader` whose loaded module produces a minimal, no-op container runtime, and `createEmptyRuntimeFactory`, which returns just the underlying `IRuntimeFactory` for composing into an existing code loader.
 
 This is useful when you need the capabilities of an `IContainer` — such as loading, connecting to, or reading the pending state of an existing container — without wiring up a real container runtime.
 The empty runtime ignores all incoming ops and signals, and it never sends any ops or signals of its own.
 Because it has no content, it can only be used to load existing containers: creating a new (detached) container with it throws.
 
+Note that the "never sends ops or signals" guarantee comes from the runtime never invoking the `submit*` callbacks on its container context — the container still connects as a normal (potentially writable) client at the network layer.
+This complements the frozen container-loader utilities (such as `createFrozenDocumentServiceFactory`), which instead enforce read-only behavior at the network/driver layer.
+Callers who need network-layer read-only enforcement should pair the empty runtime with those utilities.
+
 ```typescript
 // ...
-const loader = new Loader({
+const container = await loadExistingContainer({
 	codeLoader: createEmptyRuntimeCodeLoader(),
 	documentServiceFactory,
 	urlResolver,
+	request: { url },
 });
-const container = await loader.resolve({ url });
 // ...
 ```

--- a/.changeset/empty-runtime-code-loader.md
+++ b/.changeset/empty-runtime-code-loader.md
@@ -7,9 +7,9 @@ Add support for containers backed by an empty, no-op runtime
 A new `@alpha` `createEmptyRuntimeCodeLoader` function is now exported from `@fluidframework/container-loader`.
 It returns an `ICodeDetailsLoader` whose loaded module produces a minimal, no-op container runtime.
 
-This is useful when you need the capabilities of an `IContainer` — such as loading, connecting to, or reading the pending state of a container — without wiring up a real container runtime.
+This is useful when you need the capabilities of an `IContainer` — such as loading, connecting to, or reading the pending state of an existing container — without wiring up a real container runtime.
 The empty runtime ignores all incoming ops and signals, and it never sends any ops or signals of its own.
-Because it has no content, it does not support summarization: attaching or serializing the container will throw.
+Because it has no content, it can only be used to load existing containers: creating a new (detached) container with it throws.
 
 ```typescript
 // ...

--- a/.changeset/empty-runtime-code-loader.md
+++ b/.changeset/empty-runtime-code-loader.md
@@ -1,0 +1,23 @@
+---
+"@fluidframework/container-loader": minor
+"__section": legacy
+---
+Add support for containers backed by an empty, no-op runtime
+
+A new `@alpha` `createEmptyRuntimeCodeLoader` function is now exported from `@fluidframework/container-loader`.
+It returns an `ICodeDetailsLoader` whose loaded module produces a minimal, no-op container runtime.
+
+This is useful when you need the capabilities of an `IContainer` — such as loading, connecting to, or reading the pending state of a container — without wiring up a real container runtime.
+The empty runtime ignores all incoming ops and signals, and it never sends any ops or signals of its own.
+Because it has no content, it does not support summarization: attaching or serializing the container will throw.
+
+```typescript
+// ...
+const loader = new Loader({
+	codeLoader: createEmptyRuntimeCodeLoader(),
+	documentServiceFactory,
+	urlResolver,
+});
+const container = await loader.resolve({ url });
+// ...
+```

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -27,6 +27,9 @@ export interface ContainerAlpha extends IContainer {
 export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
 
 // @alpha @legacy
+export function createEmptyRuntimeCodeLoader(): ICodeDetailsLoader_2;
+
+// @alpha @legacy
 export function createFrozenDocumentServiceFactory(factory?: IDocumentServiceFactory | Promise<IDocumentServiceFactory>, readOnly?: boolean): IDocumentServiceFactory;
 
 // @beta @legacy (undocumented)

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -30,6 +30,9 @@ export function createDetachedContainer(createDetachedContainerProps: ICreateDet
 export function createEmptyRuntimeCodeLoader(): ICodeDetailsLoader_2;
 
 // @alpha @legacy
+export function createEmptyRuntimeFactory(): IRuntimeFactory;
+
+// @alpha @legacy
 export function createFrozenDocumentServiceFactory(factory?: IDocumentServiceFactory | Promise<IDocumentServiceFactory>, readOnly?: boolean): IDocumentServiceFactory;
 
 // @beta @legacy (undocumented)

--- a/packages/loader/container-loader/src/emptyRuntime.ts
+++ b/packages/loader/container-loader/src/emptyRuntime.ts
@@ -28,12 +28,14 @@ import { loaderCoreCompatDetails } from "./loaderLayerCompatState.js";
  * A minimal, no-op {@link @fluidframework/container-definitions#IRuntime} implementation.
  *
  * @remarks
- * This runtime exists to give a host the full set of {@link @fluidframework/container-definitions#IContainer}
- * capabilities (connect, attach, storage, quorum, audience, etc.) without wiring up a real container runtime.
+ * This runtime exists to give a host the {@link @fluidframework/container-definitions#IContainer} capabilities
+ * (connect, storage, quorum, audience, etc.) of an already-existing container without wiring up a real container
+ * runtime.
  *
  * Nearly every member is a no-op, and it crucially never invokes any of the `submit*` callbacks on the
  * {@link @fluidframework/container-definitions#IContainerContext} it is given, so it can never send an op or a signal.
- * It has no content, so {@link EmptyRuntime.createSummary} throws; and {@link EmptyRuntime.getPendingLocalState}
+ * It has no content, so it can only load existing containers (its factory throws when asked to instantiate for a
+ * newly created container) and {@link EmptyRuntime.createSummary} throws; {@link EmptyRuntime.getPendingLocalState}
  * simply echoes back whatever pending state was provided on the context.
  */
 class EmptyRuntime implements IRuntime {
@@ -95,8 +97,13 @@ class EmptyRuntimeFactory implements IRuntimeFactory {
 
 	public async instantiateRuntime(
 		context: IContainerContext,
-		_existing: boolean,
+		existing: boolean,
 	): Promise<IRuntime> {
+		if (!existing) {
+			throw new UsageError(
+				"EmptyRuntime cannot create a new container; it can only be used to load existing ones",
+			);
+		}
 		return new EmptyRuntime(context.pendingLocalState);
 	}
 }
@@ -106,11 +113,13 @@ class EmptyRuntimeFactory implements IRuntimeFactory {
  * no-op container runtime.
  *
  * @remarks
- * Use this when you need the capabilities of an {@link @fluidframework/container-definitions#IContainer} (for example
- * to load, connect to, or serialize the pending state of a container) but do not want or need a real container
- * runtime. The runtime produced by this loader does almost nothing: it ignores all incoming ops and signals and,
- * most importantly, never sends any ops or signals of its own. Because it has no content, it does not support
- * summarization (attaching or serializing the container summary will throw).
+ * Use this when you need the {@link @fluidframework/container-definitions#IContainer} capabilities of an
+ * already-existing container (for example to load, connect to, or read the pending state of a container) but do not
+ * want or need a real container runtime. The runtime produced by this loader does almost nothing: it ignores all
+ * incoming ops and signals and, most importantly, never sends any ops or signals of its own.
+ *
+ * Because it has no content, it can only be used to load existing containers: creating a new (detached) container
+ * with it throws, as does attempting to summarize (attach or serialize) a container backed by it.
  *
  * @legacy @alpha
  */

--- a/packages/loader/container-loader/src/emptyRuntime.ts
+++ b/packages/loader/container-loader/src/emptyRuntime.ts
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
+import type {
+	AttachState,
+	ConnectionStatus,
+	ICodeDetailsLoader,
+	IContainerContext,
+	IFluidCodeDetails,
+	IFluidModuleWithDetails,
+	IGetPendingLocalStateProps,
+	IRuntime,
+	IRuntimeFactory,
+} from "@fluidframework/container-definitions/internal";
+import type { FluidObject } from "@fluidframework/core-interfaces";
+import type {
+	ISequencedDocumentMessage,
+	ISummaryTree,
+} from "@fluidframework/driver-definitions/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
+import { loaderCoreCompatDetails } from "./loaderLayerCompatState.js";
+
+/**
+ * A minimal, no-op {@link @fluidframework/container-definitions#IRuntime} implementation.
+ *
+ * @remarks
+ * This runtime exists to give a host the full set of {@link @fluidframework/container-definitions#IContainer}
+ * capabilities (connect, attach, storage, quorum, audience, etc.) without wiring up a real container runtime.
+ *
+ * Nearly every member is a no-op, and it crucially never invokes any of the `submit*` callbacks on the
+ * {@link @fluidframework/container-definitions#IContainerContext} it is given, so it can never send an op or a signal.
+ * It has no content, so {@link EmptyRuntime.createSummary} throws; and {@link EmptyRuntime.getPendingLocalState}
+ * simply echoes back whatever pending state was provided on the context.
+ */
+class EmptyRuntime implements IRuntime {
+	/**
+	 * Advertise compatibility with the Loader layer so the runtime/loader compatibility check passes cleanly.
+	 * The generation is borrowed from the Loader itself, which trivially satisfies the Loader's requirements.
+	 */
+	public readonly ILayerCompatDetails: ILayerCompatDetails = {
+		...loaderCoreCompatDetails,
+		supportedFeatures: new Set<string>(),
+	};
+
+	private _disposed = false;
+
+	public constructor(private readonly pendingLocalState: unknown) {}
+
+	public get disposed(): boolean {
+		return this._disposed;
+	}
+
+	public dispose(_error?: Error): void {
+		this._disposed = true;
+	}
+
+	public setConnectionState(_canSendOps: boolean, _clientId?: string): void {}
+
+	public setConnectionStatus(_status: ConnectionStatus): void {}
+
+	public process(_message: ISequencedDocumentMessage, _local: boolean): void {}
+
+	public processSignal(_message: unknown, _local: boolean): void {}
+
+	public createSummary(_blobRedirectTable?: Map<string, string>): ISummaryTree {
+		throw new UsageError("EmptyRuntime has no content and does not support summarization");
+	}
+
+	public setAttachState(_attachState: AttachState.Attaching | AttachState.Attached): void {}
+
+	public getPendingLocalState(_props?: IGetPendingLocalStateProps): unknown {
+		return this.pendingLocalState;
+	}
+
+	public async notifyOpReplay(_message: ISequencedDocumentMessage): Promise<void> {}
+
+	public async getEntryPoint(): Promise<FluidObject> {
+		return {};
+	}
+
+	public close(): void {}
+}
+
+/**
+ * An {@link @fluidframework/container-definitions#IRuntimeFactory} that only ever produces {@link EmptyRuntime}s.
+ */
+class EmptyRuntimeFactory implements IRuntimeFactory {
+	public get IRuntimeFactory(): IRuntimeFactory {
+		return this;
+	}
+
+	public async instantiateRuntime(
+		context: IContainerContext,
+		_existing: boolean,
+	): Promise<IRuntime> {
+		return new EmptyRuntime(context.pendingLocalState);
+	}
+}
+
+/**
+ * Creates an {@link @fluidframework/container-definitions#ICodeDetailsLoader} whose loaded module produces an empty,
+ * no-op container runtime.
+ *
+ * @remarks
+ * Use this when you need the capabilities of an {@link @fluidframework/container-definitions#IContainer} (for example
+ * to load, connect to, or serialize the pending state of a container) but do not want or need a real container
+ * runtime. The runtime produced by this loader does almost nothing: it ignores all incoming ops and signals and,
+ * most importantly, never sends any ops or signals of its own. Because it has no content, it does not support
+ * summarization (attaching or serializing the container summary will throw).
+ *
+ * @legacy @alpha
+ */
+export function createEmptyRuntimeCodeLoader(): ICodeDetailsLoader {
+	const factory = new EmptyRuntimeFactory();
+	return {
+		load: async (source: IFluidCodeDetails): Promise<IFluidModuleWithDetails> => {
+			return {
+				module: { fluidExport: { IRuntimeFactory: factory } },
+				details: source,
+			};
+		},
+	};
+}

--- a/packages/loader/container-loader/src/emptyRuntime.ts
+++ b/packages/loader/container-loader/src/emptyRuntime.ts
@@ -22,7 +22,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { loaderCoreCompatDetails } from "./loaderLayerCompatState.js";
+import { loaderCompatDetailsForRuntime } from "./loaderLayerCompatState.js";
 
 /**
  * A minimal, no-op {@link @fluidframework/container-definitions#IRuntime} implementation.
@@ -35,18 +35,16 @@ import { loaderCoreCompatDetails } from "./loaderLayerCompatState.js";
  * Nearly every member is a no-op, and it crucially never invokes any of the `submit*` callbacks on the
  * {@link @fluidframework/container-definitions#IContainerContext} it is given, so it can never send an op or a signal.
  * It has no content, so it can only load existing containers (its factory throws when asked to instantiate for a
- * newly created container) and {@link EmptyRuntime.createSummary} throws; {@link EmptyRuntime.getPendingLocalState}
- * simply echoes back whatever pending state was provided on the context.
+ * newly created container) and `createSummary` throws; `getPendingLocalState` simply echoes back whatever pending
+ * state was provided on the context.
  */
 class EmptyRuntime implements IRuntime {
 	/**
-	 * Advertise compatibility with the Loader layer so the runtime/loader compatibility check passes cleanly.
-	 * The generation is borrowed from the Loader itself, which trivially satisfies the Loader's requirements.
+	 * Advertise the Loader's own compatibility details across the Loader/Runtime boundary so the runtime/loader
+	 * compatibility check passes cleanly. Reusing the canonical constant (rather than re-deriving it) keeps the empty
+	 * runtime in lockstep with what a real runtime would need to satisfy.
 	 */
-	public readonly ILayerCompatDetails: ILayerCompatDetails = {
-		...loaderCoreCompatDetails,
-		supportedFeatures: new Set<string>(),
-	};
+	public readonly ILayerCompatDetails: ILayerCompatDetails = loaderCompatDetailsForRuntime;
 
 	private _disposed = false;
 
@@ -109,6 +107,21 @@ class EmptyRuntimeFactory implements IRuntimeFactory {
 }
 
 /**
+ * Creates an {@link @fluidframework/container-definitions#IRuntimeFactory} that produces an empty, no-op container
+ * runtime.
+ *
+ * @remarks
+ * See {@link createEmptyRuntimeCodeLoader} for the higher-level entry point and a description of the behavior of the
+ * runtime this factory produces. Use this function directly when you already have a code loader and just need the
+ * empty runtime factory to compose into it.
+ *
+ * @legacy @alpha
+ */
+export function createEmptyRuntimeFactory(): IRuntimeFactory {
+	return new EmptyRuntimeFactory();
+}
+
+/**
  * Creates an {@link @fluidframework/container-definitions#ICodeDetailsLoader} whose loaded module produces an empty,
  * no-op container runtime.
  *
@@ -124,7 +137,7 @@ class EmptyRuntimeFactory implements IRuntimeFactory {
  * @legacy @alpha
  */
 export function createEmptyRuntimeCodeLoader(): ICodeDetailsLoader {
-	const factory = new EmptyRuntimeFactory();
+	const factory = createEmptyRuntimeFactory();
 	return {
 		load: async (source: IFluidCodeDetails): Promise<IFluidModuleWithDetails> => {
 			return {

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -5,7 +5,10 @@
 
 export { ConnectionState } from "./connectionState.js";
 export { type ContainerAlpha, waitContainerToCatchUp, asLegacyAlpha } from "./container.js";
-export { createEmptyRuntimeCodeLoader } from "./emptyRuntime.js";
+export {
+	createEmptyRuntimeCodeLoader,
+	createEmptyRuntimeFactory,
+} from "./emptyRuntime.js";
 export { createFrozenDocumentServiceFactory } from "./frozenServices.js";
 export {
 	captureFullContainerState,

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -5,6 +5,7 @@
 
 export { ConnectionState } from "./connectionState.js";
 export { type ContainerAlpha, waitContainerToCatchUp, asLegacyAlpha } from "./container.js";
+export { createEmptyRuntimeCodeLoader } from "./emptyRuntime.js";
 export { createFrozenDocumentServiceFactory } from "./frozenServices.js";
 export {
 	captureFullContainerState,

--- a/packages/loader/container-loader/src/test/emptyRuntime.spec.ts
+++ b/packages/loader/container-loader/src/test/emptyRuntime.spec.ts
@@ -56,7 +56,7 @@ describe("createEmptyRuntimeCodeLoader", () => {
 		const factory = module.fluidExport.IRuntimeFactory;
 		assert(factory !== undefined, "module should export an IRuntimeFactory");
 
-		const runtime = await factory.instantiateRuntime(context, false);
+		const runtime = await factory.instantiateRuntime(context, true /* existing */);
 
 		// Exercise every member; a real runtime might send ops/signals in response to some of these.
 		const dummyMessage = {} as unknown as ISequencedDocumentMessage;
@@ -92,20 +92,17 @@ describe("createEmptyRuntimeCodeLoader", () => {
 		assert.strictEqual(signalsSent, 0, "empty runtime must never send signals");
 	});
 
-	it("does not support summarization (serialize throws)", async () => {
+	it("cannot create a new (detached) container", async () => {
 		const loader = new Loader({
 			codeLoader: createEmptyRuntimeCodeLoader(),
 			documentServiceFactory: documentServiceFactoryFailProxy,
 			urlResolver: failProxy(),
 		});
 
-		const detached = await loader.createDetachedContainer({ package: "none" });
-		assert.notStrictEqual(await detached.getEntryPoint(), undefined);
-
-		assert.throws(
-			() => detached.serialize(),
-			/does not support summarization/,
-			"serializing a container backed by the empty runtime should throw",
+		await assert.rejects(
+			async () => loader.createDetachedContainer({ package: "none" }),
+			/can only be used to load existing/,
+			"creating a detached container backed by the empty runtime should throw",
 		);
 	});
 });

--- a/packages/loader/container-loader/src/test/emptyRuntime.spec.ts
+++ b/packages/loader/container-loader/src/test/emptyRuntime.spec.ts
@@ -16,7 +16,7 @@ import type {
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 
-import { createEmptyRuntimeCodeLoader } from "../emptyRuntime.js";
+import { createEmptyRuntimeCodeLoader, createEmptyRuntimeFactory } from "../emptyRuntime.js";
 import { Loader } from "../loader.js";
 
 import { AbsentProperty, failProxy, failSometimeProxy } from "./failProxy.js";
@@ -104,5 +104,26 @@ describe("createEmptyRuntimeCodeLoader", () => {
 			/can only be used to load existing/,
 			"creating a detached container backed by the empty runtime should throw",
 		);
+	});
+
+	it("createEmptyRuntimeFactory produces the same empty runtime", async () => {
+		const factory = createEmptyRuntimeFactory();
+		assert.strictEqual(
+			factory.IRuntimeFactory,
+			factory,
+			"IRuntimeFactory should be the factory itself",
+		);
+
+		await assert.rejects(
+			async () => factory.instantiateRuntime(failSometimeProxy<IContainerContext>({}), false),
+			/can only be used to load existing/,
+			"instantiating for a new container should throw",
+		);
+
+		const runtime = await factory.instantiateRuntime(
+			failSometimeProxy<IContainerContext>({ pendingLocalState: undefined }),
+			true /* existing */,
+		);
+		assert.strictEqual(runtime.disposed, false, "runtime should start not disposed");
 	});
 });

--- a/packages/loader/container-loader/src/test/emptyRuntime.spec.ts
+++ b/packages/loader/container-loader/src/test/emptyRuntime.spec.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type { IProvideLayerCompatDetails } from "@fluid-internal/client-utils";
+import { AttachState } from "@fluidframework/container-definitions";
+import type {
+	ConnectionStatus,
+	IContainerContext,
+} from "@fluidframework/container-definitions/internal";
+import type {
+	IDocumentServiceFactory,
+	ISequencedDocumentMessage,
+} from "@fluidframework/driver-definitions/internal";
+
+import { createEmptyRuntimeCodeLoader } from "../emptyRuntime.js";
+import { Loader } from "../loader.js";
+
+import { AbsentProperty, failProxy, failSometimeProxy } from "./failProxy.js";
+
+const documentServiceFactoryFailProxy = failSometimeProxy<
+	IDocumentServiceFactory & IProvideLayerCompatDetails
+>({
+	ILayerCompatDetails: AbsentProperty,
+});
+
+describe("createEmptyRuntimeCodeLoader", () => {
+	it("produces a runtime that never sends ops or signals", async () => {
+		let opsSent = 0;
+		let signalsSent = 0;
+		const pendingLocalState = { stashed: "state" };
+		const context = failSometimeProxy<IContainerContext>({
+			pendingLocalState,
+			submitFn: () => {
+				opsSent++;
+				return 0;
+			},
+			submitBatchFn: () => {
+				opsSent++;
+				return 0;
+			},
+			submitSummaryFn: () => {
+				opsSent++;
+				return 0;
+			},
+			submitSignalFn: () => {
+				signalsSent++;
+			},
+		});
+
+		const codeLoader = createEmptyRuntimeCodeLoader();
+		const { module } = await codeLoader.load({ package: "none" });
+		const factory = module.fluidExport.IRuntimeFactory;
+		assert(factory !== undefined, "module should export an IRuntimeFactory");
+
+		const runtime = await factory.instantiateRuntime(context, false);
+
+		// Exercise every member; a real runtime might send ops/signals in response to some of these.
+		const dummyMessage = {} as unknown as ISequencedDocumentMessage;
+		runtime.setConnectionState(true, "client-id");
+		runtime.setConnectionStatus?.({} as unknown as ConnectionStatus);
+		runtime.process(dummyMessage, true);
+		runtime.processSignal({}, true);
+		runtime.setAttachState(AttachState.Attaching);
+		await runtime.notifyOpReplay?.(dummyMessage);
+
+		assert.throws(
+			() => runtime.createSummary(),
+			/does not support summarization/,
+			"empty runtime should throw when asked to summarize",
+		);
+		assert.strictEqual(
+			runtime.getPendingLocalState(),
+			pendingLocalState,
+			"getPendingLocalState should echo the pending state provided on the context",
+		);
+		assert.notStrictEqual(
+			await runtime.getEntryPoint(),
+			undefined,
+			"getEntryPoint should resolve to an entry point object",
+		);
+
+		assert.strictEqual(runtime.disposed, false);
+		runtime.close?.();
+		runtime.dispose();
+		assert.strictEqual(runtime.disposed, true, "runtime should be disposed after dispose()");
+
+		assert.strictEqual(opsSent, 0, "empty runtime must never send ops");
+		assert.strictEqual(signalsSent, 0, "empty runtime must never send signals");
+	});
+
+	it("does not support summarization (serialize throws)", async () => {
+		const loader = new Loader({
+			codeLoader: createEmptyRuntimeCodeLoader(),
+			documentServiceFactory: documentServiceFactoryFailProxy,
+			urlResolver: failProxy(),
+		});
+
+		const detached = await loader.createDetachedContainer({ package: "none" });
+		assert.notStrictEqual(await detached.getEntryPoint(), undefined);
+
+		assert.throws(
+			() => detached.serialize(),
+			/does not support summarization/,
+			"serializing a container backed by the empty runtime should throw",
+		);
+	});
+});

--- a/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
+++ b/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 
 import {
+	asLegacyAlpha,
 	createDetachedContainer,
 	createEmptyRuntimeCodeLoader,
 	loadExistingContainer,
@@ -19,6 +20,7 @@ import type {
 import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
+	type ITestFluidObject,
 	timeoutPromise,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
@@ -172,6 +174,82 @@ describe("createEmptyRuntimeCodeLoader (local server)", () => {
 			"creating an empty-runtime container should throw because it can only load existing containers",
 		);
 
+		await deltaConnectionServer.webSocketServer.close();
+	});
+
+	it("round-trips a container's pending runtime state opaquely", async () => {
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const { urlResolver, codeDetails, codeLoader, loaderProps, documentServiceFactory } =
+			createLoader({ deltaConnectionServer });
+
+		// 1. Create + attach a real container, write data, go offline, and write more so
+		//    the captured pending state carries a non-empty pendingRuntimeState.
+		const realContainer = asLegacyAlpha(
+			await createDetachedContainer({ codeDetails, ...loaderProps }),
+		);
+		const realObject = (await realContainer.getEntryPoint()) as ITestFluidObject;
+		await realContainer.attach(urlResolver.createCreateNewRequest("emptyRuntimePending"));
+		await waitForContainerConnection(realContainer);
+		realObject.root.set("attached", "value-attached");
+		const url = await realContainer.getAbsoluteUrl("");
+		assert(url !== undefined, "attached container should provide an absolute url");
+
+		realContainer.disconnect();
+		realObject.root.set("offline", "value-offline");
+		const pendingFromReal = await realContainer.getPendingLocalState();
+		realContainer.close();
+
+		const parsedReal = JSON.parse(pendingFromReal) as { pendingRuntimeState?: unknown };
+		assert(
+			parsedReal.pendingRuntimeState !== undefined,
+			"the real container should produce a pendingRuntimeState",
+		);
+
+		// 2. Load the same document with the empty runtime, handing it the pending state.
+		//    The empty runtime holds the pendingRuntimeState opaquely (it does not resubmit it).
+		const emptyContainer = asLegacyAlpha(
+			await loadExistingContainer({
+				codeLoader: createEmptyRuntimeCodeLoader(),
+				documentServiceFactory,
+				urlResolver,
+				request: { url },
+				pendingLocalState: pendingFromReal,
+			}),
+		);
+
+		// 3. Serializing the empty container echoes the pendingRuntimeState back out unchanged.
+		const pendingFromEmpty = await emptyContainer.getPendingLocalState();
+		emptyContainer.close();
+		const parsedEmpty = JSON.parse(pendingFromEmpty) as { pendingRuntimeState?: unknown };
+		assert.deepStrictEqual(
+			parsedEmpty.pendingRuntimeState,
+			parsedReal.pendingRuntimeState,
+			"the empty runtime should echo the pendingRuntimeState opaquely",
+		);
+
+		// 4. A real runtime can resume from the empty runtime's output: the offline edit that
+		//    only ever lived in the pending state survives the round-trip through the empty runtime.
+		const resumedContainer = await loadExistingContainer({
+			codeLoader,
+			documentServiceFactory,
+			urlResolver,
+			request: { url },
+			pendingLocalState: pendingFromEmpty,
+		});
+		const resumedObject = (await resumedContainer.getEntryPoint()) as ITestFluidObject;
+		await waitForContainerConnection(resumedContainer);
+		assert.strictEqual(
+			resumedObject.root.get("attached"),
+			"value-attached",
+			"attached data should survive the round-trip",
+		);
+		assert.strictEqual(
+			resumedObject.root.get("offline"),
+			"value-offline",
+			"offline pending edit should survive the round-trip through the empty runtime",
+		);
+
+		resumedContainer.close();
 		await deltaConnectionServer.webSocketServer.close();
 	});
 });

--- a/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
+++ b/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
@@ -60,6 +60,10 @@ function spyOnOutbound(inner: IDocumentServiceFactory): {
 				}
 				if (prop === "submitSignal") {
 					return (content: string, targetClientId?: string): void => {
+						// Unlike ops (where the container/delta-manager sends system ops such as noops
+						// directly over the connection), the loader layer has no signal path of its own:
+						// Container.submitSignal is wired exclusively to the runtime's context.submitSignalFn.
+						// So every signal seen here is attributable to the runtime, and no filtering is needed.
 						counts.signals++;
 						target.submitSignal(content, targetClientId);
 					};

--- a/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
+++ b/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
@@ -150,23 +150,22 @@ describe("createEmptyRuntimeCodeLoader (local server)", () => {
 		await deltaConnectionServer.webSocketServer.close();
 	});
 
-	it("cannot attach a detached container because it has no summary", async () => {
+	it("cannot create a new (detached) container because it has no summary", async () => {
 		const deltaConnectionServer = LocalDeltaConnectionServer.create();
 		const { urlResolver, codeDetails, documentServiceFactory } = createLoader({
 			deltaConnectionServer,
 		});
 
-		const detached = await createDetachedContainer({
-			codeDetails,
-			codeLoader: createEmptyRuntimeCodeLoader(),
-			documentServiceFactory,
-			urlResolver,
-		});
-
 		await assert.rejects(
-			async () => detached.attach(urlResolver.createCreateNewRequest("emptyRuntimeAttach")),
-			/does not support summarization/,
-			"attaching an empty-runtime container should throw because it has no summary",
+			async () =>
+				createDetachedContainer({
+					codeDetails,
+					codeLoader: createEmptyRuntimeCodeLoader(),
+					documentServiceFactory,
+					urlResolver,
+				}),
+			/can only be used to load existing/,
+			"creating an empty-runtime container should throw because it can only load existing containers",
 		);
 
 		await deltaConnectionServer.webSocketServer.close();

--- a/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
+++ b/packages/test/local-server-tests/src/test/emptyRuntimeCodeLoader.spec.ts
@@ -1,0 +1,174 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import {
+	createDetachedContainer,
+	createEmptyRuntimeCodeLoader,
+	loadExistingContainer,
+} from "@fluidframework/container-loader/internal";
+import type {
+	IDocumentDeltaConnection,
+	IDocumentMessage,
+	IDocumentService,
+	IDocumentServiceFactory,
+} from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+	timeoutPromise,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils/internal";
+
+import { createLoader } from "./utils.js";
+
+interface OutboundCounts {
+	/**
+	 * Number of application ops (`MessageType.Operation`) submitted over the wire.
+	 * System ops the container layer may send on its own (join, noop, ...) are excluded
+	 * so the count is attributable to the runtime.
+	 */
+	appOps: number;
+	/**
+	 * Number of signals submitted over the wire.
+	 */
+	signals: number;
+}
+
+/**
+ * Wraps a document service factory so that every application op (`submit`) and signal
+ * (`submitSignal`) sent over any delta connection it creates is counted. This lets a
+ * test prove that a runtime never sends anything of its own over the wire.
+ */
+function spyOnOutbound(inner: IDocumentServiceFactory): {
+	documentServiceFactory: IDocumentServiceFactory;
+	counts: OutboundCounts;
+} {
+	const counts: OutboundCounts = { appOps: 0, signals: 0 };
+
+	const wrapConnection = (connection: IDocumentDeltaConnection): IDocumentDeltaConnection =>
+		new Proxy(connection, {
+			get: (target, prop, receiver): unknown => {
+				if (prop === "submit") {
+					return (messages: IDocumentMessage[]): void => {
+						counts.appOps += messages.filter((m) => m.type === MessageType.Operation).length;
+						target.submit(messages);
+					};
+				}
+				if (prop === "submitSignal") {
+					return (content: string, targetClientId?: string): void => {
+						counts.signals++;
+						target.submitSignal(content, targetClientId);
+					};
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+		});
+
+	const wrapService = (service: IDocumentService): IDocumentService =>
+		new Proxy(service, {
+			get: (target, prop, receiver): unknown => {
+				if (prop === "connectToDeltaStream") {
+					return async (
+						...args: Parameters<IDocumentService["connectToDeltaStream"]>
+					): Promise<IDocumentDeltaConnection> =>
+						wrapConnection(await target.connectToDeltaStream(...args));
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+		});
+
+	const documentServiceFactory: IDocumentServiceFactory = {
+		createContainer: async (...args) => wrapService(await inner.createContainer(...args)),
+		createDocumentService: async (...args) =>
+			wrapService(await inner.createDocumentService(...args)),
+	};
+	return { documentServiceFactory, counts };
+}
+
+describe("createEmptyRuntimeCodeLoader (local server)", () => {
+	it("loads and connects to an existing container without a runtime, sending no ops or signals", async () => {
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const { urlResolver, codeDetails, loaderProps, documentServiceFactory } = createLoader({
+			deltaConnectionServer,
+		});
+
+		// Create and attach a real container so there is a document in the server to load.
+		const creator = await createDetachedContainer({ codeDetails, ...loaderProps });
+		await creator.attach(urlResolver.createCreateNewRequest("emptyRuntimeTest"));
+		await waitForContainerConnection(creator);
+		const url = await creator.getAbsoluteUrl("");
+		assert(url !== undefined, "creator should provide an absolute url");
+
+		// Load the same document with the empty runtime code loader, spying on outbound traffic.
+		const { documentServiceFactory: spyFactory, counts } =
+			spyOnOutbound(documentServiceFactory);
+		const emptyContainer = await loadExistingContainer({
+			codeLoader: createEmptyRuntimeCodeLoader(),
+			documentServiceFactory: spyFactory,
+			urlResolver,
+			request: { url },
+		});
+		await waitForContainerConnection(emptyContainer);
+
+		// The full set of IContainer capabilities is available without a runtime.
+		assert(emptyContainer.clientId !== undefined, "empty container should have a clientId");
+		assert.notStrictEqual(
+			await emptyContainer.getEntryPoint(),
+			undefined,
+			"empty container should expose an entry point",
+		);
+
+		// The empty container participates in the session: it sees itself in its audience.
+		await timeoutPromise(
+			(resolve) => {
+				const clientId = emptyContainer.clientId;
+				assert(clientId !== undefined);
+				if (emptyContainer.audience.getMember(clientId) !== undefined) {
+					resolve();
+					return;
+				}
+				emptyContainer.audience.on("addMember", (newClientId: string) => {
+					if (newClientId === clientId) {
+						resolve();
+					}
+				});
+			},
+			{ durationMs: 3000, errorMsg: "empty container's audience should contain itself" },
+		);
+
+		// Give any stray op/signal a chance to flush, then assert the runtime sent nothing.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		assert.strictEqual(counts.appOps, 0, "empty runtime must not send any ops");
+		assert.strictEqual(counts.signals, 0, "empty runtime must not send any signals");
+
+		emptyContainer.close();
+		creator.close();
+		await deltaConnectionServer.webSocketServer.close();
+	});
+
+	it("cannot attach a detached container because it has no summary", async () => {
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const { urlResolver, codeDetails, documentServiceFactory } = createLoader({
+			deltaConnectionServer,
+		});
+
+		const detached = await createDetachedContainer({
+			codeDetails,
+			codeLoader: createEmptyRuntimeCodeLoader(),
+			documentServiceFactory,
+			urlResolver,
+		});
+
+		await assert.rejects(
+			async () => detached.attach(urlResolver.createCreateNewRequest("emptyRuntimeAttach")),
+			/does not support summarization/,
+			"attaching an empty-runtime container should throw because it has no summary",
+		);
+
+		await deltaConnectionServer.webSocketServer.close();
+	});
+});


### PR DESCRIPTION
## Description

Adds a new `@alpha` `createEmptyRuntimeCodeLoader` free function to
`@fluidframework/container-loader`. It returns an `ICodeDetailsLoader` whose loaded
module instantiates a minimal, no-op container runtime.

This gives hosts the full set of `IContainer` capabilities (load, connect,
audience/quorum, read pending state) without needing to wire up a real container
runtime. The empty runtime:

- ignores all incoming ops and signals,
- never sends any ops or signals of its own,
- throws from `createSummary` (so attach/serialize are unsupported, since it has no
  content), and
- echoes back whatever pending local state was provided on the container context.

The composition follows the existing container-loader pattern: free function →
`ICodeDetailsLoader` → `IRuntimeFactory` → no-op `IRuntime`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This is a **draft**: additional `local-server-tests` coverage is in progress. Unit
tests in `container-loader` are included and passing.
