### PR TITLE
Add pnpm bootstrapping script for development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,6 @@ CLAUDE.local.md
 # Output from benchmarks
 **/benchmark*Output.json
 
-# npm configuration: Currently only used by CI to redirect to an alternative registry.
+# npm configuration: used by CI to redirect to an alternative registry, and by internal
+# developers via `scripts/set-dev-registry.cjs` to point workspaces at a mirror/team feed.
 .npmrc

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Enable NodeJs's [corepack](https://github.com/nodejs/corepack/blob/main/README.m
 corepack enable
 ```
 
+> [!NOTE]
+> **Microsoft developers:** due to internal policy changes, the public npm registry
+> (`registry.npmjs.org`) is blocked on managed devices. Before running `pnpm install`, point the
+> workspaces at a non-blocked registry (an internal mirror or team-managed feed) by running:
+>
+> ```shell
+> node ./scripts/set-dev-registry.cjs <registry-url>
+> ```
+>
+> This writes a gitignored `.npmrc` into each workspace; run `node ./scripts/set-dev-registry.cjs --clear`
+> to revert. Refer to internal documentation for the registry URL to use. External/OSS
+> contributors can skip this step: the committed default already uses the public registry.
+
 Run the following to build the client packages:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ corepack enable
 > This writes a gitignored `.npmrc` into each workspace; run `node ./scripts/set-dev-registry.cjs --clear`
 > to revert. Refer to internal documentation for the registry URL to use. External/OSS
 > contributors can skip this step: the committed default already uses the public registry.
+>
+> Corepack also cannot install pnpm through the internal feeds (it uses a registry endpoint they
+> do not implement), so instead of `corepack enable`, bootstrap the pinned pnpm version with:
+>
+> ```shell
+> node ./scripts/bootstrap-pnpm.cjs --registry <registry-url>
+> ```
+>
+> If you previously ran `corepack enable`, run `corepack disable pnpm` so the npm-installed pnpm is
+> used. This is the same script CI uses to install pnpm.
 
 Run the following to build the client packages:
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ corepack enable
 >
 > If you previously ran `corepack enable`, run `corepack disable pnpm` so the npm-installed pnpm is
 > used. This is the same script CI uses to install pnpm.
+>
+> To keep Corepack enabled instead (handy when you switch between repos that pin different package
+> managers), add `--seed-corepack`. This installs the pinned pnpm and pre-populates Corepack's cache
+> for that version, so Corepack reuses it offline instead of trying to download it:
+>
+> ```shell
+> node ./scripts/bootstrap-pnpm.cjs --registry <registry-url> --seed-corepack
+> ```
+>
+> Only the seeded version is cached; re-run the script for other pinned versions you need.
 
 Run the following to build the client packages:
 

--- a/README.md
+++ b/README.md
@@ -94,44 +94,60 @@ git clone https://github.com/microsoft/FluidFramework.git
 cd FluidFramework
 ```
 
