### PR TITLE
fix(ci): update labeler config files to actions/labeler v6 schema

### DIFF
--- a/.github/labeler-areas.yml
+++ b/.github/labeler-areas.yml
@@ -4,7 +4,7 @@
 # see how this config file is used.
 
 "area: build":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - ".github/*"
       - ".github/workflows/**"
@@ -14,121 +14,121 @@
       - "tools/pipelines/**"
 
 "area: contributor experience":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: ".vscode/**"
 
 "area: dds":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - experimental/dds/**
       - packages/dds/**
 
 "area: dds: tree":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - experimental/dds/tree/**
       - experimental/dds/tree2/**
       - packages/dds/tree/**
 
 "area: dds: propertydds":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: experimental/PropertyDDS/**
 
 "area: dds: sharedstring":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: packages/dds/sequence/**
 
 "area: definitions":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - common/lib/container-definitions/**
       - common/lib/core-interfaces/**
       - common/lib/driver-definitions/**
 
 "area: dev experience":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: experimental/framework/**
 
 "area: driver":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: packages/drivers/**
 
 "area: examples":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - examples/**
       - experimental/examples/**
 
 "area: framework":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: packages/framework/**
 
 "area: loader":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: packages/loader/**
 
 "area: odsp-driver":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - packages/drivers/*odsp*/**
       - packages/utils/odsp-doclib-utils/**
 
 # Add "area: repo" label to any root or .github changes
 "area: repo":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - "*"
       - ".github/**"
       - "!BREAKING.md"
 
 "area: runtime":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: packages/runtime/**
 
 "area: server":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: server/**
 
 "area: tests":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: packages/test/**
 
 "area: tools":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - common/build/**
       - tools/**
       - "!tools/markdown-magic/**"
 
 "area: website":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - website/**
       - "!website/docs/**"
 
 "breaking change":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: BREAKING.md
 
 "changeset-present":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - .changeset/**
       - server/routerlicious/.changeset/**
 
 dependencies:
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - package-lock.json
       - pnpm-lock.yaml
 
 documentation:
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file:
       - website/docs/**
       - website/src/**
 
 # flag changes to public APIs so they can be reviewed to see if they're breaking
 "public api change":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: "**/api-report/**"

--- a/.github/labeler-changesets.yml
+++ b/.github/labeler-changesets.yml
@@ -5,5 +5,5 @@
 
 # Require changesets for server public API changes
 "changeset-required":
-  changed-files:
+  - changed-files:
     - any-glob-to-any-file: "**/routerlicious/api-report/**"


### PR DESCRIPTION
## Description

The `pr-labeler.yml` workflow uses `actions/labeler@v6` (pinned via SHA, ratchet comment `v6`), but `.github/labeler-areas.yml` and `.github/labeler-changesets.yml` were still written in the older `actions/labeler@v5` schema, where each label maps directly to a `changed-files` object. v6 requires each label to map to a **list** of match config objects instead.

This schema mismatch made every run of the "Pull Request Labeler" workflow fail with:
```
found unexpected type for label 'area: build' (should be array of config options)
```
As a result, no `area: *` labels, `changeset-present`, or `changeset-required` labels have been applied automatically since ~Dec 2, 2025, and the workflow was subsequently disabled (`disabled_manually`) after the repeated failures. I've verified this against several recent merged PRs that touched `.changeset/*.md` files but never received the `changeset-present` label.

This PR fixes both YAML files to the v6 array schema and re-enables the workflow.

- Before: `gh run list --workflow=pr-labeler.yml` shows 100% failures with the annotation above.
- After: this PR itself is the test, since it modifies `.github/**`, which triggers `pr-labeler.yml`. Check the Actions tab on this PR — the "Label areas" and "Label changeset-required" jobs should now succeed, and this PR should pick up the `area: build` label.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- Please confirm the "Pull Request Labeler" workflow run on this PR succeeds and applies the expected labels before merging.