### PR TITLE
build: tag untagged asserts for 2.112.0 release

### DIFF
--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1786,7 +1786,6 @@ export const shortCodeMap = {
 	"0xc53": "Couldn't find a matching storage ID",
 	"0xc54": "Unexpected leaf value",
 	"0xc55": "Cannot switch branches during a transaction",
-	"0xc56": "Branch does not exist",
 	"0xc57": "Branch summary must have a base",
 	"0xc58": "Main branch must exist",
 	"0xc59": "Expected branch to already exist",


### PR DESCRIPTION
## Description

Part of release prep for **2.112.0** (Step 1 of minor release prep).

Ran `pnpm run policy-check:asserts` (`flub generate assertTags --all`). No new untagged asserts were found; the only change is removal of a stale, unreferenced short-code entry (`0xc56`) from `assertionShortCodesMap.ts` whose source assert no longer exists.

This PR must merge before the version bump PR for this release.
