### PR TITLE
Revert feed changes and add utility script for internal developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Enable NodeJs's [corepack](https://github.com/nodejs/corepack/blob/main/README.m
 corepack enable
 ```
 
+> [!NOTE]
+> **Microsoft developers:** due to internal policy changes, the public npm registry
+> (`registry.npmjs.org`) is blocked on managed devices. Before running `pnpm install`, point the
+> workspaces at a non-blocked registry (an internal mirror or team-managed feed) by running:
+>
+> ```shell
+> node ./scripts/set-dev-registry.cjs <registry-url>
+> ```
+>
+> This writes a gitignored `.npmrc` into each workspace; run `node ./scripts/set-dev-registry.cjs --clear`
+> to revert. Refer to internal documentation for the registry URL to use. External/OSS
+> contributors can skip this step: the committed default already uses the public registry.
+
 Run the following to build the client packages:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -101,17 +101,9 @@ corepack enable
 ```
 
 > [!NOTE]
-> **Microsoft developers:** due to internal policy changes, the public npm registry
-> (`registry.npmjs.org`) is blocked on managed devices. Before running `pnpm install`, point the
-> workspaces at a non-blocked registry (an internal mirror or team-managed feed) by running:
->
-> ```shell
-> node ./scripts/set-dev-registry.cjs <registry-url>
-> ```
->
-> This writes a gitignored `.npmrc` into each workspace; run `node ./scripts/set-dev-registry.cjs --clear`
-> to revert. Refer to internal documentation for the registry URL to use. External/OSS
-> contributors can skip this step: the committed default already uses the public registry.
+> **Microsoft developers:** due to internal policy, the public npm registry (`registry.npmjs.org`) is blocked on managed devices.
+> Refer to our internal team onboarding guidance for details on how to contribute, either by getting an exception or by using
+> the helper script at `scripts/set-dev-registry.cjs` appropriately.
 
 Run the following to build the client packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -227,7 +227,14 @@ peerDependencyRules:
 publicHoistPattern:
   - '@arethetypeswrong/cli'
 
-registry: https://packagefeedproxy.microsoft.io/npm/
+# No `registry` is set here on purpose. pnpm resolves the built-in default (registry.npmjs.org),
+# which keeps external/OSS contributions working out of the box, and also keeps lockfile updates
+# pointed at the public registry.
+# NOTE: a `registry` value in pnpm-workspace.yaml takes precedence over a project-level `.npmrc`,
+# so setting it here (even to registry.npmjs.org) would silently defeat the per-developer override
+# below. Leave it unset instead.
+# Developers who must use an npmjs mirror or team-managed feed can make use of
+# `node ./scripts/set-dev-registry.cjs <registry-url>`.
 
 resolutionMode: highest
 
@@ -235,7 +242,8 @@ strictDepBuilds: true
 
 strictPeerDependencies: true
 
-# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# The artifact feeds used by CI and by internal developers (see the registry note above)
+# do not preserve all the npm package metadata necessary for this pnpm feature to function
 # correctly as of 7/16/2026. If this is turned back on...
 # See: https://github.com/orgs/pnpm/discussions/11084 for some discussion.
 # Enabling no-downgrade requires every transitive trust-policy violation to either be remediated

--- a/scripts/set-dev-registry.cjs
+++ b/scripts/set-dev-registry.cjs
@@ -41,13 +41,9 @@ const repoRoot = path.resolve(__dirname, "..");
 // Directory names that should never be traversed while discovering workspaces.
 const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
 
