### PR TITLE
docs: clarify allowUnknownOptionalFields breaking change scenario

### DIFF
--- a/website/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
@@ -40,7 +40,8 @@ class Note extends factory.object("Note", {
 
 To ensure [forwards compatibility](./index.mdx#understanding-compatibility), use [`allowUnknownOptionalFields`](../../../api/fluid-framework/objectschemaoptions-interface.md#allowunknownoptionalfields-propertysignature) to handle new optional fields added by newer clients.
 Note that this needs to already be set on the old clients before the field is added.
-If it's not already set, then this degenerates into an un-forwards compatible change and requires a [staged rollout](./index.mdx#staged-rollouts) - because the app has to stage the enabling of allowUnknownOptionalFields.
+If it's not already set, then adding a new optional field at the same time as enabling `allowUnknownOptionalFields` is not forwards compatible, since old clients without `allowUnknownOptionalFields` will reject the unknown field.
+In that case, a [staged rollout](./index.mdx#staged-rollouts) is needed: first release a version that enables `allowUnknownOptionalFields`, then add the new field in a subsequent release.
 
 ```typescript
 class Note extends factory.object("Note", {


### PR DESCRIPTION
## Description

Clarifies the wording in the "types of changes" schema evolution doc around `allowUnknownOptionalFields`. The previous phrasing was ambiguous about whether adding `allowUnknownOptionalFields` by itself was a breaking change, or whether adding a new optional field at the same time as enabling it was the breaking scenario. 

The updated text makes it clear that it's the latter — adding a new optional field simultaneously with enabling `allowUnknownOptionalFields` is the breaking change (because old clients without `allowUnknownOptionalFields` will reject the unknown field). It also splits the staged rollout guidance into its own sentence for readability.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).