-Enable NodeJs's [corepack](https://github.com/nodejs/corepack/blob/main/README.md):
+### Set up pnpm
+
+This repo uses [pnpm](https://pnpm.io/), pinned to a specific version via the `packageManager` field in
+`package.json`. How you install it depends on whether you can reach the public npm registry. Follow the
+one section below that matches you, then continue to [Build](#build).
+
+#### External / open-source contributors
+
+Enable NodeJs's [Corepack](https://github.com/nodejs/corepack/blob/main/README.md). It reads the pinned
+version and installs pnpm from the public npm registry automatically:
 
 ```shell
 corepack enable
 ```
 
-> [!NOTE]
-> **Microsoft developers:** due to internal policy changes, the public npm registry
-> (`registry.npmjs.org`) is blocked on managed devices. Before running `pnpm install`, point the
-> workspaces at a non-blocked registry (an internal mirror or team-managed feed) by running:
->
-> ```shell
-> node ./scripts/set-dev-registry.cjs <registry-url>
-> ```
->
-> This writes a gitignored `.npmrc` into each workspace; run `node ./scripts/set-dev-registry.cjs --clear`
-> to revert. Refer to internal documentation for the registry URL to use. External/OSS
-> contributors can skip this step: the committed default already uses the public registry.
->
-> Corepack also cannot install pnpm through the internal feeds (it uses a registry endpoint they
-> do not implement), so instead of `corepack enable`, bootstrap the pinned pnpm version with:
->
-> ```shell
-> node ./scripts/bootstrap-pnpm.cjs --registry <registry-url>
-> ```
->
-> If you previously ran `corepack enable`, run `corepack disable pnpm` so the npm-installed pnpm is
-> used. This is the same script CI uses to install pnpm.
->
-> To keep Corepack enabled instead (handy when you switch between repos that pin different package
-> managers), add `--seed-corepack`. This installs the pinned pnpm and pre-populates Corepack's cache
-> for that version, so Corepack reuses it offline instead of trying to download it:
->
-> ```shell
-> node ./scripts/bootstrap-pnpm.cjs --registry <registry-url> --seed-corepack
-> ```
->
-> Only the seeded version is cached; re-run the script for other pinned versions you need.
+#### Microsoft developers
+
+The public npm registry (`registry.npmjs.org`) is blocked on managed devices, so first point the
+workspaces at a non-blocked registry (an internal mirror or team-managed feed). Refer to internal
+documentation for the URL to use:
+
+```shell
+node ./scripts/set-dev-registry.cjs <registry-url>
+```
+
+This writes a gitignored `.npmrc` into each workspace; run `node ./scripts/set-dev-registry.cjs --clear`
+to revert. Corepack cannot install pnpm through the internal feeds (it uses a registry endpoint they do
+not implement), so use one of the two options below instead of a plain `corepack enable`.
+
+##### If you want to keep using Corepack
+
+Useful if you switch between repos that pin different package managers. Enable Corepack, then bootstrap
+the pinned pnpm and pre-seed Corepack's cache so it reuses that copy offline:
+
+```shell
+corepack enable
+node ./scripts/bootstrap-pnpm.cjs --registry <registry-url> --seed-corepack
+```
+
+Only the seeded version is cached, so re-run the second command for any other pinned version you need
+(e.g. after it changes, or when working in a repo that pins a different version).
+
+##### If you don't use Corepack
+
+Install the pinned pnpm globally via npm (this is the same script CI uses):
+
+```shell
+node ./scripts/bootstrap-pnpm.cjs --registry <registry-url>
+```
+
+If you previously ran `corepack enable`, also run `corepack disable pnpm` so this npm-installed pnpm is
+the one that runs.
+
+### Build
 
 Run the following to build the client packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -227,7 +227,14 @@ peerDependencyRules:
 publicHoistPattern:
   - '@arethetypeswrong/cli'
 
-registry: https://packagefeedproxy.microsoft.io/npm/
+# No `registry` is set here on purpose. pnpm resolves the built-in default (registry.npmjs.org),
+# which keeps external/OSS contributions working out of the box, and also keeps lockfile updates
+# pointed at the public registry.
+# NOTE: a `registry` value in pnpm-workspace.yaml takes precedence over a project-level `.npmrc`,
+# so setting it here (even to registry.npmjs.org) would silently defeat the per-developer override
+# below. Leave it unset instead.
+# Developers who must use an npmjs mirror or team-managed feed can make use of
+# `node ./scripts/set-dev-registry.cjs <registry-url>`.
 
 resolutionMode: highest
 
@@ -235,7 +242,8 @@ strictDepBuilds: true
 
 strictPeerDependencies: true
 
-# The registry.npmjs mirror does not preserve all the npm package metadata necessary for this pnpm feature to function
+# The artifact feeds used by CI and by internal developers (see the registry note above)
+# do not preserve all the npm package metadata necessary for this pnpm feature to function
 # correctly as of 7/16/2026. If this is turned back on...
 # See: https://github.com/orgs/pnpm/discussions/11084 for some discussion.
 # Enabling no-downgrade requires every transitive trust-policy violation to either be remediated

--- a/scripts/bootstrap-pnpm.cjs
+++ b/scripts/bootstrap-pnpm.cjs
@@ -1,0 +1,157 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Installs the repo's pinned pnpm version globally via `npm install -g`, bypassing Corepack.
+ *
+ * Why not Corepack? When a registry override is configured, Corepack fetches package managers from
+ * the npm "packument-by-version" endpoint (`GET {registry}/pnpm/{version}`), which the internal npm
+ * mirror and Azure Artifacts feeds do NOT implement (they return 404). `npm install` instead uses
+ * the packument (`GET {registry}/pnpm`) and tarball (`GET {registry}/pnpm/-/pnpm-{version}.tgz`)
+ * endpoints, which those feeds DO serve. On managed devices the public registry is blocked, and CI
+ * runs under network isolation, so both need this npm-based bootstrap.
+ *
+ * CI and internal developers share this script so the bootstrap logic lives in exactly one place.
+ * It intentionally hard-codes no registry URL: the registry comes from `--registry`, the `.npmrc`
+ * referenced by `--userconfig`, or the ambient npm configuration.
+ *
+ * The pinned version is read from the `packageManager` field of a package.json (the workspace's own
+ * by default), so it always matches what the repo expects.
+ *
+ * Usage:
+ *   node ./scripts/bootstrap-pnpm.cjs [options]
+ *
+ * Options:
+ *   --registry <url>        Registry to install pnpm from (forwarded to `npm install --registry`).
+ *   --userconfig <path>     .npmrc to use (forwarded to `npm install --userconfig`); used by CI.
+ *   --package-json <path>   package.json to read the pinned pnpm version from (default: ./package.json).
+ *   --dry-run               Print the npm command that would run, without executing it.
+ *   --help, -h              Show this help.
+ *
+ * Note for local developers: if you previously ran `corepack enable`, the Corepack pnpm shim may
+ * shadow this global install. Run `corepack disable pnpm` so the npm-installed pnpm is used.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+function printUsage() {
+	console.error("Usage: node ./scripts/bootstrap-pnpm.cjs [--registry <url>] [--userconfig <path>] [--package-json <path>] [--dry-run]");
+}
+
+function fail(message) {
+	console.error(`Error: ${message}\n`);
+	printUsage();
+	process.exit(1);
+}
+
+/**
+ * Parse a `--flag value` style option out of argv.
+ * @param {string[]} argv
+ * @param {string} name Flag name including leading dashes (e.g. "--registry").
+ * @returns {string | undefined}
+ */
+function takeOption(argv, name) {
+	const index = argv.indexOf(name);
+	if (index === -1) {
+		return undefined;
+	}
+	const value = argv[index + 1];
+	if (value === undefined || value.startsWith("-")) {
+		fail(`Missing value for ${name}.`);
+	}
+	argv.splice(index, 2);
+	return value;
+}
+
+/**
+ * Read the pinned pnpm spec (e.g. "pnpm@11.12.0") from a package.json's `packageManager` field,
+ * discarding the integrity hash suffix (npm provides no practical way to consume it).
+ * @param {string} packageJsonPath
+ * @returns {string}
+ */
+function readPinnedPnpmSpec(packageJsonPath) {
+	let pkg;
+	try {
+		pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+	} catch (err) {
+		fail(`Could not read ${packageJsonPath}: ${err.message}`);
+	}
+	const field = pkg.packageManager;
+	if (typeof field !== "string" || field.length === 0) {
+		fail(`No "packageManager" field found in ${packageJsonPath}.`);
+	}
+	// "pnpm@11.12.0+sha512.<hash>" -> "pnpm@11.12.0"
+	const spec = field.split("+")[0];
+	if (!spec.startsWith("pnpm@")) {
+		fail(`"packageManager" is "${field}", but this script only bootstraps pnpm.`);
+	}
+	return spec;
+}
+
+function main() {
+	const argv = process.argv.slice(2);
+	if (argv.includes("--help") || argv.includes("-h")) {
+		printUsage();
+		process.exit(0);
+	}
+
+	const registry = takeOption(argv, "--registry");
+	const userconfig = takeOption(argv, "--userconfig");
+	const packageJsonArg = takeOption(argv, "--package-json");
+	const dryRunIndex = argv.indexOf("--dry-run");
+	const dryRun = dryRunIndex !== -1;
+	if (dryRun) {
+		argv.splice(dryRunIndex, 1);
+	}
+	if (argv.length > 0) {
+		fail(`Unrecognized argument(s): ${argv.join(", ")}`);
+	}
+
+	if (registry !== undefined) {
+		try {
+			const url = new URL(registry);
+			if (url.protocol !== "http:" && url.protocol !== "https:") {
+				fail(`--registry must be an http(s) URL, got "${registry}".`);
+			}
+		} catch {
+			fail(`--registry must be a valid URL, got "${registry}".`);
+		}
+	}
+
+	const packageJsonPath = path.resolve(packageJsonArg ?? path.join(process.cwd(), "package.json"));
+	const spec = readPinnedPnpmSpec(packageJsonPath);
+
+	const npmArgs = ["install", "-g", spec];
+	if (userconfig !== undefined) {
+		npmArgs.push("--userconfig", userconfig);
+	}
+	if (registry !== undefined) {
+		npmArgs.push("--registry", registry);
+	}
+
+	// On Windows the npm executable is a .cmd shim.
+	const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+	console.log(`Bootstrapping ${spec} (pinned in ${packageJsonPath})`);
+	console.log(`> ${npmCommand} ${npmArgs.join(" ")}`);
+
+	if (dryRun) {
+		console.log("(dry run: not executing)");
+		return;
+	}
+
+	const result = spawnSync(npmCommand, npmArgs, { stdio: "inherit" });
+	if (result.error) {
+		fail(`Failed to run npm: ${result.error.message}`);
+	}
+	if (result.status !== 0) {
+		process.exit(result.status ?? 1);
+	}
+	console.log(`\nInstalled ${spec}. If a Corepack pnpm shim shadows it, run 'corepack disable pnpm'.`);
+}
+
+main();

--- a/scripts/bootstrap-pnpm.cjs
+++ b/scripts/bootstrap-pnpm.cjs
@@ -27,19 +27,58 @@
  *   --registry <url>        Registry to install pnpm from (forwarded to `npm install --registry`).
  *   --userconfig <path>     .npmrc to use (forwarded to `npm install --userconfig`); used by CI.
  *   --package-json <path>   package.json to read the pinned pnpm version from (default: ./package.json).
- *   --dry-run               Print the npm command that would run, without executing it.
+ *   --seed-corepack         After installing, seed Corepack's cache with the pinned version so that
+ *                           developers can keep `corepack enable`d (see below).
+ *   --dry-run               Print what would run, without executing it.
  *   --help, -h              Show this help.
  *
  * Note for local developers: if you previously ran `corepack enable`, the Corepack pnpm shim may
- * shadow this global install. Run `corepack disable pnpm` so the npm-installed pnpm is used.
+ * shadow this global install. Run `corepack disable pnpm` so the npm-installed pnpm is used, OR pass
+ * `--seed-corepack` and keep Corepack enabled (recommended if you juggle multiple repos).
+ *
+ * How --seed-corepack works: Corepack only reaches for its (feed-unsupported) download endpoint on a
+ * cache MISS. If `<COREPACK_HOME>/v1/pnpm/<version>/.corepack` already exists it reuses that copy
+ * offline. So after `npm install` fetches pnpm, this script copies it into that cache folder and
+ * writes the `.corepack` metadata Corepack expects. Corepack then runs the pinned version with no
+ * network. This only covers the seeded version; other (unseeded) versions still can't be fetched.
  */
 
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
+const isWindows = process.platform === "win32";
+
+/**
+ * Quote a single argument for a Windows cmd.exe command line (only used on Windows).
+ * @param {unknown} value
+ * @returns {string}
+ */
+function quoteWindowsArg(value) {
+	const str = String(value);
+	return /[\s"&|<>^()%!]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+/**
+ * Run npm cross-platform. On Windows the npm executable is a `.cmd` shim, which recent Node versions
+ * refuse to spawn without a shell; we build a single quoted command line to avoid that restriction
+ * (and the arg-escaping deprecation warning that comes with `shell: true` plus an args array).
+ * @param {string[]} args
+ * @param {{ capture?: boolean }} [options]
+ * @returns {import("node:child_process").SpawnSyncReturns<string>}
+ */
+function runNpm(args, { capture = false } = {}) {
+	const io = capture ? { encoding: "utf8" } : { stdio: "inherit" };
+	if (isWindows) {
+		const line = ["npm.cmd", ...args.map(quoteWindowsArg)].join(" ");
+		return spawnSync(line, { shell: true, ...io });
+	}
+	return spawnSync("npm", args, io);
+}
+
 function printUsage() {
-	console.error("Usage: node ./scripts/bootstrap-pnpm.cjs [--registry <url>] [--userconfig <path>] [--package-json <path>] [--dry-run]");
+	console.error("Usage: node ./scripts/bootstrap-pnpm.cjs [--registry <url>] [--userconfig <path>] [--package-json <path>] [--seed-corepack] [--dry-run]");
 }
 
 function fail(message) {
@@ -92,6 +131,101 @@ function readPinnedPnpmSpec(packageJsonPath) {
 	return spec;
 }
 
+/**
+ * Resolve Corepack's cache home, matching Corepack's own getCorepackHomeFolder() logic so we seed
+ * the exact folder it reads from.
+ * @returns {string}
+ */
+function getCorepackHomeFolder() {
+	if (process.env.COREPACK_HOME) {
+		return process.env.COREPACK_HOME;
+	}
+	const base =
+		process.env.XDG_CACHE_HOME ??
+		process.env.LOCALAPPDATA ??
+		path.join(os.homedir(), process.platform === "win32" ? "AppData/Local" : ".cache");
+	return path.join(base, "node/corepack");
+}
+
+/**
+ * Best-effort lookup of the pnpm tarball's sha512 integrity, converted to the `sha512.<hex>` form
+ * Corepack stores. Corepack does not re-verify this on the cache-reuse path, so a placeholder is
+ * acceptable when the registry can't be reached.
+ * @param {string} version
+ * @param {string | undefined} registry
+ * @param {string | undefined} userconfig
+ * @returns {string}
+ */
+function getTarballHash(version, registry, userconfig) {
+	const placeholder = `sha512.${"0".repeat(128)}`;
+	// Fail fast to the placeholder rather than stalling on npm's retry/backoff if the registry is
+	// briefly unreachable; the hash is not verified on Corepack's reuse path anyway.
+	const args = ["view", `pnpm@${version}`, "dist.integrity", "--fetch-retries=0"];
+	if (userconfig !== undefined) {
+		args.push("--userconfig", userconfig);
+	}
+	if (registry !== undefined) {
+		args.push("--registry", registry);
+	}
+	const result = runNpm(args, { capture: true });
+	const integrity = (result.stdout ?? "").trim();
+	if (!integrity.startsWith("sha512-")) {
+		console.warn("Warning: could not resolve pnpm tarball integrity; using a placeholder hash for the Corepack cache (this does not affect correctness).");
+		return placeholder;
+	}
+	const hex = Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex");
+	return `sha512.${hex}`;
+}
+
+/**
+ * Seed Corepack's cache with an already npm-installed pnpm so Corepack reuses it offline.
+ * @param {string} version
+ * @param {string | undefined} registry
+ * @param {string | undefined} userconfig
+ * @param {boolean} dryRun
+ */
+function seedCorepackCache(version, registry, userconfig, dryRun) {
+	const rootResult = runNpm(["root", "-g"], { capture: true });
+	if (rootResult.status !== 0) {
+		fail(`Could not determine the npm global root: ${(rootResult.stderr ?? "").trim()}`);
+	}
+	const pnpmPackageDir = path.join((rootResult.stdout ?? "").trim(), "pnpm");
+	const pnpmPackageJson = path.join(pnpmPackageDir, "package.json");
+	if (!fs.existsSync(pnpmPackageJson)) {
+		fail(`Expected pnpm at ${pnpmPackageDir} after install, but it was not found.`);
+	}
+	// Corepack launches the binary named in .corepack; reuse pnpm's own bin map so it stays correct
+	// across pnpm versions (e.g. .cjs vs .mjs).
+	const bin = JSON.parse(fs.readFileSync(pnpmPackageJson, "utf8")).bin;
+
+	const versionDir = path.join(getCorepackHomeFolder(), "v1", "pnpm", version);
+	const marker = path.join(versionDir, ".corepack");
+
+	if (fs.existsSync(marker)) {
+		console.log(`Corepack cache already seeded at ${versionDir}`);
+		return;
+	}
+	if (dryRun) {
+		console.log(`(dry run) would seed Corepack cache at ${versionDir}`);
+		return;
+	}
+
+	const hash = getTarballHash(version, registry, userconfig);
+	// Copy into a temp sibling then rename, so a valid .corepack only ever appears on a complete copy.
+	const tmpDir = `${versionDir}.tmp-${process.pid}`;
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+	fs.mkdirSync(path.dirname(versionDir), { recursive: true });
+	fs.cpSync(pnpmPackageDir, tmpDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(tmpDir, ".corepack"),
+		JSON.stringify({ locator: { name: "pnpm", reference: version }, bin, hash }),
+	);
+	fs.rmSync(versionDir, { recursive: true, force: true });
+	fs.renameSync(tmpDir, versionDir);
+
+	console.log(`Seeded Corepack cache at ${versionDir}. You can keep 'corepack enable'd.`);
+}
+
 function main() {
 	const argv = process.argv.slice(2);
 	if (argv.includes("--help") || argv.includes("-h")) {
@@ -102,6 +236,11 @@ function main() {
 	const registry = takeOption(argv, "--registry");
 	const userconfig = takeOption(argv, "--userconfig");
 	const packageJsonArg = takeOption(argv, "--package-json");
+	const seedCorepackIndex = argv.indexOf("--seed-corepack");
+	const seedCorepack = seedCorepackIndex !== -1;
+	if (seedCorepack) {
+		argv.splice(seedCorepackIndex, 1);
+	}
 	const dryRunIndex = argv.indexOf("--dry-run");
 	const dryRun = dryRunIndex !== -1;
 	if (dryRun) {
@@ -133,25 +272,31 @@ function main() {
 		npmArgs.push("--registry", registry);
 	}
 
-	// On Windows the npm executable is a .cmd shim.
-	const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-
 	console.log(`Bootstrapping ${spec} (pinned in ${packageJsonPath})`);
-	console.log(`> ${npmCommand} ${npmArgs.join(" ")}`);
+	console.log(`> npm ${npmArgs.join(" ")}`);
 
 	if (dryRun) {
 		console.log("(dry run: not executing)");
+		if (seedCorepack) {
+			seedCorepackCache(spec.slice("pnpm@".length), registry, userconfig, true);
+		}
 		return;
 	}
 
-	const result = spawnSync(npmCommand, npmArgs, { stdio: "inherit" });
+	const result = runNpm(npmArgs);
 	if (result.error) {
 		fail(`Failed to run npm: ${result.error.message}`);
 	}
 	if (result.status !== 0) {
 		process.exit(result.status ?? 1);
 	}
-	console.log(`\nInstalled ${spec}. If a Corepack pnpm shim shadows it, run 'corepack disable pnpm'.`);
+
+	if (seedCorepack) {
+		seedCorepackCache(spec.slice("pnpm@".length), registry, userconfig, false);
+		console.log(`\nInstalled and seeded ${spec}.`);
+	} else {
+		console.log(`\nInstalled ${spec}. If a Corepack pnpm shim shadows it, run 'corepack disable pnpm'.`);
+	}
 }
 
 main();

--- a/scripts/set-dev-registry.cjs
+++ b/scripts/set-dev-registry.cjs
@@ -43,10 +43,7 @@ const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
 
 // Path fragments that identify workspaces which are test fixtures or managed separately with their
 // own lockfiles, and therefore should not receive the override.
-const EXCLUDED_FRAGMENTS = [
-	path.join("build-infrastructure", "src", "test", "data"),
-	"compat-workspaces",
-];
+const EXCLUDED_FRAGMENTS = [path.join("build-infrastructure", "src", "test", "data")];
 
 /**
  * Recursively find every directory under `dir` that contains a `pnpm-workspace.yaml`, excluding

--- a/scripts/set-dev-registry.cjs
+++ b/scripts/set-dev-registry.cjs
@@ -1,0 +1,185 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Points every pnpm workspace in this repo at an alternative npm registry (e.g. an internal
+ * mirror or a team-managed Azure Artifacts feed) by writing a gitignored `.npmrc` into each
+ * workspace root.
+ *
+ * The committed configuration intentionally uses the public default registry
+ * (registry.npmjs.org) so that external/OSS contributions work out of the box. A value set in
+ * `pnpm-workspace.yaml` would take precedence over `.npmrc`, so the committed workspace files do
+ * NOT set a registry; this script provides the per-developer override instead.
+ *
+ * Because each release group (root, server/*, build-tools, website, common/*, tools/*, ...) is an
+ * independent pnpm project and pnpm only reads the `.npmrc` from the project it is invoked in,
+ * the override must be written into every workspace root.
+ *
+ * This script intentionally does NOT hard-code any registry URL: the URL is supplied as a
+ * command-line argument so nothing internal is committed to this public repository.
+ *
+ * Usage:
+ *   node ./scripts/set-dev-registry.cjs <registry-url>   Write the override into every workspace.
+ *   node ./scripts/set-dev-registry.cjs --clear           Remove overrides written by this script.
+ *
+ * The generated `.npmrc` files are gitignored and carry a marker comment so `--clear` only
+ * removes files this script created (it never touches an `.npmrc` you authored yourself).
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Marker written as the first line of every generated .npmrc. Used by --clear to avoid deleting
+// .npmrc files that a developer created for other purposes (e.g. auth tokens).
+const MARKER =
+	"; managed by scripts/set-dev-registry.cjs -- do not edit; run the script to change";
+
+const repoRoot = path.resolve(__dirname, "..");
+
+// Directory names that should never be traversed while discovering workspaces.
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
+
+// Path fragments that identify workspaces which are test fixtures or managed separately with their
+// own lockfiles, and therefore should not receive the override.
+const EXCLUDED_FRAGMENTS = [
+	path.join("build-infrastructure", "src", "test", "data"),
+	"compat-workspaces",
+];
+
+/**
+ * Recursively find every directory under `dir` that contains a `pnpm-workspace.yaml`, excluding
+ * skipped directories and the excluded fragments above.
+ * @param {string} dir Absolute directory to search.
+ * @param {string[]} found Accumulator of absolute workspace-root paths.
+ * @returns {string[]} `found`.
+ */
+function findWorkspaceRoots(dir, found) {
+	let entries;
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return found;
+	}
+
+	if (entries.some((e) => e.isFile() && e.name === "pnpm-workspace.yaml")) {
+		found.push(dir);
+	}
+
+	for (const entry of entries) {
+		if (!entry.isDirectory() || SKIP_DIR_NAMES.has(entry.name)) {
+			continue;
+		}
+		const child = path.join(dir, entry.name);
+		if (EXCLUDED_FRAGMENTS.some((fragment) => child.includes(fragment))) {
+			continue;
+		}
+		findWorkspaceRoots(child, found);
+	}
+
+	return found;
+}
+
+/**
+ * Validate the provided registry URL, exiting the process with a helpful message if invalid.
+ * @param {string} value Raw CLI argument.
+ * @returns {string} The normalized registry URL (with a trailing slash).
+ */
+function parseRegistryUrl(value) {
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		fail(`Invalid registry URL: "${value}". Provide an absolute http(s) URL.`);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		fail(`Registry URL must use http(s), got "${url.protocol}" in "${value}".`);
+	}
+	// npm registries are conventionally referenced with a trailing slash.
+	return url.href.endsWith("/") ? url.href : `${url.href}/`;
+}
+
+/** Print an error + usage and exit non-zero. */
+function fail(message) {
+	console.error(`Error: ${message}\n`);
+	printUsage();
+	process.exit(1);
+}
+
+function printUsage() {
+	console.error("Usage:");
+	console.error(
+		"  node ./scripts/set-dev-registry.cjs <registry-url>   Set the override in every workspace.",
+	);
+	console.error(
+		"  node ./scripts/set-dev-registry.cjs --clear          Remove overrides created by this script.",
+	);
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+		printUsage();
+		// No arguments is treated as an error so the script can never accidentally clear overrides.
+		process.exit(args.length === 0 ? 1 : 0);
+	}
+
+	const clear = args.includes("--clear") || args.includes("-c");
+	const positional = args.filter((a) => !a.startsWith("-"));
+
+	if (clear && positional.length > 0) {
+		fail("Do not pass a registry URL together with --clear.");
+	}
+	if (!clear && positional.length !== 1) {
+		fail("Provide exactly one registry URL (or use --clear).");
+	}
+
+	const registry = clear ? undefined : parseRegistryUrl(positional[0]);
+	const roots = findWorkspaceRoots(repoRoot, []);
+
+	if (roots.length === 0) {
+		fail("No pnpm workspaces found. Run this from within the FluidFramework repo.");
+	}
+
+	let changed = 0;
+	for (const root of roots) {
+		const npmrcPath = path.join(root, ".npmrc");
+		const rel = path.relative(repoRoot, root) || ".";
+
+		if (clear) {
+			if (!fs.existsSync(npmrcPath)) {
+				continue;
+			}
+			const existing = fs.readFileSync(npmrcPath, "utf8");
+			if (!existing.startsWith(MARKER)) {
+				console.warn(`Skipping ${rel}/.npmrc (not managed by this script).`);
+				continue;
+			}
+			fs.rmSync(npmrcPath);
+			console.log(`Removed ${rel}/.npmrc`);
+			changed++;
+		} else {
+			const existing = fs.existsSync(npmrcPath)
+				? fs.readFileSync(npmrcPath, "utf8")
+				: undefined;
+			if (existing !== undefined && !existing.startsWith(MARKER)) {
+				console.warn(
+					`Skipping ${rel}/.npmrc (already exists and is not managed by this script).`,
+				);
+				continue;
+			}
+			fs.writeFileSync(npmrcPath, `${MARKER}\nregistry=${registry}\n`);
+			console.log(`Wrote ${rel}/.npmrc (registry=${registry})`);
+			changed++;
+		}
+	}
+
+	console.log(
+		clear
+			? `\nCleared registry override from ${changed} workspace(s).`
+			: `\nSet registry override in ${changed} workspace(s).`,
+	);
+}
+
+main();

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -35,6 +35,12 @@ parameters:
   type: string
   default: $(ado-feeds-primary-registry)
 
+# The repo root of the FluidFramework checkout. Used to locate scripts/bootstrap-pnpm.cjs, which is
+# shared with local developers so the pnpm bootstrap logic lives in exactly one place.
+- name: repoRoot
+  type: string
+  default: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)
+
 # An optional extra segment appended to the pnpm store cache key (separated by |).
 # Note that Azure pipelines interpret unquoted cache keys as files rather than literal strings. E.g. the following specification:
 #
@@ -125,12 +131,11 @@ steps:
     workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
     script: |
       set -eu -o pipefail
-      # Parse the pnpm version pinned in package.json's "packageManager" field
-      # (e.g. "pnpm@10.33.0+sha512..." -> "pnpm@10.33.0").
-      # This discards the integrity hash suffix, which npm does not provide a practical way to use,
-      # and trusts the package repository to serve the correct version.
-      PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])")
-      npm install -g "$PNPM_VERSION" --userconfig "${{ parameters.userNpmrcPath }}"
+      # Install the pnpm version pinned in package.json's "packageManager" field. This uses
+      # scripts/bootstrap-pnpm.cjs (shared with local developers) instead of Corepack, because
+      # Corepack fetches package managers from a registry endpoint the mirrored/isolated feeds do
+      # not implement. See that script for details.
+      node "${{ parameters.repoRoot }}/scripts/bootstrap-pnpm.cjs" --userconfig "${{ parameters.userNpmrcPath }}"
       echo "Using pnpm $(pnpm -v)"
       echo "Pnpm user config location: $(pnpm config get userconfig)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}


### PR DESCRIPTION
## Description

Our current guidelines for local development setup (use `corepack`) are insufficient for Microsoft developers due to recent restrictions around use of registry.npmjs.org.

This PR adds a script which helps developers install the version of `pnpm` specified in our `packageManager` setting. It also optionally allows continued use of corepack by copying installed `npm` versions to corepack's expected file structure.