### PR TITLE
perf(client-tree): optimize NestedMap build

### DIFF
--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -106,7 +106,6 @@ export {
 	hasSingle,
 	defineLazyCachedProperty,
 	copyPropertyIfDefined as copyProperty,
-	getOrAddInMap,
 	iterableHasSome,
 } from "./utils.js";
 export { ReferenceCountedBase, type ReferenceCounted } from "./referenceCounting.js";

--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -5,7 +5,7 @@
 
 import { oob } from "@fluidframework/core-utils/internal";
 
-import { getOrAddInMap, getOrCreate } from "./utils.js";
+import { getOrCreate } from "./utils.js";
 
 /**
  * A dictionary whose values are keyed off of two objects (key1, key2).
@@ -73,6 +73,23 @@ export function populateNestedMap<Key1, Key2, Value>(
 }
 
 /**
+ * Sets the value at `key` in map to new Map if not already present.
+ * Returns the value at `key` after setting it.
+ */
+function getOrAddInMap<Key1, Key2, Value>(
+	map: NestedMap<Key1, Key2, Value>,
+	key1: Key1,
+): Map<Key2, Value> {
+	const currentValue = map.get(key1);
+	if (currentValue !== undefined) {
+		return currentValue;
+	}
+	const value = new Map<Key2, Value>();
+	map.set(key1, value);
+	return value;
+}
+
+/**
  * Sets the value at (key1, key2) in map to value.
  * If there already is a value for (key1, key2), it is replaced with the provided one.
  */
@@ -82,7 +99,7 @@ export function setInNestedMap<Key1, Key2, Value>(
 	key2: Key2,
 	value: Value,
 ): void {
-	const innerMap = getOrAddInMap(map, key1, new Map<Key2, Value>());
+	const innerMap = getOrAddInMap(map, key1);
 	innerMap.set(key2, value);
 }
 
@@ -95,7 +112,7 @@ export function getOrCreateInNestedMap<Key1, Key2, Value>(
 	key2: Key2,
 	defaultValue: (key1: Key1, key2: Key2) => Value,
 ): Value {
-	const innerMap = getOrAddInMap(map, key1, new Map<Key2, Value>());
+	const innerMap = getOrAddInMap(map, key1);
 	return getOrCreate(innerMap, key2, (): Value => defaultValue(key1, key2));
 }
 
@@ -193,7 +210,7 @@ export function nestedMapFromFlatList<Key1, Key2, Value>(
 ): NestedMap<Key1, Key2, Value> {
 	const map = new Map<Key1, Map<Key2, Value>>();
 	for (const [key1, key2, val] of list) {
-		getOrAddInMap(map, key1, new Map<Key2, Value>()).set(key2, val);
+		getOrAddInMap(map, key1).set(key2, val);
 	}
 	return map;
 }

--- a/packages/dds/tree/src/util/nestedSet.ts
+++ b/packages/dds/tree/src/util/nestedSet.ts
@@ -5,7 +5,7 @@
 
 import { type NestedMap, getOrDefaultInNestedMap, setInNestedMap } from "./nestedMap.js";
 
-export type NestedSet<Key1, Key2> = NestedMap<Key1, Key2, boolean>;
+export type NestedSet<Key1, Key2> = NestedMap<Key1, Key2, true>;
 
 export function addToNestedSet<Key1, Key2>(
 	set: NestedSet<Key1, Key2>,

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -193,24 +193,6 @@ export function compareSets<T>({
 }
 
 /**
- * Sets the value at `key` in map to value if not already present.
- * Returns the value at `key` after setting it.
- * This is equivalent to a get or default that adds the default to the map.
- */
-export function getOrAddInMap<Key, Value>(
-	map: MapGetSet<Key, Value>,
-	key: Key,
-	value: Value,
-): Value {
-	const currentValue = map.get(key);
-	if (currentValue !== undefined) {
-		return currentValue;
-	}
-	map.set(key, value);
-	return value;
-}
-
-/**
  * Retrieve a value from a map with the given key, or create a new entry if the key is not in the map.
  * @param map - The map to query/update
  * @param key - The key to lookup in the map


### PR DESCRIPTION
`getOrAddInMap` is only used by `NestedMap` and always with a newly constructed Map that may or may not be used. Relocate `getOrAddInMap` to nestedMap.ts where it is needed and embed new Map construction only when it is actually needed.

This avoid unused construction and dispose cases as well as reduces code size.

Additionally, add type clarity: `NestedSet` will (should) only ever store `true` as its values. Enforce that by changing the value type to `true` instead of `boolean`.