-// Path fragments that identify workspaces which are test fixtures or managed separately with their
-// own lockfiles, and therefore should not receive the override.
-const EXCLUDED_FRAGMENTS = [path.join("build-infrastructure", "src", "test", "data")];
-
 /**
  * Recursively find every directory under `dir` that contains a `pnpm-workspace.yaml`, excluding
- * skipped directories and the excluded fragments above.
+ * skipped directories above.
  * @param {string} dir Absolute directory to search.
  * @param {string[]} found Accumulator of absolute workspace-root paths.
  * @returns {string[]} `found`.
@@ -68,11 +64,7 @@ function findWorkspaceRoots(dir, found) {
 		if (!entry.isDirectory() || SKIP_DIR_NAMES.has(entry.name)) {
 			continue;
 		}
-		const child = path.join(dir, entry.name);
-		if (EXCLUDED_FRAGMENTS.some((fragment) => child.includes(fragment))) {
-			continue;
-		}
-		findWorkspaceRoots(child, found);
+		findWorkspaceRoots(path.join(dir, entry.name), found);
 	}
 
 	return found;
@@ -143,13 +135,16 @@ function main() {
 	for (const root of roots) {
 		const npmrcPath = path.join(root, ".npmrc");
 		const rel = path.relative(repoRoot, root) || ".";
+		const existing = fs.existsSync(npmrcPath)
+			? fs.readFileSync(npmrcPath, "utf8")
+			: undefined;
+		const managed = existing !== undefined && existing.startsWith(MARKER);
 
 		if (clear) {
-			if (!fs.existsSync(npmrcPath)) {
+			if (existing === undefined) {
 				continue;
 			}
-			const existing = fs.readFileSync(npmrcPath, "utf8");
-			if (!existing.startsWith(MARKER)) {
+			if (!managed) {
 				console.warn(`Skipping ${rel}/.npmrc (not managed by this script).`);
 				continue;
 			}
@@ -157,10 +152,7 @@ function main() {
 			console.log(`Removed ${rel}/.npmrc`);
 			changed++;
 		} else {
-			const existing = fs.existsSync(npmrcPath)
-				? fs.readFileSync(npmrcPath, "utf8")
-				: undefined;
-			if (existing !== undefined && !existing.startsWith(MARKER)) {
+			if (existing !== undefined && !managed) {
 				console.warn(
 					`Skipping ${rel}/.npmrc (already exists and is not managed by this script).`,
 				);

--- a/scripts/set-dev-registry.cjs
+++ b/scripts/set-dev-registry.cjs
@@ -43,10 +43,7 @@ const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
 
 // Path fragments that identify workspaces which are test fixtures or managed separately with their
 // own lockfiles, and therefore should not receive the override.
-const EXCLUDED_FRAGMENTS = [
-	path.join("build-infrastructure", "src", "test", "data"),
-	"compat-workspaces",
-];
+const EXCLUDED_FRAGMENTS = [path.join("build-infrastructure", "src", "test", "data")];
 
 /**
  * Recursively find every directory under `dir` that contains a `pnpm-workspace.yaml`, excluding

--- a/scripts/set-dev-registry.cjs
+++ b/scripts/set-dev-registry.cjs
@@ -135,9 +135,7 @@ function main() {
 	for (const root of roots) {
 		const npmrcPath = path.join(root, ".npmrc");
 		const rel = path.relative(repoRoot, root) || ".";
-		const existing = fs.existsSync(npmrcPath)
-			? fs.readFileSync(npmrcPath, "utf8")
-			: undefined;
+		const existing = fs.existsSync(npmrcPath) ? fs.readFileSync(npmrcPath, "utf8") : undefined;
 		const managed = existing !== undefined && existing.startsWith(MARKER);
 
 		if (clear) {

--- a/scripts/set-dev-registry.cjs
+++ b/scripts/set-dev-registry.cjs
@@ -1,0 +1,185 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Points every pnpm workspace in this repo at an alternative npm registry (e.g. an internal
+ * mirror or a team-managed Azure Artifacts feed) by writing a gitignored `.npmrc` into each
+ * workspace root.
+ *
+ * The committed configuration intentionally uses the public default registry
+ * (registry.npmjs.org) so that external/OSS contributions work out of the box. A value set in
+ * `pnpm-workspace.yaml` would take precedence over `.npmrc`, so the committed workspace files do
+ * NOT set a registry; this script provides the per-developer override instead.
+ *
+ * Because each release group (root, server/*, build-tools, website, common/*, tools/*, ...) is an
+ * independent pnpm project and pnpm only reads the `.npmrc` from the project it is invoked in,
+ * the override must be written into every workspace root.
+ *
+ * This script intentionally does NOT hard-code any registry URL: the URL is supplied as a
+ * command-line argument so nothing internal is committed to this public repository.
+ *
+ * Usage:
+ *   node ./scripts/set-dev-registry.cjs <registry-url>   Write the override into every workspace.
+ *   node ./scripts/set-dev-registry.cjs --clear           Remove overrides written by this script.
+ *
+ * The generated `.npmrc` files are gitignored and carry a marker comment so `--clear` only
+ * removes files this script created (it never touches an `.npmrc` you authored yourself).
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Marker written as the first line of every generated .npmrc. Used by --clear to avoid deleting
+// .npmrc files that a developer created for other purposes (e.g. auth tokens).
+const MARKER =
+	"; managed by scripts/set-dev-registry.cjs -- do not edit; run the script to change";
+
+const repoRoot = path.resolve(__dirname, "..");
+
+// Directory names that should never be traversed while discovering workspaces.
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
+
+// Path fragments that identify workspaces which are test fixtures or managed separately with their
+// own lockfiles, and therefore should not receive the override.
+const EXCLUDED_FRAGMENTS = [
+	path.join("build-infrastructure", "src", "test", "data"),
+	"compat-workspaces",
+];
+
+/**
+ * Recursively find every directory under `dir` that contains a `pnpm-workspace.yaml`, excluding
+ * skipped directories and the excluded fragments above.
+ * @param {string} dir Absolute directory to search.
+ * @param {string[]} found Accumulator of absolute workspace-root paths.
+ * @returns {string[]} `found`.
+ */
+function findWorkspaceRoots(dir, found) {
+	let entries;
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return found;
+	}
+
+	if (entries.some((e) => e.isFile() && e.name === "pnpm-workspace.yaml")) {
+		found.push(dir);
+	}
+
+	for (const entry of entries) {
+		if (!entry.isDirectory() || SKIP_DIR_NAMES.has(entry.name)) {
+			continue;
+		}
+		const child = path.join(dir, entry.name);
+		if (EXCLUDED_FRAGMENTS.some((fragment) => child.includes(fragment))) {
+			continue;
+		}
+		findWorkspaceRoots(child, found);
+	}
+
+	return found;
+}
+
+/**
+ * Validate the provided registry URL, exiting the process with a helpful message if invalid.
+ * @param {string} value Raw CLI argument.
+ * @returns {string} The normalized registry URL (with a trailing slash).
+ */
+function parseRegistryUrl(value) {
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		fail(`Invalid registry URL: "${value}". Provide an absolute http(s) URL.`);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		fail(`Registry URL must use http(s), got "${url.protocol}" in "${value}".`);
+	}
+	// npm registries are conventionally referenced with a trailing slash.
+	return url.href.endsWith("/") ? url.href : `${url.href}/`;
+}
+
+/** Print an error + usage and exit non-zero. */
+function fail(message) {
+	console.error(`Error: ${message}\n`);
+	printUsage();
+	process.exit(1);
+}
+
+function printUsage() {
+	console.error("Usage:");
+	console.error(
+		"  node ./scripts/set-dev-registry.cjs <registry-url>   Set the override in every workspace.",
+	);
+	console.error(
+		"  node ./scripts/set-dev-registry.cjs --clear          Remove overrides created by this script.",
+	);
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+		printUsage();
+		// No arguments is treated as an error so the script can never accidentally clear overrides.
+		process.exit(args.length === 0 ? 1 : 0);
+	}
+
+	const clear = args.includes("--clear") || args.includes("-c");
+	const positional = args.filter((a) => !a.startsWith("-"));
+
+	if (clear && positional.length > 0) {
+		fail("Do not pass a registry URL together with --clear.");
+	}
+	if (!clear && positional.length !== 1) {
+		fail("Provide exactly one registry URL (or use --clear).");
+	}
+
+	const registry = clear ? undefined : parseRegistryUrl(positional[0]);
+	const roots = findWorkspaceRoots(repoRoot, []);
+
+	if (roots.length === 0) {
+		fail("No pnpm workspaces found. Run this from within the FluidFramework repo.");
+	}
+
+	let changed = 0;
+	for (const root of roots) {
+		const npmrcPath = path.join(root, ".npmrc");
+		const rel = path.relative(repoRoot, root) || ".";
+
+		if (clear) {
+			if (!fs.existsSync(npmrcPath)) {
+				continue;
+			}
+			const existing = fs.readFileSync(npmrcPath, "utf8");
+			if (!existing.startsWith(MARKER)) {
+				console.warn(`Skipping ${rel}/.npmrc (not managed by this script).`);
+				continue;
+			}
+			fs.rmSync(npmrcPath);
+			console.log(`Removed ${rel}/.npmrc`);
+			changed++;
+		} else {
+			const existing = fs.existsSync(npmrcPath)
+				? fs.readFileSync(npmrcPath, "utf8")
+				: undefined;
+			if (existing !== undefined && !existing.startsWith(MARKER)) {
+				console.warn(
+					`Skipping ${rel}/.npmrc (already exists and is not managed by this script).`,
+				);
+				continue;
+			}
+			fs.writeFileSync(npmrcPath, `${MARKER}\nregistry=${registry}\n`);
+			console.log(`Wrote ${rel}/.npmrc (registry=${registry})`);
+			changed++;
+		}
+	}
+
+	console.log(
+		clear
+			? `\nCleared registry override from ${changed} workspace(s).`
+			: `\nSet registry override in ${changed} workspace(s).`,
+	);
+}
+
+main();


### PR DESCRIPTION
## Description

Latest guidance is that external developers should still use registry.npmjs.org to install packages.

This reverts #27705 and provides a reasonably convenient way for Microsoft developers to bootstrap a valid environment.

This should also unblock CI from dependency updates, as the mirror we use in those builds shouldn't have the same 7 day latency.
