### PR TITLE
Add minDocumentRuntimeVersion compatibility aliases

### DIFF
--- a/.changeset/bright-tigers-retire.md
+++ b/.changeset/bright-tigers-retire.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": deprecation
+---
+
+The minVersionForCollab compatibility alias is deprecated
+
+`LoadContainerRuntimeParams.minVersionForCollab` is deprecated in 2.114.0 in favor of `minDocumentRuntimeVersion` and is planned for removal in 3.10.0.
+
+See [#27180](https://github.com/microsoft/FluidFramework/issues/27180) for the cleanup plan.

--- a/.changeset/friendly-pandas-rename.md
+++ b/.changeset/friendly-pandas-rename.md
@@ -1,0 +1,21 @@
+---
+"@fluid-experimental/attributor": minor
+"@fluidframework/container-runtime": minor
+"@fluidframework/runtime-definitions": minor
+"__section": feature
+---
+
+Add document runtime version naming for compatibility configuration
+
+`LoadContainerRuntimeParams` now supports `minDocumentRuntimeVersion` as the preferred name for configuring the minimum Fluid runtime version required to open or process documents created or loaded by the container runtime. The existing `minVersionForCollab` property remains supported as a compatibility alias.
+
+```ts
+const runtime = await loadContainerRuntime({
+	// ...
+	minDocumentRuntimeVersion: "2.0.0",
+});
+```
+
+Specifying both parameter names throws a `UsageError`. The Attributor runtime wrapper also forwards the preferred parameter to the underlying container runtime.
+
+`MinDocumentRuntimeVersion` is now exported as the preferred public type name. `MinimumVersionForCollab` remains supported as a compatibility alias.

--- a/.changeset/friendly-pandas-rename.md
+++ b/.changeset/friendly-pandas-rename.md
@@ -7,7 +7,7 @@
 
 Add document runtime version naming for compatibility configuration
 
-`LoadContainerRuntimeParams` now supports `minDocumentRuntimeVersion` as the preferred name for configuring the minimum Fluid runtime version required to open or process documents created or loaded by the container runtime. The existing `minVersionForCollab` property remains supported as a compatibility alias.
+`LoadContainerRuntimeParams` now supports `minDocumentRuntimeVersion` as the preferred name for configuring the minimum Fluid runtime version required to open or process documents created or loaded by the container runtime. The existing `minVersionForCollab` property remains supported as a deprecated compatibility alias until its planned removal in 3.10.0.
 
 ```ts
 const runtime = await loadContainerRuntime({

--- a/CrossClientCompatibility.md
+++ b/CrossClientCompatibility.md
@@ -10,7 +10,7 @@ Cross-client compatibility is Fluid's ability to support collaboration between t
 2. **Multi-application ecosystems**: Different applications with different deployment schedules may host the same Fluid content. In such ecosystems, all applications integrating Fluid-based experiences must coordinate to respect the cross-client compatibility window. This avoids requiring all applications to be on exactly the same version, which would be impractical.
 
 > **Note:** The cross-client compatibility guarantee applies to all Fluid layers (Driver, Loader, Runtime, and
-> Datastore). However, the enforcement mechanisms described in this document — `minVersionForCollab`, feature
+> Datastore). However, the enforcement mechanisms described in this document — `minDocumentRuntimeVersion`, feature
 > gating, and client version checks — are currently implemented only at the **Runtime and Datastore layers**.
 > The Driver layer does not currently have cross-client compatibility concerns because it does not exchange data
 > formats between clients. Enforcement at the Loader layer may be added in the future. See the
@@ -74,18 +74,18 @@ compatibility window for a client toward the end of a Range can be up to ~24 mon
 
 ## Cross-client Compatibility Configuration and Enforcement
 
-### minVersionForCollab
+### minDocumentRuntimeVersion
 
-`minVersionForCollab` is the primary mechanism for configuring cross-client compatibility. It is a container runtime load parameter (defined in [containerRuntime.ts](./packages/runtime/container-runtime/src/containerRuntime.ts)) that specifies the minimum Fluid version that is allowed to collaborate on a document. It serves two purposes:
+`minDocumentRuntimeVersion` is the primary mechanism for configuring cross-client compatibility. It is a container runtime load parameter (defined in [containerRuntime.ts](./packages/runtime/container-runtime/src/containerRuntime.ts)) that specifies the minimum Fluid version that is allowed to collaborate on a document. The former parameter name, `minVersionForCollab`, remains available as a compatibility alias. The parameter serves two purposes:
 
 1. **Cross-client compatibility enforcement**: Clients running a Fluid version older than what the document requires will be blocked from joining the collaboration session, preventing data corruption or runtime errors. See [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor) for the specific error signals.
-2. **Feature gating**: It automatically enables or disables features based on the specified version to ensure all collaborating clients can understand the resulting data format. For example, if `minVersionForCollab` is set to `"2.0.0"`, features like grouped batching are safely enabled because all clients at version 2.0.0 or later can interpret that format.
+2. **Feature gating**: It automatically enables or disables features based on the specified version to ensure all collaborating clients can understand the resulting data format. For example, if `minDocumentRuntimeVersion` is set to `"2.0.0"`, features like grouped batching are safely enabled because all clients at version 2.0.0 or later can interpret that format.
 
-If `minVersionForCollab` is not explicitly set, the runtime uses a default derived from the currently supported compatibility checkpoints. Passing a value below the supported floor is not permitted — the runtime will fail to instantiate and throw a `UsageError` (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)). For details on the default value, see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts).
+If `minDocumentRuntimeVersion` is not explicitly set, the runtime uses a default derived from the currently supported compatibility checkpoints. Passing a value below the supported floor is not permitted — the runtime will fail to instantiate and throw a `UsageError` (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)). For details on the default value, see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts).
 
 ### What This Means for an Application
 
-As an application developer, you need to manage your Fluid Framework version upgrades carefully to ensure uninterrupted collaboration for your users. It is **highly recommended** to explicitly configure `minVersionForCollab` and monitor your client version distribution. Setting `minVersionForCollab` explicitly surfaces version mismatches at build and verification time. This prevents a release from shipping and silently raising the floor, locking older clients out.
+As an application developer, you need to manage your Fluid Framework version upgrades carefully to ensure uninterrupted collaboration for your users. It is **highly recommended** to explicitly configure `minDocumentRuntimeVersion` and monitor your client version distribution. Setting `minDocumentRuntimeVersion` explicitly surfaces version mismatches at build and verification time. This prevents a release from shipping and silently raising the floor, locking older clients out.
 
 #### Encapsulated vs Declarative Models
 
@@ -126,7 +126,7 @@ You do not need to manage individual runtime options directly.
 
 #### Configuring Cross-Client Compatibility (Encapsulated Model)
 
-If you construct a container runtime directly, cross-client compatibility is configured by setting `minVersionForCollab` in the `LoadContainerRuntimeParams` passed into the `loadContainerRuntime` function:
+If you construct a container runtime directly, cross-client compatibility is configured by setting `minDocumentRuntimeVersion` in the `LoadContainerRuntimeParams` passed into the `loadContainerRuntime` function:
 
 ```typescript
 const loadContainerRuntimeParams: LoadContainerRuntimeParams = {
@@ -139,18 +139,18 @@ const loadContainerRuntimeParams: LoadContainerRuntimeParams = {
 	containerScope,
 	provideEntryPoint,
 	// Configure cross-client compatibility by setting the minimum version
-	minVersionForCollab: "2.0.0",
+	minDocumentRuntimeVersion: "2.0.0",
 };
 const runtime = await loadContainerRuntime(loadContainerRuntimeParams);
 ```
 
-`minVersionForCollab` is a semver string representing the minimum Fluid version allowed to collaborate on a document. It automatically configures default values for runtime options to ensure compatibility with the specified version. For example, setting `minVersionForCollab` to `"2.0.0"` enables features like grouped batching that are safe for all 2.x clients.
+`minDocumentRuntimeVersion` is a semver string representing the minimum Fluid version allowed to collaborate on a document. It automatically configures default values for runtime options to ensure compatibility with the specified version. For example, setting `minDocumentRuntimeVersion` to `"2.0.0"` enables features like grouped batching that are safe for all 2.x clients.
 
-You may also set individual runtime options via `IContainerRuntimeOptions`, but they must be consistent with your `minVersionForCollab` value. If there is a mismatch (e.g., enabling a 2.x feature with `minVersionForCollab: "1.0.0"`), a `UsageError` will be thrown (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)).
+You may also set individual runtime options via `IContainerRuntimeOptions`, but they must be consistent with your `minDocumentRuntimeVersion` value. If there is a mismatch (e.g., enabling a 2.x feature with `minDocumentRuntimeVersion: "1.0.0"`), a `UsageError` will be thrown (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)).
 
-If `minVersionForCollab` is not explicitly set, the runtime uses a default derived from the currently supported compatibility checkpoints (see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts)). Passing a value below the supported floor is not permitted and will throw a `UsageError`.
+If `minDocumentRuntimeVersion` is not explicitly set, the runtime uses a default derived from the currently supported compatibility checkpoints (see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts)). Passing a value below the supported floor is not permitted and will throw a `UsageError`.
 
-Setting `minVersionForCollab` explicitly is **highly recommended**. Set it to the oldest Fluid Framework
+Setting `minDocumentRuntimeVersion` explicitly is **highly recommended**. Set it to the oldest Fluid Framework
 version your users are [saturated](#terminology) on. This will ensure:
 
 1. Older and newer clients can collaborate with each other safely.
@@ -162,10 +162,10 @@ We recommend following the below pattern to ensure cross-client compatibility. K
 
 1. Observe the distribution of Fluid versions across your application's clients. See [Observing Client Version Distribution](./FluidCompatibilityConsiderations.md#observing-client-version-distribution) for how to do this using telemetry.
 2. Update your compatibility configuration to match the oldest deployed version that your clients are
-   [saturated](#terminology) on. In both the declarative and encapsulated models, set `minVersionForCollab`
-   to that saturated version (e.g., `"2.10.0"`).
+   [saturated](#terminology) on. Pass that saturated version (e.g., `"2.10.0"`) through the service-client API in
+   the declarative model or set `minDocumentRuntimeVersion` in the encapsulated model.
 3. Verify that the configured compatibility checkpoint is within the supported compatibility window of the Fluid Framework version you want to upgrade to. If it is, bump your Fluid Framework dependencies and update your lock file (so a newer version isn't picked up implicitly); no further action is required. If not, wait for further saturation and return to step 1.
-4. Monitor telemetry for warnings/errors to ensure safe rollout (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor) below). At this point any clients running a version older than the configured `minVersionForCollab` may be blocked from accessing the document.
+4. Monitor telemetry for warnings/errors to ensure safe rollout (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor) below). At this point any clients running a version older than the configured minimum may be blocked from accessing the document.
 
 #### Errors and Warnings to Monitor
 
@@ -174,11 +174,11 @@ The following are errors and telemetry warnings you may see during and following
 <!-- prettier-ignore -->
 | Type | Signal | What it Means | What to Do |
 | --- | --- | --- | --- |
-| Telemetry Event | `MinVersionForCollabWarning` | Clients are joining with a version below your configured minimum, but are still able to understand the document's data format and therefore continue to collaborate. | If you see this warning message, it's likely a sign you updated `minVersionForCollab` too quickly. In future releases, ensure proper [saturation](#terminology) before updating. If these warning messages are ignored, you may risk seeing the below error in the future. |
-| `DataProcessingError` | `Document can't be opened with current version of the code` | An out-of-window client tried to join and was blocked due to being unable to collaborate with the newer client's document. | If this was unexpected, lower `minVersionForCollab` so newly-created documents will admit older clients. **Note:** documents whose schema has already been elevated by a higher-`minVersionForCollab` writer may continue to block older clients on those specific documents — lowering the configured value does not retroactively undo the elevation in the document's persisted schema. |
+| Telemetry Event | `MinVersionForCollabWarning` | Clients are joining with a version below your configured minimum, but are still able to understand the document's data format and therefore continue to collaborate. | If you see this warning message, it's likely a sign you updated `minDocumentRuntimeVersion` too quickly. In future releases, ensure proper [saturation](#terminology) before updating. If these warning messages are ignored, you may risk seeing the below error in the future. |
+| `DataProcessingError` | `Document can't be opened with current version of the code` | An out-of-window client tried to join and was blocked due to being unable to collaborate with the newer client's document. | If this was unexpected, lower `minDocumentRuntimeVersion` so newly-created documents will admit older clients. **Note:** documents whose schema has already been elevated by a higher-minimum writer may continue to block older clients on those specific documents — lowering the configured value does not retroactively undo the elevation in the document's persisted schema. |
 | `DataCorruptionError` | `Summary metadata mismatch` | An older out-of-window client (before 2.0.0-rc.3.0.0) tried to join and was blocked due to being unable to collaborate with the newer client's document. | Update the affected client to 2.0 or later. This signal only affects very old clients; modern cross-client enforcement surfaces through `MinVersionForCollabWarning` and the `DataProcessingError` row above. |
-| `UsageError` | `Incompatible Runtime Option` | You manually enabled a feature that requires a higher minimum than your document allows. | Turn the feature off or raise `minVersionForCollab` (if there is proper [saturation](#terminology)). |
-| `UsageError` | `Runtime option <name>:<value> requires runtime version <X>` | You manually enabled a feature that requires a higher minimum than your document allows. | Turn the feature off or raise `minVersionForCollab` (if there is proper [saturation](#terminology)). |
+| `UsageError` | `Incompatible Runtime Option` | You manually enabled a feature that requires a higher minimum than your document allows. | Turn the feature off or raise `minDocumentRuntimeVersion` (if there is proper [saturation](#terminology)). |
+| `UsageError` | `Runtime option <name>:<value> requires runtime version <X>` | You manually enabled a feature that requires a higher minimum than your document allows. | Turn the feature off or raise `minDocumentRuntimeVersion` (if there is proper [saturation](#terminology)). |
 
 ## Developer Guide
 

--- a/CrossClientCompatibility.md
+++ b/CrossClientCompatibility.md
@@ -76,7 +76,7 @@ compatibility window for a client toward the end of a Range can be up to ~24 mon
 
 ### minDocumentRuntimeVersion
 
-`minDocumentRuntimeVersion` is the primary mechanism for configuring cross-client compatibility. It is a container runtime load parameter (defined in [containerRuntime.ts](./packages/runtime/container-runtime/src/containerRuntime.ts)) that specifies the minimum Fluid version that is allowed to collaborate on a document. The former parameter name, `minVersionForCollab`, remains available as a compatibility alias. The parameter serves two purposes:
+`minDocumentRuntimeVersion` is the primary mechanism for configuring cross-client compatibility. It is a container runtime load parameter (defined in [containerRuntime.ts](./packages/runtime/container-runtime/src/containerRuntime.ts)) that specifies the minimum Fluid version that is allowed to collaborate on a document. The former parameter name, `minVersionForCollab`, remains available as a deprecated compatibility alias until its planned removal in 3.10.0. The parameter serves two purposes:
 
 1. **Cross-client compatibility enforcement**: Clients running a Fluid version older than what the document requires will be blocked from joining the collaboration session, preventing data corruption or runtime errors. See [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor) for the specific error signals.
 2. **Feature gating**: It automatically enables or disables features based on the specified version to ensure all collaborating clients can understand the resulting data format. For example, if `minDocumentRuntimeVersion` is set to `"2.0.0"`, features like grouped batching are safely enabled because all clients at version 2.0.0 or later can interpret that format.

--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -55,9 +55,6 @@ export const mixinAttributor = (
 				context,
 				registryEntries,
 				existing,
-				provideEntryPoint,
-				runtimeOptions,
-				containerScope,
 				containerRuntimeCtor = ContainerRuntimeWithAttributor as unknown as typeof ContainerRuntime,
 			} = params;
 
@@ -75,12 +72,8 @@ export const mixinAttributor = (
 			}
 
 			const runtime = await Base.loadRuntime({
-				context,
+				...params,
 				registryEntries: registryEntriesCopy,
-				provideEntryPoint,
-				runtimeOptions,
-				containerScope,
-				existing,
 				containerRuntimeCtor,
 			});
 

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type { IContainerContext } from "@fluidframework/container-definitions/internal";
+import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import { MockLogger } from "@fluidframework/telemetry-utils/internal";
+
+import { mixinAttributor } from "../mixinAttributor.js";
+
+describe("mixinAttributor", () => {
+	it("forwards minDocumentRuntimeVersion to the base runtime", async () => {
+		let forwardedParams: Parameters<typeof ContainerRuntime.loadRuntime>[0] | undefined;
+
+		class TestContainerRuntime extends ContainerRuntime {
+			public static override async loadRuntime(
+				params: Parameters<typeof ContainerRuntime.loadRuntime>[0],
+			): Promise<ContainerRuntime> {
+				forwardedParams = params;
+				return ContainerRuntime.prototype;
+			}
+		}
+
+		const ContainerRuntimeWithAttributor = mixinAttributor(TestContainerRuntime);
+		await ContainerRuntimeWithAttributor.loadRuntime({
+			context: {
+				taggedLogger: new MockLogger(),
+			} as unknown as IContainerContext,
+			registryEntries: [],
+			existing: true,
+			provideEntryPoint: async () => ({}),
+			minDocumentRuntimeVersion: "2.0.0",
+		});
+
+		assert.equal(forwardedParams?.minDocumentRuntimeVersion, "2.0.0");
+	});
+});

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -346,6 +346,7 @@ export interface LoadContainerRuntimeParams {
     containerScope?: FluidObject;
     context: IContainerContext;
     existing: boolean;
+    minDocumentRuntimeVersion?: MinDocumentRuntimeVersion;
     minVersionForCollab?: MinimumVersionForCollab;
     provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>;
     registryEntries: NamedFluidDataStoreRegistryEntries;

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -347,7 +347,8 @@ export interface LoadContainerRuntimeParams {
     context: IContainerContext;
     existing: boolean;
     minDocumentRuntimeVersion?: MinDocumentRuntimeVersion;
-    minVersionForCollab?: MinimumVersionForCollab;
+    // @deprecated
+    minVersionForCollab?: MinDocumentRuntimeVersion;
     provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>;
     registryEntries: NamedFluidDataStoreRegistryEntries;
     // @deprecated

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -131,7 +131,6 @@ import type {
 	StageControlsInternal,
 	IContainerRuntimeBaseInternal,
 	MinDocumentRuntimeVersion,
-	MinimumVersionForCollab,
 	ContainerExtensionExpectations,
 } from "@fluidframework/runtime-definitions/internal";
 import {
@@ -837,8 +836,11 @@ export interface LoadContainerRuntimeParams {
 	 * understand the new op type. If a customer were to set minVersionForCollab to 2.0.0, then `bar` would be set to
 	 * enable `foo` by default. If a customer were to set minVersionForCollab to 1.0.0, then `bar` would be set to
 	 * disable `foo` by default.
+	 *
+	 * @deprecated 2.114.0. Removed in 3.10.0. Use {@link LoadContainerRuntimeParams.minDocumentRuntimeVersion} instead.
+	 * See {@link https://github.com/microsoft/FluidFramework/issues/27180} for context.
 	 */
-	minVersionForCollab?: MinimumVersionForCollab;
+	minVersionForCollab?: MinDocumentRuntimeVersion;
 }
 /**
  * This is meant to be used by a {@link @fluidframework/container-definitions#IRuntimeFactory} to instantiate a container runtime.
@@ -854,7 +856,7 @@ export async function loadContainerRuntime(
 
 function getMinVersionForCollabFromParams(
 	minDocumentRuntimeVersion: MinDocumentRuntimeVersion | undefined,
-	minVersionForCollab: MinimumVersionForCollab | undefined,
+	minVersionForCollab: MinDocumentRuntimeVersion | undefined,
 ): MinDocumentRuntimeVersion {
 	if (minDocumentRuntimeVersion !== undefined && minVersionForCollab !== undefined) {
 		throw new UsageError(
@@ -1681,7 +1683,7 @@ export class ContainerRuntime
 		private readonly documentsSchemaController: DocumentsSchemaController,
 		featureGatesForTelemetry: Record<string, boolean | number | undefined>,
 		provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>,
-		public readonly minVersionForCollab: MinimumVersionForCollab,
+		public readonly minVersionForCollab: MinDocumentRuntimeVersion,
 		private readonly requestHandler?: (
 			request: IRequest,
 			runtime: IContainerRuntime,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -130,6 +130,7 @@ import type {
 	ISummarizerNodeWithGC,
 	StageControlsInternal,
 	IContainerRuntimeBaseInternal,
+	MinDocumentRuntimeVersion,
 	MinimumVersionForCollab,
 	ContainerExtensionExpectations,
 } from "@fluidframework/runtime-definitions/internal";
@@ -798,6 +799,27 @@ export interface LoadContainerRuntimeParams {
 	requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>;
 
 	/**
+	 * Minimum version of the FF runtime that is required to open or process documents created or loaded by the runtime.
+	 * The input should be a string that represents the minimum version of the FF runtime that should be
+	 * supported for document runtime compatibility. The format of the string must be in valid semver format.
+	 *
+	 * The inputted version will be used to determine the default configuration for
+	 * {@link IContainerRuntimeOptionsInternal} to ensure compatibility with the specified version.
+	 *
+	 * @example
+	 * minDocumentRuntimeVersion: "2.0.0"
+	 *
+	 * @privateRemarks
+	 * Used to determine the default configuration for {@link IContainerRuntimeOptionsInternal} that affect the document schema.
+	 * For example, let's say that feature `foo` was added in 2.0 which introduces a new op type. Additionally, option `bar`
+	 * was added to `IContainerRuntimeOptionsInternal` in 2.0 to enable/disable `foo` since clients prior to 2.0 would not
+	 * understand the new op type. If a customer were to set minDocumentRuntimeVersion to 2.0.0, then `bar` would be set to
+	 * enable `foo` by default. If a customer were to set minDocumentRuntimeVersion to 1.0.0, then `bar` would be set to
+	 * disable `foo` by default.
+	 */
+	minDocumentRuntimeVersion?: MinDocumentRuntimeVersion;
+
+	/**
 	 * Minimum version of the FF runtime that is required to collaborate on new documents.
 	 * The input should be a string that represents the minimum version of the FF runtime that should be
 	 * supported for collaboration. The format of the string must be in valid semver format.
@@ -828,6 +850,19 @@ export async function loadContainerRuntime(
 	params: LoadContainerRuntimeParams,
 ): Promise<IContainerRuntime & IRuntime> {
 	return ContainerRuntime.loadRuntime(params);
+}
+
+function getMinVersionForCollabFromParams(
+	minDocumentRuntimeVersion: MinDocumentRuntimeVersion | undefined,
+	minVersionForCollab: MinimumVersionForCollab | undefined,
+): MinDocumentRuntimeVersion {
+	if (minDocumentRuntimeVersion !== undefined && minVersionForCollab !== undefined) {
+		throw new UsageError(
+			"Only specify one of minDocumentRuntimeVersion or minVersionForCollab.",
+		);
+	}
+
+	return minDocumentRuntimeVersion ?? minVersionForCollab ?? defaultMinVersionForCollab;
 }
 
 /**
@@ -960,8 +995,13 @@ export class ContainerRuntime
 			runtimeOptions = {} satisfies IContainerRuntimeOptionsInternal,
 			containerScope = {},
 			containerRuntimeCtor = ContainerRuntime,
-			minVersionForCollab = defaultMinVersionForCollab,
+			minDocumentRuntimeVersion,
+			minVersionForCollab: legacyMinVersionForCollab,
 		} = params;
+		const minVersionForCollab = getMinVersionForCollabFromParams(
+			minDocumentRuntimeVersion,
+			legacyMinVersionForCollab,
+		);
 
 		// If taggedLogger exists, use it. Otherwise, wrap the vanilla logger:
 		// back-compat: Remove the TaggedLoggerAdapter fallback once all the host are using loader > 0.45

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4242,44 +4242,67 @@ describe("Runtime", () => {
 				});
 			}
 
-			it("minVersionForCollab = 1.0.0", async () => {
-				const minVersionForCollab = "1.0.0";
-				const logger = new MockLogger();
-				await ContainerRuntime.loadRuntime2({
-					context: getMockContext({ logger }) as IContainerContext,
-					registry: new FluidDataStoreRegistry([]),
-					existing: false,
-					runtimeOptions: {},
-					provideEntryPoint: mockProvideEntryPoint,
-					minVersionForCollab,
+			for (const [name, minVersionParam] of [
+				["minDocumentRuntimeVersion", { minDocumentRuntimeVersion: "1.0.0" }],
+				["minVersionForCollab", { minVersionForCollab: "1.0.0" }],
+			] as const) {
+				it(`${name} = 1.0.0`, async () => {
+					const logger = new MockLogger();
+					await ContainerRuntime.loadRuntime2({
+						context: getMockContext({ logger }) as IContainerContext,
+						registry: new FluidDataStoreRegistry([]),
+						existing: false,
+						runtimeOptions: {},
+						provideEntryPoint: mockProvideEntryPoint,
+						...minVersionParam,
+					});
+
+					const expectedRuntimeOptions: IContainerRuntimeOptionsInternal = {
+						summaryOptions: {},
+						gcOptions: {},
+						loadSequenceNumberVerification: "close",
+						flushMode: FlushMode.Immediate,
+						compressionOptions: {
+							minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
+							compressionAlgorithm: CompressionAlgorithms.lz4,
+						},
+						maxBatchSizeInBytes: 716800,
+						chunkSizeInBytes: 204800,
+						enableRuntimeIdCompressor: undefined,
+						enableGroupedBatching: false,
+						explicitSchemaControl: false,
+						stagingModeAutoFlushThreshold: 1000,
+						disableSchemaUpgrade: false,
+					};
+
+					logger.assertMatchAny([
+						{
+							eventName: "ContainerRuntime:ContainerLoadStats",
+							category: "generic",
+							options: JSON.stringify(expectedRuntimeOptions),
+							minVersionForCollab: "1.0.0",
+						},
+					]);
 				});
+			}
 
-				const expectedRuntimeOptions: IContainerRuntimeOptionsInternal = {
-					summaryOptions: {},
-					gcOptions: {},
-					loadSequenceNumberVerification: "close",
-					flushMode: FlushMode.Immediate,
-					compressionOptions: {
-						minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
-						compressionAlgorithm: CompressionAlgorithms.lz4,
-					},
-					maxBatchSizeInBytes: 716800,
-					chunkSizeInBytes: 204800,
-					enableRuntimeIdCompressor: undefined,
-					enableGroupedBatching: false,
-					explicitSchemaControl: false,
-					stagingModeAutoFlushThreshold: 1000,
-					disableSchemaUpgrade: false,
-				};
-
-				logger.assertMatchAny([
-					{
-						eventName: "ContainerRuntime:ContainerLoadStats",
-						category: "generic",
-						options: JSON.stringify(expectedRuntimeOptions),
-						minVersionForCollab,
-					},
-				]);
+			it("throws when both compatibility parameter names are provided", async () => {
+				await assert.rejects(
+					async () =>
+						ContainerRuntime.loadRuntime2({
+							context: getMockContext() as IContainerContext,
+							registry: new FluidDataStoreRegistry([]),
+							existing: false,
+							runtimeOptions: {},
+							provideEntryPoint: mockProvideEntryPoint,
+							minDocumentRuntimeVersion: "2.0.0",
+							minVersionForCollab: "2.0.0",
+						}),
+					(error: IErrorBase) =>
+						error.errorType === ContainerErrorTypes.usageError &&
+						error.message ===
+							"Only specify one of minDocumentRuntimeVersion or minVersionForCollab.",
+				);
 			});
 
 			it('minVersionForCollab = 2.0.0-defaults ("default")', async () => {

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.beta.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public @input
+export type MinDocumentRuntimeVersion = MinimumVersionForCollab;
+
+// @public @input
 export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -401,6 +401,9 @@ export interface LocalAttributionKey {
 }
 
 // @public @input
+export type MinDocumentRuntimeVersion = MinimumVersionForCollab;
+
+// @public @input
 export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
 // @beta @legacy

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -394,6 +394,9 @@ export interface LocalAttributionKey {
 }
 
 // @public @input
+export type MinDocumentRuntimeVersion = MinimumVersionForCollab;
+
+// @public @input
 export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
 // @beta @legacy

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.public.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.public.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public @input
+export type MinDocumentRuntimeVersion = MinimumVersionForCollab;
+
+// @public @input
 export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.public.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.public.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public @input
+export type MinDocumentRuntimeVersion = MinimumVersionForCollab;
+
+// @public @input
 export type MinimumVersionForCollab = `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
@@ -41,3 +41,13 @@
 export type MinimumVersionForCollab =
 	| `${1 | 2}.${bigint}.${bigint}`
 	| `${1 | 2}.${bigint}.${bigint}-${string}`;
+
+/**
+ * Preferred type name for the oldest Fluid Framework runtime version that must be able to open or process documents created or loaded by a container runtime.
+ * @remarks
+ * This type has the same validation requirements and behavior as {@link MinimumVersionForCollab}.
+ *
+ * @input
+ * @public
+ */
+export type MinDocumentRuntimeVersion = MinimumVersionForCollab;

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -94,7 +94,10 @@ export {
 	currentSummarizeStepPropertyName,
 	totalBlobSizePropertyName,
 } from "./summary.js";
-export type { MinimumVersionForCollab } from "./compatibilityDefinitions.js";
+export type {
+	MinDocumentRuntimeVersion,
+	MinimumVersionForCollab,
+} from "./compatibilityDefinitions.js";
 
 export {
 	type ContainerRuntimeBaseAlpha,


### PR DESCRIPTION
## Description

Adds `minDocumentRuntimeVersion` as the preferred, additive name for configuring container-runtime cross-client compatibility while preserving compatibility with `minVersionForCollab`.

This focused replacement for #27656:

- Exports the public `MinDocumentRuntimeVersion` type alias.
- Adds the optional `LoadContainerRuntimeParams.minDocumentRuntimeVersion` beta property.
- Deprecates `LoadContainerRuntimeParams.minVersionForCollab` in 2.114.0, with removal planned for the 3.10.0 beta break under #27180.
- Rejects calls that specify both parameter names.
- Preserves existing persisted-schema and telemetry names.
- Ensures the Attributor runtime wrapper forwards the new parameter.
- Updates focused tests, API reports, documentation, and release notes.

`MinimumVersionForCollab` remains supported and is not deprecated in this PR. Tree, datastore, service-client, and test-utility APIs are intentionally outside its scope.