### PR TITLE
Fix multiple insert assert

### DIFF
--- a/.changeset/great-lilies-stick.md
+++ b/.changeset/great-lilies-stick.md
@@ -1,0 +1,14 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Fix assert when inserting the same node multiple times
+
+When inserting the same node multiple times in a single array insertion, a `UsageError` is now thrown instead of an assert `0xa2b`.
+
+For example, this now throws a `UsageError` with message `A "ArrayNodeTest.Item" node was provided more than once in a single insertion. A node may not be in more than one place in the tree.`:
+
+```TypeScript
+array.insertAtEnd(item, item);
+```

--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -155,6 +155,18 @@ function validateAndPrepare(
 	mapTrees: readonly UnhydratedFlexTreeNode[],
 	scheduleHydrationOverride?: HydrationScheduler,
 ): void {
+	// Detecting duplicates here is the lowest level spot which is the same for hydrated and un-hydrated parents,
+	// and is also responsible for other validation, so it seem like the best layer to do this check.
+	const seenRoots = new Set<UnhydratedFlexTreeNode>();
+	for (const node of mapTrees) {
+		if (seenRoots.has(node)) {
+			throw new UsageError(
+				`A ${JSON.stringify(node.type)} node was provided more than once in a single insertion. A node may not be in more than one place in the tree.`,
+			);
+		}
+		seenRoots.add(node);
+	}
+
 	if (hydratedData !== undefined) {
 		// Run `prepareContentForHydration` before walking the tree in `isFieldInSchema`.
 		// This ensures that when `isFieldInSchema` requests identifiers (or any other contextual defaults),

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/arrayNode.spec.ts
@@ -13,8 +13,8 @@ import {
 import { asAlpha } from "../../../api.js";
 import {
 	SchemaFactory,
+	TreeArrayNode,
 	TreeViewConfiguration,
-	type TreeArrayNode,
 	type TreeArrayNodeAlpha,
 	type FixRecursiveArraySchema,
 	type InsertableTreeFieldFromImplicitField,
@@ -91,6 +91,63 @@ describe("ArrayNode", () => {
 		it("passes Array.isArray", () => {
 			const array = init(PojoEmulationNumberArray, [1, 2, 3]);
 			assert.equal(Array.isArray(array), true);
+		});
+	});
+
+	// Insertion tests in addition to the ones inside of testArrayFromSchemaType below
+	describeHydration("inserting nodes", (init, hydrated) => {
+		// This validation is done in a place that is non array specific, but can only be hit by arrays,
+		// and impacts the public API surface of arrays so testing it here makes sense.
+		it("inserting the same node more than once in a single insert throws a usage error", () => {
+			class Item extends schemaFactory.object("Item", {}) {}
+			class ItemArray extends schemaFactory.array("ItemArray", Item) {}
+			const array = init(ItemArray, []);
+			const item = new Item({});
+			const message = `A "ArrayNodeTest.Item" node was provided more than once in a single insertion. A node may not be in more than one place in the tree.`;
+			assert.throws(() => array.insertAtEnd(item, item), validateUsageError(message));
+			assert.throws(
+				() => array.insertAtEnd(TreeArrayNode.spread([item, item])),
+				validateUsageError(message),
+			);
+			assert.throws(
+				() => array.insertAt(0, TreeArrayNode.spread([item]), item),
+				validateUsageError(message),
+			);
+			assert.throws(
+				() => array.insertAtEnd(new Item({}), item, item),
+				validateUsageError(message),
+			);
+		});
+
+		// This check is implemented in an array specific way, but is included here as an integration test ensuring
+		// the public facing array API surface has a good error.
+		it("inserting already inserted node throws a usage error", () => {
+			class Item extends schemaFactory.object("Item", {}) {}
+			class ItemArray extends schemaFactory.array("ItemArray", Item) {}
+			const item = new Item({});
+			const array = init(ItemArray, [item]);
+			assert.throws(
+				() => array.insertAtEnd(item),
+				validateUsageError(
+					hydrated
+						? // The case of hydrating a node has extra context and stricter validation using that context.
+							// One sideeffect of that is we give nicer errors.
+							`A node with schema "ArrayNodeTest.Item" (name: "Item") was inserted into the tree more than once. This is not supported.`
+						: "A node may not be in more than one place in the tree",
+				),
+			);
+		});
+
+		// This check is implemented in an array specific way, but is included here as an integration test ensuring
+		// the public facing array API surface has a good error.
+		it("constructing an array with the same child twice throws a usage error", () => {
+			class Item extends schemaFactory.object("Item", {}) {}
+			class ItemArray extends schemaFactory.array("ItemArray", Item) {}
+			const item = new Item({});
+			assert.throws(
+				() => init(ItemArray, [item, item]),
+				validateUsageError("A node may not be in more than one place in the tree"),
+			);
 		});
 	});
 


### PR DESCRIPTION
## Description

Fix bug where `array.insertAtEnd(item, item);` would hit assert  `0xa2b` instead of a `UsageError`.

[AB#77712](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/77712)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
