### PR TITLE
test: verify changeset-present labeler

### DIFF
--- a/.changeset/test-verify-labeler-fix.md
+++ b/.changeset/test-verify-labeler-fix.md
@@ -1,0 +1,5 @@
+---
+"@fluidframework/core-utils": patch
+---
+
+Temporary changeset used to verify the pr-labeler.yml "changeset-present" label works correctly after the actions/labeler v6 schema fix (#27721). This changeset and PR will be closed/deleted immediately after verification.


### PR DESCRIPTION
Temporary PR containing a changeset file to verify the pr-labeler.yml 'changeset-present' label works correctly after the fix in #27721. Will close/delete after verification.